### PR TITLE
Enable Quarkus Jacoco extension

### DIFF
--- a/servers/lambda/pom.xml
+++ b/servers/lambda/pom.xml
@@ -73,6 +73,11 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>netty-nio-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -180,6 +180,11 @@
       <artifactId>quarkus-test-security</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Enable Quarkus Jacoco extension introduced in Quarkus 1.13.0. The
extension is designed to allow Jacoco to instrument code first before
code is enhanced by Quarkus own classloader, which should hopefully
improve the code coverage accuracy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/994)
<!-- Reviewable:end -->
