### PR TITLE
Report proper exception message, telling the user what actually happened

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/rest/BaseResource.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/BaseResource.java
@@ -84,7 +84,7 @@ abstract class BaseResource {
     } catch (IllegalArgumentException e) {
       throw new NessieNotFoundException("Invalid hash provided.", e);
     } catch (ReferenceConflictException e) {
-      throw new NessieConflictException("Failed to commit data. Provided hash does not match current value.", e);
+      throw new NessieConflictException("Failed to commit data. " + e.getMessage(), e);
     } catch (ReferenceNotFoundException e) {
       throw new NessieNotFoundException("Failed to commit data. Provided ref was not found.", e);
     }

--- a/servers/services/src/main/java/org/projectnessie/services/rest/BaseResource.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/BaseResource.java
@@ -82,11 +82,11 @@ abstract class BaseResource {
           operations
       );
     } catch (IllegalArgumentException e) {
-      throw new NessieNotFoundException("Invalid hash provided.", e);
+      throw new NessieNotFoundException("Invalid hash provided. " + e.getMessage(), e);
     } catch (ReferenceConflictException e) {
       throw new NessieConflictException("Failed to commit data. " + e.getMessage(), e);
     } catch (ReferenceNotFoundException e) {
-      throw new NessieNotFoundException("Failed to commit data. Provided ref was not found.", e);
+      throw new NessieNotFoundException("Failed to commit data. " + e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
`BaseResource.doOps` unconditionally returns a `new NessieConflictException("Failed to commit data. Provided hash does not match current value.", e);` to the user, even if the root-cause has a meaningful error message. In case of "overloading" the system with commits (i.e. many clients committing to the same branch concurrently), the `TieredVersionStore` throws a `ReferenceConflictException` saying `Unable to complete commit due to conflicting events. Retried %d times before failing.`. The previously hard-coded message implies a user error, where the "right" message indicates an "overload-situation" - so two distinct things.

I.e. the user sees `Provided hash does not match current value.` even if the user did not provide a hash, but just a branch name - the user should see `Unable to complete commit due to conflicting events. Retried %d times before failing.`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/826)
<!-- Reviewable:end -->
