### PR TITLE
Fix flakey Apprunner error

### DIFF
--- a/tools/apprunner-maven-plugin/src/main/java/com/dremio/nessie/quarkus/maven/QuarkusApp.java
+++ b/tools/apprunner-maven-plugin/src/main/java/com/dremio/nessie/quarkus/maven/QuarkusApp.java
@@ -17,8 +17,7 @@ package com.dremio.nessie.quarkus.maven;
 
 import java.lang.reflect.Method;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
@@ -102,13 +101,10 @@ public class QuarkusApp implements AutoCloseable {
   }
 
   private static void exitHandler(StartupAction startupAction) throws ReflectiveOperationException {
-    Consumer<Integer> consumer = i -> {
-    };
-    Method exitHandler = Arrays
-        .stream(startupAction.getClassLoader()
-            .loadClass("io.quarkus.runtime.ApplicationLifecycleManager").getMethods())
-        .filter(x -> x.getName().equals("setDefaultExitCodeHandler")).findFirst()
-        .orElseThrow(NoSuchMethodException::new);
+    final BiConsumer<Integer, Throwable> consumer = (i, t) -> {};
+    final Class<?> applicationLifecyceManagerClass = Class.forName(
+        "io.quarkus.runtime.ApplicationLifecycleManager", true, startupAction.getClassLoader());
+    final Method exitHandler = applicationLifecyceManagerClass.getMethod("setDefaultExitCodeHandler", BiConsumer.class);
     exitHandler.invoke(null, consumer);
   }
 


### PR DESCRIPTION
Fix Quarkus apprunner mojo failing from to time when trying to start the
Quarkus application with an argument mismatch error when trying to set
the default exit handler.

The issue is caused by the introduction of another method with the same
name in Quarkus ApplicationLifecycleManager, and the mojo not guarding
against/checking the method arguments.

Fix addresses this by explicitly looking for a method accepting a
BiConsumer argument.

Fixes projectnessie/nessie#357

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/358)
<!-- Reviewable:end -->
