### PR TITLE
Add additional base store tests to AbstractTestStore.

### DIFF
--- a/versioned/tiered/mongodb/src/main/java/com/dremio/nessie/versioned/store/mongodb/MongoDBStore.java
+++ b/versioned/tiered/mongodb/src/main/java/com/dremio/nessie/versioned/store/mongodb/MongoDBStore.java
@@ -224,14 +224,14 @@ public class MongoDBStore implements Store {
 
     final MongoCollection<Document> collection = getCollection(saveOp.getType());
 
-    // Use upsert so that if an item does not exist, it will be insert.
+    // Use upsert so that if an item does not exist, it will be inserted.
     final UpdateResult result = Mono.from(
         collection.updateOne(
             Filters.eq(MongoBaseValue.ID, saveOp.getId()),
             MongoSerDe.bsonForValueType(saveOp, "$set"),
             new UpdateOptions().upsert(true)
         )).block(timeout);
-    if (result == null || result.getUpsertedId() == null) {
+    if (result == null || (result.getModifiedCount() != 0 && result.getUpsertedId() == null)) {
       throw new StoreOperationException(String.format("Update of %s %s did not succeed", saveOp.getType().name(), saveOp.getId()));
     }
   }

--- a/versioned/tiered/mongodb/src/test/java/com/dremio/nessie/versioned/store/mongodb/TestMongoDBStore.java
+++ b/versioned/tiered/mongodb/src/test/java/com/dremio/nessie/versioned/store/mongodb/TestMongoDBStore.java
@@ -85,4 +85,20 @@ class TestMongoDBStore extends AbstractTestStore<MongoDBStore> {
       }
     };
   }
+
+  // Disabled tests
+  @Override
+  protected boolean supportsDelete() {
+    return false;
+  }
+
+  @Override
+  protected boolean supportsUpdate() {
+    return false;
+  }
+
+  @Override
+  protected boolean supportsConditionExpression() {
+    return false;
+  }
 }

--- a/versioned/tiered/tiered-tests/src/main/java/com/dremio/nessie/versioned/impl/AbstractTestStore.java
+++ b/versioned/tiered/tiered-tests/src/main/java/com/dremio/nessie/versioned/impl/AbstractTestStore.java
@@ -632,7 +632,7 @@ public abstract class AbstractTestStore<S extends Store> {
       putThenLoad(ValueType.REF, tag);
       final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(
           ExpressionPath.builder("name").build(), Entity.ofString("badTagName")));
