### PR TITLE
fix jacoco for test classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1099,6 +1099,12 @@ limitations under the License.
                   <dataFileIncludes>
                     <dataFileInclude>**/jacoco.exec</dataFileInclude>
                   </dataFileIncludes>
+                  <excludes>
+                    <exclude>org.projectnessie.versioned.tests.AbstractITVersionStore</exclude>
+                    <exclude>org.projectnessie.versioned.impl.AbstractITTieredVersionStore</exclude>
+                    <exclude>org.projectnessie.versioned.impl.AbstractTestStore</exclude>
+                    <exclude>org.projectnessie.versioned.impl.AbstractTieredStoreFixture</exclude>
+                  </excludes>
                   <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
                 </configuration>
               </execution>


### PR DESCRIPTION
By default all abstract test classes that were packaged w/o the `tests` classifier get added to our total coverage count. Since these are Test classes they do not get coverage info. This PR excludes them from our total test coverage stats to give a better estimation of our actual code coverage on active code.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1139)
<!-- Reviewable:end -->
