### PR TITLE
Strawman of View definition

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Dialect.java
+++ b/model/src/main/java/org/projectnessie/model/Dialect.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.projectnessie.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Abstract implementation of sql dialect within Nessie.
+ */
+@Schema(
+    type = SchemaType.OBJECT,
+    title = "Dialect",
+    oneOf = { DremioDialect.class, SparkDialect.class, HiveDialect.class, TrinoDialect.class },
+    discriminatorMapping = {
+        @DiscriminatorMapping(value = "DREMIO", schema = DremioDialect.class),
+        @DiscriminatorMapping(value = "SPARK", schema = SparkDialect.class),
+        @DiscriminatorMapping(value = "HIVE", schema = HiveDialect.class),
+        @DiscriminatorMapping(value = "TRINO", schema = TrinoDialect.class)
+    },
+    discriminatorProperty = "type"
+  )
+@JsonSubTypes({
+    @Type(DremioDialect.class),
+    @Type(SparkDialect.class),
+    @Type(HiveDialect.class),
+    @Type(TrinoDialect.class)
+})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+public interface Dialect {
+
+  public static enum DialectType {
+    HIVE,
+    SPARK,
+    DREMIO,
+    TRINO;
+  }
+
+  /**
+   * Unwrap object if possible, otherwise throw.
+   * @param <T> Type to wrap to.
+   * @param clazz Class we're trying to return.
+   * @return The return value
+   */
+  default <T> Optional<T> unwrap(Class<T> clazz) {
+    Objects.requireNonNull(clazz);
+    if (clazz.isAssignableFrom(getClass())) {
+      return Optional.of(clazz.cast(this));
+    }
+    return Optional.empty();
+  }
+
+}

--- a/model/src/main/java/org/projectnessie/model/DremioDialect.java
+++ b/model/src/main/java/org/projectnessie/model/DremioDialect.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.model;
 
