### PR TITLE
Remove codecov secret

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,6 @@ jobs:
           **/target/failsafe-reports/*
     - uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: java
 
   python:
@@ -85,5 +84,3 @@ jobs:
     - name: Test with tox
       run: tox
       working-directory: ${{env.working-directory}}
-      env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,7 +52,6 @@ jobs:
           **/target/failsafe-reports/*
     - uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: java
 
   python:
@@ -85,5 +84,3 @@ jobs:
     - name: Test with tox
       run: tox
       working-directory: ${{env.working-directory}}
-      env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Now that the repository is public on github, there's no need for a
secret to upload reports to codecov.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/251)
<!-- Reviewable:end -->
