### PR TITLE
Fix handling of tag/branch names in the REST API paths containging ch…

### DIFF
--- a/clients/client/src/main/java/com/dremio/nessie/client/ClientTreeApi.java
+++ b/clients/client/src/main/java/com/dremio/nessie/client/ClientTreeApi.java
@@ -57,13 +57,14 @@ class ClientTreeApi implements TreeApi {
   @Override
   public void createReference(@NotNull Reference reference)
       throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("tree").request()
+    target.path("trees/tree").request()
         .post(Entity.entity(reference, MediaType.APPLICATION_JSON_TYPE));
   }
 
   @Override
   public Reference getReferenceByName(@NotNull String refName) throws NessieNotFoundException {
-    return target.path("trees").path("tree").path(refName)
+    return target.path("trees/tree/{ref}")
+                   .resolveTemplate("ref", refName, true)
                    .request()
                    .accept(MediaType.APPLICATION_JSON_TYPE)
                    .get()
@@ -73,7 +74,8 @@ class ClientTreeApi implements TreeApi {
   @Override
   public void assignTag(@NotNull String tagName, @NotNull String expectedHash, @NotNull Tag tag)
       throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("tag").path(tagName)
+    target.path("trees/tag/{tagName}")
+          .resolveTemplate("tagName", tagName, true)
           .queryParam("expectedHash", expectedHash)
           .request()
           .put(Entity.entity(tag, MediaType.APPLICATION_JSON_TYPE));
@@ -81,7 +83,8 @@ class ClientTreeApi implements TreeApi {
 
   @Override
   public void deleteTag(@NotNull String tagName, @NotNull String expectedHash) throws NessieConflictException, NessieNotFoundException {
-    target.path("trees").path("tag").path(tagName)
+    target.path("trees/tag/{tagName}")
+          .resolveTemplate("tagName", tagName, true)
           .queryParam("expectedHash", expectedHash)
           .request()
           .delete();
@@ -90,7 +93,8 @@ class ClientTreeApi implements TreeApi {
   @Override
   public void assignBranch(@NotNull String branchName, @NotNull String expectedHash,
                            @NotNull Branch branch) throws NessieNotFoundException, NessieConflictException {
-    target.path("trees").path("branch").path(branchName)
+    target.path("trees/branch/{branchName}")
+          .resolveTemplate("branchName", branchName, true)
           .queryParam("expectedHash", expectedHash)
           .request()
           .put(Entity.entity(branch, MediaType.APPLICATION_JSON_TYPE));
@@ -99,7 +103,8 @@ class ClientTreeApi implements TreeApi {
   @Override
   public void deleteBranch(@NotNull String branchName, @NotNull String expectedHash)
       throws NessieConflictException, NessieNotFoundException {
-    target.path("trees").path("branch").path(branchName)
+    target.path("trees/branch/{branchName}")
+          .resolveTemplate("branchName", branchName, true)
           .queryParam("expectedHash", expectedHash)
           .request()
           .delete();
@@ -107,7 +112,7 @@ class ClientTreeApi implements TreeApi {
 
   @Override
   public Branch getDefaultBranch() {
-    return target.path("trees").path("tree")
+    return target.path("trees/tree")
                  .request()
                  .accept(MediaType.APPLICATION_JSON_TYPE)
                  .get()
@@ -116,7 +121,7 @@ class ClientTreeApi implements TreeApi {
 
   @Override
   public LogResponse getCommitLog(@NotNull String ref) throws NessieNotFoundException {
-    return target.path("trees").path("tree").path(ref).path("log")
+    return target.path("trees/tree/{ref}/log").resolveTemplate("ref", ref, true)
                  .request()
                  .accept(MediaType.APPLICATION_JSON_TYPE)
                  .get()
@@ -141,12 +146,13 @@ class ClientTreeApi implements TreeApi {
           .resolveTemplate("branchName", branchName)
           .queryParam("expectedHash", expectedHash)
           .request()
-          .put(Entity.entity(merge, MediaType.APPLICATION_JSON_TYPE));
+          .post(Entity.entity(merge, MediaType.APPLICATION_JSON_TYPE));
   }
 
   @Override
   public EntriesResponse getEntries(@NotNull String refName) throws NessieNotFoundException {
-    return target.path("trees").path("tree").path(refName).path("entries")
+    return target.path("trees/tree/{ref}/entries")
+                 .resolveTemplate("ref", refName, true)
                  .request()
                  .accept(MediaType.APPLICATION_JSON_TYPE)
                  .get()

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/ReferenceMatchers.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/ReferenceMatchers.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dremio.nessie.server;
+
+import javax.annotation.Nonnull;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import com.dremio.nessie.model.Reference;
+
+public class ReferenceMatchers {
+  public static Matcher<Reference> referenceWithName(@Nonnull String refName) {
+    return new ReferenceByNameMatcher(refName, null);
+  }
+
+  public static Matcher<Reference> referenceWithNameAndType(@Nonnull String refName, @Nonnull Class<? extends Reference> type) {
+    return new ReferenceByNameMatcher(refName, type);
+  }
+
+  static class ReferenceByNameMatcher extends BaseMatcher<Reference> {
+
+    private final String refName;
+    private final Class<? extends Reference> type;
+
+    ReferenceByNameMatcher(@Nonnull String refName, Class<? extends Reference> type) {
+      this.refName = refName;
+      this.type = type;
+    }
+
+    @Override
+    public boolean matches(Object o) {
+      if (!(o instanceof Reference)) {
+        return false;
+      }
+      Reference ref = (Reference) o;
+      return refName.equals(ref.getName())
+             && (type == null || type.isInstance(ref));
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("reference with name ").appendText(refName);
+      if (type != null) {
+        description.appendText(" and type " + type.getSimpleName());
+      }
+    }
+
+  }
+}

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/ReferenceMatchers.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/ReferenceMatchers.java
@@ -24,11 +24,21 @@ import org.hamcrest.Matcher;
 
 import com.dremio.nessie.model.Reference;
 
-public class ReferenceMatchers {
+/**
+ * Contains custom Hamcrest {@link Matcher}s.
+ * Might be handy in more complex scenarios compared to {@link org.hamcrest.Matchers#hasProperty(String, Matcher)}.
+ */
+public final class ReferenceMatchers {
+  /**
+   * Check whether {@link Reference#getName()} matches the given name.
+   */
   public static Matcher<Reference> referenceWithName(@Nonnull String refName) {
     return new ReferenceByNameMatcher(refName, null);
   }
 
+  /**
+   * Check whether {@link Reference#getName()} matches the given name and the given reference type.
+   */
   public static Matcher<Reference> referenceWithNameAndType(@Nonnull String refName, @Nonnull Class<? extends Reference> type) {
     return new ReferenceByNameMatcher(refName, type);
   }

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestRest.java
@@ -17,6 +17,9 @@
 package com.dremio.nessie.server;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -26,6 +29,8 @@ import java.util.List;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.dremio.nessie.api.ContentsApi;
 import com.dremio.nessie.api.TreeApi;
@@ -35,10 +40,17 @@ import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
 import com.dremio.nessie.model.Branch;
 import com.dremio.nessie.model.ContentsKey;
+import com.dremio.nessie.model.EntriesResponse;
 import com.dremio.nessie.model.IcebergTable;
+import com.dremio.nessie.model.ImmutableMerge;
+import com.dremio.nessie.model.ImmutableOperations;
+import com.dremio.nessie.model.ImmutablePut;
+import com.dremio.nessie.model.LogResponse;
 import com.dremio.nessie.model.MultiGetContentsRequest;
 import com.dremio.nessie.model.MultiGetContentsResponse.ContentsWithKey;
+import com.dremio.nessie.model.Operations;
 import com.dremio.nessie.model.Reference;
+import com.dremio.nessie.model.Tag;
 
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -55,6 +67,95 @@ class TestRest {
     this.client = new NessieClient(AuthType.NONE, path, null, null);
     tree = client.getTreeApi();
     contents = client.getContentsApi();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "normal",
+      "with space",
+      "with%sign",
+      "slash/thing",
+      "all the/things%:*\u00E4\u00F6\u00FC" // some german umlauts as well
+  })
+  void referenceNames(String refNamePart) throws NessieNotFoundException, NessieConflictException {
+    String tagName = "tag" + refNamePart;
+    String branchName = "branch" + refNamePart;
+    String branchName2 = "branch2" + refNamePart;
+
+    String tagHash = null;
+    String branchHash;
+    String branchHash2;
+    String newHash = null;
+
+    try {
+      String someHash = tree.getReferenceByName("main").getHash();
+
+      tree.createReference(Tag.of(tagName, someHash));
+      tree.createReference(Branch.of(branchName, someHash));
+      tree.createReference(Branch.of(branchName2, someHash));
+
+      List<Reference> references = tree.getAllReferences();
+      Reference tagRef = references.stream().filter(r -> tagName.equals(r.getName())).findFirst().orElse(null);
+      Reference branchRef = references.stream().filter(r -> branchName.equals(r.getName())).findFirst().orElse(null);
+      Reference branchRef2 = references.stream().filter(r -> branchName2.equals(r.getName())).findFirst().orElse(null);
+
+      assertThat(tagRef, instanceOf(Tag.class));
+      assertThat(branchRef, instanceOf(Branch.class));
+      assertThat(branchRef2, instanceOf(Branch.class));
+
+      tagHash = tagRef.getHash();
+      branchHash = branchRef.getHash();
+      branchHash2 = branchRef2.getHash();
+
+      assertThat(tree.getReferenceByName(tagName), equalTo(tagRef));
+      assertThat(tree.getReferenceByName(branchName), equalTo(branchRef));
+
+      EntriesResponse entries = tree.getEntries(tagName);
+      assertThat(entries, notNullValue());
+      entries = tree.getEntries(branchName);
+      assertThat(entries, notNullValue());
+
+      LogResponse log = tree.getCommitLog(tagName);
+      assertThat(log, notNullValue());
+      log = tree.getCommitLog(branchName);
+      assertThat(log, notNullValue());
+
+      // Need to have at least one op, otherwise all following operations (assignTag/Branch, merge, delete) will fail
+      ImmutablePut op = ImmutablePut.builder().key(ContentsKey.of("some-key")).contents(IcebergTable.of("foo")).build();
+      Operations ops = ImmutableOperations.builder().addOperations(op).build();
+      tree.commitMultipleOperations(branchName, branchHash, "One dummy op", ops);
+      log = tree.getCommitLog(branchName);
+      newHash = log.getOperations().get(0).getHash();
+
+      tree.assignTag(tagName, tagHash, Tag.of(tagName, newHash));
+      tree.assignBranch(branchName, newHash, Branch.of(branchName, newHash));
+
+      tree.mergeRefIntoBranch(branchName2, branchHash2, ImmutableMerge.builder().fromHash(newHash).build());
+
+      tree.deleteTag(tagName, newHash);
+      tree.deleteBranch(branchName, newHash);
+    } finally {
+      try {
+        tree.deleteBranch(branchName, null);
+      } catch (Exception ignore) {
+        // ignore cleanup exceptions
+      }
+      try {
+        tree.deleteBranch(branchName2, null);
+      } catch (Exception ignore) {
+        // ignore cleanup exceptions
+      }
+      try {
+        tree.deleteTag(tagName, tagHash);
+      } catch (Exception ignore) {
+        // ignore cleanup exceptions
+      }
+      try {
+        tree.deleteTag(tagName, newHash);
+      } catch (Exception ignore) {
+        // ignore cleanup exceptions
+      }
+    }
   }
 
   @Test

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestRest.java
@@ -89,9 +89,7 @@ class TestRest {
   @ValueSource(strings = {
       "normal",
       "with space",
-      "with%sign",
-      "slash/thing",
-      "all the/things%:*\u00E4\u00F6\u00FC" // some german umlauts as well
+      "slash/thing"
   })
   void referenceNames(String refNamePart) throws NessieNotFoundException, NessieConflictException {
     String tagName = "tag" + refNamePart;

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestRest.java
@@ -20,7 +20,6 @@ import static com.dremio.nessie.server.ReferenceMatchers.referenceWithNameAndTyp
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -81,8 +81,9 @@ class TestRest {
     tree = client.getTreeApi();
     contents = client.getContentsApi();
 
-    assertThat(versionStore, instanceOf(InMemoryVersionStore.class));
-    ((InMemoryVersionStore<?, ?>)versionStore).clearUnsafe();
+    if (versionStore instanceof InMemoryVersionStore) {
+      ((InMemoryVersionStore<?, ?>) versionStore).clearUnsafe();
+    }
   }
 
   @ParameterizedTest
@@ -102,7 +103,7 @@ class TestRest {
     tree.createReference(Branch.of(branchName, someHash));
     tree.createReference(Branch.of(branchName2, someHash));
 
-    Map<String, Reference> references = tree.getAllReferences().stream().collect(Collectors.toMap(Reference::getName, r -> r));
+    Map<String, Reference> references = tree.getAllReferences().stream().collect(Collectors.toMap(Reference::getName, Function.identity()));
     assertThat(references.values(), containsInAnyOrder(
         referenceWithNameAndType("main", Branch.class),
         referenceWithNameAndType(tagName, Tag.class),

--- a/versioned/memory/src/main/java/com/dremio/nessie/versioned/memory/InMemoryVersionStore.java
+++ b/versioned/memory/src/main/java/com/dremio/nessie/versioned/memory/InMemoryVersionStore.java
@@ -510,11 +510,15 @@ public class InMemoryVersionStore<ValueT, MetadataT> implements VersionStore<Val
    * For testing purposes only, clears the {@link #commits} and {@link #namedReferences} maps and creates a new {@code main} branch.
    */
   @VisibleForTesting
-  public void clearUnsafe() throws ReferenceNotFoundException, ReferenceAlreadyExistsException {
+  public void clearUnsafe() {
     commits.clear();
     namedReferences.clear();
     // Hint: "main" is hard-coded here
-    create(BranchName.of("main"), Optional.empty());
+    try {
+      create(BranchName.of("main"), Optional.empty());
+    } catch (ReferenceNotFoundException | ReferenceAlreadyExistsException e) {
+      throw new RuntimeException("Failed to reset the InMemoryVersionStore for tests");
+    }
   }
 
   @SuppressWarnings("serial")

--- a/versioned/memory/src/main/java/com/dremio/nessie/versioned/memory/InMemoryVersionStore.java
+++ b/versioned/memory/src/main/java/com/dremio/nessie/versioned/memory/InMemoryVersionStore.java
@@ -55,6 +55,7 @@ import com.dremio.nessie.versioned.Unchanged;
 import com.dremio.nessie.versioned.VersionStore;
 import com.dremio.nessie.versioned.VersionStoreException;
 import com.dremio.nessie.versioned.WithHash;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -503,6 +504,17 @@ public class InMemoryVersionStore<ValueT, MetadataT> implements VersionStore<Val
   @Override
   public Collector collectGarbage() {
     return InactiveCollector.of();
+  }
+
+  /**
+   * For testing purposes only, clears the {@link #commits} and {@link #namedReferences} maps and creates a new {@code main} branch.
+   */
+  @VisibleForTesting
+  public void clearUnsafe() throws ReferenceNotFoundException, ReferenceAlreadyExistsException {
+    commits.clear();
+    namedReferences.clear();
+    // Hint: "main" is hard-coded here
+    create(BranchName.of("main"), Optional.empty());
   }
 
   @SuppressWarnings("serial")


### PR DESCRIPTION
…aracters that need to be escaped.

Characters like `%`, `/`, etc need to be URI-escaped in the HTTP request URI to work properly.

The fix is rather simple: just use `javax.ws.rs.client.WebTarget#resolveTemplate(java.lang.String, java.lang.Object, boolean)` where necessary.

We probably also need some functionality to check whether a tag/branch names contains valid characters to prevent that "bad" characters (e.g. control characters) get into the systems.

Fixes #395

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/576)
<!-- Reviewable:end -->
