### PR TITLE
Re-enable `ITNativeRest`

### DIFF
--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/ITNativeRest.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/ITNativeRest.java
@@ -15,11 +15,8 @@
  */
 package com.dremio.nessie.server;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.NativeImageTest;
 
-@Disabled
 @NativeImageTest
 public class ITNativeRest extends TestRest {
 

--- a/servers/quarkus-server/src/test/java/com/dremio/nessie/server/RestGitTest.java
+++ b/servers/quarkus-server/src/test/java/com/dremio/nessie/server/RestGitTest.java
@@ -134,7 +134,7 @@ public class RestGitTest {
 
     rest().queryParam(
         "expectedHash",
-        "0011223344556677889900112233445566778899001122334455667788990011")
+        "0011223344556677889900112233445566778899001122334455667788990011".substring(0, b2.getHash().length()))
         .delete("trees/tag/tagtest").then().statusCode(409);
 
     rest().queryParam("expectedHash", b3.getHash())


### PR DESCRIPTION
As noted in #589, we can continue with the current approach and get around a `resetStoreUnsafe` by just using "unique names" in each test of `TestRest`. Therefore this PR, which re-enables `ITNativeRest`.

Also adds a nit-ish fix in `RestGitTest` to only generate hash-strings up to the length of the hash as supported by the underlying store implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/758)
<!-- Reviewable:end -->
