### PR TITLE
Provide human readable error messages for bad REST requests

### DIFF
--- a/clients/client/src/main/java/com/dremio/nessie/client/http/HttpRequest.java
+++ b/clients/client/src/main/java/com/dremio/nessie/client/http/HttpRequest.java
@@ -20,6 +20,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -96,8 +97,14 @@ public class HttpRequest {
       con.setRequestMethod(method.name());
       if (body != null && (method.equals(Method.PUT) || method.equals(Method.POST))) {
         con.setDoOutput(true);
-        con.setRequestProperty("Content-Type", "application/json");
-        mapper.writerFor(body.getClass()).writeValue(con.getOutputStream(), body);
+        con.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+        Class<?> bodyType = body.getClass();
+        if (bodyType != String.class) {
+          mapper.writerFor(bodyType).writeValue(con.getOutputStream(), body);
+        } else {
+          // This is mostly used for testing bad/broken JSON
+          con.getOutputStream().write(((String)body).getBytes(StandardCharsets.UTF_8));
+        }
       }
       con.connect();
       con.getResponseCode(); // call to ensure http request is complete

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -71,6 +71,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/model/src/main/java/com/dremio/nessie/api/ContentsApi.java
+++ b/model/src/main/java/com/dremio/nessie/api/ContentsApi.java
@@ -15,6 +15,7 @@
  */
 package com.dremio.nessie.api;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -55,7 +56,7 @@ public interface ContentsApi {
       @APIResponse(responseCode = "404", description = "Table not found on ref")
     })
   Contents getContents(
-      @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
+      @Valid @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
       @Parameter(description = "Reference to use. Defaults to default branch if not provided.") @QueryParam("ref") String ref
       ) throws NessieNotFoundException;
 
