### PR TITLE
Introduce checkpoint keylists & history, merge and transplant for DynamoDB

### DIFF
--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/DiffFinder.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/DiffFinder.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.versioned.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.dremio.nessie.versioned.ReferenceNotFoundException;
+import com.dremio.nessie.versioned.impl.DynamoStore.ValueType;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.MapDifference.ValueDifference;
+
+/**
+ * Given two L1s, determine the value differences between them.
+ */
+class DiffFinder {
+
+  private final List<L3Diff> l3Diffs = new ArrayList<>();
+  private final L1Diff l1Diff;
+
+  public DiffFinder(L1 first, L1 second) {
+    this.l1Diff = new L1Diff(first, second);
+  }
+
+  public LoadStep getLoad() {
+    return l1Diff.getLoad(l3Diffs);
+  }
+
+  public L1 getFrom() {
+    return l1Diff.from;
+  }
+
+  public L1 getTo() {
+    return l1Diff.to;
+  }
+
+  public Stream<KeyDiff> getKeyDiffs() {
+    return l3Diffs.stream().flatMap(l3 -> l3.getKeyDiffs());
+  }
+
+  private static class L1Diff {
+    private L1 from;
+    private L1 to;
+
+    public L1Diff(L1 from, L1 to) {
+      super();
+      this.from = from;
+      this.to = to;
+    }
+
+    public LoadStep getLoad(List<L3Diff> l3DiffsOutput) {
+      List<L2Diff> l2Diffs = new ArrayList<>();
+      List<LoadOp<?>> loadOps = new ArrayList<>();
+      for (int i = 0; i < L1.SIZE; i++) {
+        Id a = from.getId(i);
+        Id b = to.getId(i);
+        if (!a.equals(b)) {
+          L2Diff d = new L2Diff();
+          l2Diffs.add(d);
+          loadOps.add(new LoadOp<L2>(ValueType.L2, a, d::from));
+          loadOps.add(new LoadOp<L2>(ValueType.L2, b, d::to));
+        }
+      }
+
+      return new LoadStep(loadOps, () -> L2Diff.loadStep(l2Diffs, l3DiffsOutput));
+    }
+
+  }
+
+  private static class L2Diff {
+    private L2 from;
+    private L2 to;
+
+    void from(L2 from) {
+      this.from = from;
+    }
+
+    void to(L2 to) {
+      this.to = to;
+    }
+
+    public static Optional<LoadStep> loadStep(Collection<L2Diff> diffs, List<L3Diff> l3DiffsOutput) {
+      List<LoadOp<?>> loadOps = new ArrayList<>();
+      for (L2Diff diff : diffs) {
+        L2 from = diff.from;
+        L2 to = diff.to;
+        for (int i = 0; i < L1.SIZE; i++) {
+          Id a = from.getId(i);
+          Id b = to.getId(i);
+          if (!a.equals(b)) {
+            L3Diff d = new L3Diff();
+            l3DiffsOutput.add(d);
+            loadOps.add(new LoadOp<L3>(ValueType.L3, a, d::from));
+            loadOps.add(new LoadOp<L3>(ValueType.L3, b, d::to));
+          }
+        }
+      }
+      return loadOps.isEmpty() ? Optional.empty() : Optional.of(new LoadStep(loadOps, () -> Optional.empty()));
+    }
+  }
+
+  private static class L3Diff {
+    private L3 from;
+    private L3 to;
+
+    void from(L3 from) {
+      this.from = from;
+    }
+
+    void to(L3 to) {
+      this.to = to;
+    }
+
+    Stream<KeyDiff> getKeyDiffs() {
+      return L3.compare(from, to).entriesDiffering().entrySet().stream().map(KeyDiff::new);
+    }
+
+  }
+
+  static class KeyDiff {
+
+    private final InternalKey key;
+    private final Id from;
+    private final Id to;
+
+    public KeyDiff(Entry<InternalKey, ValueDifference<Id>> diff) {
+      this.key = diff.getKey();
+      ValueDifference<Id> id = diff.getValue();
+      from = id.leftValue();
+      to = id.rightValue();
+    }
+
+    public InternalKey getKey() {
+      return key;
+    }
+
+    public Id getFrom() {
+      return from;
+    }
+
+    public Id getTo() {
+      return to;
+    }
+
+  }
+
+  static List<DiffFinder> getFinders(List<L1> l1Ascending, DynamoStore store) throws ReferenceNotFoundException {
+    Preconditions.checkArgument(l1Ascending.size() > 1);
+    L1 previous = null;
+    List<DiffFinder> diffs = new ArrayList<>();
+    for (L1 l1 : l1Ascending) {
+      if (previous != null) {
+        DiffFinder finder = new DiffFinder(previous, l1);
+        diffs.add(finder);
+      }
+      previous = l1;
+    }
+    return diffs;
+  }
+}

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/DynamoStoreConfig.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/DynamoStoreConfig.java
@@ -44,6 +44,11 @@ public abstract class DynamoStoreConfig {
   }
 
   @Default
+  public String getKeyListTableName() {
+    return "nessie_objects";
+  }
+
+  @Default
   public String getMetadataTableName() {
     return "nessie_objects";
   }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/HistoryRetriever.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/HistoryRetriever.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.versioned.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Spliterators;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.dremio.nessie.versioned.ReferenceNotFoundException;
