### PR TITLE
Revert "Bump quarkus.version from 1.13.2.Final to 1.13.3.Final (#1151)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <spark3.version>3.0.1</spark3.version>
     <spark3.jackson.version>2.10.2</spark3.jackson.version>
     <sqlite.version>1.0.392</sqlite.version>
-    <quarkus.version>1.13.3.Final</quarkus.version>
+    <quarkus.version>1.13.2.Final</quarkus.version>
     <openapi.version>1.1.2</openapi.version>
     <jsr305.version>3.0.2</jsr305.version>
   </properties>


### PR DESCRIPTION
Temporary revert of the Quarkus version bump to get Ci back working.

Github actions environment/infra fails most of the time as GitHub's infra isn't able to download 

The original dependabot-PR failed about 3 times before it [passed](https://github.com/projectnessie/nessie/pull/1151/commits/6b2338ebf5a20bbc41b23a0de5a10b0a718800bc).

But even since then, CI on main fails with always the same error: `Error:  Failed to execute goal on project nessie-lambda: Could not resolve dependencies for project org.projectnessie:nessie-lambda:jar:0.5.2-SNAPSHOT: Failed to collect dependencies at io.quarkus:quarkus-amazon-lambda:jar:1.13.3.Final: Failed to read artifact descriptor for io.quarkus:quarkus-amazon-lambda:jar:1.13.3.Final: Could not transfer artifact io.quarkus:quarkus-amazon-lambda:pom:1.13.3.Final from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/io/quarkus/quarkus-amazon-lambda/1.13.3.Final/quarkus-amazon-lambda-1.13.3.Final.pom: Connection timed out (Read failed) -> [Help 1]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1167)
<!-- Reviewable:end -->