@@ -67,7 +68,7 @@ public interface ContentsApi {
       @APIResponse(responseCode = "404", description = "Provided ref doesn't exists")})
   public MultiGetContentsResponse getMultipleContents(
       @Parameter(description = "Reference to use. Defaults to default branch if not provided.") @QueryParam("ref") String ref,
-      @NotNull @RequestBody(description = "Keys to retrieve.") MultiGetContentsRequest request)
+      @Valid @NotNull @RequestBody(description = "Keys to retrieve.") MultiGetContentsRequest request)
       throws NessieNotFoundException;
 
   /**
@@ -82,11 +83,11 @@ public interface ContentsApi {
       @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
       @APIResponse(responseCode = "412", description = "Update conflict")})
   public void setContents(
-      @NotNull @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
+      @Valid @NotNull @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
       @Parameter(description = "Branch to change. Defaults to default branch.") @QueryParam("branch") String branch,
       @NotNull @Parameter(description = "Expected hash of branch.") @QueryParam("hash") String hash,
       @Parameter(description = "Commit message") @QueryParam("message") String message,
-      @NotNull @RequestBody(description = "Contents to be upserted") Contents contents)
+      @Valid @NotNull @RequestBody(description = "Contents to be upserted") Contents contents)
       throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -102,7 +103,7 @@ public interface ContentsApi {
       }
   )
   public void deleteContents(
-      @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
+      @Valid @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
       @Parameter(description = "Branch to delete from. Defaults to default branch.") @QueryParam("branch") String branch,
       @Parameter(description = "Expected hash of branch.") @QueryParam("hash") String hash,
       @Parameter(description = "Commit message") @QueryParam("message") String message

--- a/model/src/main/java/com/dremio/nessie/api/TreeApi.java
+++ b/model/src/main/java/com/dremio/nessie/api/TreeApi.java
@@ -17,6 +17,7 @@ package com.dremio.nessie.api;
 
 import java.util.List;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -81,7 +82,7 @@ public interface TreeApi {
       @APIResponse(responseCode = "204", description = "Created successfully."),
       @APIResponse(responseCode = "409", description = "Reference already exists")
   })
-  void createReference(@NotNull @RequestBody(description = "Reference to create.") Reference reference)
+  void createReference(@Valid @NotNull @RequestBody(description = "Reference to create.") Reference reference)
       throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -142,7 +143,7 @@ public interface TreeApi {
   void assignTag(
       @NotNull @Parameter(description = "Tag name to reassign") @PathParam("tagName") String tagName,
       @NotNull @Parameter(description = "Expected previous hash of tag") @QueryParam("expectedHash") String oldHash,
-      @NotNull @RequestBody(description = "New tag content") Tag tag
+      @Valid @NotNull @RequestBody(description = "New tag content") Tag tag
       ) throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -175,7 +176,7 @@ public interface TreeApi {
   void assignBranch(
       @NotNull @Parameter(description = "Tag name to reassign") @PathParam("branchName") String branchName,
       @NotNull @Parameter(description = "Expected previous hash of tag") @QueryParam("expectedHash") String oldHash,
-      @NotNull @RequestBody(description = "New branch content") Branch branch
+      @Valid @NotNull @RequestBody(description = "New branch content") Branch branch
       ) throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -210,7 +211,7 @@ public interface TreeApi {
       @NotNull @Parameter(description = "Branch to transplant into") @PathParam("branchName") String branchName,
       @NotNull @Parameter(description = "Expected hash of tag") @QueryParam("expectedHash") String hash,
       @Parameter(description = "commit message") @QueryParam("message") String message,
-      @RequestBody(description = "Hashes to transplant") Transplant transplant)
+      @Valid @RequestBody(description = "Hashes to transplant") Transplant transplant)
           throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -228,7 +229,7 @@ public interface TreeApi {
   void mergeRefIntoBranch(
       @NotNull @Parameter(description = "Branch to merge into") @PathParam("branchName") String branchName,
       @NotNull @Parameter(description = "Expected hash of tag") @QueryParam("expectedHash") String hash,
-      @NotNull @RequestBody(description = "Merge operation") Merge merge)
+      @Valid @NotNull @RequestBody(description = "Merge operation") Merge merge)
           throws NessieNotFoundException, NessieConflictException;
 
   @POST
@@ -243,6 +244,6 @@ public interface TreeApi {
       @NotNull @Parameter(description = "Branch to change, defaults to default branch.") @PathParam("branchName") String branchName,
       @NotNull @Parameter(description = "Expected hash of branch.") @QueryParam("expectedHash") String hash,
       @Parameter(description = "Commit message") @QueryParam("message") String message,
-      @NotNull @RequestBody(description = "Operations") Operations operations)
+      @Valid @NotNull @RequestBody(description = "Operations") Operations operations)
       throws NessieNotFoundException, NessieConflictException;
 }

--- a/model/src/main/java/com/dremio/nessie/error/NessieError.java
+++ b/model/src/main/java/com/dremio/nessie/error/NessieError.java
@@ -31,6 +31,13 @@ public class NessieError {
   private final String serverStackTrace;
   private final Exception clientProcessingException;
 
+  /**
+   * Deserialize error message from the server.
+   *
+   * @param message Error message
+   * @param status HTTP status code
+   * @param serverStackTrace exception, if present (can be empty or {@code null}
+   */
   @JsonCreator
   public NessieError(
       @JsonProperty("message") String message,
@@ -102,18 +109,28 @@ public class NessieError {
    */
   @JsonIgnore
   public String getFullMessage() {
-    if (serverStackTrace != null) {
-      return String.format("%s\nStatus Code: %d (%s)\nServer Stack Trace:\n%s", message,
-                           status, reason, serverStackTrace);
+    StringBuilder sb = new StringBuilder();
+    if (reason != null) {
+      sb.append(reason)
+        .append(" (HTTP/").append(status).append(')');
     }
 
+    if (message != null) {
+      if (sb.length() > 0) {
+        sb.append(": ");
+      }
+      sb.append(message);
+    }
+
+    if (serverStackTrace != null) {
+      sb.append("\n").append(serverStackTrace);
+    }
     if (clientProcessingException != null) {
       StringWriter sw = new StringWriter();
       clientProcessingException.printStackTrace(new PrintWriter(sw));
-      return String.format("%s\nStatus Code: %d (%s)\nClient Processing Failure:\n%s", message,
-                           status, reason, sw.toString());
+      sb.append("\n").append(sw);
     }
-    return message;
+    return sb.toString();
   }
 
   @Override

--- a/model/src/test/java/com/dremio/nessie/error/TestNessieError.java
+++ b/model/src/test/java/com/dremio/nessie/error/TestNessieError.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.error;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+
+class TestNessieError {
+  @Test
+  void allNulls() {
+    NessieError e = new NessieError(0, null, null, null);
+    assertNull(e.getMessage());
+  }
+
+  @Test
+  void userContructor() {
+    NessieError e = new NessieError(
+        "message",
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+        Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+        "foo.bar.InternalServerError\n"
+        + "\tat some.other.Class",
+        new Exception("processingException"));
+    assertEquals(
+        "message",
+        e.getMessage());
+    assertThat(
+        e.getFullMessage(),
+        startsWith(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase()
+                   + " (HTTP/" + Response.Status.INTERNAL_SERVER_ERROR.getStatusCode() + "): message\n"
+                   + "foo.bar.InternalServerError\n"
+                   + "\tat some.other.Class\n"
+                   + "java.lang.Exception: processingException\n"
+                   + "\tat com.dremio.nessie.error.TestNessieError.userContructor(TestNessieError.java:"));
+  }
+
+  @Test
+  void jsonCreator() {
+    NessieError e = new NessieError(
+        "message",
+        Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+        Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+        "foo.bar.InternalServerError\n"
+        + "\tat some.other.Class");
+    assertAll(
+        () -> assertEquals(
+            Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase()
+            + " (HTTP/" + Response.Status.INTERNAL_SERVER_ERROR.getStatusCode() + "): message\n"
+            + "foo.bar.InternalServerError\n"
+            + "\tat some.other.Class",
+            e.getFullMessage()),
+        () -> assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                           e.getStatus()),
+        () -> assertEquals("message",
+                           e.getMessage()),
+        () -> assertEquals(
+            "foo.bar.InternalServerError\n"
+            + "\tat some.other.Class",
+            e.getServerStackTrace())
+    );
+  }
+
+}

--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -59,6 +59,14 @@
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-core-spi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>

--- a/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/BaseExceptionMapper.java
+++ b/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/BaseExceptionMapper.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.server.providers;
+
+import java.util.function.Consumer;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.dremio.nessie.error.NessieError;
+import com.dremio.nessie.services.config.ServerConfig;
+import com.google.common.base.Throwables;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableInstance;
+
+/**
+ * Code shared between concrete exception-mapper implementations.
+ */
+abstract class BaseExceptionMapper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseExceptionMapper.class);
+
+  protected BaseExceptionMapper() {
+    // empty
+  }
+
+  Response buildExceptionResponse(
+      int status,
+      String reason,
+      String message,
+      Exception e) {
+
+    // Must not use `@Inject ServerConfig serverConfig`, because once that's being used
+    // for our exception-mappers, it will actually not be injected and the field will be `null`.
+    // That only happens, if there is a `implements ExceptionMapper<ValidationException>`
+    // bean, probably a bean that uses some infra/library-stuff and then the DI mechanism
+    // fails to inject it.
+    InjectableInstance<ServerConfig> injectableInstance = Arc.container()
+        .select(ServerConfig.class);
+    ServerConfig serverConfig = injectableInstance.get();
+
+    return buildExceptionResponse(
+        status,
+        reason,
+        message,
+        e,
+        serverConfig.shouldSendstackTraceToAPIClient(),
+        h -> {});
+  }
+
+  Response buildExceptionResponse(
+      int status,
+      String reason,
+      String message,
+      Exception e,
+      boolean includeExceptionStackTrace,
+      Consumer<ResponseBuilder> responseHandler) {
+
+    String stack = includeExceptionStackTrace ? Throwables.getStackTraceAsString(e) : null;
+    NessieError error = new NessieError(message, status, reason, stack);
+    LOGGER.debug("Failure on server, propagated to client. Status: {} {}, Message: {}.",
+        status, reason, message, e);
+    ResponseBuilder responseBuilder = Response.status(status)
+        .entity(error)
+        .type(MediaType.APPLICATION_JSON_TYPE);
+    responseHandler.accept(responseBuilder);
+    return responseBuilder.build();
+  }
+}

