### PR TITLE
Add "About Nessie" for humans

### DIFF
--- a/site/docs/features/_config
+++ b/site/docs/features/_config
@@ -1,5 +1,6 @@
 title: Features
 arrange:
   - index.md
+  - intro.md
   - transactions.md
   - management.md

--- a/site/docs/features/_config
+++ b/site/docs/features/_config
@@ -2,5 +2,6 @@ title: Features
 arrange:
   - index.md
   - intro.md
+  - best-practices.md
   - transactions.md
   - management.md

--- a/site/docs/features/best-practices.md
+++ b/site/docs/features/best-practices.md
@@ -1,0 +1,13 @@
+# Best Practices
+
+## Commit Messages
+
+Give Nessie commits a meaningful commit summary and message, like
+`aggregate-financial-stuff 2020/12/24`, so people that look through the
+history of the data can grasp what that commit changes and why it's there.
+
+## Reviews
+
+Before merging manually performed changes back, it is really helpful to
+let someone else who is familiar with the topic, the changes applied in a
+work-branch (aka "development branch"), review the changes.

--- a/site/docs/features/index.md
+++ b/site/docs/features/index.md
@@ -27,8 +27,8 @@ works fine, because data files[^1] are immutable.
 * Changes to the contents of the data lake are
   [recorded in Nessie](#working-with-data-in-nessie) as *commits* without copying
   the actual data.
-* Add [meanings to the changes](#commit-messages-and-more) to your data lake.
-* [Always-consistent](#branches) view of all the data 
+* Add [meaning to the changes](#commit-messages-and-more) to your data lake.
+* [Always-consistent](#branches) view to all the data 
 * Sets of changes, like the whole [work of a distributed Spark job](#working-branches-for-analytics-jobs).
   or [experiments of data engineers](#working-branches-for-humans) are
   isolated in Nessie via *branches*. Failed jobs do not add additional harm to the data.
@@ -49,14 +49,14 @@ A common (mis)understanding of Data Lakes is "throw everything in and see
 what happens". This might work for some time, leaving data, especially large
 amounts of data, unorganized is a rather bad idea. A common best-practice
 is still to properly organize the (immutable) data files in directories that
-reflect both orgenizational (think: units/groups in your company) and
+reflect both organizational (think: units/groups in your company) and
 structural (think: table schema) aspects.
 
 New data files can be added to the set of files for a particular table.
 Data files can also contain updates to and deletions of existing data. For
 example: if you need to make changes to the data in data-file `A`, you
 basically have to read that data-file, apply the changes and write a new
-data-file `A'` with the changes, which makes `data-file-A` irrelevant.
+data-file `A'` with the changes, which makes data-file `A` irrelevant.
 
 The amount of data held in data lakes is rather huge (GBs, TBs, PBs), and so
 is the number of tables and data files (100s of thousands, millions).
@@ -93,6 +93,7 @@ the [About Git](https://git-scm.com/about) pages as a quick start.
 | Term | Meaning in Nessie
 | --- | ---
 | Commit | An atomic change to a set of data files.
+| Hash | Nessie-commits are identified by a SHA-hash.[^3]
 | (Multi-table) transaction | Since a Nessie commit can group data data files from many tables, you can think of a Nessie commit as a (multi-table) transaction.
 | Branch | Named reference to a commit. A new commit to a branch updates the branch to the new commit.
 | Tag | Named reference to a commit. Not automatically changed.
@@ -304,14 +305,8 @@ is that Nessie-commits have only parent (predecessor). Nessie-merge operations
 technically work a bit different: the changes in branch to be merged are replayed
 on top of the target branch.
 
-It would be nice to give the commits a meaningful commit messages, like
-`aggregate-financial-stuff 2020/12/24`, so people that look through the
-history of the data can grasp what that commit changes and why it's there.
-
-Before you actually merge the data from a working-branch into the "main" branch,
-it is possible to review all the changes made by your job - either programmatically,
-like running some process that validates the state of the branch, or asking a human
-to take a look.
+It is recommended to give a commit a [meaningful commit message](./best-practices/#commit-messages)
+and to let someone [review the changes](./best-practices/#reviews).
 
 As described above in [Transactions in Nessie](#transaction-in-nessie), the merge
 operation in the above example can be considered a *Nessie distributed transaction*. 
@@ -378,7 +373,9 @@ Nessie keeps track of unused data files and collects the garbage for you.
 
 [^2]: Apache, Hive, Spark, Iceberg, Parquet are trademarks of The Apache Software Foundation.
 
-[^3]: This is a SHA-hash. All commits in Nessie (and in Git) are identified using such a hash.
+[^3]: Nessie-commits are identified by a SHA-hash. All commits in Nessie (and in Git) are
+  identified using such a hash. The value of each hash is generated from the relevant contents
+  and attributes of each commit that are stored in Nessie.
 
 [^4]: There are distributed relational databases that are not implemented as a single monolith.
   Those "proper" distributed relational databases use distributed consensus algorithms like

--- a/site/docs/features/index.md
+++ b/site/docs/features/index.md
@@ -96,13 +96,18 @@ the [About Git](https://git-scm.com/about) pages as a quick start.
 | (Multi-table) transaction | Since a Nessie commit can group data data files from many tables, you can think of a Nessie commit as a (multi-table) transaction.
 | Branch | Named reference to a commit. A new commit to a branch updates the branch to the new commit.
 | Tag | Named reference to a commit. Not automatically changed.
-| Merge | Combination of two commits. Usually applies the changes of one source-branch onto another target-branch. Creates a merge-commit.
+| Merge | Combination of two commits. Usually applies the changes of one source-branch onto another target-branch.
 
 ## Working with data in Nessie
 
 Each individual state in Nessie is defined by a *Nessie commit*.
 Each *commit* in Nessie, except the very first one, has references to its
-predecessors, the previous versions of the data.
+predecessor, the previous versions of the data.
+
+For those who know Git and merge-commits: One important difference of Nessie-merges
+is that Nessie-commits have only parent (predecessor). Nessie-merge operations
+technically work a bit different: the changes in branch to be merged are replayed
+on top of the target branch.
 
 Each *Nessie commit* also indirectly "knows" about the data files (via some metadata)
 in your data lake, which represent the state of all data in all tables.
@@ -290,13 +295,17 @@ into the "main"-branch.
                                     "main"
                                     branch
 ```
-Note that the merge-`commit #4` has references to two commits:
 
-* The previous commit on the "main" branch.
-* The merged commit from the "work"-branch is not yet recorded in Nessie.
+Technically, Nessie replays `commit #2` and `commit #3` on top of the most-recent
+commit of the "main" branch.
 
-It would be nice to give that `commit #4` a meaningful commit message, like
-`aggregate-financial-stuff 2020/12/24`, though, so people that look through the
+For those who know Git and merge-commits: One important difference of Nessie-merges
+is that Nessie-commits have only parent (predecessor). Nessie-merge operations
+technically work a bit different: the changes in branch to be merged are replayed
+on top of the target branch.
+
+It would be nice to give the commits a meaningful commit messages, like
+`aggregate-financial-stuff 2020/12/24`, so people that look through the
 history of the data can grasp what that commit changes and why it's there.
 
 Before you actually merge the data from a working-branch into the "main" branch,

--- a/site/docs/features/index.md
+++ b/site/docs/features/index.md
@@ -28,7 +28,7 @@ works fine, because data files[^1] are immutable.
   [recorded in Nessie](#working-with-data-in-nessie) as *commits* without copying
   the actual data.
 * Add [meaning to the changes](#commit-messages-and-more) to your data lake.
-* [Always-consistent](#branches) view to all the data 
+* [Always-consistent](#branches) view to all the data. 
 * Sets of changes, like the whole [work of a distributed Spark job](#working-branches-for-analytics-jobs).
   or [experiments of data engineers](#working-branches-for-humans) are
   isolated in Nessie via *branches*. Failed jobs do not add additional harm to the data.

--- a/site/docs/features/index.md
+++ b/site/docs/features/index.md
@@ -4,19 +4,19 @@ Nessie is to Data Lakes what git is to source code repositories. Therefore,
 Nessie uses many terms from both git and data lakes.
 
 This page explains how Nessie makes working with data in data lakes much easier
-without requiring much prior knowledge of either git nor data lakes.
+without requiring much prior knowledge of either git or data lakes.
 
-Nessie is designed to give users an always-consistent view to their data
-across all involved data sources (tables). Changes to your data, for example
+Nessie is designed to give users an always-consistent view of their data
+across all involved data sets (tables). Changes to your data, for example
 from batch jobs, happen independently and are completely isolated. Users will
 not see any incomplete changes. Once all the changes are done, all the changes
 can be atomically and consistently applied and become visible to your users.
 
-Nessie completely eliminates the hard and often manual work to keep track
+Nessie completely eliminates the hard and often manual work required to keep track
 of the individual data files. Nessie knows which data files are being used
 and which data files can safely be deleted.
 
-Production and staging and development can use the same data lake without risking
+Production, staging and development environments can use the same data lake without risking
 the consistent state of production data.
 
 Nessie does not copy your data, instead it references the existing data, which
@@ -26,14 +26,14 @@ works fine, because data files[^1] are immutable.
 
 * Changes to the contents of the data lake are
   [recorded in Nessie](#working-with-data-in-nessie) as *commits* without copying
-  the actual data
-* Add [meanings to the changes](#commit-messages-and-more) to your data lake
-* [Always-consistent](#branches) view to all the data 
-* Sets of changes, like the whole [work of a distributed Spark job](#working-branches-for-analytics-jobs)
-  or [experiments of data engineers](#working-branches-for-humans), are
+  the actual data.
+* Add [meanings to the changes](#commit-messages-and-more) to your data lake.
+* [Always-consistent](#branches) view of all the data 
+* Sets of changes, like the whole [work of a distributed Spark job](#working-branches-for-analytics-jobs).
+  or [experiments of data engineers](#working-branches-for-humans) are
   isolated in Nessie via *branches*. Failed jobs do not add additional harm to the data.
-* Known, fixed versions of all data can be [tagged](#tags)
-* Automatic removal of unused data files ([garbage collection](#garbage-collection))
+* Known, fixed versions of all data can be [tagged](#tags).
+* Automatic removal of unused data files ([garbage collection](#garbage-collection)).
 
 ## Data Lake 101
 

--- a/site/docs/features/index.md
+++ b/site/docs/features/index.md
@@ -1,107 +1,327 @@
-# Introduction
+# About Nessie
 
-Nessie is an OSS service and libraries that enable you to maintain multiple versions 
-of your data and leverage Git-like Branches & Tags for your Data Lake. Nessie enhances the following 
-table formats with version control techniques:
+Nessie is to Data Lakes what git is to source code repositories. Therefore,
+Nessie uses many terms from both git and data lakes.
 
-* Apache Iceberg Tables ([more](../tables/iceberg.md))
-* Delta Lake Tables ([more](../tables/deltalake.md))
-* Hive Metastore Tables ([more](../tables/hive.md))
-* SQL Views ([more](../tables/views.md))
+This page explains how Nessie makes working with data in data lakes much easier
+without requiring much prior knowledge of either git nor data lakes.
 
-## Basic Concepts
+Nessie is designed to give users an always-consistent view to their data
+across all involved data sources (tables). Changes to your data, for example
+from batch jobs, happen independently and are completely isolated. Users will
+not see any incomplete changes. Once all the changes are done, all the changes
+can be atomically and consistently applied and become visible to your users.
 
-Nessie is heavily inspired by Git. The main concepts Nessie exposes map directly to 
-[Git concepts](https://git-scm.com/book/en/v2). In most cases, you simply need to replace 
-references of files and directories in Git with Tables in Nessie. The primary concepts in Nessie are:
- 
-* Commit: Consistent snapshot of all tables at a particular point in time
-* Branch: Human-friendly reference that a user can add commits to.
-* Tag: Human-friendly reference that points to a particular commit.
-* Hash: Hexadecimal string representation of a particular commit
+Nessie completely eliminates the hard and often manual work to keep track
+of the individual data files. Nessie knows which data files are being used
+and which data files can safely be deleted.
 
-Out of the box, Nessie starts with a single branch called `main` that points to the 
-beginning of time. A user can immediately start adding tables to that branch. For example 
-(in pseudo code):
+Production and staging and development can use the same data lake without risking
+the consistent state of production data.
+
+Nessie does not copy your data, instead it references the existing data, which
+works fine, because data files[^1] are immutable.
+
+## Nessie 101
+
+* Changes to the contents of the data lake are
+  [recorded in Nessie](#working-with-data-in-nessie) as *commits* without copying
+  the actual data
+* Add [meanings to the changes](#commit-messages-and-more) to your data lake
+* [Always-consistent](#branches) view to all the data 
+* Sets of changes, like the whole [work of a distributed Spark job](#working-branches-for-analytics-jobs)
+  or [experiments of data engineers](#working-branches-for-humans), are
+  isolated in Nessie via *branches*. Failed jobs do not add additional harm to the data.
+* Known, fixed versions of all data can be [tagged](#tags)
+* Automatic removal of unused data files ([garbage collection](#garbage-collection))
+
+## Data Lake 101
+
+> *"A data lake is a system or repository of data stored in its natural/raw format,
+usually object blobs or files."* (cite from [Wikipedia](https://en.wikipedia.org/wiki/Data_lake))
+
+Data is stored in immutable data files[^1]. Each data file defines the schema of the
+data (i.e. names and types of the columns) and contains the data. A single,
+logical table (for example a `customers` or a `bank_account_transactions` table)
+consists of many data files.
+
+New data files can be added to the set of files for a particular table.
+Data files can also contain updates to and deletions of existing data.
+
+Since data lakes contain the history of all that data, it is possible to
+perform queries against the state of the data as it was at a point in time
+in the past.
+
+The amount of data held in data lakes is rather huge (GBs, TBs, PBs), and so
+is the number of tables and data files (100s of thousands, millions).
+
+Managing that amount of data and data files while keeping track of schema
+changes, for example adding or removing a column, changing a column's type,
+renaming a column in a table ("PDS", physical datasets) and views ("VDS",
+virtual datasets), is one of the things that Nessie tackles.
+
+Data in a data lake is usually consumed and written using tools like
+Apache [Hive](https://hive.apache.org)[^2] or Apache
+[Spark](https://spark.apache.org)[^2]. Your existing jobs can easily integrate
+Nessie without any production code changes, it's a simple configuration change.
+
+## git 101
+
+> *"Git is a free and open source distributed version control system designed to 
+handle everything from small to very large projects with speed and efficiency"*
+(cite from [git-scm.com](https://git-scm.com/))
+
+git maintains the history or all changes of a software project from the very
+first *commit* until the current state.
+
+git is used by humans, i.e. developers.
+
+Many of the concepts of git for source code are implemented by Nessie for all
+the data your data lake. It would be rather confusing to explain all git
+concepts here and then outline the differences in the next chapter.
+
+## Working with data in Nessie
+
+Each individual state in Nessie is defined by a *Nessie commit*.
+Each *commit* in Nessie, except the very first one, has references to its
+predecessors, the previous versions of the data.
+
+Each *Nessie commit* also "knows" about the data files in your data lake, which
+represent the state of all data in all tables.
+
+The following example illustrates that our *current commit* adds a 3rd data file.
+The other two data files 1+2 have been added by *previous commit*.
+```
+ +-------------------+       +-------------------------+
+ |  previous commit  | --<-- |     current commit      |
+ +-------------------+       +-------------------------+
+     |         |                 |        |        |
+   (add)     (add)               |        |      (add)
+     |         |                 |        |        |
+  +------+  +------+          +------+ +------+ +------+
+  | data |  | data |          | data | | data | | data |
+  | file |  | file |          | file | | file | | file |
+  | #1   |  | #2   |          | #1   | | #2   | | #3   |
+  |     _|  |     _|          |     _| |     _| |     _|
+  |  __/    |  __/            |  __/   |  __/   |  __/  
+  |_/       |_/               |_/      |_/      |_/     
+```
+In "relational SQL" you can think of the following sequence of SQL statements:
+```SQL
+BEGIN TRANSACTION;
+  -- The data for data file #1
+  INSERT INTO table_one (...) VALUES (...);
+  -- The data for data file #2
+  INSERT INTO other_table (...) VALUES (...);
+-- creates our "previous commit"
+COMMIT TRANSACTION;
+
+BEGIN TRANSACTION;
+  -- Data added to 'table_one' will "land" in a new data file #3, because
+  -- data files are immutable.
+  INSERT INTO table_one (...) VALUES (...);
+-- Creates our "current commit"
+COMMIT TRANSACTION; 
+```
+
+Each commit is identified by a sequence of hexadecimal characters like
+`2898591840e992ec5a7d5c811c58c8b42a8e0d0914f86a37badbeedeadaffe`, which is not
+easy to read and remember for us humans.
+
+### Branches
+
+Nessie uses the concept of "branches" to always reference the *latest* version
+in a chain of commits. Our example branch is named "master" and has just
+a single commit:
+```
+ +-------------+
+ |  commit #1  |
+ +-------------+
+        ^
+        |
+        |
+     "master"
+      branch
+```
+When we add changes to our "master" branch, a new `commit #2` will be created:
+
+* the new `commit #2` will reference `commit #1` as its predecessor and
+* the *named reference* "master" will be updated to point to our new `commit #2`
 
 ```
-$ create t1
-...
-$ insert 2 records into t1
-...
-$ create t2
-...
-$ insert 2 records into t2
-...
+ +-------------+       +-------------+
+ |  commit #1  | --<-- |  commit #2  |
+ +-------------+       +-------------+
+                              ^
+                              |
+                              |
+                           "master"
+                            branch
 ```
+This behavior ensures that the *named reference* "master" always points to the
+very latest version of our data.
 
-A user can then use the Nessie CLI to view the history of the main branch. You'll see 
-that each operation in Spark was automatically recorded as a commit within Nessie:
+### Working-branches for analytics jobs
 
+The above example with a single branch works well, if all changes to all tables
+can be grouped into a single commit. In a distributed world, computational work
+is distributed across many machines running many processes. All these individual
+tasks generate commits, but only the "sum" of all commits from all the tasks
+represents a consistent state.
+
+If all the tasks of a job would directly commit onto our "master" branch, the
+"master" branch would be *inconsistent* at least until not all tasks have finished.
+Further, if the whole job fails, it would be hard to rollback the changes, especially
+if other jobs are running. Last but not least, the "master" branch would contain a
+lot of commits (for example `job#213, task#47346, add 1234 rows to table x`), which
+do not make a lot of sense on their own, but a single commit (for example
+`aggregate-financial-stuff 2020/12/24`) would.
+
+To get around that issue, jobs can create a new "work"-branch when they start.
+The results from all tasks of a job are recorded as individual commits into that
+"work"-branch. Once the job has finished, all changes are then merged into the 
+"master" branch at once.
 ```
-$ nessie log
-hash4    t2 data added 
-hash3    t2 created
-hash2    t1 data added
-hash1    t1 created
+    "work"
+    branch
+      |
+      |
+      v
++-----------+ 
+| commit #1 | 
++-----------+ 
+      ^
+      |
+      |
+   "master"
+    branch
 ```
-
-A user can then create a new tag referencing this point in time. After doing 
-so, a user can continue changing the tables but that point in time snapshot will 
-maintain that version of data.
-
+Our example Spark job has two tasks, each generates a separate commit, which are only
+visible on our "work"-branch:
 ```
-$ nessie tag mytag hash4
-
-$ insert records into t1
-
-$ select count(*) from t1 join t2
-.. record 1 ..
-.. record 2 ..
-.. record 3 ..
-.. 3 records ..
-
-$ select count(*) from t1@mytag join t2@mytag
-.. record 1 ..
-.. record 2 ..
-.. only 2 records ..
+          task#1         task#2   "work"
+          result         result   branch
+            |                |     |
+            v                v     v
+      +-----------+       +-----------+
+      | commit #2 | --<-- | commit #3 |
+      +-----------+       +-----------+
+         |
+         v
+         |
++-----------+ 
+| commit #1 | 
++-----------+ 
+      ^
+      |
+      |
+   "master"
+    branch
 ```
+When the job has finished, you can merge the now consistent result back
+into the "master"-branch.
+```
+          task#1         task#2   "work"
+          result         result   branch
+            |                |     |
+            v                v     v
+      +-----------+       +-----------+
+      | commit #2 | --<-- | commit #3 |
+      +-----------+       +-----------+
+         |                          |        
+         v                          ^
+         |                          |
++-----------+                     +-----------+
+| commit #1 | --------<---------- | commit #4 |  
++-----------+                     +-----------+
+                                      ^
+                                      |
+                                      |
+                                   "master"
+                                    branch
+```
+Note that the merge-`commit #4` has references to two commits:
 
-## Data and Metadata
+* the previous commit on the "master" branch and
+* the merged commit from the "work"-branch
 
-Nessie does not make copies of your underlying data. Instead, it works to version 
-separate lists of files associated with your dataset. Whether using Spark, Hive or 
-some other tool, each mutation operation you do will add or delete one or more files from 
-the definition of your table. Nessies keeps tracks of which files are related to each 
-of your tables at every point in time and then allows you to recall those as needed.
+It would be nice to give that `commit #4` a meaningful commit message, like
+`aggregate-financial-stuff 2020/12/24`, though, so people that look through the
+history of the data can grasp what that commit changes and why it's there.
 
-## Scale & Performance
+Before you actually merge the data from a working-branch into the "master" branch,
+it is possible to review all the changes made by your job - either programmatically,
+like running some process that validates the state of the branch, or asking a human
+to take a look.
 
-Nessie is built for very large data warehouses. Nessie [supports](../develop/kernel.md) 
-millions of tables and 1000s of commits/second. Because Nessie builds on top of Iceberg 
-and Delta Lake, each table can have millions of files. As such, Nessie can support 
-data warehouses several magnitudes larger than the largest in the world today. This 
-is possible in large part due to the separation of transaction management (Nessie) from 
-table metadata management (Iceberg and Delta Lake).
+### Working branches for "humans"
 
-## Technology 
-Nessie can be [deployed in multiple ways](../try) and is composed primarily of the Nessie service, 
-which exposes a set of [REST APIs](../develop/rest.md) and a simple browse UI. This service works with multiple
-libraries to expose Nessie version control capabilities to common data management technologies.
+You can also use "developer" branches to run experiments against your data, test
+changes of your jobs, etc etc etc.
 
-Nessie was built as a Cloud native technology and is designed to be highly scalable, 
-[performant](../develop/kernel.md) and resilient. Built 
-on Java and leveraging [Quarkus](https://quarkus.io/), it is compiled to a GraalVM native image 
-that starts in less than 20ms. This makes Nessie work very well in docker and FaaS environments. 
-Nessie has a pluggable storage backend and comes pre-packaged with support for DynamoDB and local 
-storage.
+Production and staging and development can use the same data lake without risking
+the consistent state of production data.
 
-## License and Governance
-Nessie is Apache-Licensed and built in an open source, consensus-driven GitHub community. 
-Nessie was originally conceived and built by engineers at [Dremio](http://dremio.com).
+### Squashing commits
 
-## Getting Started
+Nessie can also help to reduce the amount of data files in a data lake.
 
-* Read more about [Nessie transactions](transactions.md)
-* Get started with the Nessie [quickstart](../try).
+You can for example merge all data files produces by all tasks of an analytics job
+before the whole change is actually merged into the "master" branch. Nessie will
+[figure out](#garbage-collection) that only the merged files need to survive and
+remove the unused files.
 
+### Tags
+
+Another type of named references are *tags*. Nessie *tags* are named references
+to specific commits but unlike branches do not get automatically "moved".
+
+*Tags* are useful to reference specific commits, for example a tag named
+`financial-data-of-FY2021` could reference all sources of financial data relevant
+used for some FY report.
+
+### Commit messages and more
+
+As briefly mentioned above, every commit in Nessie has a bunch of attributes.
+The probably most important ones are "summary" and "description", which are exactly
+that - meaningful summaries and detailed descriptions that explain what has been
+changed and why it has been changed. This gives data engineers the ability to know
+why something has changed.
+
+In addition to "summary" and "description", there are a bunch of additional attributes:
+
+| Attribute | Meaning
+| --- | ---
+| commit timestamp | the timestamp when the commit has been recorded in Nessie
+| committer | the one (human user, system id) that actually recorded the change in Nessie
+| author timestamp | the timestamp when a change has been implemented (can be different from the commit timestamp)
+| author | the one (human user, system id) that authored the change. can be different, if someone else actually commits the change to Nessie
+| summary | one-line meaningful summary of the changes
+| description | potentially long description of the changes
+| ... | there are potentially way more attributes, just too many to mention here
+
+## Garbage collection
+
+Data lakes contain a lot of data. The amount of data has a direct relation to
+the cost of ownership of a data lake. Keeping all data forever is probably going
+to be just too expensive, practically not useful and can also collide with data
+privacy regulations (for example GDPR or CCPA).
+
+Nessie keeps track of unused data files and collects the garbage for you.
+
+## Terms summary
+
+| Term | Meaning in Nessie
+| --- | ---
+| Commit | An atomic change to a set of data files.
+| (Multi-table) transaction | Since a Nessie commit can group data data files from many tables, you can think of a Nessie commit as a (multi-table) transaction.
+| Branch | Named reference to a commit. A new commit to a branch updates the branch to the new commit.
+| Tag | Named reference to a commit. Not automatically changed.
+| Merge | Combination of two commits. Usually applies the changes of one source-branch onto another target-branch. Creates a merge-commit.
+
+## Footnotes
+
+[^1]: Common data file formats are [Apache Iceberg Tables](../tables/iceberg.md),
+  [Delta Lake Tables](../tables/deltalake.md), [Hive Metastore Tables](../tables/hive.md)
+
+[^2]: Apache, Hive, Spark, Iceberg, Parquet are trademarks of The Apache Software Foundation.

--- a/site/docs/features/index.md
+++ b/site/docs/features/index.md
@@ -257,9 +257,9 @@ to take a look.
 ### Working branches for "humans"
 
 You can also use "developer" branches to run experiments against your data, test
-changes of your jobs, etc etc etc.
+changes of your jobs etc.
 
-Production and staging and development can use the same data lake without risking
+Production, staging and development environments can use the same data lake without risking
 the consistent state of production data.
 
 ### Squashing commits
@@ -278,12 +278,12 @@ to specific commits but unlike branches do not get automatically "moved".
 
 *Tags* are useful to reference specific commits, for example a tag named
 `financial-data-of-FY2021` could reference all sources of financial data relevant
-used for some FY report.
+used for some financial year report.
 
 ### Commit messages and more
 
-As briefly mentioned above, every commit in Nessie has a bunch of attributes.
-The probably most important ones are "summary" and "description", which are exactly
+As briefly mentioned above, every commit in Nessie has a set of attributes.
+Some of the more important ones are "summary" and "description", which are exactly
 that - meaningful summaries and detailed descriptions that explain what has been
 changed and why it has been changed. This gives data engineers the ability to know
 why something has changed.
@@ -292,10 +292,10 @@ In addition to "summary" and "description", there are a bunch of additional attr
 
 | Attribute | Meaning
 | --- | ---
-| commit timestamp | the timestamp when the commit has been recorded in Nessie
+| commit timestamp | the timestamp when the commit was recorded in Nessie
 | committer | the one (human user, system id) that actually recorded the change in Nessie
 | author timestamp | the timestamp when a change has been implemented (can be different from the commit timestamp)
-| author | the one (human user, system id) that authored the change. can be different, if someone else actually commits the change to Nessie
+| author | the one (human user, system id) that authored the change, can be different if someone else actually commits the change to Nessie
 | summary | one-line meaningful summary of the changes
 | description | potentially long description of the changes
 | ... | there are potentially way more attributes, just too many to mention here

--- a/site/docs/features/index.md
+++ b/site/docs/features/index.md
@@ -1,10 +1,10 @@
 # About Nessie
 
-Nessie is to Data Lakes what git is to source code repositories. Therefore,
-Nessie uses many terms from both git and data lakes.
+Nessie is to Data Lakes what Git is to source code repositories. Therefore,
+Nessie uses many terms from both Git and data lakes.
 
 This page explains how Nessie makes working with data in data lakes much easier
-without requiring much prior knowledge of either git or data lakes.
+without requiring much prior knowledge of either Git or data lakes.
 
 Nessie is designed to give users an always-consistent view of their data
 across all involved data sets (tables). Changes to your data, for example
@@ -48,37 +48,35 @@ consists of many data files.
 New data files can be added to the set of files for a particular table.
 Data files can also contain updates to and deletions of existing data.
 
-Since data lakes contain the history of all that data, it is possible to
-perform queries against the state of the data as it was at a point in time
-in the past.
-
 The amount of data held in data lakes is rather huge (GBs, TBs, PBs), and so
 is the number of tables and data files (100s of thousands, millions).
 
 Managing that amount of data and data files while keeping track of schema
 changes, for example adding or removing a column, changing a column's type,
-renaming a column in a table ("PDS", physical datasets) and views ("VDS",
-virtual datasets), is one of the things that Nessie tackles.
+renaming a column in a table and views, is one of the things that Nessie tackles.
 
 Data in a data lake is usually consumed and written using tools like
 Apache [Hive](https://hive.apache.org)[^2] or Apache
 [Spark](https://spark.apache.org)[^2]. Your existing jobs can easily integrate
 Nessie without any production code changes, it's a simple configuration change.
 
-## git 101
+## Git 101
 
 > *"Git is a free and open source distributed version control system designed to 
 handle everything from small to very large projects with speed and efficiency"*
 (cite from [git-scm.com](https://git-scm.com/))
 
-git maintains the history or all changes of a software project from the very
+Git maintains the history or all changes of a software project from the very
 first *commit* until the current state.
 
-git is used by humans, i.e. developers.
+Git is used by humans, i.e. developers.
 
-Many of the concepts of git for source code are implemented by Nessie for all
-the data your data lake. It would be rather confusing to explain all git
-concepts here and then outline the differences in the next chapter.
+Many of the concepts of Git for source code are implemented by Nessie for all
+the data your data lake. It would be rather confusing to explain all Git
+concepts here and then outline the differences in the next chapter. If you want
+to learn more about Git, we recommend looking this
+[Git book](https://git-scm.com/book/en/v2) (available in many languages) or
+the [About Git](https://git-scm.com/about) pages as a quick start.
 
 ## Working with data in Nessie
 
@@ -86,8 +84,8 @@ Each individual state in Nessie is defined by a *Nessie commit*.
 Each *commit* in Nessie, except the very first one, has references to its
 predecessors, the previous versions of the data.
 
-Each *Nessie commit* also "knows" about the data files in your data lake, which
-represent the state of all data in all tables.
+Each *Nessie commit* also indirectly "knows" about the data files (via some metadata)
+in your data lake, which represent the state of all data in all tables.
 
 The following example illustrates that our *current commit* adds a 3rd data file.
 The other two data files 1+2 have been added by *previous commit*.
@@ -125,13 +123,13 @@ COMMIT TRANSACTION;
 ```
 
 Each commit is identified by a sequence of hexadecimal characters like
-`2898591840e992ec5a7d5c811c58c8b42a8e0d0914f86a37badbeedeadaffe`, which is not
-easy to read and remember for us humans.
+`2898591840e992ec5a7d5c811c58c8b42a8e0d0914f86a37badbeedeadaffe`[^3], which is
+not easy to read and remember for us humans.
 
 ### Branches
 
 Nessie uses the concept of "branches" to always reference the *latest* version
-in a chain of commits. Our example branch is named "master" and has just
+in a chain of commits. Our example branch is named "main" and has just
 a single commit:
 ```
  +-------------+
@@ -140,13 +138,13 @@ a single commit:
         ^
         |
         |
-     "master"
+      "main"
       branch
 ```
-When we add changes to our "master" branch, a new `commit #2` will be created:
+When we add changes to our "main" branch, a new `commit #2` will be created:
 
 * the new `commit #2` will reference `commit #1` as its predecessor and
-* the *named reference* "master" will be updated to point to our new `commit #2`
+* the *named reference* "main" will be updated to point to our new `commit #2`
 
 ```
  +-------------+       +-------------+
@@ -155,10 +153,10 @@ When we add changes to our "master" branch, a new `commit #2` will be created:
                               ^
                               |
                               |
-                           "master"
+                            "main"
                             branch
 ```
-This behavior ensures that the *named reference* "master" always points to the
+This behavior ensures that the *named reference* "main" always points to the
 very latest version of our data.
 
 ### Working-branches for analytics jobs
@@ -169,10 +167,10 @@ is distributed across many machines running many processes. All these individual
 tasks generate commits, but only the "sum" of all commits from all the tasks
 represents a consistent state.
 
-If all the tasks of a job would directly commit onto our "master" branch, the
-"master" branch would be *inconsistent* at least until not all tasks have finished.
+If all the tasks of a job would directly commit onto our "main" branch, the
+"main" branch would be *inconsistent* at least until not all tasks have finished.
 Further, if the whole job fails, it would be hard to rollback the changes, especially
-if other jobs are running. Last but not least, the "master" branch would contain a
+if other jobs are running. Last but not least, the "main" branch would contain a
 lot of commits (for example `job#213, task#47346, add 1234 rows to table x`), which
 do not make a lot of sense on their own, but a single commit (for example
 `aggregate-financial-stuff 2020/12/24`) would.
@@ -180,7 +178,7 @@ do not make a lot of sense on their own, but a single commit (for example
 To get around that issue, jobs can create a new "work"-branch when they start.
 The results from all tasks of a job are recorded as individual commits into that
 "work"-branch. Once the job has finished, all changes are then merged into the 
-"master" branch at once.
+"main" branch at once.
 ```
     "work"
     branch
@@ -193,7 +191,7 @@ The results from all tasks of a job are recorded as individual commits into that
       ^
       |
       |
-   "master"
+    "main"
     branch
 ```
 Our example Spark job has two tasks, each generates a separate commit, which are only
@@ -215,11 +213,11 @@ visible on our "work"-branch:
       ^
       |
       |
-   "master"
+    "main"
     branch
 ```
 When the job has finished, you can merge the now consistent result back
-into the "master"-branch.
+into the "main"-branch.
 ```
           task#1         task#2   "work"
           result         result   branch
@@ -237,19 +235,19 @@ into the "master"-branch.
                                       ^
                                       |
                                       |
-                                   "master"
+                                    "main"
                                     branch
 ```
 Note that the merge-`commit #4` has references to two commits:
 
-* the previous commit on the "master" branch and
-* the merged commit from the "work"-branch
+* The previous commit on the "main" branch.
+* The merged commit from the "work"-branch is not yet recorded in Nessie.
 
 It would be nice to give that `commit #4` a meaningful commit message, like
 `aggregate-financial-stuff 2020/12/24`, though, so people that look through the
 history of the data can grasp what that commit changes and why it's there.
 
-Before you actually merge the data from a working-branch into the "master" branch,
+Before you actually merge the data from a working-branch into the "main" branch,
 it is possible to review all the changes made by your job - either programmatically,
 like running some process that validates the state of the branch, or asking a human
 to take a look.
@@ -262,43 +260,43 @@ changes of your jobs etc.
 Production, staging and development environments can use the same data lake without risking
 the consistent state of production data.
 
-### Squashing commits
+### Squashing
 
-Nessie can also help to reduce the amount of data files in a data lake.
-
-You can for example merge all data files produces by all tasks of an analytics job
-before the whole change is actually merged into the "master" branch. Nessie will
-[figure out](#garbage-collection) that only the merged files need to survive and
-remove the unused files.
+Nessie can not yet squash commits.
 
 ### Tags
 
 Another type of named references are *tags*. Nessie *tags* are named references
-to specific commits but unlike branches do not get automatically "moved".
+to specific commits. Tags do always point to the same commit and won't be changed
+automatically.
 
-*Tags* are useful to reference specific commits, for example a tag named
-`financial-data-of-FY2021` could reference all sources of financial data relevant
-used for some financial year report.
+This means, that *tags* are useful to reference specific commits, for example a tag
+named `financial-data-of-FY2021` could reference all sources of financial data
+relevant used for some financial year report.
+
+See [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) for comparison and
+to learn how tagging works in Git.
 
 ### Commit messages and more
 
 As briefly mentioned above, every commit in Nessie has a set of attributes.
 Some of the more important ones are "summary" and "description", which are exactly
 that - meaningful summaries and detailed descriptions that explain what has been
-changed and why it has been changed. This gives data engineers the ability to know
-why something has changed.
+changed and why it has been changed.
 
-In addition to "summary" and "description", there are a bunch of additional attributes:
+In addition to "summary" and "description", there are a bunch of additional attributes
+as shown in the following table. We plan to add more structure to these attributes
+in the future.
 
-| Attribute | Meaning
+| Attribute | Meaning in Nessie
 | --- | ---
-| commit timestamp | the timestamp when the commit was recorded in Nessie
-| committer | the one (human user, system id) that actually recorded the change in Nessie
-| author timestamp | the timestamp when a change has been implemented (can be different from the commit timestamp)
-| author | the one (human user, system id) that authored the change, can be different if someone else actually commits the change to Nessie
-| summary | one-line meaningful summary of the changes
-| description | potentially long description of the changes
-| ... | there are potentially way more attributes, just too many to mention here
+| commit timestamp | The timestamp when the commit was recorded in Nessie.
+| committer | The one (human user, system id) that actually recorded the change in Nessie.
+| author timestamp | the timestamp when a change has been implemented (can be different from the commit timestamp).
+| author | The one (human user, system id) that authored the change, can be different if someone else actually commits the change to Nessie.
+| summary | A short, one-line meaningful summary of the changes.
+| description | potentially long description of the changes.
+| ... | There are potentially way more attributes, just too many to mention here.
 
 ## Garbage collection
 
@@ -325,3 +323,5 @@ Nessie keeps track of unused data files and collects the garbage for you.
   [Delta Lake Tables](../tables/deltalake.md), [Hive Metastore Tables](../tables/hive.md)
 
 [^2]: Apache, Hive, Spark, Iceberg, Parquet are trademarks of The Apache Software Foundation.
+
+[^3]: This is a SHA-hash. All commits in Nessie (and in Git) are identified using such a hash.

--- a/site/docs/features/intro.md
+++ b/site/docs/features/intro.md
@@ -1,0 +1,107 @@
+# Introduction
+
+Nessie is an OSS service and libraries that enable you to maintain multiple versions 
+of your data and leverage Git-like Branches & Tags for your Data Lake. Nessie enhances the following 
+table formats with version control techniques:
+
+* Apache Iceberg Tables ([more](../tables/iceberg.md))
+* Delta Lake Tables ([more](../tables/deltalake.md))
+* Hive Metastore Tables ([more](../tables/hive.md))
+* SQL Views ([more](../tables/views.md))
+
+## Basic Concepts
+
+Nessie is heavily inspired by Git. The main concepts Nessie exposes map directly to 
+[Git concepts](https://git-scm.com/book/en/v2). In most cases, you simply need to replace 
+references of files and directories in Git with Tables in Nessie. The primary concepts in Nessie are:
+ 
+* Commit: Consistent snapshot of all tables at a particular point in time
+* Branch: Human-friendly reference that a user can add commits to.
+* Tag: Human-friendly reference that points to a particular commit.
+* Hash: Hexadecimal string representation of a particular commit
+
+Out of the box, Nessie starts with a single branch called `main` that points to the 
+beginning of time. A user can immediately start adding tables to that branch. For example 
+(in pseudo code):
+
+```
+$ create t1
+...
+$ insert 2 records into t1
+...
+$ create t2
+...
+$ insert 2 records into t2
+...
+```
+
+A user can then use the Nessie CLI to view the history of the main branch. You'll see 
+that each operation in Spark was automatically recorded as a commit within Nessie:
+
+```
+$ nessie log
+hash4    t2 data added 
+hash3    t2 created
+hash2    t1 data added
+hash1    t1 created
+```
+
+A user can then create a new tag referencing this point in time. After doing 
+so, a user can continue changing the tables but that point in time snapshot will 
+maintain that version of data.
+
+```
+$ nessie tag mytag hash4
+
+$ insert records into t1
+
+$ select count(*) from t1 join t2
+.. record 1 ..
+.. record 2 ..
+.. record 3 ..
+.. 3 records ..
+
+$ select count(*) from t1@mytag join t2@mytag
+.. record 1 ..
+.. record 2 ..
+.. only 2 records ..
+```
+
+## Data and Metadata
+
+Nessie does not make copies of your underlying data. Instead, it works to version 
+separate lists of files associated with your dataset. Whether using Spark, Hive or 
+some other tool, each mutation operation you do will add or delete one or more files from 
+the definition of your table. Nessies keeps tracks of which files are related to each 
+of your tables at every point in time and then allows you to recall those as needed.
+
+## Scale & Performance
+
+Nessie is built for very large data warehouses. Nessie [supports](../develop/kernel.md) 
+millions of tables and 1000s of commits/second. Because Nessie builds on top of Iceberg 
+and Delta Lake, each table can have millions of files. As such, Nessie can support 
+data warehouses several magnitudes larger than the largest in the world today. This 
+is possible in large part due to the separation of transaction management (Nessie) from 
+table metadata management (Iceberg and Delta Lake).
+
+## Technology 
+Nessie can be [deployed in multiple ways](../try) and is composed primarily of the Nessie service, 
+which exposes a set of [REST APIs](../develop/rest.md) and a simple browse UI. This service works with multiple
+libraries to expose Nessie version control capabilities to common data management technologies.
+
+Nessie was built as a Cloud native technology and is designed to be highly scalable, 
+[performant](../develop/kernel.md) and resilient. Built 
+on Java and leveraging [Quarkus](https://quarkus.io/), it is compiled to a GraalVM native image 
+that starts in less than 20ms. This makes Nessie work very well in docker and FaaS environments. 
+Nessie has a pluggable storage backend and comes pre-packaged with support for DynamoDB and local 
+storage.
+
+## License and Governance
+Nessie is Apache-Licensed and built in an open source, consensus-driven GitHub community. 
+Nessie was originally conceived and built by engineers at [Dremio](http://dremio.com).
+
+## Getting Started
+
+* Read more about [Nessie transactions](transactions.md)
+* Get started with the Nessie [quickstart](../try).
+

--- a/site/docs/features/intro.md
+++ b/site/docs/features/intro.md
@@ -36,7 +36,7 @@ $ insert 2 records into t2
 ```
 
 A user can then use the Nessie CLI to view the history of the main branch. You'll see 
-that each operation in Spark was automatically recorded as a commit within Nessie:
+that each operation was automatically recorded as a commit within Nessie:
 
 ```
 $ nessie log

--- a/site/docs/features/intro.md
+++ b/site/docs/features/intro.md
@@ -15,10 +15,10 @@ Nessie is heavily inspired by Git. The main concepts Nessie exposes map directly
 [Git concepts](https://git-scm.com/book/en/v2). In most cases, you simply need to replace 
 references of files and directories in Git with Tables in Nessie. The primary concepts in Nessie are:
  
-* Commit: Consistent snapshot of all tables at a particular point in time
+* Commit: Consistent snapshot of all tables at a particular point in time.
 * Branch: Human-friendly reference that a user can add commits to.
 * Tag: Human-friendly reference that points to a particular commit.
-* Hash: Hexadecimal string representation of a particular commit
+* Hash: Hexadecimal string representation of a particular commit.
 
 Out of the box, Nessie starts with a single branch called `main` that points to the 
 beginning of time. A user can immediately start adding tables to that branch. For example 
@@ -72,13 +72,13 @@ $ select count(*) from t1@mytag join t2@mytag
 Nessie does not make copies of your underlying data. Instead, it works to version 
 separate lists of files associated with your dataset. Whether using Spark, Hive or 
 some other tool, each mutation operation you do will add or delete one or more files from 
-the definition of your table. Nessies keeps tracks of which files are related to each 
+the definition of your table. Nessie keeps tracks of which files are related to each 
 of your tables at every point in time and then allows you to recall those as needed.
 
 ## Scale & Performance
 
 Nessie is built for very large data warehouses. Nessie [supports](../develop/kernel.md) 
-millions of tables and 1000s of commits/second. Because Nessie builds on top of Iceberg 
+millions of tables and thousands of commits/second. Because Nessie builds on top of Iceberg 
 and Delta Lake, each table can have millions of files. As such, Nessie can support 
 data warehouses several magnitudes larger than the largest in the world today. This 
 is possible in large part due to the separation of transaction management (Nessie) from 
@@ -86,13 +86,13 @@ table metadata management (Iceberg and Delta Lake).
 
 ## Technology 
 Nessie can be [deployed in multiple ways](../try) and is composed primarily of the Nessie service, 
-which exposes a set of [REST APIs](../develop/rest.md) and a simple browse UI. This service works with multiple
-libraries to expose Nessie version control capabilities to common data management technologies.
+which exposes a set of [REST APIs](../develop/rest.md) and a simple browser UI. This service works with multiple
+libraries to expose Nessie's version control capabilities to common data management technologies.
 
 Nessie was built as a Cloud native technology and is designed to be highly scalable, 
 [performant](../develop/kernel.md) and resilient. Built 
 on Java and leveraging [Quarkus](https://quarkus.io/), it is compiled to a GraalVM native image 
-that starts in less than 20ms. This makes Nessie work very well in docker and FaaS environments. 
+that starts in less than 20ms. This makes Nessie work very well in Docker and FaaS environments. 
 Nessie has a pluggable storage backend and comes pre-packaged with support for DynamoDB and local 
 storage.
 
@@ -104,4 +104,3 @@ Nessie was originally conceived and built by engineers at [Dremio](http://dremio
 
 * Read more about [Nessie transactions](transactions.md)
 * Get started with the Nessie [quickstart](../try).
-


### PR DESCRIPTION
Adds a new "About Nessie" page in front of the "Introduction" page.
The latter would probably require some work, as well, but getting some initial feedback would be nice.

Actually a bit disappointing that git(hub) doesn't properly detect the technical move of `site/docs/index.md` to `site/docs/intro.md` but instead considers the latter a new file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/599)
<!-- Reviewable:end -->
