### PR TITLE
Exclude hbase from hive3 runner

### DIFF
--- a/clients/hmsbridge/hive3/pom.xml
+++ b/clients/hmsbridge/hive3/pom.xml
@@ -158,20 +158,12 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-core</artifactId>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-client</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-server</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-json</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
           <groupId>junit</groupId>


### PR DESCRIPTION
Exclude hbase dependencies from hive3 runner as hbase defines an invalid
repository polluting maven space and creating a `${project.basedir}`
directory at the root of the project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/280)
<!-- Reviewable:end -->
