### PR TITLE
Fix site home page design on mobile & link colors

### DIFF
--- a/site/overrides/home.html
+++ b/site/overrides/home.html
@@ -70,6 +70,14 @@
       font-weight: 700;
     }
     
+    .tx-hero__content {
+      padding-bottom: 6rem;
+    }
+
+    .tx-hero .md-button {
+      color: var(--md-primary-bg-color);
+    }
+    
     @media screen and (min-width: 60em) {
       .tx-hero__content {
           max-width: 19rem;
@@ -80,7 +88,6 @@
       .tx-hero .md-button {
         margin-top: .5rem;
         margin-right: .5rem;
-        color: var(--md-primary-bg-color);
       }
       
       .tx-hero__image {


### PR DESCRIPTION
Fixes the site's home page design on mobile so that the links are not at the very button of the page and over the "wave" design. Additionally, applies link coloring unconditionally for the buttons.

Before:
![image](https://user-images.githubusercontent.com/12377481/95044400-2cb64000-0694-11eb-9f56-41c6db89f0a6.png)

After:
![image](https://user-images.githubusercontent.com/12377481/95044361-190ad980-0694-11eb-9d3e-1b01163c0fca.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/264)
<!-- Reviewable:end -->