-import javax.annotation.Nullable;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -24,21 +22,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableSqlView.class)
-@JsonDeserialize(as = ImmutableSqlView.class)
-@JsonTypeName("VIEW")
-public abstract class SqlView extends Contents {
+@JsonSerialize(as = ImmutableDremioDialect.class)
+@JsonDeserialize(as = ImmutableDremioDialect.class)
+@JsonTypeName("DREMIO")
+public interface DremioDialect extends Dialect {
 
-  public abstract String getSqlText();
-
-  @Nullable
-  public abstract String getResolvedSqlText();
-
-  @Nullable
-  public abstract String getSqlContext();
-
-  public abstract Dialect getDialect();
-
-  public abstract Schema getSchema();
+  public static Dialect of() {
+    return ImmutableDremioDialect.builder().build();
+  }
 
 }

--- a/model/src/main/java/org/projectnessie/model/Field.java
+++ b/model/src/main/java/org/projectnessie/model/Field.java
@@ -28,7 +28,54 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public interface Field {
 
   enum FieldType {
+    NULL,
+    BOOLEAN,
+    INT8,
+    UINT8,
+    INT16,
+    UINT16,
+    INT32,
+    UINT32,
+    INT64,
+    UINT64,
+    FLOAT16,
+    FLOAT32,
+    FLOAT64,
+    BINARY,
+    FIXED_BINARY,
+    LARGE_BINARY,
+    UTF8,
+    LARGE_UTF8,
+    DATE,
+    TIME,
+    TIMESTAMP,
+    DURATION,
+    INTERVAL,
+    DECIMAL,
+    LIST,
+    LARGE_LIST,
+    FIXED_LIST,
+    MAP,
+    STRUCT,
+    DENSE_UNION,
+    SPARSE_UNION
+  }
 
+  enum TimeUnit {
+    SECOND,
+    MILLISECOND,
+    MICROSECOND,
+    NANOSECOND
+  }
+
+  enum DateUnit {
+    DAY,
+    MILLISECOND
+  }
+
+  enum IntervalUnit {
+    YEAR_MONTH,
+    DAY_TIME
   }
 
   FieldType getType();

--- a/model/src/main/java/org/projectnessie/model/Field.java
+++ b/model/src/main/java/org/projectnessie/model/Field.java
@@ -15,30 +15,26 @@
  */
 package org.projectnessie.model;
 
-import javax.annotation.Nullable;
+import java.util.List;
 
 import org.immutables.value.Value;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableSqlView.class)
-@JsonDeserialize(as = ImmutableSqlView.class)
-@JsonTypeName("VIEW")
-public abstract class SqlView extends Contents {
+@JsonSerialize(as = ImmutableField.class)
+@JsonDeserialize(as = ImmutableField.class)
+public interface Field {
 
-  public abstract String getSqlText();
+  enum FieldType {
 
-  @Nullable
-  public abstract String getResolvedSqlText();
+  }
 
-  @Nullable
-  public abstract String getSqlContext();
+  FieldType getType();
 
-  public abstract Dialect getDialect();
+  String getName();
 
-  public abstract Schema getSchema();
+  List<Field> getChildren();
 
 }

--- a/model/src/main/java/org/projectnessie/model/Fields.java
+++ b/model/src/main/java/org/projectnessie/model/Fields.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public class Fields {
+
+  private static class PrimitiveField implements Field {
+    private final FieldType fieldType;
+    private final String name;
+
+    private PrimitiveField(FieldType fieldType, String name) {
+      this.fieldType = assertNonNull(fieldType, "fieldType");
+      this.name = assertNonNull(name, "name");
+    }
+
+    @Override
+    public FieldType getType() {
+      return fieldType;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public java.util.List<Field> getChildren() {
+      throw new UnsupportedOperationException("Primitive types don't have children");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      PrimitiveField that = (PrimitiveField) o;
+      return fieldType == that.fieldType && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(fieldType, name);
+    }
+
+    public FieldType getFieldType() {
+      return fieldType;
+    }
+  }
+
+  static class TimeLikeField<T extends Enum<T>> extends PrimitiveField {
+
+    private final T timeUnit;
+
+    private TimeLikeField(FieldType fieldType, String name, T timeUnit) {
+      super(fieldType, name);
+      this.timeUnit = assertNonNull(timeUnit, "timeUnit");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      TimeLikeField that = (TimeLikeField) o;
+      return timeUnit == that.timeUnit;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), timeUnit);
+    }
+
+    public T getTimeUnit() {
+      return timeUnit;
+    }
+  }
+
+  static class Null extends PrimitiveField {
+     Null(String name) {
+       super(FieldType.NULL, name);
+     }
+  }
+  static class Boolean extends PrimitiveField {
+    Boolean(String name) {
+      super(FieldType.BOOLEAN, name);
+    }
+  }
+  static class Int8 extends PrimitiveField {
+    Int8(String name) {
+      super(FieldType.INT8, name);
+    }
+  }
+  static class UInt8 extends PrimitiveField {
+    UInt8(String name) {
+      super(FieldType.UINT8, name);
+    }
+  }
+  static class Int16 extends PrimitiveField {
+    Int16(String name) {
+      super(FieldType.INT16, name);
+    }
+  }
+  static class UInt16 extends PrimitiveField {
+    UInt16(String name) {
+      super(FieldType.UINT16, name);
+    }
+  }
+  static class Int32 extends PrimitiveField {
+    Int32(String name) {
+      super(FieldType.INT32, name);
+    }
+  }
+  static class UInt32 extends PrimitiveField {
+    UInt32(String name) {
+      super(FieldType.UINT32, name);
+    }
+  }
+  static class Int64 extends PrimitiveField {
+    Int64(String name) {
+      super(FieldType.INT64, name);
+    }
+  }
+  static class UInt64 extends PrimitiveField {
+    UInt64(String name) {
+      super(FieldType.UINT64, name);
+    }
+  }
+  static class Float16 extends PrimitiveField {
+    Float16(String name) {
+      super(FieldType.FLOAT16, name);
+    }
+  }
+  static class Float32 extends PrimitiveField {
+    Float32(String name) {
+      super(FieldType.FLOAT32, name);
+    }
+  }
+  static class Float64 extends PrimitiveField {
+    Float64(String name) {
+      super(FieldType.FLOAT64, name);
+    }
+  }
+  static class Binary extends PrimitiveField {
+    Binary(String name) {
+      super(FieldType.BINARY, name);
+    }
+  }
+  static class LargeBinary extends PrimitiveField {
+    LargeBinary(String name) {
+      super(FieldType.LARGE_BINARY, name);
+    }
+  }
+  static class Utf8 extends PrimitiveField {
+    Utf8(String name) {
+      super(FieldType.UTF8, name);
+    }
+  }
+  static class LargeUtf8 extends PrimitiveField {
+    LargeUtf8(String name) {
+      super(FieldType.LARGE_UTF8, name);
+    }
+  }
+
+  static class Date extends TimeLikeField<Field.DateUnit> {
+    Date(String name, DateUnit timeUnit) {
+      super(FieldType.DATE, name, timeUnit);
+    }
+  }
+  static class Time extends TimeLikeField<Field.TimeUnit> {
+    private final int bitWidth;
+
+    Time(String name, TimeUnit timeUnit, int bitWidth) {
+      super(FieldType.TIME, name, timeUnit);
+      this.bitWidth = bitWidth;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      Time time = (Time) o;
+      return bitWidth == time.bitWidth;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), bitWidth);
+    }
+
+    public int getBitWidth() {
+      return bitWidth;
+    }
+  }
+  static class Timestamp extends TimeLikeField<Field.TimeUnit> {
+    private final String timezone;
+    Timestamp(String name, TimeUnit timeUnit, String timezone) {
+      super(FieldType.TIMESTAMP, name, timeUnit);
+      this.timezone = timezone;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      Timestamp timestamp = (Timestamp) o;
+      return timezone.equals(timestamp.timezone);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), timezone);
+    }
+
+    public String getTimezone() {
+      return timezone;
+    }
+  }
+  static class Duration extends TimeLikeField<Field.TimeUnit> {
+    Duration(String name, TimeUnit timeUnit) {
+      super(FieldType.DURATION, name, timeUnit);
+    }
+  }
+  static class Interval extends TimeLikeField<Field.IntervalUnit> {
+    Interval(String name, IntervalUnit timeUnit) {
+      super(FieldType.INTERVAL, name, timeUnit);
+    }
+  }
+  static class FixedBinary extends PrimitiveField {
+    private final int length;
+    FixedBinary(String name, int length) {
+      super(FieldType.FIXED_BINARY, name);
+      this.length = length;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      FixedBinary that = (FixedBinary) o;
+      return length == that.length;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), length);
+    }
+
+    public int getLength() {
+      return length;
+    }
+  }
+
+  static class Decimal extends PrimitiveField {
+    private final int precision;
+    private final int scale;
+    private final int bitwidth;
+    Decimal(String name, int precision, int scale, int bitwidth) {
+      super(FieldType.DECIMAL, name);
+      this.precision = precision;
+      this.scale = scale;
+      this.bitwidth = bitwidth;
+    }
+
+    Decimal(String name, int precision, int scale) {
+      this(name, precision, scale, 64);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      Decimal decimal = (Decimal) o;
+      return precision == decimal.precision && scale == decimal.scale && bitwidth == decimal.bitwidth;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), precision, scale, bitwidth);
+    }
+
+    public int getPrecision() {
+      return precision;
+    }
+
+    public int getScale() {
+      return scale;
+    }
+
+    public int getBitwidth() {
+      return bitwidth;
+    }
+  }
+
+  private static class ComplexField implements Field {
+    private final String name;
+    private final FieldType type;
+    private final java.util.List<Field> children;
+
+    ComplexField(String name, FieldType type, java.util.List<Field> children) {
+      this.name = assertNonNull(name, "name");
+      this.type = assertNonNull(type, "type");
+      this.children = assertNonNull(children, "children");
+    }
+
+    @Override
+    public FieldType getType() {
+      return type;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public java.util.List<Field> getChildren() {
+      return children;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ComplexField that = (ComplexField) o;
+      return name.equals(that.name) && type == that.type && children.equals(that.children);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, type, children);
+    }
+  }
+
+  static class List extends ComplexField {
+
+    List(String name, java.util.List<Field> children) {
+      super(name, FieldType.LIST, children);
+    }
+  }
+
+  static class Map extends ComplexField {
+
+    Map(String name, java.util.List<Field> children) {
+      super(name, FieldType.MAP, children);
+    }
+  }
+
+  static class Struct extends ComplexField {
+
+    Struct(String name, java.util.List<Field> children) {
+      super(name, FieldType.STRUCT, children);
+    }
+  }
+
+  static class LargeList extends ComplexField {
+
+    LargeList(String name, java.util.List<Field> children) {
+      super(name, FieldType.LARGE_LIST, children);
+    }
+  }
+
+  static class FixedList extends ComplexField {
+
+    private final int size;
+
+    FixedList(String name, int size, java.util.List<Field> children) {
+      super(name, FieldType.FIXED_LIST, children);
+      this.size = size;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      FixedList fixedList = (FixedList) o;
+      return size == fixedList.size;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), size);
+    }
+
+    public int getSize() {
+      return size;
+    }
+  }
+  private static <T> T assertNonNull(T val, String name) {
+    if (val == null) {
+      throw new IllegalStateException(String.format("Value can't be null in %s", name));
+    }
+    return val;
+  }
+}

