### PR TITLE
Updating access to classes of the in-memory VersionStore.

### DIFF
--- a/versioned/memory/src/main/java/org/projectnessie/versioned/memory/Commit.java
+++ b/versioned/memory/src/main/java/org/projectnessie/versioned/memory/Commit.java
@@ -43,7 +43,7 @@ import com.google.protobuf.UnsafeByteOperations;
  * @param <ValueT> commit value
  * @param <MetadataT> commit metadata
  */
-class Commit<ValueT, MetadataT> {
+public class Commit<ValueT, MetadataT> {
   private static final HashFunction COMMIT_HASH_FUNCTION = Hashing.sha256();
 
   public static final Hash NO_ANCESTOR = Hash.of(
@@ -54,6 +54,9 @@ class Commit<ValueT, MetadataT> {
   private final MetadataT metadata;
   private final List<Operation<ValueT>> operations;
 
+  /**
+   * Creates a commit object with a given hash.
+   */
   public Commit(Hash hash, Hash ancestor, MetadataT metadata, List<Operation<ValueT>> operations) {
     this.hash = requireNonNull(hash);
     this.ancestor = requireNonNull(ancestor);
@@ -61,6 +64,10 @@ class Commit<ValueT, MetadataT> {
     this.operations = ImmutableList.copyOf(requireNonNull(operations));
   }
 
+  /**
+   * Creates a commit object.
+   * @return a commit object
+   */
   public static <ValueT, MetadataT> Commit<ValueT, MetadataT> of(final Serializer<ValueT> valueSerializer,
       final Serializer<MetadataT> metadataSerializer, Hash ancestor, MetadataT metadata,
       List<Operation<ValueT>> operations) {

--- a/versioned/memory/src/main/java/org/projectnessie/versioned/memory/CommitsIterator.java
+++ b/versioned/memory/src/main/java/org/projectnessie/versioned/memory/CommitsIterator.java
@@ -22,7 +22,13 @@ import java.util.function.Function;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.WithHash;
 
-final class CommitsIterator<ValueT, MetadataT> implements Iterator<WithHash<Commit<ValueT, MetadataT>>> {
+/**
+ * Iterator for the Commit class.
+ *
+ * @param <ValueT> commit value
+ * @param <MetadataT> commit metadata
+ */
+public final class CommitsIterator<ValueT, MetadataT> implements Iterator<WithHash<Commit<ValueT, MetadataT>>> {
   private final Function<Hash, Commit<ValueT, MetadataT>> commitAccessor;
 
   private WithHash<Commit<ValueT, MetadataT>> current;


### PR DESCRIPTION
This PR updates the classes Commit and CommitIterator to be publicly accessible, instead of only accessible from within the package, as it is now.

The reason for the change is to facilitate writing VersionStore implementations that follow the same logic using different storage structures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/961)
<!-- Reviewable:end -->
