### PR TITLE
Allow multiple `Test` tasks per Gradle project

### DIFF
--- a/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppPlugin.java
+++ b/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppPlugin.java
@@ -76,7 +76,7 @@ public class QuarkusAppPlugin implements Plugin<Project> {
           @Override
           public void execute(Task ignore) {
             StartTask startTask = (StartTask) target.getTasks().getByName(START_TASK_NAME);
-            startTask.quarkusStart();
+            startTask.quarkusStart(test);
           }
         });
       }

--- a/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/StartTask.java
+++ b/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/StartTask.java
@@ -35,7 +35,7 @@ public class StartTask extends DefaultTask {
   }
 
   @SuppressWarnings("UnstableApiUsage") // omit warning about `Property`+`MapProperty`
-  void quarkusStart() {
+  void quarkusStart(Test testTask) {
     getLogger().info("Starting Quarkus application.");
 
     QuarkusAppExtension extension = getProject().getExtensions().getByType(QuarkusAppExtension.class);
@@ -65,7 +65,6 @@ public class StartTask extends DefaultTask {
     // system-properties, because those are subject to the test-task's inputs, which is used
     // as the build-cache key. Instead, pass the dynamic properties via a CommandLineArgumentProvider.
     // In other words: ensure that the `Test` tasks is cacheable.
-    Test testTask = (Test) getProject().getTasks().getByName("test");
     testTask.getJvmArgumentProviders().add(() -> props.keySet().stream()
         .filter(k -> System.getProperty(k) != null)
         .map(k -> String.format("-D%s=%s", k, System.getProperty(k)))


### PR DESCRIPTION
Previously, although the Gradle-Plugin code searched for all tasks that extend the `Test` task,
only the task named `test` was correctly configured. This patch fixes the issue and applies
the configuration (system properties) to all `Test` tasks.

Background: This is to support both "normal" unit tests and also integration-tests in Iceberg
using the `test` and a new `integrationTest`, the latter is to test Nessie against Iceberg
via Spark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1221)
<!-- Reviewable:end -->