--- a/model/src/main/java/org/projectnessie/model/HiveDialect.java
+++ b/model/src/main/java/org/projectnessie/model/HiveDialect.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.model;
 
-import javax.annotation.Nullable;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -24,21 +22,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableSqlView.class)
-@JsonDeserialize(as = ImmutableSqlView.class)
-@JsonTypeName("VIEW")
-public abstract class SqlView extends Contents {
-
-  public abstract String getSqlText();
-
-  @Nullable
-  public abstract String getResolvedSqlText();
-
-  @Nullable
-  public abstract String getSqlContext();
-
-  public abstract Dialect getDialect();
-
-  public abstract Schema getSchema();
+@JsonSerialize(as = ImmutableHiveDialect.class)
+@JsonDeserialize(as = ImmutableHiveDialect.class)
+@JsonTypeName("HIVE")
+public interface HiveDialect extends Dialect {
 
 }

--- a/model/src/main/java/org/projectnessie/model/Schema.java
+++ b/model/src/main/java/org/projectnessie/model/Schema.java
@@ -15,30 +15,18 @@
  */
 package org.projectnessie.model;
 
-import javax.annotation.Nullable;
+import java.util.List;
 
 import org.immutables.value.Value;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableSqlView.class)
-@JsonDeserialize(as = ImmutableSqlView.class)
-@JsonTypeName("VIEW")
-public abstract class SqlView extends Contents {
+@JsonSerialize(as = ImmutableSchema.class)
+@JsonDeserialize(as = ImmutableSchema.class)
+public interface Schema {
 
-  public abstract String getSqlText();
-
-  @Nullable
-  public abstract String getResolvedSqlText();
-
-  @Nullable
-  public abstract String getSqlContext();
-
-  public abstract Dialect getDialect();
-
-  public abstract Schema getSchema();
+  List<Field> getFields();
 
 }

--- a/model/src/main/java/org/projectnessie/model/SparkDialect.java
+++ b/model/src/main/java/org/projectnessie/model/SparkDialect.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.model;
 
-import javax.annotation.Nullable;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -24,21 +22,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableSqlView.class)
-@JsonDeserialize(as = ImmutableSqlView.class)
-@JsonTypeName("VIEW")
-public abstract class SqlView extends Contents {
-
-  public abstract String getSqlText();
-
-  @Nullable
-  public abstract String getResolvedSqlText();
-
-  @Nullable
-  public abstract String getSqlContext();
-
-  public abstract Dialect getDialect();
-
-  public abstract Schema getSchema();
+@JsonSerialize(as = ImmutableSparkDialect.class)
+@JsonDeserialize(as = ImmutableSparkDialect.class)
+@JsonTypeName("SPARK")
+public interface SparkDialect extends Dialect {
 
 }

--- a/model/src/main/java/org/projectnessie/model/SqlView.java
+++ b/model/src/main/java/org/projectnessie/model/SqlView.java
@@ -32,13 +32,11 @@ public abstract class SqlView extends Contents {
   public abstract String getSqlText();
 
   @Nullable
-  public abstract String getResolvedSqlText();
-
-  @Nullable
   public abstract String getSqlContext();
 
   public abstract Dialect getDialect();
 
+  @Nullable
   public abstract Schema getSchema();
 
 }

--- a/model/src/main/java/org/projectnessie/model/TrinoDialect.java
+++ b/model/src/main/java/org/projectnessie/model/TrinoDialect.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.model;
 
-import javax.annotation.Nullable;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -24,21 +22,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable(prehash = true)
-@JsonSerialize(as = ImmutableSqlView.class)
-@JsonDeserialize(as = ImmutableSqlView.class)
-@JsonTypeName("VIEW")
-public abstract class SqlView extends Contents {
-
-  public abstract String getSqlText();
-
-  @Nullable
-  public abstract String getResolvedSqlText();
-
-  @Nullable
-  public abstract String getSqlContext();
-
-  public abstract Dialect getDialect();
-
-  public abstract Schema getSchema();
+@JsonSerialize(as = ImmutableTrinoDialect.class)
+@JsonDeserialize(as = ImmutableTrinoDialect.class)
+@JsonTypeName("TRINO")
+public interface TrinoDialect extends Dialect {
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <module>perftest</module>
     <module>servers</module>
     <module>tools</module>
+    <module>schema-converters</module>
   </modules>
 
   <scm>

--- a/schema-converters/README.md
+++ b/schema-converters/README.md
@@ -1,0 +1,10 @@
+# Nessie Schema Converters
+
+This directory contains the modules which convert the internal Nessie schema representation to and from well known schema
+formats in other engies. The modules typically only provide a single public class with static methods to convert `to` and
+`from` the desired schema.
+
+## Currently supported Schema types
+
+* Arrow: Arrow is the base format for the internal Nessie Schema format so the conversion is simple and almost 1:1.
+* Iceberg: **TODO**

--- a/schema-converters/arrow/pom.xml
+++ b/schema-converters/arrow/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2020 Dremio
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>nessie-model-schema-converters</artifactId>
+    <groupId>org.projectnessie</groupId>
+    <version>0.5.2-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>nessie-arrow-schema-converter</artifactId>
+  <name>Nessie - Model - Schema Converters - Arrow</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/schema-converters/arrow/src/main/java/org/projectnessie/model/ArrowSchemaConverter.java
+++ b/schema-converters/arrow/src/main/java/org/projectnessie/model/ArrowSchemaConverter.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.IntervalUnit;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+
+public final class ArrowSchemaConverter {
+
+  private ArrowSchemaConverter() {
+
+  }
+
+  public static Schema toArrow(org.projectnessie.model.Schema nessieSchema) {
+    return new Schema(nessieSchema.getFields().stream().map(ArrowSchemaConverter::toArrow).collect(Collectors.toList()));
+  }
+
+  private static org.apache.arrow.vector.types.pojo.Field toArrow(org.projectnessie.model.Field nessieField) {
+    List<org.apache.arrow.vector.types.pojo.Field> children = Collections.emptyList();
+    switch (nessieField.getType()) {
+      case NULL:
+        return getPrimitive(nessieField.getName(), ArrowType.Null.INSTANCE);
+      case BOOLEAN:
+        return getPrimitive(nessieField.getName(), ArrowType.Bool.INSTANCE);
+      case INT8:
+        return getPrimitive(nessieField.getName(), new ArrowType.Int(8, true));
+      case UINT8:
+        return getPrimitive(nessieField.getName(), new ArrowType.Int(8, false));
+      case INT16:
+        return getPrimitive(nessieField.getName(), new ArrowType.Int(16, true));
+      case UINT16:
+        return getPrimitive(nessieField.getName(), new ArrowType.Int(16, false));
+      case INT32:
+        return getPrimitive(nessieField.getName(), new ArrowType.Int(32, true));
+      case UINT32:
+        return getPrimitive(nessieField.getName(), new ArrowType.Int(32, false));
+      case INT64:
+        return getPrimitive(nessieField.getName(), new ArrowType.Int(64, true));
+      case UINT64:
+        return getPrimitive(nessieField.getName(), new ArrowType.Int(64, false));
+      case FLOAT16:
+        return getPrimitive(nessieField.getName(), new ArrowType.FloatingPoint(FloatingPointPrecision.HALF));
+      case FLOAT32:
+        return getPrimitive(nessieField.getName(), new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE));
+      case FLOAT64:
+        return getPrimitive(nessieField.getName(), new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE));
+      case BINARY:
+        return getPrimitive(nessieField.getName(), ArrowType.Binary.INSTANCE);
+      case FIXED_BINARY:
+        return getPrimitive(nessieField.getName(), new ArrowType.FixedSizeBinary(((Fields.FixedBinary) nessieField).getLength()));
+      case LARGE_BINARY:
+        return getPrimitive(nessieField.getName(), ArrowType.LargeBinary.INSTANCE);
+      case UTF8:
+        return getPrimitive(nessieField.getName(), ArrowType.Utf8.INSTANCE);
+      case LARGE_UTF8:
+        return getPrimitive(nessieField.getName(), ArrowType.LargeUtf8.INSTANCE);
+      case DATE:
+        Fields.Date dateField = (Fields.Date) nessieField;
+        return getPrimitive(nessieField.getName(), new ArrowType.Date(DateUnit.valueOf(dateField.getTimeUnit().name())));
+      case TIME:
+        Fields.Time timeField = (Fields.Time) nessieField;
+        return getPrimitive(nessieField.getName(), new ArrowType.Time(TimeUnit.valueOf(timeField.getTimeUnit().name()),
+          timeField.getBitWidth()));
+      case TIMESTAMP:
+        Fields.Timestamp timestampField = (Fields.Timestamp) nessieField;
+        return getPrimitive(nessieField.getName(), new ArrowType.Timestamp(TimeUnit.valueOf(timestampField.getTimeUnit().name()),
+          timestampField.getTimezone()));
+      case DURATION:
+        Fields.Duration durationField = (Fields.Duration) nessieField;
+        return getPrimitive(nessieField.getName(), new ArrowType.Duration(TimeUnit.valueOf(durationField.getTimeUnit().name())));
+      case INTERVAL:
+        Fields.Interval intervalField = (Fields.Interval) nessieField;
+        return getPrimitive(nessieField.getName(), new ArrowType.Interval(IntervalUnit.valueOf(intervalField.getTimeUnit().name())));
+      case DECIMAL:
+        Fields.Decimal decimalField = (Fields.Decimal) nessieField;
+        return getPrimitive(nessieField.getName(), new ArrowType.Decimal(decimalField.getPrecision(), decimalField.getScale(),
+          decimalField.getBitwidth()));
+      case LIST:
+        children = nessieField.getChildren().stream().map(ArrowSchemaConverter::toArrow).collect(Collectors.toList());
+        return new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(), FieldType.nullable(ArrowType.List.INSTANCE), children);
+      case LARGE_LIST:
+        children = nessieField.getChildren().stream().map(ArrowSchemaConverter::toArrow).collect(Collectors.toList());
+        return new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(), FieldType.nullable(ArrowType.LargeList.INSTANCE),
+          children);
+      case FIXED_LIST:
+        Fields.FixedList listField = (Fields.FixedList) nessieField;
+        children = nessieField.getChildren().stream().map(ArrowSchemaConverter::toArrow).collect(Collectors.toList());
+        return new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(),
+          FieldType.nullable(new ArrowType.FixedSizeList(listField.getSize())), children);
+      case MAP:
+        children = nessieField.getChildren().stream().map(ArrowSchemaConverter::toArrow).collect(Collectors.toList());
+        return new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(),
+          FieldType.nullable(new ArrowType.Map(false)), children);
+      case STRUCT:
+        children = nessieField.getChildren().stream().map(ArrowSchemaConverter::toArrow).collect(Collectors.toList());
+        return new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(), FieldType.nullable(ArrowType.Struct.INSTANCE),
+          children);
+      case DENSE_UNION:
+      case SPARSE_UNION:
+      default:
+        throw new UnsupportedOperationException(String.format("uknown field type %s", nessieField.getType()));
+    }
+  }
+
+  private static org.apache.arrow.vector.types.pojo.Field getPrimitive(String name, ArrowType type) {
+    return new org.apache.arrow.vector.types.pojo.Field(name, FieldType.nullable(type), Collections.emptyList());
+  }
+
+  public static org.projectnessie.model.Schema fromArrow(Schema arrowSchema) {
+    ImmutableSchema.Builder builder = ImmutableSchema.builder();
+    arrowSchema.getFields().stream().map(arrowField -> arrowField.getFieldType().getType().accept(new Visitor(arrowField)))
+      .forEach(builder::addFields);
+    return builder.build();
+  }
+
+  private static class Visitor implements ArrowType.ArrowTypeVisitor<org.projectnessie.model.Field> {
+    private final org.apache.arrow.vector.types.pojo.Field arrowField;
+
+    private Visitor(org.apache.arrow.vector.types.pojo.Field arrowField) {
+      this.arrowField = arrowField;
+    }
+
+    @Override
+    public Field visit(ArrowType.Null type) {
+      return new Fields.Null(arrowField.getName());
+    }
+
+    @Override
+    public Field visit(ArrowType.Struct type) {
+      List<Field> children =
+        arrowField.getChildren().stream().map(x -> x.getFieldType().getType().accept(new Visitor(x))).collect(Collectors.toList());
+      return new Fields.Struct(arrowField.getName(), children);
+    }
+
+    @Override
+    public Field visit(ArrowType.List type) {
+      List<Field> children =
+        arrowField.getChildren().stream().map(x -> x.getFieldType().getType().accept(new Visitor(x))).collect(Collectors.toList());
+      return new Fields.List(arrowField.getName(), children);
+    }
+
+    @Override
+    public Field visit(ArrowType.LargeList type) {
+      List<Field> children =
+        arrowField.getChildren().stream().map(x -> x.getFieldType().getType().accept(new Visitor(x))).collect(Collectors.toList());
+      return new Fields.LargeList(arrowField.getName(), children);
+    }
+
+    @Override
+    public Field visit(ArrowType.FixedSizeList type) {
+      List<Field> children =
+        arrowField.getChildren().stream().map(x -> x.getFieldType().getType().accept(new Visitor(x))).collect(Collectors.toList());
+      return new Fields.FixedList(arrowField.getName(), type.getListSize(), children);
+    }
+
+    @Override
+    public Field visit(ArrowType.Union type) {
+      throw new UnsupportedOperationException("Union is not yet supported");
+    }
+
+    @Override
+    public Field visit(ArrowType.Map type) {
+      List<Field> children =
+        arrowField.getChildren().stream().map(x -> x.getFieldType().getType().accept(new Visitor(x))).collect(Collectors.toList());
+      return new Fields.Map(arrowField.getName(), children);
+    }
+
+    @Override
+    public Field visit(ArrowType.Int type) {
+      switch (type.getBitWidth()) {
+        case 8:
+          return type.getIsSigned() ? new Fields.Int8(arrowField.getName()) : new Fields.UInt8(arrowField.getName());
+        case 16:
+          return type.getIsSigned() ? new Fields.Int16(arrowField.getName()) : new Fields.UInt16(arrowField.getName());
+        case 32:
+          return type.getIsSigned() ? new Fields.Int32(arrowField.getName()) : new Fields.UInt32(arrowField.getName());
+        case 64:
+          return type.getIsSigned() ? new Fields.Int64(arrowField.getName()) : new Fields.UInt64(arrowField.getName());
+        default:
+          throw new IllegalStateException(String.format("Bitwidth %s is invalid for integer type", type.getBitWidth()));
+      }
+    }
+
+    @Override
+    public Field visit(ArrowType.FloatingPoint type) {
+      switch (type.getPrecision()) {
+        case HALF:
+          return new Fields.Float16(arrowField.getName());
+        case SINGLE:
+          return new Fields.Float32(arrowField.getName());
+        case DOUBLE:
+          return new Fields.Float64(arrowField.getName());
+        default:
+          throw new IllegalStateException(String.format("precision %s is invalid for float type", type.getPrecision()));
+      }
+    }
+
+    @Override
+    public Field visit(ArrowType.Utf8 type) {
+      return new Fields.Utf8(arrowField.getName());
+    }
+
+    @Override
+    public Field visit(ArrowType.LargeUtf8 type) {
+      return new Fields.LargeUtf8(arrowField.getName());
+    }
+
+    @Override
+    public Field visit(ArrowType.Binary type) {
+      return new Fields.Binary(arrowField.getName());
+    }
+
+    @Override
+    public Field visit(ArrowType.LargeBinary type) {
+      return new Fields.LargeBinary(arrowField.getName());
+    }
+
+    @Override
+    public Field visit(ArrowType.FixedSizeBinary type) {
+      return new Fields.FixedBinary(arrowField.getName(), type.getByteWidth());
+    }
+
+    @Override
+    public Field visit(ArrowType.Bool type) {
+      return new Fields.Boolean(arrowField.getName());
+    }
+
+    @Override
+    public Field visit(ArrowType.Decimal type) {
+      return new Fields.Decimal(arrowField.getName(), type.getPrecision(), type.getScale(), type.getBitWidth());
+    }
+
+    @Override
+    public Field visit(ArrowType.Date type) {
+      return new Fields.Date(arrowField.getName(), Field.DateUnit.valueOf(type.getUnit().toString()));
+    }
+
+    @Override
+    public Field visit(ArrowType.Time type) {
+      return new Fields.Time(arrowField.getName(), Field.TimeUnit.valueOf(type.getUnit().toString()), type.getBitWidth());
+    }
+
+    @Override
+    public Field visit(ArrowType.Timestamp type) {
+      return new Fields.Timestamp(arrowField.getName(), Field.TimeUnit.valueOf(type.getUnit().toString()), type.getTimezone());
+    }
+
+    @Override
+    public Field visit(ArrowType.Interval type) {
+      return new Fields.Interval(arrowField.getName(), Field.IntervalUnit.valueOf(type.getUnit().toString()));
+    }
+
+    @Override
+    public Field visit(ArrowType.Duration type) {
+      return new Fields.Duration(arrowField.getName(), Field.TimeUnit.valueOf(type.getUnit().toString()));
+    }
+  }
+}

