### PR TITLE
Ignore unknown fields in JSON objects

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Base.java
+++ b/model/src/main/java/org/projectnessie/model/Base.java
@@ -15,5 +15,8 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /** base interface for all model/api classes. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface Base {}

--- a/model/src/main/java/org/projectnessie/model/CommitMeta.java
+++ b/model/src/main/java/org/projectnessie/model/CommitMeta.java
@@ -34,7 +34,7 @@ import org.immutables.value.Value;
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableCommitMeta.class)
 @JsonDeserialize(as = ImmutableCommitMeta.class)
-public abstract class CommitMeta {
+public abstract class CommitMeta implements Base {
 
   /**
    * Hash of this commit.

--- a/model/src/main/java/org/projectnessie/model/Contents.java
+++ b/model/src/main/java/org/projectnessie/model/Contents.java
@@ -53,7 +53,7 @@ import org.immutables.value.Value;
   @Type(HiveDatabase.class)
 })
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-public abstract class Contents {
+public abstract class Contents implements Base {
 
   public static enum Type {
     UNKNOWN,

--- a/model/src/main/java/org/projectnessie/model/ContentsKey.java
+++ b/model/src/main/java/org/projectnessie/model/ContentsKey.java
@@ -34,8 +34,7 @@ import org.immutables.value.Value;
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableContentsKey.class)
 @JsonDeserialize(as = ImmutableContentsKey.class)
-public abstract class ContentsKey {
-
+public abstract class ContentsKey implements Base {
   private static final char ZERO_BYTE = '\u0000';
   private static final String ZERO_BYTE_STRING = Character.toString(ZERO_BYTE);
 

--- a/model/src/main/java/org/projectnessie/model/EntriesResponse.java
+++ b/model/src/main/java/org/projectnessie/model/EntriesResponse.java
@@ -34,7 +34,7 @@ public interface EntriesResponse extends PaginatedResponse {
   @Value.Immutable(prehash = true)
   @JsonSerialize(as = ImmutableEntry.class)
   @JsonDeserialize(as = ImmutableEntry.class)
-  interface Entry {
+  interface Entry extends Base {
 
     static ImmutableEntry.Builder builder() {
       return ImmutableEntry.builder();

--- a/model/src/main/java/org/projectnessie/model/Merge.java
+++ b/model/src/main/java/org/projectnessie/model/Merge.java
@@ -27,7 +27,7 @@ import org.immutables.value.Value;
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableMerge.class)
 @JsonDeserialize(as = ImmutableMerge.class)
-public interface Merge {
+public interface Merge extends Base {
 
   String getFromHash();
 

--- a/model/src/main/java/org/projectnessie/model/MultiGetContentsRequest.java
+++ b/model/src/main/java/org/projectnessie/model/MultiGetContentsRequest.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableMultiGetContentsRequest.class)
 @JsonDeserialize(as = ImmutableMultiGetContentsRequest.class)
-public interface MultiGetContentsRequest {
+public interface MultiGetContentsRequest extends Base {
 
   List<ContentsKey> getRequestedKeys();
 

--- a/model/src/main/java/org/projectnessie/model/MultiGetContentsResponse.java
+++ b/model/src/main/java/org/projectnessie/model/MultiGetContentsResponse.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableMultiGetContentsResponse.class)
 @JsonDeserialize(as = ImmutableMultiGetContentsResponse.class)
-public interface MultiGetContentsResponse {
+public interface MultiGetContentsResponse extends Base {
 
   List<ContentsWithKey> getContents();
 
@@ -37,7 +37,7 @@ public interface MultiGetContentsResponse {
   @Value.Immutable(prehash = true)
   @JsonSerialize(as = ImmutableContentsWithKey.class)
   @JsonDeserialize(as = ImmutableContentsWithKey.class)
-  interface ContentsWithKey {
+  interface ContentsWithKey extends Base {
 
     ContentsKey getKey();
 

--- a/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
+++ b/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableNessieConfiguration.class)
 @JsonDeserialize(as = ImmutableNessieConfiguration.class)
-public abstract class NessieConfiguration {
+public abstract class NessieConfiguration implements Base {
 
   @JsonIgnore private static final String CURRENT_VERSION = "1.0";
 

--- a/model/src/main/java/org/projectnessie/model/Operation.java
+++ b/model/src/main/java/org/projectnessie/model/Operation.java
@@ -42,7 +42,7 @@ import org.immutables.value.Value;
   @Type(Operation.Unchanged.class)
 })
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-public interface Operation {
+public interface Operation extends Base {
 
   ContentsKey getKey();
 

--- a/model/src/main/java/org/projectnessie/model/Operations.java
+++ b/model/src/main/java/org/projectnessie/model/Operations.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableOperations.class)
 @JsonDeserialize(as = ImmutableOperations.class)
-public interface Operations {
+public interface Operations extends Base {
 
   CommitMeta getCommitMeta();
 

--- a/model/src/main/java/org/projectnessie/model/PaginatedResponse.java
+++ b/model/src/main/java/org/projectnessie/model/PaginatedResponse.java
@@ -18,7 +18,7 @@ package org.projectnessie.model;
 import javax.annotation.Nullable;
 import org.immutables.value.Value.Default;
 
-public interface PaginatedResponse {
+public interface PaginatedResponse extends Base {
 
   /**
    * Whether there are more result-items than returned by this response object.

--- a/model/src/main/java/org/projectnessie/model/Transplant.java
+++ b/model/src/main/java/org/projectnessie/model/Transplant.java
@@ -28,7 +28,7 @@ import org.immutables.value.Value;
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableTransplant.class)
 @JsonDeserialize(as = ImmutableTransplant.class)
-public interface Transplant {
+public interface Transplant extends Base {
 
   List<String> getHashesToTransplant();
 

--- a/model/src/test/java/org/projectnessie/model/TestIgnoreProperties.java
+++ b/model/src/test/java/org/projectnessie/model/TestIgnoreProperties.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.util.JsonGeneratorDelegate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.model.Contents.Type;
+import org.projectnessie.model.EntriesResponse.Entry;
+import org.projectnessie.model.MultiGetContentsResponse.ContentsWithKey;
+import org.projectnessie.model.Operation.Delete;
+import org.projectnessie.model.Operation.Put;
+import org.projectnessie.model.Operation.Unchanged;
+
+/**
+ * Tests that unknown fields in a JSON do not break deserialization.
+ *
+ * <p>The implementation approach is to construct some valid objects, serialize those to JSON,
+ * inject additional (=unknown) fields during serialization and deserializing the "enriched" JSON.
+ */
+class TestIgnoreProperties {
+
+  static ObjectMapper mapper;
+
+  @BeforeAll
+  static void setup() {
+    mapper =
+        new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+  }
+
+  @Test
+  void multiGet() throws Exception {
+    doTestUnknown(
+        MultiGetContentsRequest.of(ContentsKey.of("foo", "bar")), MultiGetContentsRequest.class);
+    doTestUnknown(
+        MultiGetContentsResponse.of(
+            Collections.singletonList(
+                ContentsWithKey.of(ContentsKey.of("foo", "bar"), IcebergTable.of("here/there")))),
+        MultiGetContentsResponse.class);
+  }
+
+  @Test
+  void paginated() throws Exception {
+    doTestUnknown(
+        EntriesResponse.builder()
+            .addEntries(
+                Entry.builder().name(ContentsKey.of("entry-name")).type(Type.ICEBERG_TABLE).build())
+            .build(),
+        EntriesResponse.class);
+    doTestUnknown(
+        ImmutableLogResponse.builder()
+            .addOperations(
+                CommitMeta.builder()
+                    .commitTime(Instant.now())
+                    .authorTime(Instant.now())
+                    .properties(Collections.emptyMap())
+                    .committer("committer")
+                    .author("author")
+                    .message("something important")
+                    .signedOffBy("signed-by-human")
+                    .hash("1234123412341234123412341234123412341234")
+                    .build())
+            .hasMore(true)
+            .token("token")
+            .build(),
+        LogResponse.class);
+  }
+
+  @Test
+  void reference() throws Exception {
+    doTestUnknown(Branch.of("name", "1234123412341234123412341234123412341234"), Reference.class);
+    doTestUnknown(Tag.of("name", "1234123412341234123412341234123412341234"), Reference.class);
+    doTestUnknown(Hash.of("1234123412341234123412341234123412341234"), Reference.class);
+  }
+
+  @Test
+  void operations() throws Exception {
+    Operations ops =
+        ImmutableOperations.builder()
+            .commitMeta(
+                CommitMeta.builder()
+                    .message("some message")
+                    .commitTime(Instant.now())
+                    .authorTime(Instant.now())
+                    .hash("1234123412341234123412341234123412341234")
+                    .build())
+            .addOperations(Delete.of(ContentsKey.of("delete", "something")))
+            .addOperations(Unchanged.of(ContentsKey.of("nothing", "changed")))
+            .addOperations(
+                Put.of(ContentsKey.of("put", "iceberg"), IcebergTable.of("here/and/there")))
+            .addOperations(
+                Put.of(
+                    ContentsKey.of("put", "delta"),
+                    ImmutableDeltaLakeTable.builder()
+                        .lastCheckpoint("checkpoint")
+                        .addMetadataLocationHistory("meta", "data", "location")
+                        .addCheckpointLocationHistory("checkpoint")
+                        .id("delta-id")
+                        .build()))
+            .addOperations(
+                Put.of(
+                    ContentsKey.of("put", "hive"),
+                    ImmutableHiveTable.builder()
+                        .addPartitions(new byte[5])
+                        .tableDefinition(new byte[10])
+                        .id("hive-id")
+                        .build()))
+            .build();
+    doTestUnknown(ops, Operations.class);
+  }
+
+  private <T> void doTestUnknown(T value, Class<T> type) throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    ObjectWriter objWriter = mapper.writerFor(type);
+
+    JsonGenerator jsonGen = objWriter.createGenerator(buf, JsonEncoding.UTF8);
+
+    AtomicInteger counter = new AtomicInteger();
+
+    JsonGenerator mock =
+        new JsonGeneratorDelegate(jsonGen) {
+          @Override
+          public void writeFieldName(String name) throws IOException {
+            unknownFields();
+            super.writeFieldName(name);
+          }
+
+          @Override
+          public void writeFieldName(SerializableString name) throws IOException {
+            unknownFields();
+            super.writeFieldName(name);
+          }
+
+          private void unknownFields() throws IOException {
+            jsonGen.writeStringField("someUnknownField_" + counter.incrementAndGet(), "foo bar");
+
+            jsonGen.writeArrayFieldStart("someUnknownField_" + counter.incrementAndGet());
+            jsonGen.writeString("meep");
+            jsonGen.writeString("meep");
+            jsonGen.writeString("meep");
+            jsonGen.writeEndArray();
+
+            jsonGen.writeObjectFieldStart("someUnknownField_" + counter.incrementAndGet());
+            jsonGen.writeStringField("someUnknownField_" + counter.incrementAndGet(), "foo bar");
+            jsonGen.writeEndObject();
+          }
+        };
+
+    objWriter.writeValue(mock, value);
+
+    String str = buf.toString("UTF-8");
+
+    // System.err.println(str);
+
+    ObjectReader reader = mapper.readerFor(type);
+    Object deserialized = reader.readValue(str);
+
+    Assertions.assertEquals(value, deserialized);
+  }
+}

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -7,6 +7,7 @@ from typing import Optional
 import attr
 import desert
 from marshmallow import fields
