### PR TITLE
Add hash + ref-name validation

### DIFF
--- a/clients/client/src/main/java/com/dremio/nessie/client/ClientTreeApi.java
+++ b/clients/client/src/main/java/com/dremio/nessie/client/ClientTreeApi.java
@@ -17,6 +17,7 @@ package com.dremio.nessie.client;
 
 import java.util.List;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.dremio.nessie.api.TreeApi;
@@ -108,17 +109,24 @@ class ClientTreeApi implements TreeApi {
   }
 
   @Override
-  public void transplantCommitsIntoBranch(@NotNull String branchName, @NotNull String expectedHash, String message, Transplant transplant)
+  public void transplantCommitsIntoBranch(
+      @NotNull String branchName,
+      @NotNull String expectedHash,
+      String message,
+      @Valid Transplant transplant)
       throws NessieNotFoundException, NessieConflictException {
     client.newRequest().path("trees/branch/{branchName}/transplant")
           .resolveTemplate("branchName", branchName)
           .queryParam("expectedHash", expectedHash)
           .queryParam("message", message)
-          .put(transplant);
+          .post(transplant);
   }
 
   @Override
-  public void mergeRefIntoBranch(@NotNull String branchName, @NotNull String expectedHash, @NotNull Merge merge)
+  public void mergeRefIntoBranch(
+      @NotNull String branchName,
+      @NotNull String expectedHash,
+      @NotNull @Valid Merge merge)
       throws NessieNotFoundException, NessieConflictException {
     client.newRequest().path("trees/branch/{branchName}/merge")
           .resolveTemplate("branchName", branchName)
@@ -135,8 +143,11 @@ class ClientTreeApi implements TreeApi {
   }
 
   @Override
-  public void commitMultipleOperations(String branch, @NotNull String expectedHash, String message,
-                                       @NotNull Operations operations) throws NessieNotFoundException, NessieConflictException {
+  public void commitMultipleOperations(
+      String branch,
+      @NotNull String expectedHash,
+      String message,
+      @NotNull Operations operations) throws NessieNotFoundException, NessieConflictException {
     client.newRequest().path("trees/branch/{branchName}/commit")
           .resolveTemplate("branchName", branch)
           .queryParam("expectedHash", expectedHash)

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -85,6 +85,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 </project>

--- a/model/src/main/java/com/dremio/nessie/api/ContentsApi.java
+++ b/model/src/main/java/com/dremio/nessie/api/ContentsApi.java
@@ -17,6 +17,7 @@ package com.dremio.nessie.api;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -39,6 +40,7 @@ import com.dremio.nessie.model.Contents;
 import com.dremio.nessie.model.ContentsKey;
 import com.dremio.nessie.model.MultiGetContentsRequest;
 import com.dremio.nessie.model.MultiGetContentsResponse;
+import com.dremio.nessie.model.Validation;
 
 @Consumes(value = MediaType.APPLICATION_JSON)
 @Path("contents")
@@ -56,8 +58,14 @@ public interface ContentsApi {
       @APIResponse(responseCode = "404", description = "Table not found on ref")
     })
   Contents getContents(
-      @Valid @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
-      @Parameter(description = "Reference to use. Defaults to default branch if not provided.") @QueryParam("ref") String ref
+      @Valid
+      @Parameter(description = "object name to search for")
+      @PathParam("key")
+          ContentsKey key,
+      @Pattern(regexp = Validation.REF_NAME_OR_HASH_REGEX, message = Validation.REF_NAME_OR_HASH_MESSAGE)
+      @Parameter(description = "Reference to use. Defaults to default branch if not provided.")
+      @QueryParam("ref")
+          String ref
       ) throws NessieNotFoundException;
 
   @POST
@@ -67,8 +75,14 @@ public interface ContentsApi {
       @APIResponse(responseCode = "200", description = "Retrieved successfully."),
       @APIResponse(responseCode = "404", description = "Provided ref doesn't exists")})
   public MultiGetContentsResponse getMultipleContents(
-      @Parameter(description = "Reference to use. Defaults to default branch if not provided.") @QueryParam("ref") String ref,
-      @Valid @NotNull @RequestBody(description = "Keys to retrieve.") MultiGetContentsRequest request)
+      @Pattern(regexp = Validation.REF_NAME_OR_HASH_REGEX, message = Validation.REF_NAME_OR_HASH_MESSAGE)
+      @Parameter(description = "Reference to use. Defaults to default branch if not provided.")
+      @QueryParam("ref")
+          String ref,
+      @Valid
+      @NotNull
+      @RequestBody(description = "Keys to retrieve.")
+          MultiGetContentsRequest request)
       throws NessieNotFoundException;
 
   /**
@@ -83,11 +97,27 @@ public interface ContentsApi {
       @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
       @APIResponse(responseCode = "412", description = "Update conflict")})
   public void setContents(
-      @Valid @NotNull @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
-      @Parameter(description = "Branch to change. Defaults to default branch.") @QueryParam("branch") String branch,
-      @NotNull @Parameter(description = "Expected hash of branch.") @QueryParam("hash") String hash,
-      @Parameter(description = "Commit message") @QueryParam("message") String message,
-      @Valid @NotNull @RequestBody(description = "Contents to be upserted") Contents contents)
+      @Valid
+      @NotNull
+      @Parameter(description = "object name to search for")
+      @PathParam("key")
+          ContentsKey key,
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Branch to change. Defaults to default branch.")
+      @QueryParam("branch")
+          String branch,
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @NotNull
+      @Parameter(description = "Expected hash of branch.")
+      @QueryParam("hash")
+          String hash,
+      @Parameter(description = "Commit message")
+      @QueryParam("message")
+          String message,
+      @Valid
+      @NotNull
+      @RequestBody(description = "Contents to be upserted")
+          Contents contents)
       throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -103,10 +133,21 @@ public interface ContentsApi {
       }
   )
   public void deleteContents(
-      @Valid @Parameter(description = "object name to search for") @PathParam("key") ContentsKey key,
-      @Parameter(description = "Branch to delete from. Defaults to default branch.") @QueryParam("branch") String branch,
-      @Parameter(description = "Expected hash of branch.") @QueryParam("hash") String hash,
-      @Parameter(description = "Commit message") @QueryParam("message") String message
+      @Valid
+      @Parameter(description = "object name to search for")
+      @PathParam("key")
+          ContentsKey key,
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Branch to delete from. Defaults to default branch.")
+      @QueryParam("branch")
+          String branch,
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Parameter(description = "Expected hash of branch.")
+      @QueryParam("hash")
+          String hash,
+      @Parameter(description = "Commit message")
+      @QueryParam("message")
+          String message
       ) throws NessieNotFoundException, NessieConflictException;
 
 

--- a/model/src/main/java/com/dremio/nessie/api/TreeApi.java
+++ b/model/src/main/java/com/dremio/nessie/api/TreeApi.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -46,6 +47,7 @@ import com.dremio.nessie.model.Operations;
 import com.dremio.nessie.model.Reference;
 import com.dremio.nessie.model.Tag;
 import com.dremio.nessie.model.Transplant;
+import com.dremio.nessie.model.Validation;
 
 @Consumes(value = MediaType.APPLICATION_JSON)
 @Path("trees")
@@ -82,7 +84,11 @@ public interface TreeApi {
       @APIResponse(responseCode = "204", description = "Created successfully."),
       @APIResponse(responseCode = "409", description = "Reference already exists")
   })
-  void createReference(@Valid @NotNull @RequestBody(description = "Reference to create.") Reference reference)
+  void createReference(
+      @Valid
+      @NotNull
+      @RequestBody(description = "Reference to create.")
+          Reference reference)
       throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -97,7 +103,11 @@ public interface TreeApi {
       @APIResponse(responseCode = "404", description = "Ref not found")
     })
   Reference getReferenceByName(
-      @NotNull @Parameter(description = "name of ref to fetch") @PathParam("ref") String refName)
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_OR_HASH_REGEX, message = Validation.REF_NAME_OR_HASH_MESSAGE)
+      @Parameter(description = "name of ref to fetch")
+      @PathParam("ref")
+          String refName)
       throws NessieNotFoundException;
 
   /**
@@ -113,7 +123,11 @@ public interface TreeApi {
       @APIResponse(responseCode = "404", description = "Ref not found")}
   )
   public EntriesResponse getEntries(
-      @NotNull @Parameter(description = "name of ref to fetch from") @PathParam("ref") String refName)
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_OR_HASH_REGEX, message = Validation.REF_NAME_OR_HASH_MESSAGE)
+      @Parameter(description = "name of ref to fetch from")
+      @PathParam("ref")
+          String refName)
           throws NessieNotFoundException;
 
   /**
@@ -126,7 +140,11 @@ public interface TreeApi {
   @APIResponses({
       @APIResponse(responseCode = "200", description = "Returned commits."),
       @APIResponse(responseCode = "404", description = "Ref doesn't exists")})
-  LogResponse getCommitLog(@NotNull @Parameter(description = "ref to show log from") @PathParam("ref") String ref)
+  LogResponse getCommitLog(
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_OR_HASH_REGEX, message = Validation.REF_NAME_OR_HASH_MESSAGE)
+      @Parameter(description = "ref to show log from")
+      @PathParam("ref") String ref)
           throws NessieNotFoundException;
 
   /**
@@ -141,9 +159,20 @@ public interface TreeApi {
       @APIResponse(responseCode = "412", description = "Update conflict")
     })
   void assignTag(
-      @NotNull @Parameter(description = "Tag name to reassign") @PathParam("tagName") String tagName,
-      @NotNull @Parameter(description = "Expected previous hash of tag") @QueryParam("expectedHash") String oldHash,
-      @Valid @NotNull @RequestBody(description = "New tag content") Tag tag
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Tag name to reassign")
+      @PathParam("tagName")
+          String tagName,
+      @NotNull
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Parameter(description = "Expected previous hash of tag")
+      @QueryParam("expectedHash")
+          String oldHash,
+      @Valid
+      @NotNull
+      @RequestBody(description = "New tag content")
+          Tag tag
       ) throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -158,8 +187,15 @@ public interface TreeApi {
       @APIResponse(responseCode = "412", description = "update conflict"),
     })
   void deleteTag(
-      @NotNull @Parameter(description = "Tag to delete") @PathParam("tagName") String tagName,
-      @Parameter(description = "Expected hash of tag") @QueryParam("expectedHash") String hash
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Tag to delete")
+      @PathParam("tagName")
+          String tagName,
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Parameter(description = "Expected hash of tag")
+      @QueryParam("expectedHash")
+          String hash
       ) throws NessieConflictException, NessieNotFoundException;
 
   /**
@@ -174,9 +210,20 @@ public interface TreeApi {
       @APIResponse(responseCode = "412", description = "Update conflict")
     })
   void assignBranch(
-      @NotNull @Parameter(description = "Tag name to reassign") @PathParam("branchName") String branchName,
-      @NotNull @Parameter(description = "Expected previous hash of tag") @QueryParam("expectedHash") String oldHash,
-      @Valid @NotNull @RequestBody(description = "New branch content") Branch branch
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Tag name to reassign")
+      @PathParam("branchName")
+          String branchName,
+      @NotNull
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Parameter(description = "Expected previous hash of tag")
+      @QueryParam("expectedHash")
+          String oldHash,
+      @Valid
+      @NotNull
+      @RequestBody(description = "New branch content")
+          Branch branch
       ) throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -191,8 +238,16 @@ public interface TreeApi {
       @APIResponse(responseCode = "412", description = "update conflict"),
     })
   void deleteBranch(
-      @NotNull @Parameter(description = "Branch to delete") @PathParam("branchName") String branchName,
-      @NotNull @Parameter(description = "Expected hash of tag") @QueryParam("expectedHash") String hash
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Branch to delete")
+      @PathParam("branchName")
+          String branchName,
+      @NotNull
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Parameter(description = "Expected hash of tag")
+      @QueryParam("expectedHash")
+          String hash
       ) throws NessieConflictException, NessieNotFoundException;
 
   /**
@@ -208,10 +263,22 @@ public interface TreeApi {
       @APIResponse(responseCode = "412", description = "update conflict")}
   )
   void transplantCommitsIntoBranch(
-      @NotNull @Parameter(description = "Branch to transplant into") @PathParam("branchName") String branchName,
-      @NotNull @Parameter(description = "Expected hash of tag") @QueryParam("expectedHash") String hash,
-      @Parameter(description = "commit message") @QueryParam("message") String message,
-      @Valid @RequestBody(description = "Hashes to transplant") Transplant transplant)
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Branch to transplant into")
+      @PathParam("branchName")
+          String branchName,
+      @NotNull
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Parameter(description = "Expected hash of tag")
+      @QueryParam("expectedHash")
+          String hash,
+      @Parameter(description = "commit message")
+      @QueryParam("message")
+          String message,
+      @Valid
+      @RequestBody(description = "Hashes to transplant")
+          Transplant transplant)
           throws NessieNotFoundException, NessieConflictException;
 
   /**
@@ -227,9 +294,20 @@ public interface TreeApi {
       @APIResponse(responseCode = "412", description = "update conflict")}
   )
   void mergeRefIntoBranch(
-      @NotNull @Parameter(description = "Branch to merge into") @PathParam("branchName") String branchName,
-      @NotNull @Parameter(description = "Expected hash of tag") @QueryParam("expectedHash") String hash,
-      @Valid @NotNull @RequestBody(description = "Merge operation") Merge merge)
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Branch to merge into")
+      @PathParam("branchName")
+          String branchName,
+      @NotNull
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Parameter(description = "Expected hash of tag")
+      @QueryParam("expectedHash")
+          String hash,
+      @Valid
+      @NotNull
+      @RequestBody(description = "Merge operation")
+          Merge merge)
           throws NessieNotFoundException, NessieConflictException;
 
   @POST
@@ -241,9 +319,22 @@ public interface TreeApi {
       @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
       @APIResponse(responseCode = "412", description = "Update conflict")})
   public void commitMultipleOperations(
-      @NotNull @Parameter(description = "Branch to change, defaults to default branch.") @PathParam("branchName") String branchName,
-      @NotNull @Parameter(description = "Expected hash of branch.") @QueryParam("expectedHash") String hash,
-      @Parameter(description = "Commit message") @QueryParam("message") String message,
-      @Valid @NotNull @RequestBody(description = "Operations") Operations operations)
+      @NotNull
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+      @Parameter(description = "Branch to change, defaults to default branch.")
+      @PathParam("branchName")
+          String branchName,
+      @NotNull
+      @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Parameter(description = "Expected hash of branch.")
+      @QueryParam("expectedHash")
+          String hash,
+      @Parameter(description = "Commit message")
+      @QueryParam("message")
+          String message,
+      @Valid
+      @NotNull
+      @RequestBody(description = "Operations")
+          Operations operations)
       throws NessieNotFoundException, NessieConflictException;
 }

--- a/model/src/main/java/com/dremio/nessie/model/Branch.java
+++ b/model/src/main/java/com/dremio/nessie/model/Branch.java
@@ -16,6 +16,8 @@
 
 package com.dremio.nessie.model;
 
+import static com.dremio.nessie.model.Validation.validateReferenceName;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -30,6 +32,14 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonDeserialize(as = ImmutableBranch.class)
 @JsonTypeName("BRANCH")
 public interface Branch extends Reference {
+
+  /**
+   * Validation rule using {@link com.dremio.nessie.model.Validation#validateReferenceName(String)}.
+   */
+  @Value.Check
+  default void checkName() {
+    validateReferenceName(getName());
+  }
 
   static ImmutableBranch.Builder builder() {
     return ImmutableBranch.builder();

--- a/model/src/main/java/com/dremio/nessie/model/Hash.java
+++ b/model/src/main/java/com/dremio/nessie/model/Hash.java
@@ -38,4 +38,8 @@ public abstract class Hash implements Reference {
     return getName();
   }
 
+  public static Hash of(String hash) {
+    return ImmutableHash.builder().name(hash).build();
+  }
+
 }