--- a/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/ResteasyExceptionMapper.java
+++ b/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/ResteasyExceptionMapper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.server.providers;
+
+import javax.enterprise.inject.Alternative;
+import javax.validation.ValidationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.api.validation.ResteasyViolationException;
+import org.jboss.resteasy.api.validation.Validation;
+
+/**
+ * "Special" implementation for exceptions that extend {@link ValidationException}, as those
+ * do not "go through" {@link NessieExceptionMapper} and there need to be two
+ * {@link ExceptionMapper} beans for the Nessie-server.
+ */
+// Use our exception-mapper instead of io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyViolationExceptionMapper
+@Alternative
+@Provider
+public class ResteasyExceptionMapper
+    extends BaseExceptionMapper
+    implements ExceptionMapper<ValidationException> {
+
+  @Override
+  public Response toResponse(ValidationException exception) {
+    if (exception instanceof ResteasyViolationException) {
+      ResteasyViolationException violationException = (ResteasyViolationException) exception;
+      Exception e = violationException.getException();
+      if (e == null) {
+        boolean returnValueViolation = !violationException.getReturnValueViolations().isEmpty();
+        Status st = returnValueViolation ? Status.INTERNAL_SERVER_ERROR : Status.BAD_REQUEST;
+        return buildExceptionResponse(
+            st.getStatusCode(),
+            st.getReasonPhrase(),
+            exception.getMessage(),
+            exception,
+            false, // no need to send the stack trace for a validation-error
+            b -> b.header(Validation.VALIDATION_HEADER, "true"));
+      }
+    }
+
+    return buildExceptionResponse(
+        Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+        Status.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+        unwrapException(exception),
+        exception);
+  }
+
+  protected String unwrapException(Throwable t) {
+    StringBuffer sb = new StringBuffer();
+    doUnwrapException(sb, t);
+    return sb.toString();
+  }
+
+  private void doUnwrapException(StringBuffer sb, Throwable t) {
+    if (t == null) {
+      return;
+    }
+    sb.append(t.toString());
+    if (t.getCause() != null && t != t.getCause()) {
+      sb.append('[');
+      doUnwrapException(sb, t.getCause());
+      sb.append(']');
+    }
+  }
+}

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/ErrorTestService.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/ErrorTestService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.server.error;
+
+import javax.enterprise.context.RequestScoped;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.dremio.nessie.error.NessieNotFoundException;
+
+/**
+ * REST service used to generate a bunch of violations for {@link TestNessieError}.
+ */
+@RequestScoped
+@Path("/nessieErrorTest")
+@Consumes(MediaType.WILDCARD)
+@Produces(MediaType.APPLICATION_JSON)
+public class ErrorTestService {
+
+  @Path("nullParameterQueryGet")
+  @GET
+  public String nullParameterQueryGet(@NotNull @QueryParam("hash") String hash) {
+    return "oh oh";
+  }
+
+  @Path("nullParameterQueryPost")
+  @POST
+  public String nullParameterQueryPost(@NotNull @QueryParam("hash") String hash) {
+    return "oh oh";
+  }
+
+  @Path("emptyParameterQueryGet")
+  @GET
+  public String emptyParameterQueryGet(@NotEmpty @QueryParam("hash") String hash) {
+    return "oh oh";
+  }
+
+  @Path("blankParameterQueryGet")
+  @GET
+  public String blankParameterQueryGet(@NotBlank @QueryParam("hash") String hash) {
+    return "oh oh";
+  }
+
+  @Path("nessieNotFound")
+  @GET
+  public String nessieNotFound() throws NessieNotFoundException {
+    throw new NessieNotFoundException("not-there-message", new Exception("not-there-exception"));
+  }
+
+  @Path("basicEntity")
+  @PUT
+  @Consumes(MediaType.APPLICATION_JSON)
+  public String basicEntity(@Valid SomeEntity entity) {
+    return "oh oh";
+  }
+}

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/ErrorTestService.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/ErrorTestService.java
@@ -16,6 +16,9 @@
 package com.dremio.nessie.server.error;
 
 import javax.enterprise.context.RequestScoped;