--- a/schema-converters/arrow/src/test/java/org/projectnessie/model/ArrowSchemaConverterTest.java
+++ b/schema-converters/arrow/src/test/java/org/projectnessie/model/ArrowSchemaConverterTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.IntervalUnit;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ArrowSchemaConverterTest {
+
+  @ParameterizedTest
+  @MethodSource("arrowFields")
+  void testPrimitiveSchema(ArrowType type) {
+    Schema expectedSchema = new Schema(Collections.singletonList(new Field("x", FieldType.nullable(type), Collections.emptyList())));
+    org.projectnessie.model.Schema nessieSchema = ArrowSchemaConverter.fromArrow(expectedSchema);
+    Schema actualSchema = ArrowSchemaConverter.toArrow(nessieSchema);
+    Assertions.assertEquals(expectedSchema, actualSchema);
+  }
+
+  @ParameterizedTest
+  @MethodSource("arrowFields")
+  void testComplexSchema(ArrowType type) {
+    List<Field> children = Collections.singletonList(new Field("x", FieldType.nullable(type), Collections.emptyList()));
+
+    List<Field> schemaFields = new ArrayList<>();
+    schemaFields.add(new Field("a", FieldType.nullable(ArrowType.List.INSTANCE), children));
+    schemaFields.add(new Field("b", FieldType.nullable(new ArrowType.Map(false)), children));
+    schemaFields.add(new Field("c", FieldType.nullable(ArrowType.Struct.INSTANCE), children));
+    schemaFields.add(new Field("d", FieldType.nullable(ArrowType.LargeList.INSTANCE), children));
+    schemaFields.add(new Field("e", FieldType.nullable(new ArrowType.FixedSizeList(10)), children));
+    Schema expectedSchema = new Schema(schemaFields);
+    org.projectnessie.model.Schema nessieSchema = ArrowSchemaConverter.fromArrow(expectedSchema);
+    Schema actualSchema = ArrowSchemaConverter.toArrow(nessieSchema);
+    Assertions.assertEquals(expectedSchema, actualSchema);
+  }
+
+  private static Stream<ArrowType> arrowFields() {
+    return Stream.of(
+      ArrowType.Null.INSTANCE,
+      new ArrowType.Int(8, false),
+      new ArrowType.Int(8, false),
+      new ArrowType.Int(16, false),
+      new ArrowType.Int(16, true),
+      new ArrowType.Int(32, false),
+      new ArrowType.Int(32, true),
+      new ArrowType.Int(64, false),
+      new ArrowType.Int(64, true),
+      new ArrowType.FloatingPoint(FloatingPointPrecision.HALF),
+      new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE),
+      new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE),
+      ArrowType.Binary.INSTANCE,
+      new ArrowType.FixedSizeBinary(12),
+      ArrowType.LargeBinary.INSTANCE,
+      ArrowType.Utf8.INSTANCE,
+      ArrowType.LargeUtf8.INSTANCE,
+      new ArrowType.Date(DateUnit.MILLISECOND),
+      new ArrowType.Date(DateUnit.DAY),
+      new ArrowType.Time(TimeUnit.SECOND, 8),
+      new ArrowType.Time(TimeUnit.MILLISECOND, 8),
+      new ArrowType.Time(TimeUnit.MICROSECOND, 8),
+      new ArrowType.Time(TimeUnit.NANOSECOND, 8),
+      new ArrowType.Timestamp(TimeUnit.SECOND, "UTC"),
+      new ArrowType.Timestamp(TimeUnit.MILLISECOND, "EST"),
+      new ArrowType.Timestamp(TimeUnit.MICROSECOND, "GMT"),
+      new ArrowType.Timestamp(TimeUnit.NANOSECOND, "CET"),
+      new ArrowType.Duration(TimeUnit.SECOND),
+      new ArrowType.Duration(TimeUnit.MILLISECOND),
+      new ArrowType.Duration(TimeUnit.MICROSECOND),
+      new ArrowType.Duration(TimeUnit.NANOSECOND),
+      new ArrowType.Interval(IntervalUnit.YEAR_MONTH),
+      new ArrowType.Interval(IntervalUnit.DAY_TIME),
+      new ArrowType.Decimal(1,2,64)
+    );
+  }
+}
+
+
+//new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(), FieldType.nullable(ArrowType.List.INSTANCE), children);
+//new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(), FieldType.nullable(ArrowType.LargeList.INSTANCE),
+//new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(), ieldType.nullable(new ArrowType.FixedSizeList(listField.getSize())), children);
+//new org.apache.arrow.vector.types.pojo.Field(nessieField.getName(), FieldType.nullable(new ArrowType.Map(false)), children);

