### PR TITLE
Check for `nessie.url` if `nessie.uri` is not present

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieClient.java
@@ -19,6 +19,7 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_AUTH_TY
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_PASSWORD;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_TRACING;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URL;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_USERNAME;
 
 import java.net.URI;
@@ -89,6 +90,9 @@ public interface NessieClient extends AutoCloseable {
      */
     public Builder fromConfig(Function<String, String> configuration) {
       String uri = configuration.apply(CONF_NESSIE_URI);
+      if (uri == null) {
+        uri = configuration.apply(CONF_NESSIE_URL);
+      }
       if (uri != null) {
         this.uri = URI.create(uri);
       }

--- a/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -24,6 +24,12 @@ public final class NessieConfigConstants {
    */
   public static final String CONF_NESSIE_URI = "nessie.uri";
   /**
+   * Deprecated, old configuration key for {@link #CONF_NESSIE_URI}, do not use.
+   * <p>Only present for backwards-compatibility. Will be removed in a future version.</p>
+   */
+  @Deprecated
+  public static final String CONF_NESSIE_URL = "nessie.url";
+  /**
    * Config property name ({@value #CONF_NESSIE_USERNAME}) for the user name used for (basic) authentication.
    */
   public static final String CONF_NESSIE_USERNAME = "nessie.username";


### PR DESCRIPTION
The change #835 changed `url` to `uri`. We did talk about maintaining backwards-compatibility, i.e. don't break
Spark-configurations that for example use `conf.set("spark.sql.catalog.nessie.url", ...)` instead of
`conf.set("spark.sql.catalog.nessie.uri", ...)`.

This change ensures backwards compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1211)
<!-- Reviewable:end -->