--- a/model/src/main/java/com/dremio/nessie/model/Merge.java
+++ b/model/src/main/java/com/dremio/nessie/model/Merge.java
@@ -15,6 +15,8 @@
  */
 package com.dremio.nessie.model;
 
+import static com.dremio.nessie.model.Validation.validateHash;
+
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -32,4 +34,15 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public interface Merge {
 
   String getFromHash();
+
+  /**
+   * Validation rule using {@link com.dremio.nessie.model.Validation#validateHash(String)} (String)}.
+   */
+  @Value.Check
+  default void checkHash() {
+    String hash = getFromHash();
+    if (hash != null) {
+      validateHash(hash);
+    }
+  }
 }

--- a/model/src/main/java/com/dremio/nessie/model/Reference.java
+++ b/model/src/main/java/com/dremio/nessie/model/Reference.java
@@ -15,11 +15,14 @@
  */
 package com.dremio.nessie.model;
 
+import static com.dremio.nessie.model.Validation.validateHash;
+
 import javax.annotation.Nullable;
 
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -45,9 +48,19 @@ public interface Reference extends Base {
   String getName();
 
   /**
-   * backend system id. Usually the 20-byte hash of the commit this reference points to.
+   * backend system id. Usually the 32-byte hash of the commit this reference points to.
    */
   @Nullable
   String getHash();
 
+  /**
+   * Validation rule using {@link com.dremio.nessie.model.Validation#validateHash(String)} (String)}.
+   */
+  @Value.Check
+  default void checkHash() {
+    String hash = getHash();
+    if (hash != null) {
+      validateHash(hash);
+    }
+  }
 }

