### PR TITLE
 Rework REST API

### DIFF
--- a/clients/client/src/main/java/com/dremio/nessie/client/ClientContentsApi.java
+++ b/clients/client/src/main/java/com/dremio/nessie/client/ClientContentsApi.java
@@ -25,6 +25,8 @@ import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
 import com.dremio.nessie.model.Contents;
 import com.dremio.nessie.model.ContentsKey;
+import com.dremio.nessie.model.MultiGetContentsRequest;
+import com.dremio.nessie.model.MultiGetContentsResponse;
 
 class ClientContentsApi implements ContentsApi {
 
@@ -34,18 +36,11 @@ class ClientContentsApi implements ContentsApi {
     this.target = target;
   }
 
+
   @Override
   public Contents getContents(@NotNull ContentsKey key, String ref) throws NessieNotFoundException {
-    return target.path("contents").path(key.toPathString()).path(ref)
-                 .request()
-                 .accept(MediaType.APPLICATION_JSON_TYPE)
-                 .get()
-                 .readEntity(Contents.class);
-  }
-
-  @Override
-  public Contents getContents(ContentsKey key) throws NessieNotFoundException {
     return target.path("contents").path(key.toPathString())
+                 .queryParam("ref", ref)
                  .request()
                  .accept(MediaType.APPLICATION_JSON_TYPE)
                  .get()
@@ -53,37 +48,34 @@ class ClientContentsApi implements ContentsApi {
   }
 
   @Override
-  public void setContents(@NotNull ContentsKey key, @NotNull String hash, String message,
-                          @NotNull Contents contents) throws NessieNotFoundException, NessieConflictException {
-    target.path("contents").path(key.toPathString()).path(hash)
-          .queryParam("message", message)
-          .request()
-          .post(Entity.entity(contents, MediaType.APPLICATION_JSON_TYPE));
+  public MultiGetContentsResponse getMultipleContents(@NotNull String ref, @NotNull MultiGetContentsRequest request)
+      throws NessieNotFoundException {
+    return target.path("contents")
+        .queryParam("ref", ref)
+        .request()
+        .accept(MediaType.APPLICATION_JSON_TYPE)
+        .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE))
+        .readEntity(MultiGetContentsResponse.class);
   }
 
 
   @Override
   public void setContents(@NotNull ContentsKey key, String branch, @NotNull String hash, String message,
                           @NotNull Contents contents) throws NessieNotFoundException, NessieConflictException {
-    target.path("contents").path(key.toPathString()).path(branch).path(hash)
+    target.path("contents").path(key.toPathString())
+          .queryParam("branch", branch)
+          .queryParam("hash", hash)
           .queryParam("message", message)
           .request()
           .post(Entity.entity(contents, MediaType.APPLICATION_JSON_TYPE));
   }
 
   @Override
-  public void deleteContents(ContentsKey key, String hash, String message)
-      throws NessieNotFoundException, NessieConflictException {
-    target.path("contents").path(key.toPathString()).path(hash)
-          .queryParam("message", message)
-          .request()
-          .delete();
-  }
-
-  @Override
   public void deleteContents(ContentsKey key, String branch, String hash, String message)
       throws NessieNotFoundException, NessieConflictException {
-    target.path("contents").path(key.toPathString()).path(branch).path(hash)
+    target.path("contents").path(key.toPathString())
+          .queryParam("branch", branch)
+          .queryParam("hash", hash)
           .queryParam("message", message)
           .request()
           .delete();

--- a/clients/client/src/main/java/com/dremio/nessie/client/ClientTreeApi.java
+++ b/clients/client/src/main/java/com/dremio/nessie/client/ClientTreeApi.java
@@ -30,10 +30,9 @@ import com.dremio.nessie.model.Branch;
 import com.dremio.nessie.model.EntriesResponse;
 import com.dremio.nessie.model.LogResponse;
 import com.dremio.nessie.model.Merge;
-import com.dremio.nessie.model.MultiContents;
-import com.dremio.nessie.model.MultiGetContentsRequest;
-import com.dremio.nessie.model.MultiGetContentsResponse;
+import com.dremio.nessie.model.Operations;
 import com.dremio.nessie.model.Reference;
+import com.dremio.nessie.model.Tag;
 import com.dremio.nessie.model.Transplant;
 
 class ClientTreeApi implements TreeApi {
@@ -56,6 +55,13 @@ class ClientTreeApi implements TreeApi {
   }
 
   @Override
+  public void createReference(@NotNull Reference reference)
+      throws NessieNotFoundException, NessieConflictException {
+    target.path("trees").path("tree").request()
+        .post(Entity.entity(reference, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  @Override
   public Reference getReferenceByName(@NotNull String refName) throws NessieNotFoundException {
     return target.path("trees").path("tree").path(refName)
                    .request()
@@ -65,59 +71,36 @@ class ClientTreeApi implements TreeApi {
   }
 
   @Override
-  public void createEmptyTag(String tagName) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("tag").path(tagName)
-          .request()
-          .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
-  }
-
-  @Override
-  public void createNewTag(@NotNull String tagName, String hash) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("tag").path(tagName).path(hash)
-          .request()
-          .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
-  }
-
-  @Override
-  public void assignTag(@NotNull String tagName, @NotNull String oldHash, @NotNull String newHash)
+  public void assignTag(@NotNull String tagName, @NotNull String expectedHash, @NotNull Tag tag)
       throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("tag").path(tagName).path(oldHash).path(newHash)
+    target.path("trees").path("tag").path(tagName)
+          .queryParam("expectedHash", expectedHash)
           .request()
-          .put(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+          .put(Entity.entity(tag, MediaType.APPLICATION_JSON_TYPE));
   }
 
   @Override
-  public void deleteTag(@NotNull String tagName, @NotNull String hash) throws NessieConflictException, NessieNotFoundException {
-    target.path("trees").path("tag").path(tagName).path(hash)
+  public void deleteTag(@NotNull String tagName, @NotNull String expectedHash) throws NessieConflictException, NessieNotFoundException {
+    target.path("trees").path("tag").path(tagName)
+          .queryParam("expectedHash", expectedHash)
           .request()
           .delete();
   }
 
   @Override
-  public void createEmptyBranch(@NotNull String branchName) throws NessieNotFoundException, NessieConflictException {
+  public void assignBranch(@NotNull String branchName, @NotNull String expectedHash,
+                           @NotNull Branch branch) throws NessieNotFoundException, NessieConflictException {
     target.path("trees").path("branch").path(branchName)
+          .queryParam("expectedHash", expectedHash)
           .request()
-          .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE));
+          .put(Entity.entity(branch, MediaType.APPLICATION_JSON_TYPE));
   }
 
   @Override
-  public void createNewBranch(@NotNull String branchName, @NotNull String hash) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("branch").path(branchName).path(hash)
-          .request()
-          .post(Entity.json(null));
-  }
-
-  @Override
-  public void assignBranch(@NotNull String branchName, @NotNull String oldHash,
-                           @NotNull String newHash) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("branch").path(branchName).path(oldHash).path(newHash)
-          .request()
-          .put(Entity.entity("", MediaType.APPLICATION_JSON_TYPE));
-  }
-
-  @Override
-  public void deleteBranch(@NotNull String branchName, @NotNull String hash) throws NessieConflictException, NessieNotFoundException {
-    target.path("trees").path("branch").path(branchName).path(hash)
+  public void deleteBranch(@NotNull String branchName, @NotNull String expectedHash)
+      throws NessieConflictException, NessieNotFoundException {
+    target.path("trees").path("branch").path(branchName)
+          .queryParam("expectedHash", expectedHash)
           .request()
           .delete();
   }
@@ -125,70 +108,59 @@ class ClientTreeApi implements TreeApi {
   @Override
   public Branch getDefaultBranch() {
     return target.path("trees").path("tree")
-                   .request()
-                   .accept(MediaType.APPLICATION_JSON_TYPE)
-                   .get()
-                   .readEntity(Branch.class);
+                 .request()
+                 .accept(MediaType.APPLICATION_JSON_TYPE)
+                 .get()
+                 .readEntity(Branch.class);
   }
 
   @Override
   public LogResponse getCommitLog(@NotNull String ref) throws NessieNotFoundException {
     return target.path("trees").path("tree").path(ref).path("log")
-                   .request()
-                   .accept(MediaType.APPLICATION_JSON_TYPE)
-                   .get()
-                   .readEntity(LogResponse.class);
+                 .request()
+                 .accept(MediaType.APPLICATION_JSON_TYPE)
+                 .get()
+                 .readEntity(LogResponse.class);
   }
 
   @Override
-  public void transplantCommitsIntoBranch(String message, Transplant transplant) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("transplant")
-            .queryParam("message", message)
-            .request()
-            .put(Entity.entity(transplant, MediaType.APPLICATION_JSON_TYPE));
+  public void transplantCommitsIntoBranch(@NotNull String branchName, @NotNull String expectedHash, String message, Transplant transplant)
+      throws NessieNotFoundException, NessieConflictException {
+    target.path("trees/branch/{branchName}/transplant")
+          .resolveTemplate("branchName", branchName)
+          .queryParam("expectedHash", expectedHash)
+          .queryParam("message", message)
+          .request()
+          .put(Entity.entity(transplant, MediaType.APPLICATION_JSON_TYPE));
   }
 
   @Override
-  public void mergeRefIntoBranch(@NotNull Merge merge) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("merge")
-            .request()
-            .put(Entity.entity(merge, MediaType.APPLICATION_JSON_TYPE));
+  public void mergeRefIntoBranch(@NotNull String branchName, @NotNull String expectedHash, @NotNull Merge merge)
+      throws NessieNotFoundException, NessieConflictException {
+    target.path("trees/branch/{branchName}/merge")
+          .resolveTemplate("branchName", branchName)
+          .queryParam("expectedHash", expectedHash)
+          .request()
+          .put(Entity.entity(merge, MediaType.APPLICATION_JSON_TYPE));
   }
 
   @Override
   public EntriesResponse getEntries(@NotNull String refName) throws NessieNotFoundException {
     return target.path("trees").path("tree").path(refName).path("entries")
-                   .request()
-                   .accept(MediaType.APPLICATION_JSON_TYPE)
-                   .get()
-                   .readEntity(EntriesResponse.class);
+                 .request()
+                 .accept(MediaType.APPLICATION_JSON_TYPE)
+                 .get()
+                 .readEntity(EntriesResponse.class);
   }
 
   @Override
-  public MultiGetContentsResponse getMultipleContents(@NotNull String ref, @NotNull MultiGetContentsRequest request)
-      throws NessieNotFoundException {
-    return target.path("trees").path("multi").path(ref)
-        .request()
-        .accept(MediaType.APPLICATION_JSON_TYPE)
-        .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE))
-        .readEntity(MultiGetContentsResponse.class);
-  }
-
-  @Override
-  public void commitMultipleOperations(@NotNull String hash, String message,
-                                       @NotNull MultiContents operations) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("multi").path(hash)
+  public void commitMultipleOperations(String branch, @NotNull String expectedHash, String message,
+                                       @NotNull Operations operations) throws NessieNotFoundException, NessieConflictException {
+    target.path("trees/branch/{branchName}/commit")
+          .resolveTemplate("branchName", branch)
+          .queryParam("expectedHash", expectedHash)
           .queryParam("message", message)
           .request()
-          .put(Entity.entity(operations, MediaType.APPLICATION_JSON_TYPE));
-  }
-
-  @Override
-  public void commitMultipleOperations(String branch, @NotNull String hash, String message,
-                                       @NotNull MultiContents operations) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("multi").path(branch).path(hash)
-          .queryParam("message", message)
-          .request()
-          .put(Entity.entity(operations, MediaType.APPLICATION_JSON_TYPE));
+          .post(Entity.entity(operations, MediaType.APPLICATION_JSON_TYPE));
   }
 }

--- a/clients/hmsbridge/core/src/main/java/com/dremio/nessie/hms/TransactionStore.java
+++ b/clients/hmsbridge/core/src/main/java/com/dremio/nessie/hms/TransactionStore.java
@@ -37,8 +37,8 @@ import com.dremio.nessie.model.Contents.Type;
 import com.dremio.nessie.model.ContentsKey;
 import com.dremio.nessie.model.EntriesResponse.Entry;
 import com.dremio.nessie.model.ImmutableEntry;
-import com.dremio.nessie.model.ImmutableMultiContents;
 import com.dremio.nessie.model.ImmutableMultiGetContentsRequest;
+import com.dremio.nessie.model.ImmutableOperations;
 import com.dremio.nessie.model.MultiGetContentsResponse;
 import com.dremio.nessie.model.Operation;
 import com.dremio.nessie.model.Reference;
@@ -102,7 +102,7 @@ class TransactionStore {
 
     for (String ref : keysByRef.keySet()) {
       List<ContentsKey> keys = keysByRef.get(ref).stream().map(RefKey::getKey).collect(Collectors.toList());
-      MultiGetContentsResponse response = tree.getMultipleContents(ref,
+      MultiGetContentsResponse response = contents.getMultipleContents(ref,
           ImmutableMultiGetContentsRequest.builder().addAllRequestedKeys(keys).build());
       response.getContents().forEach(cwk -> {
         RefKey key = new RefKey(ref, cwk.getKey());
@@ -138,7 +138,7 @@ class TransactionStore {
 
     checkWritable();
     tree.commitMultipleOperations(reference.getName(), reference.getHash(), "HMS commit",
-        ImmutableMultiContents.builder().addAllOperations(operations.stream().collect(Collectors.toList())).build());
+        ImmutableOperations.builder().addAllOperations(operations.stream().collect(Collectors.toList())).build());
   }
 
   void deleteItem(ContentsKey key) {

--- a/clients/hmsbridge/core/src/test/java/com/dremio/nessie/hms/BaseDelegateOps.java
+++ b/clients/hmsbridge/core/src/test/java/com/dremio/nessie/hms/BaseDelegateOps.java
@@ -50,10 +50,10 @@ public abstract class BaseDelegateOps extends BaseHiveOps {
     assertEquals(4, results.size());
 
     // make sure we created the database and single table object in the nessie db.
-    Contents db = client.getContentsApi().getContents(ContentsKey.of("mytestdb"));
+    Contents db = client.getContentsApi().getContents(ContentsKey.of("mytestdb"), null);
     assertNotNull(db);
     assertTrue(HiveDatabase.class.isAssignableFrom(db.getClass()));
-    Contents tbl = client.getContentsApi().getContents(ContentsKey.of("mytestdb","nessie"));
+    Contents tbl = client.getContentsApi().getContents(ContentsKey.of("mytestdb","nessie"), null);
     assertNotNull(tbl);
     assertTrue(HiveTable.class.isAssignableFrom(tbl.getClass()));
 

--- a/clients/hmsbridge/core/src/test/java/com/dremio/nessie/hms/BaseHiveOps.java
+++ b/clients/hmsbridge/core/src/test/java/com/dremio/nessie/hms/BaseHiveOps.java
@@ -60,7 +60,7 @@ public abstract class BaseHiveOps {
         client.getTreeApi().deleteTag(r.getName(), r.getHash());
       }
     }
-    client.getTreeApi().createEmptyBranch("main");
+    client.getTreeApi().createReference(Branch.of("main", null));
     shell.start();
   }
 

--- a/clients/iceberg/core/src/main/java/com/dremio/nessie/iceberg/NessieCatalog.java
+++ b/clients/iceberg/core/src/main/java/com/dremio/nessie/iceberg/NessieCatalog.java
@@ -41,9 +41,9 @@ import com.dremio.nessie.model.ContentsKey;
 import com.dremio.nessie.model.EntriesResponse;
 import com.dremio.nessie.model.IcebergTable;
 import com.dremio.nessie.model.ImmutableDelete;
-import com.dremio.nessie.model.ImmutableMultiContents;
+import com.dremio.nessie.model.ImmutableOperations;
 import com.dremio.nessie.model.ImmutablePut;
-import com.dremio.nessie.model.MultiContents;
+import com.dremio.nessie.model.Operations;
 import com.dremio.nessie.model.Reference;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
@@ -267,7 +267,7 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
       throw new AlreadyExistsException("table {} already exists", to.name());
     }
 
-    MultiContents c = ImmutableMultiContents.builder()
+    Operations c = ImmutableOperations.builder()
         .addOperations(ImmutablePut.builder().key(toKey(to)).contents(existingFromTable).build())
         .addOperations(ImmutableDelete.builder().key(toKey(from)).build())
         .build();

--- a/clients/iceberg/core/src/test/java/com/dremio/nessie/iceberg/BaseTestIceberg.java
+++ b/clients/iceberg/core/src/test/java/com/dremio/nessie/iceberg/BaseTestIceberg.java
@@ -83,7 +83,7 @@ abstract class BaseTestIceberg {
         tree.deleteTag(r.getName(), r.getHash());
       }
     }
-    tree.createEmptyBranch("main");
+    tree.createReference(Branch.of("main", null));
   }
 
   @BeforeEach
@@ -97,7 +97,7 @@ abstract class BaseTestIceberg {
     resetData();
 
     try {
-      tree.createEmptyBranch(branch);
+      tree.createReference(Branch.of(branch, null));
     } catch (Exception e) {
       //ignore, already created. Cant run this in BeforeAll as quarkus hasn't disabled auth
     }
@@ -139,11 +139,7 @@ abstract class BaseTestIceberg {
   }
 
   void createBranch(String name, String hash) throws NessieNotFoundException, NessieConflictException {
-    if (hash == null) {
-      tree.createEmptyBranch(name);
-    } else {
-      tree.createNewBranch(name, hash);
-    }
+    tree.createReference(Branch.of(name, hash));
   }
 
   @AfterEach

--- a/clients/iceberg/core/src/test/java/com/dremio/nessie/iceberg/ITTestCatalogBranch.java
+++ b/clients/iceberg/core/src/test/java/com/dremio/nessie/iceberg/ITTestCatalogBranch.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
+import com.dremio.nessie.model.Branch;
 
 class ITTestCatalogBranch extends BaseTestIceberg {
 
@@ -66,7 +67,7 @@ class ITTestCatalogBranch extends BaseTestIceberg {
     Assertions.assertEquals(initialMetadataLocation, getContent(catalog, foobaz));
 
     String mainHash = tree.getReferenceByName("main").getHash();
-    tree.assignBranch("main", mainHash, newCatalog.getHash());
+    tree.assignBranch("main", mainHash, Branch.of("main", newCatalog.getHash()));
     Assertions.assertEquals(getContent(newCatalog, foobar),
                             getContent(catalog, foobar));
     Assertions.assertEquals(getContent(newCatalog, foobaz),

--- a/clients/iceberg/core/src/test/java/com/dremio/nessie/iceberg/ITTestDefaultCatalogBranch.java
+++ b/clients/iceberg/core/src/test/java/com/dremio/nessie/iceberg/ITTestDefaultCatalogBranch.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
+import com.dremio.nessie.model.Branch;
 
 /**
  * test tag operations with a default tag set by server.
@@ -42,7 +43,7 @@ class ITTestDefaultCatalogBranch extends BaseTestIceberg {
     createTable(foobaz, 1); //table 2
 
     catalog.refresh();
-    tree.createNewBranch("FORWARD", catalog.getHash());
+    tree.createReference(Branch.of("FORWARD", catalog.getHash()));
     hadoopConfig.set(NessieCatalog.CONF_NESSIE_REF, "FORWARD");
     NessieCatalog forwardCatalog = new NessieCatalog(hadoopConfig);
     forwardCatalog.loadTable(foobaz).updateSchema().addColumn("id1", Types.LongType.get()).commit();
@@ -56,7 +57,7 @@ class ITTestDefaultCatalogBranch extends BaseTestIceberg {
     System.out.println(getContent(catalog, foobar));
 
     forwardCatalog.refresh();
-    tree.assignBranch("main", tree.getReferenceByName("main").getHash(), forwardCatalog.getHash());
+    tree.assignBranch("main", tree.getReferenceByName("main").getHash(), Branch.of("main", forwardCatalog.getHash()));
 
     catalog.refresh();
 

--- a/clients/iceberg/spark2/src/test/java/com/dremio/nessie/iceberg/spark/ITIcebergSpark.java
+++ b/clients/iceberg/spark2/src/test/java/com/dremio/nessie/iceberg/spark/ITIcebergSpark.java
@@ -119,7 +119,7 @@ public class ITIcebergSpark extends AbstractSparkTest {
   @Test
   void testBranchHash() throws IOException {
 
-    client.getTreeApi().createNewBranch("test", client.getTreeApi().getReferenceByName("main").getHash());
+    client.getTreeApi().createReference(Branch.of("test", client.getTreeApi().getReferenceByName("main").getHash()));
     Branch branch = (Branch) client.getTreeApi().getReferenceByName("test");
     List<String[]> stringAsList = new ArrayList<>();
     stringAsList.add(new String[] {"bar1.1", "bar2.1"});

--- a/clients/iceberg/spark3/src/test/java/com/dremio/nessie/iceberg/spark/ITIcebergSpark3.java
+++ b/clients/iceberg/spark3/src/test/java/com/dremio/nessie/iceberg/spark/ITIcebergSpark3.java
@@ -98,7 +98,7 @@ class ITIcebergSpark3 extends AbstractSparkTest {
 
   @Test
   void testBranchHash() throws IOException {
-    client.getTreeApi().createNewBranch("test", client.getTreeApi().getReferenceByName("main").getHash());
+    client.getTreeApi().createReference(Branch.of("test", client.getTreeApi().getReferenceByName("main").getHash()));
     Branch branch = (Branch) client.getTreeApi().getReferenceByName("test");
     List<String[]> stringAsList = new ArrayList<>();
     stringAsList.add(new String[] {"bar1.1", "bar2.1"});

--- a/model/src/main/java/com/dremio/nessie/api/ContentsApi.java
+++ b/model/src/main/java/com/dremio/nessie/api/ContentsApi.java
@@ -36,6 +36,8 @@ import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
 import com.dremio.nessie.model.Contents;
 import com.dremio.nessie.model.ContentsKey;
+import com.dremio.nessie.model.MultiGetContentsRequest;
+import com.dremio.nessie.model.MultiGetContentsResponse;
 
 @Consumes(value = MediaType.APPLICATION_JSON)
 @Path("contents")
@@ -46,104 +48,63 @@ public interface ContentsApi {
    */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("{key}/{ref}")
-  @Operation(summary = "Fetch details of a table endpoint")
+  @Path("{key}")
+  @Operation(summary = "Get object content associated with key")
   @APIResponses({
       @APIResponse(responseCode = "200", description = "Information for table"),
       @APIResponse(responseCode = "404", description = "Table not found on ref")
     })
   Contents getContents(
       @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
-      @Parameter(description = "Name of ref to read from. Default branch if not provided.") @PathParam("ref") String ref
+      @Parameter(description = "Reference to use. Defaults to default branch if not provided.") @QueryParam("ref") String ref
       ) throws NessieNotFoundException;
 
-  /**
-   * Get the properties of an object.
-   */
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("{key}")
-  @Operation(summary = "Fetch details of a table endpoint for default branch")
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Operation(summary = "Get multiple objects' content")
   @APIResponses({
-      @APIResponse(responseCode = "200", description = "Information for table"),
-      @APIResponse(responseCode = "404", description = "Table not found on ref")
-    })
-  Contents getContents(@Parameter(description = "object name to search for") @PathParam("key") ContentsKey key)
+      @APIResponse(responseCode = "200", description = "Retrieved successfully."),
+      @APIResponse(responseCode = "404", description = "Provided ref doesn't exists")})
+  public MultiGetContentsResponse getMultipleContents(
+      @Parameter(description = "Reference to use. Defaults to default branch if not provided.") @QueryParam("ref") String ref,
+      @NotNull @RequestBody(description = "Keys to retrieve.") MultiGetContentsRequest request)
       throws NessieNotFoundException;
 
   /**
-   * create/update a table on default branch.
+   * create/update an object on a specific ref.
    */
   @POST
-  @Path("{key}/{hash}")
+  @Path("{key}")
   @Consumes(MediaType.APPLICATION_JSON)
-  @Operation(summary = "update contents for path")
+  @Operation(summary = "Update object content associated with key")
   @APIResponses({
       @APIResponse(responseCode = "204", description = "Contents updated successfully."),
       @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
       @APIResponse(responseCode = "412", description = "Update conflict")})
   public void setContents(
       @NotNull @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
-      @NotNull @Parameter(description = "Expected hash of branch.") @PathParam("hash") String hash,
+      @Parameter(description = "Branch to change. Defaults to default branch.") @QueryParam("branch") String branch,
+      @NotNull @Parameter(description = "Expected hash of branch.") @QueryParam("hash") String hash,
       @Parameter(description = "Commit message") @QueryParam("message") String message,
       @NotNull @RequestBody(description = "Contents to be upserted") Contents contents)
       throws NessieNotFoundException, NessieConflictException;
-
-  /**
-   * create/update a table on a specific ref.
-   */
-  @POST
-  @Path("{key}/{branch}/{hash}")
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Operation(summary = "update contents for path")
-  @APIResponses({
-      @APIResponse(responseCode = "204", description = "Contents updated successfully."),
-      @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
-      @APIResponse(responseCode = "412", description = "Update conflict")})
-  public void setContents(
-      @NotNull @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
-      @Parameter(description = "Branch to change, defaults to default branch.") @PathParam("branch") String branch,
-      @NotNull @Parameter(description = "Expected hash of branch.") @PathParam("hash") String hash,
-      @Parameter(description = "Commit message") @QueryParam("message") String message,
-      @NotNull @RequestBody(description = "Contents to be upserted") Contents contents)
-      throws NessieNotFoundException, NessieConflictException;
-
-
-
-  /**
-   * Delete a single object on default branch.
-   */
-  @DELETE
-  @Path("{key}/{hash}")
-  @Operation(summary = "delete object on ref endpoint")
-  @APIResponses({
-      @APIResponse(responseCode = "204", description = "Deleted successfully."),
-      @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
-      @APIResponse(responseCode = "412", description = "Update conflict"),
-      }
-  )
-  public void deleteContents(
-      @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
-      @Parameter(description = "Expected hash of branch.") @PathParam("hash") String hash,
-      @Parameter(description = "Commit message") @QueryParam("message") String message
-      ) throws NessieNotFoundException, NessieConflictException;
 
   /**
    * Delete a single object.
    */
   @DELETE
-  @Path("{key}/{branch}/{hash}")
-  @Operation(summary = "delete object on ref endpoint")
+  @Path("{key}")
+  @Operation(summary = "Delete object content associated with key")
   @APIResponses({
       @APIResponse(responseCode = "204", description = "Deleted successfully."),
       @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
-      @APIResponse(responseCode = "412", description = "Update conflict"),
+      @APIResponse(responseCode = "412", description = "Delete conflict"),
       }
   )
   public void deleteContents(
       @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
-      @Parameter(description = "Branch to delete from, defaults to default branch.") @PathParam("branch") String branch,
-      @Parameter(description = "Expected hash of branch.") @PathParam("hash") String hash,
+      @Parameter(description = "Branch to delete from. Defaults to default branch.") @QueryParam("branch") String branch,
+      @Parameter(description = "Expected hash of branch.") @QueryParam("hash") String hash,
       @Parameter(description = "Commit message") @QueryParam("message") String message
       ) throws NessieNotFoundException, NessieConflictException;
 

--- a/model/src/main/java/com/dremio/nessie/api/NessieApplication.java
+++ b/model/src/main/java/com/dremio/nessie/api/NessieApplication.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.api;
+
+import javax.ws.rs.core.Application;
+
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.info.Contact;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.info.License;
+
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Nessie API",
+        version = "0.2.0",
+        contact = @Contact(
+            name = "Project Nessie",
+            url = "https://projectnessie.org"),
+        license = @License(
+            name = "Apache 2.0",
+            url = "http://www.apache.org/licenses/LICENSE-2.0.html"))
+)
+public class NessieApplication extends Application {
+
+}

--- a/model/src/main/java/com/dremio/nessie/model/Hash.java
+++ b/model/src/main/java/com/dremio/nessie/model/Hash.java
@@ -19,7 +19,6 @@ package com.dremio.nessie.model;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Derived;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -33,7 +32,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonTypeName("HASH")
 public abstract class Hash implements Reference {
 
-  @JsonIgnore
+  @Override
   @Derived
   public String getHash() {
     return getName();

--- a/model/src/main/java/com/dremio/nessie/model/Merge.java
+++ b/model/src/main/java/com/dremio/nessie/model/Merge.java
@@ -32,7 +32,4 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public interface Merge {
 
   String getFromHash();
-
-  Branch getTo();
-
 }

--- a/model/src/main/java/com/dremio/nessie/model/Operations.java
+++ b/model/src/main/java/com/dremio/nessie/model/Operations.java
@@ -26,12 +26,12 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Schema(
     type = SchemaType.OBJECT,
-    title = "MultiContents"
+    title = "Operations"
   )
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableMultiContents.class)
-@JsonDeserialize(as = ImmutableMultiContents.class)
-public interface MultiContents {
+@JsonSerialize(as = ImmutableOperations.class)
+@JsonDeserialize(as = ImmutableOperations.class)
+public interface Operations {
 
   List<Operation> getOperations();
 }

--- a/model/src/main/java/com/dremio/nessie/model/Tag.java
+++ b/model/src/main/java/com/dremio/nessie/model/Tag.java
@@ -34,4 +34,8 @@ public interface Tag extends Reference {
   static ImmutableTag.Builder builder() {
     return ImmutableTag.builder();
   }
+
+  static Tag of(String name, String hash) {
+    return builder().name(name).hash(hash).build();
+  }
 }

--- a/model/src/main/java/com/dremio/nessie/model/Transplant.java
+++ b/model/src/main/java/com/dremio/nessie/model/Transplant.java
@@ -35,5 +35,4 @@ public interface Transplant {
 
   List<String> getHashesToTransplant();
 
-  Branch getBranch();
 }

--- a/perftest/src/main/java/com/dremio/nessie/perftest/NessieSampler.java
+++ b/perftest/src/main/java/com/dremio/nessie/perftest/NessieSampler.java
@@ -71,7 +71,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
     if (client == null) {
       client = new NessieClient(AuthType.BASIC, path, "admin_user", "test123");
       try {
-        client.getTreeApi().createNewBranch("master", null);
+        client.getTreeApi().createReference(Branch.of("master", null));
       } catch (Exception t) {
         //pass - likely already created master
       }
@@ -164,7 +164,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
     switch (method) {
       case CREATE_BRANCH: {
         return handle(() -> {
-          nessieClient().getTreeApi().createNewBranch(branch, baseBranch);
+          nessieClient().getTreeApi().createReference(Branch.of(branch, baseBranch));
           return (Branch) nessieClient().getTreeApi().getReferenceByName(branch);
         }, method);
       }

--- a/python/pynessie/_endpoints.py
+++ b/python/pynessie/_endpoints.py
@@ -18,8 +18,10 @@ from .error import NessiePreconidtionFailedException
 from .error import NessieUnauthorizedException
 
 
-def _get_headers() -> dict:
-    headers = {"Content-Type": "application/json"}
+def _get_headers(has_body: bool = False) -> dict:
+    headers = {"Accept": "application/json"}
+    if has_body:
+        headers = {"Content-Type": "application/json"}
     return headers
 
 
@@ -33,7 +35,7 @@ def _post(
 ) -> Union[str, dict, list]:
     if isinstance(json, str):
         json = jsonlib.loads(json)
-    r = requests.post(url, headers=_get_headers(), verify=ssl_verify, json=json, params=params)
+    r = requests.post(url, headers=_get_headers(json is not None), verify=ssl_verify, json=json, params=params)
     return _check_error(r, details)
 
 
@@ -45,7 +47,7 @@ def _delete(url: str, details: str = "", ssl_verify: bool = True, params: dict =
 def _put(url: str, json: Union[str, dict] = None, details: str = "", ssl_verify: bool = True, params: dict = None) -> Any:
     if isinstance(json, str):
         json = jsonlib.loads(json)
-    r = requests.put(url, headers=_get_headers(), verify=ssl_verify, json=json, params=params)
+    r = requests.put(url, headers=_get_headers(json is not None), verify=ssl_verify, json=json, params=params)
     return _check_error(r, details)
 
 
@@ -120,9 +122,7 @@ def delete_branch(base_url: str, branch: str, hash_: str, reason: str = None, ss
     :param hash_: branch hash
     :param ssl_verify: ignore ssl errors if False
     """
-    params = dict()
-    if hash_:
-        params["expectedHash"] = hash_
+    params = {"expectedHash": hash_}
     _delete(base_url + "/trees/branch/{}".format(branch), ssl_verify=ssl_verify, params=params)
 
 
@@ -134,9 +134,7 @@ def delete_tag(base_url: str, tag: str, hash_: str, reason: str = None, ssl_veri
     :param hash_: tag hash
     :param ssl_verify: ignore ssl errors if False
     """
-    params = dict()
-    if hash_:
-        params["expectedHash"] = hash_
+    params = {"expectedHash": hash_}
     _delete(base_url + "/trees/tag/{}".format(tag), ssl_verify=ssl_verify, params=params)
 
 
@@ -171,9 +169,7 @@ def get_table(base_url: str, ref: str, table: str, ssl_verify: bool = True) -> d
     :param ssl_verify: ignore ssl errors if False
     :return: json dict of Nessie table
     """
-    params = dict()
-    if ref:
-        params["ref"] = ref
+    params = {"ref": ref}
     return cast(dict, _get(base_url + "/contents/{}".format(table), ssl_verify=ssl_verify, params=params))
 
 
@@ -187,9 +183,7 @@ def assign_branch(base_url: str, branch: str, branch_json: dict, old_hash: str, 
     :param ssl_verify: ignore ssl errors if False
     """
     url = "/trees/branch/{}".format(branch)
-    params = dict()
-    if old_hash:
-        params["expectedHash"] = old_hash
+    params = {"expectedHash": old_hash}
     _put(base_url + url, branch_json, ssl_verify=ssl_verify, params=params)
 
 
@@ -203,9 +197,7 @@ def assign_tag(base_url: str, tag: str, tag_json: dict, old_hash: str, ssl_verif
     :param ssl_verify: ignore ssl errors if False
     """
     url = "/trees/tag/{}".format(tag)
-    params = dict()
-    if old_hash:
-        params["expectedHash"] = old_hash
+    params = {"expectedHash": old_hash}
     _put(base_url + url, tag_json, ssl_verify=ssl_verify, params=params)
 
 

--- a/python/pynessie/_endpoints.py
+++ b/python/pynessie/_endpoints.py
@@ -28,7 +28,9 @@ def _get(url: str, details: str = "", ssl_verify: bool = True, params: dict = No
     return _check_error(r, details)
 
 
-def _post(url: str, json: dict = None, details: str = "", ssl_verify: bool = True, params: dict = None) -> Union[str, dict, list]:
+def _post(
+    url: str, json: Union[str, dict] = None, details: str = "", ssl_verify: bool = True, params: dict = None
+) -> Union[str, dict, list]:
     if isinstance(json, str):
         json = jsonlib.loads(json)
     r = requests.post(url, headers=_get_headers(), verify=ssl_verify, json=json, params=params)
@@ -89,7 +91,7 @@ def get_reference(base_url: str, ref: str, ssl_verify: bool = True) -> dict:
     return cast(dict, _get(base_url + "/trees/tree/{}".format(ref), ssl_verify=ssl_verify))
 
 
-def create_reference(base_url: str, ref_json: dict, ssl_verify: bool = True) -> dict:
+def create_reference(base_url: str, ref_json: dict, ssl_verify: bool = True) -> None:
     """Create a reference.
 
     :param base_url: base Nessie url
@@ -240,9 +242,7 @@ def cherry_pick(base_url: str, branch: str, transplant_json: dict, expected_hash
     :param ssl_verify: ignore ssl errors if False
     """
     url = "/trees/branch/{}/transplant".format(branch)
-    params = dict()
-    if expected_hash:
-        params["expectedHash"] = expected_hash
+    params = {"expectedHash": expected_hash}
     _post(base_url + url, json=transplant_json, ssl_verify=ssl_verify, params=params)
 
 
@@ -256,9 +256,7 @@ def merge(base_url: str, branch: str, merge_json: dict, expected_hash: str, ssl_
     :param ssl_verify: ignore ssl errors if False
     """
     url = "/trees/branch/{}/merge".format(branch)
-    params = dict()
-    if expected_hash:
-        params["expectedHash"] = expected_hash
+    params = {"expectedHash": expected_hash}
     _post(base_url + url, json=merge_json, ssl_verify=ssl_verify, params=params)
 
 
@@ -266,8 +264,8 @@ def commit(
     base_url: str,
     branch: str,
     operations: str,
+    expected_hash: str,
     reason: Optional[str],
-    expected_hash: Optional[str],
     ssl_verify: bool = True,
 ) -> None:
     """Commit a set of operations to a branch.
@@ -280,9 +278,7 @@ def commit(
     :param ssl_verify: ignore ssl errors if False
     """
     url = "/trees/branch/{}/commit".format(branch)
-    params = dict()
+    params = {"expectedHash": expected_hash}
     if reason:
         params["message"] = reason
-    if expected_hash:
-        params["expectedHash"] = expected_hash
     _post(base_url + url, json=operations, ssl_verify=ssl_verify, params=params)

--- a/python/pynessie/_endpoints.py
+++ b/python/pynessie/_endpoints.py
@@ -36,7 +36,7 @@ def _post(url: str, json: dict = None, details: str = "", ssl_verify: bool = Tru
 
 
 def _delete(url: str, details: str = "", ssl_verify: bool = True, params: dict = None) -> Union[str, dict, list]:
-    r = requests.delete(url, headers=_get_headers(), verify=ssl_verify)
+    r = requests.delete(url, headers=_get_headers(), verify=ssl_verify, params=params)
     return _check_error(r, details)
 
 
@@ -89,6 +89,17 @@ def get_reference(base_url: str, ref: str, ssl_verify: bool = True) -> dict:
     return cast(dict, _get(base_url + "/trees/tree/{}".format(ref), ssl_verify=ssl_verify))
 
 
+def create_reference(base_url: str, ref_json: dict, ssl_verify: bool = True) -> dict:
+    """Create a reference.
+
+    :param base_url: base Nessie url
+    :param ref: reference to create as json object
+    :param ssl_verify: ignore ssl errors if False
+    :return: json Nessie branch
+    """
+    _post(base_url + "/trees/tree", ref_json, ssl_verify=ssl_verify)
+
+
 def get_default_branch(base_url: str, ssl_verify: bool = True) -> dict:
     """Fetch a reference.
 
@@ -107,7 +118,10 @@ def delete_branch(base_url: str, branch: str, hash_: str, reason: str = None, ss
     :param hash_: branch hash
     :param ssl_verify: ignore ssl errors if False
     """
-    _delete(base_url + "/trees/branch/{}/{}".format(branch, hash_), ssl_verify=ssl_verify)
+    params = dict()
+    if hash_:
+        params["expectedHash"] = hash_
+    _delete(base_url + "/trees/branch/{}".format(branch), ssl_verify=ssl_verify, params=params)
 
 
 def delete_tag(base_url: str, tag: str, hash_: str, reason: str = None, ssl_verify: bool = True) -> None:
@@ -118,7 +132,10 @@ def delete_tag(base_url: str, tag: str, hash_: str, reason: str = None, ssl_veri
     :param hash_: tag hash
     :param ssl_verify: ignore ssl errors if False
     """
-    _delete(base_url + "/trees/tag/{}/{}".format(tag, hash_), ssl_verify=ssl_verify)
+    params = dict()
+    if hash_:
+        params["expectedHash"] = hash_
+    _delete(base_url + "/trees/tag/{}".format(tag), ssl_verify=ssl_verify, params=params)
 
 
 def list_tables(base_url: str, ref: str, ssl_verify: bool = True) -> list:
@@ -152,63 +169,42 @@ def get_table(base_url: str, ref: str, table: str, ssl_verify: bool = True) -> d
     :param ssl_verify: ignore ssl errors if False
     :return: json dict of Nessie table
     """
-    return cast(dict, _get(base_url + "/contents/{}/{}".format(table, ref), ssl_verify=ssl_verify))
-
-
-def create_branch(base_url: str, branch: str, ref: str = None, ssl_verify: bool = True) -> None:
-    """Create a branch.
-
-    :param base_url: base Nessie url
-    :param branch: name of new branch
-    :param ref: ref to fork from
-    :param ssl_verify: ignore ssl errors if False
-    """
-    url = "/trees/branch/{}".format(branch)
+    params = dict()
     if ref:
-        url += "/{}".format(ref)
-
-    _post(base_url + url, None, ssl_verify=ssl_verify)
-
-
-def create_tag(base_url: str, tag: str, ref: str = None, ssl_verify: bool = True) -> None:
-    """Create a tag.
-
-    :param base_url: base Nessie url
-    :param tag: name of new tag
-    :param ref: ref to fork from
-    :param ssl_verify: ignore ssl errors if False
-    """
-    url = "/trees/tag/{}".format(tag)
-    if ref:
-        url += "/{}".format(ref)
-
-    _post(base_url + url, None, ssl_verify=ssl_verify)
+        params["ref"] = ref
+    return cast(dict, _get(base_url + "/contents/{}".format(table), ssl_verify=ssl_verify, params=params))
 
 
-def assign_branch(base_url: str, branch: str, old_hash: str, new_hash: str, ssl_verify: bool = True) -> None:
+def assign_branch(base_url: str, branch: str, branch_json: dict, old_hash: str, ssl_verify: bool = True) -> None:
     """Assign a reference to a branch.
 
     :param base_url: base Nessie url
-    :param branch: name of new branch
+    :param branch: name of the branch
+    :param branch_json: new definition of the branch
     :param old_hash: current hash of the branch
-    :param new_hash: new hash of the branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/branch/{}/{}/{}".format(branch, old_hash, new_hash)
-    _put(base_url + url, None, ssl_verify=ssl_verify)
+    url = "/trees/branch/{}".format(branch)
+    params = dict()
+    if old_hash:
+        params["expectedHash"] = old_hash
+    _put(base_url + url, branch_json, ssl_verify=ssl_verify, params=params)
 
 
-def assign_tag(base_url: str, tag: str, old_hash: str, new_hash: str, ssl_verify: bool = True) -> None:
+def assign_tag(base_url: str, tag: str, tag_json: dict, old_hash: str, ssl_verify: bool = True) -> None:
     """Assign a reference to a tag.
 
     :param base_url: base Nessie url
-    :param tag: name of new tag
-    :param old_hash: current hash of the branch
-    :param new_hash: new hash of the branch
+    :param tag: name of the tag
+    :param tag_json: new definition of the tag
+    :param old_hash: current hash of the tag
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/tag/{}/{}/{}".format(tag, old_hash, new_hash)
-    _put(base_url + url, None, ssl_verify=ssl_verify)
+    url = "/trees/tag/{}".format(tag)
+    params = dict()
+    if old_hash:
+        params["expectedHash"] = old_hash
+    _put(base_url + url, tag_json, ssl_verify=ssl_verify, params=params)
 
 
 def _raise_for_status(self: requests.models.Response) -> Tuple[Union[HTTPError, None], int, Union[Any, str]]:
@@ -234,32 +230,36 @@ def _raise_for_status(self: requests.models.Response) -> Tuple[Union[HTTPError, 
         return None, self.status_code, reason
 
 
-def cherry_pick(base_url: str, branch: str, expected_hash: str, ssl_verify: bool = True, *hashes: str) -> None:
+def cherry_pick(base_url: str, branch: str, transplant_json: dict, expected_hash: str, ssl_verify: bool = True) -> None:
     """cherry-pick a list of hashes to a branch.
 
     :param base_url: base Nessie url
     :param branch: name of branch to cherry pick onto
-    :param hashes: list of hashes
+    :param transplant_json: transplant content
     :param expected_hash: expected hash of HEAD of branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/transplant"
-    transplant = dict(branch={"hash": expected_hash, "name": branch}, hashesToTransplant=list(hashes))
-    _put(base_url + url, json=transplant, ssl_verify=ssl_verify)
+    url = "/trees/branch/{}/transplant".format(branch)
+    params = dict()
+    if expected_hash:
+        params["expectedHash"] = expected_hash
+    _post(base_url + url, json=transplant_json, ssl_verify=ssl_verify, params=params)
 
 
-def merge(base_url: str, branch: str, merge_branch: str, expected_hash: str, ssl_verify: bool = True) -> None:
+def merge(base_url: str, branch: str, merge_json: dict, expected_hash: str, ssl_verify: bool = True) -> None:
     """Merge a branch into another branch.
 
     :param base_url: base Nessie url
     :param branch: name of branch to merge onto
-    :param merge_branch: name of branch to merge from
+    :param merge_json: merge content
     :param expected_hash: expected hash of HEAD of branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/merge"
-    merge_obj = dict(to={"hash": expected_hash, "name": branch}, fromHash=merge_branch)
-    _put(base_url + url, json=merge_obj, ssl_verify=ssl_verify)
+    url = "/trees/branch/{}/merge".format(branch)
+    params = dict()
+    if expected_hash:
+        params["expectedHash"] = expected_hash
+    _post(base_url + url, json=merge_json, ssl_verify=ssl_verify, params=params)
 
 
 def commit(
@@ -279,5 +279,10 @@ def commit(
     :param expected_hash: expected hash of HEAD of branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/multi/{}/{}".format(branch, expected_hash)
-    _put(base_url + url, json=operations, ssl_verify=ssl_verify, params={"message": reason})
+    url = "/trees/branch/{}/commit".format(branch)
+    params = dict()
+    if reason:
+        params["message"] = reason
+    if expected_hash:
+        params["expectedHash"] = expected_hash
+    _post(base_url + url, json=operations, ssl_verify=ssl_verify, params=params)

--- a/python/pynessie/cli.py
+++ b/python/pynessie/cli.py
@@ -405,10 +405,10 @@ def contents(ctx: ContextObject, list: bool, delete: bool, set: bool, key: List[
         keys = ctx.nessie.list_keys(ref if ref else ctx.nessie.get_default_branch())
         results = EntrySchema().dumps(_format_keys_json(keys, *key), many=True) if ctx.json else _format_keys(keys, *key)
     elif delete:
-        ctx.nessie.commit(ref, _get_contents(ctx.nessie, ref, *key), reason=_get_message(message), old_hash=condition)
+        ctx.nessie.commit(ref, _get_contents(ctx.nessie, ref, *key), old_hash=condition, reason=_get_message(message))
         results = ""
     elif set:
-        ctx.nessie.commit(ref, _get_contents(ctx.nessie, ref, *key), reason=_get_message(message), old_hash=condition)
+        ctx.nessie.commit(ref, _get_contents(ctx.nessie, ref, *key), old_hash=condition, reason=_get_message(message))
         results = ""
     else:
 

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -171,10 +171,57 @@ class Reference:
 
     name: str = desert.ib(fields.Str())
     hash_: str = desert.ib(fields.Str(data_key="hash"))
-    kind: str = desert.ib(fields.Str(data_key="type"))
 
 
-ReferenceSchema = desert.schema_class(Reference)
+@attr.dataclass
+class Branch(Reference):
+    """Dataclass for Nessie Branch."""
+
+    pass
+
+
+BranchSchema = desert.schema_class(Branch)
+
+
+@attr.dataclass
+class Tag(Reference):
+    """Dataclass for Nessie Tag."""
+
+    pass
+
+
+TagSchema = desert.schema_class(Tag)
+
+
+@attr.dataclass
+class Hash(Reference):
+    """Dataclass for Nessie Hash."""
+
+    pass
+
+
+HashSchema = desert.schema_class(Hash)
+
+
+class ReferenceSchema(OneOfSchema):
+    """Schema for Nessie Reference."""
+
+    type_schemas = {
+        "BRANCH": BranchSchema,
+        "TAG": TagSchema,
+        "HASH": HashSchema,
+    }
+
+    def get_obj_type(self: "ReferenceSchema", obj: Reference) -> str:
+        """Returns the object type based on its class."""
+        if isinstance(obj, Branch):
+            return "BRANCH"
+        elif isinstance(obj, Tag):
+            return "TAG"
+        elif isinstance(obj, Hash):
+            return "DELETE"
+        else:
+            raise Exception("Unknown object type: {}".format(obj.__class__.__name__))
 
 
 @attr.dataclass
@@ -234,3 +281,23 @@ class LogResponse:
 
 
 LogResponseSchema = desert.schema_class(LogResponse)
+
+
+@attr.dataclass
+class Transplant:
+    """Dataclass for Transplant operation."""
+
+    hashes_to_transplant: List[str] = attr.ib(metadata=desert.metadata(fields.List(fields.Str(), data_key="hashesToTransplant")))
+
+
+TransplantSchema = desert.schema_class(Transplant)
+
+
+@attr.dataclass
+class Merge:
+    """Dataclass for Merge operation."""
+
+    from_hash: bool = attr.ib(default=False, metadata=desert.metadata(fields.Str(data_key="fromHash")))
+
+
+MergeSchema = desert.schema_class(Merge)

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Nessie Data objects."""
 from typing import List
+from typing import Optional
 
 import attr
 import desert
@@ -170,7 +171,7 @@ class Reference:
     """Dataclass for Nessie Reference."""
 
     name: str = desert.ib(fields.Str())
-    hash_: str = desert.ib(fields.Str(data_key="hash"))
+    hash_: Optional[str] = desert.ib(fields.Str(data_key="hash"))
 
 
 @attr.dataclass
@@ -297,7 +298,7 @@ TransplantSchema = desert.schema_class(Transplant)
 class Merge:
     """Dataclass for Merge operation."""
 
-    from_hash: bool = attr.ib(default=False, metadata=desert.metadata(fields.Str(data_key="fromHash")))
+    from_hash: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(data_key="fromHash")))
 
 
 MergeSchema = desert.schema_class(Merge)

--- a/python/pynessie/nessie_client.py
+++ b/python/pynessie/nessie_client.py
@@ -14,8 +14,7 @@ from ._endpoints import assign_branch
 from ._endpoints import assign_tag
 from ._endpoints import cherry_pick
 from ._endpoints import commit
-from ._endpoints import create_branch
-from ._endpoints import create_tag
+from ._endpoints import create_reference
 from ._endpoints import delete_branch
 from ._endpoints import delete_tag
 from ._endpoints import get_default_branch
@@ -24,6 +23,7 @@ from ._endpoints import get_table
 from ._endpoints import list_logs
 from ._endpoints import list_tables
 from ._endpoints import merge
+from .model import Branch
 from .model import CommitMeta
 from .model import Contents
 from .model import ContentsKey
@@ -32,10 +32,15 @@ from .model import Entries
 from .model import EntriesSchema
 from .model import LogResponse
 from .model import LogResponseSchema
+from .model import Merge
+from .model import MergeSchema
 from .model import MultiContents
 from .model import MultiContentsSchema
 from .model import Reference
 from .model import ReferenceSchema
+from .model import Tag
+from .model import Transplant
+from .model import TransplantSchema
 
 _dot_regex = re.compile('\\.(?=([^"]*"[^"]*")*[^"]*$)')
 
@@ -62,15 +67,15 @@ class NessieClient(object):
         references = all_references(self._base_url, self._ssl_verify)
         return [ReferenceSchema().load(ref) for ref in references]
 
-    def get_reference(self: "NessieClient", ref: Optional[str]) -> Reference:
+    def get_reference(self: "NessieClient", name: Optional[str]) -> Reference:
         """Fetch a ref.
 
-        :param ref: name of ref to fetch
-        :return: json Nessie reference
+        :param name: name of ref to fetch
+        :return: Nessie reference
         """
-        ref_obj = get_reference(self._base_url, ref, self._ssl_verify) if ref else get_default_branch(self._base_url, self._ssl_verify)
-        branch_obj = ReferenceSchema().load(ref_obj)
-        return branch_obj
+        ref_obj = get_reference(self._base_url, name, self._ssl_verify) if name else get_default_branch(self._base_url, self._ssl_verify)
+        ref = ReferenceSchema().load(ref_obj)
+        return ref
 
     def create_branch(self: "NessieClient", branch: str, ref: str = None) -> None:
         """Create a branch.
@@ -78,7 +83,8 @@ class NessieClient(object):
         :param branch: name of new branch
         :param ref: ref to fork from
         """
-        create_branch(self._base_url, branch, ref, self._ssl_verify)
+        ref_json = ReferenceSchema().dump(Branch(branch, ref))
+        create_reference(self._base_url, ref_json, self._ssl_verify)
 
     def delete_branch(self: "NessieClient", branch: str, hash_: str) -> None:
         """Delete a branch.
@@ -94,7 +100,8 @@ class NessieClient(object):
         :param tag: name of new tag
         :param ref: ref to fork from
         """
-        create_tag(self._base_url, tag, ref, self._ssl_verify)
+        ref_json = ReferenceSchema().dump(Tag(tag, ref))
+        create_reference(self._base_url, ref_json, self._ssl_verify)
 
     def delete_tag(self: "NessieClient", tag: str, hash_: str) -> None:
         """Delete a tag.
@@ -129,35 +136,36 @@ class NessieClient(object):
         old_hash: Optional[str] = None,
     ) -> None:
         """Modify a set of Nessie tables."""
-        print(args)
         commit(self._base_url, branch, MultiContentsSchema().dumps(args), reason, old_hash)
 
     def assign_branch(self: "NessieClient", branch: str, to_ref: str, old_hash: Optional[str] = None) -> None:
         """Assign a hash to a branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
-        to_hash = self.get_reference(to_ref).hash_
-        assign_branch(self._base_url, branch, old_hash, to_hash, self._ssl_verify)
+        branch_json = ReferenceSchema().dump(Branch(branch, to_ref))
+        assign_branch(self._base_url, branch, branch_json, old_hash, self._ssl_verify)
 
     def assign_tag(self: "NessieClient", tag: str, to_ref: str, old_hash: Optional[str] = None) -> None:
         """Assign a hash to a tag."""
         if not old_hash:
             old_hash = self.get_reference(tag).hash_
-        to_hash = self.get_reference(to_ref).hash_
-        assign_tag(self._base_url, tag, old_hash, to_hash, self._ssl_verify)
+        tag_json = ReferenceSchema().dump(Tag(tag, to_ref))
+        assign_tag(self._base_url, tag, tag_json, old_hash, self._ssl_verify)
 
     def merge(self: "NessieClient", branch: str, to_branch: str, old_hash: Optional[str] = None) -> None:
         """Merge a branch into another branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
         to_hash = self.get_reference(to_branch).hash_
-        merge(self._base_url, branch, to_hash, old_hash, self._ssl_verify)
+        merge_json = MergeSchema().dump(Merge(to_hash))
+        merge(self._base_url, branch, merge_json, old_hash, self._ssl_verify)
 
     def cherry_pick(self: "NessieClient", branch: str, old_hash: Optional[str] = None, *hashes: str) -> None:
         """Cherry pick a list of hashes to a branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
-        cherry_pick(self._base_url, branch, old_hash, self._ssl_verify, *hashes)
+        transplant_json = TransplantSchema().dump(Transplant(list(hashes)))
+        cherry_pick(self._base_url, branch, transplant_json, old_hash, self._ssl_verify)
 
     def get_log(self: "NessieClient", start_ref: str) -> Generator[CommitMeta, Any, None]:
         """Fetch all logs starting at start_ref.

--- a/python/pynessie/nessie_client.py
+++ b/python/pynessie/nessie_client.py
@@ -132,16 +132,17 @@ class NessieClient(object):
         self: "NessieClient",
         branch: str,
         args: MultiContents,
+        old_hash: str,
         reason: Optional[str] = None,
-        old_hash: Optional[str] = None,
     ) -> None:
         """Modify a set of Nessie tables."""
-        commit(self._base_url, branch, MultiContentsSchema().dumps(args), reason, old_hash)
+        commit(self._base_url, branch, MultiContentsSchema().dumps(args), old_hash, reason)
 
     def assign_branch(self: "NessieClient", branch: str, to_ref: str, old_hash: Optional[str] = None) -> None:
         """Assign a hash to a branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
+        assert old_hash is not None
         branch_json = ReferenceSchema().dump(Branch(branch, to_ref))
         assign_branch(self._base_url, branch, branch_json, old_hash, self._ssl_verify)
 
@@ -149,6 +150,7 @@ class NessieClient(object):
         """Assign a hash to a tag."""
         if not old_hash:
             old_hash = self.get_reference(tag).hash_
+        assert old_hash is not None
         tag_json = ReferenceSchema().dump(Tag(tag, to_ref))
         assign_tag(self._base_url, tag, tag_json, old_hash, self._ssl_verify)
 
@@ -156,7 +158,9 @@ class NessieClient(object):
         """Merge a branch into another branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
+        assert old_hash is not None
         to_hash = self.get_reference(to_branch).hash_
+        assert to_hash is not None
         merge_json = MergeSchema().dump(Merge(to_hash))
         merge(self._base_url, branch, merge_json, old_hash, self._ssl_verify)
 
@@ -164,6 +168,7 @@ class NessieClient(object):
         """Cherry pick a list of hashes to a branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
+        assert old_hash is not None
         transplant_json = TransplantSchema().dump(Transplant(list(hashes)))
         cherry_pick(self._base_url, branch, transplant_json, old_hash, self._ssl_verify)
 

--- a/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
@@ -3,13 +3,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -3,13 +3,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -30,13 +28,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -69,13 +65,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -105,13 +99,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET

--- a/python/tests/cassettes/test_nessie_cli/test_ref.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_ref.yaml
@@ -3,13 +3,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -55,13 +53,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -84,13 +80,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -100,26 +94,26 @@ interactions:
       string: "{\n  \"message\" : \"Unable to find reference [etl].\",\n  \"status\"\
         \ : \"NOT_FOUND\",\n  \"serverStackTrace\" : \"com.dremio.nessie.error.NessieNotFoundException:\
         \ Unable to find reference [etl].\\n\\tat com.dremio.nessie.services.rest.TreeResource.getReferenceByName(TreeResource.java:93)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.getReferenceByName$$superaccessor13(TreeResource_Subclass.zig:3228)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$13.apply(TreeResource_Subclass$$function$$13.zig:33)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.getReferenceByName$$superaccessor5(TreeResource_Subclass.zig:2141)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$5.apply(TreeResource_Subclass$$function$$5.zig:33)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:54)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor.validateMethodInvocation(AbstractMethodValidationInterceptor.java:69)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor.validateMethodInvocation(JaxrsEndPointValidationInterceptor.java:32)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor_Bean.intercept(JaxrsEndPointValidationInterceptor_Bean.zig:341)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
-        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.time(TimedInterceptor.java:54)\\\
-        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.timedMethod(TimedInterceptor.java:35)\\\
-        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:326)\\\
-        n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
-        n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
         n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor.increment(CountedInterceptor.java:51)\\\
         n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor.countedMethod(CountedInterceptor.java:33)\\\
         n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor_Bean.intercept(CountedInterceptor_Bean.zig:326)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
+        n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.time(TimedInterceptor.java:54)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.timedMethod(TimedInterceptor.java:35)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:326)\\\
+        n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)\\\
         n\\tat io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.getReferenceByName(TreeResource_Subclass.zig:3176)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.getReferenceByName(TreeResource_Subclass.zig:2089)\\\
         n\\tat com.dremio.nessie.services.rest.TreeResource_ClientProxy.getReferenceByName(TreeResource_ClientProxy.zig:259)\\\
         n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native\
         \ Method)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\\
@@ -164,7 +158,7 @@ interactions:
         n\\t... 56 more\\n\"\n}"
     headers:
       Content-Length:
-      - '6535'
+      - '6532'
       Content-Type:
       - application/json
     status:
@@ -174,13 +168,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -226,13 +218,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -256,13 +246,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -283,15 +271,13 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
       - '0'
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: DELETE
@@ -307,13 +293,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -334,15 +318,13 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
       - '0'
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: DELETE
@@ -358,13 +340,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET

--- a/python/tests/cassettes/test_nessie_cli/test_ref.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_ref.yaml
@@ -28,7 +28,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -37,13 +37,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '0'
+      - '47'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.24.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev
+    uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
       string: ''
@@ -99,29 +99,33 @@ interactions:
     body:
       string: "{\n  \"message\" : \"Unable to find reference [etl].\",\n  \"status\"\
         \ : \"NOT_FOUND\",\n  \"serverStackTrace\" : \"com.dremio.nessie.error.NessieNotFoundException:\
-        \ Unable to find reference [etl].\\n\\tat com.dremio.nessie.services.rest.TreeResource.getReferenceByName(TreeResource.java:92)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.getReferenceByName$$superaccessor8(TreeResource_Subclass.zig:2383)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$8.apply(TreeResource_Subclass$$function$$8.zig:33)\\\
+        \ Unable to find reference [etl].\\n\\tat com.dremio.nessie.services.rest.TreeResource.getReferenceByName(TreeResource.java:93)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.getReferenceByName$$superaccessor13(TreeResource_Subclass.zig:3228)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$13.apply(TreeResource_Subclass$$function$$13.zig:33)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:54)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor.validateMethodInvocation(AbstractMethodValidationInterceptor.java:69)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor.validateMethodInvocation(JaxrsEndPointValidationInterceptor.java:32)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor_Bean.intercept(JaxrsEndPointValidationInterceptor_Bean.zig:341)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor.meteredCallable(MeteredInterceptor.java:94)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor.meteredMethod(MeteredInterceptor.java:69)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor_Bean.intercept(MeteredInterceptor_Bean.zig:366)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.time(TimedInterceptor.java:54)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.timedMethod(TimedInterceptor.java:35)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:326)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor.timedCallable(TimedInterceptor.java:95)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor.timedMethod(TimedInterceptor.java:70)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:366)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor.increment(CountedInterceptor.java:51)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor.countedMethod(CountedInterceptor.java:33)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor_Bean.intercept(CountedInterceptor_Bean.zig:326)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)\\\
         n\\tat io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.getReferenceByName(TreeResource_Subclass.zig:2331)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_ClientProxy.getReferenceByName(TreeResource_ClientProxy.zig:326)\\\
-        n\\tat java.lang.reflect.Method.invoke(Method.java:566)\\n\\tat org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:170)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.getReferenceByName(TreeResource_Subclass.zig:3176)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_ClientProxy.getReferenceByName(TreeResource_ClientProxy.zig:259)\\\
+        n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native\
+        \ Method)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\\
+        n\\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\\
+        n\\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\\n\\tat\
+        \ org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:170)\\\
         n\\tat org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:130)\\\
         n\\tat org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:643)\\\
         n\\tat org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:507)\\\
@@ -141,23 +145,26 @@ interactions:
         n\\tat io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch(VertxRequestHandler.java:131)\\\
         n\\tat io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.access$000(VertxRequestHandler.java:37)\\\
         n\\tat io.quarkus.resteasy.runtime.standalone.VertxRequestHandler$1.run(VertxRequestHandler.java:94)\\\
+        n\\tat io.quarkus.runtime.CleanableExecutor$CleaningRunnable.run(CleanableExecutor.java:231)\\\
+        n\\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)\\\
+        n\\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\\\
         n\\tat org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)\\\
         n\\tat org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2046)\\\
         n\\tat org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1578)\\\
         n\\tat org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1452)\\\
         n\\tat org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)\\\
         n\\tat org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)\\\
-        n\\tat java.lang.Thread.run(Thread.java:834)\\n\\tat org.jboss.threads.JBossThread.run(JBossThread.java:479)\\\
-        n\\tat com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)\\\
-        n\\tat com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)\\\
+        n\\tat java.base/java.lang.Thread.run(Thread.java:834)\\n\\tat org.jboss.threads.JBossThread.run(JBossThread.java:479)\\\
         nCaused by: com.dremio.nessie.versioned.ReferenceNotFoundException: Ref 'etl'\
-        \ does not exist\\n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.lambda$toRef$1(InMemoryVersionStore.java:159)\\\
-        n\\tat java.util.Optional.orElseThrow(Optional.java:408)\\n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.toRef(InMemoryVersionStore.java:159)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource.getReferenceByName(TreeResource.java:90)\\\
-        n\\t... 52 more\\n\"\n}"
+        \ does not exist\\n\\tat com.dremio.nessie.versioned.ReferenceNotFoundException.forReference(ReferenceNotFoundException.java:74)\\\
+        n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.lambda$5(InMemoryVersionStore.java:159)\\\
+        n\\tat java.base/java.util.Optional.orElseThrow(Optional.java:408)\\n\\tat\
+        \ com.dremio.nessie.versioned.memory.InMemoryVersionStore.toRef(InMemoryVersionStore.java:159)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource.getReferenceByName(TreeResource.java:91)\\\
+        n\\t... 56 more\\n\"\n}"
     headers:
       Content-Length:
-      - '5966'
+      - '6535'
       Content-Type:
       - application/json
     status:
@@ -191,7 +198,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"name": "etl", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -200,13 +208,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '0'
+      - '109'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.24.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/etl/2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+    uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
       string: ''
@@ -287,7 +295,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/etl/2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
       string: ''
@@ -338,7 +346,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev/2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
       string: ''

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -28,7 +28,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -37,62 +37,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '0'
+      - '48'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.24.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main
+    uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
       string: "{\n  \"message\" : \"A reference of name [main] already exists.\",\n\
         \  \"status\" : \"CONFLICT\",\n  \"serverStackTrace\" : \"com.dremio.nessie.error.NessieConflictException:\
-        \ A reference of name [main] already exists.\\n\\tat com.dremio.nessie.services.rest.TreeResource.createNewReference(TreeResource.java:256)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource.createNewBranch(TreeResource.java:139)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createNewBranch$$superaccessor10(TreeResource_Subclass.zig:2646)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$10.apply(TreeResource_Subclass$$function$$10.zig:41)\\\
+        \ A reference of name [main] already exists.\\n\\tat com.dremio.nessie.services.rest.TreeResource.createReference(TreeResource.java:119)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource.createReference(TreeResource.java:110)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createReference$$superaccessor6(TreeResource_Subclass.zig:2283)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$6.apply(TreeResource_Subclass$$function$$6.zig:33)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:54)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor.validateMethodInvocation(AbstractMethodValidationInterceptor.java:69)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor.validateMethodInvocation(JaxrsEndPointValidationInterceptor.java:32)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor_Bean.intercept(JaxrsEndPointValidationInterceptor_Bean.zig:341)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor.meteredCallable(MeteredInterceptor.java:94)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor.meteredMethod(MeteredInterceptor.java:69)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor_Bean.intercept(MeteredInterceptor_Bean.zig:366)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.time(TimedInterceptor.java:54)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.timedMethod(TimedInterceptor.java:35)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:326)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor.timedCallable(TimedInterceptor.java:95)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor.timedMethod(TimedInterceptor.java:70)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:366)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor.increment(CountedInterceptor.java:51)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor.countedMethod(CountedInterceptor.java:33)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor_Bean.intercept(CountedInterceptor_Bean.zig:326)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)\\\
         n\\tat io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createNewBranch(TreeResource_Subclass.zig:2583)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource.createEmptyBranch(TreeResource.java:146)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createEmptyBranch$$superaccessor3(TreeResource_Subclass.zig:1723)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$3.apply(TreeResource_Subclass$$function$$3.zig:33)\\\
-        n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:54)\\\
-        n\\tat io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor.validateMethodInvocation(AbstractMethodValidationInterceptor.java:69)\\\
-        n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor.validateMethodInvocation(JaxrsEndPointValidationInterceptor.java:32)\\\
-        n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor_Bean.intercept(JaxrsEndPointValidationInterceptor_Bean.zig:341)\\\
-        n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
-        n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor.meteredCallable(MeteredInterceptor.java:94)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor.meteredMethod(MeteredInterceptor.java:69)\\\
-        n\\tat io.smallrye.metrics.interceptors.MeteredInterceptor_Bean.intercept(MeteredInterceptor_Bean.zig:366)\\\
-        n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
-        n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor.timedCallable(TimedInterceptor.java:95)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor.timedMethod(TimedInterceptor.java:70)\\\
-        n\\tat io.smallrye.metrics.interceptors.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:366)\\\
-        n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
-        n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)\\\
-        n\\tat io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createEmptyBranch(TreeResource_Subclass.zig:1662)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_ClientProxy.createEmptyBranch(TreeResource_ClientProxy.zig:262)\\\
-        n\\tat java.lang.reflect.Method.invoke(Method.java:566)\\n\\tat org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:170)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createReference(TreeResource_Subclass.zig:2222)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_ClientProxy.createReference(TreeResource_ClientProxy.zig:164)\\\
+        n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native\
+        \ Method)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\\
+        n\\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\\\
+        n\\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\\n\\tat\
+        \ org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:170)\\\
         n\\tat org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:130)\\\
         n\\tat org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:643)\\\
         n\\tat org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:507)\\\
@@ -112,33 +95,36 @@ interactions:
         n\\tat io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch(VertxRequestHandler.java:131)\\\
         n\\tat io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.access$000(VertxRequestHandler.java:37)\\\
         n\\tat io.quarkus.resteasy.runtime.standalone.VertxRequestHandler$1.run(VertxRequestHandler.java:94)\\\
+        n\\tat io.quarkus.runtime.CleanableExecutor$CleaningRunnable.run(CleanableExecutor.java:231)\\\
+        n\\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)\\\
+        n\\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\\\
         n\\tat org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)\\\
         n\\tat org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2046)\\\
         n\\tat org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1578)\\\
         n\\tat org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1452)\\\
         n\\tat org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)\\\
         n\\tat org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)\\\
-        n\\tat java.lang.Thread.run(Thread.java:834)\\n\\tat org.jboss.threads.JBossThread.run(JBossThread.java:479)\\\
-        n\\tat com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)\\\
-        n\\tat com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:192)\\\
+        n\\tat java.base/java.lang.Thread.run(Thread.java:834)\\n\\tat org.jboss.threads.JBossThread.run(JBossThread.java:479)\\\
         nCaused by: com.dremio.nessie.versioned.ReferenceAlreadyExistsException: branch\
-        \ 'main' already exists\\n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.lambda$create$10(InMemoryVersionStore.java:347)\\\
-        n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.lambda$compute$17(InMemoryVersionStore.java:503)\\\
-        n\\tat java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1932)\\\
+        \ 'main' already exists\\n\\tat com.dremio.nessie.versioned.ReferenceAlreadyExistsException.forReference(ReferenceAlreadyExistsException.java:50)\\\
+        n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.lambda$15(InMemoryVersionStore.java:347)\\\
+        n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.lambda$26(InMemoryVersionStore.java:503)\\\
+        n\\tat java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1932)\\\
         n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.compute(InMemoryVersionStore.java:501)\\\
         n\\tat com.dremio.nessie.versioned.memory.InMemoryVersionStore.create(InMemoryVersionStore.java:345)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource.createNewReference(TreeResource.java:252)\\\
-        n\\t... 74 more\\n\"\n}"
+        n\\tat com.dremio.nessie.services.rest.TreeResource.createReference(TreeResource.java:115)\\\
+        n\\t... 57 more\\n\"\n}"
     headers:
+      Content-Length:
+      - '6881'
       Content-Type:
       - application/json
-      transfer-encoding:
-      - chunked
     status:
       code: 409
       message: Conflict
 - request:
-    body: null
+    body: '{"name": "test", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -147,13 +133,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '0'
+      - '110'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.24.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/test/2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+    uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
       string: ''
@@ -234,7 +220,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/test/entries
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ ]\n\
+      string: "{\n  \"token\" : null,\n  \"hasMore\" : false,\n  \"entries\" : [ ]\n\
         }"
     headers:
       Content-Length:
@@ -260,7 +246,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/test/2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+    uri: http://localhost:19120/api/v1/trees/branch/test?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
       string: ''

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -3,13 +3,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -50,26 +48,26 @@ interactions:
         \  \"status\" : \"CONFLICT\",\n  \"serverStackTrace\" : \"com.dremio.nessie.error.NessieConflictException:\
         \ A reference of name [main] already exists.\\n\\tat com.dremio.nessie.services.rest.TreeResource.createReference(TreeResource.java:119)\\\
         n\\tat com.dremio.nessie.services.rest.TreeResource.createReference(TreeResource.java:110)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createReference$$superaccessor6(TreeResource_Subclass.zig:2283)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$6.apply(TreeResource_Subclass$$function$$6.zig:33)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createReference$$superaccessor12(TreeResource_Subclass.zig:3105)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass$$function$$12.apply(TreeResource_Subclass$$function$$12.zig:33)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:54)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor.validateMethodInvocation(AbstractMethodValidationInterceptor.java:69)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor.validateMethodInvocation(JaxrsEndPointValidationInterceptor.java:32)\\\
         n\\tat io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor_Bean.intercept(JaxrsEndPointValidationInterceptor_Bean.zig:341)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
-        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.time(TimedInterceptor.java:54)\\\
-        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.timedMethod(TimedInterceptor.java:35)\\\
-        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:326)\\\
-        n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
-        n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
         n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor.increment(CountedInterceptor.java:51)\\\
         n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor.countedMethod(CountedInterceptor.java:33)\\\
         n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.CountedInterceptor_Bean.intercept(CountedInterceptor_Bean.zig:326)\\\
         n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
+        n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.time(TimedInterceptor.java:54)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor.timedMethod(TimedInterceptor.java:35)\\\
+        n\\tat io.quarkus.micrometer.runtime.binder.mpmetrics.TimedInterceptor_Bean.intercept(TimedInterceptor_Bean.zig:326)\\\
+        n\\tat io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)\\\
         n\\tat io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)\\\
         n\\tat io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)\\\
-        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createReference(TreeResource_Subclass.zig:2222)\\\
+        n\\tat com.dremio.nessie.services.rest.TreeResource_Subclass.createReference(TreeResource_Subclass.zig:3044)\\\
         n\\tat com.dremio.nessie.services.rest.TreeResource_ClientProxy.createReference(TreeResource_ClientProxy.zig:164)\\\
         n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native\
         \ Method)\\n\\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\\\
@@ -116,7 +114,7 @@ interactions:
         n\\t... 57 more\\n\"\n}"
     headers:
       Content-Length:
-      - '6881'
+      - '6884'
       Content-Type:
       - application/json
     status:
@@ -151,13 +149,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -180,13 +176,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -207,13 +201,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET
@@ -234,15 +226,13 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
       - '0'
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: DELETE
@@ -258,13 +248,11 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       User-Agent:
       - python-requests/2.24.0
     method: GET

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 from pynessie import __version__
 from pynessie import cli
+from pynessie.model import Branch
 from pynessie.model import ReferenceSchema
 
 
@@ -32,7 +33,7 @@ def test_command_line_interface() -> None:
     references = ReferenceSchema().loads(help_result.output, many=True)
     assert len(references) == 1
     assert references[0].name == "main"
-    assert references[0].kind == "BRANCH"
+    assert isinstance(references[0], Branch)
     assert references[0].hash_ == "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
 
 

--- a/python/tests/test_nessie_client.py
+++ b/python/tests/test_nessie_client.py
@@ -5,8 +5,8 @@ import pytest
 
 from pynessie import init
 from pynessie.error import NessieConflictException
+from pynessie.model import Branch
 from pynessie.model import Entries
-from pynessie.model import Reference
 
 
 @pytest.mark.vcr
@@ -16,15 +16,15 @@ def test_client_interface_e2e() -> None:
     assert isinstance(client._base_url, str)
     references = client.list_references()
     assert len(references) == 1
-    assert references[0] == Reference("main", references[0].hash_, "BRANCH")
+    assert references[0] == Branch("main", references[0].hash_)
     main_commit = references[0].hash_
     with pytest.raises(NessieConflictException):
         client.create_branch("main")
     client.create_branch("test", main_commit)
     references = client.list_references()
     assert len(references) == 2
-    assert references[0] == Reference("main", main_commit, "BRANCH")
-    assert references[1] == Reference("test", main_commit, "BRANCH")
+    assert references[0] == Branch("main", main_commit)
+    assert references[1] == Branch("test", main_commit)
     reference = client.get_reference("test")
     tables = client.list_keys(reference.name)
     assert isinstance(tables, Entries)

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -126,15 +126,3 @@ quarkus.container-image.name=nessie
 %test.quarkus.security.users.embedded.roles.test_user=test123
 %test.nessie.backends.type=INMEMORY
 %test.nessie.version.store.jgit.type=INMEMORY
-
-mp.openapi.extensions.smallrye.info.title=Project Nessie API
-%dev.mp.openapi.extensions.smallrye.info.title=Project Nessie API (development)
-%test.mp.openapi.extensions.smallrye.info.title=Project Nessie API (test)
-mp.openapi.extensions.smallrye.info.version=0.2.0-SNAPSHOT
-mp.openapi.extensions.smallrye.info.description=Nessie REST API
-mp.openapi.extensions.smallrye.info.contact.email=projectnessie@googlegroups.com
-mp.openapi.extensions.smallrye.info.contact.name=Project Nessie Mailing list
-mp.openapi.extensions.smallrye.info.contact.url=https://projectnessie.org
-mp.openapi.extensions.smallrye.info.license.name=Apache 2.0
-mp.openapi.extensions.smallrye.info.license.url=http://www.apache.org/licenses/LICENSE-2.0.html
-mp.openapi.extensions.smallrye.operationIdStrategy=METHOD

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestAuth.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestAuth.java
@@ -58,7 +58,7 @@ class TestAuth {
     tree = client.getTreeApi();
     contents = client.getContentsApi();
     if (branch != null) {
-      tree.createEmptyBranch(branch);
+      tree.createReference(Branch.of(branch, null));
     }
   }
 
@@ -93,7 +93,7 @@ class TestAuth {
 
     Branch master = (Branch) tree.getReferenceByName("testx");
     Branch test = ImmutableBranch.builder().hash(master.getHash()).name("testy").build();
-    tryEndpointPass(() -> tree.createNewBranch(test.getName(), test.getHash()));
+    tryEndpointPass(() -> tree.createReference(Branch.of(test.getName(), test.getHash())));
     Branch test2 = (Branch) tree.getReferenceByName("testy");
     tryEndpointPass(() -> tree.deleteBranch(test2.getName(), test2.getHash()));
     tryEndpointPass(() -> contents.deleteContents(key, master.getName(), master.getHash(), ""));

--- a/servers/services/src/main/java/com/dremio/nessie/services/rest/BaseResource.java
+++ b/servers/services/src/main/java/com/dremio/nessie/services/rest/BaseResource.java
@@ -16,30 +16,44 @@
 package com.dremio.nessie.services.rest;
 
 import java.security.Principal;
+import java.util.List;
 import java.util.Optional;
 
-import javax.inject.Inject;
-
+import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
 import com.dremio.nessie.model.CommitMeta;
 import com.dremio.nessie.model.Contents;
+import com.dremio.nessie.model.ImmutableCommitMeta;
+import com.dremio.nessie.services.config.ServerConfig;
+import com.dremio.nessie.versioned.BranchName;
 import com.dremio.nessie.versioned.Hash;
 import com.dremio.nessie.versioned.Ref;
+import com.dremio.nessie.versioned.ReferenceConflictException;
 import com.dremio.nessie.versioned.ReferenceNotFoundException;
 import com.dremio.nessie.versioned.VersionStore;
 import com.dremio.nessie.versioned.WithHash;
 
 abstract class BaseResource {
+  private final ServerConfig config;
 
-  @Inject
-  protected Principal principal;
+  private final Principal principal;
 
-  @Inject
-  protected VersionStore<Contents, CommitMeta> store;
+  private final VersionStore<Contents, CommitMeta> store;
+
+  // Mandated by CDI 2.0
+  protected BaseResource() {
+    this(null, null, null);
+  }
+
+  protected BaseResource(ServerConfig config, Principal principal, VersionStore<Contents, CommitMeta> store) {
+    this.config = config;
+    this.principal = principal;
+    this.store = store;
+  }
 
   Optional<Hash> getHash(String ref) {
     try {
-      WithHash<Ref> whr = store.toRef(ref);
+      WithHash<Ref> whr = store.toRef(Optional.ofNullable(ref).orElse(config.getDefaultBranch()));
       return Optional.of(whr.getHash());
     } catch (ReferenceNotFoundException e) {
       return Optional.empty();
@@ -50,4 +64,37 @@ abstract class BaseResource {
     return getHash(ref).orElseThrow(() -> new NessieNotFoundException(String.format("Ref for %s not found", ref)));
   }
 
+  protected ServerConfig getConfig() {
+    return config;
+  }
+
+  protected VersionStore<Contents, CommitMeta> getStore() {
+    return store;
+  }
+
+  protected void doOps(String branch, String hash, String message, List<com.dremio.nessie.versioned.Operation<Contents>> operations)
+      throws NessieConflictException, NessieNotFoundException {
+    try {
+      store.commit(
+          BranchName.of(Optional.ofNullable(branch).orElse(config.getDefaultBranch())),
+          Optional.ofNullable(hash).map(Hash::of),
+          meta(principal, message),
+          operations
+      );
+    } catch (IllegalArgumentException e) {
+      throw new NessieNotFoundException("Invalid hash provided.", e);
+    } catch (ReferenceConflictException e) {
+      throw new NessieConflictException("Failed to commit data. Provided hash does not match current value.", e);
+    } catch (ReferenceNotFoundException e) {
+      throw new NessieNotFoundException("Failed to commit data. Provided ref was not found.", e);
+    }
+  }
+
+  private static CommitMeta meta(Principal principal, String message) {
+    return ImmutableCommitMeta.builder()
+        .commiter(principal == null ? "" : principal.getName())
+        .message(message == null ? "" : message)
+        .commitTime(System.currentTimeMillis())
+        .build();
+  }
 }

--- a/servers/services/src/main/java/com/dremio/nessie/services/rest/ContentsResource.java
+++ b/servers/services/src/main/java/com/dremio/nessie/services/rest/ContentsResource.java
@@ -17,17 +17,17 @@
 package com.dremio.nessie.services.rest;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.dremio.nessie.api.ContentsApi;
 import com.dremio.nessie.error.NessieConflictException;
@@ -35,14 +35,15 @@ import com.dremio.nessie.error.NessieNotFoundException;
 import com.dremio.nessie.model.CommitMeta;
 import com.dremio.nessie.model.Contents;
 import com.dremio.nessie.model.ContentsKey;
-import com.dremio.nessie.model.ImmutableCommitMeta;
+import com.dremio.nessie.model.ImmutableMultiGetContentsResponse;
+import com.dremio.nessie.model.MultiGetContentsRequest;
+import com.dremio.nessie.model.MultiGetContentsResponse;
+import com.dremio.nessie.model.MultiGetContentsResponse.ContentsWithKey;
 import com.dremio.nessie.services.config.ServerConfig;
-import com.dremio.nessie.versioned.BranchName;
 import com.dremio.nessie.versioned.Delete;
 import com.dremio.nessie.versioned.Hash;
 import com.dremio.nessie.versioned.Key;
 import com.dremio.nessie.versioned.Put;
-import com.dremio.nessie.versioned.ReferenceConflictException;
 import com.dremio.nessie.versioned.ReferenceNotFoundException;
 import com.dremio.nessie.versioned.VersionStore;
 
@@ -52,10 +53,11 @@ import com.dremio.nessie.versioned.VersionStore;
 @RequestScoped
 public class ContentsResource extends BaseResource implements ContentsApi {
 
-  private static final Logger logger = LoggerFactory.getLogger(ContentsResource.class);
-
   @Inject
-  ServerConfig config;
+  public ContentsResource(ServerConfig config, Principal principal,
+      VersionStore<Contents, CommitMeta> store) {
+    super(config, principal, store);
+  }
 
   @Metered
   @Timed(name = "timed-contents-get")
@@ -63,7 +65,7 @@ public class ContentsResource extends BaseResource implements ContentsApi {
   public Contents getContents(ContentsKey key, String incomingRef) throws NessieNotFoundException {
     Hash ref = getHashOrThrow(incomingRef);
     try {
-      Contents obj = store.getValue(ref, toKey(key));
+      Contents obj = getStore().getValue(ref, toKey(key));
       if (obj != null) {
         return obj;
       }
@@ -73,11 +75,26 @@ public class ContentsResource extends BaseResource implements ContentsApi {
     }
   }
 
-  @Metered
-  @Timed(name = "timed-contents-get-default")
+
   @Override
-  public Contents getContents(ContentsKey key) throws NessieNotFoundException {
-    return getContents(key, config.getDefaultBranch());
+  public MultiGetContentsResponse getMultipleContents(String refName, MultiGetContentsRequest request)
+      throws NessieNotFoundException {
+    try {
+      Hash ref = getHashOrThrow(refName);
+      List<ContentsKey> externalKeys = request.getRequestedKeys();
+      List<Key> internalKeys = externalKeys.stream().map(ContentsResource::toKey).collect(Collectors.toList());
+      List<Optional<Contents>> values = getStore().getValues(ref, internalKeys);
+      List<ContentsWithKey> output = new ArrayList<>();
+
+      for (int i = 0; i < externalKeys.size(); i++) {
+        final int pos = i;
+        values.get(i).ifPresent(v -> output.add(ContentsWithKey.of(externalKeys.get(pos), v)));
+      }
+
+      return ImmutableMultiGetContentsResponse.builder().contents(output).build();
+    } catch (ReferenceNotFoundException ex) {
+      throw new NessieNotFoundException("Unable to find the requested ref.", ex);
+    }
   }
 
   @Metered
@@ -89,59 +106,11 @@ public class ContentsResource extends BaseResource implements ContentsApi {
   }
 
   @Metered
-  @Timed(name = "timed-contents-set-default")
-  @Override
-  public void setContents(ContentsKey key, String hash, String message, Contents contents)
-      throws NessieNotFoundException, NessieConflictException {
-    setContents(key, config.getDefaultBranch(), hash, message, contents);
-  }
-
-  @Metered
   @Timed(name = "timed-contents-delete")
   @Override
   public void deleteContents(ContentsKey key, String branch, String hash, String message)
       throws NessieNotFoundException, NessieConflictException {
     doOps(branch, hash, message, Arrays.asList(Delete.of(toKey(key))));
-  }
-
-  @Metered
-  @Timed(name = "timed-contents-delete-default")
-  @Override
-  public void deleteContents(ContentsKey key, String hash, String message)
-      throws NessieNotFoundException, NessieConflictException {
-    deleteContents(key, config.getDefaultBranch(), hash, message);
-  }
-
-  private void doOps(String branch,
-      String hash, String message, List<com.dremio.nessie.versioned.Operation<Contents>> operations)
-      throws NessieConflictException, NessieNotFoundException {
-    doOps(store, principal, branch, hash, message, operations);
-  }
-
-  static void doOps(VersionStore<Contents, CommitMeta> store, Principal principal, String branch,
-      String hash, String message, List<com.dremio.nessie.versioned.Operation<Contents>> operations)
-      throws NessieConflictException, NessieNotFoundException {
-    try {
-      store.commit(
-          BranchName.of(branch),
-          Optional.of(Hash.of(hash)),
-          meta(principal, message),
-          operations);
-    } catch (IllegalArgumentException e) {
-      throw new NessieNotFoundException("Invalid hash provided.", e);
-    } catch (ReferenceConflictException e) {
-      throw new NessieConflictException("Failed to commit data. Provided hash does not match current value.", e);
-    } catch (ReferenceNotFoundException e) {
-      throw new NessieNotFoundException("Failed to commit data. Provided ref was not found.", e);
-    }
-  }
-
-  private static CommitMeta meta(Principal principal, String message) {
-    return ImmutableCommitMeta.builder()
-        .commiter(principal == null ? "" : principal.getName())
-        .message(message == null ? "" : message)
-        .commitTime(System.currentTimeMillis())
-        .build();
   }
 
   static Key toKey(ContentsKey key) {


### PR DESCRIPTION
Rework REST API to be closer to RESTful design principles:
* Move Content Multi-GET operation to the Content API
* Use query parameters instead of path arguments for expected hash
* Replace multi endpoints with actions resources associated with branch path
* Add default Application with OpenAPI annotations
    
Update both Java and Python clients (but not JS/UI).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/305)
<!-- Reviewable:end -->