--- a/schema-converters/pom.xml
+++ b/schema-converters/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2020 Dremio
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>nessie</artifactId>
+    <groupId>org.projectnessie</groupId>
+    <version>0.5.2-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
+
+  <artifactId>nessie-model-schema-converters</artifactId>
+  <name>Nessie - Model - Schema Converters Parent</name>
+
+  <modules>
+    <module>arrow</module>
+    <!--    <module>iceberg</module>-->
+<!--    <module>spark</module>-->
+  </modules>
+
+</project>

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -68,6 +68,7 @@ import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Contents;
 import org.projectnessie.model.ContentsKey;
+import org.projectnessie.model.DremioDialect;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.Hash;
 import org.projectnessie.model.IcebergTable;
@@ -301,8 +302,7 @@ class TestRest {
     ContentsKey a = ContentsKey.of("a");
     ContentsKey b = ContentsKey.of("b");
     IcebergTable ta = IcebergTable.of("path1");
-    SqlView tb = ImmutableSqlView.builder().sqlText("select * from table")
-        .dialect(SqlView.Dialect.DREMIO).build();
+    SqlView tb = ImmutableSqlView.builder().sqlText("select * from table").dialect(DremioDialect.of()).build();
     contents.setContents(a, branch, r.getHash(), "commit 1", ta);
     contents.setContents(b, branch, r.getHash(), "commit 2", tb);
     List<EntriesResponse.Entry> entries = tree.getEntries(branch, null, null, Collections.emptyList()).getEntries();

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -21,18 +21,26 @@ import java.util.stream.Collectors;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Contents;
 import org.projectnessie.model.DeltaLakeTable;
+import org.projectnessie.model.DremioDialect;
 import org.projectnessie.model.HiveDatabase;
+import org.projectnessie.model.HiveDialect;
 import org.projectnessie.model.HiveTable;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.ImmutableDeltaLakeTable;
 import org.projectnessie.model.ImmutableDeltaLakeTable.Builder;
+import org.projectnessie.model.ImmutableDremioDialect;
 import org.projectnessie.model.ImmutableHiveDatabase;
+import org.projectnessie.model.ImmutableHiveDialect;
 import org.projectnessie.model.ImmutableHiveTable;
 import org.projectnessie.model.ImmutableIcebergTable;
+import org.projectnessie.model.ImmutableSparkDialect;
 import org.projectnessie.model.ImmutableSqlView;
+import org.projectnessie.model.ImmutableTrinoDialect;
+import org.projectnessie.model.SparkDialect;
 import org.projectnessie.model.SqlView;
-import org.projectnessie.model.SqlView.Dialect;
+import org.projectnessie.model.Dialect;
+import org.projectnessie.model.TrinoDialect;
 import org.projectnessie.store.ObjectTypes;
 import org.projectnessie.versioned.Serializer;
 import org.projectnessie.versioned.SerializerWithPayload;
@@ -90,8 +98,7 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Contents, CommitM
             .setDatabase(UnsafeByteOperations.unsafeWrap(((HiveDatabase) value).getDatabaseDefinition())));
       } else if (value instanceof SqlView) {
         SqlView view = (SqlView) value;
-        builder.setSqlView(ObjectTypes.SqlView.newBuilder().setDialect(view.getDialect().name())
-            .setSqlText(view.getSqlText()));
+        builder.setSqlView(ObjectTypes.SqlView.newBuilder().setDialect(convertFromDialect(view.getDialect()).build()).setSqlText(view.getSqlText()));
       } else {
         throw new IllegalArgumentException("Unknown type" + value);
       }
