### PR TITLE
Requires JDK11 to build Nessie

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:

--- a/README.md
+++ b/README.md
@@ -30,19 +30,23 @@ in a single package
 * **Delta Lake** - experimental Delta Lake `LogStore` using Nessie for atomic metadata updates
 * **Serverless** - AWS Lambda for Nessie w/ IAM support.
 
+## Requirements
+
+- JDK 11 or higher: JDK11 or higher is needed to build Nessie although artifacts are still compatible with Java 8
+
 ## Installation
 
 Clone this repository and run maven:
 ```bash
 git clone https://github.com/dremio/nessie
 cd nessie
-mvn clean install
+./mvnw clean install
 ```
 
 ## Distribution
 To run:
 1. configure port, backend, security etc in `distribution/src/main/resources/config.yaml`
-2. execute `mvn exec:exec -pl :nessie-distribution`
+2. execute `./mvnw exec:exec -pl :nessie-distribution`
 3. go to `http://localhost:19120`
 4. Default user (when using basic backend is admin_user:test123)
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,7 @@
   <properties>
     <!-- Build properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <argLine></argLine>
 
     <!-- 3rd party repositories -->
@@ -516,6 +515,19 @@ limitations under the License.
               </rules>
             </configuration>
           </execution>
+          <execution>
+            <id>enforce-java-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>11</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>
@@ -834,7 +846,7 @@ limitations under the License.
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>2.11.6</version>
+        <version>2.11.12</version>
       </dependency>
       <dependency>
         <groupId>org.scalatest</groupId>
@@ -998,30 +1010,6 @@ limitations under the License.
                   <version>2.4.0</version>
                 </path>
               </annotationProcessorPaths>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
-    <profile>
-      <id>error-prone-jdk8</id>
-      <activation>
-        <jdk>1.8</jdk>
-        <property>
-           <name>!m2e.version</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <fork>true</fork>
-              <compilerArgs combine.children="append">
-                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${errorprone.javac.version}/javac-${errorprone.javac.version}.jar</arg>
-              </compilerArgs>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Requires JDK11 to build Nessie as it is recommended by Quarkus:
- The restriction is enforced by maven enforcer plugin
- Generated bytecode is still compatible with Java8 thanks to the
release compiler option
- Github CI action updated as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dremio-hub/nessie/33)
<!-- Reviewable:end -->
