### PR TITLE
[site] Add links to Nessie demos

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -13,7 +13,7 @@ The site is built using mkdocs. To install mkdocs and the theme, run:
 ```
 # Activate the virtual environment (if installed)
 cd site/
-. bin/activate
+. venv/bin/activate
 # Install or update the dependencies
 pip install -r ./requirements.txt
 ```

--- a/site/docs/try/_config
+++ b/site/docs/try/_config
@@ -1,1 +1,7 @@
 title: Try Now
+arrange:
+  - index.md
+  - docker.md
+  - configuration.md
+  - releases.md
+  

--- a/site/docs/try/docker.md
+++ b/site/docs/try/docker.md
@@ -1,8 +1,8 @@
-# Setting Up Nessie 
+# Setting Up Nessie
 
 <iframe width="780" height="500" src="https://www.youtube.com/embed/QUmOU8ea_i4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-As part of each release, Nessie is made available as a fast-start docker 
+As part of each release, Nessie is made available as a fast-start docker
 image. This is the easiest and fastest way to try out nessie locally and test all its capabilities.
 The image is relatively small and builds on top of standard base images. To get started:
 
@@ -39,7 +39,7 @@ Once the docker image is up and running, you can install the [Nessie cli](../too
 $ pip install pynessie
 ```
 
-You're now ready to start using Nessie. To create a new branch, you can do 
+You're now ready to start using Nessie. To create a new branch, you can do
 the following:
 
 ```bash
@@ -55,4 +55,4 @@ From there, you can use one of the three main Nessie integrations of:
 * NessieCatalog for Iceberg [within Spark](../tools/spark.md)
 * Nessie Log Handle for Delta Lake [within Spark](../tools/spark.md)
 * Hive or HMS compatible tool use with the [Nessie HMS Bridge](../tools/hive.md)
-  
+

--- a/site/docs/try/docker.md
+++ b/site/docs/try/docker.md
@@ -1,0 +1,58 @@
+# Setting up Nessie 
+
+<iframe width="780" height="500" src="https://www.youtube.com/embed/QUmOU8ea_i4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+As part of each release, Nessie is made available as a fast-start docker 
+image. This is the easiest and fastest way to try out nessie locally and test all its capabilities.
+The image is relatively small and builds on top of standard base images. To get started:
+
+```bash
+$ docker pull projectnessie/nessie
+```
+
+```bash
+Pulling from projectnessie/nessie
+0fd3b5213a9b: Already exists
+aebb8c556853: Already exists
+a50558612231: Pull complete
+Digest: sha256:bda3dead4eb51a4c0ff87c7ce5a81ad49a37dd17d785f2549f4559f06cbf24d6
+Status: Downloaded newer image for projectnessie/nessie
+```
+
+```bash
+$ docker run -p 19120:19120 projectnessie/nessie
+```
+
+```bash
+__  ____  __  _____   ___  __ ____  ______
+ --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
+ -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
+--\___\_\____/_/ |_/_/|_/_/|_|\____/___/
+2020-10-01 21:50:27,166 INFO  [io.quarkus] (main) nessie-quarkus 0.1-SNAPSHOT native (powered by Quarkus 1.8.1.Final) started in 0.025s. Listening on: http://0.0.0.0:19120
+2020-10-01 21:50:27,166 INFO  [io.quarkus] (main) Profile prod activated.
+2020-10-01 21:50:27,166 INFO  [io.quarkus] (main) Installed features: [amazon-dynamodb, cdi, hibernate-validator, jaeger, resteasy, resteasy-jackson, security, security-properties-file, sentry, smallrye-health, smallrye-metrics, smallrye-openapi, smallrye-opentracing]
+```
+
+Once the docker image is up and running, you can install the [Nessie cli](../tools/cli.md).
+
+```bash
+$ pip install pynessie
+```
+
+You're now ready to start using Nessie. To create a new branch, you can do 
+the following:
+
+```bash
+# create a branch pointing to the same hash as
+# the current default branch (typically the main branch)
+$ nessie branch my_branch
+```
+
+
+From there, you can use one of the three main Nessie integrations of:
+
+* Take a look at your current empty repository in the [Web UI](../tools/ui.md)
+* NessieCatalog for Iceberg [within Spark](../tools/spark.md)
+* Nessie Log Handle for Delta Lake [within Spark](../tools/spark.md)
+* Hive or HMS compatible tool use with the [Nessie HMS Bridge](../tools/hive.md)
+  

--- a/site/docs/try/docker.md
+++ b/site/docs/try/docker.md
@@ -1,4 +1,4 @@
-# Setting up Nessie 
+# Setting Up Nessie 
 
 <iframe width="780" height="500" src="https://www.youtube.com/embed/QUmOU8ea_i4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/site/docs/try/index.md
+++ b/site/docs/try/index.md
@@ -1,58 +1,11 @@
-# Getting Started
+# Getting started 
 
-<iframe width="780" height="500" src="https://www.youtube.com/embed/QUmOU8ea_i4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+For a quick overview of nessie capabilities, several demos which do not require
+any special setup except for a web browser have been made available:
 
-As part of each release, Nessie is made available as a fast-start docker 
-image. This is the easiest and fastest way to try out nessie. The image is relatively small 
-and builds on top of standard base images. To get started:
+* [Nessie and Spark via Binder](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=colab%2Fnessie-iceberg-demo-nba.ipynb)
+* [Nessie and Spark via Google Colab](https://colab.research.google.com/github/projectnessie/nessie-demos/blob/main/colab/nessie-iceberg-demo-nba.ipynb)
 
-```bash
-$ docker pull projectnessie/nessie
-```
-
-```bash
-Pulling from projectnessie/nessie
-0fd3b5213a9b: Already exists
-aebb8c556853: Already exists
-a50558612231: Pull complete
-Digest: sha256:bda3dead4eb51a4c0ff87c7ce5a81ad49a37dd17d785f2549f4559f06cbf24d6
-Status: Downloaded newer image for projectnessie/nessie
-```
-
-```bash
-$ docker run -p 19120:19120 projectnessie/nessie
-```
-
-```bash
-__  ____  __  _____   ___  __ ____  ______
- --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
- -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
---\___\_\____/_/ |_/_/|_/_/|_|\____/___/
-2020-10-01 21:50:27,166 INFO  [io.quarkus] (main) nessie-quarkus 0.1-SNAPSHOT native (powered by Quarkus 1.8.1.Final) started in 0.025s. Listening on: http://0.0.0.0:19120
-2020-10-01 21:50:27,166 INFO  [io.quarkus] (main) Profile prod activated.
-2020-10-01 21:50:27,166 INFO  [io.quarkus] (main) Installed features: [amazon-dynamodb, cdi, hibernate-validator, jaeger, resteasy, resteasy-jackson, security, security-properties-file, sentry, smallrye-health, smallrye-metrics, smallrye-openapi, smallrye-opentracing]
-```
-
-Once the docker image is up and running, you can install the [Nessie cli](../tools/cli.md).
-
-```bash
-$ pip install pynessie
-```
-
-You're now ready to start using Nessie. To create a new branch, you can do 
-the following:
-
-```bash
-# create a branch pointing to the same hash as
-# the current default branch (typically the main branch)
-$ nessie branch my_branch
-```
-
-
-From there, you can use one of the three main Nessie integrations of:
-
-* Take a look at your current empty repository in the [Web UI](../tools/ui.md)
-* NessieCatalog for Iceberg [within Spark](../tools/spark.md)
-* Nessie Log Handle for Delta Lake [within Spark](../tools/spark.md)
-* Hive or HMS compatible tool use with the [Nessie HMS Bridge](../tools/hive.md)
-  
+For people who are interested in trying out all nessie features, they can use
+the docker images published with each release and setup the server by following
+the instructions available [here](docker.md)

--- a/site/docs/try/index.md
+++ b/site/docs/try/index.md
@@ -1,4 +1,4 @@
-# Getting Started 
+# Getting Started
 
 For a quick overview of nessie capabilities, several demos which do not require
 any special setup except for a web browser have been made available:

--- a/site/docs/try/index.md
+++ b/site/docs/try/index.md
@@ -1,4 +1,4 @@
-# Getting started 
+# Getting Started 
 
 For a quick overview of nessie capabilities, several demos which do not require
 any special setup except for a web browser have been made available:

--- a/site/docs/try/index.md
+++ b/site/docs/try/index.md
@@ -3,8 +3,8 @@
 For a quick overview of nessie capabilities, several demos which do not require
 any special setup except for a web browser have been made available:
 
-* [Nessie and Spark via Binder](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=colab%2Fnessie-iceberg-demo-nba.ipynb)
-* [Nessie and Spark via Google Colab](https://colab.research.google.com/github/projectnessie/nessie-demos/blob/main/colab/nessie-iceberg-demo-nba.ipynb)
+* [Nessie, Iceberg and Spark via Binder](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=colab%2Fnessie-iceberg-demo-nba.ipynb)
+* [Nessie, Iceberg and Spark via Google Colab](https://colab.research.google.com/github/projectnessie/nessie-demos/blob/main/colab/nessie-iceberg-demo-nba.ipynb)
 
 For people who are interested in trying out all nessie features, they can use
 the docker images published with each release and setup the server by following


### PR DESCRIPTION
Reorganize the "Try out" section of the website by adding the Nessie
demos in addition of the instructions for setting up the docker image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1246)
<!-- Reviewable:end -->