+import com.dremio.nessie.versioned.impl.DynamoStore.ValueType;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Enables retrieval of L1 history.
+ */
+class HistoryRetriever {
+
+  private final boolean retrieveL1;
+  private final boolean retrieveCommit;
+  private final boolean includeEndEmpty;
+  private final DynamoStore store;
+  private final L1 start;
+  private final Id end;
+
+  public HistoryRetriever(DynamoStore store, L1 start, Id end, boolean retrieveL1, boolean retrieveCommit, boolean includeEndEmpty) {
+    super();
+    this.store = store;
+    this.start = start;
+    this.end = end;
+    this.retrieveL1 = retrieveL1;
+    this.retrieveCommit = retrieveCommit;
+    this.includeEndEmpty = includeEndEmpty;
+  }
+
+  class HistoryItem {
+
+    private Id id;
+    private L1 l1;
+    private InternalCommitMetadata commitMetadata;
+
+    public HistoryItem(Id id) {
+      this.id = id;
+    }
+
+    public L1 getL1() {
+      return l1;
+    }
+
+    public Id getId() {
+      return id;
+    }
+
+    public InternalCommitMetadata getMetadata() {
+      return commitMetadata;
+    }
+
+  }
+
+  Stream<HistoryItem> getStream() {
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new HistoryIterator(), 0), false);
+  }
+
+  private class HistoryIterator extends AbstractIterator<HistoryItem> {
+
+    private Iterator<HistoryItem> currentIterator;
+    private boolean isLast = false;
+    private HistoryItem previous;
+
+    public HistoryIterator() {
+      this.previous = null;
+
+      if (start.getId().equals(L1.EMPTY_ID) && !includeEndEmpty) {
+        this.currentIterator = Collections.emptyIterator();
+        this.isLast = true;
+      } else {
+        HistoryItem item = new HistoryItem(start.getId());
+        item.l1 = start;
+        if (retrieveCommit && !start.getMetadataId().isEmpty()) {
+          item.commitMetadata = store.loadSingle(ValueType.COMMIT_METADATA, start.getMetadataId());
+        }
+        this.currentIterator = Collections.singleton(item).iterator();
+      }
+    }
+
+    @Override
+    protected HistoryItem computeNext() {
+      while (!currentIterator.hasNext() && !isLast) {
+        try {
+          calculateNextList(previous.getL1().getParentList());
+        } catch (ReferenceNotFoundException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      if (!currentIterator.hasNext()) {
+        endOfData();
+        return null;
+      }
+
+      previous = currentIterator.next();
+      return previous;
+    }
+
+    private void calculateNextList(ParentList list) throws ReferenceNotFoundException {
+      int max = list.getParents().size();
+      final List<HistoryItem> items = new ArrayList<>();
+      final List<LoadOp<?>> loadOps = new ArrayList<>();
+      final List<Supplier<LoadOp<?>>> secondOps = new ArrayList<>();
+      final List<Id> ids = list.getParents();
+      for (int i = 0; i < max; i++) {
+        final boolean lastInList = i == max - 1;
+        Id parent = ids.get(i);
+
+        if (parent.isEmpty()) {
+          break;
+        }
+
+        if (!includeEndEmpty && parent.equals(L1.EMPTY_ID)) {
+          isLast = true;
+          break;
+        }
+
+        final HistoryItem item = new HistoryItem(parent);
+        items.add(item);
+        if (retrieveL1 || retrieveCommit || lastInList) {
+          loadOps.add(new LoadOp<L1>(ValueType.L1, parent, l1 -> item.l1 = l1));
+        }
+
+        if (retrieveCommit && !parent.equals(L1.EMPTY_ID)) {
+          secondOps.add(() -> new LoadOp<InternalCommitMetadata>(
+              ValueType.COMMIT_METADATA, item.l1.getMetadataId(), cmd -> item.commitMetadata = cmd));
+        }
+
+        if (parent.equals(end)) {
+          isLast = true;
+          break;
+        }
+      }
+
+      if (loadOps.isEmpty()) {
+        currentIterator = Collections.emptyIterator();
+        isLast = true;
+        return;
+      }
+
+      store.load(new LoadStep(loadOps, () -> {
+        if (secondOps.isEmpty()) {
+          return Optional.empty();
+        }
+
+        return Optional.of(new LoadStep(secondOps.stream().map(Supplier::get).collect(ImmutableList.toImmutableList())));
+      }));
+      currentIterator = items.iterator();
+    }
+
+  }
+
+}

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/InternalKey.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/InternalKey.java
@@ -71,6 +71,10 @@ class InternalKey implements Comparable<InternalKey>, HasId {
         .map(s -> AttributeValue.builder().s(s).build()).collect(Collectors.toList())).build();
   }
 