-      Assertions.assertThrows(ConditionFailedException.class, () -> store.update(
+      Assertions.assertFalse(store.update(
           ValueType.REF,
           tag.getId(),
           UpdateExpression.of(RemoveClause.of(ExpressionPath.builder("metadata").build())),
@@ -741,7 +741,8 @@ public abstract class AbstractTestStore<S extends Store> {
       final boolean result = store.update(
           ValueType.KEY_FRAGMENT,
           fragment.getId(),
-          UpdateExpression.of(SetClause.appendToList(ExpressionPath.builder("keys").build(), Entity.ofList(Entity.ofString(key)))),
+          UpdateExpression.of(SetClause.appendToList(
+              ExpressionPath.builder("keys").build(), Entity.ofList(Entity.ofList(Entity.ofString(key))))),
           Optional.empty(),
           Optional.of(builder));
       Assertions.assertTrue(result);

--- a/versioned/tiered/tiered-tests/src/main/java/com/dremio/nessie/versioned/impl/AbstractTestStore.java
+++ b/versioned/tiered/tiered-tests/src/main/java/com/dremio/nessie/versioned/impl/AbstractTestStore.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.dremio.nessie.tiered.builder.BaseValue;
@@ -53,6 +55,7 @@ import com.google.common.collect.Multimap;
  * @param <S> The type of the Store being tested.
  */
 public abstract class AbstractTestStore<S extends Store> {
+
   static class CreatorPair {
     final ValueType<?> type;
     final Supplier<PersistentBase<?>> supplier;
@@ -60,6 +63,18 @@ public abstract class AbstractTestStore<S extends Store> {
     CreatorPair(ValueType<?> type, Supplier<PersistentBase<?>> supplier) {
       this.type = type;
       this.supplier = supplier;
+    }
+  }
+
+  static class EntitySaveOp<C extends BaseValue<C>> {
+    final ValueType<C> type;
+    final PersistentBase<C> entity;
+    final SaveOp<C> saveOp;
+
+    EntitySaveOp(ValueType<C> type, PersistentBase<C> entity) {
+      this.type = type;
+      this.entity = entity;
+      this.saveOp = EntityType.forType(type).createSaveOpForEntity(entity);
     }
   }
 
@@ -132,646 +147,647 @@ public abstract class AbstractTestStore<S extends Store> {
     localStore.close(); // This should be a no-op.
   }
 
-  // Tests for load()
+  @Nested
+  @DisplayName("load() tests")
+  class LoadTests {
+    @Test
+    void load() {
+      final ImmutableList<CreatorPair> creators = ImmutableList.<CreatorPair>builder()
+          .add(new CreatorPair(ValueType.REF, () -> SampleEntities.createTag(random)))
+          .add(new CreatorPair(ValueType.REF, () -> SampleEntities.createBranch(random)))
+          .add(new CreatorPair(ValueType.COMMIT_METADATA, () -> SampleEntities.createCommitMetadata(random)))
+          .add(new CreatorPair(ValueType.VALUE, () -> SampleEntities.createValue(random)))
+          .add(new CreatorPair(ValueType.L1, () -> SampleEntities.createL1(random)))
+          .add(new CreatorPair(ValueType.L2, () -> SampleEntities.createL2(random)))
+          .add(new CreatorPair(ValueType.L3, () -> SampleEntities.createL3(random)))
+          .add(new CreatorPair(ValueType.KEY_FRAGMENT, () -> SampleEntities.createFragment(random)))
+          .build();
+      final ImmutableMultimap.Builder<ValueType<?>, HasId> builder = ImmutableMultimap.builder();
+      for (int i = 0; i < 100; ++i) {
+        final int index = i % creators.size();
+        final HasId obj = creators.get(index).supplier.get();
+        builder.put(creators.get(index).type, obj);
+      }
 
-  @Test
-  void load() {
-    final ImmutableList<CreatorPair> creators = ImmutableList.<CreatorPair>builder()
-      .add(new CreatorPair(ValueType.REF, () -> SampleEntities.createTag(random)))
-      .add(new CreatorPair(ValueType.REF, () -> SampleEntities.createBranch(random)))
-      .add(new CreatorPair(ValueType.COMMIT_METADATA, () -> SampleEntities.createCommitMetadata(random)))
-      .add(new CreatorPair(ValueType.VALUE, () -> SampleEntities.createValue(random)))
-      .add(new CreatorPair(ValueType.L1, () -> SampleEntities.createL1(random)))
-      .add(new CreatorPair(ValueType.L2, () -> SampleEntities.createL2(random)))
-      .add(new CreatorPair(ValueType.L3, () -> SampleEntities.createL3(random)))
-      .add(new CreatorPair(ValueType.KEY_FRAGMENT, () -> SampleEntities.createFragment(random)))
-      .build();
-    final ImmutableMultimap.Builder<ValueType<?>, HasId> builder = ImmutableMultimap.builder();
-    for (int i = 0; i < 100; ++i) {
-      final int index = i % creators.size();
-      final HasId obj = creators.get(index).supplier.get();
-      builder.put(creators.get(index).type, obj);
+      final Multimap<ValueType<?>, HasId> objs = builder.build();
+      objs.forEach(AbstractTestStore.this::putThenLoad);
+
+      store.load(createTestLoadStep(objs));
     }
 
-    final Multimap<ValueType<?>, HasId> objs = builder.build();
-    objs.forEach(this::putThenLoad);
+    @Test
+    void loadSteps() {
+      final Multimap<ValueType<?>, HasId> objs = ImmutableMultimap.<ValueType<?>, HasId>builder()
+          .put(ValueType.REF, SampleEntities.createBranch(random))
+          .put(ValueType.REF, SampleEntities.createBranch(random))
+          .put(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random))
+          .build();
 
-    store.load(createTestLoadStep(objs));
-  }
+      final Multimap<ValueType<?>, HasId> objs2 = ImmutableMultimap.<ValueType<?>, HasId>builder()
+          .put(ValueType.L3, SampleEntities.createL3(random))
+          .put(ValueType.VALUE, SampleEntities.createValue(random))
+          .put(ValueType.VALUE, SampleEntities.createValue(random))
+          .put(ValueType.VALUE, SampleEntities.createValue(random))
+          .put(ValueType.REF, SampleEntities.createTag(random))
+          .build();
 
-  @Test
-  void loadSteps() {
-    final Multimap<ValueType<?>, HasId> objs = ImmutableMultimap.<ValueType<?>, HasId>builder()
-        .put(ValueType.REF, SampleEntities.createBranch(random))
-        .put(ValueType.REF, SampleEntities.createBranch(random))
-        .put(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random))
-        .build();
+      objs.forEach(AbstractTestStore.this::putThenLoad);
+      objs2.forEach(AbstractTestStore.this::putThenLoad);
 
-    final Multimap<ValueType<?>, HasId> objs2 = ImmutableMultimap.<ValueType<?>, HasId>builder()
-        .put(ValueType.L3, SampleEntities.createL3(random))
-        .put(ValueType.VALUE, SampleEntities.createValue(random))
-        .put(ValueType.VALUE, SampleEntities.createValue(random))
-        .put(ValueType.VALUE, SampleEntities.createValue(random))
-        .put(ValueType.REF, SampleEntities.createTag(random))
-        .build();
+      final LoadStep step2 = createTestLoadStep(objs2);
+      final LoadStep step1 = createTestLoadStep(objs, Optional.of(step2));
 
-    objs.forEach(this::putThenLoad);
-    objs2.forEach(this::putThenLoad);
-
-    final LoadStep step2 = createTestLoadStep(objs2);
-    final LoadStep step1 = createTestLoadStep(objs, Optional.of(step2));
-
-    store.load(step1);
-  }
-
-  @Test
-  void loadNone() {
-    store.load(createTestLoadStep(ImmutableMultimap.of()));
-  }
-
-  @Test
-  void loadInvalid() {
-    putThenLoad(ValueType.REF, SampleEntities.createBranch(random));
-    final Multimap<ValueType<?>, HasId> objs = ImmutableMultimap.of(ValueType.REF, SampleEntities.createBranch(random));
-
-    Assertions.assertThrows(NotFoundException.class, () -> store.load(createTestLoadStep(objs)));
-  }
-
-  @Test
-  void loadPagination() {
-    final ImmutableMultimap.Builder<ValueType<?>, HasId> builder = ImmutableMultimap.builder();
-    for (int i = 0; i < (10 + loadSize()); ++i) {
-      // Only create a single type as this is meant to test the pagination within the store, not the variety. Variety is
-      // taken care of by another test.
-      builder.put(ValueType.REF, SampleEntities.createTag(random));
+      store.load(step1);
     }
 
-    final Multimap<ValueType<?>, HasId> objs = builder.build();
-    objs.forEach(this::putThenLoad);
+    @Test
+    void loadNone() {
+      store.load(createTestLoadStep(ImmutableMultimap.of()));
+    }
 
-    store.load(createTestLoadStep(objs));
-  }
+    @Test
+    void loadInvalid() {
+      putThenLoad(ValueType.REF, SampleEntities.createBranch(random));
+      final Multimap<ValueType<?>, HasId> objs = ImmutableMultimap.of(ValueType.REF, SampleEntities.createBranch(random));
 
-  // Test for loadSingle()
+      Assertions.assertThrows(NotFoundException.class, () -> store.load(createTestLoadStep(objs)));
+    }
 
-  @Test
-  void loadSingleInvalid() {
-    Assertions.assertThrows(NotFoundException.class, () -> EntityType.REF.loadSingle(store, SampleEntities.createId(random)));
-  }
+    @Test
+    void loadPagination() {
+      final ImmutableMultimap.Builder<ValueType<?>, HasId> builder = ImmutableMultimap.builder();
+      for (int i = 0; i < (10 + loadSize()); ++i) {
+        // Only create a single type as this is meant to test the pagination within the store, not the variety. Variety is
+        // taken care of by another test.
+        builder.put(ValueType.REF, SampleEntities.createTag(random));
+      }
 
-  @Test
-  void loadSingleL1() {
-    putThenLoad(ValueType.L1, SampleEntities.createL1(random));
-  }
+      final Multimap<ValueType<?>, HasId> objs = builder.build();
+      objs.forEach(AbstractTestStore.this::putThenLoad);
 
-  @Test
-  void loadSingleL2() {
-    putThenLoad(ValueType.L2, SampleEntities.createL2(random));
-  }
+      store.load(createTestLoadStep(objs));
+    }
 
-  @Test
-  void loadSingleL3() {
-    putThenLoad(ValueType.L3, SampleEntities.createL3(random));
-  }
+    private LoadStep createTestLoadStep(Multimap<ValueType<?>, HasId> objs) {
+      return createTestLoadStep(objs, Optional.empty());
+    }
 
-  @Test
-  void loadFragment() {
-    putThenLoad(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
-  }
-
-  @Test
-  void loadBranch() {
-    putThenLoad(ValueType.REF, SampleEntities.createBranch(random));
-  }
-
-  @Test
-  void loadTag() {
-    putThenLoad(ValueType.REF, SampleEntities.createTag(random));
-  }
-
-  @Test
-  void loadCommitMetadata() {
-    putThenLoad(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
-  }
-
-  @Test
-  void loadValue() {
-    putThenLoad(ValueType.VALUE, SampleEntities.createValue(random));
-  }
-
-  // Tests for putIfAbsent()
-
-  @Test
-  void putIfAbsentL1() {
-    testPutIfAbsent(ValueType.L1, SampleEntities.createL1(random));
-  }
-
-  @Test
-  void putIfAbsentL2() {
-    testPutIfAbsent(ValueType.L2, SampleEntities.createL2(random));
-  }
-
-  @Test
-  void putIfAbsentL3() {
-    testPutIfAbsent(ValueType.L3, SampleEntities.createL3(random));
-  }
-
-  @Test
-  void putIfAbsentFragment() {
-    testPutIfAbsent(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
-  }
-
-  @Test
-  void putIfAbsentBranch() {
-    testPutIfAbsent(ValueType.REF, SampleEntities.createBranch(random));
-  }
-
-  @Test
-  void putIfAbsentTag() {
-    testPutIfAbsent(ValueType.REF, SampleEntities.createTag(random));
-  }
-
-  @Test
-  void putIfAbsentCommitMetadata() {
-    testPutIfAbsent(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
-  }
-
-  @Test
-  void putIfAbsentValue() {
-    testPutIfAbsent(ValueType.VALUE, SampleEntities.createValue(random));
-  }
-
-  // Tests for save()
-
-  static class EntitySaveOp<C extends BaseValue<C>> {
-    final ValueType<C> type;
-    final PersistentBase<C> entity;
-    final SaveOp<C> saveOp;
-
-    EntitySaveOp(ValueType<C> type, PersistentBase<C> entity) {
-      this.type = type;
-      this.entity = entity;
-      this.saveOp = EntityType.forType(type).createSaveOpForEntity(entity);
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private LoadStep createTestLoadStep(Multimap<ValueType<?>, HasId> objs, Optional<LoadStep> next) {
+      final EntityLoadOps loadOps = new EntityLoadOps();
+      objs.forEach((type, val) -> loadOps.load(((EntityType) EntityType.forType(type)), val.getId(), r -> assertEquals(val, r)));
+      return loadOps.build(() -> next);
     }
   }
 
-  @Test
-  void save() {
-    final List<EntitySaveOp<?>> entities = Arrays.asList(
-        new EntitySaveOp<>(ValueType.L1, SampleEntities.createL1(random)),
-        new EntitySaveOp<>(ValueType.L2, SampleEntities.createL2(random)),
-        new EntitySaveOp<>(ValueType.L3, SampleEntities.createL3(random)),
-        new EntitySaveOp<>(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random)),
-        new EntitySaveOp<>(ValueType.REF, SampleEntities.createBranch(random)),
-        new EntitySaveOp<>(ValueType.REF, SampleEntities.createTag(random)),
-        new EntitySaveOp<>(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random)),
-        new EntitySaveOp<>(ValueType.VALUE, SampleEntities.createValue(random))
-    );
+  @Nested
+  @DisplayName("loadSingle() tests")
+  class LoadSingleTests {
+    @Test
+    void loadSingleInvalid() {
+      Assertions.assertThrows(NotFoundException.class, () -> EntityType.REF.loadSingle(store, SampleEntities.createId(random)));
+    }
 
-    store.save(entities.stream().map(e -> e.saveOp).collect(Collectors.toList()));
+    @Test
+    void loadSingleL1() {
+      putThenLoad(ValueType.L1, SampleEntities.createL1(random));
+    }
 
-    Assertions.assertAll(entities.stream().map(s -> () -> {
-      try {
-        final HasId saveOpValue = s.entity;
-        HasId loadedValue = EntityType.forType(s.type).loadSingle(store, saveOpValue.getId());
-        Assertions.assertEquals(saveOpValue, loadedValue, "type " + s.type);
+    @Test
+    void loadSingleL2() {
+      putThenLoad(ValueType.L2, SampleEntities.createL2(random));
+    }
 
+    @Test
+    void loadSingleL3() {
+      putThenLoad(ValueType.L3, SampleEntities.createL3(random));
+    }
+
+    @Test
+    void loadFragment() {
+      putThenLoad(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
+    }
+
+    @Test
+    void loadBranch() {
+      putThenLoad(ValueType.REF, SampleEntities.createBranch(random));
+    }
+
+    @Test
+    void loadTag() {
+      putThenLoad(ValueType.REF, SampleEntities.createTag(random));
+    }
+
+    @Test
+    void loadCommitMetadata() {
+      putThenLoad(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
+    }
+
+    @Test
+    void loadValue() {
+      putThenLoad(ValueType.VALUE, SampleEntities.createValue(random));
+    }
+  }
+
+  @Nested
+  @DisplayName("putIfAbsent() tests")
+  class PutIfAbsentTests {
+    @Test
+    void putIfAbsentL1() {
+      testPutIfAbsent(ValueType.L1, SampleEntities.createL1(random));
+    }
+
+    @Test
+    void putIfAbsentL2() {
+      testPutIfAbsent(ValueType.L2, SampleEntities.createL2(random));
+    }
+
+    @Test
+    void putIfAbsentL3() {
+      testPutIfAbsent(ValueType.L3, SampleEntities.createL3(random));
+    }
+
+    @Test
+    void putIfAbsentFragment() {
+      testPutIfAbsent(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
+    }
+
+    @Test
+    void putIfAbsentBranch() {
+      testPutIfAbsent(ValueType.REF, SampleEntities.createBranch(random));
+    }
+
+    @Test
+    void putIfAbsentTag() {
+      testPutIfAbsent(ValueType.REF, SampleEntities.createTag(random));
+    }
+
+    @Test
+    void putIfAbsentCommitMetadata() {
+      testPutIfAbsent(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
+    }
+
+    @Test
+    void putIfAbsentValue() {
+      testPutIfAbsent(ValueType.VALUE, SampleEntities.createValue(random));
+    }
+
+    protected <C extends BaseValue<C>, T extends PersistentBase<C>> void testPutIfAbsent(ValueType<C> type, T sample) {
+      Assertions.assertTrue(store.putIfAbsent(new EntitySaveOp<>(type, sample).saveOp));
+      testLoadSingle(type, sample);
+      Assertions.assertFalse(store.putIfAbsent(new EntitySaveOp<>(type, sample).saveOp));
+      testLoadSingle(type, sample);
+    }
+  }
+
+  @Nested
+  @DisplayName("save() tests")
+  class SaveTests {
+    @Test
+    void save() {
+      final List<EntitySaveOp<?>> entities = Arrays.asList(
+          new EntitySaveOp<>(ValueType.L1, SampleEntities.createL1(random)),
+          new EntitySaveOp<>(ValueType.L2, SampleEntities.createL2(random)),
+          new EntitySaveOp<>(ValueType.L3, SampleEntities.createL3(random)),
+          new EntitySaveOp<>(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random)),
+          new EntitySaveOp<>(ValueType.REF, SampleEntities.createBranch(random)),
+          new EntitySaveOp<>(ValueType.REF, SampleEntities.createTag(random)),
+          new EntitySaveOp<>(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random)),
+          new EntitySaveOp<>(ValueType.VALUE, SampleEntities.createValue(random))
+      );
+
+      store.save(entities.stream().map(e -> e.saveOp).collect(Collectors.toList()));
+
+      Assertions.assertAll(entities.stream().map(s -> () -> {
         try {
-          loadedValue = EntityType.forType(s.type).buildEntity(producer -> {
-            @SuppressWarnings("rawtypes") ValueType t = s.type;
-            @SuppressWarnings("rawtypes") BaseValue p = producer;
-            store.loadSingle(t, saveOpValue.getId(), p);
-          });
+          final HasId saveOpValue = s.entity;
+          HasId loadedValue = EntityType.forType(s.type).loadSingle(store, saveOpValue.getId());
           Assertions.assertEquals(saveOpValue, loadedValue, "type " + s.type);
-        } catch (UnsupportedOperationException e) {
-          // TODO ignore this for now
+
+          try {
+            loadedValue = EntityType.forType(s.type).buildEntity(producer -> {
+              @SuppressWarnings("rawtypes") ValueType t = s.type;
+              @SuppressWarnings("rawtypes") BaseValue p = producer;
+              store.loadSingle(t, saveOpValue.getId(), p);
+            });
+            Assertions.assertEquals(saveOpValue, loadedValue, "type " + s.type);
+          } catch (UnsupportedOperationException e) {
+            // TODO ignore this for now
+          }
+
+        } catch (NotFoundException e) {
+          Assertions.fail("type " + s.type, e);
+        }
+      }));
+    }
+  }
+
+  @Nested
+  @DisplayName("put() tests")
+  class PutWithoutConditionExpressionTests {
+    @Test
+    void putWithConditionValue() {
+      putWithCondition(ValueType.VALUE, SampleEntities.createValue(random));
+    }
+
+    @Test
+    void putWithConditionBranch() {
+      putWithCondition(ValueType.REF, SampleEntities.createBranch(random));
+    }
+
+    @Test
+    void putWithConditionTag() {
+      putWithCondition(ValueType.REF, SampleEntities.createTag(random));
+    }
+
+    @Test
+    void putWithConditionCommitMetadata() {
+      putWithCondition(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
+    }
+
+    @Test
+    void putWithConditionKeyFragment() {
+      putWithCondition(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
+    }
+
+    @Test
+    void putWithConditionL1() {
+      putWithCondition(ValueType.L1, SampleEntities.createL1(random));
+    }
+
+    @Test
+    void putWithConditionL2() {
+      putWithCondition(ValueType.L2, SampleEntities.createL2(random));
+    }
+
+    @Test
+    void putWithConditionL3() {
+      putWithCondition(ValueType.L3, SampleEntities.createL3(random));
+    }
+
+    @Test
+    void putTwice() {
+      final HasId l3 = SampleEntities.createL3(random);
+      putThenLoad(ValueType.L3, l3);
+      putThenLoad(ValueType.L3, l3);
+    }
+
+    @Test
+    void putWithCompoundConditionTag() {
+      final InternalRef sample = SampleEntities.createTag(random);
+      putThenLoad(ValueType.REF, sample);
+      final InternalRef.Type type = InternalRef.Type.TAG;
+      final ConditionExpression condition = ConditionExpression.of(
+          ExpressionFunction.equals(ExpressionPath.builder(InternalRef.TYPE).build(), type.toEntity()),
+          ExpressionFunction.equals(ExpressionPath.builder("name").build(), Entity.ofString("tagName"))
+      );
+      putConditional(ValueType.REF, sample, true, Optional.of(condition));
+    }
+
+    @Test
+    void putWithFailingConditionExpression() {
+      final InternalRef sample = SampleEntities.createBranch(random);
+      final InternalRef.Type type = InternalRef.Type.BRANCH;
+      final ConditionExpression condition = ConditionExpression.of(
+          ExpressionFunction.equals(ExpressionPath.builder(InternalRef.TYPE).build(), type.toEntity()),
+          ExpressionFunction.equals(ExpressionPath.builder("commit").build(), Entity.ofString("notEqual")));
+      putConditional(ValueType.REF, sample, false, Optional.of(condition));
+    }
+
+    private <T extends HasId> void putWithCondition(ValueType<?> type, T sample) {
+      // Tests that attempt to put (update) an existing entry should only occur when the condition expression is met.
+      putThenLoad(type, sample);
+
+      final ExpressionPath keyName = ExpressionPath.builder(Store.KEY_NAME).build();
+      final ConditionExpression conditionExpression = ConditionExpression.of(ExpressionFunction.equals(keyName, sample.getId().toEntity()));
+      putConditional(type, sample, true, Optional.of(conditionExpression));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <C extends BaseValue<C>> void putConditional(ValueType<C> type, HasId sample, boolean shouldSucceed,
+                                                           Optional<ConditionExpression> conditionExpression) {
+      if (!supportsConditionExpression()) {
+        return;
+      }
+
+      try {
+        store.put(new EntitySaveOp<>(type, (PersistentBase<C>) sample).saveOp, conditionExpression);
+        if (!shouldSucceed) {
+          Assertions.fail();
+        }
+        testLoadSingle(type, sample);
+      } catch (ConditionFailedException cfe) {
+        if (shouldSucceed) {
+          Assertions.fail(cfe);
         }
 
-      } catch (NotFoundException e) {
-        Assertions.fail("type " + s.type, e);
+        Assertions.assertThrows(NotFoundException.class, () -> EntityType.forType(type).loadSingle(store, sample.getId()));
       }
-    }));
+    }
   }
 
-  // Tests for put()
+  @Nested
+  @DisplayName("delete() tests")
+  class DeleteTests {
+    @Test
+    void deleteNoConditionValue() {
+      if (!supportsDelete()) {
+        return;
+      }
 
-  @Test
-  void putWithConditionValue() {
-    putWithCondition(ValueType.VALUE, SampleEntities.createValue(random));
-  }
-
-  @Test
-  void putWithConditionBranch() {
-    putWithCondition(ValueType.REF, SampleEntities.createBranch(random));
-  }
-
-  @Test
-  void putWithConditionTag() {
-    putWithCondition(ValueType.REF, SampleEntities.createTag(random));
-  }
-
-  @Test
-  void putWithConditionCommitMetadata() {
-    putWithCondition(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
-  }
-
-  @Test
-  void putWithConditionKeyFragment() {
-    putWithCondition(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
-  }
-
-  @Test
-  void putWithConditionL1() {
-    putWithCondition(ValueType.L1, SampleEntities.createL1(random));
-  }
-
-  @Test
-  void putWithConditionL2() {
-    putWithCondition(ValueType.L2, SampleEntities.createL2(random));
-  }
-
-  @Test
-  void putWithConditionL3() {
-    putWithCondition(ValueType.L3, SampleEntities.createL3(random));
-  }
-
-  @Test
-  void putTwice() {
-    final HasId l3 = SampleEntities.createL3(random);
-    putThenLoad(ValueType.L3, l3);
-    putThenLoad(ValueType.L3, l3);
-  }
-
-  // Tests for put() with conditions
-
-  @Test
-  void putWithCompoundConditionTag() {
-    final InternalRef sample = SampleEntities.createTag(random);
-    putThenLoad(ValueType.REF, sample);
-    final InternalRef.Type type = InternalRef.Type.TAG;
-    final ConditionExpression condition = ConditionExpression.of(
-        ExpressionFunction.equals(ExpressionPath.builder(InternalRef.TYPE).build(), type.toEntity()),
-        ExpressionFunction.equals(ExpressionPath.builder("name").build(), Entity.ofString("tagName"))
-    );
-    putConditional(ValueType.REF, sample, true, Optional.of(condition));
-  }
-
-  @Test
-  void putWithFailingConditionExpression() {
-    final InternalRef sample = SampleEntities.createBranch(random);
-    final InternalRef.Type type = InternalRef.Type.BRANCH;
-    final ConditionExpression condition = ConditionExpression.of(
-        ExpressionFunction.equals(ExpressionPath.builder(InternalRef.TYPE).build(), type.toEntity()),
-        ExpressionFunction.equals(ExpressionPath.builder("commit").build(), Entity.ofString("notEqual")));
-    putConditional(ValueType.REF, sample, false, Optional.of(condition));
-  }
-
-  // Tests for delete()
-
-  @Test
-  void deleteNoConditionValue() {
-    if (!supportsDelete()) {
-      return;
+      deleteWithCondition(ValueType.VALUE, SampleEntities.createValue(random), true, Optional.empty());
     }
 
-    deleteCondition(ValueType.VALUE, SampleEntities.createValue(random), true, Optional.empty());
-  }
+    @Test
+    void deleteNoConditionL1() {
+      if (!supportsDelete()) {
+        return;
+      }
 
-  @Test
-  void deleteNoConditionL1() {
-    if (!supportsDelete()) {
-      return;
+      deleteWithCondition(ValueType.L1, SampleEntities.createL1(random), true, Optional.empty());
     }
 
-    deleteCondition(ValueType.L1, SampleEntities.createL1(random), true, Optional.empty());
-  }
+    @Test
+    void deleteNoConditionL2() {
+      if (!supportsDelete()) {
+        return;
+      }
 
-  @Test
-  void deleteNoConditionL2() {
-    if (!supportsDelete()) {
-      return;
+      deleteWithCondition(ValueType.L2, SampleEntities.createL2(random), true, Optional.empty());
     }
 
-    deleteCondition(ValueType.L2, SampleEntities.createL2(random), true, Optional.empty());
-  }
+    @Test
+    void deleteNoConditionL3() {
+      if (!supportsDelete()) {
+        return;
+      }
 
-  @Test
-  void deleteNoConditionL3() {
-    if (!supportsDelete()) {
-      return;
+      deleteWithCondition(ValueType.L3, SampleEntities.createL3(random), true, Optional.empty());
     }
 
-    deleteCondition(ValueType.L3, SampleEntities.createL3(random), true, Optional.empty());
-  }
+    @Test
+    void deleteNoConditionFragment() {
+      if (!supportsDelete()) {
+        return;
+      }
 
-  @Test
-  void deleteNoConditionFragment() {
-    if (!supportsDelete()) {
-      return;
+      deleteWithCondition(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random), true, Optional.empty());
     }
 
-    deleteCondition(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random), true, Optional.empty());
-  }
+    @Test
+    void deleteNoConditionBranch() {
+      if (!supportsDelete()) {
+        return;
+      }
 
-  @Test
-  void deleteNoConditionBranch() {
-    if (!supportsDelete()) {
-      return;
+      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(random), true, Optional.empty());
     }
 
-    deleteCondition(ValueType.REF, SampleEntities.createBranch(random), true, Optional.empty());
-  }
+    @Test
+    void deleteNoConditionTag() {
+      if (!supportsDelete()) {
+        return;
+      }
 
-  @Test
-  void deleteNoConditionTag() {
-    if (!supportsDelete()) {
-      return;
+      deleteWithCondition(ValueType.REF, SampleEntities.createTag(random), true, Optional.empty());
     }
 
-    deleteCondition(ValueType.REF, SampleEntities.createTag(random), true, Optional.empty());
-  }
+    @Test
+    void deleteNoConditionCommitMetadata() {
+      if (!supportsDelete()) {
+        return;
+      }
 
-  @Test
-  void deleteNoConditionCommitMetadata() {
-    if (!supportsDelete()) {
-      return;
+      deleteWithCondition(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random), true, Optional.empty());
     }
 
-    deleteCondition(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random), true, Optional.empty());
-  }
+    @Test
+    void deleteConditionMismatchAttributeValue() {
+      if (!supportsDelete() || !supportsConditionExpression()) {
+        return;
+      }
 
-  @Test
-  void deleteConditionMismatchAttributeValue() {
-    if (!supportsDelete() || !supportsConditionExpression()) {
-      return;
+      final ExpressionFunction expressionFunction = ExpressionFunction.equals(ExpressionPath.builder("value").build(),
+          SampleEntities.createStringEntity(random, random.nextInt(10) + 1));
+      final ConditionExpression ex = ConditionExpression.of(expressionFunction);
+      deleteWithCondition(ValueType.VALUE, SampleEntities.createValue(random), false, Optional.of(ex));
     }
 
-    final ExpressionFunction expressionFunction = ExpressionFunction.equals(ExpressionPath.builder("value").build(),
-        SampleEntities.createStringEntity(random, random.nextInt(10) + 1));
-    final ConditionExpression ex = ConditionExpression.of(expressionFunction);
-    deleteCondition(ValueType.VALUE, SampleEntities.createValue(random), false, Optional.of(ex));
-  }
+    @Test
+    void deleteConditionMismatchAttributeBranch() {
+      if (!supportsDelete() || !supportsConditionExpression()) {
+        return;
+      }
 
-  @Test
-  void deleteConditionMismatchAttributeBranch() {
-    if (!supportsDelete() || !supportsConditionExpression()) {
-      return;
+      final ExpressionFunction expressionFunction = ExpressionFunction.equals(ExpressionPath.builder("commit").build(),
+          SampleEntities.createStringEntity(random, random.nextInt(10) + 1));
+      final ConditionExpression ex = ConditionExpression.of(expressionFunction);
+      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(random), false, Optional.of(ex));
     }
 
-    final ExpressionFunction expressionFunction = ExpressionFunction.equals(ExpressionPath.builder("commit").build(),
-        SampleEntities.createStringEntity(random, random.nextInt(10) + 1));
-    final ConditionExpression ex = ConditionExpression.of(expressionFunction);
-    deleteCondition(ValueType.REF, SampleEntities.createBranch(random), false, Optional.of(ex));
-  }
+    @Test
+    void deleteBranchSizeFail() {
+      if (!supportsDelete() || !supportsConditionExpression()) {
+        return;
+      }
 
-  @Test
-  void deleteBranchSizeFail() {
-    if (!supportsDelete() || !supportsConditionExpression()) {
-      return;
+      final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(ExpressionFunction.size(COMMITS), ONE));
+      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(random), false, Optional.of(expression));
     }
 
-    final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(ExpressionFunction.size(COMMITS), ONE));
-    deleteCondition(ValueType.REF, SampleEntities.createBranch(random), false, Optional.of(expression));
-  }
+    @Test
+    void deleteBranchSizeSucceed() {
+      if (!supportsDelete() || !supportsConditionExpression()) {
+        return;
+      }
 
-  @Test
-  void deleteBranchSizeSucceed() {
-    if (!supportsDelete() || !supportsConditionExpression()) {
-      return;
+      final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(ExpressionFunction.size(COMMITS), TWO));
+      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(random), true, Optional.of(expression));
     }
 
-    final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(ExpressionFunction.size(COMMITS), TWO));
-    deleteCondition(ValueType.REF, SampleEntities.createBranch(random), true, Optional.of(expression));
+    protected <T extends HasId> void deleteWithCondition(ValueType<?> type, T sample, boolean shouldSucceed,
+                                                         Optional<ConditionExpression> conditionExpression) {
+      putThenLoad(type, sample);
+      if (shouldSucceed) {
+        Assertions.assertTrue(store.delete(type, sample.getId(), conditionExpression));
+        Assertions.assertThrows(NotFoundException.class, () -> EntityType.forType(type).loadSingle(store, sample.getId()));
+      } else {
+        Assertions.assertFalse(store.delete(type, sample.getId(), conditionExpression));
+        testLoadSingle(type, sample);
+      }
+    }
   }
 
-  // Tests for update()
+  @Nested
+  @DisplayName("update() tests")
+  class UpdateTests {
 
-  @Test
-  void updateWithFailedCondition() {
-    if (!supportsUpdate() || !supportsConditionExpression()) {
-      return;
+    @Test
+    void updateWithFailedCondition() {
+      if (!supportsUpdate() || !supportsConditionExpression()) {
+        return;
+      }
+
+      final InternalRef tag = SampleEntities.createTag(random);
+      putThenLoad(ValueType.REF, tag);
+      final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(
+          ExpressionPath.builder("name").build(), Entity.ofString("badTagName")));
+      Assertions.assertThrows(ConditionFailedException.class, () -> store.update(
+          ValueType.REF,
+          tag.getId(),
+          UpdateExpression.of(RemoveClause.of(ExpressionPath.builder("metadata").build())),
+          Optional.of(expression),
+          Optional.empty()));
     }
 
-    final InternalRef tag = SampleEntities.createTag(random);
-    putThenLoad(ValueType.REF, tag);
-    final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(
-        ExpressionPath.builder("name").build(), Entity.ofString("badTagName")));
-    Assertions.assertThrows(ConditionFailedException.class, () -> store.update(
-        ValueType.REF,
-        tag.getId(),
-        UpdateExpression.of(RemoveClause.of(ExpressionPath.builder("metadata").build())),
-        Optional.of(expression),
-        Optional.empty()));
-  }
+    @Test
+    void updateWithSuccessfulCondition() {
+      if (!supportsUpdate() || !supportsConditionExpression()) {
+        return;
+      }
 
-  @Test
-  void updateWithSuccessfulCondition() {
-    if (!supportsUpdate() || !supportsConditionExpression()) {
-      return;
+      final String tagName = "myTag";
+      final InternalTag tag = SampleEntities.createTag(random).getTag();
+      putThenLoad(ValueType.REF, tag);
+      final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(
+          ExpressionPath.builder("name").build(), Entity.ofString("tagName")));
+      final InternalRef.Builder<?> builder = EntityType.REF.newEntityProducer();
+      final boolean result = store.update(
+          ValueType.REF,
+          tag.getId(),
+          UpdateExpression.of(SetClause.equals(ExpressionPath.builder("name").build(), Entity.ofString(tagName))),
+          Optional.of(expression),
+          Optional.of(builder));
+      Assertions.assertTrue(result);
+      final InternalTag updated = builder.build().getTag();
+
+      Assertions.assertEquals(tag.getId(), updated.getId());
+      Assertions.assertEquals(tag.getCommit(), updated.getCommit());
+      Assertions.assertEquals(tag.getDt(), updated.getDt());
+      Assertions.assertNotEquals(tag.getName(), updated.getName());
+      Assertions.assertEquals(tagName, updated.getName());
+
+      testLoadSingle(ValueType.REF, updated);
     }
 
-    final String tagName = "myTag";
-    final InternalTag tag = SampleEntities.createTag(random).getTag();
-    putThenLoad(ValueType.REF, tag);
-    final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(
-        ExpressionPath.builder("name").build(), Entity.ofString("tagName")));
-    final InternalRef.Builder<?> builder = EntityType.REF.newEntityProducer();
-    final boolean result = store.update(
-        ValueType.REF,
-        tag.getId(),
-        UpdateExpression.of(SetClause.equals(ExpressionPath.builder("name").build(), Entity.ofString(tagName))),
-        Optional.of(expression),
-        Optional.of(builder));
-    Assertions.assertTrue(result);
-    final InternalTag updated = builder.build().getTag();
-
-    Assertions.assertEquals(tag.getId(), updated.getId());
-    Assertions.assertEquals(tag.getCommit(), updated.getCommit());
-    Assertions.assertEquals(tag.getDt(), updated.getDt());
-    Assertions.assertNotEquals(tag.getName(), updated.getName());
-    Assertions.assertEquals(tagName, updated.getName());
-
-    testLoadSingle(ValueType.REF, updated);
-  }
-
-  @Test
-  protected void updateRemoveOneArray() {
-    updateRemoveArray(UpdateExpression.of(RemoveClause.of(ExpressionPath.builder("keys").position(0).build())), 1, 10);
-  }
-
-  @Test
-  protected void updateRemoveOneArrayEnd() {
-    updateRemoveArray(UpdateExpression.of(RemoveClause.of(ExpressionPath.builder("keys").position(9).build())), 0, 9);
-  }
-
-  @Test
-  protected void updateRemoveMultipleArrayAscending() {
-    UpdateExpression update = UpdateExpression.of();
-    for (int i = 0; i < 5; ++i) {
-      update = update.and(RemoveClause.of(ExpressionPath.builder("keys").position(i).build()));
+    @Test
+    protected void updateRemoveOneArray() {
+      updateRemoveArray(UpdateExpression.of(RemoveClause.of(ExpressionPath.builder("keys").position(0).build())), 1, 10);
     }
 
-    updateRemoveArray(update, 5, 10);
-  }
-
-  @Test
-  protected void updateRemoveMultipleArrayDescending() {
-    UpdateExpression update = UpdateExpression.of();
-    for (int i = 4; i >= 0; --i) {
-      update = update.and(RemoveClause.of(ExpressionPath.builder("keys").position(i).build()));
+    @Test
+    protected void updateRemoveOneArrayEnd() {
+      updateRemoveArray(UpdateExpression.of(RemoveClause.of(ExpressionPath.builder("keys").position(9).build())), 0, 9);
     }
 
-    updateRemoveArray(update, 5, 10);
-  }
+    @Test
+    protected void updateRemoveMultipleArrayAscending() {
+      UpdateExpression update = UpdateExpression.of();
+      for (int i = 0; i < 5; ++i) {
+        update = update.and(RemoveClause.of(ExpressionPath.builder("keys").position(i).build()));
+      }
 
-  @Test
-  void updateSetEquals() {
-    if (!supportsUpdate()) {
-      return;
+      updateRemoveArray(update, 5, 10);
     }
 
-    final String tagName = "myTag";
-    final InternalTag tag = SampleEntities.createTag(random).getTag();
-    putThenLoad(ValueType.REF, tag);
-    final InternalRef.Builder<?> builder = EntityType.REF.newEntityProducer();
-    final boolean result = store.update(
-        ValueType.REF,
-        tag.getId(),
-        UpdateExpression.of(SetClause.equals(ExpressionPath.builder("name").build(), Entity.ofString(tagName))),
-        Optional.empty(),
-        Optional.of(builder));
-    Assertions.assertTrue(result);
-    final InternalTag updated = builder.build().getTag();
+    @Test
+    protected void updateRemoveMultipleArrayDescending() {
+      UpdateExpression update = UpdateExpression.of();
+      for (int i = 4; i >= 0; --i) {
+        update = update.and(RemoveClause.of(ExpressionPath.builder("keys").position(i).build()));
+      }
 
-    Assertions.assertEquals(tag.getId(), updated.getId());
-    Assertions.assertEquals(tag.getCommit(), updated.getCommit());
-    Assertions.assertEquals(tag.getDt(), updated.getDt());
-    Assertions.assertNotEquals(tag.getName(), updated.getName());
-    Assertions.assertEquals(tagName, updated.getName());
-
-    testLoadSingle(ValueType.REF, updated);
-  }
-
-  @Test
-  void updateSetListAppend() {
-    if (!supportsUpdate()) {
-      return;
+      updateRemoveArray(update, 5, 10);
     }
 
-    final String key = "newKey";
-    final InternalFragment fragment = SampleEntities.createFragment(random);
-    putThenLoad(ValueType.KEY_FRAGMENT, fragment);
-    final InternalFragment.Builder builder = EntityType.KEY_FRAGMENT.newEntityProducer();
-    final boolean result = store.update(
-        ValueType.KEY_FRAGMENT,
-        fragment.getId(),
-        UpdateExpression.of(SetClause.appendToList(ExpressionPath.builder("keys").build(), Entity.ofList(Entity.ofString(key)))),
-        Optional.empty(),
-        Optional.of(builder));
-    Assertions.assertTrue(result);
-    final InternalFragment updated = builder.build();
+    @Test
+    void updateSetEquals() {
+      if (!supportsUpdate()) {
+        return;
+      }
 
-    Assertions.assertEquals(fragment.getId(), updated.getId());
+      final String tagName = "myTag";
+      final InternalTag tag = SampleEntities.createTag(random).getTag();
+      putThenLoad(ValueType.REF, tag);
+      final InternalRef.Builder<?> builder = EntityType.REF.newEntityProducer();
+      final boolean result = store.update(
+          ValueType.REF,
+          tag.getId(),
+          UpdateExpression.of(SetClause.equals(ExpressionPath.builder("name").build(), Entity.ofString(tagName))),
+          Optional.empty(),
+          Optional.of(builder));
+      Assertions.assertTrue(result);
+      final InternalTag updated = builder.build().getTag();
 
-    final List<InternalKey> oldKeys = new ArrayList<>(fragment.getKeys());
-    oldKeys.add(InternalKey.fromEntity(Entity.ofList(Entity.ofString(key))));
-    Assertions.assertEquals(oldKeys, updated.getKeys());
+      Assertions.assertEquals(tag.getId(), updated.getId());
+      Assertions.assertEquals(tag.getCommit(), updated.getCommit());
+      Assertions.assertEquals(tag.getDt(), updated.getDt());
+      Assertions.assertNotEquals(tag.getName(), updated.getName());
+      Assertions.assertEquals(tagName, updated.getName());
 
-    testLoadSingle(ValueType.KEY_FRAGMENT, updated);
+      testLoadSingle(ValueType.REF, updated);
+    }
+
+    @Test
+    void updateSetListAppend() {
+      if (!supportsUpdate()) {
+        return;
+      }
+
+      final String key = "newKey";
+      final InternalFragment fragment = SampleEntities.createFragment(random);
+      putThenLoad(ValueType.KEY_FRAGMENT, fragment);
+      final InternalFragment.Builder builder = EntityType.KEY_FRAGMENT.newEntityProducer();
+      final boolean result = store.update(
+          ValueType.KEY_FRAGMENT,
+          fragment.getId(),
+          UpdateExpression.of(SetClause.appendToList(ExpressionPath.builder("keys").build(), Entity.ofList(Entity.ofString(key)))),
+          Optional.empty(),
+          Optional.of(builder));
+      Assertions.assertTrue(result);
+      final InternalFragment updated = builder.build();
+
+      Assertions.assertEquals(fragment.getId(), updated.getId());
+
+      final List<InternalKey> oldKeys = new ArrayList<>(fragment.getKeys());
+      oldKeys.add(InternalKey.fromEntity(Entity.ofList(Entity.ofString(key))));
+      Assertions.assertEquals(oldKeys, updated.getKeys());
+
+      testLoadSingle(ValueType.KEY_FRAGMENT, updated);
+    }
+
+    private void updateRemoveArray(UpdateExpression update, int beginArrayIndex, int endArrayIndex) {
+      if (!supportsUpdate()) {
+        return;
+      }
+
+      final InternalFragment fragment = SampleEntities.createFragment(random);
+      putThenLoad(ValueType.KEY_FRAGMENT, fragment);
+      final InternalFragment.Builder builder = EntityType.KEY_FRAGMENT.newEntityProducer();
+      final boolean result = store.update(
+          ValueType.KEY_FRAGMENT,
+          fragment.getId(),
+          update,
+          Optional.empty(),
+          Optional.of(builder));
+      Assertions.assertTrue(result);
+      final InternalFragment updated = builder.build();
+
+      Assertions.assertEquals(fragment.getId(), updated.getId());
+
+      final List<InternalKey> oldKeys = fragment.getKeys().subList(beginArrayIndex, endArrayIndex);
+      Assertions.assertEquals(oldKeys, updated.getKeys());
+
+      testLoadSingle(ValueType.KEY_FRAGMENT, updated);
+    }
   }
 
   // Utility functions for the tests
-
-  private void updateRemoveArray(UpdateExpression update, int beginArrayIndex, int endArrayIndex) {
-    if (!supportsUpdate()) {
-      return;
-    }
-
-    final InternalFragment fragment = SampleEntities.createFragment(random);
-    putThenLoad(ValueType.KEY_FRAGMENT, fragment);
-    final InternalFragment.Builder builder = EntityType.KEY_FRAGMENT.newEntityProducer();
-    final boolean result = store.update(
-        ValueType.KEY_FRAGMENT,
-        fragment.getId(),
-        update,
-        Optional.empty(),
-        Optional.of(builder));
-    Assertions.assertTrue(result);
-    final InternalFragment updated = builder.build();
-
-    Assertions.assertEquals(fragment.getId(), updated.getId());
-
-    final List<InternalKey> oldKeys = fragment.getKeys().subList(beginArrayIndex, endArrayIndex);
-    Assertions.assertEquals(oldKeys, updated.getKeys());
-
-    testLoadSingle(ValueType.KEY_FRAGMENT, updated);
-  }
-
-  protected <T extends HasId> void deleteCondition(ValueType<?> type, T sample, boolean shouldSucceed,
-                                                   Optional<ConditionExpression> conditionExpression) {
-    putThenLoad(type, sample);
-    if (shouldSucceed) {
-      Assertions.assertTrue(store.delete(type, sample.getId(), conditionExpression));
-      Assertions.assertThrows(NotFoundException.class, () -> EntityType.forType(type).loadSingle(store, sample.getId()));
-    } else {
-      Assertions.assertFalse(store.delete(type, sample.getId(), conditionExpression));
-      testLoadSingle(type, sample);
-    }
-  }
-
-  private <T extends HasId> void putWithCondition(ValueType<?> type, T sample) {
-    // Tests that attempt to put (update) an existing entry should only occur when the condition expression is met.
-    putThenLoad(type, sample);
-
-    final ExpressionPath keyName = ExpressionPath.builder(Store.KEY_NAME).build();
-    final ConditionExpression conditionExpression = ConditionExpression.of(ExpressionFunction.equals(keyName, sample.getId().toEntity()));
-    putConditional(type, sample, true, Optional.of(conditionExpression));
-  }
-
-  @SuppressWarnings("unchecked")
-  protected <C extends BaseValue<C>> void putConditional(ValueType<C> type, HasId sample, boolean shouldSucceed,
-                                                         Optional<ConditionExpression> conditionExpression) {
-    if (!supportsConditionExpression()) {
-      return;
-    }
-
-    try {
-      store.put(new EntitySaveOp<>(type, (PersistentBase<C>) sample).saveOp, conditionExpression);
-      if (!shouldSucceed) {
-        Assertions.fail();
-      }
-      testLoadSingle(type, sample);
-    } catch (ConditionFailedException cfe) {
-      if (shouldSucceed) {
-        Assertions.fail(cfe);
-      }
-
-      Assertions.assertThrows(NotFoundException.class, () -> EntityType.forType(type).loadSingle(store, sample.getId()));
-    }
-  }
-
-  protected <C extends BaseValue<C>, T extends PersistentBase<C>> void testPutIfAbsent(ValueType<C> type, T sample) {
-    Assertions.assertTrue(store.putIfAbsent(new EntitySaveOp<>(type, sample).saveOp));
-    testLoadSingle(type, sample);
-    Assertions.assertFalse(store.putIfAbsent(new EntitySaveOp<>(type, sample).saveOp));
-    testLoadSingle(type, sample);
-  }
 
   @SuppressWarnings("unchecked")
   private <C extends BaseValue<C>> void putThenLoad(ValueType<C> type, HasId sample) {
     store.put(new EntitySaveOp<>(type, (PersistentBase<C>) sample).saveOp, Optional.empty());
     testLoadSingle(type, sample);
-  }
-
-  protected LoadStep createTestLoadStep(Multimap<ValueType<?>, HasId> objs) {
-    return createTestLoadStep(objs, Optional.empty());
-  }
-
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  protected LoadStep createTestLoadStep(Multimap<ValueType<?>, HasId> objs, Optional<LoadStep> next) {
-    final EntityLoadOps loadOps = new EntityLoadOps();
-    objs.forEach((type, val) -> loadOps.load(((EntityType) EntityType.forType(type)), val.getId(), r -> assertEquals(val, r)));
-    return loadOps.build(() -> next);
   }
 
   @SuppressWarnings("unchecked")

--- a/versioned/tiered/tiered-tests/src/main/java/com/dremio/nessie/versioned/impl/SampleEntities.java
+++ b/versioned/tiered/tiered-tests/src/main/java/com/dremio/nessie/versioned/impl/SampleEntities.java
@@ -20,6 +20,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.dremio.nessie.versioned.Key;
+import com.dremio.nessie.versioned.store.Entity;
 import com.dremio.nessie.versioned.store.Id;
 import com.dremio.nessie.versioned.store.KeyDelta;
 import com.google.protobuf.ByteString;
@@ -158,6 +159,16 @@ public class SampleEntities {
    */
   public static Id createId(Random random) {
     return Id.of(createBinary(random, 20));
+  }
+
+  /**
+   * Create a String Entity of random characters.
+   * @param random random number generator to use.
+   * @param numChars the size of the String.
+   * @return the String Entity of random characters.
+   */
+  public static Entity createStringEntity(Random random, int numChars) {
+    return Entity.ofString(createString(random, numChars));
   }
 
   /**


### PR DESCRIPTION
Separate additional base store tests from specific Mongo patch so they can be
used before that is completed.
Add flags to disable delete/update/ConditionExpression tests if the relevant store
has not yet implemented them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/796)
<!-- Reviewable:end -->
