### PR TITLE
Support lazy start of Nessie-Quarkus-App via Gradle plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,12 +46,11 @@ node_modules/
 .project
 .settings
 .checkstyle
-.gradle
-build
+out/
 
 # gradle
-gradle/
-out
+.gradle/
+build/
 gradle/wrapper/gradle-wrapper.jar
 version.txt
 

--- a/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusApp.java
+++ b/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusApp.java
@@ -68,7 +68,7 @@ public class QuarkusApp extends org.projectnessie.quarkus.maven.QuarkusApp {
 
   public static AutoCloseable newApplication(Configuration configuration, Project project, Properties props) {
 
-    Configuration deploy = project.getConfigurations().create("quarkusAppDeploy");
+    Configuration deploy = project.getConfigurations().create("nessieQuarkusDeploy");
     final AppModel appModel;
 
     appModel = convert(configuration, deploy, props);
@@ -197,9 +197,8 @@ public class QuarkusApp extends org.projectnessie.quarkus.maven.QuarkusApp {
   }
 
   private static AppArtifact toDependency(Dependency dependency) {
-    AppArtifact artifact = new AppArtifact(dependency.getGroup(), dependency.getName(), null,
+    return new AppArtifact(dependency.getGroup(), dependency.getName(), null,
       "jar", dependency.getVersion());
-    return artifact;
   }
 
   private static AppDependency toDependency(ResolvedArtifact dependency) {

--- a/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
+++ b/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
@@ -15,16 +15,41 @@
  */
 package org.projectnessie.quarkus.gradle;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.gradle.api.Project;
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
 
+@SuppressWarnings("UnstableApiUsage") // omit warning about `Property`+`MapProperty`
 public class QuarkusAppExtension {
   private final MapProperty<String, Object> props;
-  public QuarkusAppExtension(Project project) {
-    props = project.getObjects().mapProperty(String.class, Object.class);
+  private final Property<String> nativeBuilderImage;
+
+  private static Map<String, Object> defaultProps() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("quarkus.http.test-port", 0);
+    return map;
   }
 
-  public MapProperty<String, Object> getProps() {
+  public QuarkusAppExtension(Project project) {
+    props = project.getObjects().mapProperty(String.class, Object.class).convention(defaultProps());
+
+    // This is not doing anything with Docker or building a native image, just a quirk of Quarkus since 1.10.
+    nativeBuilderImage = project.getObjects().property(String.class).convention("quay.io/quarkus/ubi-quarkus-native-image:21.0.0-java11");
+  }
+
+  public MapProperty<String, Object> getPropsProperty() {
     return props;
+  }
+
+  public Property<String> getNativeBuilderImageProperty() {
+    return nativeBuilderImage;
+  }
+
+  @SuppressWarnings("unused") // convenience method
+  public void setNativeBuilderImage(String nativeBuilderImage) {
+    this.nativeBuilderImage.set(nativeBuilderImage);
   }
 }

--- a/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/StopTask.java
+++ b/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/StopTask.java
@@ -29,7 +29,8 @@ public class StopTask extends DefaultTask {
   public void stop() {
 
     if (application == null) {
-      getLogger().warn("No application found.");
+      getLogger().debug("No application found.");
+      return;
     }
 
     try {

--- a/tools/apprunner-gradle-plugin/src/main/resources/org/projectnessie/quarkus/gradle/log4j2-quarkus.xml
+++ b/tools/apprunner-gradle-plugin/src/main/resources/org/projectnessie/quarkus/gradle/log4j2-quarkus.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2020 Dremio
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="${env:NESSIE_QUARKUS_LOG_LEVEL:-info}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
Move most of the boilerplate code from the Iceberg (a Gradle project) test-build-script-code into the plugin.

Two relevant changes:

* The `quarkus.test.http-port` system property must not be in the Gradle `Test` tasks system property, because it's a rather random port, and system properties are part of the Gradle build-cache-key. This has been moved to a `CommandLineArgumentProvider` that's added to `Test.getJvmArgumentProviders()`.
* Gradle has no explicit support to "run a task only if another task would run". I.e. the `quarkus-start` task would always run, even if the `test` task is cached. The workaround here is to let the Nessie-Quarkus-App start via a `Test.doFirst()`-closure.

Minor changes:
* Cleanup user-side (Iceberg) Gradle build-script (will be done via a "bump Nessie to 0.5.0" Iceberg-PR)
* Add the relevant inputs for the Gradle build-cache to the `Test` task as well
* Change nomenclature to make clear that configs/tasks are not general Quarkus tasks, but Nessie-specific Quarkus tasks
* Add a log4j2 configuration to allow logging (no log4j2 config means no logging at all) + an env var to override the default log level of "warn"

WIP for the Bump-Nessie-to-0.5-in-Iceberg-PR is here: https://github.com/snazy/iceberg/tree/nessie-0.5 (it uses a locally mvn-install'd 0.4.1-SNAPSHOT)

The "nessie-quarkus" configuration in Iceberg's `build.gralde` *must* have a `nessieQuarkusRunner(enforcedPlatform("io.quarkus:quarkus-bom:1.13.0.Final"))` dependency, otherwise dependency hell will break lose --> latest 0.4.1-SNAPSHOT: all HTTP/POST requests have a completely empty response. HTTP/GET requests work fine - also the web-UI works fine. I suspect, that some dependency-version bump in latest Nessie conflicts with some libraries that come in via Iceberg or Gradle or whatever and causes this weird behavior. Netty had two conflicting versions (4.1.49 + 4.1.61), some javax-APIs and jackson deps in conflicting versions.

Fixes #1022

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1042)
<!-- Reviewable:end -->