+import javax.validation.ConstraintDeclarationException;
+import javax.validation.ConstraintDefinitionException;
+import javax.validation.GroupDefinitionException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
@@ -75,5 +78,29 @@ public class ErrorTestService {
   @Consumes(MediaType.APPLICATION_JSON)
   public String basicEntity(@Valid SomeEntity entity) {
     return "oh oh";
+  }
+
+  // Triggers the "else-ish" part in ResteasyExceptionMapper.toResponse()
+  @Path("constraintDefinitionException")
+  @GET
+  @Consumes(MediaType.APPLICATION_JSON)
+  public String constraintDefinitionException() {
+    throw new ConstraintDefinitionException("meep");
+  }
+
+  // Triggers the "else-ish" part in ResteasyExceptionMapper.toResponse()
+  @Path("constraintDeclarationException")
+  @GET
+  @Consumes(MediaType.APPLICATION_JSON)
+  public String constraintDeclarationException() {
+    throw new ConstraintDeclarationException("meep");
+  }
+
+  // Triggers the "else-ish" part in ResteasyExceptionMapper.toResponse()
+  @Path("groupDefinitionException")
+  @GET
+  @Consumes(MediaType.APPLICATION_JSON)
+  public String groupDefinitionException() {
+    throw new GroupDefinitionException("meep");
   }
 }

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/ITNativeNessieError.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/ITNativeNessieError.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.server.error;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.dremio.nessie.api.ContentsApi;
+import com.dremio.nessie.client.NessieClient;
+import com.dremio.nessie.client.NessieClient.AuthType;
+import com.dremio.nessie.client.rest.NessieBadRequestException;
+import com.dremio.nessie.model.ContentsKey;
+import com.dremio.nessie.model.IcebergTable;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+/**
+ * Rudimentary version of {@link TestNessieError}, because we cannot dynamically add beans
+ * and REST-endpoints declared in test-source to the native-image-binary; so this test checks
+ * just some very basic validation functionality.
+ */
+@NativeImageTest
+public class ITNativeNessieError {
+
+  private ContentsApi contents;
+
+  @BeforeEach
+  void init() {
+    String path = "http://localhost:19121/api/v1";
+    NessieClient client = new NessieClient(AuthType.NONE, path, null, null);
+    contents = client.getContentsApi();
+  }
+
+  @Test
+  void testNullParamViolation() {
+    ContentsKey k = ContentsKey.of("a");
+    IcebergTable t = IcebergTable.of("path1");
+    assertEquals(
+        "Bad Request (HTTP/400): setContents.hash: must not be null",
+        assertThrows(
+            NessieBadRequestException.class,
+            () -> contents.setContents(k, "branchName", null, "message", t))
+              .getMessage());
+  }
+
+}

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/OtherEntity.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/OtherEntity.java
@@ -13,25 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.dremio.nessie.server.error;
 
