### PR TITLE
Respect DynamoDB limit of max 25 requests per batch-write

### DIFF
--- a/versioned/tiered/dynamodb/pom.xml
+++ b/versioned/tiered/dynamodb/pom.xml
@@ -116,6 +116,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/versioned/tiered/dynamodb/src/test/java/org/projectnessie/versioned/dynamodb/TestBatchesCollector.java
+++ b/versioned/tiered/dynamodb/src/test/java/org/projectnessie/versioned/dynamodb/TestBatchesCollector.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.dynamodb;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.versioned.dynamodb.DynamoStore.BatchesCollector;
+
+import com.google.common.base.Objects;
+
+public class TestBatchesCollector {
+
+  static Integer[][] testCombinations() {
+    return new Integer[][] {
+        {5, 0, 0},
+        {3, 0, 0},
+        {5, 1, 1},
+        {5, 4, 1},
+        {5, 5, 1},
+        {5, 6, 2},
+        {5, 42, 9},
+        {25, 0, 0},
+        {25, 1, 1},
+        {25, 4, 1},
+        {25, 5, 1},
+        {25, 6, 1},
+        {25, 24, 1},
+        {25, 25, 1},
+        {25, 26, 2},
+        {25, 49, 2},
+        {25, 50, 2},
+        {25, 51, 3},
+        {25, 249, 10},
+        {25, 250, 10},
+        {25, 251, 11}
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource({"testCombinations"})
+  void test(int batchSize, int numSaves, int expectedBatchCount) {
+    BatchesCollector<Save, Key, Req, Map<Key, Collection<Req>>> c = newCollector(batchSize);
+
+    List<Save> saves = IntStream.range(0, numSaves)
+        .mapToObj(i -> new Save(new Key("key" + i / 3), new Req("req" + i)))
+        .collect(Collectors.toList());
+
+    List<Map<Key, Collection<Req>>> collected = c.collect(saves.stream());
+
+    assertEquals(expectedBatchCount, collected.size());
+
+    Map<Key, Collection<Req>> current = new HashMap<>();
+    Iterator<Map<Key, Collection<Req>>> collectedIter = collected.iterator();
+    for (int i = 0; i < saves.size(); i++) {
+      if (i > 0 && (i % batchSize) == 0) {
+        Map<Key, Collection<Req>> batch = collectedIter.next();
+        assertEquals(current, batch);
+        current = new HashMap<>();
+      }
+
+      Save save = saves.get(i);
+      current.computeIfAbsent(save.key, k -> new ArrayList<>()).add(save.req);
+    }
+    if (current.isEmpty()) {
+      assertFalse(collectedIter.hasNext());
+    } else {
+      Map<Key, Collection<Req>> batch = collectedIter.next();
+      assertEquals(current, batch);
+    }
+  }
+
+  @Test
+  void testInvalidArgs() {
+    assertAll(
+        () -> assertThrows(IllegalArgumentException.class, () -> newCollector(0)),
+        () -> assertThrows(IllegalArgumentException.class, () -> newCollector(-1)),
+        () -> assertThrows(NullPointerException.class,
+            () -> new BatchesCollector<Save, Key, Req, Map<Key, Collection<Req>>>(null, e -> e.req, collected -> collected, 42)),
+        () -> assertThrows(NullPointerException.class,
+            () -> new BatchesCollector<Save, Key, Req, Map<Key, Collection<Req>>>(e -> e.key, null, collected -> collected, 42)),
+        () -> assertThrows(NullPointerException.class,
+            () -> new BatchesCollector<Save, Key, Req, Map<Key, Collection<Req>>>(e -> e.key, e -> e.req, null, 42))
+    );
+  }
+
+  private BatchesCollector<Save, Key, Req, Map<Key, Collection<Req>>> newCollector(int batchSize) {
+    return new BatchesCollector<>(
+        e -> e.key,
+        e -> e.req,
+        Function.identity(),
+        batchSize
+    );
+  }
+
+  // Relates to a DynamoDB table-name in the use of BatchesCollector in DynamoStore.save()
+  static class Key {
+    final String key;
+
+    Key(String key) {
+      this.key = key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      return Objects.equal(key, ((Key) o).key);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(key);
+    }
+  }
+
+  // Relates to a DynamoDB WriteRequest in the use of BatchesCollector in DynamoStore.save()
+  static class Req {
+    final String req;
+
+    Req(String req) {
+      this.req = req;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      return Objects.equal(req, ((Req) o).req);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(req);
+    }
+  }
+
+  static class Save {
+    final Key key;
+    final Req req;
+
+    Save(Key key, Req req) {
+      this.key = key;
+      this.req = req;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      return Objects.equal(key, ((Save) o).key)
+          && Objects.equal(req, ((Save) o).req);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(key, req);
+    }
+  }
+}


### PR DESCRIPTION
While running some perf-test experiments, I ran into situations that DynamoDB refused a Batch-Write for a `save()` due to exceeded limits. The current implementation of `com.dremio.nessie.versioned.store.dynamo.DynamoStore#save` does some already some grouping, but it was incorrect and used a way too high limit (100).

The [DynamoDB BatchWriteItem docs](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html) says, that all batch-writes with more than 25 requests will be rejected.

I'm not sure, why the existing `DynamoStore.save()` implementation used the `paginationSize` (defaults to  `LOAD_SIZE`, defaults to `100`), so I left it there, but limited the number of requests to 25.

I don't _think_ that we need to assert on a single request being > 400kB or the whole batch > 16MB, because IIRC Nessie objects are already "capped" at 400kB and 25*400 is not > 16MB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/798)
<!-- Reviewable:end -->
