### PR TITLE
Fix gpg ioctl issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1128,6 +1128,12 @@ limitations under the License.
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
It seems gpg tries to get passphrase from tty instead of the value
provided by maven settings.
Following suggestion from https://stackoverflow.com/questions/53992950,
change pinentry mode to loopback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/262)
<!-- Reviewable:end -->
