### PR TITLE
Moved TableCommitMetaStoreWorker to nessie-services

### DIFF
--- a/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/VersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/VersionStoreFactory.java
@@ -41,6 +41,7 @@ import com.dremio.nessie.server.config.ApplicationConfig;
 import com.dremio.nessie.server.config.ApplicationConfig.VersionStoreDynamoConfig;
 import com.dremio.nessie.server.config.converters.VersionStoreType;
 import com.dremio.nessie.services.config.ServerConfig;
+import com.dremio.nessie.services.providers.TableCommitMetaStoreWorker;
 import com.dremio.nessie.versioned.BranchName;
 import com.dremio.nessie.versioned.NamedRef;
 import com.dremio.nessie.versioned.ReferenceAlreadyExistsException;

--- a/servers/services/pom.xml
+++ b/servers/services/pom.xml
@@ -37,8 +37,21 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-jgit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-spi</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -61,4 +74,28 @@
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <configuration>
+          <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/servers/services/src/main/java/com/dremio/nessie/services/providers/TableCommitMetaStoreWorker.java
+++ b/servers/services/src/main/java/com/dremio/nessie/services/providers/TableCommitMetaStoreWorker.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.dremio.nessie.server.providers;
+package com.dremio.nessie.services.providers;
 
 import java.io.IOException;
 import java.util.stream.Collectors;

--- a/servers/services/src/main/proto/table.proto
+++ b/servers/services/src/main/proto/table.proto
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+package com.dremio.plugin.partsyn;
+
+option java_package = "com.dremio.nessie.jgit";
+option java_outer_classname = "ObjectTypes";
+option java_generate_equals_and_hash = true;
+
+message PContents {
+  oneof ObjectType {
+    PIcebergTable iceberg_table = 1;
+    PHiveTable hive_table = 2;
+    PHiveDatabase hive_database = 3;
+    PSqlView sql_view = 4;
+    PDeltaLakeTable delta_lake_table = 5;
+  }
+}
+
+message PIcebergTable {
+  string metadata_location = 1;
+}
+
+message PHiveTable {
+  bytes table = 1;
+  repeated bytes partition = 2;
+}
+
+message PHiveDatabase {
+  bytes database = 1;
+}
+
+message PSqlView {
+  string sql_text = 1;
+  string dialect = 2;
+}
+
+message PDeltaLakeTable {
+  string last_checkpoint = 1;
+  repeated string checkpoint_location_history = 2;
+  repeated string metadata_location_history = 3;
+}


### PR DESCRIPTION
In this PR, I am moving the class TableCommitMetaStoreWorker from the nessie-quarkus subproject to the nessie-services project.

The reason for this move is to embed Nessie within Dremio.
Embedding Nessie in Dremio will instantiate the backend and expose Nessie API endpoints within the server running Dremio.

Standalone Nessie runs through Quarkus. Embedded Nessie will not use Quarkus.

In order to create a VersionStore, a StoreWorker is needed. Prior to that change, Dremio would have to depend on nessie-quarkus in order to instantiate a StoreWorker.

With this change, Dremio will now only depend on nessie-model and nessie-services, not importing anything related to Quarkus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/759)
<!-- Reviewable:end -->
