### PR TITLE
Use Quarkus BOM version of MongoDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
     <logback.version>1.2.3</logback.version>
     <protobuf.version>3.15.0</protobuf.version>
     <mockito.version>3.7.7</mockito.version>
-    <mongodb.version>4.2.1</mongodb.version>
     <prometheus.version>0.9.0</prometheus.version>
     <reactor.version>2020.0.4</reactor.version>
     <serverless.version>1.5</serverless.version>
@@ -445,21 +444,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>mongodb-driver-reactivestreams</artifactId>
-        <version>${mongodb.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>mongodb-driver-core</artifactId>
-        <version>${mongodb.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>bson</artifactId>
-        <version>${mongodb.version}</version>
       </dependency>
       <dependency>
         <groupId>de.flapdoodle.embed</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,11 @@
       </dependency>
       <dependency>
         <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-core</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mongodb</groupId>
         <artifactId>bson</artifactId>
         <version>${mongodb.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <logback.version>1.2.3</logback.version>
     <protobuf.version>3.15.0</protobuf.version>
     <mockito.version>3.7.7</mockito.version>
-    <mongodb.version>4.1.1</mongodb.version>
+    <mongodb.version>4.2.1</mongodb.version>
     <prometheus.version>0.9.0</prometheus.version>
     <reactor.version>2020.0.4</reactor.version>
     <serverless.version>1.5</serverless.version>

--- a/versioned/tiered/mongodb/pom.xml
+++ b/versioned/tiered/mongodb/pom.xml
@@ -73,6 +73,10 @@
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
       <artifactId>bson</artifactId>
     </dependency>
     <dependency>

--- a/versioned/tiered/mongodb/pom.xml
+++ b/versioned/tiered/mongodb/pom.xml
@@ -73,10 +73,6 @@
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mongodb</groupId>
       <artifactId>bson</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Remove MongoDB from dependencyMangagement in favour of versions in the Quarkus BOM to avoid version mismatches.

Keep flapdoodle as we rely on a later version then is in the Quarkus BOM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/850)
<!-- Reviewable:end -->
