### PR TITLE
Build and release docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,14 @@ jobs:
       run: mvn -B deploy --file pom.xml -Pcode-coverage -DdeployAtEnd=true
       env:
         GITHUB_TOKEN: ${{ github.token }} 
+    - name: Push Docker images
+      run: |
+          echo '${{ secrets.GITHUB_TOKEN }}' | docker login https://docker.pkg.github.com -u '${{ github.actor }}' --password-stdin
+          docker images --filter 'reference=projectnessie/nessie' --format '{{.ID}}\t{{.Tag}}' |
+          while read IMAGE_ID IMAGE_TAG; do
+            docker tag "$IMAGE_ID" "docker.pkg.github.com/${{ github.repository }}/nessie:${IMAGE_TAG}"
+            docker push "docker.pkg.github.com/${{ github.repository }}/nessie:${IMAGE_TAG}"
+          done
     - name: Capture test results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,15 +31,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Build with Maven
-      run: mvn -B install --file pom.xml -Pcode-coverage,release
-    - name: Push Docker images
-      run: |
-          echo '${{ secrets.GITHUB_TOKEN }}' | docker login https://docker.pkg.github.com -u '${{ github.actor }}' --password-stdin
-          docker images --filter 'reference=projectnessie/nessie' --format '{{.ID}}\t{{.Tag}}' |
-          while read IMAGE_ID IMAGE_TAG; do
-            docker tag "$IMAGE_ID" "docker.pkg.github.com/${{ github.repository }}/nessie:${IMAGE_TAG}"
-            docker push "docker.pkg.github.com/${{ github.repository }}/nessie:${IMAGE_TAG}"
-          done
+      run: mvn -B install --file pom.xml -Pcode-coverage
     - name: Capture test results
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Current native profile fails on MacOS with GraalVM as the generated
native binary is not compatible with the Linux base docker image

* Add a `release` profile which will control when docker image is built.
* Configure main build to use the profile and push the image to the local registry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/191)
<!-- Reviewable:end -->
