### PR TITLE
Start version-store when Quarkus app starts

### DIFF
--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
@@ -43,6 +43,8 @@ import org.projectnessie.versioned.WithHash;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.quarkus.runtime.Startup;
+
 /**
  * A version store factory leveraging CDI to delegate to a {@code VersionStoreFactory} instance
  * based on the store type.
@@ -79,6 +81,7 @@ public class ConfigurableVersionStoreFactory {
    */
   @Produces
   @Singleton
+  @Startup
   public VersionStore<Contents, CommitMeta> getVersionStore() {
     VersionStore<Contents, CommitMeta> store = newVersionStore();
     try (Stream<WithHash<NamedRef>> str = store.getNamedRefs()) {


### PR DESCRIPTION
Currently, the `VersionStore` is lazily started when the first REST request arrives. This changes the behavior
to eagerly start the `VersionStore` when the Nessie-Quarkus app is started.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/912)
<!-- Reviewable:end -->
