### PR TITLE
Add RandomSource utility class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <module>perftest</module>
     <module>servers</module>
     <module>tools</module>
+    <module>utils</module>
   </modules>
 
   <scm>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -21,24 +21,19 @@
 
   <parent>
     <groupId>org.projectnessie</groupId>
-    <artifactId>nessie-versioned-tiered</artifactId>
+    <artifactId>nessie</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>nessie-versioned-tiered-impl</artifactId>
+  <artifactId>nessie-utils</artifactId>
 
-  <name>Nessie - Versioned - Tiered - Core Implementation</name>
+  <name>Nessie - Utils</name>
 
   <dependencies>
-    <dependency>
-      <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-versioned-spi</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-utils</artifactId>
-      <version>${project.version}</version>
+  <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -46,35 +41,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/utils/src/main/java/org/projectnessie/Closeable.java
+++ b/utils/src/main/java/org/projectnessie/Closeable.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie;
+
+/**
+ * A {@code AutoCloseable} extension which doesn't need
+ * to throw checked exceptions.
+ *
+ */
+@FunctionalInterface
+public interface Closeable extends AutoCloseable {
+  @Override
+  public void close();
+}

--- a/utils/src/main/java/org/projectnessie/RandomSource.java
+++ b/utils/src/main/java/org/projectnessie/RandomSource.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+/**
+ * A random generator similar to {@code ThreadLocalRandom}
+ * but which allows to use a different seed in test contexts.
+ */
+@SuppressWarnings("serial")
+public class RandomSource extends Random {
+  private static final ThreadLocal<Random> RNG = ThreadLocal.withInitial(ThreadLocalRandom::current);
+
+  private static final RandomSource INSTANCE = new RandomSource();
+
+  private final boolean isInitialized;
+
+  private RandomSource() {
+    this.isInitialized = true;
+  }
+
+  /**
+   * Get the current random generator.
+   *
+   * <p>The instance validity is only guaranteed for the current thread.
+   * As a consequence it is not recommend to store the result of this method.
+   * @return the current random generator
+   */
+  public static RandomSource current() {
+    return INSTANCE;
+  }
+
+  /**
+   * Changes the current random generator with a new one.
+   *
+   * <p>The change is only valid in the current thread, until the context is
+   * restored by closing the returned object.
+   *
+   * @param seed the seed to initialize the new random generator with.
+   * @return a {@code Closeable} instance to restore the previous conext
+   */
+  @CheckReturnValue
+  public static Closeable withSeed(long seed) {
+    final Random previousRng = RNG.get();
+    RNG.set(new Random(seed));
+    return () -> RNG.set(previousRng);
+  }
+
+  @Override
+  public synchronized void setSeed(long seed) {
+    if (!isInitialized) {
+      return;
+    }
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void nextBytes(byte[] bytes) {
+    super.nextBytes(bytes);
+  }
+
+  @Override
+  public int nextInt() {
+    return rng().nextInt();
+  }
+
+  @Override
+  public int nextInt(int bound) {
+    return rng().nextInt(bound);
+  }
+
+  @Override
+  public long nextLong() {
+    return rng().nextLong();
+  }
+
+  @Override
+  public boolean nextBoolean() {
+    return rng().nextBoolean();
+  }
+
+  @Override
+  public float nextFloat() {
+    return rng().nextFloat();
+  }
+
+  @Override
+  public double nextDouble() {
+    return rng().nextDouble();
+  }
+
+  @Override
+  public synchronized double nextGaussian() {
+    return rng().nextGaussian();
+  }
+
+  @Override
+  public IntStream ints(long streamSize) {
+    return rng().ints(streamSize);
+  }
+
+  @Override
+  public IntStream ints() {
+    return rng().ints();
+  }
+
+  @Override
+  public IntStream ints(long streamSize, int randomNumberOrigin, int randomNumberBound) {
+    return rng().ints(streamSize, randomNumberOrigin, randomNumberBound);
+  }
+
+  @Override
+  public IntStream ints(int randomNumberOrigin, int randomNumberBound) {
+    return rng().ints(randomNumberOrigin, randomNumberBound);
+  }
+
+  @Override
+  public LongStream longs(long streamSize) {
+    return rng().longs(streamSize);
+  }
+
+  @Override
+  public LongStream longs() {
+    return rng().longs();
+  }
+
+  @Override
+  public LongStream longs(long streamSize, long randomNumberOrigin,
+      long randomNumberBound) {
+    return rng().longs(streamSize, randomNumberOrigin, randomNumberBound);
+  }
+
+  @Override
+  public LongStream longs(long randomNumberOrigin, long randomNumberBound) {
+    return rng().longs(randomNumberOrigin, randomNumberBound);
+  }
+
+  @Override
+  public DoubleStream doubles(long streamSize) {
+    return rng().doubles(streamSize);
+  }
+
+  @Override
+  public DoubleStream doubles() {
+    return rng().doubles();
+  }
+
+  @Override
+  public DoubleStream doubles(long streamSize, double randomNumberOrigin,
+      double randomNumberBound) {
+    return rng().doubles(streamSize, randomNumberOrigin, randomNumberBound);
+  }
+
+  @Override
+  public DoubleStream doubles(double randomNumberOrigin, double randomNumberBound) {
+    return rng().doubles(randomNumberOrigin, randomNumberBound);
+  }
+
+  // Visible for testing
+  final Random rng() {
+    return RNG.get();
+  }
+}

--- a/utils/src/test/java/org/projectnessie/TestRandomSource.java
+++ b/utils/src/test/java/org/projectnessie/TestRandomSource.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.projectnessie.RandomSource.current;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@code RandomSource}.
+ */
+public class TestRandomSource {
+
+  @Test
+  public void checkRng() throws IOException {
+    assertThat(current().rng(), is(sameInstance(ThreadLocalRandom.current())));
+    try (final Closeable c = RandomSource.withSeed(42L)) {
+      assertThat(current().rng(), is(not(sameInstance(ThreadLocalRandom.current()))));
+    }
+    assertThat(current().rng(), is(sameInstance(ThreadLocalRandom.current())));
+
+  }
+
+  @Test
+  public void nextBytes() {
+    doCheckNextMethod(r -> {
+      byte[] b = new byte[42];
+      r.nextBytes(b);
+      return b;
+    });
+  }
+
+  @Test
+  public void nextInt() {
+    doCheckNextMethod(Random::nextInt);
+  }
+
+  public void nextIntWithBound() {
+    doCheckNextMethod(r -> r.nextInt(42));
+  }
+
+  @Test
+  public void nextLong() {
+    doCheckNextMethod(Random::nextLong);
+  }
+
+  @Test
+  public void nextBoolean() {
+    doCheckNextMethod(Random::nextBoolean);
+  }
+
+  @Test
+  public void nextFloat() {
+    doCheckNextMethod(Random::nextFloat);
+  }
+
+  @Test
+  public void nextDouble() {
+    doCheckNextMethod(Random::nextDouble);
+  }
+
+  @Test
+  public void nextGaussian() {
+    doCheckNextMethod(Random::nextGaussian);
+  }
+
+  @Test
+  public void intsWithStreamSize() {
+    doCheckIntStreamMethod(r -> r.ints(42));
+  }
+
+  @Test
+  public void ints() {
+    doCheckIntStreamMethod(Random::ints);
+  }
+
+  @Test
+  public void intsWithStreamSizeAndBoundaries() {
+    doCheckIntStreamMethod(r -> r.ints(42, 18, 127));
+  }
+
+  @Test
+  public void intsWithdBoundaries() {
+    doCheckIntStreamMethod(r -> r.ints(18, 127));
+  }
+
+  private void doCheckIntStreamMethod(Function<Random, IntStream> method) {
+    doCheckStreamMethod(method.andThen(s -> s.mapToObj(Integer::valueOf)));
+  }
+
+  @Test
+  public void longsWithStreamSize() {
+    doCheckLongStreamMethod(r -> r.longs(42));
+  }
+
+  @Test
+  public void longs() {
+    doCheckLongStreamMethod(Random::longs);
+  }
+
+  @Test
+  public void longsWithStreamSizeAndBoundaries() {
+    doCheckLongStreamMethod(r -> r.longs(42, 18, 127));
+  }
+
+  @Test
+  public void longsWithBoundaries() {
+    doCheckLongStreamMethod(r -> r.longs(18, 127));
+  }
+
+  private void doCheckLongStreamMethod(Function<Random, LongStream> method) {
+    doCheckStreamMethod(method.andThen(s -> s.mapToObj(Long::valueOf)));
+  }
+
+  @Test
+  public void doublesWithStreamSize() {
+    doCheckDoubleStreamMethod(r -> r.doubles(42));
+  }
+
+  @Test
+  public void doubles() {
+    doCheckDoubleStreamMethod(Random::doubles);
+  }
+
+  @Test
+  public void doublesWithStreamSizeAndBoundaries() {
+    doCheckDoubleStreamMethod(r -> r.doubles(42, 13.37d, 314.15d));
+  }
+
+  @Test
+  public void doublesWithAndBoundaries() {
+    doCheckDoubleStreamMethod(r -> r.doubles(13.37d, 314.15d));
+  }
+
+  private void doCheckDoubleStreamMethod(Function<Random, DoubleStream> method) {
+    doCheckStreamMethod(method.andThen(s -> s.mapToObj(Double::valueOf)));
+  }
+
+  private <T> void doCheckNextMethod(Function<Random, T> method) {
+    long seed = ThreadLocalRandom.current().nextLong();
+    Random r = new Random(seed);
+    try (final Closeable c = RandomSource.withSeed(seed)) {
+      for (int i = 0; i < 100; i++) {
+        assertThat(method.apply(RandomSource.current()), is(method.apply(r)));
+      }
+    }
+  }
+
+  private <T> void doCheckStreamMethod(Function<Random, Stream<T>> method) {
+    doCheckNextMethod(method.andThen(s -> s.limit(100).collect(Collectors.toList())));
+  }
+}

