### PR TITLE
Fix passing file.encoding system property + update maven-failsafe-plugin as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,12 +545,11 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire.version}</version>
           <configuration>
-            <argLine>@{argLine}</argLine>
+            <argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>
             <systemProperties>
               <user.language>en</user.language>
               <user.country>US</user.country>
               <user.variant/>
-              <file.encoding>UTF-8</file.encoding>
             </systemProperties>
           </configuration>
         </plugin>
@@ -559,7 +558,12 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${surefire.version}</version>
           <configuration>
-            <argLine>@{argLine}</argLine>
+            <argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>
+            <systemProperties>
+              <user.language>en</user.language>
+              <user.country>US</user.country>
+              <user.variant/>
+            </systemProperties>
             <useModulePath>false</useModulePath>
           </configuration>
         </plugin>


### PR DESCRIPTION
Maven build warning before this patch:
```
[WARNING] file.encoding cannot be set as system property, use <argLine>-Dfile.encoding=...</argLine> instead
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/767)
<!-- Reviewable:end -->
