### PR TITLE
Change scope of `nessie-deltalake-core` to `provided`

### DIFF
--- a/clients/deltalake/spark2/pom.xml
+++ b/clients/deltalake/spark2/pom.xml
@@ -35,6 +35,7 @@
       <artifactId>nessie-deltalake-core</artifactId>
       <version>${project.version}</version>
       <classifier>sources</classifier>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>

--- a/clients/deltalake/spark3/pom.xml
+++ b/clients/deltalake/spark3/pom.xml
@@ -35,6 +35,7 @@
       <artifactId>nessie-deltalake-core</artifactId>
       <version>${project.version}</version>
       <classifier>sources</classifier>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>


### PR DESCRIPTION
Spark fails with the following exception, when the Nessie-Delta-client is references via `spark.jars.packages`:
```
  conf.set(
    "spark.jars.packages",
    "org.projectnessie:nessie-deltalake-spark3:0.5.1")
```

```
21/05/11 18:41:29 ERROR SparkContext: Failed to add file:/home/snazy/.ivy2/jars/org.projectnessie_nessie-deltalake-core-0.5.1.jar to Spark environment
java.io.FileNotFoundException: Jar /home/snazy/.ivy2/jars/org.projectnessie_nessie-deltalake-core-0.5.1.jar not found
	at org.apache.spark.SparkContext.addLocalJarFile$1(SparkContext.scala:1848)
	at org.apache.spark.SparkContext.addJar(SparkContext.scala:1902)
	at org.apache.spark.SparkContext.$anonfun$new$11(SparkContext.scala:491)
	at org.apache.spark.SparkContext.$anonfun$new$11$adapted(SparkContext.scala:491)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:491)
	at org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:58)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:247)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:238)
	at py4j.commands.ConstructorCommand.invokeConstructor(ConstructorCommand.java:80)
	at py4j.commands.ConstructorCommand.execute(ConstructorCommand.java:69)
	at py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

Note: `nessie-deltalake-core` has the `source` classifier, there's no code in that Maven module.
Ivy itself correctly has the "right jar" (`org.projectnessie_nessie-deltalake-core-0.5.1-sources.jar`) in `~/.ivy2/jars`, but somehow Spark ignores the `source` classifier, tries to find the "normal" jar (which does not exist) and fails to start.

Chaning the scope of `nessie-deltalake-core` to provided seems to fix the problem.

Fixes #1222

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1223)
<!-- Reviewable:end -->
