### PR TITLE
Store generated OpenAPI schema locally

### DIFF
--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -29,6 +29,10 @@
 
   <name>Nessie - Quarkus</name>
 
+  <properties>
+    <quarkus.smallrye-openapi.store-schema-directory>${project.build.directory}/openapi</quarkus.smallrye-openapi.store-schema-directory>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.projectnessie</groupId>


### PR DESCRIPTION
Store generated OpenAPI schema during quarkus server build under
servers/quarkus-server/target/openapi.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/360)
<!-- Reviewable:end -->