+from marshmallow.utils import EXCLUDE
 from marshmallow_oneofschema import OneOfSchema
 
 
@@ -32,7 +33,7 @@ class IcebergTable(Contents):
         return "Iceberg table:\n\t{}".format(self.metadata_location)
 
 
-IcebergTableSchema = desert.schema_class(IcebergTable)
+IcebergTableSchema = desert.schema_class(IcebergTable, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -52,7 +53,22 @@ class DeltaLakeTable(Contents):
         )
 
 
-DeltaLakeTableSchema = desert.schema_class(DeltaLakeTable)
+DeltaLakeTableSchema = desert.schema_class(DeltaLakeTable, {"unknown": EXCLUDE})
+
+
+@attr.dataclass
+class HiveTable(Contents):
+    """Dataclass for Nessie Contents."""
+
+    table_definition: str = desert.ib(fields.Str(data_key="tableDefinition"))
+    partitions: List[str] = desert.ib(fields.List(fields.Str))
+
+    def pretty_print(self: "HiveTable") -> str:
+        """Print out for cli."""
+        return "Hive table:\n\tTable definition: {}\n\tPartitions: {}".format(self.table_definition, "\n\t\t".join(self.partitions))
+
+
+HiveTableSchema = desert.schema_class(HiveTable, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -67,7 +83,7 @@ class SqlView(Contents):
         return "SqlView:\n\tDialect: {}\n\tSql: {}".format(self.dialect, self.sql_test)  # todo use a sql parser to pretty print this
 
 
-SqlViewSchema = desert.schema_class(SqlView)
+SqlViewSchema = desert.schema_class(SqlView, {"unknown": EXCLUDE})
 
 
 class ContentsSchema(OneOfSchema):
@@ -76,6 +92,7 @@ class ContentsSchema(OneOfSchema):
     type_schemas = {
         "ICEBERG_TABLE": IcebergTableSchema,
         "DELTA_LAKE_TABLE": DeltaLakeTableSchema,
+        "HIVE_TABLE": HiveTableSchema,
         "VIEW": SqlViewSchema,
     }
 
@@ -98,24 +115,24 @@ class ContentsKey:
     elements: List[str] = desert.ib(fields.List(fields.Str))
 
 
-ContentsKeySchema = desert.schema_class(ContentsKey)
+ContentsKeySchema = desert.schema_class(ContentsKey, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
 class Operation:
     """Single Commit Operation."""
 
-    key: ContentsKey = desert.ib(fields.Nested(ContentsKeySchema))
+    key: ContentsKey = desert.ib(fields.Nested(ContentsKeySchema, unknown=EXCLUDE))
 
 
 @attr.dataclass
 class Put(Operation):
     """Single Commit Operation."""
 
-    contents: Contents = desert.ib(fields.Nested(ContentsSchema))
+    contents: Contents = desert.ib(fields.Nested(ContentsSchema, unknown=EXCLUDE))
 
 
-PutOperationSchema = desert.schema_class(Put)
+PutOperationSchema = desert.schema_class(Put, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -125,7 +142,7 @@ class Delete(Operation):
     pass
 
 
-DeleteOperationSchema = desert.schema_class(Delete)
+DeleteOperationSchema = desert.schema_class(Delete, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -135,7 +152,7 @@ class Unchanged(Operation):
     pass
 
 
-UnchangedOperationSchema = desert.schema_class(Unchanged)
+UnchangedOperationSchema = desert.schema_class(Unchanged, {"unknown": EXCLUDE})
 
 
 class OperationsSchema(OneOfSchema):
@@ -174,7 +191,7 @@ class Branch(Reference):
     pass
 
 
-BranchSchema = desert.schema_class(Branch)
+BranchSchema = desert.schema_class(Branch, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -184,7 +201,7 @@ class Tag(Reference):
     pass
 
 
-TagSchema = desert.schema_class(Tag)
+TagSchema = desert.schema_class(Tag, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -194,7 +211,7 @@ class Hash(Reference):
     pass
 
 
-HashSchema = desert.schema_class(Hash)
+HashSchema = desert.schema_class(Hash, {"unknown": EXCLUDE})
 
 
 class ReferenceSchema(OneOfSchema):
@@ -225,7 +242,7 @@ class EntryName:
     elements: List[str] = desert.ib(fields.List(fields.Str()))
 
 
-EntryNameSchema = desert.schema_class(EntryName)
+EntryNameSchema = desert.schema_class(EntryName, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -233,22 +250,22 @@ class Entry:
     """Dataclass for Nessie Entry."""
 
     kind: str = desert.ib(fields.Str(data_key="type"))
-    name: EntryName = desert.ib(fields.Nested(EntryNameSchema))
+    name: EntryName = desert.ib(fields.Nested(EntryNameSchema, unknown=EXCLUDE))
 
 
-EntrySchema = desert.schema_class(Entry)
+EntrySchema = desert.schema_class(Entry, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
 class Entries:
     """Dataclass for Content Entries."""
 
-    entries: List[Entry] = desert.ib(fields.List(fields.Nested(EntrySchema())))
+    entries: List[Entry] = desert.ib(fields.List(fields.Nested(EntrySchema(), unknown=EXCLUDE)))
     has_more: bool = attr.ib(default=False, metadata=desert.metadata(fields.Bool(allow_none=True, data_key="hasMore")))
     token: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(allow_none=True)))
 
 
-EntriesSchema = desert.schema_class(Entries)
+EntriesSchema = desert.schema_class(Entries, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -266,19 +283,19 @@ class CommitMeta:
     properties: dict = desert.ib(fields.Dict(), default=None)
 
 
-CommitMetaSchema = desert.schema_class(CommitMeta)
+CommitMetaSchema = desert.schema_class(CommitMeta, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
 class LogResponse:
     """Dataclass for Log Response."""
 
-    operations: List[CommitMeta] = desert.ib(fields.List(fields.Nested(CommitMetaSchema())))
+    operations: List[CommitMeta] = desert.ib(fields.List(fields.Nested(CommitMetaSchema(), unknown=EXCLUDE)))
     has_more: bool = attr.ib(default=False, metadata=desert.metadata(fields.Bool(allow_none=True, data_key="hasMore")))
     token: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(allow_none=True)))
 
 
-LogResponseSchema = desert.schema_class(LogResponse)
+LogResponseSchema = desert.schema_class(LogResponse, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -288,7 +305,7 @@ class Transplant:
     hashes_to_transplant: List[str] = attr.ib(metadata=desert.metadata(fields.List(fields.Str(), data_key="hashesToTransplant")))
 
 
-TransplantSchema = desert.schema_class(Transplant)
+TransplantSchema = desert.schema_class(Transplant, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
@@ -298,15 +315,15 @@ class Merge:
     from_hash: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(data_key="fromHash")))
 
 
-MergeSchema = desert.schema_class(Merge)
+MergeSchema = desert.schema_class(Merge, {"unknown": EXCLUDE})
 
 
 @attr.dataclass
 class MultiContents:
     """Contents container for commit."""
 
-    commit_meta: CommitMeta = desert.ib(fields.Nested(CommitMetaSchema, data_key="commitMeta"))
-    operations: List[Operation] = desert.ib(fields.List(fields.Nested(OperationsSchema())))
+    commit_meta: CommitMeta = desert.ib(fields.Nested(CommitMetaSchema, data_key="commitMeta", unknown=EXCLUDE))
+    operations: List[Operation] = desert.ib(fields.List(fields.Nested(OperationsSchema(), unknown=EXCLUDE)))
 
 
-MultiContentsSchema = desert.schema_class(MultiContents)
+MultiContentsSchema = desert.schema_class(MultiContents, {"unknown": EXCLUDE})

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tests for `pynessie` package."""
+
+from json import loads
+
+from pynessie.model import BranchSchema, EntriesSchema, LogResponseSchema, MultiContentsSchema
+
+
+class TestIgnoreProperties(object):
+    """Test whether JSON deserialization works with unknown properties.
+
+    The JSON strings here have been "captures" from the output of the
+    `org.projectnessie.model.TestIgnoreProperties` test by uncommenting
+    a `System.err.println`.
+    """
+
+    def test_branch(self: "TestIgnoreProperties") -> None:
+        """Test Branch deserialization."""
+        str = u"""
+        {
+          "someUnknownField_1" : "foo bar",
+          "someUnknownField_2" : [ "meep", "meep", "meep" ],
+          "someUnknownField_3" : {
+            "someUnknownField_4" : "foo bar"
+          },
+          "type" : "BRANCH",
+          "someUnknownField_5" : "foo bar",
+          "someUnknownField_6" : [ "meep", "meep", "meep" ],
+          "someUnknownField_7" : {
+            "someUnknownField_8" : "foo bar"
+          },
+          "name" : "name",
+          "someUnknownField_9" : "foo bar",
+          "someUnknownField_10" : [ "meep", "meep", "meep" ],
+          "someUnknownField_11" : {
+            "someUnknownField_12" : "foo bar"
+          },
+          "hash" : "1234123412341234123412341234123412341234"
+        }
+        """
+        json = loads(str)
+        BranchSchema().load(json)
+
+    def test_tag(self: "TestIgnoreProperties") -> None:
+        """Test Tag deserialization."""
+        str = u"""
+        {
+          "someUnknownField_1" : "foo bar",
+          "someUnknownField_2" : [ "meep", "meep", "meep" ],
+          "someUnknownField_3" : {
+            "someUnknownField_4" : "foo bar"
+          },
+          "type" : "TAG",
+          "someUnknownField_5" : "foo bar",
+          "someUnknownField_6" : [ "meep", "meep", "meep" ],
+          "someUnknownField_7" : {
+            "someUnknownField_8" : "foo bar"
+          },
+          "name" : "name",
+          "someUnknownField_9" : "foo bar",
+          "someUnknownField_10" : [ "meep", "meep", "meep" ],
+          "someUnknownField_11" : {
+            "someUnknownField_12" : "foo bar"
+          },
+          "hash" : "1234123412341234123412341234123412341234"
+        }
+        """
+        json = loads(str)
+        BranchSchema().load(json)
+
+    def test_hash(self: "TestIgnoreProperties") -> None:
+        """Test Hash deserialization."""
+        str = u"""
+        {
+          "someUnknownField_1" : "foo bar",
+          "someUnknownField_2" : [ "meep", "meep", "meep" ],
+          "someUnknownField_3" : {
+            "someUnknownField_4" : "foo bar"
+          },
+          "type" : "HASH",
+          "someUnknownField_5" : "foo bar",
+          "someUnknownField_6" : [ "meep", "meep", "meep" ],
+          "someUnknownField_7" : {
+            "someUnknownField_8" : "foo bar"
+          },
+          "name" : "1234123412341234123412341234123412341234",
+          "someUnknownField_9" : "foo bar",
+          "someUnknownField_10" : [ "meep", "meep", "meep" ],
+          "someUnknownField_11" : {
+            "someUnknownField_12" : "foo bar"
+          },
+          "hash" : "1234123412341234123412341234123412341234"
+        }
+        """
+        json = loads(str)
+        BranchSchema().load(json)
+
+    def test_operations(self: "TestIgnoreProperties") -> None:
+        """Test MultiContentsSchema (= Operations in Java) deserialization."""
+        str = u"""
+        {
+          "someUnknownField_1" : "foo bar",
+          "someUnknownField_2" : [ "meep", "meep", "meep" ],
+          "someUnknownField_3" : {
+            "someUnknownField_4" : "foo bar"
+          },
+          "commitMeta" : {
+            "someUnknownField_5" : "foo bar",
+            "someUnknownField_6" : [ "meep", "meep", "meep" ],
+            "someUnknownField_7" : {
+              "someUnknownField_8" : "foo bar"
+            },
+            "hash" : "1234123412341234123412341234123412341234",
+            "someUnknownField_9" : "foo bar",
+            "someUnknownField_10" : [ "meep", "meep", "meep" ],
+            "someUnknownField_11" : {
+              "someUnknownField_12" : "foo bar"
+            },
+            "committer" : null,
+            "someUnknownField_13" : "foo bar",
+            "someUnknownField_14" : [ "meep", "meep", "meep" ],
+            "someUnknownField_15" : {
+              "someUnknownField_16" : "foo bar"
+            },
+            "author" : null,
+            "someUnknownField_17" : "foo bar",
+            "someUnknownField_18" : [ "meep", "meep", "meep" ],
+            "someUnknownField_19" : {
+              "someUnknownField_20" : "foo bar"
+            },
+            "signedOffBy" : null,
+            "someUnknownField_21" : "foo bar",
+            "someUnknownField_22" : [ "meep", "meep", "meep" ],
+            "someUnknownField_23" : {
+              "someUnknownField_24" : "foo bar"
+            },
+            "message" : "some message",
+            "someUnknownField_25" : "foo bar",
+            "someUnknownField_26" : [ "meep", "meep", "meep" ],
+            "someUnknownField_27" : {
+              "someUnknownField_28" : "foo bar"
+            },
+            "commitTime" : "2021-05-18T13:15:11.646155Z",
+            "someUnknownField_29" : "foo bar",
+            "someUnknownField_30" : [ "meep", "meep", "meep" ],
+            "someUnknownField_31" : {
+              "someUnknownField_32" : "foo bar"
+            },
+            "authorTime" : "2021-05-18T13:15:11.646164Z",
+            "someUnknownField_33" : "foo bar",
+            "someUnknownField_34" : [ "meep", "meep", "meep" ],
+            "someUnknownField_35" : {
+              "someUnknownField_36" : "foo bar"
+            },
+            "properties" : { }
+          },
+          "someUnknownField_37" : "foo bar",
+          "someUnknownField_38" : [ "meep", "meep", "meep" ],
+          "someUnknownField_39" : {
+            "someUnknownField_40" : "foo bar"
+          },
+          "operations" : [ {
+            "someUnknownField_41" : "foo bar",
+            "someUnknownField_42" : [ "meep", "meep", "meep" ],
+            "someUnknownField_43" : {
+              "someUnknownField_44" : "foo bar"
+            },
+            "type" : "DELETE",
+            "someUnknownField_45" : "foo bar",
+            "someUnknownField_46" : [ "meep", "meep", "meep" ],
+            "someUnknownField_47" : {
+              "someUnknownField_48" : "foo bar"
+            },
+            "key" : {
+              "someUnknownField_49" : "foo bar",
+              "someUnknownField_50" : [ "meep", "meep", "meep" ],
+              "someUnknownField_51" : {
+                "someUnknownField_52" : "foo bar"
+              },
+              "elements" : [ "delete", "something" ]
+            }
+          }, {
+            "someUnknownField_53" : "foo bar",
+            "someUnknownField_54" : [ "meep", "meep", "meep" ],
+            "someUnknownField_55" : {
+              "someUnknownField_56" : "foo bar"
+            },
+            "type" : "UNCHANGED",
+            "someUnknownField_57" : "foo bar",
+            "someUnknownField_58" : [ "meep", "meep", "meep" ],
+            "someUnknownField_59" : {
+              "someUnknownField_60" : "foo bar"
+            },
+            "key" : {
+              "someUnknownField_61" : "foo bar",
+              "someUnknownField_62" : [ "meep", "meep", "meep" ],
+              "someUnknownField_63" : {
+                "someUnknownField_64" : "foo bar"
+              },
+              "elements" : [ "nothing", "changed" ]
+            }
+          }, {
+            "someUnknownField_65" : "foo bar",
+            "someUnknownField_66" : [ "meep", "meep", "meep" ],
+            "someUnknownField_67" : {
+              "someUnknownField_68" : "foo bar"
+            },
+            "type" : "PUT",
+            "someUnknownField_69" : "foo bar",
+            "someUnknownField_70" : [ "meep", "meep", "meep" ],
+            "someUnknownField_71" : {
+              "someUnknownField_72" : "foo bar"
+            },
+            "key" : {
+              "someUnknownField_73" : "foo bar",
+              "someUnknownField_74" : [ "meep", "meep", "meep" ],
+              "someUnknownField_75" : {
+                "someUnknownField_76" : "foo bar"
+              },
+              "elements" : [ "put", "iceberg" ]
+            },
+            "someUnknownField_77" : "foo bar",
+            "someUnknownField_78" : [ "meep", "meep", "meep" ],
+            "someUnknownField_79" : {
+              "someUnknownField_80" : "foo bar"
+            },
+            "contents" : {
+              "someUnknownField_81" : "foo bar",
+              "someUnknownField_82" : [ "meep", "meep", "meep" ],
+              "someUnknownField_83" : {
+                "someUnknownField_84" : "foo bar"
+              },
+              "type" : "ICEBERG_TABLE",
+              "someUnknownField_85" : "foo bar",
+              "someUnknownField_86" : [ "meep", "meep", "meep" ],
+              "someUnknownField_87" : {
+                "someUnknownField_88" : "foo bar"
+              },
+              "id" : "1269b019-ad6f-4be7-8ada-6d1e7ce22770",
+              "someUnknownField_89" : "foo bar",
+              "someUnknownField_90" : [ "meep", "meep", "meep" ],
+              "someUnknownField_91" : {
+                "someUnknownField_92" : "foo bar"
+              },
+              "metadataLocation" : "here/and/there"
+            }
+          }, {
+            "someUnknownField_93" : "foo bar",
+            "someUnknownField_94" : [ "meep", "meep", "meep" ],
+            "someUnknownField_95" : {
+              "someUnknownField_96" : "foo bar"
+            },
+            "type" : "PUT",
+            "someUnknownField_97" : "foo bar",
+            "someUnknownField_98" : [ "meep", "meep", "meep" ],
+            "someUnknownField_99" : {
+              "someUnknownField_100" : "foo bar"
+            },
+            "key" : {
+              "someUnknownField_101" : "foo bar",
+              "someUnknownField_102" : [ "meep", "meep", "meep" ],
+              "someUnknownField_103" : {
+                "someUnknownField_104" : "foo bar"
+              },
+              "elements" : [ "put", "delta" ]
+            },
+            "someUnknownField_105" : "foo bar",
+            "someUnknownField_106" : [ "meep", "meep", "meep" ],
+            "someUnknownField_107" : {
+              "someUnknownField_108" : "foo bar"
+            },
+            "contents" : {
+              "someUnknownField_109" : "foo bar",
+              "someUnknownField_110" : [ "meep", "meep", "meep" ],
+              "someUnknownField_111" : {
+                "someUnknownField_112" : "foo bar"
+              },
+              "type" : "DELTA_LAKE_TABLE",
+              "someUnknownField_113" : "foo bar",
+              "someUnknownField_114" : [ "meep", "meep", "meep" ],
+              "someUnknownField_115" : {
+                "someUnknownField_116" : "foo bar"
+              },
+              "id" : "delta-id",
+              "someUnknownField_117" : "foo bar",
+              "someUnknownField_118" : [ "meep", "meep", "meep" ],
+              "someUnknownField_119" : {
+                "someUnknownField_120" : "foo bar"
+              },
+              "metadataLocationHistory" : [ "meta", "data", "location" ],
+              "someUnknownField_121" : "foo bar",
+              "someUnknownField_122" : [ "meep", "meep", "meep" ],
+              "someUnknownField_123" : {
+                "someUnknownField_124" : "foo bar"
+              },
+              "checkpointLocationHistory" : [ "checkpoint" ],
+              "someUnknownField_125" : "foo bar",
+              "someUnknownField_126" : [ "meep", "meep", "meep" ],
+              "someUnknownField_127" : {
+                "someUnknownField_128" : "foo bar"
+              },
+              "lastCheckpoint" : "checkpoint"
+            }
+          }, {
+            "someUnknownField_129" : "foo bar",
+            "someUnknownField_130" : [ "meep", "meep", "meep" ],
+            "someUnknownField_131" : {
+              "someUnknownField_132" : "foo bar"
+            },
+            "type" : "PUT",
+            "someUnknownField_133" : "foo bar",
+            "someUnknownField_134" : [ "meep", "meep", "meep" ],
+            "someUnknownField_135" : {
+              "someUnknownField_136" : "foo bar"
+            },
+            "key" : {
+              "someUnknownField_137" : "foo bar",
+              "someUnknownField_138" : [ "meep", "meep", "meep" ],
+              "someUnknownField_139" : {
+                "someUnknownField_140" : "foo bar"
+              },
+              "elements" : [ "put", "hive" ]
+            },
+            "someUnknownField_141" : "foo bar",
+            "someUnknownField_142" : [ "meep", "meep", "meep" ],
+            "someUnknownField_143" : {
+              "someUnknownField_144" : "foo bar"
+            },
+            "contents" : {
+              "someUnknownField_145" : "foo bar",
+              "someUnknownField_146" : [ "meep", "meep", "meep" ],
+              "someUnknownField_147" : {
+                "someUnknownField_148" : "foo bar"
+              },
+              "type" : "HIVE_TABLE",
+              "someUnknownField_149" : "foo bar",
+              "someUnknownField_150" : [ "meep", "meep", "meep" ],
+              "someUnknownField_151" : {
+                "someUnknownField_152" : "foo bar"
+              },
+              "id" : "hive-id",
+              "someUnknownField_153" : "foo bar",
+              "someUnknownField_154" : [ "meep", "meep", "meep" ],
+              "someUnknownField_155" : {
+                "someUnknownField_156" : "foo bar"
+              },
+              "tableDefinition" : "AAAAAAAAAAAAAA==",
+              "someUnknownField_157" : "foo bar",
+              "someUnknownField_158" : [ "meep", "meep", "meep" ],
+              "someUnknownField_159" : {
+                "someUnknownField_160" : "foo bar"
+              },
+              "partitions" : [ "AAAAAAA=" ]
+            }
+          } ]
+        }
+        """
+        json = loads(str)
+        MultiContentsSchema().load(json)
+
+    def test_entries_response(self: "TestIgnoreProperties") -> None:
+        """Test EntriesResponse deserialization."""
+        str = u"""
+        {
+          "someUnknownField_1" : "foo bar",
+          "someUnknownField_2" : [ "meep", "meep", "meep" ],
+          "someUnknownField_3" : {
+            "someUnknownField_4" : "foo bar"
+          },
+          "hasMore" : false,
+          "someUnknownField_5" : "foo bar",
+          "someUnknownField_6" : [ "meep", "meep", "meep" ],
+          "someUnknownField_7" : {
+            "someUnknownField_8" : "foo bar"
+          },
+          "token" : null,
+          "someUnknownField_9" : "foo bar",
+          "someUnknownField_10" : [ "meep", "meep", "meep" ],
+          "someUnknownField_11" : {
+            "someUnknownField_12" : "foo bar"
+          },
+          "entries" : [ {
+            "someUnknownField_13" : "foo bar",
+            "someUnknownField_14" : [ "meep", "meep", "meep" ],
+            "someUnknownField_15" : {
+              "someUnknownField_16" : "foo bar"
+            },
+            "type" : "ICEBERG_TABLE",
+            "someUnknownField_17" : "foo bar",
+            "someUnknownField_18" : [ "meep", "meep", "meep" ],
+            "someUnknownField_19" : {
+              "someUnknownField_20" : "foo bar"
+            },
+            "name" : {
+              "someUnknownField_21" : "foo bar",
+              "someUnknownField_22" : [ "meep", "meep", "meep" ],
+              "someUnknownField_23" : {
+                "someUnknownField_24" : "foo bar"
+              },
+              "elements" : [ "entry-name" ]
+            }
+          } ]
+        }
+        """
+        json = loads(str)
+        EntriesSchema().load(json)
+
+    def test_log_response(self: "TestIgnoreProperties") -> None:
+        """Test LogResponse deserialization."""
+        str = u"""
+        {
+          "someUnknownField_1" : "foo bar",
+          "someUnknownField_2" : [ "meep", "meep", "meep" ],
+          "someUnknownField_3" : {
+            "someUnknownField_4" : "foo bar"
+          },
+          "hasMore" : true,
+          "someUnknownField_5" : "foo bar",
+          "someUnknownField_6" : [ "meep", "meep", "meep" ],
+          "someUnknownField_7" : {
+            "someUnknownField_8" : "foo bar"
+          },
+          "token" : "token",
+          "someUnknownField_9" : "foo bar",
+          "someUnknownField_10" : [ "meep", "meep", "meep" ],
+          "someUnknownField_11" : {
+            "someUnknownField_12" : "foo bar"
+          },
+          "operations" : [ {
+            "someUnknownField_13" : "foo bar",
+            "someUnknownField_14" : [ "meep", "meep", "meep" ],
+            "someUnknownField_15" : {
+              "someUnknownField_16" : "foo bar"
+            },
+            "hash" : "1234123412341234123412341234123412341234",
+            "someUnknownField_17" : "foo bar",
+            "someUnknownField_18" : [ "meep", "meep", "meep" ],
+            "someUnknownField_19" : {
+              "someUnknownField_20" : "foo bar"
+            },
+            "committer" : "committer",
+            "someUnknownField_21" : "foo bar",
+            "someUnknownField_22" : [ "meep", "meep", "meep" ],
+            "someUnknownField_23" : {
+              "someUnknownField_24" : "foo bar"
+            },
+            "author" : "author",
+            "someUnknownField_25" : "foo bar",
+            "someUnknownField_26" : [ "meep", "meep", "meep" ],
+            "someUnknownField_27" : {
+              "someUnknownField_28" : "foo bar"
+            },
+            "signedOffBy" : "signed-by-human",
+            "someUnknownField_29" : "foo bar",
+            "someUnknownField_30" : [ "meep", "meep", "meep" ],
+            "someUnknownField_31" : {
+              "someUnknownField_32" : "foo bar"
+            },
+            "message" : "something important",
+            "someUnknownField_33" : "foo bar",
+            "someUnknownField_34" : [ "meep", "meep", "meep" ],
+            "someUnknownField_35" : {
+              "someUnknownField_36" : "foo bar"
+            },
+            "commitTime" : "2021-05-18T13:16:07.863038Z",
+            "someUnknownField_37" : "foo bar",
+            "someUnknownField_38" : [ "meep", "meep", "meep" ],
+            "someUnknownField_39" : {
+              "someUnknownField_40" : "foo bar"
+            },
+            "authorTime" : "2021-05-18T13:16:07.863044Z",
+            "someUnknownField_41" : "foo bar",
+            "someUnknownField_42" : [ "meep", "meep", "meep" ],
+            "someUnknownField_43" : {
+              "someUnknownField_44" : "foo bar"
+            },
+            "properties" : { }
+          } ]
+        }
+        """
+        json = loads(str)
+        LogResponseSchema().load(json)


### PR DESCRIPTION
JSON object deserialization fails when it tries to deserialize an unknown field.
New fields can, and have been, added in newer Nessie versions, which causes older clients
to fail. For example, the `Contents.id` field added in Nessie 0.6.0 made Nessie 0.5.1
clients incompatible.

This change consists of the Java related changes, which basically lets all model-types
extend/implement `Base`, which got the `@JsonIgnoreProperties(ignoreUnknown=true)` annotation.
A unit test that covers hopefully all types verifies the behavior by artificually injecting
additional fields into the JSON objects.

The Python changes are a less nice, as `unknown=EXCLUDE` had to be added to a lot of places.
The generated JSON from the Java tests has been used to add new Python unit tests. A few
functional changes have been made to fix existing issues in the `pynessie` library:
* Fix `data_key` for attributes in `DeltaLakeTable`
* Add missing `HiveTable`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1260)
<!-- Reviewable:end -->
