### PR TITLE
Switch delta repository from github to gcs nessie-maven

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,8 +65,6 @@ jobs:
           ${{ runner.os }}-node-
     - name: Build with Maven
       run: mvn -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage,jdk8-tests
-      env:
-        GITHUB_TOKEN: ${{ github.token }} 
     - name: Capture test results
       uses: actions/upload-artifact@v2
       with:

--- a/README.md
+++ b/README.md
@@ -54,15 +54,7 @@ cd nessie
 
 #### Delta Lake artifacts
 
-Nessie required some minor changes to Delta for full support of branching and history. These changes are currently being integrated into the [mainline repo](https://github.com/delta-io/delta). Until these have been merged we have provided custom builds in [our fork](https://github.com/projectnessie/delta) which can be downloaded from Github Packages's maven repo. Please follow the instructions [here](https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-apache-maven-for-use-with-github-packages#authenticating-to-github-packages) to obtain a github PAT and updating `settings.xml` accordingly. An additional `server` is requiured in your `settings.xml`:
-
-``` xml
-    <server>
-      <id>github</id>
-      <username>__github__username__</username>
-      <password>__github__pat__</password>
-    </server>
-```
+Nessie required some minor changes to Delta for full support of branching and history. These changes are currently being integrated into the [mainline repo](https://github.com/delta-io/delta). Until these have been merged we have provided custom builds in [our fork](https://github.com/projectnessie/delta) which can be downloaded from a separate maven repository. 
 
 ### Distribution
 To run:

--- a/clients/deltalake/core/pom.xml
+++ b/clients/deltalake/core/pom.xml
@@ -33,7 +33,7 @@
     <repository>
       <id>github</id>
       <name>Nessie Delta custom Repository</name>
-      <url>https://maven.pkg.github.com/projectnessie/delta</url>
+      <url>https://storage.googleapis.com/nessie-maven</url>
     </repository>
   </repositories>
 

--- a/clients/deltalake/spark2/pom.xml
+++ b/clients/deltalake/spark2/pom.xml
@@ -145,7 +145,7 @@
     <repository>
       <id>github</id>
       <name>Nessie Delta custom Repository</name>
-      <url>https://maven.pkg.github.com/projectnessie/delta</url>
+      <url>https://storage.googleapis.com/nessie-maven</url>
     </repository>
   </repositories>
 

--- a/clients/deltalake/spark3/pom.xml
+++ b/clients/deltalake/spark3/pom.xml
@@ -145,7 +145,7 @@
     <repository>
       <id>github</id>
       <name>Nessie Delta custom Repository</name>
-      <url>https://maven.pkg.github.com/projectnessie/delta</url>
+      <url>https://storage.googleapis.com/nessie-maven</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Switch repository used to download delta-core artifacts from github
registry to google cloud storage bucket nessie-maven. The new artifacts
are fully public, meaning people do not have to setup credentials to
access them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/370)
<!-- Reviewable:end -->
