### PR TITLE
Fix REST API basepath

### DIFF
--- a/ui/src/utils/api-wrapper.tsx
+++ b/ui/src/utils/api-wrapper.tsx
@@ -15,9 +15,10 @@
  */
 
 import {DefaultApi} from "./api/apis";
+import {Configuration} from "./api";
 
 function api() {
-  return new DefaultApi();
+  return new DefaultApi(new Configuration({"basePath": ""}));
 }
 
 export {api};


### PR DESCRIPTION
Default REST API basepath used by UI is http://localhost, which causes
REST calls to fail if server is not hosted under the same endpoint.

Change the UI code to use a relative path instead of an absolute one.

Fix projectnessie/nessie#478

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/479)
<!-- Reviewable:end -->
