### PR TITLE
fix native image:

### DIFF
--- a/backends/dynamodb/pom.xml
+++ b/backends/dynamodb/pom.xml
@@ -38,17 +38,17 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>dynamodb</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>apache-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>apache-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>    
+      <artifactId>url-connection-client</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>

--- a/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/DynamoDbBackend.java
+++ b/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/DynamoDbBackend.java
@@ -25,7 +25,7 @@ import com.dremio.nessie.backend.EntityBackend;
 import com.dremio.nessie.model.BranchControllerObject;
 import com.dremio.nessie.model.BranchControllerReference;
 
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
@@ -62,7 +62,7 @@ public class DynamoDbBackend implements Backend {
       clientBuilder = clientBuilder.region(Region.of(region));
     }
 
-    DynamoDbClient client = clientBuilder.httpClient(ApacheHttpClient.create())
+    DynamoDbClient client = clientBuilder.httpClient(UrlConnectionHttpClient.builder().build())
                                          .build();
 
     return new DynamoDbBackend(client, registry);

--- a/backends/dynamodb/src/test/java/com/dremio/nessie/backend/dynamodb/LocalDynamoDB.java
+++ b/backends/dynamodb/src/test/java/com/dremio/nessie/backend/dynamodb/LocalDynamoDB.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
 import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
 import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
 
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
@@ -52,7 +52,7 @@ public class LocalDynamoDB extends TypeBasedParameterResolver<DynamoDbClient> im
       server = ServerRunner.createServerFromCommandLineArgs(localArgs);
       server.start();
       client = DynamoDbClient.builder()
-          .httpClient(ApacheHttpClient.create())
+          .httpClient(UrlConnectionHttpClient.create())
           .endpointOverride(URI.create("http://localhost:8000"))
           .region(Region.US_WEST_2)
           .build();

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -80,6 +80,7 @@ quarkus.jaeger.sampler-param=1
 # fixed at buildtime
 quarkus.jaeger.metrics.enabled=true
 
+quarkus.dynamodb.sync-client.type=url
 
 ## sentry specific settings
 quarkus.log.sentry.level=ERROR

--- a/servers/quarkus-server/src/main/resources/reflection-config.json
+++ b/servers/quarkus-server/src/main/resources/reflection-config.json
@@ -34,5 +34,32 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "org.eclipse.jgit.lib.CoreConfig",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "org.eclipse.jgit.lib.CoreConfig$HideDotFiles",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "org.eclipse.jgit.lib.CoreConfig$LogRefUpdates",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]

--- a/versioned/dynamodb/pom.xml
+++ b/versioned/dynamodb/pom.xml
@@ -61,6 +61,12 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>dynamodb</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>apache-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -68,13 +74,7 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>apache-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>url-connection-client</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/DynamoStore.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/DynamoStore.java
@@ -43,8 +43,8 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientBuilder;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -147,7 +147,7 @@ public class DynamoStore implements AutoCloseable {
    */
   public void start() {
     DynamoDbClientBuilder b1 = DynamoDbClient.builder();
-    b1.httpClient(ApacheHttpClient.create());
+    b1.httpClient(UrlConnectionHttpClient.create());
     DynamoDbAsyncClientBuilder b2 = DynamoDbAsyncClient.builder();
     b2.httpClient(NettyNioAsyncHttpClient.create());
     config.getEndpoint().ifPresent(ep -> {


### PR DESCRIPTION
* use url-connection over apache client
* don't initialize jgit if not being used
* add jgit classes to reflection-config.json to ensure jgit works w/ native image

The native image works now with the following:

`docker run -p 19120:19120 -e QUARKUS_DYNAMODB_AWS_CREDENTIALS_TYPE=env-variable -e NESSIE_VERSION_STORE_TYPE=DYNAMO -e QUARKUS_DYNAMODB_ENDPOINT_OVERRIDE=http://172.17.0.2:8000 -e NESSIE_VERSION_STORE_DYNAMO_INITIALIZE=true -e AWS_ACCESS_KEY_ID=xxx -e AWS_SECRET_ACCESS_KEY=xxx projectnessie/nessie:0.1-SNAPSHOT`

`QUARKUS_DYNAMODB_AWS_CREDENTIALS_TYPE` -> only look for env variables in credentials management
`NESSIE_VERSION_STORE_TYPE` -> Use dynamo verison store
`QUARKUS_DYNAMODB_ENDPOINT_OVERRIDE` -> local dynamos ip address in docker `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <local-dynamo-image>`
`AWS_ACCESS_KEY_ID` -> dummy key
`AWS_SECRET_ACCESS_KEY` -> dummy secret

see https://quarkus.io/guides/all-config#quarkus-amazon-dynamodb_quarkus.dynamodb.aws.credentials.type for all the ways to specify credentials. Including instance profile and container metadata

Also tested with:
`sam local start-api --template target/sam.native.yaml`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/227)
<!-- Reviewable:end -->
