### PR TITLE
Dynamo: split initializeDatabase + setupTables configs

### DIFF
--- a/servers/quarkus-server/src/main/java/com/dremio/nessie/server/config/ApplicationConfig.java
+++ b/servers/quarkus-server/src/main/java/com/dremio/nessie/server/config/ApplicationConfig.java
@@ -117,6 +117,9 @@ public class ApplicationConfig {
     @ConfigProperty(name = "initialize", defaultValue = "false")
     boolean isDynamoInitialize();
 
+    @ConfigProperty(name = "setupTables", defaultValue = "false")
+    boolean isSetupTables();
+
     @ConfigProperty(defaultValue = DynamoStoreConfig.TABLE_PREFIX)
     String getTablePrefix();
 

--- a/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/VersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/VersionStoreFactory.java
@@ -140,6 +140,7 @@ public class VersionStoreFactory {
           }))
           .region(Region.of(region))
           .initializeDatabase(in.isDynamoInitialize())
+          .setupTables(in.isSetupTables())
           .tablePrefix(in.getTablePrefix())
           .build());
     dynamo.start();

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -29,7 +29,9 @@ nessie.version.store.jgit.type=DISK
 nessie.version.store.jgit.directory=/tmp/jgit
 
 ## Dynamo version store specific configuration
-### should Nessie create its own dynamo tables
+### should Nessie create its own DynamoDB tables
+nessie.version.store.dynamo.setupTables=false
+### should Nessie initialize any missing initial objects in DynamoDB
 nessie.version.store.dynamo.initialize=false
 ### table names for ref, tree and value tables respectively
 nessie.version.store.dynamo.tablePrefix=nessie_

--- a/versioned/tiered/dynamodb/src/main/java/com/dremio/nessie/versioned/store/dynamo/DynamoStore.java
+++ b/versioned/tiered/dynamodb/src/main/java/com/dremio/nessie/versioned/store/dynamo/DynamoStore.java
@@ -147,12 +147,13 @@ public class DynamoStore implements Store {
       client = b1.build();
       async = b2.build();
 
-      if (config.initializeDatabase()) {
+      if (config.setupTables()) {
         ValueType.values().stream()
-          .map(tableNames::get)
-          .collect(Collectors.toSet())
+            .map(tableNames::get)
+            .collect(Collectors.toSet())
             .forEach(this::createIfMissing);
-
+      }
+      if (config.initializeDatabase()) {
         // make sure we have an empty l1 (ignore result, doesn't matter)
         EntityStoreHelper.storeMinimumEntities(this::putIfAbsent);
       }

--- a/versioned/tiered/dynamodb/src/main/java/com/dremio/nessie/versioned/store/dynamo/DynamoStoreConfig.java
+++ b/versioned/tiered/dynamodb/src/main/java/com/dremio/nessie/versioned/store/dynamo/DynamoStoreConfig.java
@@ -37,6 +37,11 @@ public abstract class DynamoStoreConfig {
   }
 
   @Default
+  public boolean setupTables() {
+    return true;
+  }
+
+  @Default
   public boolean initializeDatabase() {
     return true;
   }


### PR DESCRIPTION
Splits the DynamoDB config `initialize` that actually does two things:
* create any missing tables
* write any missing _initial_ objects (`L1`, `L2`, `L3`) that are needed for an initial setup

A single property doesn't account for "upgrade scenarios": the case when we change the schema or add more tables but want to keep existing content without letting the store re-add initial objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/757)
<!-- Reviewable:end -->