--- a/model/src/main/java/com/dremio/nessie/model/Tag.java
+++ b/model/src/main/java/com/dremio/nessie/model/Tag.java
@@ -16,6 +16,8 @@
 
 package com.dremio.nessie.model;
 
+import static com.dremio.nessie.model.Validation.validateReferenceName;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -30,6 +32,14 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonDeserialize(as = ImmutableTag.class)
 @JsonTypeName("TAG")
 public interface Tag extends Reference {
+
+  /**
+   * Validation rule using {@link com.dremio.nessie.model.Validation#validateReferenceName(String)}.
+   */
+  @Value.Check
+  default void checkName() {
+    validateReferenceName(getName());
+  }
 
   static ImmutableTag.Builder builder() {
     return ImmutableTag.builder();

--- a/model/src/main/java/com/dremio/nessie/model/Transplant.java
+++ b/model/src/main/java/com/dremio/nessie/model/Transplant.java
@@ -15,6 +15,8 @@
  */
 package com.dremio.nessie.model;
 
+import static com.dremio.nessie.model.Validation.validateHash;
+
 import java.util.List;
 
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -34,5 +36,18 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public interface Transplant {
 
   List<String> getHashesToTransplant();
+
+  /**
+   * Validation rule using {@link com.dremio.nessie.model.Validation#validateHash(String)} (String)}.
+   */
+  @Value.Check
+  default void checkHashes() {
+    List<String> hashes = getHashesToTransplant();
+    if (hashes != null) {
+      for (String hash : hashes) {
+        validateHash(hash);
+      }
+    }
+  }
 
 }

--- a/model/src/main/java/com/dremio/nessie/model/Validation.java
+++ b/model/src/main/java/com/dremio/nessie/model/Validation.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.model;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Collection of validation rules.
+ */
+public final class Validation {
+  public static final String HASH_REGEX = "^[0-9a-fA-F]{64}$";
+  public static final String REF_NAME_REGEX = "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9._-])?$";
+  public static final String REF_NAME_OR_HASH_REGEX = "^(([0-9a-fA-F]{64})|([A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9._-])?))$";
+
+  public static final Pattern HASH_PATTERN = Pattern.compile(HASH_REGEX);
+  public static final Pattern REF_NAME_PATTERN = Pattern.compile(REF_NAME_REGEX);
+  public static final Pattern REF_NAME_OR_HASH_PATTERN = Pattern.compile(REF_NAME_OR_HASH_REGEX);
+
+  private static final String HASH_RULE = "consist of the hex representation of 32 bytes";
+  private static final String REF_RULE = "start with a letter, followed by letters, digits, a ./_- character, "
+      + "not end with a slash, not contain ..";
+
+  public static final String HASH_MESSAGE =
+      "Hash must " + HASH_RULE;
+  public static final String REF_NAME_MESSAGE =
+      "Reference name must " + REF_RULE;
+  public static final String REF_NAME_OR_HASH_MESSAGE =
+      "Reference must be either a reference name or hash, " + REF_RULE + " or " + HASH_RULE;
+
+  private Validation() {
+    // empty
+  }
+
+  /**
+   * Just checks whether a string is a valid reference-name, but doesn't throw an exception.
+   * @see #validateReferenceName(String)
+   */
+  public static boolean isValidReferenceName(String referenceName) {
+    Objects.requireNonNull(referenceName, "referenceName must not be null");
+    Matcher matcher = Validation.REF_NAME_PATTERN.matcher(referenceName);
+    return matcher.matches();
+  }
+
+  /**
+   * Just checks whether a string is a valid hash, but doesn't throw an exception.
+   * @see #validateHash(String)
+   */
+  public static boolean isValidHash(String hash) {
+    Objects.requireNonNull(hash, "hash must not be null");
+    Matcher matcher = Validation.HASH_PATTERN.matcher(hash);
+    return matcher.matches();
+  }
+
+  /**
+   * Just checks whether a string is a valid reference-name (as per {@link #isValidReferenceName(String)}) or a valid hash
+   * (as per {@link #isValidHash(String)}).
+   */
+  public static boolean isValidReferenceNameOrHash(String ref) {
+    Objects.requireNonNull(ref, "reference (name or hash) must not be null");
+    Matcher matcher = Validation.REF_NAME_OR_HASH_PATTERN.matcher(ref);
+    return matcher.matches();
+  }
+
+  /**
+   * Validates whether a string is a valid reference-name.
+   * <p>
+   * The rules are: <em>{@value #REF_RULE}</em>
+   * </p>
+   * @param referenceName the reference name string to test.
+   */
+  public static String validateReferenceName(String referenceName) {
+    if (isValidReferenceName(referenceName)) {
+      return referenceName;
+    }
+    throw new IllegalArgumentException(REF_NAME_MESSAGE + " - but was: " + referenceName);
+  }
+
+  /**
+   * Validates whether a string is a valid hash.
+   * <p>
+   * The rules are: <em>{@value #HASH_RULE}</em>
+   * </p>
+   * @param referenceName the reference name string to test.
+   */
+  public static String validateHash(String referenceName) {
+    if (isValidHash(referenceName)) {
+      return referenceName;
+    }
+    throw new IllegalArgumentException(HASH_MESSAGE + " - but was: " + referenceName);
+  }
+
+  /**
+   * Validates whether a string is a valid reference name or hash.
+   * <p>
+   * See {@link #validateReferenceName(String)} and {@link #validateHash(String)} for the rules.
+   * </p>
+   * @param ref the reference name string to test.
+   */
+  public static String validateReferenceNameOrHash(String ref) {
+    if (isValidReferenceNameOrHash(ref)) {
+      return ref;
+    }
+    throw new IllegalArgumentException(REF_NAME_OR_HASH_MESSAGE + " - but was: " + ref);
+  }
+}

--- a/model/src/test/java/com/dremio/nessie/model/TestValidation.java
+++ b/model/src/test/java/com/dremio/nessie/model/TestValidation.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.nessie.model;
+
+import static com.dremio.nessie.model.Validation.validateHash;
+import static com.dremio.nessie.model.Validation.validateReferenceName;
+import static com.dremio.nessie.model.Validation.validateReferenceNameOrHash;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TestValidation {
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "a",
+      "a_b-",
+      "a_-c",
+      "abc/def"
+  })
+  void validNames(String referenceName) {
+    validateReferenceName(referenceName);
+    validateReferenceNameOrHash(referenceName);
+    Branch.of(referenceName, null);
+    Tag.of(referenceName, null);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "",
+      "abc/",
+      ".foo",
+      "abc/def/../blah",
+      "abc/de..blah",
+      "abc/de@{blah"
+  })
+  void invalidNames(String referenceName) {
+    assertAll(
+        () -> assertEquals(Validation.REF_NAME_MESSAGE + " - but was: " + referenceName,
+            assertThrows(IllegalArgumentException.class,
+                () -> validateReferenceName(referenceName)).getMessage()),
+        () -> assertEquals(Validation.REF_NAME_OR_HASH_MESSAGE + " - but was: " + referenceName,
+            assertThrows(IllegalArgumentException.class,
+                () -> validateReferenceNameOrHash(referenceName)).getMessage()),
+        () -> assertEquals(Validation.REF_NAME_MESSAGE + " - but was: " + referenceName,
+            assertThrows(IllegalArgumentException.class,
+                () -> Branch.of(referenceName, null)).getMessage()),
+        () -> assertEquals(Validation.REF_NAME_MESSAGE + " - but was: " + referenceName,
+            assertThrows(IllegalArgumentException.class,
+                () -> Tag.of(referenceName, null)).getMessage()));
+  }
+
+  @Test
+  void nullParam() {
+    assertAll(
+        () -> assertThrows(NullPointerException.class,
+            () -> validateReferenceName(null)),
+        () -> assertThrows(NullPointerException.class,
+            () -> Hash.of(null)),
+        () -> assertThrows(NullPointerException.class,
+            () -> Branch.of(null, null)),
+        () -> assertThrows(NullPointerException.class,
+            () -> Tag.of(null, null)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "1122334455667788990011223344556677889900112233445566778899001122",
+      "abcDEF4242424242424242424242BEEF00DEAD42112233445566778899001122"
+  })
+  void validHashes(String hash) {
+    validateHash(hash);
+    validateReferenceNameOrHash(hash);
+    Hash.of(hash);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "",
+      "abc/",
+      ".foo",
+      "abc/def/../blah",
+      "abc/de..blah",
+      "abc/de@{blah"
+  })
+  void invalidHashes(String hash) {
+    String referenceName = "thisIsAValidName";
+    assertAll(
+        () -> assertEquals(Validation.HASH_MESSAGE + " - but was: " + hash,
+            assertThrows(IllegalArgumentException.class,
+                () -> validateHash(hash)).getMessage()),
+        () -> assertEquals(Validation.HASH_MESSAGE + " - but was: " + hash,
+            assertThrows(IllegalArgumentException.class,
+                () -> Hash.of(hash)).getMessage()),
+        () -> assertEquals(Validation.HASH_MESSAGE + " - but was: " + hash,
+            assertThrows(IllegalArgumentException.class,
+                () -> Branch.of(referenceName, hash)).getMessage()),
+        () -> assertEquals(Validation.HASH_MESSAGE + " - but was: " + hash,
+            assertThrows(IllegalArgumentException.class,
+                () -> Tag.of(referenceName, hash)).getMessage()));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "a,112233445566778899001122abcDEF4242424242424242424242BEEF00DEAD42",
+      "a,1122334455667788990011221122334455667788990011223344556677889900",
+      "a_b-,112233445566778899001122abcDEF4242424242424242424242BEEF00DEAD42",
+      "a_b-,1122334455667788990011221122334455667788990011223344556677889900",
+      "a_-c,112233445566778899001122abcDEF4242424242424242424242BEEF00DEAD42",
+      "a_-c,1122334455667788990011221122334455667788990011223344556677889900",
+      "abc/def,1122334455667788990011221122334455667788990011223344556677889900"
+  })
+  void validNamesAndHashes(String referenceName, String hash) {
+    Branch.of(referenceName, hash);
+    Tag.of(referenceName, hash);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "a,abcDEF4242424242424242424242BEEF00DEADxy",
+      "a,11",
+      "a_b-,meep",
+      "a_b-,0",
+      "a_-c,##",
+      "a_-c,123",
+      "abc/def,nonono"
+  })
+  void validNamesAndInvalidHashes(String referenceName, String hash) {
+    assertAll(
+        () -> assertEquals(Validation.HASH_MESSAGE + " - but was: " + hash,
+            assertThrows(IllegalArgumentException.class,
+                () -> Branch.of(referenceName, hash)).getMessage()),
+        () -> assertEquals(Validation.HASH_MESSAGE + " - but was: " + hash,
+            assertThrows(IllegalArgumentException.class,
+                () -> Tag.of(referenceName, hash)).getMessage()));
+  }
+}

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/RestGitTest.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/RestGitTest.java
@@ -132,10 +132,13 @@ public class RestGitTest {
 
     rest().get("trees/tree/tagtest").then().statusCode(200).body("hash", equalTo(b3.getHash()));
 
-    rest().queryParam("expectedHash","aa").delete("trees/tag/tagtest").then().statusCode(409);
+    rest().queryParam(
+        "expectedHash",
+        "0011223344556677889900112233445566778899001122334455667788990011")
+        .delete("trees/tag/tagtest").then().statusCode(409);
 
-    rest().queryParam("expectedHash", b3.getHash()).delete("trees/tag/tagtest").then().statusCode(204);
-
+    rest().queryParam("expectedHash", b3.getHash())
+        .delete("trees/tag/tagtest").then().statusCode(204);
 
     LogResponse log = rest().get("trees/tree/test/log").then().statusCode(200).extract().as(LogResponse.class);
     Assertions.assertEquals(3, log.getOperations().size());

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/TestRest.java
@@ -16,11 +16,18 @@
 
 package com.dremio.nessie.server;
 
+import static com.dremio.nessie.model.Validation.HASH_MESSAGE;
+import static com.dremio.nessie.model.Validation.REF_NAME_MESSAGE;
+import static com.dremio.nessie.model.Validation.REF_NAME_OR_HASH_MESSAGE;
 import static com.dremio.nessie.server.ReferenceMatchers.referenceWithNameAndType;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -36,12 +43,17 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.dremio.nessie.api.ContentsApi;
 import com.dremio.nessie.api.TreeApi;
 import com.dremio.nessie.client.NessieClient;
+import com.dremio.nessie.client.http.HttpClient;
+import com.dremio.nessie.client.http.HttpClientException;
+import com.dremio.nessie.client.rest.NessieBadRequestException;
+import com.dremio.nessie.client.rest.NessieHttpResponseFilter;
 import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
 import com.dremio.nessie.model.Branch;
@@ -61,24 +73,35 @@ import com.dremio.nessie.model.Reference;
 import com.dremio.nessie.model.Tag;
 import com.dremio.nessie.versioned.VersionStore;
 import com.dremio.nessie.versioned.memory.InMemoryVersionStore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class TestRest {
 
+  public static final String VALID_HASH = "1234567890123456789012345678901234567890123456789012345678901234";
+
   private NessieClient client;
   private TreeApi tree;
   private ContentsApi contents;
+  private HttpClient httpClient;
 
   @Inject
   VersionStore<Contents, CommitMeta> versionStore;
 
   @BeforeEach
   void init() {
+    String path = "http://localhost:19121/api/v1";
     client = NessieClient.none("http://localhost:19121/api/v1");
     tree = client.getTreeApi();
     contents = client.getContentsApi();
+
+    ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
+        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+    httpClient = HttpClient.builder().setBaseUri(path).setObjectMapper(mapper).build();
+    httpClient.register(new NessieHttpResponseFilter(mapper));
 
     if (versionStore instanceof InMemoryVersionStore) {
       ((InMemoryVersionStore<?, ?>) versionStore).clearUnsafe();
@@ -93,7 +116,7 @@ class TestRest {
   @ParameterizedTest
   @ValueSource(strings = {
       "normal",
-      "with space",
+      "with-no_space",
       "slash/thing"
   })
   void referenceNames(String refNamePart) throws NessieNotFoundException, NessieConflictException {
@@ -189,5 +212,202 @@ class TestRest {
     tree.createReference(Branch.of(branch, null));
     NessieConflictException e = assertThrows(NessieConflictException.class, () -> tree.createReference(Branch.of(branch, null)));
     assertThat(e.getMessage(), Matchers.containsString("already exists"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "x/",
+      "abc'",
+      ".foo",
+      "abc'def'..'blah",
+      "abc'de..blah",
+      "abc'de@{blah"
+  })
+  void invalidBranchNames(String invalidBranchName) {
+    Operations ops = ImmutableOperations.builder().build();
+    ContentsKey key = ContentsKey.of("x");
+    Contents cts = IcebergTable.of("moo");
+    MultiGetContentsRequest mgReq = MultiGetContentsRequest.of(key);
+    Tag tag = Tag.of("valid", VALID_HASH);
+    assertAll(
+        () -> assertEquals("Bad Request (HTTP/400): commitMultipleOperations.branchName: " + REF_NAME_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.commitMultipleOperations(invalidBranchName, VALID_HASH, null, ops)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): deleteBranch.branchName: " + REF_NAME_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.deleteBranch(invalidBranchName, VALID_HASH)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): getCommitLog.ref: " + REF_NAME_OR_HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.getCommitLog(invalidBranchName)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): getEntries.refName: " + REF_NAME_OR_HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.getEntries(invalidBranchName)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): getReferenceByName.refName: " + REF_NAME_OR_HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.getReferenceByName(invalidBranchName)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): assignTag.tagName: " + REF_NAME_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.assignTag(invalidBranchName, VALID_HASH, tag)).getMessage()),
+        () -> assertThat(
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.mergeRefIntoBranch(invalidBranchName, VALID_HASH, null)).getMessage(),
+            allOf(
+                containsString("Bad Request (HTTP/400): "),
+                containsString("mergeRefIntoBranch.branchName: " + REF_NAME_MESSAGE),
+                containsString("mergeRefIntoBranch.merge: must not be null")
+            )),
+        () -> assertEquals("Bad Request (HTTP/400): deleteTag.tagName: " + REF_NAME_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.deleteTag(invalidBranchName, VALID_HASH)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): transplantCommitsIntoBranch.branchName: " + REF_NAME_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.transplantCommitsIntoBranch(invalidBranchName, VALID_HASH, null, null)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): setContents.branch: " + REF_NAME_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> contents.setContents(key, invalidBranchName, VALID_HASH, null, cts)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): deleteContents.branch: " + REF_NAME_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> contents.deleteContents(key, invalidBranchName, VALID_HASH, null)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): getContents.ref: " + REF_NAME_OR_HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> contents.getContents(key, invalidBranchName)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): getMultipleContents.ref: " + REF_NAME_OR_HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> contents.getMultipleContents(invalidBranchName, mgReq)).getMessage())
+    );
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "",
+      "abc'",
+      ".foo",
+      "abc'def'..'blah",
+      "abc'de..blah",
+      "abc'de@{blah"
+  })
+  void invalidHashes(String invalidHash) {
+    String validBranchName = "hello";
+    Operations ops = ImmutableOperations.builder().build();
+    ContentsKey key = ContentsKey.of("x");
+    Contents cts = IcebergTable.of("moo");
+    MultiGetContentsRequest mgReq = MultiGetContentsRequest.of(key);
+    Tag tag = Tag.of("valid", VALID_HASH);
+    assertAll(
+        () -> assertEquals("Bad Request (HTTP/400): commitMultipleOperations.hash: " + HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.commitMultipleOperations(validBranchName, invalidHash, null, ops)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): deleteBranch.hash: " + HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.deleteBranch(validBranchName, invalidHash)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): assignTag.oldHash: " + HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.assignTag(validBranchName, invalidHash, tag)).getMessage()),
+        () -> assertThat(
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.mergeRefIntoBranch(validBranchName, invalidHash, null)).getMessage(),
+            allOf(
+                containsString("Bad Request (HTTP/400): "),
+                containsString("mergeRefIntoBranch.merge: must not be null"),
+                containsString("mergeRefIntoBranch.hash: " + HASH_MESSAGE)
+            )),
+        () -> assertEquals("Bad Request (HTTP/400): deleteTag.hash: " + HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.deleteTag(validBranchName, invalidHash)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): transplantCommitsIntoBranch.hash: " + HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> tree.transplantCommitsIntoBranch(validBranchName, invalidHash, null, null)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): setContents.hash: " + HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> contents.setContents(key, validBranchName, invalidHash, null, cts)).getMessage()),
+        () -> assertEquals("Bad Request (HTTP/400): deleteContents.hash: " + HASH_MESSAGE,
+            assertThrows(NessieBadRequestException.class,
+                () -> contents.deleteContents(key, validBranchName, invalidHash, null)).getMessage()),
+        () -> assertThat(
+            assertThrows(NessieBadRequestException.class,
+                () -> contents.getMultipleContents(invalidHash, null)).getMessage(),
+            allOf(
+                containsString("Bad Request (HTTP/400): "),
+                containsString("getMultipleContents.request: must not be null"),
+                containsString("getMultipleContents.ref: " + REF_NAME_OR_HASH_MESSAGE)
+            ))
+    );
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "",
+      "abc'",
+      ".foo",
+      "abc'def'..'blah",
+      "abc'de..blah",
+      "abc'de@{blah"
+  })
+  void invalidTags(String invalidTagName) {
+    String validBranchName = "hello";
+    ContentsKey key = ContentsKey.of("x");
+    MultiGetContentsRequest mgReq = MultiGetContentsRequest.of(key);
+    // Need the string-ified JSON representation of `Tag` here, because `Tag` itself performs
+    // validation.
+    String tag = "{\"type\": \"TAG\", \"name\": \"" + invalidTagName + "\", \"hash\": \"" + VALID_HASH + "\"}";
+    String branch = "{\"type\": \"BRANCH\", \"name\": \"" + invalidTagName + "\", \"hash\": \"" + VALID_HASH + "\"}";
+    String different = "{\"type\": \"FOOBAR\", \"name\": \"" + invalidTagName + "\", \"hash\": \"" + VALID_HASH + "\"}";
+    assertAll(
+        () -> assertEquals("Bad Request (HTTP/400): assignTag.tag: must not be null",
+            assertThrows(NessieBadRequestException.class,
+                () -> unwrap(() ->
+                    httpClient.newRequest().path("trees/tag/{tagName}")
+                        .resolveTemplate("tagName", validBranchName)
+                        .queryParam("expectedHash", VALID_HASH)
+                        .put(null))
+            ).getMessage()),
+        () -> assertThat(
+            assertThrows(NessieBadRequestException.class,
+                () -> unwrap(() ->
+                    httpClient.newRequest().path("trees/tag/{tagName}")
+                        .resolveTemplate("tagName", validBranchName)
+                        .queryParam("expectedHash", VALID_HASH)
+                        .put(tag))
+            ).getMessage(),
+            startsWith("Bad Request (HTTP/400): Cannot construct instance of "
+                + "`com.dremio.nessie.model.ImmutableTag`, problem: "
+                + REF_NAME_MESSAGE + " - but was: " + invalidTagName + "\n")),
+        () -> assertThat(
+            assertThrows(NessieBadRequestException.class,
+                () -> unwrap(() ->
+                    httpClient.newRequest().path("trees/tag/{tagName}")
+                        .resolveTemplate("tagName", validBranchName)
+                        .queryParam("expectedHash", VALID_HASH)
+                        .put(branch))
+            ).getMessage(),
+            startsWith("Bad Request (HTTP/400): Could not resolve type id 'BRANCH' as a subtype of "
+                + "`com.dremio.nessie.model.Tag`: Class `com.dremio.nessie.model.Branch` "
+                + "not subtype of `com.dremio.nessie.model.Tag`\n")),
+        () -> assertThat(
+            assertThrows(NessieBadRequestException.class,
+                () -> unwrap(() ->
+                    httpClient.newRequest().path("trees/tag/{tagName}")
+                        .resolveTemplate("tagName", validBranchName)
+                        .queryParam("expectedHash", VALID_HASH)
+                        .put(different))
+            ).getMessage(),
+            startsWith("Bad Request (HTTP/400): Could not resolve type id 'FOOBAR' as a subtype of "
+                + "`com.dremio.nessie.model.Tag`: known type ids = [BRANCH, HASH, TAG]\n"))
+    );
+  }
+
+  void unwrap(Executable exec) throws Throwable {
+    try {
+      exec.execute();
+    } catch (Throwable targetException) {
+      if (targetException instanceof HttpClientException) {
+        if (targetException.getCause() instanceof NessieNotFoundException
+            || targetException.getCause() instanceof NessieConflictException) {
+          throw targetException.getCause();
+        }
+      }
+
+      throw targetException;
+    }
   }
 }


### PR DESCRIPTION
Implements regex-based validation of reference names + commit hashes.

These are the actual regex patterns, which comply to the rules mentioned in #578:
* `^[0-9a-fA-F]{64}$` for hashes
* `^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9._-])?$` for reference names

This change adds the parameter/value validation to:
* the REST API parameters via `@Pattern` annotations
* the "value" classes like `Tag`, `Hash`, etc

Two chunks of unit-tests exercise the validation-code-paths and the related patterns.

Fixes #578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/633)
<!-- Reviewable:end -->
