### PR TITLE
Generate Aggregate code coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -975,6 +975,32 @@ limitations under the License.
                   <goal>report-integration</goal>
                 </goals>
               </execution>
+              <execution>
+                <id>default-aggregate-report</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+                <configuration>
+                  <dataFileIncludes>
+                    <dataFileInclude>**/jacoco.exec</dataFileInclude>
+                  </dataFileIncludes>
+                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>default-aggregate-report-integration</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+                <configuration>
+                  <dataFileIncludes>
+                    <dataFileInclude>jacoco-it.exec</dataFileInclude>
+                  </dataFileIncludes>
+                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate-it</outputDirectory>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
         </plugins>


### PR DESCRIPTION
Generate aggregate code coverage reports using jacoco report-aggregate
mojo. Those reports include dependencies coverage for the module test
execution.

Note that it might be possible that those reports are still not fully
accurate as jacoco do not check dependencies transitively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/211)
<!-- Reviewable:end -->
