### PR TITLE
Isolate quarkus bootstrap framework in its own classloader

### DIFF
--- a/tools/apprunner-maven-plugin/src/main/java/com/dremio/nessie/quarkus/maven/AbstractQuarkusAppMojo.java
+++ b/tools/apprunner-maven-plugin/src/main/java/com/dremio/nessie/quarkus/maven/AbstractQuarkusAppMojo.java
@@ -19,7 +19,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.model.AppArtifactCoords;
 
@@ -60,13 +59,23 @@ abstract class AbstractQuarkusAppMojo extends AbstractMojo {
     return project;
   }
 
-  RunningQuarkusApplication getApplication() {
+  private String getContextKey() {
     final String key = CONTEXT_KEY + '.' + getExecutionId();
-    return (RunningQuarkusApplication) project.getContextValue(key);
+    return key;
   }
 
-  protected void setApplicationHandle(RunningQuarkusApplication application) {
-    final String key = CONTEXT_KEY + '.' + getExecutionId();
+  protected AutoCloseable getApplication() {
+    final String key = getContextKey();
+    return (AutoCloseable) project.getContextValue(key);
+  }
+
+  protected void resetApplication() {
+    final String key = getContextKey();
+    project.setContextValue(key, null);
+  }
+
+  protected void setApplicationHandle(AutoCloseable application) {
+    final String key = getContextKey();
     final Object previous = project.getContextValue(key);
     if (previous != null) {
       getLog().warn(String.format("Found a previous application for execution id %s.", getExecutionId()));

--- a/tools/apprunner-maven-plugin/src/main/java/com/dremio/nessie/quarkus/maven/QuarkusApp.java
+++ b/tools/apprunner-maven-plugin/src/main/java/com/dremio/nessie/quarkus/maven/QuarkusApp.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.quarkus.maven;
+
+import java.lang.reflect.Method;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.app.QuarkusBootstrap.Mode;
+import io.quarkus.bootstrap.app.RunningQuarkusApplication;
+import io.quarkus.bootstrap.app.StartupAction;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+
+/**
+ * Test.
+ *
+ */
+public class QuarkusApp implements AutoCloseable {
+
+  private final RunningQuarkusApplication runningApp;
+
+  private QuarkusApp(RunningQuarkusApplication runningApp) {
+    this.runningApp = runningApp;
+  }
+
+  /**
+   * Instantiate and start a quarkus application.
+   *
+   * <p>Instantiates and start a quarkus application using Quarkus bootstrap framework. Only one application can be started at a time
+   * in the same classloader.
+   *
+   * @param project the Maven project
+   * @param repoSystem the Maven repository system instanxce
+   * @param repoSession the Maven repository system session
+   * @param appArtifactId the quarkus application artifact id
+   * @return a quarkus app instance
+   * @throws MojoExecutionException if an error occurs during execution
+   */
+  public static QuarkusApp newApplication(MavenProject project, RepositorySystem repoSystem,
+      RepositorySystemSession repoSession, String appArtifactId)
+      throws MojoExecutionException {
+    final AppArtifactCoords appCoords = AppArtifactCoords.fromString(appArtifactId);
+    final AppArtifact appArtifact = new AppArtifact(appCoords.getGroupId(),
+        appCoords.getArtifactId(), appCoords.getClassifier(), appCoords.getType(),
+        appCoords.getVersion());
+
+    final AppModel appModel;
+    try {
+      MavenArtifactResolver resolver = MavenArtifactResolver.builder().setWorkspaceDiscovery(false)
+          .setRepositorySystem(repoSystem).setRepositorySystemSession(repoSession)
+          .setRemoteRepositories(project.getRemoteProjectRepositories()).build();
+
+      appModel = new BootstrapAppModelResolver(resolver).setDevMode(false).setTest(false)
+          .resolveModel(appArtifact);
+    } catch (Exception e) {
+      throw new MojoExecutionException(
+          "Failed to resolve application model " + appArtifact + " dependencies", e);
+    }
+
+    final QuarkusBootstrap bootstrap = QuarkusBootstrap.builder()
+        .setAppArtifact(appModel.getAppArtifact())
+        .setBaseClassLoader(QuarkusApp.class.getClassLoader()).setExistingModel(appModel)
+        .setProjectRoot(project.getBasedir().toPath())
+        .setTargetDirectory(Paths.get(project.getBuild().getDirectory())).setIsolateDeployment(true)
+        .setMode(Mode.TEST).build();
+
+    try {
+      final CuratedApplication app = bootstrap.bootstrap();
+      StartupAction startupAction = app.createAugmentor().createInitialRuntimeApplication();
+      exitHandler(startupAction);
+      RunningQuarkusApplication runningApp = startupAction.runMainClass();
+      return new QuarkusApp(runningApp);
+    } catch (Exception e) {
+      throw new MojoExecutionException("Failure starting Nessie Daemon",
+          e instanceof MojoExecutionException ? e.getCause() : e);
+    }
+  }
+
+  private static void exitHandler(StartupAction startupAction) throws ReflectiveOperationException {
+    Consumer<Integer> consumer = i -> {
+    };
+    Method exitHandler = Arrays
+        .stream(startupAction.getClassLoader()
+            .loadClass("io.quarkus.runtime.ApplicationLifecycleManager").getMethods())
+        .filter(x -> x.getName().equals("setDefaultExitCodeHandler")).findFirst()
+        .orElseThrow(NoSuchMethodException::new);
+    exitHandler.invoke(null, consumer);
+  }
+
+  @Override public void close() throws Exception {
+    runningApp.close();
+  }
+}

--- a/tools/apprunner-maven-plugin/src/main/java/com/dremio/nessie/quarkus/maven/QuarkusAppStopMojo.java
+++ b/tools/apprunner-maven-plugin/src/main/java/com/dremio/nessie/quarkus/maven/QuarkusAppStopMojo.java
@@ -20,8 +20,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import io.quarkus.bootstrap.app.RunningQuarkusApplication;
-
 /**
  * Stop Quarkus application.
  */
@@ -37,7 +35,7 @@ public class QuarkusAppStopMojo extends AbstractQuarkusAppMojo {
       return;
     }
 
-    final RunningQuarkusApplication application = getApplication();
+    final AutoCloseable application = getApplication();
     if (application == null) {
       getLog().warn(String.format("No application found for execution id '%s'.", getExecutionId()));
     }
@@ -47,6 +45,8 @@ public class QuarkusAppStopMojo extends AbstractQuarkusAppMojo {
       getLog().info("Quarkus application stopped.");
     } catch (Exception e) {
       throw new MojoExecutionException("Error while stopping Quarkus application", e);
+    } finally {
+      resetApplication();
     }
   }
 


### PR DESCRIPTION
Quarkus Bootstrap framework does not allow to start multiple
applications at the same time unless each boostrap invokation is managed
in its own classloader.

Refactor Maven apprunner plugin to move boostrap usage into a separate
class which can be easily invoked from a different classloader. Start
mojo will "clone" its own classloader in order to isolate each
invokation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/206)
<!-- Reviewable:end -->
