### PR TITLE
remove unused transient dependency

### DIFF
--- a/clients/hmsbridge/core/pom.xml
+++ b/clients/hmsbridge/core/pom.xml
@@ -131,6 +131,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.glassfish</groupId>
+          <artifactId>javax.el</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
This has been occasionally causing errors on build or warnings locally. Not used so just exclude it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/848)
<!-- Reviewable:end -->
