### PR TITLE
Only copy native libraries dependencies

### DIFF
--- a/backends/dynamodb/pom.xml
+++ b/backends/dynamodb/pom.xml
@@ -35,11 +35,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} -Dsqlite4java.library.path=${basedir}/target/dependencies
-          </argLine>
           <systemPropertyVariables>
             <aws.accessKeyId>xxx</aws.accessKeyId>
             <aws.secretAccessKey>xxx</aws.secretAccessKey>
+            <sqlite4java.library.path>${project.build.directory}/native-libraries</sqlite4java.library.path>
           </systemPropertyVariables>
         </configuration>
         <executions>
@@ -56,20 +55,17 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>copy-dependencies</id>
+            <id>copy-native-libraries</id>
             <phase>process-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+              <outputDirectory>${project.build.directory}/native-libraries</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>false</overWriteSnapshots>
               <overWriteIfNewer>true</overWriteIfNewer>
-              <excludeGroupIds>
-                com.dremio.nessie,com.amazonaws,software.amazon,org.slf4j,org.eclipse.jetty,org.junit.jupiter,ch.qos.logback
-              </excludeGroupIds>
-              <excludeTransitive>true</excludeTransitive>
+              <includeTypes>dll,so,dylib</includeTypes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Small build optimization to only copy native libraries used by local
dynamodb server instead of copying several project dependencies.