### PR TITLE
Remove unused jib-maven-plugin from pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,11 +574,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>com.google.cloud.tools</groupId>
-          <artifactId>jib-maven-plugin</artifactId>
-          <version>2.6.0</version>
-        </plugin>
-        <plugin>
           <groupId>com.google.code.maven-replacer-plugin</groupId>
           <artifactId>replacer</artifactId>
           <version>1.5.3</version>


### PR DESCRIPTION
Project now relies on Quarkus image builder to produce docker images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/539)
<!-- Reviewable:end -->