@@ -133,13 +140,45 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Contents, CommitM
 
         case SQL_VIEW:
           ObjectTypes.SqlView view = contents.getSqlView();
-          return ImmutableSqlView.builder().dialect(Dialect.valueOf(view.getDialect())).sqlText(view.getSqlText())
-              .id(contents.getId()).build();
+          return ImmutableSqlView.builder().dialect(convertToDialect(view.getDialect())).sqlText(view.getSqlText())
+            .id(contents.getId()).build();
 
         case OBJECTTYPE_NOT_SET:
         default:
           throw new IllegalArgumentException("Unknown type" + contents.getObjectTypeCase());
 
+      }
+    }
+
+    private ObjectTypes.Dialect.Builder convertFromDialect(Dialect value) {
+      ObjectTypes.Dialect.Builder builder = ObjectTypes.Dialect.newBuilder();
+      if (value instanceof DremioDialect) {
+        builder.setDremioDialect(ObjectTypes.DremioDialect.newBuilder().build());
+      } else if (value instanceof HiveDialect) {
+        builder.setHiveDialect(ObjectTypes.HiveDialect.newBuilder().build());
+      } else if (value instanceof SparkDialect) {
+        builder.setSparkDialect(ObjectTypes.SparkDialect.newBuilder().build());
+      } else if (value instanceof TrinoDialect) {
+        builder.setTrinoDialect(ObjectTypes.TrinoDialect.newBuilder().build());
+      } else {
+        throw new IllegalArgumentException("Unknown type" + value);
+      }
+      return builder;
+    }
+
+    private Dialect convertToDialect(ObjectTypes.Dialect dialect) {
+      switch (dialect.getObjectTypeCase()) {
+        case DREMIO_DIALECT:
+          return ImmutableDremioDialect.builder().build();
+        case HIVE_DIALECT:
+          return ImmutableHiveDialect.builder().build();
+        case SPARK_DIALECT:
+          return ImmutableSparkDialect.builder().build();
+        case TRINO_DIALECT:
+          return ImmutableTrinoDialect.builder().build();
+        case OBJECTTYPE_NOT_SET:
+        default:
+          throw new IllegalArgumentException("Unknown type" + dialect.getObjectTypeCase());
       }
     }
 