-package com.dremio.nessie.client.rest;
+import javax.validation.constraints.NotNull;
 
-import com.dremio.nessie.error.NessieError;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * A Nessie REST API runtime exception.
+ * Just a dummy entity.
  */
-public class NessieServiceException extends RuntimeException {
+public class OtherEntity {
+  private final String foo;
 
-  private final NessieError error;
-
-  public NessieServiceException(NessieError error) {
-    super(error.getFullMessage());
-    this.error = error;
+  @JsonCreator
+  public OtherEntity(
+      @NotNull @JsonProperty("foo") String foo) {
+    this.foo = foo;
   }
 
-  public NessieError getError() {
-    return error;
+  public String getFoo() {
+    return foo;
   }
-
 }

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/SomeEntity.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/SomeEntity.java
@@ -13,25 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.dremio.nessie.server.error;
 
-package com.dremio.nessie.client.rest;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 
-import com.dremio.nessie.error.NessieError;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * A Nessie REST API runtime exception.
+ * Just a dummy entity.
  */
-public class NessieServiceException extends RuntimeException {
+public class SomeEntity {
+  @NotNull @Min(3) @Max(42)
+  private final Integer value;
 
-  private final NessieError error;
-
-  public NessieServiceException(NessieError error) {
-    super(error.getFullMessage());
-    this.error = error;
+  @JsonCreator
+  public SomeEntity(
+      @JsonProperty(value = "value", required = true) Integer value) {
+    this.value = value;
   }
 
-  public NessieError getError() {
-    return error;
+  public Integer getValue() {
+    return value;
   }
-
 }

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/TestNessieError.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.dremio.nessie.client.rest.NessieInternalServerException;
 import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -33,6 +32,7 @@ import com.dremio.nessie.client.http.HttpClient;
 import com.dremio.nessie.client.http.HttpClientException;
 import com.dremio.nessie.client.rest.NessieBadRequestException;
 import com.dremio.nessie.client.rest.NessieHttpResponseFilter;
+import com.dremio.nessie.client.rest.NessieInternalServerException;
 import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/TestNessieError.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.server.error;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import com.dremio.nessie.client.http.HttpClient;
+import com.dremio.nessie.client.http.HttpClientException;
+import com.dremio.nessie.client.rest.NessieBadRequestException;
+import com.dremio.nessie.client.rest.NessieHttpResponseFilter;
+import com.dremio.nessie.error.NessieConflictException;
+import com.dremio.nessie.error.NessieNotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Test reported exceptions both for cases when {@code javax.validation} fails (when the Nessie infra
+ * code isn't even run) and exceptions reported <em>by</em> Nessie.
+ */
+@QuarkusTest
+class TestNessieError {
+
+  static String baseURI = "http://localhost:19121/api/v1/nessieErrorTest";
+
+  private static HttpClient client;
+
+  @BeforeAll
+  static void setup() {
+    ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
+        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+    client = HttpClient.builder()
+        .setBaseUri(baseURI)
+        .setObjectMapper(mapper)
+        .build();
+    client.register(new NessieHttpResponseFilter(mapper));
+  }
+
+  @Test
+  void nullParameterQueryGet() {
+    assertEquals("Bad Request (HTTP/400): nullParameterQueryGet.hash: must not be null",
+                 assertThrows(NessieBadRequestException.class,
+                   () ->
+                       client.newRequest()
+                             .path("nullParameterQueryGet")
+                             .get()).getMessage());
+  }
+
+  @Test
+  void nullParameterQueryPost() {
+    assertEquals("Bad Request (HTTP/400): nullParameterQueryPost.hash: must not be null",
+                 assertThrows(NessieBadRequestException.class,
+                   () ->
+                       client.newRequest()
+                             .path("nullParameterQueryPost")
+                             .post("")).getMessage());
+  }
+
+  @Test
+  void emptyParameterQueryGet() {
+    assertAll(
+        () -> assertEquals("Bad Request (HTTP/400): emptyParameterQueryGet.hash: must not be empty",
+                 assertThrows(NessieBadRequestException.class,
+                   () ->
+                       client.newRequest()
+                             .path("emptyParameterQueryGet")
+                             .get()).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): emptyParameterQueryGet.hash: must not be empty",
+                 assertThrows(NessieBadRequestException.class,
+                   () ->
+                       client.newRequest()
+                             .path("emptyParameterQueryGet")
+                             .queryParam("hash", "")
+                             .get()).getMessage())
+    );
+  }
+
+  @Test
+  void blankParameterQueryGet() {
+    assertAll(
+        () -> assertEquals("Bad Request (HTTP/400): blankParameterQueryGet.hash: must not be blank",
+                 assertThrows(NessieBadRequestException.class,
+                   () ->
+                       client.newRequest()
+                             .path("blankParameterQueryGet")
+                             .get()).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): blankParameterQueryGet.hash: must not be blank",
+                 assertThrows(NessieBadRequestException.class,
+                   () ->
+                       client.newRequest()
+                             .path("blankParameterQueryGet")
+                             .queryParam("hash", "")
+                             .get()).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): blankParameterQueryGet.hash: must not be blank",
+                 assertThrows(NessieBadRequestException.class,
+                   () ->
+                       client.newRequest()
+                             .path("blankParameterQueryGet")
+                             .queryParam("hash", "   ")
+                             .get()).getMessage())
+    );
+  }
+
+  @Test
+  void entityValueViolation() {
+    assertAll(
+        () -> assertThat(assertThrows(NessieBadRequestException.class,
+          () ->
+              client.newRequest()
+                    .path("basicEntity")
+                    .put("not really valid json")
+         ).getMessage(),
+         startsWith("Bad Request (HTTP/400): Unrecognized token 'not': was expecting (JSON String, Number, "
+                    + "Array, Object or token 'null', 'true' or 'false')\n")),
+        () -> assertThat(assertThrows(NessieBadRequestException.class,
+          () ->
+              client.newRequest()
+                    .path("basicEntity")
+                    .put("{}")
+         ).getMessage(),
+         startsWith("Bad Request (HTTP/400): Missing required creator property 'value' (index 0)\n")),
+        () -> assertThat(assertThrows(NessieBadRequestException.class,
+          () ->
+              client.newRequest()
+                    .path("basicEntity")
+                    .put("{\"value\":null}")
+         ).getMessage(),
+         equalTo("Bad Request (HTTP/400): basicEntity.entity.value: must not be null")),
+        () -> assertThat(assertThrows(NessieBadRequestException.class,
+          () ->
+              client.newRequest()
+                    .path("basicEntity")
+                    .put("{\"value\":1.234}")
+         ).getMessage(),
+         equalTo("Bad Request (HTTP/400): basicEntity.entity.value: must be greater than or equal to 3"))
+    );
+  }
+
+  @Test
+  void brokenEntitySerialization() {
+    // send something that cannot be deserialized
+    assertThat(assertThrows(NessieBadRequestException.class,
+        () ->
+            unwrap(() -> client.newRequest()
+                  .path("basicEntity")
+                  .put(new OtherEntity("bar")))
+       ).getMessage(),
+        startsWith("Bad Request (HTTP/400): Missing required creator property 'value' (index 0)\n"));
+  }
+
+  @Test
+  void nessieNotFoundException() {
+    NessieNotFoundException ex = assertThrows(NessieNotFoundException.class,
+        () -> unwrap(() ->
+            client.newRequest()
+                  .path("nessieNotFound")
+                  .get()));
+    assertAll(
+        () -> assertEquals("not-there-message",
+                           ex.getMessage()),
+        () -> assertThat(ex.getServerStackTrace(),
+                         startsWith("com.dremio.nessie.error.NessieNotFoundException: not-there-message\n")),
+        () -> assertEquals(Response.Status.NOT_FOUND.getStatusCode(), ex.getStatus())
+    );
+  }
+
+  void unwrap(Executable exec) throws Throwable {
+    try {
+      exec.execute();
+    } catch (Throwable targetException) {
+      if (targetException instanceof HttpClientException) {
+        if (targetException.getCause() instanceof NessieNotFoundException
+            || targetException.getCause() instanceof NessieConflictException) {
+          throw targetException.getCause();
+        }
+      }
+
+      throw targetException;
+    }
+  }
+}

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/error/TestNessieError.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.dremio.nessie.client.rest.NessieInternalServerException;
 import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -186,6 +187,34 @@ class TestNessieError {
         () -> assertThat(ex.getServerStackTrace(),
                          startsWith("com.dremio.nessie.error.NessieNotFoundException: not-there-message\n")),
         () -> assertEquals(Response.Status.NOT_FOUND.getStatusCode(), ex.getStatus())
+    );
+  }
+
+  @Test
+  void nonConstraintValidationExceptions() {
+    // Exceptions that trigger the "else-ish" part in ResteasyExceptionMapper.toResponse()
+    assertAll(
+        () -> assertThat(
+            assertThrows(NessieInternalServerException.class,
+                () -> unwrap(() ->
+                    client.newRequest()
+                        .path("constraintDefinitionException")
+                        .get())).getMessage(),
+            startsWith("Internal Server Error (HTTP/500): javax.validation.ConstraintDefinitionException: meep\n")),
+        () -> assertThat(
+            assertThrows(NessieInternalServerException.class,
+                () -> unwrap(() ->
+                    client.newRequest()
+                        .path("constraintDeclarationException")
+                        .get())).getMessage(),
+            startsWith("Internal Server Error (HTTP/500): javax.validation.ConstraintDeclarationException: meep\n")),
+        () -> assertThat(
+            assertThrows(NessieInternalServerException.class,
+                () -> unwrap(() ->
+                    client.newRequest()
+                        .path("groupDefinitionException")
+                        .get())).getMessage(),
+            startsWith("Internal Server Error (HTTP/500): javax.validation.GroupDefinitionException: meep\n"))
     );
   }
 


### PR DESCRIPTION
Resteasy's validation kicks in quite early on the server side, before any Nessie code gets called.

For example, if you call `com.dremio.nessie.api.ContentsApi.setContents()` with a `null` value for the `hash` parameter, the caller will get a HTTP/400 with a message like `com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "exception" (class com.dremio.nessie.error.NessieError), not marked as ignorable (3 known properties: "serverStackTrace", "status", "message"])`, which is rather not helpful.

The reason is, that Resteasy sends a serialized `org.jboss.resteasy.api.validation.ViolationReport`, which has that `exception` field plus a bunch of lists explaining all the violations. `com.dremio.nessie.client.rest.ResponseCheckFilter.decodeErrorObject()` then fails to deserialize that as a `NessieError`.

The approach of this PR is to rename `NessieError.serverStackTrace` to `NessieError.exception` and add the 4 lists from `ViolationReport` as parameters to the `@JsonCreator`.

With this PR, Nessie users get somewhat helpful error messages like these:
* `Bad Request (HTTP/400): parameter nullParameterQueryGet.hash must not be null`
* `Bad Request (HTTP/400): parameter basicEntity.entity.value must be greater than or equal to 3 (value='1')`
* `Bad Request (HTTP/400): parameter blankParameterQueryGet.hash must not be blank (value='   ')`

The added unit test illustrates a couple of validation errors "directly" against the REST method parameters and "indirectly" in the deserialized entities.

Also adds the `@Valid` annotation to all "complex" parameters of the REST API methods, so the validator can process the deserialized entities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/612)
<!-- Reviewable:end -->
