### PR TITLE
Add filtering by entity type in `getEntities`

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/ClientTreeApi.java
+++ b/clients/client/src/main/java/org/projectnessie/client/ClientTreeApi.java
@@ -23,6 +23,7 @@ import javax.validation.constraints.NotNull;
 
 import org.projectnessie.api.TreeApi;
 import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.HttpRequest;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -140,13 +141,13 @@ class ClientTreeApi implements TreeApi {
 
   @Override
   public EntriesResponse getEntries(@NotNull String refName, @Nullable Integer maxEntriesHint,
-      @Nullable String pageToken) throws NessieNotFoundException {
-    return client.newRequest().path("trees/tree/{ref}/entries")
-                 .resolveTemplate("ref", refName)
-                 .queryParam("max", maxEntriesHint != null ? maxEntriesHint.toString() : null)
-                 .queryParam("pageToken", pageToken)
-                 .get()
-                 .readEntity(EntriesResponse.class);
+      @Nullable String pageToken, @NotNull List<String> valueTypes) throws NessieNotFoundException {
+    HttpRequest builder = client.newRequest().path("trees/tree/{ref}/entries").resolveTemplate("ref", refName);
+    valueTypes.forEach(x -> builder.queryParam("types", x));
+    return builder.queryParam("max", maxEntriesHint != null ? maxEntriesHint.toString() : null)
+                  .queryParam("pageToken", pageToken)
+                  .get()
+                  .readEntity(EntriesResponse.class);
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
+++ b/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client;
 
+import java.util.List;
 import java.util.OptionalInt;
 import java.util.stream.Stream;
 
@@ -38,18 +39,19 @@ public final class StreamingUtil {
 
   /**
    * Default implementation to return a stream of objects for a ref, functionally equivalent to
-   * calling {@link TreeApi#getEntries(String, Integer, String)} with manual paging.
+   * calling {@link TreeApi#getEntries(String, Integer, String, List)} with manual paging.
    * <p>The {@link Stream} returned by {@code getEntriesStream(ref, OptionalInt.empty())},
    * if not limited, returns all commit-log entries.</p>
    *
    * @param ref a named reference (branch or tag name) or a commit-hash
    * @param pageSizeHint page-size hint for the backend
+   * @param types types to filter on. Empty list means no filtering.
    * @return stream of {@link Entry} objects
    */
   public static Stream<Entry> getEntriesStream(@NotNull TreeApi treeApi, @NotNull String ref,
-      OptionalInt pageSizeHint) throws NessieNotFoundException {
-    return new ResultStreamPaginator<>(EntriesResponse::getEntries, treeApi::getEntries)
-        .generateStream(ref, pageSizeHint);
+      OptionalInt pageSizeHint, List<String> types) throws NessieNotFoundException {
+    return new ResultStreamPaginator<>(EntriesResponse::getEntries,
+        (ref1, pageSize, token) -> treeApi.getEntries(ref1, pageSize, token, types)).generateStream(ref, pageSizeHint);
   }
 
   /**

--- a/clients/hmsbridge/core/src/main/java/org/projectnessie/hms/TransactionStore.java
+++ b/clients/hmsbridge/core/src/main/java/org/projectnessie/hms/TransactionStore.java
@@ -16,6 +16,7 @@
 package org.projectnessie.hms;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,7 +120,7 @@ class TransactionStore {
   }
 
   public Stream<Entry> getEntriesForDefaultRef() throws NessieNotFoundException {
-    List<Entry> entries = tree.getEntries(reference.getHash(), null, null).getEntries();
+    List<Entry> entries = tree.getEntries(reference.getHash(), null, null, Collections.emptyList()).getEntries();
     Supplier<Stream<RefKey>> defaultRefKeys = () -> cachedItems.keySet().stream().filter(k -> k.getRef().equals(reference.getHash()));
     Set<ContentsKey> toRemove = defaultRefKeys.get().map(RefKey::getKey).collect(Collectors.toSet());
     return Stream.concat(entries.stream().filter(k -> !toRemove.contains(k.getName())),

--- a/clients/hmsbridge/core/src/test/java/org/projectnessie/hms/BaseDelegateOps.java
+++ b/clients/hmsbridge/core/src/test/java/org/projectnessie/hms/BaseDelegateOps.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -57,7 +58,7 @@ public abstract class BaseDelegateOps extends BaseHiveOps {
     assertTrue(HiveTable.class.isAssignableFrom(tbl.getClass()));
 
     // ensure only one table was created in Nessie.
-    assertEquals(2, client.getTreeApi().getEntries("main", null, null).getEntries().size());
+    assertEquals(2, client.getTreeApi().getEntries("main", null, null, Collections.emptyList()).getEntries().size());
   }
 
 }

--- a/model/src/main/java/org/projectnessie/api/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/TreeApi.java
@@ -164,7 +164,10 @@ public interface TreeApi {
           Integer maxRecords,
       @Parameter(description = "pagination continuation token, as returned in the previous EntriesResponse.token")
       @QueryParam("pageToken")
-          String pageToken)
+          String pageToken,
+      @Parameter(description = "list of value types to return. Return all if empty")
+      @QueryParam("types")
+        List<String> types)
           throws NessieNotFoundException;
 
   /**

--- a/python/docs/contents.rst
+++ b/python/docs/contents.rst
@@ -1,24 +1,24 @@
 .. code-block:: bash
 
 	Usage: cli contents [OPTIONS] [KEY]...
-	
+
 	  Contents operations.
-	
+
 	  KEY name of object to view, delete. If listing the key will limit by
 	  namespace what is included.
-	
+
 	Options:
 	  -l, --list            list tables
 	  -d, --delete          delete a table
 	  -s, --set             modify a table
 	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
 	                        currently points to condition.
-	
+
 	  -r, --ref TEXT        branch to list from. If not supplied the default branch
 	                        from config is used
-	
-	  -m, --message TEXT    commit message
-	  --help                Show this message and exit.
-	
-	
 
+	  -m, --message TEXT    commit message
+	  -t, --type TEXT       entity types to filter on, if no entity types are passed
+	                        then all types are returned
+
+	  --help                Show this message and exit.

--- a/python/pynessie/_endpoints.py
+++ b/python/pynessie/_endpoints.py
@@ -146,7 +146,7 @@ def list_tables(
     ref: str,
     max_result_hint: Optional[int] = None,
     page_token: Optional[str] = None,
-    entity_types: Optional[list] = None,
+    types: Optional[list] = None,
     ssl_verify: bool = True,
 ) -> list:
     """Fetch a list of all tables from a known reference.
@@ -155,14 +155,14 @@ def list_tables(
     :param ref: reference
     :param max_result_hint: hint for the server, maximum number of results to return
     :param page_token: the token retrieved from a previous page returned for the same ref
-    :param entity_types: list of types to filter keys on
+    :param types: list of types to filter keys on
     :param ssl_verify: ignore ssl errors if False
     :return: json list of Nessie table names
     """
-    if not entity_types:
-        entity_types = list()
-    entity_type_header = ",".join(entity_types)
-    params = {"types": entity_type_header}
+    params = dict()
+    if types:
+        entity_type_header = ",".join(types)
+        params["types"] = entity_type_header
     if max_result_hint:
         params["max"] = str(max_result_hint)
     if page_token:

--- a/python/pynessie/_endpoints.py
+++ b/python/pynessie/_endpoints.py
@@ -142,8 +142,12 @@ def delete_tag(base_url: str, tag: str, hash_: str, reason: str = None, ssl_veri
 
 
 def list_tables(
-    base_url: str, ref: str, max_result_hint: Optional[int] = None, page_token: Optional[str] = None,
-    entity_types: Optional[list] = None, ssl_verify: bool = True
+    base_url: str,
+    ref: str,
+    max_result_hint: Optional[int] = None,
+    page_token: Optional[str] = None,
+    entity_types: Optional[list] = None,
+    ssl_verify: bool = True,
 ) -> list:
     """Fetch a list of all tables from a known reference.
 

--- a/python/pynessie/_endpoints.py
+++ b/python/pynessie/_endpoints.py
@@ -142,7 +142,8 @@ def delete_tag(base_url: str, tag: str, hash_: str, reason: str = None, ssl_veri
 
 
 def list_tables(
-    base_url: str, ref: str, max_result_hint: Optional[int] = None, page_token: Optional[str] = None, ssl_verify: bool = True
+    base_url: str, ref: str, max_result_hint: Optional[int] = None, page_token: Optional[str] = None,
+    entity_types: Optional[list] = None, ssl_verify: bool = True
 ) -> list:
     """Fetch a list of all tables from a known reference.
 
@@ -150,10 +151,14 @@ def list_tables(
     :param ref: reference
     :param max_result_hint: hint for the server, maximum number of results to return
     :param page_token: the token retrieved from a previous page returned for the same ref
+    :param entity_types: list of types to filter keys on
     :param ssl_verify: ignore ssl errors if False
     :return: json list of Nessie table names
     """
-    params = {}
+    if not entity_types:
+        entity_types = list()
+    entity_type_header = ",".join(entity_types)
+    params = {"types": entity_type_header}
     if max_result_hint:
         params["max"] = str(max_result_hint)
     if page_token:

--- a/python/pynessie/cli.py
+++ b/python/pynessie/cli.py
@@ -425,7 +425,7 @@ def contents(
     KEY name of object to view, delete. If listing the key will limit by namespace what is included.
     """
     if list:
-        keys = ctx.nessie.list_keys(ref if ref else ctx.nessie.get_default_branch(), entity_type)
+        keys = ctx.nessie.list_keys(ref if ref else ctx.nessie.get_default_branch(), entity_types=entity_type)
         results = EntrySchema().dumps(_format_keys_json(keys, *key), many=True) if ctx.json else _format_keys(keys, *key)
     elif delete:
         ctx.nessie.commit(ref, condition, _get_message(message), *_get_contents(ctx.nessie, ref, delete, *key))

--- a/python/pynessie/cli.py
+++ b/python/pynessie/cli.py
@@ -407,16 +407,25 @@ def cherry_pick(ctx: ContextObject, branch: str, force: bool, condition: str, ha
 )
 @click.option("-r", "--ref", help="branch to list from. If not supplied the default branch from config is used")
 @click.option("-m", "--message", help="commit message")
+@click.option(
+    "-t",
+    "--type",
+    "entity_type",
+    help="entity types to filter on, if no entity types are passed then all types are returned",
+    multiple=True,
+)
 @click.argument("key", nargs=-1, required=False)
 @pass_client
 @error_handler
-def contents(ctx: ContextObject, list: bool, delete: bool, set: bool, key: List[str], ref: str, message: str, condition: str) -> None:
+def contents(
+    ctx: ContextObject, list: bool, delete: bool, set: bool, key: List[str], ref: str, message: str, condition: str, entity_type: list
+) -> None:
     """Contents operations.
 
     KEY name of object to view, delete. If listing the key will limit by namespace what is included.
     """
     if list:
-        keys = ctx.nessie.list_keys(ref if ref else ctx.nessie.get_default_branch())
+        keys = ctx.nessie.list_keys(ref if ref else ctx.nessie.get_default_branch(), entity_type)
         results = EntrySchema().dumps(_format_keys_json(keys, *key), many=True) if ctx.json else _format_keys(keys, *key)
     elif delete:
         ctx.nessie.commit(ref, condition, _get_message(message), *_get_contents(ctx.nessie, ref, delete, *key))

--- a/python/pynessie/nessie_client.py
+++ b/python/pynessie/nessie_client.py
@@ -112,13 +112,17 @@ class NessieClient(object):
         """
         delete_tag(self._base_url, tag, hash_, self._ssl_verify)
 
-    def list_keys(self: "NessieClient", ref: str, max_result_hint: Optional[int] = None, page_token: Optional[str] = None) -> Entries:
+    def list_keys(self: "NessieClient", ref: str, max_result_hint: Optional[int] = None,
+      page_token: Optional[str] = None, entity_types: Optional[list] = None) -> Entries:
         """Fetch a list of all tables from a known branch.
 
         :param ref: name of branch
+        :param entity_types: list of types to filter keys on
         :return: list of Nessie table names
         """
-        return EntriesSchema().load(list_tables(self._base_url, ref, max_result_hint, page_token, self._ssl_verify))
+        if not entity_types:
+            entity_types = list()
+        return EntriesSchema().load(list_tables(self._base_url, ref, max_result_hint, page_token, entity_types, self._ssl_verify))
 
     def get_values(self: "NessieClient", ref: str, *tables: str) -> Generator[Contents, Any, None]:
         """Fetch a table from a known ref.

--- a/python/pynessie/nessie_client.py
+++ b/python/pynessie/nessie_client.py
@@ -112,8 +112,13 @@ class NessieClient(object):
         """
         delete_tag(self._base_url, tag, hash_, self._ssl_verify)
 
-    def list_keys(self: "NessieClient", ref: str, max_result_hint: Optional[int] = None,
-      page_token: Optional[str] = None, entity_types: Optional[list] = None) -> Entries:
+    def list_keys(
+        self: "NessieClient",
+        ref: str,
+        max_result_hint: Optional[int] = None,
+        page_token: Optional[str] = None,
+        entity_types: Optional[list] = None,
+    ) -> Entries:
         """Fetch a list of all tables from a known branch.
 
         :param ref: name of branch

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuth.java
@@ -18,6 +18,7 @@ package org.projectnessie.server;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -90,7 +91,7 @@ class TestAuth {
   void testAdmin() throws NessieNotFoundException, NessieConflictException {
     getCatalog("testx");
     Branch branch = (Branch) tree.getReferenceByName("testx");
-    List<Entry> tables = tree.getEntries("testx", null, null).getEntries();
+    List<Entry> tables = tree.getEntries("testx", null, null, Collections.emptyList()).getEntries();
     Assertions.assertTrue(tables.isEmpty());
     ContentsKey key = ContentsKey.of("x","x");
     tryEndpointPass(() -> contents.setContents(key, branch.getName(), branch.getHash(), "empty message", IcebergTable.of("foo")));

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -274,12 +274,10 @@ class TestRest {
         EntriesResponse.Entry.builder().name(b).type(Contents.Type.VIEW).build());
     assertThat(entries, Matchers.containsInAnyOrder(expected.toArray()));
     entries = tree.getEntries(branch, null, null, ImmutableList.of(Contents.Type.ICEBERG_TABLE.name())).getEntries();
-    assertEquals(1, entries.size());
-    assertEquals(expected.get(0),entries.get(0));
+    assertEquals(Collections.singletonList(expected.get(0)), entries);
 
     entries = tree.getEntries(branch, null, null, ImmutableList.of(Contents.Type.VIEW.name())).getEntries();
-    assertEquals(1, entries.size());
-    assertEquals(expected.get(1), entries.get(0));
+    assertEquals(Collections.singletonList(expected.get(1)), entries);
 
     entries = tree.getEntries(branch, null, null, ImmutableList.of(Contents.Type.VIEW.name(),
         Contents.Type.ICEBERG_TABLE.name())).getEntries();

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ErrorTestService.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ErrorTestService.java
@@ -137,7 +137,7 @@ public class ErrorTestService {
     Store store = Mockito.mock(Store.class);
     Mockito.when(store.getValues(ValueType.REF)).thenThrow(ex);
 
-    TieredVersionStore<String, String> tvs = new TieredVersionStore<>(
+    TieredVersionStore<String, String, StringSerializer.TestEnum> tvs = new TieredVersionStore<>(
         StoreWorker.of(StringSerializer.getInstance(), StringSerializer.getInstance()), store,
         true);
     tvs.getNamedRefs().forEach(ref -> {});

--- a/servers/services/src/main/java/org/projectnessie/services/rest/TreeResource.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/TreeResource.java
@@ -219,9 +219,9 @@ public class TreeResource extends BaseResource implements TreeApi {
     //  server or client. We have to figure out _how_ to implement paging for keys/entries, i.e.
     //  whether we shall just do the whole computation for a specific hash for every page or have
     //  a more sophisticated approach, potentially with support from the (tiered-)version-store.
+    //  note currently we are filtering types at the REST level. This could in theory be pushed down to the store though
+    //  all existing VersionStore implementations have to read all keys anyways so we don't get much
     try {
-      // note currently we are filtering types at the REST level. This could in theory be pushed down to the store though
-      // all existing VersionStore implementations have to read all keys anyways so we don't get much
       List<EntriesResponse.Entry> entries;
       try (Stream<EntriesResponse.Entry> s = getStore().getKeys(hash).filter(x -> payloads.contains(x.getType()))
           .map(key -> EntriesResponse.Entry.builder().name(fromKey(key.getValue())).type((Type) key.getType()).build())) {


### PR DESCRIPTION
This requires the following:
1) add query param to getEntities for which types we want (empty list means all)
2) version store now returns a tuple of Key, entity type
3) in memory and jgit store and populate types on return. Tiered store does not and requires extra lookups

For follow-up PR:
* possibly push filtering into version store. Can potentially be more efficient depending on store impl
* add an entity-type-id to the key list in tiered version store to make it more efficient (#836)

Closes #780

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/837)
<!-- Reviewable:end -->