+  public int estimatedSize() {
+    return 3 + delegate.getElements().stream().mapToInt(s -> s.length()).sum();
+  }
+
   public static InternalKey fromAttributeValue(AttributeValue value) {
     return new InternalKey(ImmutableKey.builder()
         .addAllElements(value.l().stream().map(AttributeValue::s)
@@ -98,7 +102,7 @@ class InternalKey implements Comparable<InternalKey>, HasId {
     if (!(obj instanceof InternalKey)) {
       return false;
     }
-    Key other = (Key) obj;
+    InternalKey other = (InternalKey) obj;
     List<String> thisLower = delegate.getElements().stream().map(String::toLowerCase).collect(Collectors.toList());
     List<String> otherLower = other.getElements().stream().map(String::toLowerCase).collect(Collectors.toList());
     return thisLower.equals(otherLower);

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/KeyList.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/KeyList.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.versioned.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.immutables.value.Value.Immutable;
+
+import com.dremio.nessie.versioned.impl.DynamoStore.ValueType;
+import com.dremio.nessie.versioned.impl.KeyMutation.MutationType;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Interface and implementations related to managing the key list within Dynamo.
+ */
+abstract class KeyList {
+
+  private static final String IS_CHECKPOINT = "chk";
+
+  public static final KeyList EMPTY = new CompleteList(Collections.emptyList(), ImmutableList.of());
+
+  static enum Type {
+    INCREMENTAL,
+    FULL
+  }
+
+  abstract KeyList plus(Id parent, List<KeyMutation> mutations);
+
+  abstract Optional<KeyList> createCheckpointIfNeeded(L1 startingPoint, DynamoStore store);
+
+  abstract Type getType();
+
+  static IncrementalList incremental(
+      Id previousCheckpointL1,
+      List<KeyMutation> mutations,
+      int distanceFromCheckpointCommits) {
+    return ImmutableIncrementalList.builder()
+        .previousCheckpoint(previousCheckpointL1)
+        .distanceFromCheckpointCommits(distanceFromCheckpointCommits)
+        .mutations(mutations).build();
+  }
+
+  abstract Stream<InternalKey> getKeys(L1 startingPoint, DynamoStore store);
+
+
+  abstract List<KeyMutation> getMutations();
+
+  abstract AttributeValue toAttributeValue();
+
+  static KeyList fromAttributeValue(AttributeValue value) {
+    if (value.m().get(IS_CHECKPOINT).bool()) {
+      return CompleteList.fromAttributeValue(value.m());
+    } else {
+      return IncrementalList.fromAttributeValue(value.m());
+    }
+  }
+
+  boolean isEmptyIncremental() {
+    return getType() == Type.INCREMENTAL && ((IncrementalList) this).getMutations().isEmpty();
+  }
+
+  boolean isFull() {
+    return getType() == Type.FULL;
+  }
+
+  @Immutable
+  abstract static class IncrementalList extends KeyList {
+
+    private static final String MUTATIONS = "mutations";
+    private static final String ORIGIN = "origin";
+    private static final String DISTANCE = "dist";
+
+    public static final int MAX_DELTAS = 50;
+
+    public abstract List<KeyMutation> getMutations();
+
+    public abstract Id getPreviousCheckpoint();
+
+    public abstract int getDistanceFromCheckpointCommits();
+
+    @Override
+    public KeyList plus(Id parent, List<KeyMutation> mutations) {
+      return ImmutableIncrementalList.builder()
+          .addAllMutations(mutations)
+          .distanceFromCheckpointCommits(getDistanceFromCheckpointCommits() + 1)
+          .previousCheckpoint(getPreviousCheckpoint()).build();
+    }
+
+    @Override
+    public Optional<KeyList> createCheckpointIfNeeded(L1 startingPoint, DynamoStore store) {
+      if (getDistanceFromCheckpointCommits() < MAX_DELTAS) {
+        return Optional.empty();
+      }
+
+
+      return Optional.of(generateNewCheckpoint(startingPoint, store));
+    }
+
+
+    @Override
+    Stream<InternalKey> getKeys(L1 startingPoint, DynamoStore store) {
+      IterResult keys = getKeysIter(startingPoint, store);
+      if (keys.isChanged()) {
+        return keys.keyList;
+      }
+
+      return keys.list.getKeys(startingPoint, store);
+    }
+
+    private CompleteList generateNewCheckpoint(L1 startingPoint, DynamoStore store) {
+
+      IterResult result = getKeysIter(startingPoint, store);
+      if (!result.isChanged()) {
+        return result.list;
+      }
+
+      final KeyAccumulator accum = new KeyAccumulator(store, result.previousFragmentIds);
+      result.keyList.forEach(accum::addKey);
+      accum.close();
+
+      return accum.getCompleteList(getMutations());
+    }
+
+    private IterResult getKeysIter(L1 startingPoint, DynamoStore store) {
+      HistoryRetriever retriever = new HistoryRetriever(store, startingPoint, getPreviousCheckpoint(), true, false, true);
+      final CompleteList complete;
+      // incrementals, from oldest to newest.
+      final List<KeyList> incrementals;
+
+      { // load the lists.
+        ImmutableList<KeyList> keyLists = retriever.getStream()
+            .map(h -> h.getL1().getKeyList())
+            .filter(kl -> !kl.isEmptyIncremental())
+            .collect(ImmutableList.toImmutableList());
+
+        // the very last keylist should be a completelist, given the correct stop.
+        KeyList last = keyLists.get(keyLists.size() - 1);
+        Preconditions.checkArgument(last.isFull());
+        complete = (CompleteList) last;
+        incrementals = Lists.reverse(keyLists.subList(0, keyLists.size() - 1));
+      }
+
+      Set<InternalKey> removals = new HashSet<>();
+      Set<InternalKey> adds = new HashSet<>();
+
+
+      // determine the unique list of mutations. Operations that cancel each other out are ignored for checkpoint purposes.
+      for (KeyList kl : incrementals) {
+        Preconditions.checkArgument(kl.getType() == Type.INCREMENTAL);
+        IncrementalList il = (IncrementalList) kl;
+        il.getMutations().forEach(m -> {
+          final InternalKey key = m.getKey();
+          if (m.getType() == MutationType.ADDITION) {
+            if (removals.contains(key)) {
+              removals.remove(key);
+            } else {
+              adds.add(key);
+            }
+          } else if (m.getType() == MutationType.REMOVAL) {
+            if (adds.contains(key)) {
+              adds.remove(key);
+            } else {
+              removals.add(key);
+            }
+          } else {
+            throw new IllegalStateException("Invalid mutation type: " + m.getType().name());
+          }
+        });
+      }
+
+
+      if (removals.isEmpty() && adds.isEmpty()) {
+        return IterResult.unchanged(complete);
+      }
+
+      return IterResult.changed(
+          complete.fragmentIds.stream().collect(ImmutableSet.toImmutableSet()),
+          Stream.concat(
+              complete.getKeys(startingPoint, store).filter(k -> !removals.contains(k)),
+              adds.stream()));
+    }
+
+    @Override
+    public AttributeValue toAttributeValue() {
+      return AttributeValue.builder().m(ImmutableMap.<String, AttributeValue>of(
+            IS_CHECKPOINT, AttributeValue.builder().bool(false).build(),
+            MUTATIONS, AttributeValue.builder().l(getMutations().stream()
+                .map(KeyMutation::toAttributeValue)
+                .collect(Collectors.toList())).build(),
+            ORIGIN, getPreviousCheckpoint().toAttributeValue(),
+            DISTANCE, AttributeValue.builder().n(Integer.toString(getDistanceFromCheckpointCommits())).build()
+            )).build();
+    }
+
+    @Override
+    public Type getType() {
+      return Type.INCREMENTAL;
+    }
+
+    static KeyList fromAttributeValue(Map<String, AttributeValue> value) {
+      return ImmutableIncrementalList.builder()
+          .addAllMutations(value.get(MUTATIONS).l().stream().map(KeyMutation::fromAttributeValue).collect(Collectors.toList()))
+          .previousCheckpoint(Id.fromAttributeValue(value.get(ORIGIN)))
+          .distanceFromCheckpointCommits(Integer.parseInt(value.get(DISTANCE).n()))
+          .build();
+    }
+
+    private static class IterResult {
+      private final CompleteList list;
+      private final Stream<InternalKey> keyList;
+      private final Set<Id> previousFragmentIds;
+
+      private IterResult(CompleteList list, Stream<InternalKey> keyList, Set<Id> previousFragmentIds) {
+        super();
+        this.list = list;
+        this.keyList = keyList;
+        this.previousFragmentIds = previousFragmentIds;
+      }
+
+      public static IterResult unchanged(CompleteList list) {
+        return new IterResult(list, null, null);
+      }
+
+      public static IterResult changed(Set<Id> previousFragmentIds, Stream<InternalKey> keys) {
+        return new IterResult(null, keys, previousFragmentIds);
+      }
+
+      public boolean isChanged() {
+        return keyList != null;
+      }
+
+    }
+
+  }
+
+
+  /**
+   * A complete list is composed as one or more fragments. Each fragment's id is generated by the hashed value of its
+   * contents.
+   *
+   * <p>Fragments lists are designed to minimize Dynamo record churn. Early fragment lists have the oldest entries.
+   * Whenever a key is added, it is added to the last fragment (or a new fragment if the last fragment is oversized).
+   * As such, over time the early fragments rarely if ever get restated.
+   */
+  static class CompleteList extends KeyList {
+    private static final String FRAGMENTS = "fragments";
+    private static final String MUTATIONS = "mutations";
+
+    private final List<Id> fragmentIds;
+    private final List<KeyMutation> mutations;
+
+    public CompleteList(List<Id> fragmentIds, List<KeyMutation> mutations) {
+      this.fragmentIds = Preconditions.checkNotNull(fragmentIds);
+      this.mutations = ImmutableList.copyOf(mutations);
+    }
+
+    @Override
+    public KeyList plus(Id parent, List<KeyMutation> mutations) {
+      return ImmutableIncrementalList.builder()
+          .addAllMutations(mutations)
+          .distanceFromCheckpointCommits(1)
+          .previousCheckpoint(parent)
+          .build();
+    }
+
+    @Override
+    public Type getType() {
+      return Type.FULL;
+    }
+
+    @Override
+    public Optional<KeyList> createCheckpointIfNeeded(L1 startingPoint, DynamoStore store) {
+      // checkpoint not needed, already a checkpoint.
+      return Optional.empty();
+    }
+
+    @Override
+    public AttributeValue toAttributeValue() {
+      return AttributeValue.builder().m(ImmutableMap.<String, AttributeValue>of(
+            IS_CHECKPOINT,
+            AttributeValue.builder().bool(true).build(),
+            FRAGMENTS,
+            AttributeValue.builder()
+                .l(fragmentIds.stream().map(Id::toAttributeValue).collect(Collectors.toList())).build(),
+            MUTATIONS,
+            AttributeValue.builder()
+                .l(mutations.stream().map(KeyMutation::toAttributeValue).collect(Collectors.toList())).build()
+            )).build();
+    }
+
+    static KeyList fromAttributeValue(Map<String, AttributeValue> value) {
+      return new CompleteList(
+          value.get(FRAGMENTS).l().stream().map(Id::fromAttributeValue).collect(ImmutableList.toImmutableList()),
+          value.get(MUTATIONS).l().stream().map(KeyMutation::fromAttributeValue).collect(ImmutableList.toImmutableList()));
+    }
+
+    @Override
+    Stream<InternalKey> getKeys(L1 startingPoint, DynamoStore store) {
+      return fragmentIds.stream().flatMap(f -> {
+        Fragment fragment = store.loadSingle(ValueType.KEY_FRAGMENT, f);
+        return fragment.getKeys().stream();
+      });
+    }
+
+    @Override
+    List<KeyMutation> getMutations() {
+      return mutations;
+    }
+  }
+
+
+  static class Fragment extends MemoizedId {
+
+    private final List<InternalKey> keys;
+
+    public Fragment(List<InternalKey> keys) {
+      super();
+      this.keys = ImmutableList.copyOf(keys);
+    }
+
+    @Override
+    Id generateId() {
+      return Id.build(h -> {
+        keys.stream().forEach(k -> InternalKey.addToHasher(k, h));
+      });
+    }
+
+    public List<InternalKey> getKeys() {
+      return keys;
+    }
+
+    public static final SimpleSchema<Fragment> SCHEMA = new SimpleSchema<Fragment>(Fragment.class) {
+      private static final String ID = "id";
+      private static final String KEYS = "keys";
+
+      @Override
+      public Fragment deserialize(Map<String, AttributeValue> attributeMap) {
+        List<InternalKey> keys = attributeMap.get(KEYS).l().stream().map(InternalKey::fromAttributeValue).collect(Collectors.toList());
+        return new Fragment(keys);
+      }
+
+      @Override
+      public Map<String, AttributeValue> itemToMap(Fragment item, boolean ignoreNulls) {
+        return ImmutableMap.<String, AttributeValue>builder()
+            .put(ID, item.getId().toAttributeValue())
+            .put(KEYS, AttributeValue.builder()
+                .l(item.getKeys().stream().map(InternalKey::toAttributeValue).collect(Collectors.toList()))
+                .build())
+            .build();
+      }
+
+    };
+
+  }
+
+
+  /**
+   * Accumulates keys until we have enough to fill the ~max DynamoDB record size.
+   *
+   * <p>TODO: consider moving this data to S3.
+   *
+   * <p>TODO: move to a prefix encoded format.
+   */
+  static class KeyAccumulator {
+    private static final int MAX_SIZE = 400_000 - 8096;
+    private DynamoStore store;
+    private Set<Id> presaved;
+    private List<InternalKey> currentList = new ArrayList<>();
+    private List<Id> fragmentIds = new ArrayList<>();
+    private int currentListSize;
+
+    public KeyAccumulator(DynamoStore store, Set<Id> presaved) {
+      super();
+      this.store = store;
+      this.presaved = presaved;
+    }
+
+    public void addKey(InternalKey key) {
+      currentList.add(key);
+      currentListSize += key.estimatedSize();
+
+      rotate(false);
+    }
+
+    private void rotate(boolean always) {
+      if (!currentList.isEmpty() && (always || aboveThreshold())) {
+        Fragment fragment = new Fragment(currentList);
+        currentList.clear();
+        currentListSize = 0;
+        if (!presaved.contains(fragment.getId())) {
+          // only save if we didn't save on the last checkpoint. This could still be a dupe of an older list but since the object
+          // is hashed, the value will be a simple overwrite of the same data.
+          store.save(Collections.singletonList(new SaveOp<HasId>(ValueType.KEY_FRAGMENT, fragment)));
+          fragmentIds.add(fragment.getId());
+        }
+      }
+    }
+
+    private boolean aboveThreshold() {
+      if (currentListSize > MAX_SIZE) {
+        return true;
+      }
+
+      return false;
+    }
+
+    public void close() {
+      rotate(true);
+    }
+
+    public CompleteList getCompleteList(List<KeyMutation> mutations) {
+      Preconditions.checkArgument(currentList.isEmpty());
+      return new CompleteList(fragmentIds, mutations);
+    }
+  }
+
+
+}

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/KeyMutation.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/KeyMutation.java
@@ -25,9 +25,6 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class KeyMutation {
 
-  static final String DELETE = "d";
-  static final String ADD = "a";
-
   static enum MutationType {
     ADDITION("a"),
     REMOVAL("d");

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/KeyMutation.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/KeyMutation.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.versioned.impl;
+
+import java.util.Map;
+
+import org.immutables.value.Value.Immutable;
+
+import com.google.common.collect.ImmutableMap;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+abstract class KeyMutation {
+
+  static final String DELETE = "d";
+  static final String ADD = "a";
+
+  static enum MutationType {
+    ADDITION("a"),
+    REMOVAL("d");
+
+    private final String field;
+
+    MutationType(String field) {
+      this.field = field;
+    }
+  }
+
+  abstract InternalKey getKey();
+
+  abstract MutationType getType();
+
+  @Immutable
+  public abstract static class KeyAddition extends KeyMutation {
+
+    @Override
+    public final MutationType getType() {
+      return MutationType.ADDITION;
+    }
+
+    public static KeyAddition of(InternalKey key) {
+      return ImmutableKeyAddition.builder().key(key).build();
+    }
+  }
+
+  @Immutable
+  public abstract static class KeyRemoval extends KeyMutation {
+
+    @Override
+    public final MutationType getType() {
+      return MutationType.REMOVAL;
+    }
+
+    public static KeyRemoval of(InternalKey key) {
+      return ImmutableKeyRemoval.builder().key(key).build();
+    }
+
+  }
+
+  AttributeValue toAttributeValue() {
+    return AttributeValue.builder().m(ImmutableMap.<String, AttributeValue>of(getType().field, getKey().toAttributeValue())).build();
+  }
+
+  public static KeyMutation fromAttributeValue(AttributeValue value) {
+    Map<String, AttributeValue> mp = value.m();
+    if (mp.containsKey(MutationType.ADDITION.field)) {
+      return KeyAddition.of(InternalKey.fromAttributeValue(mp.get(MutationType.ADDITION.field)));
+    } else if (mp.containsKey(MutationType.REMOVAL.field)) {
+      return KeyRemoval.of(InternalKey.fromAttributeValue(mp.get(MutationType.REMOVAL.field)));
+    } else {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/KeyMutationList.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/KeyMutationList.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.versioned.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.immutables.value.Value.Immutable;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@Immutable
+abstract class KeyMutationList {
+
+  abstract List<KeyMutation> getMutations();
+
+  static KeyMutationList of(List<KeyMutation> mutations) {
+    return ImmutableKeyMutationList.builder().mutations(mutations).build();
+  }
+
+  public AttributeValue toAttributeValue() {
+    return AttributeValue.builder().l(getMutations().stream().map(KeyMutation::toAttributeValue).collect(Collectors.toList())).build();
+  }
+
+  public static KeyMutationList fromAttributeValue(AttributeValue value) {
+    return ImmutableKeyMutationList.builder().addAllMutations(
+        value.l().stream().map(KeyMutation::fromAttributeValue).collect(Collectors.toList()))
+        .build();
+  }
+
+}

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/L3.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/L3.java
@@ -22,6 +22,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.dremio.nessie.versioned.impl.DiffFinder.KeyDiff;
 import com.dremio.nessie.versioned.impl.KeyMutation.KeyAddition;
 import com.dremio.nessie.versioned.impl.KeyMutation.KeyRemoval;
 import com.google.common.collect.ImmutableMap;
@@ -176,11 +177,24 @@ class L3 extends MemoizedId {
     return map.size();
   }
 
-  public static MapDifference<InternalKey, Id> compare(L3 from, L3 to) {
-    MapDifference<InternalKey, Id> comparison =  Maps.difference(
+  /**
+   * Get a list of all the key -> valueId differences between two L3s.
+   *
+   * <p>This returns the difference between the updated (not original) state of the two L3s (if the L3s have been mutated).
+   *
+   * @param from The initial tree state.
+   * @param to The final tree state.
+   * @return The differences when going from initial to final state.
+   */
+  public static Stream<KeyDiff> compare(L3 from, L3 to) {
+    MapDifference<InternalKey, Id> difference =  Maps.difference(
         Maps.transformValues(from.map, p -> p.getNewId()),
         Maps.transformValues(to.map, p -> p.getNewId())
         );
-    return comparison;
+    return Stream.concat(
+        difference.entriesDiffering().entrySet().stream().map(KeyDiff::new),
+        Stream.concat(
+            difference.entriesOnlyOnLeft().entrySet().stream().map(KeyDiff::onlyOnLeft),
+            difference.entriesOnlyOnRight().entrySet().stream().map(KeyDiff::onlyOnRight)));
   }
 }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/L3.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/L3.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
 import com.dremio.nessie.versioned.impl.KeyMutation.KeyAddition;
 import com.dremio.nessie.versioned.impl.KeyMutation.KeyRemoval;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
 
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -172,5 +174,12 @@ class L3 extends MemoizedId {
    */
   int size() {
     return map.size();
+  }
+
+  public static MapDifference<InternalKey, Id> compare(L3 from, L3 to) {
+    return Maps.difference(
+        Maps.transformValues(from.map, p -> p.getNewId()),
+        Maps.transformValues(to.map, p -> p.getNewId())
+        );
   }
 }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/L3.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/L3.java
@@ -177,9 +177,10 @@ class L3 extends MemoizedId {
   }
 
   public static MapDifference<InternalKey, Id> compare(L3 from, L3 to) {
-    return Maps.difference(
+    MapDifference<InternalKey, Id> comparison =  Maps.difference(
         Maps.transformValues(from.map, p -> p.getNewId()),
         Maps.transformValues(to.map, p -> p.getNewId())
         );
+    return comparison;
   }
 }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/LoadOp.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/LoadOp.java
@@ -40,7 +40,7 @@ class LoadOp<V extends HasId> {
 
   void loaded(Map<String, AttributeValue> load) {
     SimpleSchema<V> schema = type.getSchema();
-    consumer.accept(schema.mapToItem(load));
+    consumer.accept(schema.mapToItem(type.checkType(load)));
   }
 
   public Id getId() {

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/LoadStep.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/LoadStep.java
@@ -34,6 +34,10 @@ class LoadStep {
   private Collection<LoadOp<?>> ops;
   private Supplier<Optional<LoadStep>> next;
 
+  public LoadStep(Collection<LoadOp<?>> ops) {
+    this(ops, () -> Optional.empty());
+  }
+
   public LoadStep(Collection<LoadOp<?>> ops, Supplier<Optional<LoadStep>> next) {
     this.ops = consolidate(ops);
     this.next = next;

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/LoadStep.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/LoadStep.java
@@ -17,9 +17,11 @@ package com.dremio.nessie.versioned.impl;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -81,5 +83,37 @@ class LoadStep {
 
   public static LoadStep of(LoadOp<?>...ops) {
     return new LoadStep(Arrays.asList(ops), () -> Optional.empty());
+  }
+
+  public static Collector<LoadStep, StepCollectorState, LoadStep> toLoadStep() {
+    return COLLECTOR;
+  }
+
+  private static final Collector<LoadStep, StepCollectorState, LoadStep> COLLECTOR = Collector.of(
+      StepCollectorState::new,
+      (o1, l1) -> o1.plus(l1),
+      (o1, o2) -> o1.plus(o2),
+      StepCollectorState::getStep
+      );
+
+  private static class StepCollectorState {
+
+    private LoadStep step = new LoadStep(Collections.emptyList());
+
+    private StepCollectorState() {
+    }
+
+    public LoadStep getStep() {
+      return step;
+    }
+
+    public StepCollectorState plus(StepCollectorState s) {
+      plus(s.step);
+      return this;
+    }
+
+    public void plus(LoadStep s) {
+      step = step.combine(s);
+    }
   }
 }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/ParentList.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/ParentList.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.versioned.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.immutables.value.Value.Immutable;
+
+import com.google.common.collect.ImmutableList;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Describes a list of parent hashes from the current hash.
+ */
+@Immutable
+abstract class ParentList {
+
+  static final int MAX_PARENT_LIST_SIZE = 50;
+
+  public static final ParentList EMPTY = ImmutableParentList.builder().addParents(Id.EMPTY).build();
+
+  public abstract List<Id> getParents();
+
+  public ParentList cloneWithAdditional(Id id) {
+    return ImmutableParentList.builder().addAllParents(
+        Stream.concat(
+            Stream.of(id),
+            getParents().stream())
+        .limit(MAX_PARENT_LIST_SIZE)
+        .collect(ImmutableList.toImmutableList()))
+        .build();
+  }
+
+  public final Id getParent() {
+    return getParents().get(0);
+  }
+
+  public AttributeValue toAttributeValue() {
+    return AttributeValue.builder().l(getParents().stream().map(Id::toAttributeValue).collect(Collectors.toList())).build();
+  }
+
+  public static ParentList fromAttributeValue(AttributeValue value) {
+    return ImmutableParentList.builder().addAllParents(value.l().stream().map(Id::fromAttributeValue).collect(Collectors.toList())).build();
+  }
+
+}

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/PartialTree.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/PartialTree.java
@@ -296,6 +296,15 @@ class PartialTree<V> {
     return Optional.of(vh.getValue());
   }
 
+  /**
+   * Set operation that doesn't store values.
+   *
+   * <p>This should be used in operations like merge and
+   * cherry-pick, when we know that the values are already stored.
+   *
+   * @param key The key to set.
+   * @param id The value or empty to set.
+   */
   public void setValueIdForKey(InternalKey key, Optional<Id> id) {
     checkMutable();
     final Pointer<L1> l1 = this.l1;

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/PartialTree.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/PartialTree.java
@@ -17,6 +17,7 @@ package com.dremio.nessie.versioned.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,7 +31,6 @@ import java.util.stream.Stream;
 
 import com.dremio.nessie.versioned.Serializer;
 import com.dremio.nessie.versioned.impl.DynamoStore.ValueType;
-import com.dremio.nessie.versioned.impl.DynamoVersionStore.OperationHolder;
 import com.dremio.nessie.versioned.impl.InternalBranch.Commit;
 import com.dremio.nessie.versioned.impl.InternalBranch.UnsavedDelta;
 import com.dremio.nessie.versioned.impl.InternalKey.Position;
@@ -41,6 +41,7 @@ import com.dremio.nessie.versioned.impl.condition.ExpressionPath;
 import com.dremio.nessie.versioned.impl.condition.SetClause;
 import com.dremio.nessie.versioned.impl.condition.UpdateExpression;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -63,7 +64,7 @@ class PartialTree<V> {
 
   private final Serializer<V> serializer;
   private final InternalRefId refId;
-  private InternalRef ref;
+  private InternalRef.Type refType;
   private Id rootId;
   private Pointer<L1> l1;
   private final Map<Integer, Pointer<L2>> l2s = new HashMap<>();
@@ -71,19 +72,20 @@ class PartialTree<V> {
   private final Map<InternalKey, ValueHolder<V>> values = new HashMap<>();
   private final Collection<InternalKey> keys;
 
-  public static <V> PartialTree<V> of(Serializer<V> serializer, InternalRefId id, List<InternalKey> keys) {
+  static <V> PartialTree<V> of(Serializer<V> serializer, InternalRefId id, List<InternalKey> keys) {
     return new PartialTree<V>(serializer, id, keys);
   }
 
-  public static <V> PartialTree<V> of(Serializer<V> serializer, L1 l1, Collection<InternalKey> keys) {
+  static <V> PartialTree<V> of(Serializer<V> serializer, InternalRef.Type refType, L1 l1, Collection<InternalKey> keys) {
     PartialTree<V> tree = new PartialTree<V>(serializer, InternalRefId.ofHash(l1.getId()), keys);
     tree.l1 = new Pointer<L1>(l1);
+    tree.refType = refType;
     return tree;
   }
 
   private void checkMutable() {
-    Preconditions.checkArgument(ref.getType() == Type.BRANCH,
-        "You can only mutate a partial tree that references a branch. This is type %s.", ref.getType());
+    Preconditions.checkArgument(refType == Type.BRANCH,
+        "You can only mutate a partial tree that references a branch. This is type %s.", refType.name());
   }
 
   private PartialTree(Serializer<V> serializer, InternalRefId refId, Collection<InternalKey> keys) {
@@ -94,14 +96,18 @@ class PartialTree<V> {
   }
 
   public LoadStep getLoadChain(Function<InternalBranch, L1> l1Converter, LoadType loadType) {
-    if (refId.getType() == Type.HASH && l1.get() == null) {
+    if (refId.getType() == Type.HASH && l1 == null) {
       rootId = refId.getId();
-      ref = refId.getId();
+      refType = Type.HASH;
+      return getLoadStep1(loadType).get();
+    }
+
+    if (l1 != null) {
       return getLoadStep1(loadType).get();
     }
 
     LoadOp<InternalRef> op = new LoadOp<InternalRef>(ValueType.REF, refId.getId(), loadedRef -> {
-      ref = loadedRef;
+      refType = loadedRef.getType();
       if (loadedRef.getType() == Type.BRANCH) {
         L1 loaded = l1Converter.apply(loadedRef.getBranch());
         l1 = new Pointer<L1>(loaded);
@@ -132,28 +138,24 @@ class PartialTree<V> {
         );
   }
 
-  public Stream<KeyMutation> getKeyMutations() {
-    return l3s.values().stream().map(Pointer::get).flatMap(L3::getMutations);
-  }
-
   /**
    * Gets L1 mutations required to save tree.
    *
    * @return
    */
-  public CommitOp getCommitOp(Id metadataId, Stream<DynamoVersionStore<V, ?>.OperationHolder> holders,
+  public CommitOp getCommitOp(Id metadataId, Collection<InternalKey> unchangedKeys,
       boolean includeTreeUpdates,
       boolean includeCommitUpdates) {
     checkMutable();
 
-    UpdateExpression update = UpdateExpression.initial();
+    UpdateExpression treeUpdate = UpdateExpression.initial();
 
     // record positions that we're checking so we don't add the same positional check twice (for unchanged statements).
     final Set<Integer> conditionPositions = new HashSet<>();
 
     List<UnsavedDelta> deltas = new ArrayList<>();
 
-    ConditionExpression condition = ConditionExpression.of(
+    ConditionExpression treeCondition = ConditionExpression.of(
         ExpressionFunction.equals(ExpressionPath.builder(InternalRef.TYPE).build(), InternalRef.Type.BRANCH.toAttributeValue()));
 
     // for all mutations that are dirty, create conditional and update expressions.
@@ -162,58 +164,73 @@ class PartialTree<V> {
       assert added;
       ExpressionPath p = ExpressionPath.builder(InternalBranch.TREE).position(pm.getPosition()).build();
       if (includeTreeUpdates) {
-        update = update.and(SetClause.equals(p, pm.getNewId().toAttributeValue()));
-        condition = condition.and(ExpressionFunction.equals(p, pm.getOldId().toAttributeValue()));
+        treeUpdate = treeUpdate.and(SetClause.equals(p, pm.getNewId().toAttributeValue()));
+        treeCondition = treeCondition.and(ExpressionFunction.equals(p, pm.getOldId().toAttributeValue()));
       }
       deltas.add(pm.toUnsavedDelta());
     }
 
-    for (DynamoVersionStore<V, ?>.OperationHolder oh : (Iterable<DynamoVersionStore<V, ?>.OperationHolder>)
-        holders.filter(OperationHolder::isUnchangedOperation)::iterator) {
-      int position = oh.getKey().getL1Position();
+    for (InternalKey unchanged : unchangedKeys) {
+      int position = unchanged.getL1Position();
       if (includeTreeUpdates && conditionPositions.add(position)) {
         // this doesn't already have a condition. Add one.
         ExpressionPath p = ExpressionPath.builder(InternalBranch.TREE).position(position).build();
-        condition = condition.and(ExpressionFunction.equals(p, getCurrentL1().getId(position).toAttributeValue()));
+        treeCondition = treeCondition.and(ExpressionFunction.equals(p, getCurrentL1().getId(position).toAttributeValue()));
       }
     }
 
-    // Add the new commit
-    Commit commitIntention = new Commit(Id.generateRandom(), metadataId, deltas,
-        KeyMutationList.of(getKeyMutations().collect(Collectors.toList())));
+    Commit commitIntention = null;
     if (includeCommitUpdates) {
-      update = update.and(SetClause.appendToList(
-          ExpressionPath.builder(InternalBranch.COMMITS).build(),
-          AttributeValue.builder().l(commitIntention.toAttributeValue()).build()));
+      // Add the new commit
+      commitIntention = new Commit(Id.generateRandom(), metadataId, deltas,
+          KeyMutationList.of(l3s.values().stream().map(Pointer::get).flatMap(L3::getMutations).collect(Collectors.toList())));
     }
 
-    return new CommitOp(update, condition);
+    return new CommitOp(
+        includeCommitUpdates ? commitIntention : null,
+        includeTreeUpdates ? treeUpdate : null,
+        includeTreeUpdates ? treeCondition : null);
   }
 
   public static class CommitOp  {
-    private final UpdateExpression update;
-    private final ConditionExpression condition;
+    private final Commit commitIntention;
+    private final UpdateExpression treeUpdate;
+    private final ConditionExpression treeCondition;
 
-    public CommitOp(UpdateExpression update, ConditionExpression condition) {
+    public CommitOp(Commit commitIntention, UpdateExpression treeUpdate, ConditionExpression condition) {
       super();
-      this.update = update;
-      this.condition = condition;
+      this.commitIntention = commitIntention;
+      this.treeUpdate = treeUpdate;
+      this.treeCondition = condition;
     }
 
-    public UpdateExpression getUpdate() {
-      return update;
+    public UpdateExpression getTreeUpdate() {
+      return Preconditions.checkNotNull(treeUpdate);
     }
 
-    public ConditionExpression getCondition() {
-      return condition;
+    public UpdateExpression getUpdateWithCommit() {
+      return getTreeUpdate().and(getCommitSet(Collections.singletonList(commitIntention)));
     }
 
+    public Commit getCommitIntention() {
+      return Preconditions.checkNotNull(commitIntention);
+    }
+
+    public ConditionExpression getTreeCondition() {
+      return Preconditions.checkNotNull(treeCondition);
+    }
+
+    static SetClause getCommitSet(List<Commit> commits) {
+      return SetClause.appendToList(
+          ExpressionPath.builder(InternalBranch.COMMITS).build(),
+          AttributeValue.builder().l(commits.stream().map(Commit::toAttributeValue).collect(ImmutableList.toImmutableList())).build());
+    }
   }
 
   private Optional<LoadStep> getLoadStep1(LoadType loadType) {
     final Supplier<Optional<LoadStep>> loadFunc = () -> getLoadStep2(loadType == LoadType.SELECT_VALUES);
 
-    if (l1 != null) { // if we loaded a branch, we were able to prepopulate the l1 information.
+    if (l1 != null) { // if we loaded a branch, we were able to pre-populate the l1 information.
       return loadFunc.get();
     }
 

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/PositionDelta.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/PositionDelta.java
@@ -42,6 +42,18 @@ abstract class PositionDelta {
     return !getOldId().equals(getNewId());
   }
 
+  boolean wasAdded() {
+    return getOldId().isEmpty() && !getNewId().isEmpty();
+  }
+
+  boolean wasAddedOrRemoved() {
+    return wasAdded() || wasRemoved();
+  }
+
+  boolean wasRemoved() {
+    return !getOldId().isEmpty() && getNewId().isEmpty();
+  }
+
   final boolean isEmpty() {
     return !isDirty() && getOldId().equals(Id.EMPTY);
   }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/SaveOp.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/SaveOp.java
@@ -41,7 +41,7 @@ class SaveOp<V extends HasId> {
 
   public Map<String, AttributeValue> toAttributeValues() {
     SimpleSchema<V> schema = type.getSchema();
-    return schema.itemToMap(value, true);
+    return type.addType(schema.itemToMap(value, true));
   }
 
   @Override

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/condition/ConditionExpression.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/condition/ConditionExpression.java
@@ -23,6 +23,7 @@ import org.immutables.value.Value;
 
 import com.dremio.nessie.versioned.impl.condition.AliasCollector.Aliasable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 @Value.Immutable
 public abstract class ConditionExpression implements Aliasable<ConditionExpression> {
@@ -76,11 +77,15 @@ public abstract class ConditionExpression implements Aliasable<ConditionExpressi
    * Collect condition expressions into a single compound condition expression.
    * @return combined update.
    */
-  public static final Collector<ConditionExpression, ConditionExpression, ConditionExpression> toConditionExpression() {
+  public static final Collector<ConditionExpression, List<ExpressionFunction>, ConditionExpression> toConditionExpression() {
     return Collector.of(
-      ConditionExpression::initial,
-      (o1, l1) -> o1.and(l1),
-      (o1, o2) -> o1.and(o2)
+      Lists::newArrayList,
+      (o1, l1) -> o1.addAll(l1.getFunctions()),
+      (o1, o2) -> {
+        o1.addAll(o2);
+        return o1;
+      },
+      o1 ->  ImmutableConditionExpression.builder().addAllFunctions(o1).build()
       );
   }
 }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/condition/ConditionExpression.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/condition/ConditionExpression.java
@@ -16,6 +16,7 @@
 package com.dremio.nessie.versioned.impl.condition;
 
 import java.util.List;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
@@ -57,5 +58,29 @@ public abstract class ConditionExpression implements Aliasable<ConditionExpressi
         .addAllFunctions(getFunctions())
         .addFunctions(function)
         .build();
+  }
+
+  /**
+   * AND the existing condition with this newly provided condition.
+   * @param expr The expression to AND with.
+   * @return The new compound expression.
+   */
+  public ConditionExpression and(ConditionExpression expr) {
+    return ImmutableConditionExpression.builder()
+        .addAllFunctions(getFunctions())
+        .addAllFunctions(expr.getFunctions())
+        .build();
+  }
+
+  /**
+   * Collect condition expressions into a single compound condition expression.
+   * @return combined update.
+   */
+  public static final Collector<ConditionExpression, ConditionExpression, ConditionExpression> toConditionExpression() {
+    return Collector.of(
+      ConditionExpression::initial,
+      (o1, l1) -> o1.and(l1),
+      (o1, o2) -> o1.and(o2)
+      );
   }
 }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/condition/UpdateExpression.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/condition/UpdateExpression.java
@@ -16,6 +16,7 @@
 package com.dremio.nessie.versioned.impl.condition;
 
 import java.util.List;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
@@ -74,5 +75,21 @@ public abstract class UpdateExpression implements Aliasable<UpdateExpression> {
 
   public UpdateExpression and(UpdateClause clause) {
     return ImmutableUpdateExpression.builder().from(this).addClauses(clause).build();
+  }
+
+  public UpdateExpression and(UpdateExpression expr) {
+    return ImmutableUpdateExpression.builder().from(this).addAllClauses(expr.getClauses()).build();
+  }
+
+  /**
+   * Collect update expressions into a single compound update expression.
+   * @return combined update.
+   */
+  public static final Collector<UpdateExpression, UpdateExpression, UpdateExpression> toUpdateExpression() {
+    return Collector.of(
+      UpdateExpression::initial,
+      (o1, l1) -> o1.and(l1),
+      (o1, o2) -> o1.and(o2)
+      );
   }
 }

--- a/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/condition/UpdateExpression.java
+++ b/versioned/dynamodb/src/main/java/com/dremio/nessie/versioned/impl/condition/UpdateExpression.java
@@ -26,6 +26,7 @@ import com.dremio.nessie.versioned.impl.condition.UpdateClause.Type;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 
 @Value.Immutable
@@ -85,11 +86,15 @@ public abstract class UpdateExpression implements Aliasable<UpdateExpression> {
    * Collect update expressions into a single compound update expression.
    * @return combined update.
    */
-  public static final Collector<UpdateExpression, UpdateExpression, UpdateExpression> toUpdateExpression() {
+  public static final Collector<UpdateExpression, List<UpdateClause>, UpdateExpression> toUpdateExpression() {
     return Collector.of(
-      UpdateExpression::initial,
-      (o1, l1) -> o1.and(l1),
-      (o1, o2) -> o1.and(o2)
+      Lists::newArrayList,
+      (o1, l1) -> o1.addAll(l1.getClauses()),
+      (o1, o2) -> {
+        o1.addAll(o2);
+        return o1;
+      },
+      o1 ->  ImmutableUpdateExpression.builder().addAllClauses(o1).build()
       );
   }
 }

--- a/versioned/dynamodb/src/test/java/com/dremio/nessie/versioned/impl/ITDynamoDBVersionStore.java
+++ b/versioned/dynamodb/src/test/java/com/dremio/nessie/versioned/impl/ITDynamoDBVersionStore.java
@@ -15,16 +15,12 @@
  */
 package com.dremio.nessie.versioned.impl;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.dremio.nessie.backend.dynamodb.LocalDynamoDB;
 import com.dremio.nessie.versioned.VersionStore;
-import com.dremio.nessie.versioned.VersionStoreException;
 import com.dremio.nessie.versioned.tests.AbstractITVersionStore;
 
 @ExtendWith(LocalDynamoDB.class)
@@ -47,9 +43,4 @@ public class ITDynamoDBVersionStore extends AbstractITVersionStore {
     return fixture;
   }
 
-  @Test
-  protected void transplant() throws VersionStoreException {
-    // TODO: implement transplant.
-    assertThrows(UnsupportedOperationException.class, () -> super.transplant());
-  }
 }

--- a/versioned/dynamodb/src/test/java/com/dremio/nessie/versioned/impl/ITDynamoVersionStore.java
+++ b/versioned/dynamodb/src/test/java/com/dremio/nessie/versioned/impl/ITDynamoVersionStore.java
@@ -22,10 +22,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.stream.Collectors;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -41,6 +45,7 @@ import com.dremio.nessie.versioned.ImmutableKey;
 import com.dremio.nessie.versioned.ImmutablePut;
 import com.dremio.nessie.versioned.ImmutableTagName;
 import com.dremio.nessie.versioned.Key;
+import com.dremio.nessie.versioned.Operation;
 import com.dremio.nessie.versioned.Put;
 import com.dremio.nessie.versioned.Ref;
 import com.dremio.nessie.versioned.ReferenceAlreadyExistsException;
@@ -94,6 +99,38 @@ class ITDynamoVersionStore {
     assertEquals(0, fixture.getStore().<L2>loadSingle(ValueType.L2, L2.EMPTY_ID).size());
     assertThat(fixture.getKeys(branch).map(Key::toString).collect(ImmutableSet.toImmutableSet()),
         containsInAnyOrder("hi", "no", "mad mad"));
+  }
+
+  @Test
+  void ensureKeyCheckpointsAndMultiFragmentsWork() throws Exception {
+    BranchName branch = BranchName.of("lots-of-keys");
+    fixture.create(branch, Optional.empty());
+    Hash current = fixture.toHash(branch);
+    Random r = new Random(1234);
+    char[] longName = new char[4096];
+    Arrays.fill(longName, 'a');
+    String prefix = new String(longName);
+    List<Key> names = new LinkedList<>();
+    for (int i = 1; i < 200; i++) {
+      if (i % 5 == 0) {
+        // every so often, remove a key.
+        Key removal = names.remove(r.nextInt(names.size()));
+        fixture.commit(branch, Optional.of(current), "commit " + i, Collections.<Operation<String>>singletonList(Delete.of(removal)));
+      } else {
+        Key name = Key.of(prefix + i);
+        names.add(name);
+        fixture.commit(branch, Optional.of(current), "commit " + i, Collections.<Operation<String>>singletonList(Put.of(name, "bar")));
+      }
+      current = fixture.toHash(branch);
+    }
+
+    List<Key> keysFromStore = fixture.getKeys(branch).collect(Collectors.toList());
+
+    // ensure that our total key size is greater than a single dynamo page.
+    assertThat(keysFromStore.size() * longName.length, Matchers.greaterThan(400000));
+
+    // ensure that keys stored match those expected.
+    assertThat(keysFromStore, containsInAnyOrder(names.toArray(new Key[0])));
   }
 
   @Test

--- a/versioned/dynamodb/src/test/java/com/dremio/nessie/versioned/impl/TestVersionEquality.java
+++ b/versioned/dynamodb/src/test/java/com/dremio/nessie/versioned/impl/TestVersionEquality.java
@@ -18,6 +18,7 @@ package com.dremio.nessie.versioned.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import com.dremio.nessie.versioned.impl.InternalBranch.UpdateState;
 
@@ -29,7 +30,9 @@ class TestVersionEquality {
   @Test
   void internalBranchL1IdEqualsEmpty() {
     InternalBranch b = new InternalBranch("n/a");
-    UpdateState us = b.getUpdateState();
+    DynamoStore store = Mockito.mock(DynamoStore.class);
+    Mockito.when(store.loadSingle(Mockito.any(), Mockito.any())).thenReturn(L1.EMPTY);
+    UpdateState us = b.getUpdateState(store);
     us.ensureAvailable(null, null, 1, true);
     assertEquals(L1.EMPTY_ID, us.getL1().getId());
   }


### PR DESCRIPTION
* Add type attributes to all objects and validate on load
* Change representation of a L1 to include a parent list instead of a single parent
* Change representation of a commit to include list of keys added and/or removed
* Store full and incremental keylists to improve key retrieval efficiency
* Use parent lists to improve commit history retrieval efficiency
* Add support for Merge operation
* Add support for Transplant operation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/303)
<!-- Reviewable:end -->
