### PR TITLE
Add profile "docker" to `:nessie-quarkus`

### DIFF
--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -281,6 +281,14 @@
       </build>
     </profile>
     <profile>
+      <!-- Use the "docker" profile to just build the Docker container image when the native image's been built -->
+      <id>docker</id>
+      <properties>
+        <quarkus.container-image.build>true</quarkus.container-image.build>
+      </properties>
+    </profile>
+    <profile>
+      <!-- Profile "release" is rather exclusively used by CI -->
       <id>release</id>
       <properties>
         <quarkus.container-image.build>true</quarkus.container-image.build>


### PR DESCRIPTION
To build a container-image in `:nessie-quarkus` it's currently necessary to use the
`release` profile. But the `release` profile also signs the artifacts, so users have
to have set up all-the-things gpg and have the password handy.

Adding a new profile `docker` to just build the container image is more convenient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1097)
<!-- Reviewable:end -->
