### PR TITLE
Ignore files+folders that get generated by venv + mkdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ gradle/
 out
 gradle/wrapper/gradle-wrapper.jar
 version.txt
+
+# Python venv
+venv/

--- a/site/README.md
+++ b/site/README.md
@@ -30,9 +30,9 @@ dependencies.
   # cd to the site/ directory
   cd site/
   # setup the virtual environment (only needed once)
-  virtualenv -p $(which python3) .
+  virtualenv -p $(which python3) venv
   # activate the virtual environment
-  . bin/activate
+  . venv/bin/activate
   # Install or update the dependencies as usual
   pip install -r ./requirements.txt
   ```


### PR DESCRIPTION
When following the instructions in the `README.md`, the Python `venv` creates a `.gitignore` in `site/` covering all files (contains a single `*` entry), which is not good.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/659)
<!-- Reviewable:end -->
