### PR TITLE
Make build+test use en/US

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,12 @@
           <version>${surefire.version}</version>
           <configuration>
             <argLine>@{argLine}</argLine>
+            <systemProperties>
+              <user.language>en</user.language>
+              <user.country>US</user.country>
+              <user.variant/>
+              <file.encoding>UTF-8</file.encoding>
+            </systemProperties>
           </configuration>
         </plugin>
         <plugin>

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -91,7 +91,7 @@ quarkus.log.sentry=false
 # fixed at buildtime
 quarkus.index-dependency.guava.group-id=com.google.guava
 quarkus.index-dependency.guava.artifact-id=guava
-quarkus.native.additional-build-args =-H:ReflectionConfigurationFiles=reflection-config.json,-H:IncludeResourceBundles=org.eclipse.jgit.internal.JGitText
+quarkus.native.additional-build-args =-H:ReflectionConfigurationFiles=reflection-config.json,-H:IncludeResourceBundles=org.eclipse.jgit.internal.JGitText,-J-Duser.language=en,-J-Duser.country=US,-J-Duser.variant=,-J-Dfile.encoding=UTF-8
 
 ## quarkus container specific settings
 # fixed at buildtime


### PR DESCRIPTION
Integration-tests like `TestRest` and derived native-image tests use the user's language. This lets the tests fail, when the user's language is not `en`. This PR changes the language to `en`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/751)
<!-- Reviewable:end -->
