### PR TITLE
Improve dependency ordering in the Gradle plugin

### DIFF
--- a/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/StartTask.java
+++ b/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/StartTask.java
@@ -21,14 +21,10 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.testing.Test;
 
 public class StartTask extends DefaultTask {
-  private Configuration config;
 
   public StartTask() {
     // intentionally empty
@@ -63,7 +59,7 @@ public class StartTask extends DefaultTask {
       System.setProperty("log4j2.configurationFile", log4j2config.toString());
     }
 
-    AutoCloseable quarkusApp = QuarkusApp.newApplication(config, getProject(), properties);
+    AutoCloseable quarkusApp = QuarkusApp.newApplication(getProject(), properties);
 
     // Do not put the "dynamic" properties (quarkus.http.test-port) to the `Test` task's
     // system-properties, because those are subject to the test-task's inputs, which is used
@@ -77,15 +73,6 @@ public class StartTask extends DefaultTask {
 
     getLogger().info("Quarkus application started.");
     setApplicationHandle(quarkusApp);
-  }
-
-  @InputFiles
-  private FileCollection getConfig() {
-    return config;
-  }
-
-  public void setConfig(Configuration files) {
-    this.config = files;
   }
 
   private void setApplicationHandle(AutoCloseable application) {


### PR DESCRIPTION
Since we have to add the quarkus-bom as an `enforcedPlatform()`-dependency in Gradle build script,
there were two dependencies instead of one handled by the apprunner-gradle-plugin. The Gradle plugin
accidentally used a `j.u.HashSet`, which has a non-deterministic iteration order (can change from
one JVM launch to another). Since all tests were run against the same Gradle Daemon instance, and
that JVM instance caused the "right" iteration order --> returning the nessie-quarkus-server dependency
before the quarkus-bom dependency - everything was fine.

This PR changes `j.u.HashSet` to `j.u.LinkedHashSet` but also splits the Gradle configuration into two:
one only for the application artifact (nessie-quarkus-server) and one for the runtime dependencies
(quarkus-bom), so it's easier for users to reason about the difference there.

Also adds some logging at info and debug levels.

Removed unnecessary "input-parameter" from `StartTask`, which isn't cacheable at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1064)
<!-- Reviewable:end -->
