### PR TITLE
Add a BOM artifact for Nessie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ version.txt
 
 # Python venv
 venv/
+
+# Maven flatten plugin
+.flattened-pom.xml

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -247,7 +247,7 @@
             <goals>
               <goal>flatten</goal>
             </goals>
-			<configuration>
+            <configuration>
               <flattenMode>bom</flattenMode>
             </configuration>
           </execution>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie</artifactId>
+    <version>0.6.1-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.projectnessie</groupId>
+  <artifactId>nessie-bom</artifactId>
+  <version>0.6.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Nessie - Bill of Materials (BOM)</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-model</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-clients</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-hms-parent</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-hms-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-hms-hive2</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-hms-hive3</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-deltalake</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-deltalake-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-client-tests</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-tools</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-apprunner-maven-plugin</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-spi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-server-parent</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-services</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-server-store</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-tests</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-jgit</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-tiered</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-tiered-impl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-tiered-tests</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-tiered-dynamodb</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-memory</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-ui</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-quarkus</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-deltalake-spark2</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-deltalake-spark3</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-gc-parent</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-gc</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-tiered-gc</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-tiered-mongodb</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-gc-iceberg</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-gc-iceberg-actions</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-perf-test</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-lambda</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <!-- Skip pom check as the final pom is auto generated -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>tidy-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>validate-pom</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+			<configuration>
+              <flattenMode>bom</flattenMode>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/clients/hmsbridge/hive2/pom.xml
+++ b/clients/hmsbridge/hive2/pom.xml
@@ -261,20 +261,20 @@
             <goals>
               <goal>exec</goal>
             </goals>
+            <configuration>
+              <executable>java</executable>
+              <classpathScope>test</classpathScope>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath />
+                <argument>org.projectnessie.hms.CodeGenerator</argument>
+                <argument>-m=HIVE2</argument>
+                <argument>-o=${project.build.directory}/generated-sources/generator</argument>
+              </arguments>
+              <sourceRoot>${project.build.directory}/generated-sources/generator</sourceRoot>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <executable>java</executable>
-          <classpathScope>test</classpathScope>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath />
-            <argument>org.projectnessie.hms.CodeGenerator</argument>
-            <argument>-m=HIVE2</argument>
-            <argument>-o=${project.build.directory}/generated-sources/generator</argument>
-          </arguments>
-          <sourceRoot>${project.build.directory}/generated-sources/generator</sourceRoot>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/clients/hmsbridge/hive3/pom.xml
+++ b/clients/hmsbridge/hive3/pom.xml
@@ -242,20 +242,20 @@
             <goals>
               <goal>exec</goal>
             </goals>
+            <configuration>
+              <executable>java</executable>
+              <classpathScope>test</classpathScope>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath />
+                <argument>org.projectnessie.hms.CodeGenerator</argument>
+                <argument>-m=HIVE3</argument>
+                <argument>-o=${project.build.directory}/generated-sources/generator</argument>
+              </arguments>
+              <sourceRoot>${project.build.directory}/generated-sources/generator</sourceRoot>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <executable>java</executable>
-          <classpathScope>test</classpathScope>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath />
-            <argument>org.projectnessie.hms.CodeGenerator</argument>
-            <argument>-m=HIVE3</argument>
-            <argument>-o=${project.build.directory}/generated-sources/generator</argument>
-          </arguments>
-          <sourceRoot>${project.build.directory}/generated-sources/generator</sourceRoot>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -30,7 +30,7 @@
   <name>Nessie - API</name>
 
   <dependencies>
-  <dependency>
+    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
   </mailingLists>
 
   <modules>
+    <module>bom</module>
     <module>model</module>
     <module>clients</module>
     <module>ui</module>


### PR DESCRIPTION
Add a Bill of Material Maven artifacts for Nessie project, identified by
org.projectnessie:nessie-bom, so that Nessie BOM can be imported into
other projects and make sure consistent versions are used across
artifacts.

(To generate the initial version of the BOM, exec-maven-plugin was used
to list all maven artifacts, which required to fix the hms modules).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1234)
<!-- Reviewable:end -->
