### PR TITLE
Keep Python and Java code samples in sync

### DIFF
--- a/site/docs/tools/spark.md
+++ b/site/docs/tools/spark.md
@@ -63,7 +63,8 @@ These are set as follows in code (or through other methods as described [here](h
     //for a local spark instance
     conf.set("spark.hadoop.nessie.url", url)
         .set("spark.hadoop.nessie.ref", branch)
-        .set("spark.hadoop.nessie.auth_type", authType);
+        .set("spark.hadoop.nessie.auth_type", authType)
+        .set("spark.sql.catalog.nessie", "com.dremio.nessie.iceberg.spark.NessieIcebergSparkCatalog");
     spark = SparkSession.builder()
                         .master("local[2]")
                         .config(conf)


### PR DESCRIPTION
Small fix to set a Spark 3.0 Catalog to Nessie in both code samples, as originally it was only present in the Python one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/562)
<!-- Reviewable:end -->
