### PR TITLE
Less stack-trace-noise for concurrent branch updates

### DIFF
--- a/versioned/tiered/tiered-impl/src/main/java/com/dremio/nessie/versioned/impl/TieredVersionStore.java
+++ b/versioned/tiered/tiered-impl/src/main/java/com/dremio/nessie/versioned/impl/TieredVersionStore.java
@@ -285,7 +285,11 @@ public class TieredVersionStore<DATA, METADATA> implements VersionStore<DATA, ME
     try {
       updatedBranch.getUpdateState(store).ensureAvailable(store, executor, p2commitRetry, waitOnCollapse);
     } catch (Exception ex) {
-      LOGGER.info("Failure while collapsing intention log after commit.", ex);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.info("Failure while collapsing intention log after commit.", ex);
+      } else {
+        LOGGER.info("Failure while collapsing intention log after commit: {}", ex.toString());
+      }
     }
   }
 


### PR DESCRIPTION
Only log stacktrace for "final" `updatedBranch.getUpdateState(store).ensureAvailable` with DEBUG logging.

People tend to interpret a dumped stack-trace automatically as an error, and expected errors shouldn't be logged at INFO level.

```
2021-02-10 14:42:00,096 INFO  [com.dre.nes.ver.imp.TieredVersionStore] (executor-thread-13) Failure while collapsing intention log after commit.: com.dremio.nessie.versioned.store.NotFoundException: Unable to load item l1:eeddf7d94cec227431553d46c63d25a5b8a7ec79.
	at com.dremio.nessie.versioned.store.dynamo.DynamoStore.loadSingle(DynamoStore.java:378)
	at com.dremio.nessie.versioned.store.TracingStore.loadSingle(TracingStore.java:129)
	at com.dremio.nessie.versioned.impl.EntityType.lambda$loadSingle$0(EntityType.java:87)
	at com.dremio.nessie.versioned.impl.EntityType.buildEntity(EntityType.java:132)
	at com.dremio.nessie.versioned.impl.EntityType.loadSingle(EntityType.java:87)
	at com.dremio.nessie.versioned.impl.InternalBranch.getUpdateState(InternalBranch.java:253)
	at com.dremio.nessie.versioned.impl.TieredVersionStore.commit(TieredVersionStore.java:300)
	at com.dremio.nessie.versioned.TracingVersionStore.commit(TracingVersionStore.java:79)
	at com.dremio.nessie.services.rest.BaseResource.doOps(BaseResource.java:78)
	at com.dremio.nessie.services.rest.ContentsResource.setContents(ContentsResource.java:98)
	at com.dremio.nessie.services.rest.ContentsResource_Subclass.setContents$$superaccessor1(ContentsResource_Subclass.zig:376)
	at com.dremio.nessie.services.rest.ContentsResource_Subclass$$function$$1.apply(ContentsResource_Subclass$$function$$1.zig:59)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/797)
<!-- Reviewable:end -->
