### PR TITLE
Introduce `resetStoreUnsafe` operation on new `AdminApi` interface.

### DIFF
--- a/clients/client-test/pom.xml
+++ b/clients/client-test/pom.xml
@@ -21,19 +21,30 @@
 
   <parent>
     <groupId>org.projectnessie</groupId>
-    <artifactId>nessie</artifactId>
+    <artifactId>nessie-clients</artifactId>
     <version>0.2.2-SNAPSHOT</version>
   </parent>
 
-  <artifactId>nessie-server-parent</artifactId>
-  <packaging>pom</packaging>
+  <artifactId>nessie-client-test</artifactId>
 
-  <name>Nessie - Servers - Parent</name>
+  <name>Nessie - Client</name>
 
-  <modules>
-    <module>services</module>
-    <module>services-test</module>
-    <module>quarkus-server</module>
-    <module>lambda</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.1.1</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
 </project>

--- a/clients/client-test/src/main/java/com/dremio/nessie/client/ClientTestSupportApi.java
+++ b/clients/client-test/src/main/java/com/dremio/nessie/client/ClientTestSupportApi.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.client;
+
+import javax.ws.rs.client.WebTarget;
+
+import com.dremio.nessie.api.TestSupportApi;
+import com.dremio.nessie.error.NessieUnsupportedOperationException;
+
+/**
+ * Administrative interface for Nessie.
+ */
+class ClientTestSupportApi implements TestSupportApi {
+  private final WebTarget target;
+
+  ClientTestSupportApi(WebTarget target) {
+    this.target = target;
+  }
+
+  @Override
+  public void resetStoreUnsafe() throws NessieUnsupportedOperationException {
+    target.path("testSupport/resetStoreUnsafe")
+          .request()
+          .delete();
+  }
+}

--- a/clients/client-test/src/main/java/com/dremio/nessie/client/NessieTestClient.java
+++ b/clients/client-test/src/main/java/com/dremio/nessie/client/NessieTestClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.client;
+
+import com.dremio.nessie.api.TestSupportApi;
+
+public class NessieTestClient extends NessieClient {
+  private final TestSupportApi testSupport;
+
+  /**
+   * create new nessie client. All REST api endpoints are mapped here. This client should support any jaxrs implementation
+   *
+   * @param path URL for the nessie client (eg http://localhost:19120/api/v1)
+   */
+  public NessieTestClient(AuthType authType, String path, String username, String password) {
+    super(authType, path, username, password);
+    testSupport = wrap(TestSupportApi.class, new ClientTestSupportApi(target));
+  }
+
+  public TestSupportApi getTestSupportApi() {
+    return testSupport;
+  }
+}

--- a/clients/client/src/main/java/com/dremio/nessie/client/NessieClient.java
+++ b/clients/client/src/main/java/com/dremio/nessie/client/NessieClient.java
@@ -57,6 +57,7 @@ public class NessieClient implements Closeable {
     System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
   }
 
+  protected final WebTarget target;
   private final Client client;
   private final TreeApi tree;
   private final ConfigApi config;