--- a/versioned/jgit/pom.xml
+++ b/versioned/jgit/pom.xml
@@ -36,6 +36,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-utils</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>

--- a/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/TestJGitVersionStore.java
+++ b/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/TestJGitVersionStore.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,6 +41,7 @@ import org.junit.jupiter.params.converter.ArgumentConversionException;
 import org.junit.jupiter.params.converter.ArgumentConverter;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.projectnessie.RandomSource;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Delete;
 import org.projectnessie.versioned.Hash;
@@ -70,7 +70,6 @@ import com.google.common.collect.ImmutableSet;
 class TestJGitVersionStore {
   private static final Hash EMPTY_HASH = Hash.of(ObjectId.zeroId().name());
   private static File jgitDirStatic;
-  private final Random random = new Random();
 
   @TempDir
   File jgitDir;
@@ -145,7 +144,7 @@ class TestJGitVersionStore {
 
     // avoid create to invalid l1.
     byte[] randomBytes = new byte[20];
-    random.nextBytes(randomBytes);
+    RandomSource.current().nextBytes(randomBytes);
     Hash randomHash = Hash.of(ObjectId.fromRaw(randomBytes).name());
     assertThrows(ReferenceNotFoundException.class, () -> impl.create(tag, Optional.of(randomHash)));
 
@@ -201,7 +200,7 @@ class TestJGitVersionStore {
 
     // avoid create to invalid l1
     byte[] randomBytes = new byte[20];
-    random.nextBytes(randomBytes);
+    RandomSource.current().nextBytes(randomBytes);
     Hash randomHash = Hash.of(ObjectId.fromRaw(randomBytes).name());
     assertThrows(ReferenceNotFoundException.class, () -> impl.create(branch, Optional.of(randomHash)));
 

--- a/versioned/tiered/dynamodb/src/test/java/org/projectnessie/versioned/impl/ITDynamoMetrics.java
+++ b/versioned/tiered/dynamodb/src/test/java/org/projectnessie/versioned/impl/ITDynamoMetrics.java
@@ -68,7 +68,7 @@ public class ITDynamoMetrics {
 
   @Test
   void testMetrics() {
-    store.putIfAbsent(new EntitySaveOp<>(ValueType.REF, SampleEntities.createBranch(random)));
+    store.putIfAbsent(new EntitySaveOp<>(ValueType.REF, SampleEntities.createBranch()));
 
     //make sure standard Dynamo metrics are visible. Expect status codes for each of the 3 dynamo calls made (describe, create, put)
     Assertions.assertFalse(Metrics.globalRegistry.get("DynamoDB.HttpStatusCode.summary").meters().isEmpty());

--- a/versioned/tiered/dynamodb/src/test/java/org/projectnessie/versioned/impl/ITDynamoTestStore.java
+++ b/versioned/tiered/dynamodb/src/test/java/org/projectnessie/versioned/impl/ITDynamoTestStore.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.versioned.dynamodb.DynamoStore;
 import org.projectnessie.versioned.dynamodb.LocalDynamoDB;
-import org.projectnessie.versioned.impl.AbstractTestStore;
 
 /**
  * A test class that contains DynamoDB tests.
@@ -46,11 +45,6 @@ class ITDynamoTestStore extends AbstractTestStore<DynamoStore> {
   @Override
   protected DynamoStore createRawStore() {
     return fixture.createStoreImpl();
-  }
-
-  @Override
-  protected long getRandomSeed() {
-    return 8612341233543L;
   }
 
   @Override

--- a/versioned/tiered/mongodb/src/test/java/org/projectnessie/versioned/mongodb/TestMongoDBStore.java
+++ b/versioned/tiered/mongodb/src/test/java/org/projectnessie/versioned/mongodb/TestMongoDBStore.java
@@ -57,11 +57,6 @@ class TestMongoDBStore extends AbstractTestStore<MongoDBStore> {
   }
 
   @Override
-  protected long getRandomSeed() {
-    return 8612341233543L;
-  }
-
-  @Override
   protected void resetStoreState() {
     store.resetCollections();
   }

--- a/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/store/Id.java
+++ b/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/store/Id.java
@@ -20,9 +20,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
+import org.projectnessie.RandomSource;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 
@@ -151,7 +151,7 @@ public final class Id {
    */
   public static Id generateRandom() {
     byte[] bytes = new byte[LENGTH];
-    ThreadLocalRandom.current().nextBytes(bytes);
+    RandomSource.current().nextBytes(bytes);
     return Id.of(bytes);
   }
 

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/RandomSourceExtension.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/RandomSourceExtension.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+
+/**
+ * A JUnit extension to setup the random generator seed before executing tests
+ * and restoring it to its previous state after the test completes.
+ *
+ * <p>The seed value is specified using {@code WithSeed} annotation.
+ */
+public class RandomSourceExtension implements BeforeEachCallback, AfterEachCallback {
+  private static final String RANDOM_CLOSEABLE = "Random Source Closeable";
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    // check for the seed annotation from the most specific context to the root
+    ExtensionContext currentContext = context;
+    while (currentContext != null) {
+      // Look for a seed annotation
+      Optional<Long> seed = currentContext.getElement()
+          .map(a -> a.getAnnotation(WithSeed.class))
+          .map(WithSeed::value);
+
+      // If the current context is annotated with a seed,
+      // set the random generator and exit
+      if (seed.isPresent()) {
+        Closeable c = RandomSource.withSeed(seed.get());
+        getStore(context).put(RANDOM_CLOSEABLE, c);
+        return;
+      }
+
+      currentContext = currentContext.getParent().orElse(null);
+    }
+  }
+
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    Closeable c = (Closeable) getStore(context).get(RANDOM_CLOSEABLE);
+    if (c != null) {
+      c.close();
+    }
+
+  }
+
+  private Store getStore(ExtensionContext context) {
+    return context.getStore(Namespace.create(getClass(), context.getRequiredTestMethod()));
+  }
+}

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/WithSeed.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/WithSeed.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * A JUnit annotation to set up the random generator seed before
+ * executing the test method.
+ *
+ * <p>This annotation automatically registers the necessary JUnit extensions.
+ */
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+@ExtendWith(RandomSourceExtension.class)
+public @interface WithSeed {
+  /**
+   * The random generator seed value.
+   * @return the seed value
+   */
+  long value();
+}

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractTestStore.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractTestStore.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -29,6 +28,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.RandomSource;
+import org.projectnessie.WithSeed;
 import org.projectnessie.versioned.impl.condition.ConditionExpression;
 import org.projectnessie.versioned.impl.condition.ExpressionFunction;
 import org.projectnessie.versioned.impl.condition.ExpressionPath;
@@ -54,6 +55,7 @@ import com.google.common.collect.Multimap;
  * This class should be moved to the versioned/tests project when it will not introduce a circular dependency.
  * @param <S> The type of the Store being tested.
  */
+@WithSeed(8612341233543L)
 public abstract class AbstractTestStore<S extends Store> {
 
   static class CreatorPair {
@@ -82,7 +84,6 @@ public abstract class AbstractTestStore<S extends Store> {
   protected static final Entity ONE = Entity.ofNumber(1);
   protected static final Entity TWO = Entity.ofNumber(2);
 
-  protected Random random;
   protected S store;
 
   /**
@@ -93,7 +94,6 @@ public abstract class AbstractTestStore<S extends Store> {
     if (store == null) {
       this.store = createStore();
       this.store.start();
-      random = new Random(getRandomSeed());
     }
   }
 
@@ -112,8 +112,6 @@ public abstract class AbstractTestStore<S extends Store> {
   protected abstract S createStore();
 
   protected abstract S createRawStore();
-
-  protected abstract long getRandomSeed();
 
   protected abstract void resetStoreState();
 
@@ -153,14 +151,14 @@ public abstract class AbstractTestStore<S extends Store> {
     @Test
     void load() {
       final ImmutableList<CreatorPair> creators = ImmutableList.<CreatorPair>builder()
-          .add(new CreatorPair(ValueType.REF, () -> SampleEntities.createTag(random)))
-          .add(new CreatorPair(ValueType.REF, () -> SampleEntities.createBranch(random)))
-          .add(new CreatorPair(ValueType.COMMIT_METADATA, () -> SampleEntities.createCommitMetadata(random)))
-          .add(new CreatorPair(ValueType.VALUE, () -> SampleEntities.createValue(random)))
-          .add(new CreatorPair(ValueType.L1, () -> SampleEntities.createL1(random)))
-          .add(new CreatorPair(ValueType.L2, () -> SampleEntities.createL2(random)))
-          .add(new CreatorPair(ValueType.L3, () -> SampleEntities.createL3(random)))
-          .add(new CreatorPair(ValueType.KEY_FRAGMENT, () -> SampleEntities.createFragment(random)))
+          .add(new CreatorPair(ValueType.REF, () -> SampleEntities.createTag()))
+          .add(new CreatorPair(ValueType.REF, () -> SampleEntities.createBranch()))
+          .add(new CreatorPair(ValueType.COMMIT_METADATA, () -> SampleEntities.createCommitMetadata()))
+          .add(new CreatorPair(ValueType.VALUE, () -> SampleEntities.createValue()))
+          .add(new CreatorPair(ValueType.L1, () -> SampleEntities.createL1()))
+          .add(new CreatorPair(ValueType.L2, () -> SampleEntities.createL2()))
+          .add(new CreatorPair(ValueType.L3, () -> SampleEntities.createL3()))
+          .add(new CreatorPair(ValueType.KEY_FRAGMENT, () -> SampleEntities.createFragment()))
           .build();
       final ImmutableMultimap.Builder<ValueType<?>, HasId> builder = ImmutableMultimap.builder();
       for (int i = 0; i < 100; ++i) {
@@ -178,17 +176,17 @@ public abstract class AbstractTestStore<S extends Store> {
     @Test
     void loadSteps() {
       final Multimap<ValueType<?>, HasId> objs = ImmutableMultimap.<ValueType<?>, HasId>builder()
-          .put(ValueType.REF, SampleEntities.createBranch(random))
-          .put(ValueType.REF, SampleEntities.createBranch(random))
-          .put(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random))
+          .put(ValueType.REF, SampleEntities.createBranch())
+          .put(ValueType.REF, SampleEntities.createBranch())
+          .put(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata())
           .build();
 
       final Multimap<ValueType<?>, HasId> objs2 = ImmutableMultimap.<ValueType<?>, HasId>builder()
-          .put(ValueType.L3, SampleEntities.createL3(random))
-          .put(ValueType.VALUE, SampleEntities.createValue(random))
-          .put(ValueType.VALUE, SampleEntities.createValue(random))
-          .put(ValueType.VALUE, SampleEntities.createValue(random))
-          .put(ValueType.REF, SampleEntities.createTag(random))
+          .put(ValueType.L3, SampleEntities.createL3())
+          .put(ValueType.VALUE, SampleEntities.createValue())
+          .put(ValueType.VALUE, SampleEntities.createValue())
+          .put(ValueType.VALUE, SampleEntities.createValue())
+          .put(ValueType.REF, SampleEntities.createTag())
           .build();
 
       objs.forEach(AbstractTestStore.this::putThenLoad);
@@ -207,8 +205,8 @@ public abstract class AbstractTestStore<S extends Store> {
 
     @Test
     void loadInvalid() {
-      putThenLoad(ValueType.REF, SampleEntities.createBranch(random));
-      final Multimap<ValueType<?>, HasId> objs = ImmutableMultimap.of(ValueType.REF, SampleEntities.createBranch(random));
+      putThenLoad(ValueType.REF, SampleEntities.createBranch());
+      final Multimap<ValueType<?>, HasId> objs = ImmutableMultimap.of(ValueType.REF, SampleEntities.createBranch());
 
       Assertions.assertThrows(NotFoundException.class, () -> store.load(createTestLoadStep(objs)));
     }
@@ -219,7 +217,7 @@ public abstract class AbstractTestStore<S extends Store> {
       for (int i = 0; i < (10 + loadSize()); ++i) {
         // Only create a single type as this is meant to test the pagination within the store, not the variety. Variety is
         // taken care of by another test.
-        builder.put(ValueType.REF, SampleEntities.createTag(random));
+        builder.put(ValueType.REF, SampleEntities.createTag());
       }
 
       final Multimap<ValueType<?>, HasId> objs = builder.build();
@@ -245,47 +243,47 @@ public abstract class AbstractTestStore<S extends Store> {
   class LoadSingleTests {
     @Test
     void loadSingleInvalid() {
-      Assertions.assertThrows(NotFoundException.class, () -> EntityType.REF.loadSingle(store, SampleEntities.createId(random)));
+      Assertions.assertThrows(NotFoundException.class, () -> EntityType.REF.loadSingle(store, SampleEntities.createId()));
     }
 
     @Test
     void loadSingleL1() {
-      putThenLoad(ValueType.L1, SampleEntities.createL1(random));
+      putThenLoad(ValueType.L1, SampleEntities.createL1());
     }
 
     @Test
     void loadSingleL2() {
-      putThenLoad(ValueType.L2, SampleEntities.createL2(random));
+      putThenLoad(ValueType.L2, SampleEntities.createL2());
     }
 
     @Test
     void loadSingleL3() {
-      putThenLoad(ValueType.L3, SampleEntities.createL3(random));
+      putThenLoad(ValueType.L3, SampleEntities.createL3());
     }
 
     @Test
     void loadFragment() {
-      putThenLoad(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
+      putThenLoad(ValueType.KEY_FRAGMENT, SampleEntities.createFragment());
     }
 
     @Test
     void loadBranch() {
-      putThenLoad(ValueType.REF, SampleEntities.createBranch(random));
+      putThenLoad(ValueType.REF, SampleEntities.createBranch());
     }
 
     @Test
     void loadTag() {
-      putThenLoad(ValueType.REF, SampleEntities.createTag(random));
+      putThenLoad(ValueType.REF, SampleEntities.createTag());
     }
 
     @Test
     void loadCommitMetadata() {
-      putThenLoad(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
+      putThenLoad(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata());
     }
 
     @Test
     void loadValue() {
-      putThenLoad(ValueType.VALUE, SampleEntities.createValue(random));
+      putThenLoad(ValueType.VALUE, SampleEntities.createValue());
     }
   }
 
@@ -294,42 +292,42 @@ public abstract class AbstractTestStore<S extends Store> {
   class PutIfAbsentTests {
     @Test
     void putIfAbsentL1() {
-      testPutIfAbsent(ValueType.L1, SampleEntities.createL1(random));
+      testPutIfAbsent(ValueType.L1, SampleEntities.createL1());
     }
 
     @Test
     void putIfAbsentL2() {
-      testPutIfAbsent(ValueType.L2, SampleEntities.createL2(random));
+      testPutIfAbsent(ValueType.L2, SampleEntities.createL2());
     }
 
     @Test
     void putIfAbsentL3() {
-      testPutIfAbsent(ValueType.L3, SampleEntities.createL3(random));
+      testPutIfAbsent(ValueType.L3, SampleEntities.createL3());
     }
 
     @Test
     void putIfAbsentFragment() {
-      testPutIfAbsent(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
+      testPutIfAbsent(ValueType.KEY_FRAGMENT, SampleEntities.createFragment());
     }
 
     @Test
     void putIfAbsentBranch() {
-      testPutIfAbsent(ValueType.REF, SampleEntities.createBranch(random));
+      testPutIfAbsent(ValueType.REF, SampleEntities.createBranch());
     }
 
     @Test
     void putIfAbsentTag() {
-      testPutIfAbsent(ValueType.REF, SampleEntities.createTag(random));
+      testPutIfAbsent(ValueType.REF, SampleEntities.createTag());
     }
 
     @Test
     void putIfAbsentCommitMetadata() {
-      testPutIfAbsent(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
+      testPutIfAbsent(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata());
     }
 
     @Test
     void putIfAbsentValue() {
-      testPutIfAbsent(ValueType.VALUE, SampleEntities.createValue(random));
+      testPutIfAbsent(ValueType.VALUE, SampleEntities.createValue());
     }
 
     protected <C extends BaseValue<C>, T extends PersistentBase<C>> void testPutIfAbsent(ValueType<C> type, T sample) {
@@ -346,14 +344,14 @@ public abstract class AbstractTestStore<S extends Store> {
     @Test
     void save() {
       final List<EntitySaveOp<?>> entities = Arrays.asList(
-          new EntitySaveOp<>(ValueType.L1, SampleEntities.createL1(random)),
-          new EntitySaveOp<>(ValueType.L2, SampleEntities.createL2(random)),
-          new EntitySaveOp<>(ValueType.L3, SampleEntities.createL3(random)),
-          new EntitySaveOp<>(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random)),
-          new EntitySaveOp<>(ValueType.REF, SampleEntities.createBranch(random)),
-          new EntitySaveOp<>(ValueType.REF, SampleEntities.createTag(random)),
-          new EntitySaveOp<>(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random)),
-          new EntitySaveOp<>(ValueType.VALUE, SampleEntities.createValue(random))
+          new EntitySaveOp<>(ValueType.L1, SampleEntities.createL1()),
+          new EntitySaveOp<>(ValueType.L2, SampleEntities.createL2()),
+          new EntitySaveOp<>(ValueType.L3, SampleEntities.createL3()),
+          new EntitySaveOp<>(ValueType.KEY_FRAGMENT, SampleEntities.createFragment()),
+          new EntitySaveOp<>(ValueType.REF, SampleEntities.createBranch()),
+          new EntitySaveOp<>(ValueType.REF, SampleEntities.createTag()),
+          new EntitySaveOp<>(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata()),
+          new EntitySaveOp<>(ValueType.VALUE, SampleEntities.createValue())
       );
 
       store.save(entities.stream().map(e -> e.saveOp).collect(Collectors.toList()));
@@ -387,54 +385,54 @@ public abstract class AbstractTestStore<S extends Store> {
   class PutWithoutConditionExpressionTests {
     @Test
     void putWithConditionValue() {
-      putWithCondition(ValueType.VALUE, SampleEntities.createValue(random));
+      putWithCondition(ValueType.VALUE, SampleEntities.createValue());
     }
 
     @Test
     void putWithConditionBranch() {
-      putWithCondition(ValueType.REF, SampleEntities.createBranch(random));
+      putWithCondition(ValueType.REF, SampleEntities.createBranch());
     }
 
     @Test
     void putWithConditionTag() {
-      putWithCondition(ValueType.REF, SampleEntities.createTag(random));
+      putWithCondition(ValueType.REF, SampleEntities.createTag());
     }
 
     @Test
     void putWithConditionCommitMetadata() {
-      putWithCondition(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random));
+      putWithCondition(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata());
     }
 
     @Test
     void putWithConditionKeyFragment() {
-      putWithCondition(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random));
+      putWithCondition(ValueType.KEY_FRAGMENT, SampleEntities.createFragment());
     }
 
     @Test
     void putWithConditionL1() {
-      putWithCondition(ValueType.L1, SampleEntities.createL1(random));
+      putWithCondition(ValueType.L1, SampleEntities.createL1());
     }
 
     @Test
     void putWithConditionL2() {
-      putWithCondition(ValueType.L2, SampleEntities.createL2(random));
+      putWithCondition(ValueType.L2, SampleEntities.createL2());
     }
 
     @Test
     void putWithConditionL3() {
-      putWithCondition(ValueType.L3, SampleEntities.createL3(random));
+      putWithCondition(ValueType.L3, SampleEntities.createL3());
     }
 
     @Test
     void putTwice() {
-      final HasId l3 = SampleEntities.createL3(random);
+      final HasId l3 = SampleEntities.createL3();
       putThenLoad(ValueType.L3, l3);
       putThenLoad(ValueType.L3, l3);
     }
 
     @Test
     void putWithCompoundConditionTag() {
-      final InternalRef sample = SampleEntities.createTag(random);
+      final InternalRef sample = SampleEntities.createTag();
       putThenLoad(ValueType.REF, sample);
       final InternalRef.Type type = InternalRef.Type.TAG;
       final ConditionExpression condition = ConditionExpression.of(
@@ -446,7 +444,7 @@ public abstract class AbstractTestStore<S extends Store> {
 
     @Test
     void putWithFailingConditionExpression() {
-      final InternalRef sample = SampleEntities.createBranch(random);
+      final InternalRef sample = SampleEntities.createBranch();
       final InternalRef.Type type = InternalRef.Type.BRANCH;
       final ConditionExpression condition = ConditionExpression.of(
           ExpressionFunction.equals(ExpressionPath.builder(InternalRef.TYPE).build(), type.toEntity()),
@@ -495,7 +493,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      deleteWithCondition(ValueType.VALUE, SampleEntities.createValue(random), true, Optional.empty());
+      deleteWithCondition(ValueType.VALUE, SampleEntities.createValue(), true, Optional.empty());
     }
 
     @Test
@@ -504,7 +502,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      deleteWithCondition(ValueType.L1, SampleEntities.createL1(random), true, Optional.empty());
+      deleteWithCondition(ValueType.L1, SampleEntities.createL1(), true, Optional.empty());
     }
 
     @Test
@@ -513,7 +511,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      deleteWithCondition(ValueType.L2, SampleEntities.createL2(random), true, Optional.empty());
+      deleteWithCondition(ValueType.L2, SampleEntities.createL2(), true, Optional.empty());
     }
 
     @Test
@@ -522,7 +520,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      deleteWithCondition(ValueType.L3, SampleEntities.createL3(random), true, Optional.empty());
+      deleteWithCondition(ValueType.L3, SampleEntities.createL3(), true, Optional.empty());
     }
 
     @Test
@@ -531,7 +529,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      deleteWithCondition(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(random), true, Optional.empty());
+      deleteWithCondition(ValueType.KEY_FRAGMENT, SampleEntities.createFragment(), true, Optional.empty());
     }
 
     @Test
@@ -540,7 +538,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(random), true, Optional.empty());
+      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(), true, Optional.empty());
     }
 
     @Test
@@ -549,7 +547,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      deleteWithCondition(ValueType.REF, SampleEntities.createTag(random), true, Optional.empty());
+      deleteWithCondition(ValueType.REF, SampleEntities.createTag(), true, Optional.empty());
     }
 
     @Test
@@ -558,7 +556,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      deleteWithCondition(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(random), true, Optional.empty());
+      deleteWithCondition(ValueType.COMMIT_METADATA, SampleEntities.createCommitMetadata(), true, Optional.empty());
     }
 
     @Test
@@ -568,9 +566,9 @@ public abstract class AbstractTestStore<S extends Store> {
       }
 
       final ExpressionFunction expressionFunction = ExpressionFunction.equals(ExpressionPath.builder("value").build(),
-          SampleEntities.createStringEntity(random, random.nextInt(10) + 1));
+          SampleEntities.createStringEntity(RandomSource.current().nextInt(10) + 1));
       final ConditionExpression ex = ConditionExpression.of(expressionFunction);
-      deleteWithCondition(ValueType.VALUE, SampleEntities.createValue(random), false, Optional.of(ex));
+      deleteWithCondition(ValueType.VALUE, SampleEntities.createValue(), false, Optional.of(ex));
     }
 
     @Test
@@ -580,9 +578,9 @@ public abstract class AbstractTestStore<S extends Store> {
       }
 
       final ExpressionFunction expressionFunction = ExpressionFunction.equals(ExpressionPath.builder("commit").build(),
-          SampleEntities.createStringEntity(random, random.nextInt(10) + 1));
+          SampleEntities.createStringEntity(RandomSource.current().nextInt(10) + 1));
       final ConditionExpression ex = ConditionExpression.of(expressionFunction);
-      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(random), false, Optional.of(ex));
+      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(), false, Optional.of(ex));
     }
 
     @Test
@@ -592,7 +590,7 @@ public abstract class AbstractTestStore<S extends Store> {
       }
 
       final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(ExpressionFunction.size(COMMITS), ONE));
-      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(random), false, Optional.of(expression));
+      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(), false, Optional.of(expression));
     }
 
     @Test
@@ -602,7 +600,7 @@ public abstract class AbstractTestStore<S extends Store> {
       }
 
       final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(ExpressionFunction.size(COMMITS), TWO));
-      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(random), true, Optional.of(expression));
+      deleteWithCondition(ValueType.REF, SampleEntities.createBranch(), true, Optional.of(expression));
     }
 
     protected <T extends HasId> void deleteWithCondition(ValueType<?> type, T sample, boolean shouldSucceed,
@@ -628,7 +626,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      final InternalRef tag = SampleEntities.createTag(random);
+      final InternalRef tag = SampleEntities.createTag();
       putThenLoad(ValueType.REF, tag);
       final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(
           ExpressionPath.builder("name").build(), Entity.ofString("badTagName")));
@@ -647,7 +645,7 @@ public abstract class AbstractTestStore<S extends Store> {
       }
 
       final String tagName = "myTag";
-      final InternalTag tag = SampleEntities.createTag(random).getTag();
+      final InternalTag tag = SampleEntities.createTag().getTag();
       putThenLoad(ValueType.REF, tag);
       final ConditionExpression expression = ConditionExpression.of(ExpressionFunction.equals(
           ExpressionPath.builder("name").build(), Entity.ofString("tagName")));
@@ -707,7 +705,7 @@ public abstract class AbstractTestStore<S extends Store> {
       }
 
       final String tagName = "myTag";
-      final InternalTag tag = SampleEntities.createTag(random).getTag();
+      final InternalTag tag = SampleEntities.createTag().getTag();
       putThenLoad(ValueType.REF, tag);
       final InternalRef.Builder<?> builder = EntityType.REF.newEntityProducer();
       final boolean result = store.update(
@@ -735,7 +733,7 @@ public abstract class AbstractTestStore<S extends Store> {
       }
 
       final String key = "newKey";
-      final InternalFragment fragment = SampleEntities.createFragment(random);
+      final InternalFragment fragment = SampleEntities.createFragment();
       putThenLoad(ValueType.KEY_FRAGMENT, fragment);
       final InternalFragment.Builder builder = EntityType.KEY_FRAGMENT.newEntityProducer();
       final boolean result = store.update(
@@ -762,7 +760,7 @@ public abstract class AbstractTestStore<S extends Store> {
         return;
       }
 
-      final InternalFragment fragment = SampleEntities.createFragment(random);
+      final InternalFragment fragment = SampleEntities.createFragment();
       putThenLoad(ValueType.KEY_FRAGMENT, fragment);
       final InternalFragment.Builder builder = EntityType.KEY_FRAGMENT.newEntityProducer();
       final boolean result = store.update(

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/SampleEntities.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/SampleEntities.java
@@ -15,10 +15,10 @@
  */
 package org.projectnessie.versioned.impl;
 
-import java.util.Random;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.projectnessie.RandomSource;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.store.Entity;
 import org.projectnessie.versioned.store.Id;
@@ -36,150 +36,138 @@ import com.google.protobuf.ByteString;
 public class SampleEntities {
   /**
    * Create a Sample L1 entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample L1 entity.
    */
-  public static InternalL1 createL1(Random random) {
-    return EntityType.L1.buildEntity(producer -> producer.commitMetadataId(createId(random))
-        .children(IntStream.range(0, InternalL1.SIZE).mapToObj(x -> createId(random)))
+  public static InternalL1 createL1() {
+    return EntityType.L1.buildEntity(producer -> producer.commitMetadataId(createId())
+        .children(IntStream.range(0, InternalL1.SIZE).mapToObj(x -> createId()))
         .ancestors(Stream.of(InternalL1.EMPTY.getId(), Id.EMPTY))
-        .keyMutations(Stream.of(Key.of(createString(random, 8), createString(random, 9)).asAddition()))
+        .keyMutations(Stream.of(Key.of(createString(8), createString(9)).asAddition()))
         .incrementalKeyList(InternalL1.EMPTY.getId(), 1));
   }
 
   /**
    * Create a Sample L2 entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample L2 entity.
    */
-  public static InternalL2 createL2(Random random) {
-    return EntityType.L2.buildEntity(producer -> producer.id(createId(random))
-        .children(IntStream.range(0, InternalL2.SIZE).mapToObj(x -> createId(random))));
+  public static InternalL2 createL2() {
+    return EntityType.L2.buildEntity(producer -> producer.id(createId())
+        .children(IntStream.range(0, InternalL2.SIZE).mapToObj(x -> createId())));
   }
 
   /**
    * Create a Sample L3 entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample L3 entity.
    */
-  public static InternalL3 createL3(Random random) {
+  public static InternalL3 createL3() {
     return EntityType.L3.buildEntity(producer -> producer.keyDelta(IntStream.range(0, 100)
         .mapToObj(i -> KeyDelta
-            .of(Key.of(createString(random, 5), createString(random, 9), String.valueOf(i)),
-                createId(random)))));
+            .of(Key.of(createString(5), createString(9), String.valueOf(i)),
+                createId()))));
   }
 
   /**
    * Create a Sample Fragment entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample Fragment entity.
    */
-  public static InternalFragment createFragment(Random random) {
+  public static InternalFragment createFragment() {
     return EntityType.KEY_FRAGMENT.buildEntity(producer -> producer.keys(IntStream.range(0, 10)
         .mapToObj(
-            i -> Key.of(createString(random, 5), createString(random, 9), String.valueOf(i)))));
+            i -> Key.of(createString(5), createString(9), String.valueOf(i)))));
   }
 
   /**
    * Create a Sample Branch (InternalRef) entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample Branch (InternalRef) entity.
    */
-  public static InternalRef createBranch(Random random) {
-    final String name = createString(random, 10);
+  public static InternalRef createBranch() {
+    final String name = createString(10);
 
     return EntityType.REF.buildEntity(producer -> producer.id(Id.build(name))
         .name(name)
         .branch()
-        .children(IntStream.range(0, InternalL1.SIZE).mapToObj(x -> createId(random)))
-        .metadata(createId(random))
+        .children(IntStream.range(0, InternalL1.SIZE).mapToObj(x -> createId()))
+        .metadata(createId())
         .commits(bc -> {
-          bc.id(createId(random))
-              .commit(createId(random))
+          bc.id(createId())
+              .commit(createId())
               .saved()
-              .parent(createId(random))
+              .parent(createId())
               .done();
-          bc.id(createId(random))
-              .commit(createId(random))
+          bc.id(createId())
+              .commit(createId())
               .unsaved()
-              .delta(1, createId(random), createId(random))
+              .delta(1, createId(), createId())
               .mutations()
-              .keyMutation(Key.of(createString(random, 8), createString(random, 8)).asAddition())
+              .keyMutation(Key.of(createString(8), createString(8)).asAddition())
               .done();
         }));
   }
 
   /**
    * Create a Sample Tag (InternalRef) entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample Tag (InternalRef) entity.
    */
-  public static InternalRef createTag(Random random) {
-    return EntityType.REF.buildEntity(producer -> producer.id(createId(random))
+  public static InternalRef createTag() {
+    return EntityType.REF.buildEntity(producer -> producer.id(createId())
         .name("tagName")
         .tag()
-        .commit(createId(random)));
+        .commit(createId()));
   }
 
   /**
    * Create a Sample CommitMetadata entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample CommitMetadata entity.
    */
-  public static InternalCommitMetadata createCommitMetadata(Random random) {
-    return EntityType.COMMIT_METADATA.buildEntity(producer -> producer.id(createId(random))
-        .value(ByteString.copyFrom(createBinary(random, 6))));
+  public static InternalCommitMetadata createCommitMetadata() {
+    return EntityType.COMMIT_METADATA.buildEntity(producer -> producer.id(createId())
+        .value(ByteString.copyFrom(createBinary(6))));
   }
 
   /**
    * Create a Sample Value entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample Value entity.
    */
-  public static InternalValue createValue(Random random) {
-    return EntityType.VALUE.buildEntity(producer -> producer.id(createId(random))
-        .value(ByteString.copyFrom(createBinary(random, 6))));
+  public static InternalValue createValue() {
+    return EntityType.VALUE.buildEntity(producer -> producer.id(createId())
+        .value(ByteString.copyFrom(createBinary(6))));
   }
 
   /**
    * Create an array of random bytes.
-   * @param random random number generator to use.
    * @param numBytes the size of the array.
    * @return the array of random bytes.
    */
-  public static byte[] createBinary(Random random, int numBytes) {
+  public static byte[] createBinary(int numBytes) {
     final byte[] buffer = new byte[numBytes];
-    random.nextBytes(buffer);
+    RandomSource.current().nextBytes(buffer);
     return buffer;
   }
 
   /**
    * Create a Sample ID entity.
-   * @param random object to use for randomization of entity creation.
    * @return sample ID entity.
    */
-  public static Id createId(Random random) {
-    return Id.of(createBinary(random, 20));
+  public static Id createId() {
+    return Id.of(createBinary(20));
   }
 
   /**
    * Create a String Entity of random characters.
-   * @param random random number generator to use.
    * @param numChars the size of the String.
    * @return the String Entity of random characters.
    */
-  public static Entity createStringEntity(Random random, int numChars) {
-    return Entity.ofString(createString(random, numChars));
+  public static Entity createStringEntity(int numChars) {
+    return Entity.ofString(createString(numChars));
   }
 
   /**
    * Create a String of random characters.
-   * @param random random number generator to use.
    * @param numChars the size of the String.
    * @return the String of random characters.
    */
-  private static String createString(Random random, int numChars) {
-    return random.ints('a', 'z' + 1)
+  private static String createString(int numChars) {
+    return RandomSource.current().ints('a', 'z' + 1)
         .limit(numChars)
         .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
         .toString();


### PR DESCRIPTION
In order for some unit tests to be repeteable, it is required to be able
to set the seed for the random generator used by the source.

Currently it requires code to accept a Random instance argument with the
test framework to set the seed before hand, but this approach makes code
heavier (the Random instance needs to be passed between function calls)
for what should is usually an internal concern.

Replace this pattern with a new utility class named `RandomSource` which
behave exactly like `ThreadLocalRandom` except that it is possible to
temporarily override the current random generator with one initialized
with a specific seed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/862)
<!-- Reviewable:end -->
