### PR TITLE
Use Maven toolchains for JDK8 tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,7 +64,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Build with Maven
-      run: mvn -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage,jdk8-tests
+      run: mvn -B install --file pom.xml -Pcode-coverage,jdk8-tests
       env:
         GITHUB_TOKEN: ${{ github.token }} 
     - name: Capture test results

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
         targets: 'JDK8_HOME'
     - name: Set up Maven toolchains.xml
       run: | 
-          cat << EOT > ${HOME}/.m2/toolchains.xml
+          cat << 'EOT' > ${HOME}/.m2/toolchains.xml
           <?xml version="1.0" encoding="UTF8"?>
           <toolchains>
             <toolchain>

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,34 @@ jobs:
       with:
         version: '8'
         targets: 'JDK8_HOME'
+    - name: Set up Maven toolchains.xml
+      run: | 
+          cat << EOT > ${HOME}/.m2/toolchains.xml
+          <?xml version="1.0" encoding="UTF8"?>
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>11</version>
+                <vendor>zulu</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>${env.JAVA_HOME}</jdkHome>
+              </configuration>
+            </toolchain>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>1.8</version>
+                <vendor>adoptopenjdk</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>${env.JDK8_HOME}</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          EOT
+
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:
@@ -36,13 +64,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Build with Maven
-      run: mvn -B install --file pom.xml -Pcode-coverage
+      run: mvn -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage,jdk8-tests
       env:
         GITHUB_TOKEN: ${{ github.token }} 
-    - name: Run Hive tests with JDK8
-      run: mvn -B verify --file pom.xml -DJDK8 -pl ':nessie-hms-hive2,:nessie-hms-hive3' -Pcode-coverage
-      env:
-        JAVA_HOME: ${{ env.JDK8_HOME }}
     - name: Capture test results
       uses: actions/upload-artifact@v2
       with:

--- a/clients/hmsbridge/core/pom.xml
+++ b/clients/hmsbridge/core/pom.xml
@@ -147,14 +147,14 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <annotationProcessorPaths>
+          <annotationProcessorPaths combine.children="append">
             <path>
               <groupId>info.picocli</groupId>
               <artifactId>picocli-codegen</artifactId>
               <version>4.5.1</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
+          <compilerArgs combine.children="append">
             <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
           </compilerArgs>
         </configuration>

--- a/clients/hmsbridge/hive2/pom.xml
+++ b/clients/hmsbridge/hive2/pom.xml
@@ -135,33 +135,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-<!--     <dependency> -->
-<!--       <groupId>org.apache.hadoop</groupId> -->
-<!--       <artifactId>hadoop-mapreduce-client-core</artifactId> -->
-<!--       <version>3.1.0</version> -->
-<!--       <exclusions> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey</groupId> -->
-<!--           <artifactId>jersey-core</artifactId> -->
-<!--         </exclusion> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey</groupId> -->
-<!--           <artifactId>jersey-client</artifactId> -->
-<!--         </exclusion> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey</groupId> -->
-<!--           <artifactId>jersey-server</artifactId> -->
-<!--         </exclusion> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey</groupId> -->
-<!--           <artifactId>jersey-json</artifactId> -->
-<!--         </exclusion> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey.contribs</groupId> -->
-<!--           <artifactId>jersey-guice</artifactId> -->
-<!--         </exclusion> -->
-<!--       </exclusions> -->
-<!--     </dependency> -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
@@ -321,12 +294,7 @@
 
   <profiles>
     <profile>
-      <id>JDK8</id>
-      <activation>
-        <property>
-          <name>JDK8</name>
-        </property>
-      </activation>
+      <id>jdk8-tests</id>
       <build>
         <plugins>
           <plugin>
@@ -364,10 +332,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
-              <systemProperties>
-              </systemProperties>
-              <systemPropertyVariables>
-              </systemPropertyVariables>
+              <jdkToolchain>
+                <version>1.8</version>
+              </jdkToolchain>
             </configuration>
             <executions>
               <execution>
@@ -377,36 +344,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-project-rules</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules combine.self="append">
-                    <requireJavaVersion>
-                      <version>1.8</version>
-                    </requireJavaVersion>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-              <compilerArgs combine.self="override">
-              </compilerArgs>
-              <annotationProcessorPaths combine.self="override" />
-              <maven.compiler.release/>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/clients/hmsbridge/hive3/pom.xml
+++ b/clients/hmsbridge/hive3/pom.xml
@@ -52,30 +52,6 @@
       <artifactId>jcl-over-slf4j</artifactId>
       <scope>runtime</scope>
     </dependency>
-<!--     <dependency> -->
-<!--       <groupId>org.apache.hive</groupId> -->
-<!--       <artifactId>hive-standalone-metastore</artifactId> -->
-<!--       <version>3.1.2</version> -->
-<!--       <scope>runtime</scope> -->
-<!--       <exclusions> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey</groupId> -->
-<!--           <artifactId>jersey-core</artifactId> -->
-<!--         </exclusion> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey</groupId> -->
-<!--           <artifactId>jersey-client</artifactId> -->
-<!--         </exclusion> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey</groupId> -->
-<!--           <artifactId>jersey-json</artifactId> -->
-<!--         </exclusion> -->
-<!--         <exclusion> -->
-<!--           <groupId>com.sun.jersey.contribs</groupId> -->
-<!--           <artifactId>jersey-guice</artifactId> -->
-<!--         </exclusion> -->
-<!--       </exclusions> -->
-<!--     </dependency>     -->
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
@@ -309,12 +285,7 @@
 
   <profiles>
     <profile>
-      <id>JDK8</id>
-      <activation>
-        <property>
-          <name>JDK8</name>
-        </property>
-      </activation>
+      <id>jdk8-tests</id>
       <build>
         <plugins>
           <plugin>
@@ -352,10 +323,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
-              <systemProperties>
-              </systemProperties>
-              <systemPropertyVariables>
-              </systemPropertyVariables>
+              <jdkToolchain>
+                <version>1.8</version>
+              </jdkToolchain>
             </configuration>
             <executions>
               <execution>
@@ -365,36 +335,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-project-rules</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules combine.self="append">
-                    <requireJavaVersion>
-                      <version>1.8</version>
-                    </requireJavaVersion>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-              <compilerArgs combine.self="override">
-              </compilerArgs>
-              <annotationProcessorPaths combine.self="override" />
-              <maven.compiler.release/>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
   <properties>
     <!-- Build properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>8</maven.compiler.release>
     <argLine></argLine>
 
     <!-- 3rd party repositories -->
@@ -922,18 +923,6 @@ limitations under the License.
   </build>
 
   <profiles>
-    <profile>
-      <id>release8-when11</id>
-      <activation>
-        <property>
-          <name>!JDK8</name>
-        </property>
-      </activation>
-      <properties>
-        <maven.compiler.release>8</maven.compiler.release>
-      </properties>
-
-    </profile>
     <profile>
       <id>code-coverage</id>
       <build>


### PR DESCRIPTION
Configure toolchains.xml for both JDK 11 and 8 versions and configure
failsafe plugin for hmsclient tests to use JDK 8 toolchain as Hive tests
are not compatible with JDK11

Fixes projectnessie/nessie#213

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/260)
<!-- Reviewable:end -->
