### PR TITLE
Ensure source plugin is only invoked once for deltalake/core

### DIFF
--- a/clients/deltalake/core/pom.xml
+++ b/clients/deltalake/core/pom.xml
@@ -60,10 +60,15 @@
         <artifactId>maven-source-plugin</artifactId>
         <executions>
           <execution>
-            <id>attach-sources</id>
+            <id>default-sourcesJar</id>
             <goals>
-              <goal>jar</goal>
-              <goal>test-jar</goal>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-testSourcesJar</id>
+            <goals>
+              <goal>test-jar-no-fork</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1086,7 +1086,7 @@ limitations under the License.
             <artifactId>maven-source-plugin</artifactId>
             <executions>
               <execution>
-                <id>default-soucesJar</id>
+                <id>default-sourcesJar</id>
                 <goals>
                   <goal>jar-no-fork</goal>
                 </goals>


### PR DESCRIPTION
Fix execution id for maven-source-plugin execution in
clients/deltalake/core as 2 concurrent executions would cause the same
artifact to be deployed twice, which is not permitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/291)
<!-- Reviewable:end -->
