### PR TITLE
Add tracing to our http-client, make NessieClient an interface

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
@@ -128,6 +128,15 @@ public interface NessieClient extends AutoCloseable {
     }
 
     /**
+     * Convenience method for {@link #withUri(URI)} taking a string.
+     * @param uri server URI
+     * @return {@code this}
+     */
+    public Builder withUri(String uri) {
+      return withUri(URI.create(uri));
+    }
+
+    /**
      * Set the username for {@link AuthType#BASIC} authentication.
      * @param username username
      * @return {@code this}

--- a/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
@@ -21,6 +21,7 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_TRACING
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_USERNAME;
 
+import java.net.URI;
 import java.util.function.Function;
 
 import org.projectnessie.api.ConfigApi;
@@ -59,7 +60,7 @@ public interface NessieClient extends AutoCloseable {
    */
   class Builder {
     private AuthType authType = AuthType.NONE;
-    private String uri;
+    private URI uri;
     private String username;
     private String password;
     private boolean tracing;
@@ -85,7 +86,7 @@ public interface NessieClient extends AutoCloseable {
     public Builder fromConfig(Function<String, String> configuration) {
       String uri = configuration.apply(CONF_NESSIE_URI);
       if (uri != null) {
-        this.uri = uri;
+        this.uri = URI.create(uri);
       }
       String username = configuration.apply(CONF_NESSIE_USERNAME);
       if (username != null) {
@@ -121,7 +122,7 @@ public interface NessieClient extends AutoCloseable {
      * @param uri server URI
      * @return {@code this}
      */
-    public Builder withUri(String uri) {
+    public Builder withUri(URI uri) {
       this.uri = uri;
       return this;
     }

--- a/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
@@ -18,7 +18,7 @@ package org.projectnessie.client;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_AUTH_TYPE;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_PASSWORD;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_TRACING;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_USERNAME;
 
 import java.util.function.Function;
@@ -83,7 +83,7 @@ public interface NessieClient extends AutoCloseable {
      * @see #fromSystemProperties()
      */
     public Builder fromConfig(Function<String, String> configuration) {
-      String uri = configuration.apply(CONF_NESSIE_URL);
+      String uri = configuration.apply(CONF_NESSIE_URI);
       if (uri != null) {
         this.uri = uri;
       }

--- a/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
@@ -59,7 +59,7 @@ public interface NessieClient extends AutoCloseable {
    */
   class Builder {
     private AuthType authType = AuthType.NONE;
-    private String path;
+    private String uri;
     private String username;
     private String password;
     private boolean tracing;
@@ -83,9 +83,9 @@ public interface NessieClient extends AutoCloseable {
      * @see #fromSystemProperties()
      */
     public Builder fromConfig(Function<String, String> configuration) {
-      String path = configuration.apply(CONF_NESSIE_URL);
-      if (path != null) {
-        this.path = path;
+      String uri = configuration.apply(CONF_NESSIE_URL);
+      if (uri != null) {
+        this.uri = uri;
       }
       String username = configuration.apply(CONF_NESSIE_USERNAME);
       if (username != null) {
@@ -118,11 +118,11 @@ public interface NessieClient extends AutoCloseable {
 
     /**
      * Set the Nessie server URI. A server URI must be configured.
-     * @param path server URI
+     * @param uri server URI
      * @return {@code this}
      */
-    public Builder withPath(String path) {
-      this.path = path;
+    public Builder withUri(String uri) {
+      this.uri = uri;
       return this;
     }
 
@@ -162,7 +162,7 @@ public interface NessieClient extends AutoCloseable {
      * @return new {@link NessieClient}
      */
     public NessieClient build() {
-      return new NessieHttpClient(authType, path, username, password, tracing);
+      return new NessieHttpClient(authType, uri, username, password, tracing);
     }
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
@@ -21,177 +21,43 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_TRACING
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URL;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_USERNAME;
 
-import java.io.Closeable;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.HashMap;
 import java.util.function.Function;
 
 import org.projectnessie.api.ConfigApi;
 import org.projectnessie.api.ContentsApi;
 import org.projectnessie.api.TreeApi;
-import org.projectnessie.client.auth.AwsAuth;
-import org.projectnessie.client.auth.BasicAuthFilter;
-import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.client.http.HttpClientException;
-import org.projectnessie.client.http.RequestFilter;
-import org.projectnessie.client.rest.NessieHttpResponseFilter;
-import org.projectnessie.error.NessieConflictException;
-import org.projectnessie.error.NessieNotFoundException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+public interface NessieClient extends AutoCloseable {
 
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.propagation.Format.Builtin;
-import io.opentracing.propagation.TextMap;
-import io.opentracing.propagation.TextMapInjectAdapter;
-import io.opentracing.util.GlobalTracer;
-
-public class NessieClient implements Closeable {
-
-  private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
-                                                        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-
-  public enum AuthType {
+  enum AuthType {
     AWS,
     BASIC,
     NONE
   }
 
-  private final TreeApi tree;
-  private final ConfigApi config;
-  private final ContentsApi contents;
+  // Overridden to "remove 'throws Exception'"
+  void close();
 
-  /**
-   * create new nessie client. All REST api endpoints are mapped here. This client should support any jaxrs implementation
-   *
-   * @param authType authentication type (AWS, NONE, BASIC)
-   * @param path URL for the nessie client (eg http://localhost:19120/api/v1)
-   * @param username username (only for BASIC auth)
-   * @param password password (only for BASIC auth)
-   */
-  NessieClient(AuthType authType, String path, String username, String password, boolean enableTracing) {
-    HttpClient client = HttpClient.builder().setBaseUri(path).setObjectMapper(mapper).build();
-    if (enableTracing) {
-      addTracing(client);
-    }
-    authFilter(client, authType, username, password);
-    client.register(new NessieHttpResponseFilter(mapper));
-    contents = wrap(ContentsApi.class, new ClientContentsApi(client));
-    tree = wrap(TreeApi.class, new ClientTreeApi(client));
-    config = wrap(ConfigApi.class, new ClientConfigApi(client));
-  }
+  TreeApi getTreeApi();
 
-  private static void addTracing(HttpClient httpClient) {
-    // It's safe to reference `GlobalTracer` here even without the required dependencies available
-    // at runtime, as long as tracing is not enabled. I.e. as long as tracing is not enabled, this
-    // method will not be called and the JVM won't try to load + initialize `GlobalTracer`.
-    Tracer tracer = GlobalTracer.get();
-    if (tracer != null) {
-      httpClient.register((RequestFilter) context -> {
-        Span span = tracer.activeSpan();
-        if (span != null) {
-          try (Scope scope = tracer.buildSpan("Nessie-HTTP").startActive(true)) {
-            HashMap<String, String> headerMap = new HashMap<>();
-            TextMap httpHeadersCarrier = new TextMapInjectAdapter(headerMap);
-            tracer.inject(scope.span().context(), Builtin.HTTP_HEADERS, httpHeadersCarrier);
-            headerMap.forEach(context::putHeader);
-          }
-        }
-      });
-    }
-  }
+  ContentsApi getContentsApi();
 
-  private void authFilter(HttpClient client, AuthType authType, String username, String password) {
-    switch (authType) {
-      case AWS:
-        client.register(new AwsAuth(mapper));
-        break;
-      case BASIC:
-        client.register(new BasicAuthFilter(username, password));
-        break;
-      case NONE:
-        break;
-      default:
-        throw new IllegalArgumentException(String.format("Cannot instantiate auth filter for %s. Not a valid auth type", authType));
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private <T> T wrap(Class<T> iface, T delegate) {
-    return (T) Proxy.newProxyInstance(delegate.getClass().getClassLoader(), new Class[] {iface}, new ExceptionRewriter(delegate));
-  }
-
-  /**
-   * This will rewrite exceptions so they are correctly thrown by the api classes.
-   * (since the filter will cause them to be wrapped in ResposneProcessingException)
-   */
-  private static class ExceptionRewriter implements InvocationHandler {
-
-    private final Object delegate;
-
-    public ExceptionRewriter(Object delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-      try {
-        return method.invoke(delegate, args);
-      } catch (InvocationTargetException ex) {
-        Throwable targetException = ex.getTargetException();
-        if (targetException instanceof HttpClientException) {
-          if (targetException.getCause() instanceof NessieNotFoundException) {
-            throw targetException.getCause();
-          }
-          if (targetException.getCause() instanceof NessieConflictException) {
-            throw targetException.getCause();
-          }
-        }
-
-        if (targetException instanceof RuntimeException) {
-          throw targetException;
-        }
-
-
-        throw ex;
-      }
-    }
-  }
-
-
-  public TreeApi getTreeApi() {
-    return tree;
-  }
-
-  public ContentsApi getContentsApi() {
-    return contents;
-  }
-
-  public ConfigApi getConfigApi() {
-    return config;
-  }
-
-  @Override
-  public void close() {
-  }
+  ConfigApi getConfigApi();
 
   /**
    * Create a new {@link Builder} to configure a new {@link NessieClient}.
+   * Currently, the {@link Builder} is only capable of building a {@link NessieClient} for HTTP,
+   * but that may change.
    */
-  public static Builder builder() {
+  static Builder builder() {
     return new Builder();
   }
 
   /**
-   * Builder to configure a new {@link NessieClient}.
+   * Builder to configure a new {@link NessieClient}. Currently, the {@link Builder} is only
+   * capable of building a {@link NessieClient} for HTTP, but that may change.
    */
-  public static class Builder {
+  class Builder {
     private AuthType authType = AuthType.NONE;
     private String path;
     private String username;
@@ -212,7 +78,7 @@ public class NessieClient implements Closeable {
      * configuration keys defined by the constants defined in {@link NessieConfigConstants}.
      * Non-{@code null} values returned by the {@code configuration}-function will override
      * previously configured values.
-     * @param configuration The function that exploses configuration keys.
+     * @param configuration The function that returns a configuration value for a configuration key.
      * @return {@code this}
      * @see #fromSystemProperties()
      */
@@ -296,7 +162,7 @@ public class NessieClient implements Closeable {
      * @return new {@link NessieClient}
      */
     public NessieClient build() {
-      return new NessieClient(authType, path, username, password, tracing);
+      return new NessieHttpClient(authType, path, username, password, tracing);
     }
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -47,6 +47,12 @@ public final class NessieConfigConstants {
    * Config property name ({@value #CONF_NESSIE_REF}) for the nessie reference used by clients.
    */
   public static final String CONF_NESSIE_REF = "nessie.ref";
+  /**
+   * Config property name ({@value #CONF_NESSIE_TRACING}) to enable adding the HTTP headers of
+   * an active OpenTracing span to all Nessie requests. Valid values are {@code true}
+   * and {@code false}.
+   */
+  public static final String CONF_NESSIE_TRACING = "nessie.tracing";
 
   private NessieConfigConstants() {
     // empty

--- a/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -20,9 +20,9 @@ package org.projectnessie.client;
  */
 public final class NessieConfigConstants {
   /**
-   * Config property name ({@value #CONF_NESSIE_URL}) for the Nessie service URL.
+   * Config property name ({@value #CONF_NESSIE_URI}) for the Nessie service URL.
    */
-  public static final String CONF_NESSIE_URL = "nessie.url";
+  public static final String CONF_NESSIE_URI = "nessie.uri";
   /**
    * Config property name ({@value #CONF_NESSIE_USERNAME}) for the user name used for (basic) authentication.
    */

--- a/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
@@ -92,7 +92,7 @@ class NessieHttpClient implements NessieClient {
           context.addResponseCallback((responseContext, exception) -> {
             if (responseContext != null) {
               try {
-                scope.span().setTag("http.status", responseContext.getResponseCode().getCode());
+                scope.span().setTag("http.status_code", responseContext.getResponseCode().getCode());
               } catch (IOException e) {
                 // There's not much we can (and probably should) do here.
               }
@@ -106,7 +106,8 @@ class NessieHttpClient implements NessieClient {
             scope.close();
           });
 
-          scope.span().setTag("http.uri", context.getUri().toString());
+          scope.span().setTag("http.uri", context.getUri().toString())
+              .setTag("http.method", context.getMethod().name());
 
           HashMap<String, String> headerMap = new HashMap<>();
           TextMap httpHeadersCarrier = new TextMapInjectAdapter(headerMap);

--- a/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.projectnessie.api.ConfigApi;
+import org.projectnessie.api.ContentsApi;
+import org.projectnessie.api.TreeApi;
+import org.projectnessie.client.auth.AwsAuth;
+import org.projectnessie.client.auth.BasicAuthFilter;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.HttpClientException;
+import org.projectnessie.client.http.RequestFilter;
+import org.projectnessie.client.rest.NessieHttpResponseFilter;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.log.Fields;
+import io.opentracing.propagation.Format.Builtin;
+import io.opentracing.propagation.TextMap;
+import io.opentracing.propagation.TextMapInjectAdapter;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
+
+class NessieHttpClient implements NessieClient {
+
+  private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
+                                                        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+
+  private final TreeApi tree;
+  private final ConfigApi config;
+  private final ContentsApi contents;
+
+  /**
+   * Create new HTTP {@link NessieClient}. All REST api endpoints are mapped here. This client should support
+   * any jaxrs implementation
+   *
+   * @param authType authentication type (AWS, NONE, BASIC)
+   * @param path URL for the nessie client (eg http://localhost:19120/api/v1)
+   * @param username username (only for BASIC auth)
+   * @param password password (only for BASIC auth)
+   */
+  NessieHttpClient(AuthType authType, String path, String username, String password, boolean enableTracing) {
+    HttpClient client = HttpClient.builder().setBaseUri(path).setObjectMapper(mapper).build();
+    if (enableTracing) {
+      addTracing(client);
+    }
+    authFilter(client, authType, username, password);
+    client.register(new NessieHttpResponseFilter(mapper));
+    contents = wrap(ContentsApi.class, new ClientContentsApi(client));
+    tree = wrap(TreeApi.class, new ClientTreeApi(client));
+    config = wrap(ConfigApi.class, new ClientConfigApi(client));
+  }
+
+  private static void addTracing(HttpClient httpClient) {
+    // It's safe to reference `GlobalTracer` here even without the required dependencies available
+    // at runtime, as long as tracing is not enabled. I.e. as long as tracing is not enabled, this
+    // method will not be called and the JVM won't try to load + initialize `GlobalTracer`.
+    Tracer tracer = GlobalTracer.get();
+    if (tracer != null) {
+      httpClient.register((RequestFilter) context -> {
+        Span span = tracer.activeSpan();
+        if (span != null) {
+          Scope scope = tracer.buildSpan("Nessie-HTTP").startActive(true);
+          context.addResponseCallback((responseContext, exception) -> {
+            if (responseContext != null) {
+              try {
+                scope.span().setTag("http.status", responseContext.getResponseCode().getCode());
+              } catch (IOException e) {
+                // There's not much we can (and probably should) do here.
+              }
+            }
+            if (exception != null) {
+              Map<String, String> log = new HashMap<>();
+              log.put(Fields.EVENT, Tags.ERROR.getKey());
+              log.put(Fields.ERROR_OBJECT, exception.toString());
+              Tags.ERROR.set(scope.span().log(log), true);
+            }
+            scope.close();
+          });
+
+          scope.span().setTag("http.uri", context.getUri());
+
+          HashMap<String, String> headerMap = new HashMap<>();
+          TextMap httpHeadersCarrier = new TextMapInjectAdapter(headerMap);
+          tracer.inject(scope.span().context(), Builtin.HTTP_HEADERS, httpHeadersCarrier);
+          headerMap.forEach(context::putHeader);
+        }
+      });
+    }
+  }
+
+  private void authFilter(HttpClient client, AuthType authType, String username, String password) {
+    switch (authType) {
+      case AWS:
+        client.register(new AwsAuth(mapper));
+        break;
+      case BASIC:
+        client.register(new BasicAuthFilter(username, password));
+        break;
+      case NONE:
+        break;
+      default:
+        throw new IllegalArgumentException(String.format("Cannot instantiate auth filter for %s. Not a valid auth type", authType));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T wrap(Class<T> iface, T delegate) {
+    return (T) Proxy.newProxyInstance(delegate.getClass().getClassLoader(), new Class[] {iface}, new ExceptionRewriter(delegate));
+  }
+
+  /**
+   * This will rewrite exceptions so they are correctly thrown by the api classes.
+   * (since the filter will cause them to be wrapped in {@link javax.ws.rs.client.ResponseProcessingException})
+   */
+  private static class ExceptionRewriter implements InvocationHandler {
+
+    private final Object delegate;
+
+    public ExceptionRewriter(Object delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      try {
+        return method.invoke(delegate, args);
+      } catch (InvocationTargetException ex) {
+        Throwable targetException = ex.getTargetException();
+        if (targetException instanceof HttpClientException) {
+          if (targetException.getCause() instanceof NessieNotFoundException) {
+            throw targetException.getCause();
+          }
+          if (targetException.getCause() instanceof NessieConflictException) {
+            throw targetException.getCause();
+          }
+        }
+
+        if (targetException instanceof RuntimeException) {
+          throw targetException;
+        }
+
+
+        throw ex;
+      }
+    }
+  }
+
+
+  public TreeApi getTreeApi() {
+    return tree;
+  }
+
+  public ContentsApi getContentsApi() {
+    return contents;
+  }
+
+  public ConfigApi getConfigApi() {
+    return config;
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
@@ -62,12 +62,12 @@ class NessieHttpClient implements NessieClient {
    * any jaxrs implementation
    *
    * @param authType authentication type (AWS, NONE, BASIC)
-   * @param path URL for the nessie client (eg http://localhost:19120/api/v1)
+   * @param uri URL for the nessie client (eg http://localhost:19120/api/v1)
    * @param username username (only for BASIC auth)
    * @param password password (only for BASIC auth)
    */
-  NessieHttpClient(AuthType authType, String path, String username, String password, boolean enableTracing) {
-    HttpClient client = HttpClient.builder().setBaseUri(path).setObjectMapper(mapper).build();
+  NessieHttpClient(AuthType authType, String uri, String username, String password, boolean enableTracing) {
+    HttpClient client = HttpClient.builder().setBaseUri(uri).setObjectMapper(mapper).build();
     if (enableTracing) {
       addTracing(client);
     }

--- a/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -66,7 +67,7 @@ class NessieHttpClient implements NessieClient {
    * @param username username (only for BASIC auth)
    * @param password password (only for BASIC auth)
    */
-  NessieHttpClient(AuthType authType, String uri, String username, String password, boolean enableTracing) {
+  NessieHttpClient(AuthType authType, URI uri, String username, String password, boolean enableTracing) {
     HttpClient client = HttpClient.builder().setBaseUri(uri).setObjectMapper(mapper).build();
     if (enableTracing) {
       addTracing(client);
@@ -105,7 +106,7 @@ class NessieHttpClient implements NessieClient {
             scope.close();
           });
 
-          scope.span().setTag("http.uri", context.getUri());
+          scope.span().setTag("http.uri", context.getUri().toString());
 
           HashMap<String, String> headerMap = new HashMap<>();
           TextMap httpHeadersCarrier = new TextMapInjectAdapter(headerMap);

--- a/clients/client/src/main/java/org/projectnessie/client/auth/AwsAuth.java
+++ b/clients/client/src/main/java/org/projectnessie/client/auth/AwsAuth.java
@@ -53,9 +53,8 @@ public class AwsAuth implements RequestFilter {
     this.objectMapper = objectMapper;
   }
 
-  private SdkHttpFullRequest prepareRequest(String url, HttpClient.Method method, Optional<Object> entity) {
+  private SdkHttpFullRequest prepareRequest(URI uri, HttpClient.Method method, Optional<Object> entity) {
     try {
-      URI uri = new URI(url);
       SdkHttpFullRequest.Builder builder = SdkHttpFullRequest.builder()
                                                              .uri(uri)
                                                              .method(SdkHttpMethod.fromValue(method.name()));

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -94,7 +94,7 @@ public class HttpClient {
     private ObjectMapper mapper;
     private SSLContext sslContext;
 
-    public HttpClientBuilder() {
+    private HttpClientBuilder() {
     }
 
     public String getBaseUri() {

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -15,9 +15,11 @@
  */
 package org.projectnessie.client.http;
 
+import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.net.ssl.SSLContext;
 
@@ -37,7 +39,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class HttpClient {
 
-  private final String baseUri;
+  private final URI baseUri;
   private final String accept;
   private final ObjectMapper mapper;
   private final SSLContext sslContext;
@@ -57,13 +59,14 @@ public class HttpClient {
    * @param baseUri uri base eg https://example.com
    * @param accept Accept header eg "application/json"
    */
-  private HttpClient(String baseUri, String accept, ObjectMapper mapper, SSLContext sslContext) {
-    this.baseUri = HttpUtils.checkNonNullTrim(baseUri);
+  private HttpClient(URI baseUri, String accept, ObjectMapper mapper, SSLContext sslContext) {
+    this.baseUri = Objects.requireNonNull(baseUri);
     this.accept = HttpUtils.checkNonNullTrim(accept);
     this.mapper = mapper;
     this.sslContext = sslContext;
-    HttpUtils.checkArgument(baseUri.startsWith("http://") || baseUri.startsWith("https://"),
-                            "Cannot start http client. %s must be a valid http or https address", baseUri);
+    if (!"http".equals(baseUri.getScheme()) && !"https".equals(baseUri.getScheme())) {
+      throw new IllegalArgumentException(String.format("Cannot start http client. %s must be a valid http or https address", baseUri));
+    }
   }
 
   /**
@@ -89,7 +92,7 @@ public class HttpClient {
   }
 
   public static class HttpClientBuilder {
-    private String baseUri;
+    private URI baseUri;
     private String accept = "application/json";
     private ObjectMapper mapper;
     private SSLContext sslContext;
@@ -97,11 +100,11 @@ public class HttpClient {
     private HttpClientBuilder() {
     }
 
-    public String getBaseUri() {
+    public URI getBaseUri() {
       return baseUri;
     }
 
-    public HttpClientBuilder setBaseUri(String baseUri) {
+    public HttpClientBuilder setBaseUri(URI baseUri) {
       this.baseUri = baseUri;
       return this;
     }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpRequest.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashMap;
@@ -50,7 +50,7 @@ public class HttpRequest {
   private final List<ResponseFilter> responseFilters;
   private SSLContext sslContext;
 
-  HttpRequest(String baseUri, String accept, ObjectMapper mapper, List<RequestFilter> requestFilters,
+  HttpRequest(URI baseUri, String accept, ObjectMapper mapper, List<RequestFilter> requestFilters,
               List<ResponseFilter> responseFilters, SSLContext context) {
     this.uriBuilder = new UriBuilder(baseUri);
     this.mapper = mapper;
@@ -84,9 +84,8 @@ public class HttpRequest {
 
   private HttpResponse executeRequest(Method method, Object body) throws HttpClientException {
     try {
-      String uri = uriBuilder.build();
-      URL url = new URL(uri);
-      HttpURLConnection con = (HttpURLConnection) url.openConnection();
+      URI uri = uriBuilder.build();
+      HttpURLConnection con = (HttpURLConnection) uri.toURL().openConnection();
       if (con instanceof HttpsURLConnection) {
         ((HttpsURLConnection) con).setSSLSocketFactory(sslContext.getSocketFactory());
       }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpRequest.java
@@ -126,6 +126,7 @@ public class HttpRequest {
         if (callbacks != null) {
           callbacks.forEach(callback -> callback.accept(null, e));
         }
+        throw e;
       }
 
       responseFilters.forEach(responseFilter -> responseFilter.filter(responseContext));

--- a/clients/client/src/main/java/org/projectnessie/client/http/RequestContext.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/RequestContext.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.http;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +31,7 @@ import org.projectnessie.client.http.HttpClient.Method;
 public class RequestContext {
 
   private final Map<String, Set<String>> headers;
-  private final String uri;
+  private final URI uri;
   private final Method method;
   private final Object body;
   private List<BiConsumer<ResponseContext, Exception>> responseCallbacks;
@@ -43,7 +44,7 @@ public class RequestContext {
    * @param method verb to be used
    * @param body optional body of request
    */
-  public RequestContext(Map<String, Set<String>> headers, String uri, Method method, Object body) {
+  public RequestContext(Map<String, Set<String>> headers, URI uri, Method method, Object body) {
     this.headers = headers;
     this.uri = uri;
     this.method = method;
@@ -58,7 +59,7 @@ public class RequestContext {
     HttpRequest.putHeader(name, value, headers);
   }
 
-  public String getUri() {
+  public URI getUri() {
     return uri;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/RequestContext.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/RequestContext.java
@@ -15,9 +15,12 @@
  */
 package org.projectnessie.client.http;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import org.projectnessie.client.http.HttpClient.Method;
 
@@ -30,6 +33,7 @@ public class RequestContext {
   private final String uri;
   private final Method method;
   private final Object body;
+  private List<BiConsumer<ResponseContext, Exception>> responseCallbacks;
 
   /**
    * Construct a request context.
@@ -64,5 +68,26 @@ public class RequestContext {
 
   public Optional<Object> getBody() {
     return body == null ? Optional.empty() : Optional.of(body);
+  }
+
+  /**
+   * Adds a callback to be called when the request has finished. The {@code responseCallback}
+   * {@link BiConsumer consumer} is called with a non-{@code null} {@link ResponseContext}, if the
+   * HTTP request technically succeeded. The The {@code responseCallback}
+   * {@link BiConsumer consumer} is called with a non-{@code null} {@link Exception} object, if the
+   * HTTP request technically failed.
+   *
+   * @param responseCallback callback that receives either a non-{@code null} {@link ResponseContext}
+   *                         or a non-{@code null} {@link Exception}.
+   */
+  public void addResponseCallback(BiConsumer<ResponseContext, Exception> responseCallback) {
+    if (responseCallbacks == null) {
+      responseCallbacks = new ArrayList<>();
+    }
+    responseCallbacks.add(responseCallback);
+  }
+
+  List<BiConsumer<ResponseContext, Exception>> getResponseCallbacks() {
+    return responseCallbacks;
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/ResponseContextImpl.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/ResponseContextImpl.java
@@ -23,7 +23,7 @@ class ResponseContextImpl implements ResponseContext {
 
   private final HttpURLConnection connection;
 
-  public ResponseContextImpl(HttpURLConnection connection) {
+  ResponseContextImpl(HttpURLConnection connection) {
     this.connection = connection;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/UriBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/UriBuilder.java
@@ -16,24 +16,25 @@
 package org.projectnessie.client.http;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Construct a URI from base and paths. Adds query parameters, supports templates and handles url encoding of path.
  */
 class UriBuilder {
 
-  private final String baseUri;
+  private final URI baseUri;
   private final StringBuilder uri = new StringBuilder();
   private final StringBuilder query = new StringBuilder();
   private final Map<String, String> templateValues = new HashMap<>();
 
-  UriBuilder(String baseUri) {
-    this.baseUri = HttpUtils.checkNonNullTrim(baseUri);
-    HttpUtils.checkArgument(this.baseUri.length() > 0, "Base uri %s must be of length greater than 0", this.baseUri);
+  UriBuilder(URI baseUri) {
+    this.baseUri = Objects.requireNonNull(baseUri);
   }
 
   UriBuilder path(String path) {
@@ -75,7 +76,7 @@ class UriBuilder {
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
-  String build() throws HttpClientException {
+  URI build() throws HttpClientException {
     StringBuilder uriBuilder = new StringBuilder();
     uriBuilder.append(baseUri);
 
@@ -99,7 +100,7 @@ class UriBuilder {
 
       // clean off the last / that the joiner added
       if ('/' == uriBuilder.charAt(uriBuilder.length() - 1)) {
-        return uriBuilder.subSequence(0, uriBuilder.length() - 1).toString();
+        return URI.create(uriBuilder.subSequence(0, uriBuilder.length() - 1).toString());
       }
     } else {
       checkEmpty(templateValues, uri);
@@ -110,7 +111,7 @@ class UriBuilder {
       uriBuilder.append(query);
     }
 
-    return uriBuilder.toString();
+    return URI.create(uriBuilder.toString());
   }
 
   private static String encode(String s) throws HttpClientException {

--- a/clients/client/src/test/java/org/projectnessie/client/TestNessieHttpClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/TestNessieHttpClient.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.projectnessie.client;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.OutputStream;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.NessieClient.AuthType;
+import org.projectnessie.client.util.TestServer;
+
+import com.sun.net.httpserver.HttpHandler;
+
+import io.jaegertracing.internal.JaegerTracer;
+import io.opentracing.Scope;
+import io.opentracing.util.GlobalTracer;
+
+class TestNessieHttpClient {
+  @BeforeAll
+  static void setupTracer() {
+    GlobalTracer.register(new JaegerTracer.Builder("TestNessieHttpClient").build());
+  }
+
+  @Test
+  void testNullUri() {
+    assertThrows(IllegalArgumentException.class, () -> NessieClient.builder().withUri(null).build());
+  }
+
+  @Test
+  void testAuthBasic() throws Exception {
+    AtomicReference<String> authHeader = new AtomicReference<>();
+
+    try (TestServer server = new TestServer(handlerForHeaderTest("Authorization", authHeader))) {
+      NessieClient client = NessieClient.builder().withUri(server.getUri())
+          .withAuthType(AuthType.BASIC).withUsername("my_username").withPassword("very_secret")
+          .build();
+      client.getConfigApi().getConfig();
+    }
+
+    assertEquals("Basic " + new String(
+        Base64.getUrlEncoder().encode("my_username:very_secret".getBytes(UTF_8)), UTF_8),
+        authHeader.get());
+  }
+
+  @Test
+  void testTracing() throws Exception {
+    AtomicReference<String> traceId = new AtomicReference<>();
+
+    try (TestServer server = new TestServer(handlerForHeaderTest("Uber-trace-id", traceId))) {
+      NessieClient client = NessieClient.builder().withUri(server.getUri())
+          .withTracing(true)
+          .build();
+      try (Scope ignore = GlobalTracer.get().buildSpan("testOpenTracing").startActive(true)) {
+        client.getConfigApi().getConfig();
+      }
+    }
+
+    // Cannot really assert on the value of the Uber-trace-id header, because the APIs don't
+    // give us access to that. Verifying that the Uber-trace-id header is being sent should
+    // be good enough though.
+    assertNotNull(traceId.get());
+  }
+
+  @Test
+  void testTracingNotEnabled() throws Exception {
+    AtomicReference<String> traceId = new AtomicReference<>();
+
+    try (TestServer server = new TestServer(handlerForHeaderTest("Uber-trace-id", traceId))) {
+      NessieClient client = NessieClient.builder().withUri(server.getUri())
+          .withTracing(false)
+          .build();
+      try (Scope ignore = GlobalTracer.get().buildSpan("testOpenTracing").startActive(true)) {
+        client.getConfigApi().getConfig();
+      }
+    }
+
+    assertNull(traceId.get());
+  }
+
+  static HttpHandler handlerForHeaderTest(String headerName, AtomicReference<String> receiver) {
+    return h -> {
+      receiver.set(h.getRequestHeaders().getFirst(headerName));
+
+      h.getRequestBody().close();
+
+      h.sendResponseHeaders(200, 2);
+      try (OutputStream out = h.getResponseBody()) {
+        out.write("{}".getBytes(UTF_8));
+      }
+    };
+  }
+}

--- a/clients/client/src/test/java/org/projectnessie/client/TestNessieHttpClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/TestNessieHttpClient.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.Base64;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -45,7 +46,7 @@ class TestNessieHttpClient {
 
   @Test
   void testNullUri() {
-    assertThrows(IllegalArgumentException.class, () -> NessieClient.builder().withUri(null).build());
+    assertThrows(IllegalArgumentException.class, () -> NessieClient.builder().withUri((URI) null).build());
   }
 
   @Test

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
@@ -19,6 +19,7 @@ import java.io.IOError;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -39,7 +40,7 @@ public class TestHttpClient {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static HttpRequest get(InetSocketAddress address) {
-    return HttpClient.builder().setBaseUri("http://localhost:" + address.getPort()).setObjectMapper(MAPPER).build().newRequest();
+    return HttpClient.builder().setBaseUri(URI.create("http://localhost:" + address.getPort())).setObjectMapper(MAPPER).build().newRequest();
   }
 
   @Test
@@ -202,7 +203,7 @@ public class TestHttpClient {
     };
     try (TestServer server = new TestServer(handler)) {
       HttpClient client = HttpClient.builder()
-                                    .setBaseUri("http://localhost:" + server.getAddress().getPort())
+                                    .setBaseUri(URI.create("http://localhost:" + server.getAddress().getPort()))
                                     .setObjectMapper(MAPPER)
                                     .build();
       client.register((RequestFilter) context -> {

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.http;
 
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -86,7 +87,7 @@ class TestHttpsClient {
       SSLContext sc = SSLContext.getInstance("SSL");
       sc.init(null, trustManager[0], new java.security.SecureRandom());
       HttpRequest client = HttpClient.builder()
-                                     .setBaseUri("https://localhost:" + server.getAddress().getPort())
+                                     .setBaseUri(URI.create("https://localhost:" + server.getAddress().getPort()))
                                      .setObjectMapper(MAPPER)
                                      .setSslContext(sc)
                                      .build()
@@ -94,7 +95,7 @@ class TestHttpsClient {
       client.get();
 
       final HttpRequest insecureClient = HttpClient.builder()
-                         .setBaseUri("https://localhost:" + server.getAddress().getPort())
+                         .setBaseUri(URI.create("https://localhost:" + server.getAddress().getPort()))
                          .setObjectMapper(MAPPER)
                          .build()
                          .newRequest();

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
@@ -49,9 +49,7 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.client.http.HttpClientException;
-import org.projectnessie.client.http.HttpRequest;
+import org.projectnessie.client.util.TestServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +86,7 @@ class TestHttpsClient {
       SSLContext sc = SSLContext.getInstance("SSL");
       sc.init(null, trustManager[0], new java.security.SecureRandom());
       HttpRequest client = HttpClient.builder()
-                                     .setBaseUri("https://localhost:" + server.server.getAddress().getPort())
+                                     .setBaseUri("https://localhost:" + server.getAddress().getPort())
                                      .setObjectMapper(MAPPER)
                                      .setSslContext(sc)
                                      .build()
@@ -96,7 +94,7 @@ class TestHttpsClient {
       client.get();
 
       final HttpRequest insecureClient = HttpClient.builder()
-                         .setBaseUri("https://localhost:" + server.server.getAddress().getPort())
+                         .setBaseUri("https://localhost:" + server.getAddress().getPort())
                          .setObjectMapper(MAPPER)
                          .build()
                          .newRequest();

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestUriBuilder.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestUriBuilder.java
@@ -19,55 +19,53 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.net.URI;
+
 import org.junit.jupiter.api.Test;
-import org.projectnessie.client.http.HttpClientException;
-import org.projectnessie.client.http.UriBuilder;
 
 class TestUriBuilder {
 
   @Test
   void simple() {
     assertEquals("http://localhost/foo/bar/",
-                 new UriBuilder("http://localhost/foo/bar/").build());
+                 new UriBuilder(URI.create("http://localhost/foo/bar/")).build().toString());
   }
 
   @Test
   void parameterValidation() {
     assertAll(
         () -> assertThrows(NullPointerException.class, () -> new UriBuilder(null)),
-        () -> assertThrows(NullPointerException.class, () -> new UriBuilder("http://base/").path(null)),
-        () -> assertThrows(NullPointerException.class,
-          () -> new UriBuilder("http://base/").resolveTemplate(null, "value")),
-        () -> assertThrows(NullPointerException.class,
-          () -> new UriBuilder("http://base/").resolveTemplate("name", null))
+        () -> assertThrows(NullPointerException.class, () -> new UriBuilder(URI.create("http://base/")).path(null)),
+        () -> assertThrows(NullPointerException.class, () -> new UriBuilder(URI.create("http://base/")).resolveTemplate(null, "value")),
+        () -> assertThrows(NullPointerException.class, () -> new UriBuilder(URI.create("http://base/")).resolveTemplate("name", null))
     );
   }
 
   @Test
   void addMissingSlash() {
     assertEquals("http://localhost/",
-                 new UriBuilder("http://localhost")
-                   .build());
+                 new UriBuilder(URI.create("http://localhost"))
+                   .build().toString());
     assertEquals("http://localhost/foo/bar",
-                 new UriBuilder("http://localhost")
+                 new UriBuilder(URI.create("http://localhost"))
                    .path("foo")
                    .path("bar")
-                   .build());
+                   .build().toString());
   }
 
   @Test
   void pathTemplates() {
-    UriBuilder builder = new UriBuilder("http://localhost/foo/bar/");
+    UriBuilder builder = new UriBuilder(URI.create("http://localhost/foo/bar/"));
 
     builder = builder.path("{my-var}")
                      .resolveTemplate("my-var", "baz");
     assertEquals("http://localhost/foo/bar/baz",
-                 builder.build());
+                 builder.build().toString());
 
     builder = builder.path("something/{in}/here")
                      .resolveTemplate("in", "out");
     assertEquals("http://localhost/foo/bar/baz/something/out/here",
-                 builder.build());
+                 builder.build().toString());
 
     builder = builder.resolveTemplate("no", "boo");
     UriBuilder bulder1 = builder;
@@ -77,31 +75,27 @@ class TestUriBuilder {
 
   @Test
   void pathEncoding() {
-    UriBuilder builder = new UriBuilder("http://localhost/foo/bar/");
+    UriBuilder builder = new UriBuilder(URI.create("http://localhost/foo/bar/"));
 
     builder = builder.path("some spaces in here");
     assertEquals("http://localhost/foo/bar/some%20spaces%20in%20here",
-                 builder.build());
+                 builder.build().toString());
   }
 
   @Test
   void queryParameters() {
-    UriBuilder builder = new UriBuilder("http://localhost/foo/bar/");
+    UriBuilder builder = new UriBuilder(URI.create("http://localhost/foo/bar/"));
 
     builder = builder.queryParam("a", "b");
-    assertEquals("http://localhost/foo/bar/?a=b",
-                 builder.build());
+    assertEquals("http://localhost/foo/bar/?a=b", builder.build().toString());
 
     builder = builder.queryParam("c", "d");
-    assertEquals("http://localhost/foo/bar/?a=b&c=d",
-                 builder.build());
+    assertEquals("http://localhost/foo/bar/?a=b&c=d", builder.build().toString());
 
     builder = builder.queryParam("e", "f&? /");
-    assertEquals("http://localhost/foo/bar/?a=b&c=d&e=f%26%3F%20%2F",
-                 builder.build());
+    assertEquals("http://localhost/foo/bar/?a=b&c=d&e=f%26%3F%20%2F", builder.build().toString());
 
     builder = builder.queryParam("c", "d-more");
-    assertEquals("http://localhost/foo/bar/?a=b&c=d&e=f%26%3F%20%2F&c=d-more",
-                 builder.build());
+    assertEquals("http://localhost/foo/bar/?a=b&c=d&e=f%26%3F%20%2F&c=d-more", builder.build().toString());
   }
 }

--- a/clients/client/src/test/java/org/projectnessie/client/util/TestServer.java
+++ b/clients/client/src/test/java/org/projectnessie/client/util/TestServer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.http;
+package org.projectnessie.client.util;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -23,15 +23,25 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsServer;
 
-class TestServer implements AutoCloseable {
+/**
+ * A HTTP test server.
+ */
+public class TestServer implements AutoCloseable {
 
-  final HttpServer server;
+  private final HttpServer server;
 
-  TestServer(String context, HttpHandler handler) throws IOException {
+  public TestServer(String context, HttpHandler handler) throws IOException {
     this(context, handler, null);
   }
 
-  TestServer(String context, HttpHandler handler, Consumer<HttpsServer> init) throws IOException {
+  /**
+   * Constructor.
+   * @param context server context
+   * @param handler http request handler
+   * @param init init method (optional)
+   * @throws IOException maybe
+   */
+  public TestServer(String context, HttpHandler handler, Consumer<HttpsServer> init) throws IOException {
     HttpHandler safeHandler = exchange -> {
       try {
         handler.handle(exchange);
@@ -52,8 +62,16 @@ class TestServer implements AutoCloseable {
     server.start();
   }
 
-  TestServer(HttpHandler handler) throws IOException {
+  public TestServer(HttpHandler handler) throws IOException {
     this("/", handler);
+  }
+
+  public InetSocketAddress getAddress() {
+    return server.getAddress();
+  }
+
+  public String getUri() {
+    return "http://" + getAddress().getAddress().getHostAddress() + ":" + getAddress().getPort() + "/";
   }
 
   @Override

--- a/clients/client/src/test/java/org/projectnessie/client/util/TestServer.java
+++ b/clients/client/src/test/java/org/projectnessie/client/util/TestServer.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.util;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.util.function.Consumer;
 
 import com.sun.net.httpserver.HttpHandler;
@@ -70,12 +71,12 @@ public class TestServer implements AutoCloseable {
     return server.getAddress();
   }
 
-  public String getUri() {
-    return "http://" + getAddress().getAddress().getHostAddress() + ":" + getAddress().getPort() + "/";
+  public URI getUri() {
+    return URI.create("http://" + getAddress().getAddress().getHostAddress() + ":" + getAddress().getPort() + "/");
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     server.stop(0);
   }
 }

--- a/clients/deltalake/core/src/main/scala/org/projectnessie/deltalake/NessieLogStore.scala
+++ b/clients/deltalake/core/src/main/scala/org/projectnessie/deltalake/NessieLogStore.scala
@@ -48,7 +48,7 @@ class NessieLogStore(sparkConf: SparkConf, hadoopConf: Configuration)
   var lastSnapshotUuid: Option[String] = None
 
   private val client: NessieClient = {
-    NessieClient.withConfig(c => hadoopConf.get(c))
+    NessieClient.builder().fromConfig(c => hadoopConf.get(c)).build()
   }
 
   private def getOrCreate(): Reference = {

--- a/clients/deltalake/core/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
+++ b/clients/deltalake/core/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
@@ -16,6 +16,7 @@
 package org.projectnessie.deltalake;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -62,7 +63,7 @@ class ITDeltaLogBranches extends AbstractSparkTest {
 
   @BeforeEach
   public void createClient() {
-    client = NessieClient.builder().withUri(url).build();
+    client = NessieClient.builder().withUri(URI.create(url)).build();
   }
 
   @AfterEach

--- a/clients/deltalake/core/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
+++ b/clients/deltalake/core/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
@@ -62,7 +62,7 @@ class ITDeltaLogBranches extends AbstractSparkTest {
 
   @BeforeEach
   public void createClient() {
-    client = NessieClient.builder().withPath(url).build();
+    client = NessieClient.builder().withUri(url).build();
   }
 
   @AfterEach

--- a/clients/deltalake/core/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
+++ b/clients/deltalake/core/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
@@ -16,7 +16,6 @@
 package org.projectnessie.deltalake;
 
 import java.io.File;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -63,7 +62,7 @@ class ITDeltaLogBranches extends AbstractSparkTest {
 
   @BeforeEach
   public void createClient() {
-    client = NessieClient.builder().withUri(URI.create(url)).build();
+    client = NessieClient.builder().withUri(url).build();
   }
 
   @AfterEach

--- a/clients/deltalake/core/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
+++ b/clients/deltalake/core/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
@@ -62,7 +62,7 @@ class ITDeltaLogBranches extends AbstractSparkTest {
 
   @BeforeEach
   public void createClient() {
-    client = NessieClient.none(url);
+    client = NessieClient.builder().withPath(url).build();
   }
 
   @AfterEach

--- a/clients/hmsbridge/core/src/main/java/org/projectnessie/hms/NessieStoreImpl.java
+++ b/clients/hmsbridge/core/src/main/java/org/projectnessie/hms/NessieStoreImpl.java
@@ -81,7 +81,7 @@ public class NessieStoreImpl implements NessieStore {
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
-    client = NessieClient.withConfig(conf::get);
+    client = NessieClient.builder().fromConfig(conf::get).build();
     try {
       ref = client.getTreeApi().getDefaultBranch().getName();
     } catch (NessieNotFoundException e) {

--- a/clients/hmsbridge/core/src/test/java/org/projectnessie/hms/BaseHiveOps.java
+++ b/clients/hmsbridge/core/src/test/java/org/projectnessie/hms/BaseHiveOps.java
@@ -52,7 +52,7 @@ public abstract class BaseHiveOps {
 
   @BeforeEach
   void resetData() throws NessieConflictException, NessieNotFoundException {
-    NessieClient client = NessieClient.withConfig(configFunction());
+    NessieClient client = NessieClient.builder().fromConfig(configFunction()).build();
     for (Reference r : client.getTreeApi().getAllReferences()) {
       if (r instanceof Branch) {
         client.getTreeApi().deleteBranch(r.getName(), r.getHash());

--- a/clients/hmsbridge/hive2/src/test/java/org/projectnessie/hms/ITTestHive2DelegateOps.java
+++ b/clients/hmsbridge/hive2/src/test/java/org/projectnessie/hms/ITTestHive2DelegateOps.java
@@ -42,7 +42,7 @@ public class ITTestHive2DelegateOps extends BaseDelegateOps {
 
   @BeforeAll
   static void setupNessieClient() {
-    client = NessieClient.withConfig(properties::get);
+    client = NessieClient.builder().fromConfig(properties::get).build();
   }
 
   @Override

--- a/clients/hmsbridge/hive2/src/test/java/org/projectnessie/hms/ITTestHive2DelegateOps.java
+++ b/clients/hmsbridge/hive2/src/test/java/org/projectnessie/hms/ITTestHive2DelegateOps.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.hms;
 
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -24,8 +24,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.jupiter.api.BeforeAll;
 import org.projectnessie.DelegatingHive2NessieRawStore;
 import org.projectnessie.client.NessieClient;
-import org.projectnessie.hms.BaseDelegateOps;
-import org.projectnessie.hms.NessieStore;
 
 import com.google.common.collect.ImmutableMap;
 import com.klarna.hiverunner.annotations.HiveProperties;
@@ -37,7 +35,7 @@ public class ITTestHive2DelegateOps extends BaseDelegateOps {
       .put(HiveConf.ConfVars.METASTORE_RAW_STORE_IMPL.varname, DelegatingHive2NessieRawStore.class.getName())
       .put("hive.exec.dynamic.partition.mode","nonstrict")
       .put(NessieStore.NESSIE_WHITELIST_DBS_OPTION,"nessie,mytestdb")
-      .put(CONF_NESSIE_URL, URL)
+      .put(CONF_NESSIE_URI, URL)
       .build();
 
   @BeforeAll

--- a/clients/hmsbridge/hive2/src/test/java/org/projectnessie/hms/ITTestHive2TableOperations.java
+++ b/clients/hmsbridge/hive2/src/test/java/org/projectnessie/hms/ITTestHive2TableOperations.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.hms;
 
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -24,7 +24,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.jupiter.api.BeforeAll;
 import org.projectnessie.Hive2NessieRawStore;
 import org.projectnessie.client.NessieClient;
-import org.projectnessie.hms.BaseTableOperations;
 
 import com.google.common.collect.ImmutableMap;
 import com.klarna.hiverunner.annotations.HiveProperties;
@@ -35,7 +34,7 @@ public class ITTestHive2TableOperations extends BaseTableOperations {
   public static final Map<String, String> properties = ImmutableMap.<String, String>builder()
       .put(HiveConf.ConfVars.METASTORE_RAW_STORE_IMPL.varname, Hive2NessieRawStore.class.getName())
       .put("hive.exec.dynamic.partition.mode","nonstrict")
-      .put(CONF_NESSIE_URL, URL)
+      .put(CONF_NESSIE_URI, URL)
       .build();
 
   @BeforeAll

--- a/clients/hmsbridge/hive2/src/test/java/org/projectnessie/hms/ITTestHive2TableOperations.java
+++ b/clients/hmsbridge/hive2/src/test/java/org/projectnessie/hms/ITTestHive2TableOperations.java
@@ -40,7 +40,7 @@ public class ITTestHive2TableOperations extends BaseTableOperations {
 
   @BeforeAll
   static void setupNessieClient() {
-    client = NessieClient.withConfig(properties::get);
+    client = NessieClient.builder().fromConfig(properties::get).build();
   }
 
   @Override

--- a/clients/hmsbridge/hive3/src/test/java/org/projectnessie/hms/ITTestHive3DelegateOps.java
+++ b/clients/hmsbridge/hive3/src/test/java/org/projectnessie/hms/ITTestHive3DelegateOps.java
@@ -42,7 +42,7 @@ public class ITTestHive3DelegateOps extends BaseDelegateOps {
 
   @BeforeAll
   static void setupNessieClient() {
-    client = NessieClient.withConfig(properties::get);
+    client = NessieClient.builder().fromConfig(properties::get).build();
   }
 
   @Override

--- a/clients/hmsbridge/hive3/src/test/java/org/projectnessie/hms/ITTestHive3DelegateOps.java
+++ b/clients/hmsbridge/hive3/src/test/java/org/projectnessie/hms/ITTestHive3DelegateOps.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.hms;
 
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -24,8 +24,6 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.junit.jupiter.api.BeforeAll;
 import org.projectnessie.DelegatingHive3NessieRawStore;
 import org.projectnessie.client.NessieClient;
-import org.projectnessie.hms.BaseDelegateOps;
-import org.projectnessie.hms.NessieStore;
 
 import com.google.common.collect.ImmutableMap;
 import com.klarna.hiverunner.annotations.HiveProperties;
@@ -37,7 +35,7 @@ public class ITTestHive3DelegateOps extends BaseDelegateOps {
       .put(MetastoreConf.ConfVars.RAW_STORE_IMPL.getVarname(), DelegatingHive3NessieRawStore.class.getName())
       .put("hive.exec.dynamic.partition.mode","nonstrict")
       .put(NessieStore.NESSIE_WHITELIST_DBS_OPTION,"nessie,mytestdb")
-      .put(CONF_NESSIE_URL, URL)
+      .put(CONF_NESSIE_URI, URL)
       .build();
 
   @BeforeAll

--- a/clients/hmsbridge/hive3/src/test/java/org/projectnessie/hms/ITTestHive3TableOperations.java
+++ b/clients/hmsbridge/hive3/src/test/java/org/projectnessie/hms/ITTestHive3TableOperations.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.hms;
 
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -24,7 +24,6 @@ import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.junit.jupiter.api.BeforeAll;
 import org.projectnessie.Hive3NessieRawStore;
 import org.projectnessie.client.NessieClient;
-import org.projectnessie.hms.BaseTableOperations;
 
 import com.google.common.collect.ImmutableMap;
 import com.klarna.hiverunner.annotations.HiveProperties;
@@ -35,7 +34,7 @@ public class ITTestHive3TableOperations extends BaseTableOperations {
   public static final Map<String, String> properties = ImmutableMap.<String, String>builder()
       .put(MetastoreConf.ConfVars.RAW_STORE_IMPL.getVarname(), Hive3NessieRawStore.class.getName())
       .put("hive.exec.dynamic.partition.mode","nonstrict")
-      .put(CONF_NESSIE_URL, URL)
+      .put(CONF_NESSIE_URI, URL)
       .build();
 
   @BeforeAll

--- a/clients/hmsbridge/hive3/src/test/java/org/projectnessie/hms/ITTestHive3TableOperations.java
+++ b/clients/hmsbridge/hive3/src/test/java/org/projectnessie/hms/ITTestHive3TableOperations.java
@@ -40,7 +40,7 @@ public class ITTestHive3TableOperations extends BaseTableOperations {
 
   @BeforeAll
   static void setupNessieClient() {
-    client = NessieClient.withConfig(properties::get);
+    client = NessieClient.builder().fromConfig(properties::get).build();
   }
 
   @Override

--- a/clients/tests/src/main/java/org/projectnessie/client/tests/AbstractSparkTest.java
+++ b/clients/tests/src/main/java/org/projectnessie/client/tests/AbstractSparkTest.java
@@ -17,7 +17,7 @@ package org.projectnessie.client.tests;
 
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_AUTH_TYPE;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_REF;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
 
 import java.io.IOException;
 import java.util.List;
@@ -48,11 +48,11 @@ public abstract class AbstractSparkTest {
     String branch = "main";
     String authType = "NONE";
 
-    hadoopConfig.set(CONF_NESSIE_URL, url);
+    hadoopConfig.set(CONF_NESSIE_URI, url);
     hadoopConfig.set(CONF_NESSIE_REF, branch);
     hadoopConfig.set(CONF_NESSIE_AUTH_TYPE, authType);
 
-    conf.set("spark.hadoop." + CONF_NESSIE_URL, url)
+    conf.set("spark.hadoop." + CONF_NESSIE_URI, url)
         .set("spark.hadoop." + CONF_NESSIE_REF, branch)
         .set("spark.hadoop." + CONF_NESSIE_AUTH_TYPE, authType)
         .set(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic");

--- a/perftest/README.md
+++ b/perftest/README.md
@@ -14,7 +14,7 @@ To Run:
   - cadvisor - docker image and host metrics
   - localstack - for dynamodb and future AWS services
 * build project (`mvn clean install`)  
-* enter `perftest` directory and execute `mvn exec:java jmeter:jmeter -Dnessie.jmeter.users=10 -Dnessie.jmeter.queries=100 -Dnessie.jmeter.dbsize=10000 -Dnessie.jmeter.path=http://localhost:19131/api/v1`
+* enter `perftest` directory and execute `mvn exec:java jmeter:jmeter -Dnessie.jmeter.users=10 -Dnessie.jmeter.queries=100 -Dnessie.jmeter.dbsize=10000 -Dnessie.jmeter.uri=http://localhost:19131/api/v1`
 * have a look at `target/jmeter/results` for results and check grafana and jaeger for timings
 
 
@@ -39,7 +39,7 @@ These instructions are for running nessie on an EC2 instance and using dynamodb.
     - [jaeger](http://localhost:16686) - trace executions
     - cadvisor - docker image and host metrics
 1. build project (`mvn clean install`)  
-1. enter `perftest` directory and execute `mvn jmeter:jmeter -Dnessie.jmeter.users=10 -Dnessie.jmeter.queries=100 -Dnessie.jmeter.dbsize=10000 -Dnessie.jmeter.path=http://<ec2_host>:19131/api/v1 -Dnessie.dynamo.region=us-west-2 -Dnessie.dynamo.endpoint=https://dynamodb.us-west-2.amazonaws.com`
+1. enter `perftest` directory and execute `mvn jmeter:jmeter -Dnessie.jmeter.users=10 -Dnessie.jmeter.queries=100 -Dnessie.jmeter.dbsize=10000 -Dnessie.jmeter.uri=http://<ec2_host>:19131/api/v1 -Dnessie.dynamo.region=us-west-2 -Dnessie.dynamo.endpoint=https://dynamodb.us-west-2.amazonaws.com`
 1. have a look at `target/jmeter/results` for results and check grafana and jaeger for timings
 
 ## ECS test

--- a/perftest/src/main/java/org/projectnessie/perftest/NessieSampler.java
+++ b/perftest/src/main/java/org/projectnessie/perftest/NessieSampler.java
@@ -45,7 +45,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
   private static final Logger logger = LoggerFactory.getLogger(NessieSampler.class);
   private static final Joiner SLASH = Joiner.on("/");
   private static final String METHOD_TAG = "method";
-  private static final String PATH_TAG = "path";
+  private static final String URI_TAG = "uri";
   private static final String BRANCH_TAG = "branch";
   private static final String BASE_BRANCH_TAG = "base_branch";
   private static final String TABLE_TAG = "table";
@@ -58,7 +58,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
   }
 
   private NessieClient client;
-  private String path;
+  private String uri;
   private String branch;
   private String baseBranch;
   private ThreadLocal<Branch> commitId = new ThreadLocal<>();
@@ -68,7 +68,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
    */
   private synchronized NessieClient nessieClient() {
     if (client == null) {
-      client = NessieClient.builder().withPath(path).withUsername("admin_user").withPassword("test123").build();
+      client = NessieClient.builder().withUri(uri).withUsername("admin_user").withPassword("test123").build();
       try {
         client.getTreeApi().createReference(Branch.of("main", null));
       } catch (Exception t) {
@@ -85,7 +85,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
   public Arguments getDefaultParameters() {
     Arguments defaultParameters = new Arguments();
     defaultParameters.addArgument(METHOD_TAG, "test");
-    defaultParameters.addArgument(PATH_TAG, "testurl");
+    defaultParameters.addArgument(URI_TAG, "testurl");
     defaultParameters.addArgument(BRANCH_TAG, "main");
     defaultParameters.addArgument(BASE_BRANCH_TAG, "main");
     defaultParameters.addArgument(TABLE_TAG, "table");
@@ -108,7 +108,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
     sampleResult.setBytes(message.getBytes().length);
     sampleResult.setResponseCode(Integer.toString(retCode));
     try {
-      sampleResult.setURL(new URL(SLASH.join(path, method.name())));
+      sampleResult.setURL(new URL(SLASH.join(uri, method.name())));
     } catch (MalformedURLException e) {
       //pass
     }
@@ -196,7 +196,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
 
   @Override
   public void setupTest(JavaSamplerContext context) {
-    path = context.getParameter(PATH_TAG);
+    uri = context.getParameter(URI_TAG);
     branch = context.getParameter(BRANCH_TAG, "x");
     baseBranch = context.getParameter(BASE_BRANCH_TAG, "main");
   }

--- a/perftest/src/main/java/org/projectnessie/perftest/NessieSampler.java
+++ b/perftest/src/main/java/org/projectnessie/perftest/NessieSampler.java
@@ -68,7 +68,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
    */
   private synchronized NessieClient nessieClient() {
     if (client == null) {
-      client = NessieClient.basic(path, "admin_user", "test123");
+      client = NessieClient.builder().withPath(path).withUsername("admin_user").withPassword("test123").build();
       try {
         client.getTreeApi().createReference(Branch.of("main", null));
       } catch (Exception t) {

--- a/perftest/src/main/java/org/projectnessie/perftest/NessieSampler.java
+++ b/perftest/src/main/java/org/projectnessie/perftest/NessieSampler.java
@@ -17,6 +17,7 @@ package org.projectnessie.perftest;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 
 import org.apache.jmeter.config.Arguments;
@@ -68,7 +69,7 @@ public class NessieSampler extends AbstractJavaSamplerClient {
    */
   private synchronized NessieClient nessieClient() {
     if (client == null) {
-      client = NessieClient.builder().withUri(uri).withUsername("admin_user").withPassword("test123").build();
+      client = NessieClient.builder().withUri(URI.create(uri)).withUsername("admin_user").withPassword("test123").build();
       try {
         client.getTreeApi().createReference(Branch.of("main", null));
       } catch (Exception t) {

--- a/perftest/src/test/jmeter/test.jmx
+++ b/perftest/src/test/jmeter/test.jmx
@@ -53,7 +53,7 @@
         </RandomVariableConfig>
         <hashTree/>
         <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Java Request" enabled="true">
-          <stringProp name="TestPlan.comments">Set path to Nessie URL in nessie.jmeter.path</stringProp>
+          <stringProp name="TestPlan.comments">Set Nessie URL in nessie.jmeter.uri</stringProp>
           <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
             <collectionProp name="Arguments.arguments">
               <elementProp name="method" elementType="Argument">
@@ -61,9 +61,9 @@
                 <stringProp name="Argument.value">2</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
-              <elementProp name="path" elementType="Argument">
-                <stringProp name="Argument.name">path</stringProp>
-                <stringProp name="Argument.value">${__property(nessie.jmeter.path)}</stringProp>
+              <elementProp name="uri" elementType="Argument">
+                <stringProp name="Argument.name">uri</stringProp>
+                <stringProp name="Argument.value">${__property(nessie.jmeter.uri)}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
               <elementProp name="branch" elementType="Argument">

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
@@ -60,7 +60,7 @@ class TestAuth {
   }
 
   void getCatalog(String branch) throws NessieNotFoundException, NessieConflictException {
-    client = NessieClient.none("http://localhost:19121/api/v1");
+    client = NessieClient.builder().withPath("http://localhost:19121/api/v1").build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
     if (branch != null) {

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
@@ -18,7 +18,6 @@ package org.projectnessie.server;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -60,7 +59,7 @@ class TestAuth {
   }
 
   void getCatalog(String branch) throws NessieNotFoundException, NessieConflictException {
-    client = NessieClient.builder().withUri(URI.create("http://localhost:19121/api/v1")).build();
+    client = NessieClient.builder().withUri("http://localhost:19121/api/v1").build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
     if (branch != null) {

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.projectnessie.server;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -60,7 +60,7 @@ class TestAuth {
   }
 
   void getCatalog(String branch) throws NessieNotFoundException, NessieConflictException {
-    client = NessieClient.builder().withUri("http://localhost:19121/api/v1").build();
+    client = NessieClient.builder().withUri(URI.create("http://localhost:19121/api/v1")).build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
     if (branch != null) {

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
@@ -60,7 +60,7 @@ class TestAuth {
   }
 
   void getCatalog(String branch) throws NessieNotFoundException, NessieConflictException {
-    client = NessieClient.builder().withPath("http://localhost:19121/api/v1").build();
+    client = NessieClient.builder().withUri("http://localhost:19121/api/v1").build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
     if (branch != null) {

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -89,7 +89,7 @@ class TestRest {
   @BeforeEach
   void init() {
     String path = "http://localhost:19121/api/v1";
-    client = NessieClient.builder().withPath(path).build();
+    client = NessieClient.builder().withUri(path).build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -89,7 +89,7 @@ class TestRest {
   @BeforeEach
   void init() {
     String path = "http://localhost:19121/api/v1";
-    client = NessieClient.none("http://localhost:19121/api/v1");
+    client = NessieClient.builder().withPath(path).build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -31,6 +31,7 @@ import static org.projectnessie.model.Validation.REF_NAME_MESSAGE;
 import static org.projectnessie.model.Validation.REF_NAME_OR_HASH_MESSAGE;
 import static org.projectnessie.server.ReferenceMatchers.referenceWithNameAndType;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -88,14 +89,14 @@ class TestRest {
 
   @BeforeEach
   void init() {
-    String path = "http://localhost:19121/api/v1";
-    client = NessieClient.builder().withUri(path).build();
+    URI uri = URI.create("http://localhost:19121/api/v1");
+    client = NessieClient.builder().withUri(uri).build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
 
     ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
         .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-    httpClient = HttpClient.builder().setBaseUri(path).setObjectMapper(mapper).build();
+    httpClient = HttpClient.builder().setBaseUri(uri).setObjectMapper(mapper).build();
     httpClient.register(new NessieHttpResponseFilter(mapper));
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.api.ContentsApi;
 import org.projectnessie.client.NessieClient;
-import org.projectnessie.client.NessieClient.AuthType;
 import org.projectnessie.client.rest.NessieBadRequestException;
 import org.projectnessie.model.ContentsKey;
 import org.projectnessie.model.IcebergTable;
@@ -42,7 +41,7 @@ public class ITNativeNessieError {
   @BeforeEach
   void init() {
     String path = "http://localhost:19121/api/v1";
-    NessieClient client = new NessieClient(AuthType.NONE, path, null, null);
+    NessieClient client = NessieClient.builder().withPath(path).build();
     contents = client.getContentsApi();
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
@@ -41,7 +41,7 @@ public class ITNativeNessieError {
   @BeforeEach
   void init() {
     String path = "http://localhost:19121/api/v1";
-    NessieClient client = NessieClient.builder().withPath(path).build();
+    NessieClient client = NessieClient.builder().withUri(path).build();
     contents = client.getContentsApi();
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
@@ -18,6 +18,8 @@ package org.projectnessie.server.error;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.net.URI;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.api.ContentsApi;
@@ -40,8 +42,8 @@ public class ITNativeNessieError {
 
   @BeforeEach
   void init() {
-    String path = "http://localhost:19121/api/v1";
-    NessieClient client = NessieClient.builder().withUri(path).build();
+    URI uri = URI.create("http://localhost:19121/api/v1");
+    NessieClient client = NessieClient.builder().withUri(uri).build();
     contents = client.getContentsApi();
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.net.URI;
+
 import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -56,7 +58,7 @@ class TestNessieError {
     ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
         .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     client = HttpClient.builder()
-        .setBaseUri(baseURI)
+        .setBaseUri(URI.create(baseURI))
         .setObjectMapper(mapper)
         .build();
     client.register(new NessieHttpResponseFilter(mapper));


### PR DESCRIPTION
Adds the OpenTracing/OpenTracing/Jaeger HTTP header(s) required for distributed tracing to requests sent by our HTTP client.

Refactors `NessieClient` to an interface, adds a builder, because there were now too many parameters/options.

Renames the term "path" used as the uri for the Nessie server to "uri" and also use the type `java.net.URI` for it.

Fixes #643

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/835)
<!-- Reviewable:end -->
