### PR TITLE
Fix handling of unsaved commits in getUpdateState()

### DIFF
--- a/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/impl/InternalBranch.java
+++ b/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/impl/InternalBranch.java
@@ -267,8 +267,12 @@ class InternalBranch extends InternalRef {
       for (UnsavedDelta delta : c.deltas) {
         tree = delta.apply(tree);
       }
-      lastL1 = lastL1.getChildWithTree(c.commit, tree, c.keyMutationList)
-          .withCheckpointAsNecessary(store);
+
+      lastL1 = lastL1.getChildWithTree(c.commit, tree, c.keyMutationList);
+      if (lastL1 == lastSavedL1) {
+        lastL1 = lastL1.withCheckpointAsNecessary(store);
+      }
+
       toSave.add(EntityType.L1.createSaveOpForEntity(lastL1));
       lastId = c.id;
       if (lastUnsaved != c) {

--- a/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/impl/InternalBranch.java
+++ b/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/impl/InternalBranch.java
@@ -46,6 +46,7 @@ import org.projectnessie.versioned.tiered.Ref.UnsavedCommitMutations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -314,6 +315,11 @@ class InternalBranch extends InternalRef {
       if (finalL1position == 0 && !deletes.isEmpty()) {
         throw new IllegalStateException("We should never have deletes if the final position is zero.");
       }
+    }
+
+    @VisibleForTesting
+    InternalL1 unsafeGetL1() {
+      return finalL1;
     }
 
     /**
@@ -589,4 +595,8 @@ class InternalBranch extends InternalRef {
         .backToRef();
   }
 
+  @VisibleForTesting
+  List<Commit> getCommits() {
+    return Collections.unmodifiableList(commits);
+  }
 }

--- a/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/impl/InternalL1.java
+++ b/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/impl/InternalL1.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -63,8 +64,8 @@ class InternalL1 extends PersistentBase<L1> {
     return new InternalL1(metadataId, tree, null, keyList, parents, DT.now());
   }
 
-  InternalL1 withCheckpointAsNecessary(Store store) {
-    return keyList.createCheckpointIfNeeded(this, store)
+  InternalL1 withCheckpointAsNecessary(Store store, Map<Id, InternalL1> unsavedL1s) {
+    return keyList.createCheckpointIfNeeded(this, store, unsavedL1s)
         .map(keylist -> new InternalL1(metadataId, tree, null, keylist, parentList, DT.now())).orElse(this);
   }
 

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractITTieredVersionStore.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractITTieredVersionStore.java
@@ -399,6 +399,20 @@ public abstract class AbstractITTieredVersionStore {
 
   }
 
+  /**
+   * This is a copy of {@link TieredVersionStore#commit(BranchName, Optional, Object, List)} that
+   * allows the test {@link #checkpointWithUnsavedL1()} to produce commits to a branch with
+   * unsaved commits and without collapsing the intention log.
+   * <p>It is not particularly great to have a "stripped down" and "heavily adjusted" version
+   * of the original {@link TieredVersionStore#commit(BranchName, Optional, Object, List)} in
+   * a unit test, but the other option to prepare the pre-requisites for
+   * {@link #checkpointWithUnsavedL1()}, namely unsaved commits + uncollapsed branch, would have
+   * been to refactor the original method and add a bunch of hooks, which felt too heavy.</p>
+   *
+   * @param ref branch ID
+   * @param num number of the commit
+   * @return the updated branch
+   */
   private InternalBranch simulateCommit(InternalRefId ref, int num) {
     List<Operation<String>> ops = Collections.singletonList(Put.of(Key.of("key" + num), "foo" + num));
     List<InternalKey> keys = ops.stream().map(op -> new InternalKey(op.getKey())).collect(Collectors.toList());

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractITTieredVersionStore.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractITTieredVersionStore.java
@@ -27,6 +27,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,11 +48,14 @@ import org.projectnessie.versioned.ImmutablePut;
 import org.projectnessie.versioned.ImmutableTagName;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.Operation;
 import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.Ref;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.Serializer;
+import org.projectnessie.versioned.SerializerWithPayload;
 import org.projectnessie.versioned.StringSerializer;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.Unchanged;
@@ -59,6 +65,7 @@ import org.projectnessie.versioned.WithType;
 import org.projectnessie.versioned.impl.InconsistentValue.InconsistentValueException;
 import org.projectnessie.versioned.store.Id;
 import org.projectnessie.versioned.store.Store;
+import org.projectnessie.versioned.store.ValueType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -358,6 +365,88 @@ public abstract class AbstractITTieredVersionStore {
 
     // can't use tag delete on branch.
     assertThrows(ReferenceConflictException.class, () -> versionStore().delete(TagName.of("foo"), Optional.empty()));
+  }
+
+  @Test
+  void checkpointWithUnsavedL1() throws Exception {
+    // KeyList.IncrementalList.generateNewCheckpoint collects parent L1s for a branch
+    // via HistoryRetriever to "checkpoint" the keylist. However, this only works if
+    // HistoryRetriever has access to both saved AND unsaved L1s, so L1s that are persisted
+    // and those that are still in the branch's REF. This test verifies that generateNewCheckpoint
+    // does not fail in that case.
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    try {
+
+      BranchName branch = BranchName.of("checkpointWithUnsavedL1");
+
+      versionStore().create(branch, Optional.empty());
+
+      InternalRefId ref = InternalRefId.of(branch);
+
+      // generate MAX_DELTAS-1 keys in the key-list - just enough to *NOT*
+      // trigger KeyList.IncrementalList.generateNewCheckpoint
+      for (int i = 1; i < KeyList.IncrementalList.MAX_DELTAS; i++) {
+        InternalBranch internalBranch = simulateCommit(ref, executor, i);
+
+        // verify that the branch has an unsaved L1
+        assertEquals(i, internalBranch.getCommits().stream().filter(c -> !c.isSaved()).count());
+        KeyList keyList = internalBranch.getUpdateState(store()).unsafeGetL1().getKeyList();
+        assertFalse(keyList.isFull());
+        assertFalse(keyList.isEmptyIncremental());
+        KeyList.IncrementalList incrementalList = (KeyList.IncrementalList) keyList;
+        assertEquals(i, incrementalList.getDistanceFromCheckpointCommits());
+      }
+
+      InternalBranch internalBranch = simulateCommit(ref, executor, KeyList.IncrementalList.MAX_DELTAS);
+      KeyList keyList = internalBranch.getUpdateState(store()).unsafeGetL1().getKeyList();
+      assertTrue(keyList.isFull());
+      assertFalse(keyList.isEmptyIncremental());
+    } finally {
+      executor.shutdown();
+    }
+
+  }
+
+  private InternalBranch simulateCommit(InternalRefId ref, Executor executor, int num) {
+    List<Operation<String>> ops = Collections.singletonList(Put.of(Key.of("key" + num), "foo" + num));
+    List<InternalKey> keys = ops.stream().map(op -> new InternalKey(op.getKey())).collect(Collectors.toList());
+
+    SerializerWithPayload<String, StringSerializer.TestEnum> serializer = AbstractTieredStoreFixture.WORKER.getValueSerializer();
+    Serializer<String> metadataSerializer = AbstractTieredStoreFixture.WORKER.getMetadataSerializer();
+
+    PartialTree<String, StringSerializer.TestEnum> current = PartialTree.of(serializer, ref, keys);
+
+    String incomingCommit = "metadata";
+    InternalCommitMetadata metadata = InternalCommitMetadata.of(metadataSerializer.toBytes(incomingCommit));
+
+    store().load(current.getLoadChain(b -> {
+      InternalBranch.UpdateState updateState = b.getUpdateState(store());
+      return updateState.unsafeGetL1();
+    }, PartialTree.LoadType.NO_VALUES));
+
+    // do updates.
+    ops.forEach(op ->
+        current.setValueForKey(new InternalKey(op.getKey()), Optional.of(((Put<String>) op).getValue())));
+
+    // save all but l1 and branch.
+    store().save(
+        Stream.concat(
+            current.getMostSaveOps(),
+            Stream.of(EntityType.COMMIT_METADATA.createSaveOpForEntity(metadata))
+        ).collect(Collectors.toList()));
+
+    PartialTree.CommitOp commitOp = current.getCommitOp(
+        metadata.getId(),
+        Collections.emptyList(),
+        true,
+        true);
+
+    InternalRef.Builder<?> builder = EntityType.REF.newEntityProducer();
+    boolean updated = store().update(ValueType.REF, ref.getId(),
+        commitOp.getUpdateWithCommit(), Optional.of(commitOp.getTreeCondition()), Optional.of(builder));
+    assertTrue(updated);
+    return builder.build().getBranch();
   }
 
   @Test

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractITTieredVersionStore.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractITTieredVersionStore.java
@@ -27,9 +27,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -375,40 +372,34 @@ public abstract class AbstractITTieredVersionStore {
     // and those that are still in the branch's REF. This test verifies that generateNewCheckpoint
     // does not fail in that case.
 
-    ExecutorService executor = Executors.newCachedThreadPool();
-    try {
+    BranchName branch = BranchName.of("checkpointWithUnsavedL1");
 
-      BranchName branch = BranchName.of("checkpointWithUnsavedL1");
+    versionStore().create(branch, Optional.empty());
 
-      versionStore().create(branch, Optional.empty());
+    InternalRefId ref = InternalRefId.of(branch);
 
-      InternalRefId ref = InternalRefId.of(branch);
+    // generate MAX_DELTAS-1 keys in the key-list - just enough to *NOT*
+    // trigger KeyList.IncrementalList.generateNewCheckpoint
+    for (int i = 1; i < KeyList.IncrementalList.MAX_DELTAS; i++) {
+      InternalBranch internalBranch = simulateCommit(ref, i);
 
-      // generate MAX_DELTAS-1 keys in the key-list - just enough to *NOT*
-      // trigger KeyList.IncrementalList.generateNewCheckpoint
-      for (int i = 1; i < KeyList.IncrementalList.MAX_DELTAS; i++) {
-        InternalBranch internalBranch = simulateCommit(ref, executor, i);
-
-        // verify that the branch has an unsaved L1
-        assertEquals(i, internalBranch.getCommits().stream().filter(c -> !c.isSaved()).count());
-        KeyList keyList = internalBranch.getUpdateState(store()).unsafeGetL1().getKeyList();
-        assertFalse(keyList.isFull());
-        assertFalse(keyList.isEmptyIncremental());
-        KeyList.IncrementalList incrementalList = (KeyList.IncrementalList) keyList;
-        assertEquals(i, incrementalList.getDistanceFromCheckpointCommits());
-      }
-
-      InternalBranch internalBranch = simulateCommit(ref, executor, KeyList.IncrementalList.MAX_DELTAS);
+      // verify that the branch has an unsaved L1
+      assertEquals(i, internalBranch.getCommits().stream().filter(c -> !c.isSaved()).count());
       KeyList keyList = internalBranch.getUpdateState(store()).unsafeGetL1().getKeyList();
-      assertTrue(keyList.isFull());
+      assertFalse(keyList.isFull());
       assertFalse(keyList.isEmptyIncremental());
-    } finally {
-      executor.shutdown();
+      KeyList.IncrementalList incrementalList = (KeyList.IncrementalList) keyList;
+      assertEquals(i, incrementalList.getDistanceFromCheckpointCommits());
     }
+
+    InternalBranch internalBranch = simulateCommit(ref, KeyList.IncrementalList.MAX_DELTAS);
+    KeyList keyList = internalBranch.getUpdateState(store()).unsafeGetL1().getKeyList();
+    assertTrue(keyList.isFull());
+    assertFalse(keyList.isEmptyIncremental());
 
   }
 
-  private InternalBranch simulateCommit(InternalRefId ref, Executor executor, int num) {
+  private InternalBranch simulateCommit(InternalRefId ref, int num) {
     List<Operation<String>> ops = Collections.singletonList(Put.of(Key.of("key" + num), "foo" + num));
     List<InternalKey> keys = ops.stream().map(op -> new InternalKey(op.getKey())).collect(Collectors.toList());
 


### PR DESCRIPTION
From #813, (this comment](https://github.com/projectnessie/nessie/issues/813#issuecomment-779817450) :

From `TieredVersionStore.commit`, in the `store.load` for current+expected, `TieredVersionStore.ensureValidL1` is called, which calls `InternalBranch.getUpdateState`, which performs a loop over the `unsavedCommits`: it's `lastL1` is initialized to `lastSavedL1` and `lastL1` is "moved iteratively forward in history" via `lastL1.getChildWithTree(c.commit, tree, c.keyMutationList).withCheckpointAsNecessary(store)`.
That `withCheckpointAsNecessary()` occasionally throws a `(Reference)NotFoundException` when it tries to load an unsaved L1 via the `HistoryRetriever`, causing the commit-operation to fail.
I'm not sure whether that should distinguish between saved and unsaved commits or whether it's okay to only call `withCheckpointAsNecessary()` for the `lastSavedL1` in `getUpdateState`:
```
class InternalBranch extends InternalRef {
...
  public UpdateState getUpdateState(Store store)  {
...
    for (Commit c : unsavedCommits) {
      for (UnsavedDelta delta : c.deltas) {
        tree = delta.apply(tree);
      }

      lastL1 = lastL1.getChildWithTree(c.commit, tree, c.keyMutationList);
      if (lastL1 == lastSavedL1) {
        lastL1 = lastL1.withCheckpointAsNecessary(store);
      }

      toSave.add(EntityType.L1.createSaveOpForEntity(lastL1));
...
```

I went with the latter (only call `withCheckpointAsNecessary()` for the `lastSavedL1` in `getUpdateState`) and ran into no more errors during my test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/915)
<!-- Reviewable:end -->
