### PR TITLE
Handle errors during (Version)Store initialization in Quarkus

### DIFF
--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/VersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/VersionStoreFactory.java
@@ -130,7 +130,7 @@ public class VersionStoreFactory {
               .build();
           break;
         default:
-          throw new RuntimeException(String.format("unknown jgit repo type %s",
+          throw new RuntimeException(String.format("unknown version-store type %s",
               config.getVersionStoreConfig().getVersionStoreType()));
       }
       lastUnsuccessfulStart = 0L;

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/VersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/VersionStoreFactory.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import javax.enterprise.inject.Produces;
@@ -72,6 +73,8 @@ public class VersionStoreFactory {
   @ConfigProperty(name = "quarkus.dynamodb.endpoint-override")
   Optional<String> endpoint;
 
+  private static final long START_RETRY_MIN_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(2);
+  private volatile long lastUnsuccessfulStart = 0L;
 
   @Produces
   public StoreWorker<Contents, CommitMeta> worker() {
@@ -101,21 +104,41 @@ public class VersionStoreFactory {
   }
 
   private VersionStore<Contents, CommitMeta> getVersionStore(TableCommitMetaStoreWorker storeWorker, Repository repository) {
-    switch (config.getVersionStoreConfig().getVersionStoreType()) {
-      case DYNAMO:
-        LOGGER.info("Using Dyanmo Version store");
-        return new TieredVersionStore<>(storeWorker, createDynamoConnection(), false);
-      case JGIT:
-        LOGGER.info("Using JGit Version Store");
-        return new JGitVersionStore<>(repository, storeWorker);
-      case INMEMORY:
-        LOGGER.info("Using In Memory version store");
-        return InMemoryVersionStore.<Contents, CommitMeta>builder()
-            .metadataSerializer(storeWorker.getMetadataSerializer())
-            .valueSerializer(storeWorker.getValueWorker())
-            .build();
-      default:
-        throw new RuntimeException(String.format("unknown jgit repo type %s", config.getVersionStoreConfig().getVersionStoreType()));
+    if (System.nanoTime() - lastUnsuccessfulStart < START_RETRY_MIN_INTERVAL_NANOS) {
+      LOGGER.warn("{} version store failed to start recently, try again later.",
+          config.getVersionStoreConfig().getVersionStoreType());
+      throw new RuntimeException(String.format("%s version store failed to start recently, try again later.",
+          config.getVersionStoreConfig().getVersionStoreType()));
+    }
+
+    try {
+      VersionStore<Contents, CommitMeta> versionStore;
+      switch (config.getVersionStoreConfig().getVersionStoreType()) {
+        case DYNAMO:
+          LOGGER.info("Using Dyanmo Version store");
+          versionStore = new TieredVersionStore<>(storeWorker, createDynamoConnection(), false);
+          break;
+        case JGIT:
+          LOGGER.info("Using JGit Version Store");
+          versionStore = new JGitVersionStore<>(repository, storeWorker);
+          break;
+        case INMEMORY:
+          LOGGER.info("Using In Memory version store");
+          versionStore = InMemoryVersionStore.<Contents, CommitMeta>builder()
+              .metadataSerializer(storeWorker.getMetadataSerializer())
+              .valueSerializer(storeWorker.getValueWorker())
+              .build();
+          break;
+        default:
+          throw new RuntimeException(String.format("unknown jgit repo type %s",
+              config.getVersionStoreConfig().getVersionStoreType()));
+      }
+      lastUnsuccessfulStart = 0L;
+      return versionStore;
+    } catch (RuntimeException e) {
+      lastUnsuccessfulStart = System.nanoTime();
+      LOGGER.error("Failed to configure/start {} version store", config.getVersionStoreConfig().getVersionStoreType(), e);
+      throw e;
     }
   }
 

--- a/versioned/tiered/dynamodb/src/main/java/org/projectnessie/versioned/dynamodb/DynamoStore.java
+++ b/versioned/tiered/dynamodb/src/main/java/org/projectnessie/versioned/dynamodb/DynamoStore.java
@@ -140,6 +140,7 @@ public class DynamoStore implements Store {
     if (client != null && async != null) {
       return; // no-op
     }
+
     try {
       DynamoMetricsPublisher publisher = new DynamoMetricsPublisher();
       TracingExecutionInterceptor tracing = new TracingExecutionInterceptor(GlobalTracer.get());
@@ -176,8 +177,7 @@ public class DynamoStore implements Store {
         // make sure we have an empty l1 (ignore result, doesn't matter)
         EntityStoreHelper.storeMinimumEntities(this::putIfAbsent);
       }
-
-    } catch (DynamoDbException ex) {
+    } catch (Exception ex) {
       try {
         close();
       } catch (Exception e) {
@@ -191,6 +191,8 @@ public class DynamoStore implements Store {
   public void close() {
     try {
       AutoCloseables.close(client, async);
+      client = null;
+      async = null;
     } catch (Exception e) {
       throw new StoreOperationException("Failed to close store", e);
     }


### PR DESCRIPTION
When the a (Version)Store fails to start (network broken, local Dynamo-instance not started, etc), the current implementation implicitly retries the (Version)Store initialization for every incoming request. Since a failed start can take very long, this implicitly results in many requests piling up and fail sequentially (as Quarkus synchronizes the bean initialization and eventually the call to `DynamoStore.start()`).

The proposed implementation is quite "dumb": if a previous (Version)Store initialization failed, all following initialization attempts within 5 seconds will just fail as well. This gives Quarkus some room to "abandon" the requests that have piled up in the meantime so those do not force a likely-to-fail (Version)Store initialization as well, sequentially.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/825)
<!-- Reviewable:end -->
