### PR TITLE
Bump Maven to 3.8.1 and update wrapper

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -13,105 +13,105 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import java.net.*;
+import java.io.*;
+import java.nio.channels.*;
 import java.util.Properties;
 
 public class MavenWrapperDownloader {
 
-  private static final String WRAPPER_VERSION = "0.5.4";
-  /**
-   * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
-   */
-  private static final String DEFAULT_DOWNLOAD_URL =
-    "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/"
-      + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + " .jar";
+    private static final String WRAPPER_VERSION = "0.5.6";
+    /**
+     * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
+     */
+    private static final String DEFAULT_DOWNLOAD_URL = "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/"
+        + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
 
-  /**
-   * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to
-   * use instead of the default one.
-   */
-  private static final String MAVEN_WRAPPER_PROPERTIES_PATH =
-    ".mvn/wrapper/maven-wrapper.properties";
+    /**
+     * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to
+     * use instead of the default one.
+     */
+    private static final String MAVEN_WRAPPER_PROPERTIES_PATH =
+            ".mvn/wrapper/maven-wrapper.properties";
 
-  /**
-   * Path where the maven-wrapper.jar will be saved to.
-   */
-  private static final String MAVEN_WRAPPER_JAR_PATH =
-    ".mvn/wrapper/maven-wrapper.jar";
+    /**
+     * Path where the maven-wrapper.jar will be saved to.
+     */
+    private static final String MAVEN_WRAPPER_JAR_PATH =
+            ".mvn/wrapper/maven-wrapper.jar";
 
-  /**
-   * Name of the property which should be used to override the default download url for the wrapper.
-   */
-  private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
+    /**
+     * Name of the property which should be used to override the default download url for the wrapper.
+     */
+    private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
 
-  public static void main(String args[]) {
-    System.out.println("- Downloader started");
-    File baseDirectory = new File(args[0]);
-    System.out.println("- Using base directory: " + baseDirectory.getAbsolutePath());
+    public static void main(String args[]) {
+        System.out.println("- Downloader started");
+        File baseDirectory = new File(args[0]);
+        System.out.println("- Using base directory: " + baseDirectory.getAbsolutePath());
 
-    // If the maven-wrapper.properties exists, read it and check if it contains a custom
-    // wrapperUrl parameter.
-    File mavenWrapperPropertyFile = new File(baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH);
-    String url = DEFAULT_DOWNLOAD_URL;
-    if (mavenWrapperPropertyFile.exists()) {
-      FileInputStream mavenWrapperPropertyFileInputStream = null;
-      try {
-        mavenWrapperPropertyFileInputStream = new FileInputStream(mavenWrapperPropertyFile);
-        Properties mavenWrapperProperties = new Properties();
-        mavenWrapperProperties.load(mavenWrapperPropertyFileInputStream);
-        url = mavenWrapperProperties.getProperty(PROPERTY_NAME_WRAPPER_URL, url);
-      } catch (IOException e) {
-        System.out.println("- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'");
-      } finally {
+        // If the maven-wrapper.properties exists, read it and check if it contains a custom
+        // wrapperUrl parameter.
+        File mavenWrapperPropertyFile = new File(baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH);
+        String url = DEFAULT_DOWNLOAD_URL;
+        if(mavenWrapperPropertyFile.exists()) {
+            FileInputStream mavenWrapperPropertyFileInputStream = null;
+            try {
+                mavenWrapperPropertyFileInputStream = new FileInputStream(mavenWrapperPropertyFile);
+                Properties mavenWrapperProperties = new Properties();
+                mavenWrapperProperties.load(mavenWrapperPropertyFileInputStream);
+                url = mavenWrapperProperties.getProperty(PROPERTY_NAME_WRAPPER_URL, url);
+            } catch (IOException e) {
+                System.out.println("- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'");
+            } finally {
+                try {
+                    if(mavenWrapperPropertyFileInputStream != null) {
+                        mavenWrapperPropertyFileInputStream.close();
+                    }
+                } catch (IOException e) {
+                    // Ignore ...
+                }
+            }
+        }
+        System.out.println("- Downloading from: " + url);
+
+        File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
+        if(!outputFile.getParentFile().exists()) {
+            if(!outputFile.getParentFile().mkdirs()) {
+                System.out.println(
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+            }
+        }
+        System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
         try {
-          if (mavenWrapperPropertyFileInputStream != null) {
-            mavenWrapperPropertyFileInputStream.close();
-          }
-        } catch (IOException e) {
-          // Ignore ...
+            downloadFileFromURL(url, outputFile);
+            System.out.println("Done");
+            System.exit(0);
+        } catch (Throwable e) {
+            System.out.println("- Error downloading");
+            e.printStackTrace();
+            System.exit(1);
         }
-      }
     }
-    System.out.println("- Downloading from: " + url);
 
-    File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
-    if (!outputFile.getParentFile().exists()) {
-      if (!outputFile.getParentFile().mkdirs()) {
-        System.out.println(
-          "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() +
-            "'");
-      }
-    }
-    System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
-    try {
-      downloadFileFromURL(url, outputFile);
-      System.out.println("Done");
-      System.exit(0);
-    } catch (Throwable e) {
-      System.out.println("- Error downloading");
-      e.printStackTrace();
-      System.exit(1);
-    }
-  }
-
-  private static void downloadFileFromURL(String urlString, File destination) throws Exception {
-    if (System.getenv("MVNW_USERNAME") != null && System.getenv("MVNW_PASSWORD") != null) {
-      String username = System.getenv("MVNW_USERNAME");
-      char[] password = System.getenv("MVNW_PASSWORD").toCharArray();
-      Authenticator.setDefault(new Authenticator() {
-        @Override
-        protected PasswordAuthentication getPasswordAuthentication() {
-          return new PasswordAuthentication(username, password);
+    private static void downloadFileFromURL(String urlString, File destination) throws Exception {
+        if (System.getenv("MVNW_USERNAME") != null && System.getenv("MVNW_PASSWORD") != null) {
+            String username = System.getenv("MVNW_USERNAME");
+            char[] password = System.getenv("MVNW_PASSWORD").toCharArray();
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username, password);
+                }
+            });
         }
-      });
+        URL website = new URL(urlString);
+        ReadableByteChannel rbc;
+        rbc = Channels.newChannel(website.openStream());
+        FileOutputStream fos = new FileOutputStream(destination);
+        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+        fos.close();
+        rbc.close();
     }
-    URL website = new URL(urlString);
-    ReadableByteChannel rbc;
-    rbc = Channels.newChannel(website.openStream());
-    FileOutputStream fos = new FileOutputStream(destination);
-    fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
-    fos.close();
-    rbc.close();
-  }
 
 }

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/clients/hmsbridge/hive2/pom.xml
+++ b/clients/hmsbridge/hive2/pom.xml
@@ -203,6 +203,10 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -220,13 +224,6 @@
     </dependency>
 
   </dependencies>
