### PR TITLE
Fix build issue on OSX, net.alchim31.maven:scala-maven-plugin confuses the classpath

### DIFF
--- a/clients/deltalake/core/pom.xml
+++ b/clients/deltalake/core/pom.xml
@@ -42,17 +42,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <configuration>
-          <sendJavaToScalac>false</sendJavaToScalac>
-          <scalaVersion>${scala2.12.version}</scalaVersion>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala2.12.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>scala-compile-first</id>
@@ -124,17 +113,6 @@
           <plugin>
             <groupId>net.alchim31.maven</groupId>
             <artifactId>scala-maven-plugin</artifactId>
-            <configuration>
-              <sendJavaToScalac>false</sendJavaToScalac>
-              <scalaVersion>${scala2.12.version}</scalaVersion>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>${scala2.12.version}</version>
-              </dependency>
-            </dependencies>
             <executions>
               <execution>
                 <id>scala-compile-first</id>

--- a/clients/deltalake/core/pom.xml
+++ b/clients/deltalake/core/pom.xml
@@ -44,7 +44,15 @@
         <artifactId>scala-maven-plugin</artifactId>
         <configuration>
           <sendJavaToScalac>false</sendJavaToScalac>
+          <scalaVersion>${scala2.12.version}</scalaVersion>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala2.12.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>scala-compile-first</id>
@@ -118,7 +126,15 @@
             <artifactId>scala-maven-plugin</artifactId>
             <configuration>
               <sendJavaToScalac>false</sendJavaToScalac>
+              <scalaVersion>${scala2.12.version}</scalaVersion>
             </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>${scala2.12.version}</version>
+              </dependency>
+            </dependencies>
             <executions>
               <execution>
                 <id>scala-compile-first</id>

--- a/clients/deltalake/spark2/pom.xml
+++ b/clients/deltalake/spark2/pom.xml
@@ -188,17 +188,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <configuration>
-          <sendJavaToScalac>false</sendJavaToScalac>
-          <scalaVersion>${scala2.12.version}</scalaVersion>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala2.12.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>scala-compile-first</id>

--- a/clients/deltalake/spark2/pom.xml
+++ b/clients/deltalake/spark2/pom.xml
@@ -190,7 +190,15 @@
         <artifactId>scala-maven-plugin</artifactId>
         <configuration>
           <sendJavaToScalac>false</sendJavaToScalac>
+          <scalaVersion>${scala2.12.version}</scalaVersion>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala2.12.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>scala-compile-first</id>

--- a/clients/deltalake/spark3/pom.xml
+++ b/clients/deltalake/spark3/pom.xml
@@ -188,17 +188,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <configuration>
-          <sendJavaToScalac>false</sendJavaToScalac>
-          <scalaVersion>${scala2.12.version}</scalaVersion>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala2.12.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>scala-compile-first</id>

--- a/clients/deltalake/spark3/pom.xml
+++ b/clients/deltalake/spark3/pom.xml
@@ -190,7 +190,15 @@
         <artifactId>scala-maven-plugin</artifactId>
         <configuration>
           <sendJavaToScalac>false</sendJavaToScalac>
+          <scalaVersion>${scala2.12.version}</scalaVersion>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala2.12.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>scala-compile-first</id>

--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,17 @@
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
           <version>4.4.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.scala-lang</groupId>
+              <artifactId>scala-library</artifactId>
+              <version>${scala2.12.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <sendJavaToScalac>false</sendJavaToScalac>
+            <scalaVersion>${scala2.12.version}</scalaVersion>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
     <serverless.version>1.5</serverless.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <slf4j.version>1.7.30</slf4j.version>
+    <scala2.12.version>2.12.12</scala2.12.version>
     <spark2.version>2.4.2</spark2.version>
     <spark2.jersey.version>2.22.2</spark2.jersey.version>
     <spark2.jackson.version>2.8.8</spark2.jackson.version>


### PR DESCRIPTION
On OSX it (may?) happen that the Nessie build fails with errors like this:

```
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.4.0:compile (scala-compile-first) on project nessie-deltalake-spark2: Execution scala-compile-first of goal net.alchim31.maven:scala-maven-plugin:4.4.0:compile failed: A required class was missing while executing net.alchim31.maven:scala-maven-plugin:4.4.0:compile: scala/Function1
...
[ERROR] urls[31] = file:/Users/snazy/.m2/repository/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar
[ERROR] urls[57] = file:/Users/snazy/.m2/repository/org/scala-lang/scala-reflect/2.12.8/scala-reflect-2.12.8.jar
...
[ERROR]
[ERROR] -----------------------------------------------------
[ERROR] : scala.Function1
```

I.e. despite it should use 2.12.12 everywhere, the classpath for the plugin/compiler gets messed up. Just putting in `<scalaVersion>2.12.12</scalaVersion>` into the plugin configuration didn't help, but adding an explicit `<dependency>` to the plugin works. I left the `<scalaVersion>` configuration, because IIRC that's the one passed to zinc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/552)
<!-- Reviewable:end -->
