### PR TITLE
Mongodb dependency

### DIFF
--- a/clients/hmsbridge/core/pom.xml
+++ b/clients/hmsbridge/core/pom.xml
@@ -131,6 +131,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.glassfish</groupId>
+          <artifactId>javax.el</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,11 @@
       </dependency>
       <dependency>
         <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-core</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mongodb</groupId>
         <artifactId>bson</artifactId>
         <version>${mongodb.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <!--<dynamodb-local.repository.url>https://s3.us-west-2.amazonaws.com/dynamodb-local/release</dynamodb-local.repository.url>-->
 
     <!-- Version properties -->
-    <awssdk.version>2.16.1</awssdk.version>
+    <awssdk.version>2.16.2</awssdk.version>
     <bouncycastle.version>1.66</bouncycastle.version>
     <deltalake2.version>0.6.2-nessie</deltalake2.version>
     <deltalake3.version>0.8.0-nessie</deltalake3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <jmeter.version>5.4.1</jmeter.version>
     <junit.version>5.7.1</junit.version>
     <logback.version>1.2.3</logback.version>
-    <protobuf.version>3.14.0</protobuf.version>
+    <protobuf.version>3.15.0</protobuf.version>
     <mockito.version>3.7.7</mockito.version>
     <mongodb.version>4.1.1</mongodb.version>
     <prometheus.version>0.9.0</prometheus.version>

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 attrs==20.3.0
-botocore==1.20.10
+botocore==1.20.11
 Click==7.1.2
 confuse==1.4.0
 desert==2020.11.18

--- a/versioned/tiered/mongodb/pom.xml
+++ b/versioned/tiered/mongodb/pom.xml
@@ -73,6 +73,10 @@
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
       <artifactId>bson</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Add mongodb-driver-core as an explicit dependency since the transitive dependencies of mongodb-driver-reactivestreams is incorrect for 4.2.x and causes exceptions on instantation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/849)
<!-- Reviewable:end -->
