### PR TITLE
Fix for Quarkus deprecated native-image goal

### DIFF
--- a/servers/lambda/pom.xml
+++ b/servers/lambda/pom.xml
@@ -89,11 +89,10 @@
             <executions>
               <execution>
                 <goals>
-                  <goal>native-image</goal>
+                  <goal>generate-code</goal>
+                  <goal>generate-code-tests</goal>
+                  <goal>build</goal>
                 </goals>
-                <configuration>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Quarkus currently emits a
```
[WARNING] The quarkus:native-image goal is deprecated, and will be removed in a future version. To build a native executable set the config property quarkus.package.type=native. For more info see https://quarkus.io/guides/building-native-image
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/943)
<!-- Reviewable:end -->
