### PR TITLE
In-memory `Store` implementation

### DIFF
--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -53,6 +53,11 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tiered-inmem</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-tiered-dynamodb</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/TieredInMemVersionStoreConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/TieredInMemVersionStoreConfig.java
@@ -15,20 +15,11 @@
  */
 package org.projectnessie.server.config;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.projectnessie.versioned.dynamodb.DynamoStoreConfig;
-
 import io.quarkus.arc.config.ConfigProperties;
 
 /**
- * DynamoDB version store configuration.
+ * Tiered-In-Memory version store configuration.
  */
-@ConfigProperties(prefix = "nessie.version.store.dynamo")
-public interface DynamoVersionStoreConfig extends TieredVersionStoreConfig {
-
-  @ConfigProperty(name = "initialize", defaultValue = "false")
-  boolean isDynamoInitialize();
-
-  @ConfigProperty(defaultValue = DynamoStoreConfig.TABLE_PREFIX)
-  String getTablePrefix();
+@ConfigProperties(prefix = "nessie.version.store.tiered-inmem")
+public interface TieredInMemVersionStoreConfig extends TieredVersionStoreConfig {
 }

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/TieredVersionStoreConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/TieredVersionStoreConfig.java
@@ -16,19 +16,8 @@
 package org.projectnessie.server.config;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.projectnessie.versioned.dynamodb.DynamoStoreConfig;
 
-import io.quarkus.arc.config.ConfigProperties;
-
-/**
- * DynamoDB version store configuration.
- */
-@ConfigProperties(prefix = "nessie.version.store.dynamo")
-public interface DynamoVersionStoreConfig extends TieredVersionStoreConfig {
-
-  @ConfigProperty(name = "initialize", defaultValue = "false")
-  boolean isDynamoInitialize();
-
-  @ConfigProperty(defaultValue = DynamoStoreConfig.TABLE_PREFIX)
-  String getTablePrefix();
+public interface TieredVersionStoreConfig {
+  @ConfigProperty(name = "tracing", defaultValue = "true")
+  boolean enableTracing();
 }

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/VersionStoreConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/VersionStoreConfig.java
@@ -30,7 +30,8 @@ public interface VersionStoreConfig {
   public enum VersionStoreType {
     DYNAMO,
     INMEMORY,
-    JGIT
+    JGIT,
+    TIERED_INMEMORY
   }
 
   @ConfigProperty(name = "type", defaultValue = "INMEMORY")

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/TieredInMemVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/TieredInMemVersionStoreFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.providers;
+
+import static org.projectnessie.server.config.VersionStoreConfig.VersionStoreType.TIERED_INMEMORY;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.projectnessie.server.config.TieredInMemVersionStoreConfig;
+import org.projectnessie.versioned.inmem.InMemStore;
+import org.projectnessie.versioned.store.Store;
+import org.projectnessie.versioned.store.TracingStore;
+
+@StoreType(TIERED_INMEMORY)
+@Dependent
+public class TieredInMemVersionStoreFactory extends TieredVersionStoreFactory {
+
+  private final TieredInMemVersionStoreConfig config;
+
+  @Inject
+  public TieredInMemVersionStoreFactory(TieredInMemVersionStoreConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  @Override
+  protected Store createStore() {
+    Store store = new InMemStore();
+
+    if (config.enableTracing()) {
+      store = new TracingStore(store);
+    }
+
+    store.start();
+    return store;
+  }
+}

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/TieredVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/TieredVersionStoreFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.providers;
+
+import org.projectnessie.server.config.TieredVersionStoreConfig;
+import org.projectnessie.versioned.StoreWorker;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.impl.ImmutableTieredVersionStoreConfig;
+import org.projectnessie.versioned.impl.TieredVersionStore;
+import org.projectnessie.versioned.store.Store;
+
+abstract class TieredVersionStoreFactory implements VersionStoreFactory {
+  private final TieredVersionStoreConfig config;
+
+  public TieredVersionStoreFactory(TieredVersionStoreConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public <VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYPE>> VersionStore<VALUE, METADATA, VALUE_TYPE> newStore(
+      StoreWorker<VALUE, METADATA, VALUE_TYPE> worker) {
+    return new TieredVersionStore<>(worker, createStore(), ImmutableTieredVersionStoreConfig
+        .builder()
+        .enableTracing(config.enableTracing()).build());
+  }
+
+  protected abstract Store createStore();
+}

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -19,7 +19,9 @@
 nessie.server.default-branch=main
 nessie.server.send-stacktrace-to-client=false
 
-### which type of version store to use: JGIT, INMEMORY, DYNAMO. JGIT is best for local testing, DYNAMO preferred for production
+### which type of version store to use: JGIT, INMEMORY, DYNAMO, TIERED_INMEMORY.
+# JGIT is best for local testing, DYNAMO preferred for production.
+# INMEMORY + TIERED_INMEMORY are good for ephemeral tests, do not persist anything - not suitable for production.
 nessie.version.store.type=INMEMORY
 
 ## JGit version store specific configuration

--- a/versioned/tiered/inmem/pom.xml
+++ b/versioned/tiered/inmem/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie-versioned-tiered</artifactId>
+    <version>0.5.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-versioned-tiered-inmem</artifactId>
+
+  <name>Nessie - Versioned - Tiered - InMemory</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tiered-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tiered-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/BaseObj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/BaseObj.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
+
+import org.projectnessie.versioned.impl.condition.ExpressionPath;
+import org.projectnessie.versioned.impl.condition.RemoveClause;
+import org.projectnessie.versioned.impl.condition.SetClause;
+import org.projectnessie.versioned.impl.condition.UpdateClause;
+import org.projectnessie.versioned.impl.condition.UpdateExpression;
+import org.projectnessie.versioned.store.ConditionFailedException;
+import org.projectnessie.versioned.store.Entity;
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.store.ValueType;
+import org.projectnessie.versioned.tiered.BaseValue;
+
+/**
+ * Base class of all value-types in of the in-memory {@link org.projectnessie.versioned.store.Store}
+ * implementation.
+ * <p>All subclasses <em>must</em> implement {@link Object#hashCode()} and
+ * {@link Object#equals(Object)}, because the some functionality in the
+ * {@link org.projectnessie.versioned.store.Store} implementation require this, for example
+ * {@link InMemStore#delete(ValueType, Id, Optional)}.</p>
+ * @param <C> value-type
+ */
+abstract class BaseObj<C extends BaseValue<C>> {
+  static final String ID = "id";
+
+  private final Id id;
+  private final long dt;
+
+  BaseObj(Id id, long dt) {
+    this.id = id;
+    this.dt = dt;
+  }
+
+  Id getId() {
+    return id;
+  }
+
+  long getDt() {
+    return dt;
+  }
+
+  C consume(C consumer) {
+    return consumer.id(id).dt(dt);
+  }
+
+  void evaluate(List<Function> functions) throws ConditionFailedException {
+    for (Function function: functions) {
+      if (function.getPath().getRoot().isName()) {
+        try {
+          evaluate(function);
+        } catch (IllegalStateException e) {
+          // Catch exceptions raise due to incorrect Entity type in FunctionExpression being compared to the
+          // target attribute.
+          throw new ConditionFailedException(invalidValueMessage(function));
+        }
+      }
+    }
+  }
+
+  void evaluate(Function function) throws ConditionFailedException {
+    throw new UnsupportedOperationException("Conditions not supported for " + getClass().getSimpleName());
+  }
+
+  boolean evaluate(Function function, List<Id> idList) {
+    // EQUALS will either compare a specified position or the whole idList as a List.
+    if (function.getOperator().equals(Function.Operator.EQUALS)) {
+      final ExpressionPath.PathSegment pathSegment = function.getPath().getRoot().getChild().orElse(null);
+      if (pathSegment == null) {
+        return toEntity(idList).equals(function.getValue());
+      } else if (pathSegment.isPosition()) { // compare individual element of list
+        final int position = pathSegment.asPosition().getPosition();
+        return toEntity(idList, position).equals(function.getValue());
+      }
+    } else if (function.getOperator().equals(Function.Operator.SIZE)) {
+      return (idList.size() == function.getValue().getNumber());
+    }
+
+    return false;
+  }
+
+  static Entity toEntity(List<Id> idList) {
+    return Entity.ofList(idList.stream().map(Id::toEntity).collect(Collectors.toList()));
+  }
+
+  static Entity toEntity(List<Id> idList, int position) {
+    return idList.stream().skip(position).findFirst().orElseThrow(NoSuchElementException::new).toEntity();
+  }
+
+  void evaluatesId(Function function) throws ConditionFailedException {
+    if (!function.isRootNameSegmentChildlessAndEquals()
+        || !getId().toEntity().equals(function.getValue())) {
+      throw new ConditionFailedException(conditionNotMatchedMessage(function));
+    }
+  }
+
+  protected static String invalidOperatorSegmentMessage(Function function) {
+    return String.format("Operator: %s is not applicable to segment %s",
+        function.getOperator(), function.getRootPathAsNameSegment().getName());
+  }
+
+  protected static String invalidValueMessage(Function function) {
+    return String.format("Not able to apply type: %s to segment: %s", function.getValue().getType(),
+        function.getRootPathAsNameSegment().getName());
+  }
+
+  protected static String conditionNotMatchedMessage(Function function) {
+    return String.format("Condition %s did not match the actual value for %s", function.getValue().getType(),
+        function.getRootPathAsNameSegment().getName());
+  }
+
+  abstract BaseObj<C> copy();
+
+  static final class DeferredRemove implements Comparable<DeferredRemove> {
+
+    private final int position;
+    private final IntConsumer removeOperation;
+
+    protected DeferredRemove(int position, IntConsumer removeOperation) {
+      this.position = position;
+      this.removeOperation = removeOperation;
+    }
+
+    @Override
+    public int compareTo(DeferredRemove o) {
+      return Integer.compare(o.position, position);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      DeferredRemove that = (DeferredRemove) o;
+
+      if (position != that.position) {
+        return false;
+      }
+      return removeOperation.equals(that.removeOperation);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = position;
+      result = 31 * result + removeOperation.hashCode();
+      return result;
+    }
+
+    void apply() {
+      removeOperation.accept(position);
+    }
+  }
+
+  BaseObj<C> update(UpdateExpression update) {
+    BaseObj<C> copy = copy();
+    List<DeferredRemove> deferred = new ArrayList<>();
+    update.getClauses().forEach(clause -> copy.apply(clause, deferred::add));
+    deferred.stream().sorted().forEach(DeferredRemove::apply);
+    return copy;
+  }
+
+  private void apply(UpdateClause updateClause, Consumer<DeferredRemove> deferredRemoveConsumer) {
+    switch (updateClause.getType()) {
+      case DELETE:
+        applyDelete(updateClause);
+        break;
+      case REMOVE:
+        applyRemove((RemoveClause) updateClause, deferredRemoveConsumer);
+        break;
+      case SET:
+        applySet((SetClause) updateClause);
+        break;
+      default:
+        throw new UnsupportedOperationException(updateClause.toString());
+    }
+  }
+
+  void applyDelete(UpdateClause updateClause) {
+    throw new UnsupportedOperationException(String.format("%s does not support UpdateClause/DELETE", getClass().getSimpleName()));
+  }
+
+  void applyRemove(RemoveClause removeClause,
+      Consumer<DeferredRemove> deferredRemoveConsumer) {
+    throw new UnsupportedOperationException(String.format("%s does not support RemoveClause", getClass().getSimpleName()));
+  }
+
+  void applySet(SetClause setClause) {
+    throw new UnsupportedOperationException(String.format("%s does not support SetClause", getClass().getSimpleName()));
+  }
+
+  abstract static class BaseObjProducer<C extends BaseValue<C>> implements BaseValue<C> {
+    private Id id;
+    private long dt;
+
+    Id getId() {
+      return id;
+    }
+
+    long getDt() {
+      return dt;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public C id(Id id) {
+      this.id = id;
+      return (C) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public C dt(long dt) {
+      this.dt = dt;
+      return (C) this;
+    }
+
+    abstract BaseObj<C> build();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BaseObj<?> baseObj = (BaseObj<?>) o;
+
+    if (dt != baseObj.dt) {
+      return false;
+    }
+    return id.equals(baseObj.id);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id.hashCode();
+    result = 31 * result + (int) (dt ^ (dt >>> 32));
+    return result;
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/CommitMetadataObj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/CommitMetadataObj.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.tiered.CommitMetadata;
+
+import com.google.protobuf.ByteString;
+
+final class CommitMetadataObj extends WrappedValueObj<CommitMetadata> {
+
+  CommitMetadataObj(Id id, long dt, ByteString value) {
+    super(id, dt, value);
+  }
+
+  @Override
+  BaseObj<CommitMetadata> copy() {
+    return new CommitMetadataObj(getId(), getDt(), getValue());
+  }
+
+  static class CommitMetadataProducer extends BaseWrappedValueObjProducer<CommitMetadata> implements CommitMetadata {
+    @Override
+    BaseObj<CommitMetadata> build() {
+      return new CommitMetadataObj(getId(), getDt(), getValue());
+    }
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/FragmentObj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/FragmentObj.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.WithPayload;
+import org.projectnessie.versioned.impl.condition.ExpressionFunction;
+import org.projectnessie.versioned.impl.condition.ExpressionPath.NameSegment;
+import org.projectnessie.versioned.impl.condition.RemoveClause;
+import org.projectnessie.versioned.impl.condition.SetClause;
+import org.projectnessie.versioned.store.ConditionFailedException;
+import org.projectnessie.versioned.store.Entity;
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.tiered.Fragment;
+
+final class FragmentObj extends BaseObj<Fragment> {
+  static final String KEY_LIST = "keys";
+
+  private final List<WithPayload<Key>> keys;
+
+  FragmentObj(Id id, long dt, List<WithPayload<Key>> keys) {
+    super(id, dt);
+    this.keys = keys;
+  }
+
+  @Override
+  Fragment consume(Fragment consumer) {
+    return super.consume(consumer).keys(keys.stream());
+  }
+
+  static class FragmentProducer extends BaseObjProducer<Fragment> implements Fragment {
+    private List<WithPayload<Key>> keys;
+
+    @Override
+    public Fragment keys(Stream<WithPayload<Key>> keys) {
+      this.keys = keys.collect(Collectors.toList());
+      return this;
+    }
+
+    @Override
+    BaseObj<Fragment> build() {
+      return new FragmentObj(getId(), getDt(), keys);
+    }
+  }
+
+  @Override
+  BaseObj<Fragment> copy() {
+    return new FragmentObj(getId(), getDt(),
+        keys != null ? new ArrayList<>(keys) : null);
+  }
+
+  @Override
+  void applyRemove(RemoveClause removeClause, Consumer<DeferredRemove> deferredRemoveConsumer) {
+    NameSegment root = removeClause.getPath().getRoot();
+    switch (root.getName()) {
+      case KEY_LIST:
+        int pos = root.getChild().orElseThrow(() -> new IllegalStateException("Position required")).asPosition().getPosition();
+        deferredRemoveConsumer.accept(new DeferredRemove(pos, keys::remove));
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
+  void applySet(SetClause setClause) {
+    NameSegment root = setClause.getPath().getRoot();
+    switch (root.getName()) {
+      case KEY_LIST:
+        switch (setClause.getValue().getType()) {
+          case FUNCTION:
+            ExpressionFunction expressionFunction = (ExpressionFunction) setClause.getValue();
+            switch (expressionFunction.getName()) {
+              case LIST_APPEND:
+                List<Entity> valueList = expressionFunction.getArguments().get(1).getValue().getList();
+                valueList.forEach(value -> {
+                  List<Entity> list = value.getList();
+                  keys.add(
+                      WithPayload.of(Byte.parseByte(list.get(0).getString()),
+                      Key.of(list.stream().skip(1).map(Entity::getString).toArray(String[]::new))
+                  ));
+                });
+                break;
+              case EQUALS:
+              case SIZE:
+              case ATTRIBUTE_NOT_EXISTS:
+              default:
+                throw new UnsupportedOperationException();
+            }
+            break;
+          case VALUE:
+          case PATH:
+          default:
+            throw new UnsupportedOperationException();
+        }
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
+  public void evaluate(Function function) throws ConditionFailedException {
+    final String segment = function.getRootPathAsNameSegment().getName();
+    switch (segment) {
+      case ID:
+        evaluatesId(function);
+        break;
+      case KEY_LIST:
+        if (function.getRootPathAsNameSegment().getChild().isPresent()) {
+          throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+        } else if (function.getOperator().equals(Function.Operator.EQUALS)) {
+          if (!keysAsEntityList().equals(function.getValue())) {
+            throw new ConditionFailedException(conditionNotMatchedMessage(function));
+          }
+        } else if (function.getOperator().equals(Function.Operator.SIZE)) {
+          if (keys.size() != function.getValue().getNumber()) {
+            throw new ConditionFailedException(conditionNotMatchedMessage(function));
+          }
+        } else {
+          throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+        }
+        break;
+      default:
+        // NameSegment could not be applied to FunctionExpression.
+        throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+    }
+  }
+
+  private Entity keysAsEntityList() {
+    return Entity.ofList(keys.stream().map(k -> Entity.ofList(
+        Stream.concat(Stream.of(k.getPayload().toString()),
+            k.getValue().getElements().stream()).map(Entity::ofString)
+    )));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    FragmentObj that = (FragmentObj) o;
+
+    return keys.equals(that.keys);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + keys.hashCode();
+    return result;
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/Function.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/Function.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.Objects;
+
+import org.immutables.value.Value.Immutable;
+import org.projectnessie.versioned.impl.condition.ExpressionPath;
+import org.projectnessie.versioned.store.Entity;
+
+/**
+ * An expression that is asserted against an Entity.
+ */
+@Immutable
+abstract class Function {
+  /**
+   * An enum encapsulating.
+   */
+  enum Operator {
+    // An operator comparing the equality of entities.
+    EQUALS,
+
+    // An operator comparing the size of entities.
+    SIZE
+  }
+
+  /**
+   * Compares for equality with a provided Function object.
+   * @param object  the object to compare
+   * @return true if this is equal to provided object
+   */
+  @Override
+  public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
+
+    if (!(object instanceof Function)) {
+      return false;
+    }
+
+    final Function function = (Function) object;
+    return (getOperator().equals(function.getOperator())
+        && getPath().equals(function.getPath())
+        && getValue().equals(function.getValue()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getOperator(), getPath(), getValue());
+  }
+
+  abstract Operator getOperator();
+
+  abstract ExpressionPath getPath();
+
+  abstract Entity getValue();
+
+  ExpressionPath.NameSegment getRootPathAsNameSegment() {
+    return getPath().getRoot().asName();
+  }
+
+  /**
+   * A utility to aid evaluation of the Function in checking for equality on
+   * a leaf {@link org.projectnessie.versioned.impl.condition.ExpressionPath.NameSegment}.
+   * @return true if both root nameSegment is childless and function has an equality operator
+   */
+  boolean isRootNameSegmentChildlessAndEquals() {
+    return !getRootPathAsNameSegment().getChild().isPresent()
+        && getOperator().equals(Operator.EQUALS);
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/InMemStore.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/InMemStore.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.projectnessie.versioned.impl.EntityStoreHelper;
+import org.projectnessie.versioned.impl.condition.ConditionExpression;
+import org.projectnessie.versioned.impl.condition.UpdateExpression;
+import org.projectnessie.versioned.inmem.BaseObj.BaseObjProducer;
+import org.projectnessie.versioned.store.ConditionFailedException;
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.store.LoadOp;
+import org.projectnessie.versioned.store.LoadStep;
+import org.projectnessie.versioned.store.NotFoundException;
+import org.projectnessie.versioned.store.SaveOp;
+import org.projectnessie.versioned.store.Store;
+import org.projectnessie.versioned.store.ValueType;
+import org.projectnessie.versioned.tiered.BaseValue;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
+/**
+ * A <em>non-production</em> {@link Store} implementation for testing and benchmarking purposes.
+ * <p>Based on one {@link ConcurrentMap} for each value-type.</p>
+ */
+public class InMemStore implements Store {
+
+  private static final InMemValueVisitor VALUE_VISITOR = new InMemValueVisitor();
+
+  private final Map<ValueType<?>, ConcurrentMap<Id, BaseObj<?>>> store;
+
+  private final Map<ValueType<?>, Supplier<? extends BaseObjProducer<?>>> typeSupplierMap;
+
+  /**
+   * Construct the in-memory {@link Store} implementation.
+   */
+  public InMemStore() {
+    Builder<ValueType<?>, ConcurrentMap<Id, BaseObj<?>>> storeBuilder = ImmutableMap.builder();
+    Builder<ValueType<?>, Supplier<? extends BaseObjProducer<?>>> typeSupplierBuilder = ImmutableMap.builder();
+
+    for (ValueType<?> value : ValueType.values()) {
+      storeBuilder.put(value, new ConcurrentHashMap<>());
+    }
+
+    typeSupplierBuilder.put(ValueType.L1, L1Obj.L1Producer::new);
+    typeSupplierBuilder.put(ValueType.L2, L2Obj.L2Producer::new);
+    typeSupplierBuilder.put(ValueType.L3, L3Obj.L3Producer::new);
+    typeSupplierBuilder.put(ValueType.COMMIT_METADATA, CommitMetadataObj.CommitMetadataProducer::new);
+    typeSupplierBuilder.put(ValueType.KEY_FRAGMENT, FragmentObj.FragmentProducer::new);
+    typeSupplierBuilder.put(ValueType.REF, RefObj.RefProducer::new);
+    typeSupplierBuilder.put(ValueType.VALUE, ValueObj.ValueProducer::new);
+
+    this.store = storeBuilder.build();
+    this.typeSupplierMap = typeSupplierBuilder.build();
+  }
+
+  @Override
+  public void start() {
+    // make sure we have an empty l1 (ignore result, doesn't matter)
+    EntityStoreHelper.storeMinimumEntities(this::putIfAbsent);
+  }
+
+  @Override
+  public void close() {
+    store.values().forEach(Map::clear);
+  }
+
+  @Override
+  public void load(LoadStep loadstep) {
+    while (true) {
+      Map<ValueType<?>, List<Id>> missing = new HashMap<>();
+      loadstep.getOps().forEach(op -> loadSingle(op, missing));
+
+      if (!missing.isEmpty()) {
+        throw new NotFoundException(missing.toString());
+      }
+
+      Optional<LoadStep> next = loadstep.getNext();
+      if (!next.isPresent()) {
+        break;
+      }
+      loadstep = next.get();
+    }
+  }
+
+  private <C extends BaseValue<C>> void loadSingle(LoadOp<C> op, Map<ValueType<?>, List<Id>> missing) {
+    BaseObj<C> obj = store(op.getValueType()).get(op.getId());
+    if (obj == null) {
+      missing.computeIfAbsent(op.getValueType(), x -> new ArrayList<>()).add(op.getId());
+    } else {
+      obj.consume(op.getReceiver());
+      op.done();
+    }
+  }
+
+  @Override
+  public <C extends BaseValue<C>> void loadSingle(ValueType<C> type, Id id, C consumer) {
+    BaseObj<C> obj = store(type).get(id);
+    if (obj == null) {
+      throw new NotFoundException(String.format("Unable to load item %s:%s.", type, id));
+    }
+    obj.consume(consumer);
+  }
+
+  @Override
+  public <C extends BaseValue<C>> boolean putIfAbsent(SaveOp<C> saveOp) {
+    return store(saveOp.getType()).putIfAbsent(saveOp.getId(), produce(saveOp)) == null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private <C extends BaseValue<C>> BaseObj<C> produce(SaveOp<C> saveOp) {
+    BaseObjProducer<C> objProducer = newProducer(saveOp.getType());
+    saveOp.serialize((C) objProducer);
+    return objProducer.build();
+  }
+
+  @SuppressWarnings("unchecked")
+  @VisibleForTesting
+  <C extends BaseValue<C>> BaseObjProducer<C> newProducer(ValueType<C> type) {
+    BaseObjProducer<C> objProducer = (BaseObjProducer<C>) typeSupplierMap.get(type).get();
+    return objProducer;
+  }
+
+  @Override
+  public <C extends BaseValue<C>> void put(SaveOp<C> saveOp,
+      Optional<ConditionExpression> condition) {
+    ConcurrentMap<Id, BaseObj<C>> map = store(saveOp.getType());
+    if (condition.isPresent()) {
+      map.compute(saveOp.getId(), (id, v) -> {
+        if (v != null) {
+          v.evaluate(translate(condition.get()));
+        } else {
+          throw new ConditionFailedException("foo");
+        }
+        return produce(saveOp);
+      });
+    } else {
+      map.put(saveOp.getId(), produce(saveOp));
+    }
+  }
+
+  static List<Function> translate(ConditionExpression conditionExpression) {
+    return conditionExpression.getFunctions().stream()
+        .map(f -> f.accept(VALUE_VISITOR))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public <C extends BaseValue<C>> boolean delete(ValueType<C> type, Id id,
+      Optional<ConditionExpression> condition) {
+    ConcurrentMap<Id, BaseObj<C>> map = store(type);
+    if (condition.isPresent()) {
+      BaseObj<C> value = map.get(id);
+      if (value == null) {
+        return false;
+      }
+      try {
+        value.evaluate(translate(condition.get()));
+      } catch (ConditionFailedException failed) {
+        return false;
+      }
+      return map.remove(id, value);
+    } else {
+      return map.remove(id) != null;
+    }
+  }
+
+  @Override
+  public void save(List<SaveOp<?>> ops) {
+    ops.forEach(op -> store.get(op.getType()).put(op.getId(), produce(op)));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <C extends BaseValue<C>> boolean update(ValueType<C> type, Id id, UpdateExpression update,
+      Optional<ConditionExpression> condition, Optional<BaseValue<C>> consumer)
+      throws NotFoundException {
+    ConcurrentMap<Id, BaseObj<C>> map = store(type);
+    while (true) {
+      BaseObj<C> value = map.get(id);
+      if (value == null) {
+        throw new NotFoundException(String.format("Not found: %s:%s", type, id));
+      }
+      if (condition.isPresent()) {
+        try {
+          value.evaluate(translate(condition.get()));
+        } catch (ConditionFailedException failed) {
+          return false;
+        }
+      }
+      try {
+        BaseObj<C> updated = value.update(update);
+        map.compute(id, (i, current) -> {
+          if (current != value) {
+            throw new ConcurrentModificationException();
+          }
+          return updated;
+        });
+        consumer.ifPresent(c -> updated.consume((C) c));
+        return true;
+      } catch (ConcurrentModificationException modified) {
+        // ignore, just retry
+      }
+    }
+  }
+
+  @Override
+  public <C extends BaseValue<C>> Stream<Acceptor<C>> getValues(ValueType<C> type) {
+    return store(type).values().stream().map(obj -> obj::consume);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private <C extends BaseValue<C>> ConcurrentMap<Id, BaseObj<C>> store(ValueType<C> type) {
+    ConcurrentMap m = store.get(type);
+    return (ConcurrentMap<Id, BaseObj<C>>) m;
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/InMemValueVisitor.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/InMemValueVisitor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.security.InvalidParameterException;
+import java.util.List;
+
+import org.projectnessie.versioned.impl.condition.ExpressionFunction;
+import org.projectnessie.versioned.impl.condition.ExpressionPath;
+import org.projectnessie.versioned.impl.condition.Value;
+import org.projectnessie.versioned.impl.condition.ValueVisitor;
+import org.projectnessie.versioned.store.Entity;
+
+/**
+ * This provides a separation of queries on @{ExpressionFunction} from the object itself.
+ * This uses the Visitor design pattern to retrieve object attributes.
+ */
+class InMemValueVisitor implements ValueVisitor<Function> {
+  private static class ExpressionPathVisitor implements ValueVisitor<ExpressionPath> {
+    @Override
+    public ExpressionPath visit(Entity entity) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpressionPath visit(ExpressionFunction value) {
+      final ExpressionFunction.FunctionName name = value.getName();
+      throw new UnsupportedOperationException(String.format("%s is not a supported top-level RocksDB function.", name));
+    }
+
+    @Override
+    public ExpressionPath visit(ExpressionPath value) {
+      return value;
+    }
+  }
+
+  private static final ExpressionPathVisitor EXPRESSION_PATH_VALUE_VISITOR = new ExpressionPathVisitor();
+
+  @Override
+  public Function visit(Entity entity) {
+    throw new UnsupportedOperationException(String.format("%s is not supported as a RocksDB Function", entity.toString()));
+  }
+
+  @Override
+  public Function visit(ExpressionFunction value) {
+    final ExpressionFunction.FunctionName name = value.getName();
+    final List<Value> arguments = value.getArguments();
+    if (arguments.size() != name.getArgCount()) {
+      throw new InvalidParameterException(
+          String.format("Number of arguments provided [%d] does not match the number expected [%d] for %s.",
+              arguments.size(), name.getArgCount(), name));
+    }
+
+    switch (name) {
+      case EQUALS:
+        // Special case SIZE, as the object representation is not contained in one level of ExpressionFunction.
+        if (isSize(arguments.get(0))) {
+          return ImmutableFunction.builder().operator(Function.Operator.SIZE)
+              .path(arguments.get(0).getFunction().getArguments().get(0).accept(EXPRESSION_PATH_VALUE_VISITOR))
+              .value(arguments.get(1).getValue()).build();
+        }
+
+        return ImmutableFunction.builder().operator(Function.Operator.EQUALS)
+            .path(arguments.get(0).accept(EXPRESSION_PATH_VALUE_VISITOR))
+            .value(arguments.get(1).getValue()).build();
+      default:
+        throw new UnsupportedOperationException(String.format("%s is not a supported top-level RocksDB function.", name));
+    }
+  }
+
+  @Override
+  public Function visit(ExpressionPath value) {
+    throw new UnsupportedOperationException(String.format("%s is not supported as a RocksDB Function", value.toString()));
+  }
+
+  private boolean isSize(Value value) {
+    return (value.getType() == Value.Type.FUNCTION) && (((ExpressionFunction)value).getName() == ExpressionFunction.FunctionName.SIZE);
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/L1Obj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/L1Obj.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.projectnessie.versioned.impl.condition.ExpressionPath;
+import org.projectnessie.versioned.store.ConditionFailedException;
+import org.projectnessie.versioned.store.Entity;
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.tiered.L1;
+import org.projectnessie.versioned.tiered.Mutation;
+
+final class L1Obj extends BaseObj<L1> {
+  static final String COMMIT_METADATA = "metadataId";
+  static final String ANCESTORS = "ancestors";
+  static final String CHILDREN = "children";
+  static final String KEY_LIST = "keylist";
+  static final String INCREMENTAL_KEY_LIST = "incrementalKeyList";
+  static final String COMPLETE_KEY_LIST = "completeKeyList";
+  static final String CHECKPOINT_ID = "checkpointId";
+  static final String DISTANCE_FROM_CHECKPOINT = "distanceFromCheckpoint";
+
+  private final Id commitMetadataId;
+  private final List<Id> ancestors;
+  private final List<Id> children;
+  private final List<Mutation> keyMutations;
+  private final int distanceFromCheckpoint;
+  private final Id checkpointId;
+  private final List<Id> completeKeyList;
+
+  L1Obj(Id id, long dt, Id commitMetadataId,
+      List<Id> ancestors, List<Id> children,
+      List<Mutation> keyMutations, int distanceFromCheckpoint,
+      Id checkpointId, List<Id> completeKeyList) {
+    super(id, dt);
+    this.commitMetadataId = commitMetadataId;
+    this.ancestors = ancestors;
+    this.children = children;
+    this.keyMutations = keyMutations;
+    this.distanceFromCheckpoint = distanceFromCheckpoint;
+    this.checkpointId = checkpointId;
+    this.completeKeyList = completeKeyList;
+  }
+
+  @Override
+  L1 consume(L1 consumer) {
+    super.consume(consumer)
+        .commitMetadataId(commitMetadataId)
+        .ancestors(ancestors.stream())
+        .children(children.stream())
+        .keyMutations(keyMutations.stream());
+    if (completeKeyList != null) {
+      return consumer.completeKeyList(completeKeyList.stream());
+    } else {
+      return consumer.incrementalKeyList(checkpointId, distanceFromCheckpoint);
+    }
+  }
+
+  static class L1Producer extends BaseObjProducer<L1> implements L1 {
+
+    private Id commitMetadataId;
+    private List<Id> ancestors;
+    private List<Id> children;
+    private List<Mutation> keyMutations;
+    private int distanceFromCheckpoint;
+    private Id checkpointId;
+    private List<Id> completeKeyList;
+
+    @Override
+    public L1 commitMetadataId(Id id) {
+      this.commitMetadataId = id;
+      return this;
+    }
+
+    @Override
+    public L1 ancestors(Stream<Id> ids) {
+      this.ancestors = ids.collect(Collectors.toList());
+      return this;
+    }
+
+    @Override
+    public L1 children(Stream<Id> ids) {
+      this.children = ids.collect(Collectors.toList());
+      return this;
+    }
+
+    @Override
+    public L1 keyMutations(Stream<Mutation> keyMutations) {
+      this.keyMutations = keyMutations.collect(Collectors.toList());
+      return this;
+    }
+
+    @Override
+    public L1 incrementalKeyList(Id checkpointId, int distanceFromCheckpoint) {
+      this.checkpointId = checkpointId;
+      this.distanceFromCheckpoint = distanceFromCheckpoint;
+      return this;
+    }
+
+    @Override
+    public L1 completeKeyList(Stream<Id> fragmentIds) {
+      this.completeKeyList = fragmentIds.collect(Collectors.toList());
+      return this;
+    }
+
+    @Override
+    BaseObj<L1> build() {
+      return new L1Obj(getId(), getDt(),
+          commitMetadataId, ancestors, children, keyMutations, distanceFromCheckpoint, checkpointId, completeKeyList);
+    }
+  }
+
+  @Override
+  BaseObj<L1> copy() {
+    return new L1Obj(getId(), getDt(), commitMetadataId,
+        ancestors != null ? new ArrayList<>(ancestors) : null,
+        children != null ? new ArrayList<>(children) : null,
+        keyMutations != null ? new ArrayList<>(keyMutations) : null,
+        distanceFromCheckpoint, checkpointId,
+        completeKeyList != null ? new ArrayList<>(completeKeyList) : null);
+  }
+
+  @Override
+  public void evaluate(Function function) throws ConditionFailedException {
+    final ExpressionPath.NameSegment nameSegment = function.getRootPathAsNameSegment();
+    final String segment = nameSegment.getName();
+    switch (segment) {
+      case ID:
+        evaluatesId(function);
+        break;
+      case COMMIT_METADATA:
+        if (!function.isRootNameSegmentChildlessAndEquals()
+            || !commitMetadataId.toEntity().equals(function.getValue())) {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        break;
+      case ANCESTORS:
+        evaluate(function, ancestors);
+        break;
+      case CHILDREN:
+        evaluate(function, children);
+        break;
+      case KEY_LIST:
+        throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+      case INCREMENTAL_KEY_LIST:
+        if (!nameSegment.getChild().isPresent() || !function.getOperator().equals(Function.Operator.EQUALS)) {
+          throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+        }
+        final String childName = nameSegment.getChild().get().asName().getName();
+        if (childName.equals(CHECKPOINT_ID)) {
+          if (!checkpointId.toEntity().equals(function.getValue())) {
+            throw new ConditionFailedException(conditionNotMatchedMessage(function));
+          }
+        } else if (childName.equals((DISTANCE_FROM_CHECKPOINT))) {
+          if (!Entity.ofNumber(distanceFromCheckpoint).equals(function.getValue())) {
+            throw new ConditionFailedException(conditionNotMatchedMessage(function));
+          }
+        } else {
+          // Invalid Condition Function.
+          throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+        }
+        break;
+      case COMPLETE_KEY_LIST:
+        evaluate(function, completeKeyList);
+        break;
+      default:
+        // Invalid Condition Function.
+        throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    L1Obj l1Obj = (L1Obj) o;
+
+    return (distanceFromCheckpoint == l1Obj.distanceFromCheckpoint)
+        && Objects.equals(commitMetadataId, l1Obj.commitMetadataId)
+        && Objects.equals(ancestors, l1Obj.ancestors)
+        && Objects.equals(children, l1Obj.children)
+        && Objects.equals(keyMutations, l1Obj.keyMutations)
+        && Objects.equals(checkpointId, l1Obj.checkpointId)
+        && Objects.equals(completeKeyList, l1Obj.completeKeyList);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (commitMetadataId != null ? commitMetadataId.hashCode() : 0);
+    result = 31 * result + (ancestors != null ? ancestors.hashCode() : 0);
+    result = 31 * result + (children != null ? children.hashCode() : 0);
+    result = 31 * result + (keyMutations != null ? keyMutations.hashCode() : 0);
+    result = 31 * result + distanceFromCheckpoint;
+    result = 31 * result + (checkpointId != null ? checkpointId.hashCode() : 0);
+    result = 31 * result + (completeKeyList != null ? completeKeyList.hashCode() : 0);
+    return result;
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/L2Obj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/L2Obj.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.projectnessie.versioned.store.ConditionFailedException;
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.tiered.L2;
+
+final class L2Obj extends BaseObj<L2> {
+  private static final String CHILDREN = "children";
+  private final List<Id> children;
+
+  L2Obj(Id id, long dt, List<Id> children) {
+    super(id, dt);
+    this.children = children;
+  }
+
+  @Override
+  L2 consume(L2 consumer) {
+    return super.consume(consumer).children(children.stream());
+  }
+
+  static class L2Producer extends BaseObjProducer<L2> implements L2 {
+    private List<Id> children;
+
+    @Override
+    public L2 children(Stream<Id> ids) {
+      this.children = ids.collect(Collectors.toList());
+      return this;
+    }
+
+    @Override
+    BaseObj<L2> build() {
+      return new L2Obj(getId(), getDt(), children);
+    }
+  }
+
+  @Override
+  BaseObj<L2> copy() {
+    return new L2Obj(getId(), getDt(), new ArrayList<>(children));
+  }
+
+  @Override
+  public void evaluate(Function function) throws ConditionFailedException {
+    final String segment = function.getRootPathAsNameSegment().getName();
+    switch (segment) {
+      case ID:
+        evaluatesId(function);
+        break;
+      case CHILDREN:
+        evaluate(function, children);
+        break;
+      default:
+        // Invalid Condition Function.
+        throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    L2Obj that = (L2Obj) o;
+
+    return children.equals(that.children);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + children.hashCode();
+    return result;
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/L3Obj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/L3Obj.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.projectnessie.versioned.store.ConditionFailedException;
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.store.KeyDelta;
+import org.projectnessie.versioned.tiered.L3;
+
+final class L3Obj extends BaseObj<L3> {
+  private final List<KeyDelta> keyDelta;
+
+  L3Obj(Id id, long dt, List<KeyDelta> keyDelta) {
+    super(id, dt);
+    this.keyDelta = keyDelta;
+  }
+
+  @Override
+  L3 consume(L3 consumer) {
+    return super.consume(consumer).keyDelta(keyDelta.stream());
+  }
+
+  static class L3Producer extends BaseObjProducer<L3> implements L3 {
+    private List<KeyDelta> keyDelta;
+
+    @Override
+    public L3 keyDelta(Stream<KeyDelta> keyDelta) {
+      this.keyDelta = keyDelta.collect(Collectors.toList());
+      return this;
+    }
+
+    @Override
+    BaseObj<L3> build() {
+      return new L3Obj(getId(), getDt(), keyDelta);
+    }
+  }
+
+  @Override
+  BaseObj<L3> copy() {
+    return new L3Obj(getId(), getDt(),
+        keyDelta != null ? new ArrayList<>(keyDelta) : null);
+  }
+
+  @Override
+  public void evaluate(Function function) throws ConditionFailedException {
+    final String segment = function.getRootPathAsNameSegment().getName();
+    if (segment.equals(ID)) {
+      evaluatesId(function);
+    } else {
+      throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    L3Obj that = (L3Obj) o;
+
+    return keyDelta.equals(that.keyDelta);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + keyDelta.hashCode();
+    return result;
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/RefObj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/RefObj.java
@@ -1,0 +1,655 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.impl.condition.ExpressionFunction;
+import org.projectnessie.versioned.impl.condition.ExpressionPath.NameSegment;
+import org.projectnessie.versioned.impl.condition.ExpressionPath.PathSegment;
+import org.projectnessie.versioned.impl.condition.RemoveClause;
+import org.projectnessie.versioned.impl.condition.SetClause;
+import org.projectnessie.versioned.store.ConditionFailedException;
+import org.projectnessie.versioned.store.Entity;
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.tiered.Mutation;
+import org.projectnessie.versioned.tiered.Ref;
+import org.projectnessie.versioned.tiered.Ref.BranchCommit;
+import org.projectnessie.versioned.tiered.Ref.UnsavedCommitDelta;
+import org.projectnessie.versioned.tiered.Ref.UnsavedCommitMutations;
+
+import com.google.common.primitives.Ints;
+
+public class RefObj extends BaseObj<Ref> {
+  static final String TYPE = "type";
+  static final String NAME = "name";
+  static final String METADATA = "metadata";
+  static final String COMMITS = "commits";
+  static final String COMMIT = "commit";
+  static final String CHILDREN = "children";
+  static final String TREE = "tree";
+  static final String PARENT = "parent";
+  static final String DELTAS = "deltas";
+  static final String KEYS = "keys";
+
+  private String name;
+  // tag
+  private final Id commit;
+  // branch
+  private final Id metadata;
+  private final List<Id> children;
+  private final List<Commit> commits;
+
+  RefObj(Id id, long dt, String name, Id commit, Id metadata, List<Id> children, List<Commit> commits) {
+    super(id, dt);
+    this.name = name;
+    this.commit = commit;
+    this.metadata = metadata;
+    this.children = children;
+    this.commits = commits;
+  }
+
+  @Override
+  Ref consume(Ref consumer) {
+    super.consume(consumer)
+        .name(name);
+    if (commit != null) {
+      consumer.tag().commit(commit);
+    } else {
+      consumer.branch().metadata(metadata)
+          .children(children.stream())
+          .commits(bc -> commits.forEach(c -> c.consume(bc)));
+    }
+    return consumer;
+  }
+
+  @Override
+  BaseObj<Ref> copy() {
+    return new RefObj(getId(), getDt(), name, commit, metadata,
+        children != null ? new ArrayList<>(children) : null,
+        commits != null ? commits.stream().map(Commit::copy).collect(Collectors.toList()) : null);
+  }
+
+  @Override
+  void applyRemove(RemoveClause removeClause, Consumer<DeferredRemove> deferredRemoveConsumer) {
+    NameSegment root = removeClause.getPath().getRoot();
+    switch (root.getName()) {
+      case COMMITS:
+        PathSegment position = root.getChild().orElseThrow(() -> new IllegalStateException("Position required"));
+        int pos = position.asPosition().getPosition();
+        if (position.getChild().isPresent()) {
+          commits.get(pos).applyRemove(position.getChild().get().asName().getName());
+        } else {
+          deferredRemoveConsumer.accept(new DeferredRemove(pos, commits::remove));
+        }
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
+  void applySet(SetClause setClause) {
+    NameSegment root = setClause.getPath().getRoot();
+    switch (root.getName()) {
+      case NAME:
+        switch (setClause.getValue().getType()) {
+          case VALUE:
+            this.name = setClause.getValue().getValue().getString();
+            break;
+          case FUNCTION:
+          case PATH:
+          default:
+            throw new UnsupportedOperationException();
+        }
+        break;
+      case TREE:
+        switch (setClause.getValue().getType()) {
+          case VALUE:
+            int position = root.getChild().orElseThrow(() -> new IllegalStateException("Position required")).asPosition().getPosition();
+            children.set(position, Id.fromEntity(setClause.getValue().getValue()));
+            break;
+          case FUNCTION:
+          case PATH:
+          default:
+            throw new UnsupportedOperationException();
+        }
+        break;
+      case COMMITS:
+        switch (setClause.getValue().getType()) {
+          case FUNCTION:
+            ExpressionFunction expressionFunction = (ExpressionFunction) setClause.getValue();
+            switch (expressionFunction.getName()) {
+              case LIST_APPEND:
+                List<Entity> valueList = expressionFunction.getArguments().get(1).getValue().getList();
+                valueList.stream().map(Commit::fromEntity).forEach(commits::add);
+                break;
+              case EQUALS:
+              case SIZE:
+              case ATTRIBUTE_NOT_EXISTS:
+              default:
+                throw new UnsupportedOperationException();
+            }
+            break;
+          case VALUE:
+            PathSegment position = root.getChild().orElseThrow(() -> new IllegalStateException("Position required"));
+            String valueName = position.getChild().orElseThrow(() -> new IllegalStateException("Name required")).asName().getName();
+            commits.get(position.asPosition().getPosition()).setValue(valueName, setClause.getValue().getValue());
+            break;
+          case PATH:
+          default:
+            throw new UnsupportedOperationException();
+        }
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
+  public void evaluate(Function function) throws ConditionFailedException {
+    final String segment = function.getRootPathAsNameSegment().getName();
+
+    switch (segment) {
+      case ID:
+        evaluatesId(function);
+        break;
+      case TYPE:
+        String typeFromFunction;
+        if (function.getValue().getString().equals("b")) {
+          typeFromFunction = "b";
+        } else if (function.getValue().getString().equals("t")) {
+          typeFromFunction = "t";
+        } else {
+          throw new IllegalArgumentException(String.format("Unknown type name [%s].", function.getValue().getString()));
+        }
+
+        String type = commit != null ? "t" : "b";
+
+        if (!function.isRootNameSegmentChildlessAndEquals() || !type.equals(typeFromFunction)) {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        break;
+      case NAME:
+        if (!function.isRootNameSegmentChildlessAndEquals()
+            || !name.equals(function.getValue().getString())) {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        break;
+      case TREE:
+      case CHILDREN:
+        if (commit != null) {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        if (!evaluate(function, children)) {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        break;
+      case METADATA:
+        if (!function.isRootNameSegmentChildlessAndEquals()
+            || commit != null
+            || !metadata.toEntity().equals(function.getValue())) {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        break;
+      case COMMIT:
+        evaluateTagCommit(function);
+        break;
+      case COMMITS:
+        evaluateBranchCommits(function);
+        break;
+      default:
+        throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+    }
+  }
+
+  /**
+   * Evaluates that this branch meets the condition.
+   *
+   * @param function the function that is tested against the nameSegment
+   * @throws ConditionFailedException thrown if the condition expression is invalid or the condition is not met.
+   */
+  private void evaluateBranchCommits(Function function) {
+    switch (function.getOperator()) {
+      case EQUALS:
+        if (function.getRootPathAsNameSegment().getChild().isPresent()
+            || commit != null) {
+          PathSegment position = function.getRootPathAsNameSegment().getChild().get();
+          Commit c = commits.get(position.asPosition().getPosition());
+          PathSegment name = position.getChild().orElseThrow(() -> new IllegalStateException("Name required"));
+          if (!c.evaluate(name.asName().getName(), function.getValue())) {
+            throw new ConditionFailedException(conditionNotMatchedMessage(function));
+          }
+        } else {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        break;
+      case SIZE:
+        if (function.getRootPathAsNameSegment().getChild().isPresent()
+            || commit != null
+            || commits.size() != function.getValue().getNumber()) {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        break;
+      default:
+        throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+    }
+  }
+
+  /**
+   * Evaluates that this tag meets the condition.
+   *
+   * @param function the function that is tested against the nameSegment
+   * @throws ConditionFailedException thrown if the condition expression is invalid or the condition is not met.
+   */
+  private void evaluateTagCommit(Function function) {
+    if (!function.getOperator().equals(Function.Operator.EQUALS)
+        || commit == null
+        || !commit.toEntity().equals(function.getValue())) {
+      throw new ConditionFailedException(conditionNotMatchedMessage(function));
+    }
+  }
+
+  static class RefProducer extends BaseObjProducer<Ref> implements Ref {
+
+    private String name;
+    private Id commit;
+    private Id metadata;
+    private List<Id> children;
+    private final List<Commit> commits = new ArrayList<>();
+
+    @Override
+    public Ref name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    @Override
+    public Tag tag() {
+      return new Tag() {
+        @Override
+        public Tag commit(Id commit) {
+          RefProducer.this.commit = commit;
+          return this;
+        }
+
+        @Override
+        public Ref backToRef() {
+          return RefProducer.this;
+        }
+      };
+    }
+
+    @Override
+    public Branch branch() {
+      return new Branch() {
+        @Override
+        public Branch metadata(Id metadata) {
+          RefProducer.this.metadata = metadata;
+          return this;
+        }
+
+        @Override
+        public Branch children(Stream<Id> children) {
+          RefProducer.this.children = children.collect(Collectors.toList());
+          return this;
+        }
+
+        @Override
+        public Branch commits(Consumer<BranchCommit> commits) {
+          commits.accept(new BranchCommitObj());
+          return this;
+        }
+
+        @Override
+        public Ref backToRef() {
+          return RefProducer.this;
+        }
+      };
+    }
+
+    private final class BranchCommitObj implements BranchCommit {
+      private Id id;
+      private Id commit;
+
+      @Override
+      public BranchCommit id(Id id) {
+        this.id = id;
+        return this;
+      }
+
+      @Override
+      public BranchCommit commit(Id commit) {
+        this.commit = commit;
+        return this;
+      }
+
+      @Override
+      public SavedCommit saved() {
+        return new SavedCommit() {
+          private Id parent;
+
+          @Override
+          public SavedCommit parent(Id parent) {
+            this.parent = parent;
+            return this;
+          }
+
+          @Override
+          public BranchCommit done() {
+            commits.add(new Commit(id, commit, parent));
+            return BranchCommitObj.this;
+          }
+        };
+      }
+
+      @Override
+      public UnsavedCommitDelta unsaved() {
+        return new UnsavedCommitDelta() {
+          private final List<UnsavedDelta> deltas = new ArrayList<>();
+
+          @Override
+          public UnsavedCommitDelta delta(int position, Id oldId, Id newId) {
+            this.deltas.add(new UnsavedDelta(position, oldId, newId));
+            return this;
+          }
+
+          @Override
+          public UnsavedCommitMutations mutations() {
+            return new UnsavedCommitMutations() {
+              private final List<Mutation> keyMutations = new ArrayList<>();
+
+              @Override
+              public UnsavedCommitMutations keyMutation(Mutation keyMutation) {
+                this.keyMutations.add(keyMutation);
+                return this;
+              }
+
+              @Override
+              public BranchCommit done() {
+                commits.add(new Commit(id, commit, deltas, keyMutations));
+                return BranchCommitObj.this;
+              }
+            };
+          }
+        };
+      }
+    }
+
+    @Override
+    BaseObj<Ref> build() {
+      return new RefObj(getId(), getDt(), name, commit, metadata, children, commits);
+    }
+  }
+
+  private static final class Commit {
+    private Id id;
+    private Id commit;
+
+    private Id parent;
+
+    private final List<UnsavedDelta> deltas;
+    private final List<Mutation> keyMutations;
+
+    private Commit(Id id, Id commit, Id parent, List<UnsavedDelta> deltas, List<Mutation> keyMutations) {
+      this.id = id;
+      this.commit = commit;
+
+      this.parent = parent;
+
+      this.deltas = deltas;
+      this.keyMutations = keyMutations;
+    }
+
+    Commit(Id id, Id commit, Id parent) {
+      this(id, commit, parent, new ArrayList<>(), new ArrayList<>());
+    }
+
+    Commit(Id id, Id commit, List<UnsavedDelta> deltas, List<Mutation> keyMutations) {
+      this(id, commit, null, deltas, keyMutations);
+    }
+
+    Id getId() {
+      return id;
+    }
+
+    Id getCommit() {
+      return commit;
+    }
+
+    void consume(BranchCommit bc) {
+      bc.id(id).commit(commit);
+
+      if (parent != null) {
+        // saved
+        bc.saved().parent(parent).done();
+      } else {
+        // unsaved
+        UnsavedCommitDelta unsaved = bc.unsaved();
+        deltas.forEach(d -> unsaved.delta(d.getPosition(), d.getOldId(), d.getNewId()));
+        UnsavedCommitMutations mutations = unsaved.mutations();
+        keyMutations.forEach(mutations::keyMutation);
+        mutations.done();
+      }
+    }
+
+    Commit copy() {
+      return new Commit(getId(), getCommit(), parent, new ArrayList<>(deltas), new ArrayList<>(keyMutations));
+    }
+
+    static Commit fromEntity(Entity entity) {
+      Map<String, Entity> map = entity.getMap();
+      if (map.containsKey(PARENT)) {
+        return new Commit(
+            Id.fromEntity(map.get(ID)),
+            Id.fromEntity(map.get(COMMIT)),
+            Id.fromEntity(map.get(PARENT)));
+      } else {
+        return new Commit(
+            Id.fromEntity(map.get(ID)),
+            Id.fromEntity(map.get(COMMIT)),
+            map.get(DELTAS).getList().stream().map(UnsavedDelta::fromEntity).collect(Collectors.toList()),
+            map.get(KEYS).getList().stream().map(Commit::keyMutationFromEntity).collect(Collectors.toList())
+        );
+      }
+    }
+
+    private static Mutation keyMutationFromEntity(Entity entity) {
+      Map<String, Entity> map = entity.getMap();
+      if (map.containsKey("a")) {
+        List<Entity> list = map.get("a").getList();
+        String payloadString = list.get(0).getString();
+        Byte payload = payloadString != null && payloadString.length() > 0 && payloadString.charAt(0) != 0
+            ? Byte.parseByte(payloadString) : null;
+        return Mutation.Addition.of(keyFromList(list), payload);
+      }
+      if (map.containsKey("d")) {
+        List<Entity> list = map.get("d").getList();
+        return Mutation.Removal.of(keyFromList(list));
+      }
+      throw new UnsupportedOperationException();
+    }
+
+    private static Key keyFromList(List<Entity> list) {
+      return Key.of(list.stream().skip(1).map(Entity::getString).toArray(String[]::new));
+    }
+
+    boolean evaluate(String name, Entity value) {
+      switch (name) {
+        case ID:
+          return Id.fromEntity(value).equals(id);
+        case COMMIT:
+          return Id.fromEntity(value).equals(commit);
+        case PARENT:
+          return Id.fromEntity(value).equals(parent);
+        default:
+          return false;
+      }
+    }
+
+    void setValue(String name, Entity value) {
+      switch (name) {
+        case ID:
+          this.id = Id.fromEntity(value);
+          break;
+        case COMMIT:
+          this.commit = Id.fromEntity(value);
+          break;
+        case PARENT:
+          this.parent = Id.fromEntity(value);
+          break;
+        default:
+          throw new UnsupportedOperationException();
+      }
+    }
+
+    public void applyRemove(String name) {
+      switch (name) {
+        case DELTAS:
+          deltas.clear();
+          break;
+        case KEYS:
+          keyMutations.clear();
+          break;
+        case PARENT:
+          parent = null;
+          break;
+        default:
+          throw new UnsupportedOperationException();
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Commit commit1 = (Commit) o;
+
+      return Objects.equals(id, commit1.id)
+          && Objects.equals(commit, commit1.commit)
+          && Objects.equals(parent, commit1.parent)
+          && Objects.equals(deltas, commit1.deltas)
+          && Objects.equals(keyMutations, commit1.keyMutations);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = id != null ? id.hashCode() : 0;
+      result = 31 * result + (commit != null ? commit.hashCode() : 0);
+      result = 31 * result + (parent != null ? parent.hashCode() : 0);
+      result = 31 * result + (deltas != null ? deltas.hashCode() : 0);
+      result = 31 * result + (keyMutations != null ? keyMutations.hashCode() : 0);
+      return result;
+    }
+  }
+
+  private static final class UnsavedDelta {
+    private static final String POSITION = "position";
+    private static final String OLD = "old";
+    private static final String NEW = "new";
+
+    private final int position;
+    private final Id oldId;
+    private final Id newId;
+
+    UnsavedDelta(int position, Id oldId, Id newId) {
+      this.position = position;
+      this.oldId = oldId;
+      this.newId = newId;
+    }
+
+    int getPosition() {
+      return position;
+    }
+
+    Id getOldId() {
+      return oldId;
+    }
+
+    Id getNewId() {
+      return newId;
+    }
+
+    static UnsavedDelta fromEntity(Entity entity) {
+      Map<String, Entity> map = entity.getMap();
+      return new UnsavedDelta(Ints.saturatedCast(map.get(POSITION).getNumber()),
+        Id.fromEntity(map.get(OLD)),
+        Id.fromEntity(map.get(NEW)));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      UnsavedDelta that = (UnsavedDelta) o;
+      return position == that.position && Objects.equals(oldId, that.oldId)
+          && Objects.equals(newId, that.newId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(position, oldId, newId);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    RefObj refObj = (RefObj) o;
+
+    return Objects.equals(name, refObj.name)
+        && Objects.equals(commit, refObj.commit)
+        && Objects.equals(metadata, refObj.metadata)
+        && Objects.equals(children, refObj.children)
+        && Objects.equals(commits, refObj.commits);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (commit != null ? commit.hashCode() : 0);
+    result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+    result = 31 * result + (children != null ? children.hashCode() : 0);
+    result = 31 * result + (commits != null ? commits.hashCode() : 0);
+    return result;
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/ValueObj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/ValueObj.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.tiered.Value;
+
+import com.google.protobuf.ByteString;
+
+final class ValueObj extends WrappedValueObj<Value> {
+
+  ValueObj(Id id, long dt, ByteString value) {
+    super(id, dt, value);
+  }
+
+  @Override
+  BaseObj<Value> copy() {
+    return new ValueObj(getId(), getDt(), getValue());
+  }
+
+  static class ValueProducer extends BaseWrappedValueObjProducer<Value> implements Value {
+
+    @Override
+    BaseObj<Value> build() {
+      return new ValueObj(getId(), getDt(), getValue());
+    }
+  }
+}

--- a/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/WrappedValueObj.java
+++ b/versioned/tiered/inmem/src/main/java/org/projectnessie/versioned/inmem/WrappedValueObj.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.projectnessie.versioned.inmem;
+
+import org.projectnessie.versioned.store.ConditionFailedException;
+import org.projectnessie.versioned.store.Id;
+import org.projectnessie.versioned.tiered.BaseWrappedValue;
+
+import com.google.protobuf.ByteString;
+
+abstract class WrappedValueObj<C extends BaseWrappedValue<C>> extends BaseObj<C> {
+  static final String VALUE = "value";
+  private final ByteString value;
+
+  WrappedValueObj(Id id, long dt, ByteString value) {
+    super(id, dt);
+    this.value = value;
+  }
+
+  ByteString getValue() {
+    return value;
+  }
+
+  @Override
+  C consume(C consumer) {
+    return super.consume(consumer).value(value);
+  }
+
+  abstract static class BaseWrappedValueObjProducer<C extends BaseWrappedValue<C>>
+      extends BaseObjProducer<C> implements BaseWrappedValue<C> {
+
+    private ByteString value;
+
+    ByteString getValue() {
+      return value;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public C value(ByteString value) {
+      this.value = value;
+      return (C) this;
+    }
+  }
+
+  @Override
+  public void evaluate(Function function) throws ConditionFailedException {
+    final String segment = function.getRootPathAsNameSegment().getName();
+    switch (segment) {
+      case ID:
+        evaluatesId(function);
+        break;
+      case VALUE:
+        if (!function.isRootNameSegmentChildlessAndEquals()
+            || !value.equals(function.getValue().getBinary())) {
+          throw new ConditionFailedException(conditionNotMatchedMessage(function));
+        }
+        break;
+      default:
+        // Invalid Condition Function.
+        throw new ConditionFailedException(invalidOperatorSegmentMessage(function));
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    WrappedValueObj<?> that = (WrappedValueObj<?>) o;
+
+    return value.equals(that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + value.hashCode();
+    return result;
+  }
+}

--- a/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/ITInMemTestStore.java
+++ b/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/ITInMemTestStore.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import org.junit.jupiter.api.AfterEach;
+import org.projectnessie.versioned.impl.AbstractTestStore;
+
+/**
+ * A test class that contains DynamoDB tests.
+ */
+class ITInMemTestStore extends AbstractTestStore<InMemStore> {
+  private InMemStoreFixture fixture;
+
+  @AfterEach
+  void deleteResources() {
+    fixture.close();
+  }
+
+  /**
+   * Creates an instance of MongoDBStore on which tests are executed.
+   * @return the store to test.
+   */
+  @Override
+  protected InMemStore createStore() {
+    fixture = new InMemStoreFixture();
+    return fixture.getStore();
+  }
+
+  @Override
+  protected InMemStore createRawStore() {
+    return fixture.createStoreImpl();
+  }
+
+  @Override
+  protected long getRandomSeed() {
+    return 8612341233543L;
+  }
+
+  @Override
+  protected void resetStoreState() {
+    super.store = null;
+  }
+
+  @Override
+  protected int loadSize() {
+    return 100;
+  }
+}

--- a/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/ITInMemTieredVersionStore.java
+++ b/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/ITInMemTieredVersionStore.java
@@ -13,22 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.server.config;
+package org.projectnessie.versioned.inmem;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.projectnessie.versioned.dynamodb.DynamoStoreConfig;
+import org.projectnessie.versioned.impl.AbstractITTieredVersionStore;
 
-import io.quarkus.arc.config.ConfigProperties;
-
-/**
- * DynamoDB version store configuration.
- */
-@ConfigProperties(prefix = "nessie.version.store.dynamo")
-public interface DynamoVersionStoreConfig extends TieredVersionStoreConfig {
-
-  @ConfigProperty(name = "initialize", defaultValue = "false")
-  boolean isDynamoInitialize();
-
-  @ConfigProperty(defaultValue = DynamoStoreConfig.TABLE_PREFIX)
-  String getTablePrefix();
+class ITInMemTieredVersionStore extends AbstractITTieredVersionStore {
+  @Override
+  protected InMemStoreFixture createNewFixture() {
+    return new InMemStoreFixture();
+  }
 }

--- a/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/ITInMemVersionStore.java
+++ b/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/ITInMemVersionStore.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.projectnessie.versioned.ReferenceAlreadyExistsException;
+import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.VersionStoreException;
+import org.projectnessie.versioned.tests.AbstractITVersionStore;
+
+public class ITInMemVersionStore extends AbstractITVersionStore {
+
+  private InMemStoreFixture fixture;
+
+  @BeforeEach
+  void setup() {
+    fixture = new InMemStoreFixture();
+  }
+
+  @AfterEach
+  void deleteResources() {
+    fixture.close();
+  }
+
+  @Override
+  protected VersionStore<String, String, StringSerializer.TestEnum> store() {
+    return fixture;
+  }
+
+  @Disabled
+  @Override
+  public void commitWithInvalidReference() throws ReferenceNotFoundException,
+      ReferenceConflictException, ReferenceAlreadyExistsException {
+    super.commitWithInvalidReference();
+  }
+
+  @Nested
+  @DisplayName("when transplanting")
+  class WhenTransplanting extends AbstractITVersionStore.WhenTransplanting {
+    @Disabled
+    @Override
+    protected void checkInvalidBranchHash() throws VersionStoreException {
+      super.checkInvalidBranchHash();
+    }
+  }
+}

--- a/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/InMemStoreFixture.java
+++ b/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/InMemStoreFixture.java
@@ -13,22 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.server.config;
+package org.projectnessie.versioned.inmem;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.projectnessie.versioned.dynamodb.DynamoStoreConfig;
-
-import io.quarkus.arc.config.ConfigProperties;
+import org.projectnessie.versioned.impl.AbstractTieredStoreFixture;
 
 /**
- * DynamoDB version store configuration.
+ * DynamoDB Store fixture.
+ *
+ * <p>Combine a local dynamodb server with a {@code VersionStore} instance to be used for tests.
  */
-@ConfigProperties(prefix = "nessie.version.store.dynamo")
-public interface DynamoVersionStoreConfig extends TieredVersionStoreConfig {
+public class InMemStoreFixture extends AbstractTieredStoreFixture<InMemStore, String> {
+  public InMemStoreFixture() {
+    super("");
+  }
 
-  @ConfigProperty(name = "initialize", defaultValue = "false")
-  boolean isDynamoInitialize();
+  @Override
+  public InMemStore createStoreImpl() {
+    return new InMemStore();
+  }
 
-  @ConfigProperty(defaultValue = DynamoStoreConfig.TABLE_PREFIX)
-  String getTablePrefix();
+  @Override
+  public void close() {
+    getStore().close();
+  }
 }

--- a/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/TestInMemObject.java
+++ b/versioned/tiered/inmem/src/test/java/org/projectnessie/versioned/inmem/TestInMemObject.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.inmem;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.versioned.impl.SampleEntities;
+import org.projectnessie.versioned.inmem.BaseObj.BaseObjProducer;
+import org.projectnessie.versioned.store.ValueType;
+import org.projectnessie.versioned.tiered.BaseValue;
+
+public class TestInMemObject {
+
+  private final InMemStore store = new InMemStore();
+
+  private static Stream<ValueType<?>> allTypes() {
+    return ValueType.values().stream()
+        // repeat 20 times, cannot mix @ParameterizedTest + @RepeatedTest
+        .flatMap(t -> IntStream.range(0, 20).mapToObj(x -> t));
+  }
+
+  @ParameterizedTest
+  @MethodSource("allTypes")
+  void testEqualsAndHashCode(ValueType<?> type) {
+    Random r = new Random();
+
+    long seed = r.nextLong();
+    BaseObj<?> inst1 = createInstance(type, new Random(seed));
+    BaseObj<?> inst2 = createInstance(type, new Random(seed));
+
+    Assertions.assertEquals(inst1, inst2);
+    Assertions.assertEquals(inst1.hashCode(), inst2.hashCode());
+  }
+
+  @ParameterizedTest
+  @MethodSource("allTypes")
+  void testCopy(ValueType<?> type) {
+    Random r = new Random();
+
+    BaseObj<?> inst = createInstance(type, r);
+    BaseObj<?> copy = inst.copy();
+
+    Assertions.assertEquals(inst, copy);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <C extends BaseValue<C>, V extends BaseObj<C>> V createInstance(ValueType<C> type, Random r) {
+    BaseObjProducer<C> producer = store.newProducer(type);
+    SampleEntities.produceRandomTo(type, (C) producer, r);
+    return (V) producer.build();
+  }
+}

--- a/versioned/tiered/inmem/src/test/resources/logback-test.xml
+++ b/versioned/tiered/inmem/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration debug="true">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root>
+    <level value="warn"/>
+    <appender-ref ref="console"/>
+  </root>
+</configuration>

--- a/versioned/tiered/pom.xml
+++ b/versioned/tiered/pom.xml
@@ -31,6 +31,7 @@
   <name>Nessie - Versioned - Tiered - Parent</name>
 
   <modules>
+    <module>inmem</module>
     <module>dynamodb</module>
     <module>gc</module>
     <module>mongodb</module>

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/SampleEntities.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/SampleEntities.java
@@ -24,6 +24,8 @@ import org.projectnessie.versioned.WithPayload;
 import org.projectnessie.versioned.store.Entity;
 import org.projectnessie.versioned.store.Id;
 import org.projectnessie.versioned.store.KeyDelta;
+import org.projectnessie.versioned.store.ValueType;
+import org.projectnessie.versioned.tiered.BaseValue;
 import org.projectnessie.versioned.tiered.Mutation;
 
 import com.google.protobuf.ByteString;
@@ -37,6 +39,36 @@ import com.google.protobuf.ByteString;
  */
 public class SampleEntities {
   private static final Byte DEFAULT_PAYLOAD = (byte) 0;
+
+  public static <C extends BaseValue<C>> void produceRandomTo(ValueType<C> type, C consumer, Random r) {
+    PersistentBase<C> internalRandom = createRandom(type, r);
+    internalRandom.applyToConsumer(consumer);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <C extends BaseValue<C>> PersistentBase<C> createRandom(ValueType<C> type, Random r) {
+    if (type == ValueType.L1) {
+      return (PersistentBase<C>) createL1(r);
+    } else if (type == ValueType.L2) {
+      return (PersistentBase<C>) createL2(r);
+    } else if (type == ValueType.L3) {
+      return (PersistentBase<C>) createL3(r);
+    } else if (type == ValueType.VALUE) {
+      return (PersistentBase<C>) createValue(r);
+    } else if (type == ValueType.COMMIT_METADATA) {
+      return (PersistentBase<C>) createCommitMetadata(r);
+    } else if (type == ValueType.KEY_FRAGMENT) {
+      return (PersistentBase<C>) createFragment(r);
+    } else if (type == ValueType.REF) {
+      if (r.nextBoolean()) {
+        return (PersistentBase<C>) createBranch(r);
+      } else {
+        return (PersistentBase<C>) createTag(r);
+      }
+    } else {
+      throw new IllegalArgumentException("Unknown type " + type);
+    }
+  }
 
   /**
    * Create a Sample L1 entity.


### PR DESCRIPTION
Adds a CHM base in-memory `Store` implementation for local testing and perf-testing.

Changes that abstract the factory and config (`TieredVersionStoreFactory` + `TieredVersionStoreConfig`) are precursors for a follow-up PR that adds more information to Jaeger tracing around the version-store and store (those changes look pretty useless at the moment though).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/939)
<!-- Reviewable:end -->
