### PR TITLE
put jersey client onto the hive shaded classpath

### DIFF
--- a/clients/hmsbridge/hive2/pom.xml
+++ b/clients/hmsbridge/hive2/pom.xml
@@ -205,7 +205,6 @@
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
       <version>2.22.2</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
@@ -250,15 +249,49 @@
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <artifactSet>
                 <includes>
-                  <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
-                  <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
                   <include>org.projectnessie</include>
+                  <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
                   <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+                  <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
+                  <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                  <include>com.fasterxml.jackson.core:jackson-databind</include>
+                  <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>javax.activation:javax.activation-api</include>
+                  <include>javax.inject</include>
+                  <include>javax.ws.rs:javax.ws.rs-api</include>
+                  <include>javax.annotation:javax.annotation</include>
+                  <include>javax.annotation:javax.annotation-api</include>
+                  <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
+                  <include>org.glassfish.jersey.core:jersey-common</include>
                   <include>org.glassfish.jersey.ext:jersey-entity-filtering</include>
+                  <include>org.glassfish.jersey.client:jersey-client</include>
+                  <include>org.glassfish.jersey.bundles.repackaged:jersey-guava</include>
+                  <include>org.glassfish.jersey.core:jersey-client</include>
+                  <include>org.glassfish.hk2:osgi-resource-locator</include>
+                  <include>org.glassfish.hk2:hk2-api</include>
+                  <include>org.glassfish.hk2:hk2-utils</include>
+                  <include>org.glassfish.hk2.external:aopalliance-repackaged</include>
+                  <include>org.glassfish.hk2.external:javax.inject</include>
+                  <include>org.glassfish.hk2:hk2-locator</include>
                 </includes>
               </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>org.glassfish.jersey</pattern>
+                  <shadedPattern>nessie.org.glassfish.jersey</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.ws.rs</pattern>
+                  <shadedPattern>nessie.javax.ws.rs</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>nessie.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+              </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>


### PR DESCRIPTION
Hive 2.3.x has only jax-rs 1.1 by default. This PR adds jax-rs 2.0 to the shaded jar. Because 1.1 and 2.0 have overlapping classes we have to relocate most of the shaded dependencies.

Bad news: shaded jar went from 500kb to 5MB :-(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/557)
<!-- Reviewable:end -->
