### PR TITLE
Gradle plugin: proper fix to run multiple gradle test tasks + support "reducing the log level"

### DIFF
--- a/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
+++ b/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
@@ -25,6 +25,7 @@ import org.gradle.api.provider.Property;
 @SuppressWarnings("UnstableApiUsage") // omit warning about `Property`+`MapProperty`
 public class QuarkusAppExtension {
   private final MapProperty<String, Object> props;
+  private final MapProperty<String, String> systemProperties;
   private final Property<String> nativeBuilderImage;
 
   private static Map<String, Object> defaultProps() {
@@ -34,7 +35,10 @@ public class QuarkusAppExtension {
   }
 
   public QuarkusAppExtension(Project project) {
-    props = project.getObjects().mapProperty(String.class, Object.class).convention(defaultProps());
+    props = project.getObjects().mapProperty(String.class, Object.class);
+    props.set(defaultProps());
+
+    systemProperties = project.getObjects().mapProperty(String.class, String.class);
 
     // This is not doing anything with Docker or building a native image, just a quirk of Quarkus since 1.10.
     nativeBuilderImage = project.getObjects().property(String.class).convention("quay.io/quarkus/ubi-quarkus-native-image:21.0.0-java11");
@@ -42,6 +46,10 @@ public class QuarkusAppExtension {
 
   public MapProperty<String, Object> getPropsProperty() {
     return props;
+  }
+
+  public MapProperty<String, String> getSystemProperties() {
+    return systemProperties;
   }
 
   public Property<String> getNativeBuilderImageProperty() {

--- a/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/StopTask.java
+++ b/tools/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/StopTask.java
@@ -15,11 +15,15 @@
  */
 package org.projectnessie.quarkus.gradle;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 
 public class StopTask extends DefaultTask {
   private AutoCloseable application;
+
+  final Map<String, String> restoreSystemProps = new HashMap<>();
 
   public StopTask() {
     // intentionally empty
@@ -40,6 +44,15 @@ public class StopTask extends DefaultTask {
       throw new RuntimeException(e);
     } finally {
       application = null;
+
+      // Restore System properties
+      restoreSystemProps.forEach((k, v) -> {
+        if (v != null) {
+          System.setProperty(k, v);
+        } else {
+          System.getProperties().remove(k);
+        }
+      });
     }
   }
 

--- a/tools/apprunner-gradle-plugin/src/main/resources/org/projectnessie/quarkus/gradle/log4j2-quarkus.xml
+++ b/tools/apprunner-gradle-plugin/src/main/resources/org/projectnessie/quarkus/gradle/log4j2-quarkus.xml
@@ -21,7 +21,10 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="${env:NESSIE_QUARKUS_LOG_LEVEL:-info}">
+    <Logger name="io.quarkus.http.access-log" level="${sys:nessie.quarkus.log.http.level:-info}">
+      <AppenderRef ref="Console"/>
+    </Logger>
+    <Root level="${sys:nessie.quarkus.log.level:-info}">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
The previous fix #1221 to support multiple Gradle `Test` tasks unfortunately did only fix it for the Gradle configuration-phase, but actually running both a `:iceberg-nessie:test` plus `:iceberg-nessie:integrationTest` tasks failed. The fix is to "just" not start Quarkus twice.

This PR also adds a new `systemProperties` property to the `QuarkusAppExtension`, to set additional system-properties, which is necessary to reduce the log level as requested by https://github.com/apache/iceberg/issues/2557

On top, it restores the previous system-properties when the `StopTask` is executed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1243)
<!-- Reviewable:end -->
