### PR TITLE
Skip testjar if not test classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,9 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <skipIfEmpty>true</skipIfEmpty>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Set skipIfEmpty flag to `true` for jar:test-jar mojo to suppress
warnings about nonexistent test classes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/141)
<!-- Reviewable:end -->
