### PR TITLE
Revert "Bump microprofile-openapi-api from 1.1.2 to 2.0-MR1 (#150)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <spark.version>2.4.7</spark.version>
     <sqlite.version>1.0.392</sqlite.version>
     <quarkus.version>1.8.1.Final</quarkus.version>
-    <openapi.version>2.0-MR1</openapi.version>
+    <openapi.version>1.1.2</openapi.version>
     <jsr305.version>3.0.2</jsr305.version>
   </properties>
 


### PR DESCRIPTION
Revert microprofile-openapi-api version change as:
- smallrye-openapi stills depends on 1.1.2 and 1.x and 2.x versions are
incompatible
- 2.0.0-MR1 is actually a fairly old version (2.0.0-RC3 is actually the
latest available version)

Fix native image building

This reverts commit d814f9cdf1933a5f617ba1b7fb0e4ba066e54be4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/181)
<!-- Reviewable:end -->
