### PR TITLE
Moved TableCommitMetaStoreWorker outside of nessie-quarkus-server module

### DIFF
--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -34,5 +34,6 @@
     <module>services</module>
     <module>quarkus-server</module>
     <module>lambda</module>
+    <module>server</module>
   </modules>
 </project>

--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -41,6 +41,11 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-jgit</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -196,25 +201,6 @@
               <goal>generate-code-tests</goal>
               <goal>build</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.6.1</version>
-        <configuration>
-          <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/VersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/com/dremio/nessie/server/providers/VersionStoreFactory.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import com.dremio.nessie.model.CommitMeta;
 import com.dremio.nessie.model.Contents;
+import com.dremio.nessie.server.TableCommitMetaStoreWorker;
 import com.dremio.nessie.server.config.ApplicationConfig;
 import com.dremio.nessie.server.config.ApplicationConfig.VersionStoreDynamoConfig;
 import com.dremio.nessie.server.config.converters.VersionStoreType;

--- a/servers/server/pom.xml
+++ b/servers/server/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie-server-parent</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-server</artifactId>
+
+  <name>Nessie - Server</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <configuration>
+          <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/servers/server/src/main/java/com/dremio/nessie/server/TableCommitMetaStoreWorker.java
+++ b/servers/server/src/main/java/com/dremio/nessie/server/TableCommitMetaStoreWorker.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.dremio.nessie.server.providers;
+package com.dremio.nessie.server;
 
 import java.io.IOException;
 import java.util.stream.Collectors;
@@ -21,12 +21,6 @@ import java.util.stream.Stream;
 
 import javax.inject.Singleton;
 
-import com.dremio.nessie.jgit.ObjectTypes.PContents;
-import com.dremio.nessie.jgit.ObjectTypes.PDeltaLakeTable;
-import com.dremio.nessie.jgit.ObjectTypes.PHiveDatabase;
-import com.dremio.nessie.jgit.ObjectTypes.PHiveTable;
-import com.dremio.nessie.jgit.ObjectTypes.PIcebergTable;
-import com.dremio.nessie.jgit.ObjectTypes.PSqlView;
 import com.dremio.nessie.model.CommitMeta;
 import com.dremio.nessie.model.Contents;
 import com.dremio.nessie.model.DeltaLakeTable;
@@ -42,6 +36,12 @@ import com.dremio.nessie.model.ImmutableIcebergTable;
 import com.dremio.nessie.model.ImmutableSqlView;
 import com.dremio.nessie.model.SqlView;
 import com.dremio.nessie.model.SqlView.Dialect;
+import com.dremio.nessie.server.model.ObjectTypes.PContents;
+import com.dremio.nessie.server.model.ObjectTypes.PDeltaLakeTable;
+import com.dremio.nessie.server.model.ObjectTypes.PHiveDatabase;
+import com.dremio.nessie.server.model.ObjectTypes.PHiveTable;
+import com.dremio.nessie.server.model.ObjectTypes.PIcebergTable;
+import com.dremio.nessie.server.model.ObjectTypes.PSqlView;
 import com.dremio.nessie.versioned.AssetKey;
 import com.dremio.nessie.versioned.AssetKey.NoOpAssetKey;
 import com.dremio.nessie.versioned.Serializer;

--- a/servers/server/src/main/proto/table.proto
+++ b/servers/server/src/main/proto/table.proto
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 syntax = "proto3";
-package com.dremio.plugin.partsyn;
+package com.dremio.nessie.model;
 
-option java_package = "com.dremio.nessie.jgit";
+option java_package = "com.dremio.nessie.server.model";
 option java_outer_classname = "ObjectTypes";
 option java_generate_equals_and_hash = true;
 

--- a/servers/services/src/main/java/com/dremio/nessie/services/rest/TreeResource.java
+++ b/servers/services/src/main/java/com/dremio/nessie/services/rest/TreeResource.java
@@ -69,7 +69,7 @@ import com.google.common.collect.ImmutableList;
 public class TreeResource extends BaseResource implements TreeApi {
 
   @Inject
-  protected TreeResource(ServerConfig config, Principal principal,
+  public TreeResource(ServerConfig config, Principal principal,
       VersionStore<Contents, CommitMeta> store) {
     super(config, principal, store);
   }


### PR DESCRIPTION
In this PR, I am moving the class TableCommitMetaStoreWorker from the nessie-quarkus subproject to the nessie-services project.

The reason for this move is to facilitate embedding Nessie within other projects.
Standalone Nessie runs through Quarkus. Embedding Nessie into another project will probably not use Quarkus.

In order to create a VersionStore, a StoreWorker is needed. Prior to that change, projects would have to depend on nessie-quarkus in order to instantiate a StoreWorker.

With this change, projects will now only depend on nessie-model and nessie-services, not importing anything related to Quarkus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/783)
<!-- Reviewable:end -->
