### PR TITLE
Make BackendFactory a singleton

### DIFF
--- a/jgit/src/main/java/com/dremio/nessie/jgit/NessieRepository.java
+++ b/jgit/src/main/java/com/dremio/nessie/jgit/NessieRepository.java
@@ -61,7 +61,7 @@ public class NessieRepository extends DfsRepository {
    *
    * @param builder description of the repository.
    */
-  protected NessieRepository(DfsRepositoryBuilder builder) {
+  protected NessieRepository(DfsRepositoryBuilder<?, ?> builder) {
     super(builder);
     objectDb = new NessieObjDatabase(this, new DfsReaderOptions(), ((Builder) builder).backend);
     refDatabase = new NessieRefDatabase(this, ((Builder) builder).refBackend);

--- a/server/src/main/java/com/dremio/nessie/server/NessieServerBinder.java
+++ b/server/src/main/java/com/dremio/nessie/server/NessieServerBinder.java
@@ -29,6 +29,7 @@ import com.dremio.nessie.server.auth.NessieSecurityContext;
 import com.dremio.nessie.server.auth.UserServiceDbBackend;
 import java.util.List;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.ws.rs.core.SecurityContext;
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -50,7 +51,7 @@ public class NessieServerBinder extends AbstractBinder {
                              .getUserServiceClassName();
 
     bind(BasicKeyGenerator.class).to(KeyGenerator.class);
-    bindFactory(BackendFactory.class).to(Backend.class);
+    bindFactory(BackendFactory.class).to(Backend.class).in(Singleton.class);
 
     Class<?> usClazz;
     try {


### PR DESCRIPTION
Jersey instantiates a new backend factory with each request causing
inmemory store to be created anew each time.

Change bindings to make BackendFactory a singleton so the store is
shared across all requests.