### PR TITLE
Fix handling of server-side IllegalArgumentException

### DIFF
--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -68,6 +68,7 @@ import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Contents;
 import org.projectnessie.model.ContentsKey;
 import org.projectnessie.model.EntriesResponse;
+import org.projectnessie.model.Hash;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableMerge;
 import org.projectnessie.model.ImmutableOperations;
@@ -112,6 +113,13 @@ class TestRest {
   @AfterEach
   void closeClient() {
     client.close();
+  }
+
+  @Test
+  void illegalArgumentException() {
+    assertThat(
+        assertThrows(NessieBadRequestException.class, () -> tree.createReference(Hash.of("12341234cafebeef"))).getMessage(),
+        startsWith("Bad Request (HTTP/400): Only tag and branch references can be created"));
   }
 
   @ParameterizedTest

--- a/servers/services/src/main/java/org/projectnessie/services/rest/NessieExceptionMapper.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/NessieExceptionMapper.java
@@ -71,7 +71,8 @@ public class NessieExceptionMapper
       status = e.getStatus();
       reason = e.getReason();
     } else if (exception instanceof JsonParseException
-        || exception instanceof JsonMappingException) {
+        || exception instanceof JsonMappingException
+        || exception instanceof IllegalArgumentException) {
       status = Status.BAD_REQUEST.getStatusCode();
       reason = Status.BAD_REQUEST.getReasonPhrase();
     } else {


### PR DESCRIPTION
When the server (`VersionStore`) throws an `IllegalArgumentException` indicating a parameter error, so a user-mistake, it is returned as an HTTP/500 (server-error).

This PR maps `IllegalArgumentException` to HTTP/400.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1003)
<!-- Reviewable:end -->
