### PR TITLE
Tweak logging and don't log HTTP accesses to the console

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -44,6 +44,14 @@ quarkus.dynamodb.aws.credentials.type=DEFAULT
 ## Visit here for all configs: https://quarkus.io/guides/all-config
 ## some parameters are only configured at build time. These have been marked as such https://quarkus.io/guides/config#overriding-properties-at-runtime
 quarkus.log.level=INFO
+quarkus.log.console.level=INFO
+# Somehow the trace-relevant IDs do not appear on the console, but they do in a log file... :(
+#quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
+quarkus.log.file.level=INFO
+quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
+quarkus.log.category."io.netty".level=WARN
+# Effectively disable HTTP request logging to the console (HTTP access logs happen at INFO level)
+quarkus.log.category."io.quarkus.http.access-log".level=WARN
 
 ## Quarkus http related settings
 quarkus.http.port=19120

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -51,7 +51,7 @@ quarkus.log.file.level=INFO
 quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
 quarkus.log.category."io.netty".level=WARN
 # Effectively disable HTTP request logging to the console (HTTP access logs happen at INFO level)
-quarkus.log.category."io.quarkus.http.access-log".level=WARN
+quarkus.log.category."io.quarkus.http.access-log".level=${HTTP_ACCESS_LOG_LEVEL:INFO}
 
 ## Quarkus http related settings
 quarkus.http.port=19120


### PR DESCRIPTION
* Prepares but doesn't enabel file-level logging
* Adds jaeger-tracing IDs to the log file
* Effectively disable HTTP access log to be able to see errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/913)
<!-- Reviewable:end -->
