### PR TITLE
Enable Java11 for Quarkus modules

### DIFF
--- a/servers/lambda/pom.xml
+++ b/servers/lambda/pom.xml
@@ -30,6 +30,7 @@
   <name>Nessie - Lambda Function</name>
 
   <properties>
+    <maven.compiler.release>11</maven.compiler.release>
     <quarkus.jacoco.data-file>jacoco.exec</quarkus.jacoco.data-file>
     <test.log.level>INFO</test.log.level>
   </properties>

--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -30,6 +30,7 @@
   <name>Nessie - Quarkus</name>
 
   <properties>
+    <maven.compiler.release>11</maven.compiler.release>
     <quarkus.jacoco.data-file>jacoco.exec</quarkus.jacoco.data-file>
     <quarkus.smallrye-openapi.store-schema-directory>${project.build.directory}/openapi</quarkus.smallrye-openapi.store-schema-directory>
     <test.log.level>INFO</test.log.level>


### PR DESCRIPTION
As Quarkus is designed for Java11 and Quarkus 2.0 will remove Java 8
support, allow quarkus server and lambda modules to be build with the
Java 11 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1245)
<!-- Reviewable:end -->
