### PR TITLE
Update maven-deploy-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.0.0-M3</version>
         </plugin>


### PR DESCRIPTION
Update maven-deploy-plugin version to 3.0.0-M1. The default one (2.7) is
from 2011, and does not support deployAtEnd option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/182)
<!-- Reviewable:end -->