--- a/servers/store/src/main/proto/table.proto
+++ b/servers/store/src/main/proto/table.proto
@@ -44,13 +44,41 @@ message HiveDatabase {
   bytes database = 1;
 }
 
+message Dialect {
+  oneof object_type {
+    DremioDialect dremio_dialect = 1;
+    HiveDialect hive_dialect = 2;
+    SparkDialect spark_dialect = 3;
+    TrinoDialect trino_dialect = 4;
+  }
+}
+
 message SqlView {
   string sql_text = 1;
-  string dialect = 2;
+  Dialect dialect = 2;
+  string context = 3;
+  string resolved_sql_text = 4;
+  bytes schema = 5;
 }
 
 message DeltaLakeTable {
   string last_checkpoint = 1;
   repeated string checkpoint_location_history = 2;
   repeated string metadata_location_history = 3;
+}
+
+message DremioDialect {
+
+}
+
+message HiveDialect {
+
+}
+
+message SparkDialect {
+
+}
+
+message TrinoDialect {
+
 }

--- a/site/docs/develop/spec.md
+++ b/site/docs/develop/spec.md
@@ -37,6 +37,27 @@ Therefore, the Iceberg table spec should be considered subject to change in the 
 
 ### View
 
+The View definition provides the minimum viable set of features that a SQL view requires. The SQL View object is defined as follows:
+1. Dialect: This is the specific SQL Dialect that this View stores (eg Dremio, Trino, Hive etc). The Dialect object can also have
+   engine specific settings stored in the object. As of today these containers are empty. The dialect is a marker only to identify
+   the store this View _should_ be used for.
+1. SQL Text: This is clearly the important part of the view. This contains the SQL expression that describes the view in the given
+   dialect. **Note** Nessie does not do any verification or checks to ensure that a SQL statement is valid for a given dialect.
+   The SQL text should not contain DDL, eg the statement should be a `SELECT` and can omit the `CREATE VIEW` portion.
+1. SQL Context: the base from which tables should be resolved. eg which database the view belongs to
+1. Schema: Optional field. This is the expected schema of the SQL view, but is not validated. It is expected that the engine will
+   be able to derive the schema on its own as this field may be missing or not up to date. The format of this field is detailed below.
+
+#### Schema object
+The schema object is a limited version of the Arrow schema definition. See eg
+[Arrow Data Types and Schemas](https://arrow.apache.org/docs/python/api/datatypes.html). It supports the same fields and types
+as the Arrow schema and is a 1:1 translation of the Arrow objects. The reason we have created our own schema definition is to avoid
+couplign arrow or another format to our client libraries. The internal Schema definition has been created such that it isn't easily
+accessible outside of Nessie's `org.projectnessie` namespace in Java. This highlights that these objects are not created or modified
+by users directly. Nessie provides several converter modules (see [Schema Converters](https://github.com/projectnessie/nessie/tree/main/schema-converters)).
+Here translation to and from known Schemas are provided and engines should only import the appropriate module.
+
+Note that the default on disk format for the schema object is the arrow flatbuffer format.
 ### Delta Lake Table
 
 ### Hive Table & Database


### PR DESCRIPTION
Based on @sandhyasun 's work I have implemented a strawman for a more complete View definition.

Additions:
1. sql context to normalise tables to a namespace (optional)
2. resolved sql text if an engine can normalise tables and fully resolve the sql text (optional)
3. Dialect is now an object: to convey engine specific options (currently none)
4. Schema

Note: 1 above + `sqlText` should be able to produce 2. 

The schema is the most interesting here. I have mocked out a simple schema object in an attempt to convey the minimal set of fields for a schema. This schema should not be considered a canonical schema rather an intermediary schema for transport. Still to do is provide utilities to convert between this format and arrow/hive/iceberg etc

Curious to see what people think @vvellanki @laurentgo @snazy @sandhyasun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1046)
<!-- Reviewable:end -->