-
-  <repositories>
-    <repository>
-      <id>conjars.org</id>
-      <url>https://conjars.wensel.net/repo/</url>
-    </repository>
-  </repositories>
 
   <build>
     <plugins>

--- a/clients/hmsbridge/hive2/pom.xml
+++ b/clients/hmsbridge/hive2/pom.xml
@@ -221,6 +221,13 @@
 
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>conjars.org</id>
+      <url>https://conjars.wensel.net/repo/</url>
+    </repository>
+  </repositories>
+
   <build>
     <plugins>
       <plugin>

--- a/mvnw
+++ b/mvnw
@@ -16,7 +16,7 @@
 #
 
 # ----------------------------------------------------------------------------
-# Maven2 Start Up Batch script
+# Maven Start Up Batch script
 #
 # Required ENV vars:
 # ------------------
@@ -209,9 +209,9 @@ else
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
     if [ -n "$MVNW_REPOURL" ]; then
-      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     else
-      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     fi
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -15,7 +15,7 @@
 @REM
 
 @REM ----------------------------------------------------------------------------
-@REM Maven2 Start Up Batch script
+@REM Maven Start Up Batch script
 @REM
 @REM Required ENV vars:
 @REM JAVA_HOME - location of a JDK home dir
@@ -23,7 +23,7 @@
 @REM Optional ENV vars
 @REM M2_HOME - location of maven2's installed home dir
 @REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
-@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a key stroke before ending
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
 @REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
 @REM     e.g. to debug Maven itself, use
 @REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
@@ -117,7 +117,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
 
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
@@ -131,7 +131,7 @@ if exist %WRAPPER_JAR% (
     )
 ) else (
     if not "%MVNW_REPOURL%" == "" (
-        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     )
     if "%MVNW_VERBOSE%" == "true" (
         echo Couldn't find %WRAPPER_JAR%, downloading it ...


### PR DESCRIPTION
Most of the PR is rather "noise" due to the updated `MavenWrapperDownloader.java` and updates to the `mvn*` scripts.

The actual "fix" to use Maven 3.8 is in `clients/hmsbridge/hive2/pom.xml`

Tested locally with empty `~/.m2/repository` and `~/.m2/wrapper` directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1154)
<!-- Reviewable:end -->
