### PR TITLE
Nessie shaded client

### DIFF
--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -107,6 +107,36 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+          <shadedClassifierName>distribution</shadedClassifierName>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/jandex.idx</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <artifactSet>
+            <includes>
+              <include>org.projectnessie</include>
+            </includes>
+          </artifactSet>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
         <executions>

--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -105,36 +105,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <createDependencyReducedPom>false</createDependencyReducedPom>
-          <shadedArtifactAttached>true</shadedArtifactAttached>
-          <shadedClassifierName>minimal</shadedClassifierName>
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>META-INF/jandex.idx</exclude>
-              </excludes>
-            </filter>
-          </filters>
-          <artifactSet>
-            <includes>
-              <include>org.projectnessie</include>
-            </includes>
-          </artifactSet>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
         <executions>

--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -43,12 +43,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
@@ -112,7 +110,7 @@
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <shadedArtifactAttached>true</shadedArtifactAttached>
-          <shadedClassifierName>distribution</shadedClassifierName>
+          <shadedClassifierName>minimal</shadedClassifierName>
           <filters>
             <filter>
               <artifact>*:*</artifact>

--- a/clients/deltalake/core/pom.xml
+++ b/clients/deltalake/core/pom.xml
@@ -137,14 +137,9 @@
       <dependencies>
         <dependency>
           <groupId>org.projectnessie</groupId>
-          <artifactId>nessie-model</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.projectnessie</groupId>
           <artifactId>nessie-client</artifactId>
           <version>${project.version}</version>
-          <classifier>distribution</classifier>
+          <classifier>minimal</classifier>
         </dependency>
         <dependency>
           <groupId>org.apache.spark</groupId>

--- a/clients/deltalake/core/pom.xml
+++ b/clients/deltalake/core/pom.xml
@@ -137,9 +137,8 @@
       <dependencies>
         <dependency>
           <groupId>org.projectnessie</groupId>
-          <artifactId>nessie-client</artifactId>
+          <artifactId>nessie-client-minimal</artifactId>
           <version>${project.version}</version>
-          <classifier>minimal</classifier>
         </dependency>
         <dependency>
           <groupId>org.apache.spark</groupId>

--- a/clients/deltalake/core/pom.xml
+++ b/clients/deltalake/core/pom.xml
@@ -144,6 +144,7 @@
           <groupId>org.projectnessie</groupId>
           <artifactId>nessie-client</artifactId>
           <version>${project.version}</version>
+          <classifier>distribution</classifier>
         </dependency>
         <dependency>
           <groupId>org.apache.spark</groupId>

--- a/clients/deltalake/spark2/pom.xml
+++ b/clients/deltalake/spark2/pom.xml
@@ -38,9 +38,8 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-client</artifactId>
+      <artifactId>nessie-client-minimal</artifactId>
       <version>${project.version}</version>
-      <classifier>minimal</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/clients/deltalake/spark2/pom.xml
+++ b/clients/deltalake/spark2/pom.xml
@@ -38,14 +38,9 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-model</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
       <version>${project.version}</version>
-      <classifier>distribution</classifier>
+      <classifier>minimal</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/clients/deltalake/spark2/pom.xml
+++ b/clients/deltalake/spark2/pom.xml
@@ -45,6 +45,7 @@
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
       <version>${project.version}</version>
+      <classifier>distribution</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/clients/deltalake/spark3/pom.xml
+++ b/clients/deltalake/spark3/pom.xml
@@ -38,9 +38,8 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-client</artifactId>
+      <artifactId>nessie-client-minimal</artifactId>
       <version>${project.version}</version>
-      <classifier>minimal</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/clients/deltalake/spark3/pom.xml
+++ b/clients/deltalake/spark3/pom.xml
@@ -38,14 +38,9 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-model</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
       <version>${project.version}</version>
-      <classifier>distribution</classifier>
+      <classifier>minimal</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/clients/deltalake/spark3/pom.xml
+++ b/clients/deltalake/spark3/pom.xml
@@ -45,6 +45,7 @@
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
       <version>${project.version}</version>
+      <classifier>distribution</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/clients/hmsbridge/core/pom.xml
+++ b/clients/hmsbridge/core/pom.xml
@@ -34,6 +34,7 @@
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
       <version>${project.version}</version>
+      <classifier>minimal</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/clients/hmsbridge/core/pom.xml
+++ b/clients/hmsbridge/core/pom.xml
@@ -32,9 +32,8 @@
   <dependencies>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-client</artifactId>
+      <artifactId>nessie-client-minimal</artifactId>
       <version>${project.version}</version>
-      <classifier>minimal</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/clients/iceberg/core/pom.xml
+++ b/clients/iceberg/core/pom.xml
@@ -34,6 +34,7 @@
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
       <version>${project.version}</version>
+      <classifier>minimal</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/clients/iceberg/core/pom.xml
+++ b/clients/iceberg/core/pom.xml
@@ -32,9 +32,8 @@
   <dependencies>
     <dependency>
       <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-client</artifactId>
+      <artifactId>nessie-client-minimal</artifactId>
       <version>${project.version}</version>
-      <classifier>minimal</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/clients/minimal-client/pom.xml
+++ b/clients/minimal-client/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie-clients</artifactId>
+    <version>0.2.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-client-minimal</artifactId>
+
+  <name>Nessie - Minimal Client</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <createDependencyReducedPom>true</createDependencyReducedPom>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/jandex.idx</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <artifactSet>
+            <includes>
+              <include>org.projectnessie</include>
+            </includes>
+          </artifactSet>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>tidy-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Skip tidy as the dependency reduced pom will fail this check -->
+            <id>validate-pom</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jboss.jandex</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -32,6 +32,7 @@
 
   <modules>
     <module>client</module>
+    <module>minimal-client</module>
     <module>hmsbridge</module>
     <module>iceberg</module>
     <module>deltalake</module>


### PR DESCRIPTION
This PR adds a shaded Nessie client and removes optional dependencies for jackson. The purpose is twofold:

1. To provide a small and complete Nessie Client implementation for downstream tools with fixed jackson versions (eg hive and spark). This can be run anywhere that jackson >=2.6 already exists and is ~200KB in size. It assumes the implementer has tested Nessie Client with the pre-existing version of jackson and they are compatible
2. To provide a full Nessie dependency with a fixed jackson version to implementers who are ;not using fixed jackson versions or who do not yet use Jackson in their project

Note: the `minimal` shaded jar removes the jandex index from the model. This is used to compile native images w/ graalvm and quarkus. Any client using graalvm or who needs the jandex index should not use the `minimal` jar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/629)
<!-- Reviewable:end -->
