### PR TITLE
Backwards compatible payload parsing in Dynamo.

### DIFF
--- a/versioned/tiered/dynamodb/src/main/java/org/projectnessie/versioned/dynamodb/AttributeValueUtil.java
+++ b/versioned/tiered/dynamodb/src/main/java/org/projectnessie/versioned/dynamodb/AttributeValueUtil.java
@@ -251,10 +251,15 @@ public final class AttributeValueUtil {
     ImmutableKey.Builder keyBuilder = ImmutableKey.builder();
     String payloadString = raw.l().get(0).s();
     Byte payload = null;
-    if (payloadString.charAt(0) != ZERO_BYTE) {
-      payload = Byte.parseByte(payloadString);
+    int skip = 0;
+    try {
+      payload = (payloadString.charAt(0) == ZERO_BYTE) ? null : Byte.parseByte(payloadString);
+      skip = 1;
+    } catch (NumberFormatException e) {
+      // assume old client first element is actually first element of key
+      // todo remove once format is stable
     }
-    raw.l().stream().skip(1).forEach(keyPart -> keyBuilder.addElements(keyPart.s()));
+    raw.l().stream().skip(skip).forEach(keyPart -> keyBuilder.addElements(keyPart.s()));
     return WithPayload.of(payload, keyBuilder.build());
   }
 


### PR DESCRIPTION
If payload doesn't exist then ignore and assume key is the whole key and not a byte prefixed key.

This fix is slightly annoying but not harmful. This happens mostly in testing of GC packages because of version mismatches between the iceberg version of Nessie and the version of nessie on HEAD. As the format stabilises and the iceberg version of Nessie catches up we should be able to remove this shim.

The goal of the fix is:
1) if the first element of the key is `\u0000` then the payload byte is present but the payload is null
2) if the first element of the key is not `\u0000` and parseable as a Byte then its a payload
3) otherwise the first element of the key isn't a payload and is the first part of the key

Case 1 or 2 should skip the first element when building the key and 3 should use the first element to build the key


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1029)
<!-- Reviewable:end -->
