### PR TITLE
changes to gc algo in prep for iceberg

### DIFF
--- a/versioned/tiered/gc/pom.xml
+++ b/versioned/tiered/gc/pom.xml
@@ -81,7 +81,7 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <scope>test</scope>
-    </dependency>    
+    </dependency>
 
     <dependency>
       <groupId>org.projectnessie</groupId>

--- a/versioned/tiered/gc/src/main/java/org/projectnessie/versioned/gc/IdFrame.java
+++ b/versioned/tiered/gc/src/main/java/org/projectnessie/versioned/gc/IdFrame.java
@@ -19,6 +19,9 @@ import java.util.Arrays;
 
 import org.projectnessie.versioned.store.Id;
 
+/**
+ * simple container to hold an Id in its byte[] form. Useful as a container in a Spark Row.
+ */
 public class IdFrame {
 
   private byte[] id;

--- a/versioned/tiered/gc/src/main/java/org/projectnessie/versioned/gc/IdentifyUnreferencedAssets.java
+++ b/versioned/tiered/gc/src/main/java/org/projectnessie/versioned/gc/IdentifyUnreferencedAssets.java
@@ -32,7 +32,6 @@ import org.projectnessie.versioned.AssetKey;
 import org.projectnessie.versioned.Serializer;
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.ValueWorker;
-import org.projectnessie.versioned.store.HasId;
 import org.projectnessie.versioned.store.Store;
 import org.projectnessie.versioned.store.ValueType;
 

--- a/versioned/tiered/gc/src/main/java/org/projectnessie/versioned/gc/RefToL2Producer.java
+++ b/versioned/tiered/gc/src/main/java/org/projectnessie/versioned/gc/RefToL2Producer.java
@@ -51,7 +51,7 @@ class RefToL2Producer {
 
     // expose a table of all l1s.
     Dataset<L1Frame> l1s = L1Frame.asDataset(store, spark);
-    l1s.createTempView("l1");
+    l1s.createOrReplaceTempView("l1");
 
     // create a potential view for l1s to consider.
     refs.select("id", "name").createOrReplaceTempView("potential");
@@ -112,4 +112,3 @@ class RefToL2Producer {
   }
 
 }
-

--- a/versioned/tiered/gc/src/main/java/org/projectnessie/versioned/gc/ValueFrame.java
+++ b/versioned/tiered/gc/src/main/java/org/projectnessie/versioned/gc/ValueFrame.java
@@ -28,6 +28,11 @@ import org.projectnessie.versioned.tiered.Value;
 
 import com.google.protobuf.ByteString;
 
+/**
+ * Container for a value. Holds its serialized representation, its Id and the last time an L1 that references it was modified.
+ *
+ * <p>This container is useful for passing around inside of Spark
+ */
 public class ValueFrame {
   private byte[] bytes;
   private long dt;


### PR DESCRIPTION
Changes in prep for iceberg gc algo.

* more docs
* `createOrReplace` instead of `create` the L1 table
* remove `extends HasId` from algo parameter. Parameter is specialised to Contents for the aglo which doesn't extend `HasId`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/811)
<!-- Reviewable:end -->
