### PR TITLE
Add talisman scanner to pre-commit hooks

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -26,3 +26,12 @@ repos:
     - id: mixed-line-ending
     - id: check-yaml
     - id: end-of-file-fixer
+-   repo: local
+    hooks:
+    - id: talisman-precommit
+      name: talisman
+      entry: bash -c 'if [ -n "${TALISMAN_HOME:-}" ]; then ${TALISMAN_HOME}/talisman_hook_script pre-commit; else echo "TALISMAN does not exist. Consider installing from https://github.com/thoughtworks/talisman . If you already have talisman installed, please ensure TALISMAN_HOME variable is set to where talisman_hook_script resides, for example, TALISMAN_HOME=${HOME}/.talisman/bin"; fi'
+      language: system
+      pass_filenames: false
+      types: [text]
+      verbose: true


### PR DESCRIPTION
Add Talisman secret scanning for those using optional [pre-commit](https://pre-commit.com/) hooks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/468)
<!-- Reviewable:end -->
