### PR TITLE
Move backend api/model classes to their own module

### DIFF
--- a/backends/dynamodb/pom.xml
+++ b/backends/dynamodb/pom.xml
@@ -32,7 +32,7 @@
   <dependencies>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-model</artifactId>
+      <artifactId>nessie-backends-spi</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/AbstractEntityDynamoDbBackend.java
+++ b/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/AbstractEntityDynamoDbBackend.java
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
 import com.dremio.nessie.backend.EntityBackend;
-import com.dremio.nessie.model.VersionedWrapper;
+import com.dremio.nessie.backend.VersionedWrapper;
 
 import io.opentracing.Scope;
 import io.opentracing.Span;

--- a/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/DynamoDbBackend.java
+++ b/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/DynamoDbBackend.java
@@ -21,9 +21,9 @@ import java.net.URI;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
 import com.dremio.nessie.backend.Backend;
+import com.dremio.nessie.backend.BranchControllerObject;
+import com.dremio.nessie.backend.BranchControllerReference;
 import com.dremio.nessie.backend.EntityBackend;
-import com.dremio.nessie.model.BranchControllerObject;
-import com.dremio.nessie.model.BranchControllerReference;
 
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;

--- a/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/GitObjectDynamoDbBackend.java
+++ b/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/GitObjectDynamoDbBackend.java
@@ -21,10 +21,9 @@ import java.util.Map;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
-import com.dremio.nessie.model.BranchControllerObject;
-import com.dremio.nessie.model.ImmutableBranchControllerObject;
-import com.dremio.nessie.model.ImmutableBranchControllerObject.Builder;
-import com.dremio.nessie.model.VersionedWrapper;
+import com.dremio.nessie.backend.BranchControllerObject;
+import com.dremio.nessie.backend.ImmutableBranchControllerObject;
+import com.dremio.nessie.backend.VersionedWrapper;
 
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -61,7 +60,7 @@ public class GitObjectDynamoDbBackend extends
   @Override
   protected VersionedWrapper<BranchControllerObject> fromDynamoDB(
       Map<String, AttributeValue> from) {
-    Builder builder = ImmutableBranchControllerObject.builder();
+    ImmutableBranchControllerObject.Builder builder = ImmutableBranchControllerObject.builder();
     byte[] data = from.get("data").b().asByteArray();
     builder.data(data.length == 1 && data[0] == ((byte) -1) ? new byte[0] : data)
            .id(from.get("uuid").s())

--- a/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/GitRefDynamoDbBackend.java
+++ b/backends/dynamodb/src/main/java/com/dremio/nessie/backend/dynamodb/GitRefDynamoDbBackend.java
@@ -21,10 +21,9 @@ import java.util.Map;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
-import com.dremio.nessie.model.BranchControllerReference;
-import com.dremio.nessie.model.ImmutableBranchControllerReference;
-import com.dremio.nessie.model.ImmutableBranchControllerReference.Builder;
-import com.dremio.nessie.model.VersionedWrapper;
+import com.dremio.nessie.backend.BranchControllerReference;
+import com.dremio.nessie.backend.ImmutableBranchControllerReference;
+import com.dremio.nessie.backend.VersionedWrapper;
 
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -55,7 +54,7 @@ public class GitRefDynamoDbBackend extends
   @Override
   protected VersionedWrapper<BranchControllerReference> fromDynamoDB(
       Map<String, AttributeValue> from) {
-    Builder builder = ImmutableBranchControllerReference.builder();
+    ImmutableBranchControllerReference.Builder builder = ImmutableBranchControllerReference.builder();
     builder.refId(from.get("ref").s())
            .id(from.get("uuid").s())
            .updateTime(Long.parseLong(from.get("updateTime").n()));

--- a/backends/dynamodb/src/test/java/com/dremio/nessie/backend/dynamodb/ITTestDynamo.java
+++ b/backends/dynamodb/src/test/java/com/dremio/nessie/backend/dynamodb/ITTestDynamo.java
@@ -27,11 +27,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.dremio.nessie.backend.Backend;
-import com.dremio.nessie.model.BranchControllerObject;
-import com.dremio.nessie.model.BranchControllerReference;
-import com.dremio.nessie.model.ImmutableBranchControllerObject;
-import com.dremio.nessie.model.ImmutableBranchControllerReference;
-import com.dremio.nessie.model.VersionedWrapper;
+import com.dremio.nessie.backend.BranchControllerObject;
+import com.dremio.nessie.backend.BranchControllerReference;
+import com.dremio.nessie.backend.ImmutableBranchControllerObject;
+import com.dremio.nessie.backend.ImmutableBranchControllerReference;
+import com.dremio.nessie.backend.VersionedWrapper;
 
 import io.smallrye.metrics.MetricRegistries;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;

--- a/backends/simple/pom.xml
+++ b/backends/simple/pom.xml
@@ -32,7 +32,7 @@
   <dependencies>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-model</artifactId>
+      <artifactId>nessie-backends-spi</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/backends/simple/src/main/java/com/dremio/nessie/backend/simple/InMemory.java
+++ b/backends/simple/src/main/java/com/dremio/nessie/backend/simple/InMemory.java
@@ -22,10 +22,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.dremio.nessie.backend.Backend;
+import com.dremio.nessie.backend.BranchControllerObject;
+import com.dremio.nessie.backend.BranchControllerReference;
 import com.dremio.nessie.backend.EntityBackend;
-import com.dremio.nessie.model.BranchControllerObject;
-import com.dremio.nessie.model.BranchControllerReference;
-import com.dremio.nessie.model.VersionedWrapper;
+import com.dremio.nessie.backend.VersionedWrapper;
 
 /**
  * basic class to demonstrate the backend model. WARNING do not use in production.

--- a/backends/spi/pom.xml
+++ b/backends/spi/pom.xml
@@ -21,18 +21,19 @@
 
   <parent>
     <groupId>org.projectnessie</groupId>
-    <artifactId>nessie</artifactId>
+    <artifactId>nessie-backends</artifactId>
     <version>0.2.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>nessie-backends</artifactId>
-  <packaging>pom</packaging>
+  <artifactId>nessie-backends-spi</artifactId>
 
-  <name>Nessie - Backends</name>
+  <name>Nessie - Versioned Store SPI</name>
 
-  <modules>
-    <module>dynamodb</module>
-    <module>simple</module>
-    <module>spi</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/backends/spi/src/main/java/com/dremio/nessie/backend/Backend.java
+++ b/backends/spi/src/main/java/com/dremio/nessie/backend/Backend.java
@@ -16,10 +16,6 @@
 
 package com.dremio.nessie.backend;
 
-
-import com.dremio.nessie.model.BranchControllerObject;
-import com.dremio.nessie.model.BranchControllerReference;
-
 /**
  * Backend for all interactions between database and the Nessie Server.
  *

--- a/backends/spi/src/main/java/com/dremio/nessie/backend/BranchControllerObject.java
+++ b/backends/spi/src/main/java/com/dremio/nessie/backend/BranchControllerObject.java
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-package com.dremio.nessie.model;
+package com.dremio.nessie.backend;
 
 import org.immutables.value.Value;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableBranchControllerReference.class)
-@JsonDeserialize(as = ImmutableBranchControllerReference.class)
-public abstract class BranchControllerReference implements Base {
+public abstract class BranchControllerObject {
 
-  public abstract String getRefId();
+  public abstract byte[] getData();
+
+  public abstract int getType();
 
   public abstract long getUpdateTime();
 

--- a/backends/spi/src/main/java/com/dremio/nessie/backend/BranchControllerReference.java
+++ b/backends/spi/src/main/java/com/dremio/nessie/backend/BranchControllerReference.java
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-package com.dremio.nessie.model;
+package com.dremio.nessie.backend;
 
 import org.immutables.value.Value;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableBranchControllerObject.class)
-@JsonDeserialize(as = ImmutableBranchControllerObject.class)
-public abstract class BranchControllerObject implements Base {
+public abstract class BranchControllerReference {
 
-  public abstract byte[] getData();
-
-  public abstract int getType();
+  public abstract String getRefId();
 
   public abstract long getUpdateTime();
 

--- a/backends/spi/src/main/java/com/dremio/nessie/backend/EntityBackend.java
+++ b/backends/spi/src/main/java/com/dremio/nessie/backend/EntityBackend.java
@@ -20,8 +20,6 @@ package com.dremio.nessie.backend;
 import java.util.List;
 import java.util.Map;
 
-import com.dremio.nessie.model.VersionedWrapper;
-
 
 /**
  * Backend for a single type of API object (eg Tag/Table/User etc).
@@ -30,7 +28,7 @@ import com.dremio.nessie.model.VersionedWrapper;
  *   This class handles all database backend operations with the Server for a particular
  *   data type. The database is expected to provide strong consistency and to keep a version
  *   attribute to facilitate optimistic locking of individual records.
- *   {@link com.dremio.nessie.model.VersionedWrapper} holds the data object and the optimistic
+ *   {@link com.dremio.nessie.backend.VersionedWrapper} holds the data object and the optimistic
  *   locking attribute as a pair.
  * </p>
  *

--- a/backends/spi/src/main/java/com/dremio/nessie/backend/VersionedWrapper.java
+++ b/backends/spi/src/main/java/com/dremio/nessie/backend/VersionedWrapper.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.dremio.nessie.model;
+package com.dremio.nessie.backend;
 
 /**
  * wrap object with a version id. For eTag &amp; Match-If

--- a/versioned/jgit/pom.xml
+++ b/versioned/jgit/pom.xml
@@ -54,7 +54,7 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-model</artifactId>
+      <artifactId>nessie-backends-spi</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/versioned/jgit/src/main/java/com/dremio/nessie/versioned/impl/experimental/NessieObjDatabase.java
+++ b/versioned/jgit/src/main/java/com/dremio/nessie/versioned/impl/experimental/NessieObjDatabase.java
@@ -43,10 +43,10 @@ import org.eclipse.jgit.lib.ObjectLoader.SmallObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.dremio.nessie.backend.BranchControllerObject;
 import com.dremio.nessie.backend.EntityBackend;
-import com.dremio.nessie.model.BranchControllerObject;
-import com.dremio.nessie.model.ImmutableBranchControllerObject;
-import com.dremio.nessie.model.VersionedWrapper;
+import com.dremio.nessie.backend.ImmutableBranchControllerObject;
+import com.dremio.nessie.backend.VersionedWrapper;
 
 /**
  * Object databse for Nessie. This uses dynamodb to store git objects.

--- a/versioned/jgit/src/main/java/com/dremio/nessie/versioned/impl/experimental/NessieRefDatabase.java
+++ b/versioned/jgit/src/main/java/com/dremio/nessie/versioned/impl/experimental/NessieRefDatabase.java
@@ -32,10 +32,10 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Ref.Storage;
 import org.eclipse.jgit.util.RefList;
 
+import com.dremio.nessie.backend.BranchControllerReference;
 import com.dremio.nessie.backend.EntityBackend;
-import com.dremio.nessie.model.BranchControllerReference;
-import com.dremio.nessie.model.ImmutableBranchControllerReference;
-import com.dremio.nessie.model.VersionedWrapper;
+import com.dremio.nessie.backend.ImmutableBranchControllerReference;
+import com.dremio.nessie.backend.VersionedWrapper;
 
 public class NessieRefDatabase extends DfsRefDatabase {
 

--- a/versioned/jgit/src/main/java/com/dremio/nessie/versioned/impl/experimental/NessieRepository.java
+++ b/versioned/jgit/src/main/java/com/dremio/nessie/versioned/impl/experimental/NessieRepository.java
@@ -24,9 +24,9 @@ import org.eclipse.jgit.internal.storage.dfs.DfsRepository;
 import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryBuilder;
 import org.eclipse.jgit.lib.RefDatabase;
 
+import com.dremio.nessie.backend.BranchControllerObject;
+import com.dremio.nessie.backend.BranchControllerReference;
 import com.dremio.nessie.backend.EntityBackend;
-import com.dremio.nessie.model.BranchControllerObject;
-import com.dremio.nessie.model.BranchControllerReference;
 
 public class NessieRepository extends DfsRepository {
 


### PR DESCRIPTION
Move backend api/model classes from model to backends/spi module as
those are not required in order to use/implement the Nessie REST api.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/361)
<!-- Reviewable:end -->