@@ -73,7 +74,7 @@ public class NessieClient implements Closeable {
                                        .register(ResponseCheckFilter.class)
                                        .register(NessieObjectKeyConverterProvider.class)
                                        .build();
-    WebTarget target = client.target(path);
+    target = client.target(path);
     AuthFilter authFilter = new AuthFilter(authType, username, password, target);
     client.register(authFilter);
     contents = wrap(ContentsApi.class, new ClientContentsApi(target));
@@ -82,7 +83,7 @@ public class NessieClient implements Closeable {
   }
 
   @SuppressWarnings("unchecked")
-  private <T> T wrap(Class<T> iface, T delegate) {
+  protected <T> T wrap(Class<T> iface, T delegate) {
     return (T) Proxy.newProxyInstance(delegate.getClass().getClassLoader(), new Class[]{iface}, new ExceptionRewriter(delegate));
   }
 

--- a/clients/client/src/main/java/com/dremio/nessie/client/rest/ResponseCheckFilter.java
+++ b/clients/client/src/main/java/com/dremio/nessie/client/rest/ResponseCheckFilter.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.Response.Status;
 import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieError;
 import com.dremio.nessie.error.NessieNotFoundException;
+import com.dremio.nessie.error.NessieUnsupportedOperationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
@@ -62,6 +63,8 @@ public class ResponseCheckFilter implements ClientResponseFilter {
         throw new NessieForbiddenException(error);
       case INTERNAL_SERVER_ERROR:
         throw new NessieInternalServerException(error);
+      case NOT_IMPLEMENTED:
+        throw new NessieUnsupportedOperationException(error);
       default:
         throw new NessieServiceException(error);
     }

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -32,6 +32,7 @@
 
   <modules>
     <module>client</module>
+    <module>client-test</module>
     <module>hmsbridge</module>
     <module>iceberg</module>
     <module>deltalake</module>

--- a/model-test/pom.xml
+++ b/model-test/pom.xml
@@ -25,15 +25,26 @@
     <version>0.2.2-SNAPSHOT</version>
   </parent>
 
-  <artifactId>nessie-server-parent</artifactId>
-  <packaging>pom</packaging>
+  <artifactId>nessie-model-test</artifactId>
 
-  <name>Nessie - Servers - Parent</name>
+  <name>Nessie - API extension for tests</name>
 
-  <modules>
-    <module>services</module>
-    <module>services-test</module>
-    <module>quarkus-server</module>
-    <module>lambda</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.1.1</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
 </project>

--- a/model-test/src/main/java/com/dremio/nessie/api/TestSupportApi.java
+++ b/model-test/src/main/java/com/dremio/nessie/api/TestSupportApi.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.api;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+
+import com.dremio.nessie.error.NessieUnsupportedOperationException;
+
+/**
+ * Administrative interface for Nessie.
+ */
+@Path("testSupport")
+public interface TestSupportApi {
+
+  /**
+   * Reset the version store to the initial state, removing all data.
+   */
+  @DELETE
+  @Path("resetStoreUnsafe")
+  @Operation(summary = "Reset the contents store",
+             description = "This operation is only available if explicitly included in the server runtime and enabled.")
+  @APIResponses({
+      @APIResponse(responseCode = "501", description = "Operation not available.")}
+  )
+  void resetStoreUnsafe() throws NessieUnsupportedOperationException;
+
+}

--- a/model/src/main/java/com/dremio/nessie/error/NessieUnsupportedOperationException.java
+++ b/model/src/main/java/com/dremio/nessie/error/NessieUnsupportedOperationException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.error;
+
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * Indicates that a specific operation is not supported, not enabled or not implemented with the
+ * current configuration.
+ */
+public class NessieUnsupportedOperationException extends BaseNessieClientServerException {
+
+  public NessieUnsupportedOperationException(String message, Throwable cause) {
+    super(message, Status.NOT_IMPLEMENTED, cause);
+  }
+
+  public NessieUnsupportedOperationException(String message) {
+    super(message, Status.NOT_IMPLEMENTED);
+  }
+
+  public NessieUnsupportedOperationException(NessieError error) {
+    super(error);
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
 
   <modules>
     <module>model</module>
+    <module>model-test</module>
     <module>clients</module>
     <module>ui</module>
     <module>versioned</module>

--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -41,6 +41,24 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-services-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-jgit</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/servers/services-test/pom.xml
+++ b/servers/services-test/pom.xml
@@ -21,19 +21,24 @@
 
   <parent>
     <groupId>org.projectnessie</groupId>
-    <artifactId>nessie</artifactId>
+    <artifactId>nessie-server-parent</artifactId>
     <version>0.2.2-SNAPSHOT</version>
   </parent>
 
-  <artifactId>nessie-server-parent</artifactId>
-  <packaging>pom</packaging>
+  <artifactId>nessie-services-test</artifactId>
 
-  <name>Nessie - Servers - Parent</name>
+  <name>Nessie - Services for Tests</name>
 
-  <modules>
-    <module>services</module>
-    <module>services-test</module>
-    <module>quarkus-server</module>
-    <module>lambda</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-services</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/servers/services-test/src/main/java/com/dremio/nessie/services/rest/TestSupportResource.java
+++ b/servers/services-test/src/main/java/com/dremio/nessie/services/rest/TestSupportResource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dremio.nessie.services.rest;
+
+import java.security.Principal;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.dremio.nessie.api.TestSupportApi;
+import com.dremio.nessie.error.NessieUnsupportedOperationException;
+import com.dremio.nessie.model.CommitMeta;
+import com.dremio.nessie.model.Contents;
+import com.dremio.nessie.services.config.ServerConfig;
+import com.dremio.nessie.versioned.VersionStore;
+
+/**
+ * REST endpoint to retrieve server settings.
+ */
+@RequestScoped
+@Alternative
+@Priority(javax.interceptor.Interceptor.Priority.APPLICATION)
+public class TestSupportResource extends BaseResource implements TestSupportApi {
+
+  private static final Logger logger = LoggerFactory.getLogger(TestSupportResource.class);
+
+  @Inject
+  public TestSupportResource(ServerConfig config, Principal principal,
+                             VersionStore<Contents, CommitMeta> store) {
+    super(config, principal, store);
+  }
+
+  @Override
+  public void resetStoreUnsafe() throws NessieUnsupportedOperationException {
+    try {
+      getStore().resetStoreUnsafe(getConfig().getDefaultBranch());
+    } catch (UnsupportedOperationException e) {
+      throw new NessieUnsupportedOperationException("Operation not implemented");
+    }
+  }
+}

--- a/versioned/dynamodb/src/test/java/com/dremio/nessie/versioned/impl/DynamoStoreFixture.java
+++ b/versioned/dynamodb/src/test/java/com/dremio/nessie/versioned/impl/DynamoStoreFixture.java
@@ -189,6 +189,11 @@ public class DynamoStoreFixture implements VersionStore<String, String>, AutoClo
   }
 
   @Override
+  public void resetStoreUnsafe(String defaultBranch) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
   public void close() {
     store.deleteTables();
     store.close();

--- a/versioned/jgit/src/main/java/com/dremio/nessie/versioned/impl/JGitVersionStore.java
+++ b/versioned/jgit/src/main/java/com/dremio/nessie/versioned/impl/JGitVersionStore.java
@@ -556,6 +556,11 @@ public class JGitVersionStore<TABLE, METADATA> implements VersionStore<TABLE, ME
     throw new IllegalStateException("Not yet implemented.");
   }
 
+  @Override
+  public void resetStoreUnsafe(String defaultBranch) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
   private void commitTree(BranchName branch, ObjectId newTree, Optional<Hash> expectedHash, METADATA metadata, boolean force, boolean empty)
       throws IOException, ReferenceConflictException {
     ObjectInserter inserter = repository.newObjectInserter();

--- a/versioned/memory/src/main/java/com/dremio/nessie/versioned/memory/InMemoryVersionStore.java
+++ b/versioned/memory/src/main/java/com/dremio/nessie/versioned/memory/InMemoryVersionStore.java
@@ -55,7 +55,6 @@ import com.dremio.nessie.versioned.Unchanged;
 import com.dremio.nessie.versioned.VersionStore;
 import com.dremio.nessie.versioned.VersionStoreException;
 import com.dremio.nessie.versioned.WithHash;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -506,18 +505,15 @@ public class InMemoryVersionStore<ValueT, MetadataT> implements VersionStore<Val
     return InactiveCollector.of();
   }
 
-  /**
-   * For testing purposes only, clears the {@link #commits} and {@link #namedReferences} maps and creates a new {@code main} branch.
-   */
-  @VisibleForTesting
-  public void clearUnsafe() {
+  @Override
+  public void resetStoreUnsafe(String defaultBranch) {
     commits.clear();
     namedReferences.clear();
-    // Hint: "main" is hard-coded here
+
     try {
-      create(BranchName.of("main"), Optional.empty());
+      create(BranchName.of(defaultBranch), Optional.empty());
     } catch (ReferenceNotFoundException | ReferenceAlreadyExistsException e) {
-      throw new RuntimeException("Failed to reset the InMemoryVersionStore for tests");
+      throw new RuntimeException("Unexpected operation while re-creating the default branch", e);
     }
   }
 

--- a/versioned/memory/src/test/java/com/dremio/nessie/versioned/memory/ITInMemoryVersionStore.java
+++ b/versioned/memory/src/test/java/com/dremio/nessie/versioned/memory/ITInMemoryVersionStore.java
@@ -55,7 +55,7 @@ public class ITInMemoryVersionStore extends AbstractITVersionStore {
   }
 
   @Test
-  void clearUnsafe() throws Exception {
+  void resetStoreUnsafe() throws Exception {
     InMemoryVersionStore<String, String> inMemoryVersionStore = (InMemoryVersionStore<String, String>) store;
 
     BranchName fooBranch = BranchName.of("foo");
@@ -66,7 +66,7 @@ public class ITInMemoryVersionStore extends AbstractITVersionStore {
                                 Collections.singletonList(ImmutablePut.<String>builder().key(Key.of("bar")).value("baz").build()));
     assertEquals(1L, inMemoryVersionStore.getCommits(fooBranch).count());
 
-    inMemoryVersionStore.clearUnsafe();
+    inMemoryVersionStore.resetStoreUnsafe("main");
     assertThrows(ReferenceNotFoundException.class, () -> assertNull(inMemoryVersionStore.toRef("foo")));
     assertThrows(ReferenceNotFoundException.class, () -> assertNull(inMemoryVersionStore.getCommits(fooBranch)));
   }

--- a/versioned/spi/src/main/java/com/dremio/nessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/com/dremio/nessie/versioned/VersionStore.java
@@ -209,6 +209,13 @@ public interface VersionStore<VALUE, METADATA> {
   Collector collectGarbage();
 
   /**
+   * Clear all the contents. This functionality is only exposed via the Nessie REST server in test execution via the
+   * {@code nessie-services-test} artifact.
+   * @param defaultBranch name of the branch to (re-)create as the default branch
+   */
+  void resetStoreUnsafe(String defaultBranch);
+
+  /**
    * A garbage collector that can be used to collect metadata.
    */
   public interface Collector extends AutoCloseable, Iterator<CollectionProgress> {}

--- a/versioned/tiered/src/main/java/com/dremio/nessie/versioned/impl/TieredVersionStore.java
+++ b/versioned/tiered/src/main/java/com/dremio/nessie/versioned/impl/TieredVersionStore.java
@@ -471,6 +471,11 @@ public class TieredVersionStore<DATA, METADATA> implements VersionStore<DATA, ME
   }
 
   @Override
+  public void resetStoreUnsafe(String defaultBranch) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
   public void transplant(BranchName targetBranch, Optional<Hash> currentBranchHash, List<Hash> sequenceToTransplant)
       throws ReferenceNotFoundException, ReferenceConflictException {
 


### PR DESCRIPTION
PR #576 introduced a function to clear the version-store for tests before each test runs.
The the only test class using this was `TestRest` by using `@Inject` to get the version-store implementation.
That however fails with `@NativeImageTest`, because native-tests don't support `@Inject`.

So the idea here is to introduce a REST functionality to programmatically reset version-store
for test and development purposes. As none of the existing interfaces (`ConfigApi`, `TreeApi`, `ContentsApi`)
are good fits for such an "reset-unsafe" operation, this PR introduces a new `AdminApi` interface.

The `AdminApi.resetStoreUnsafe()` functionality is disabled by default and needs to be explicitly
enabled in the configuration. Later on, it should probably also get some special permissions, but that's
out of scope here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/589)
<!-- Reviewable:end -->
