### PR TITLE
Fix finding the previous tag + generation of release-notes

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -258,8 +258,8 @@ jobs:
       run: |
         DIR=$(mktemp -d)
         NOTES_FILE=${DIR}/release-notes.md
-        LAST_TAG=$(git describe --tags --abbrev=0 ${GIT_TAG}^1)
-        NUM_COMMITS=$(git log --format='format:%h' ${LAST_TAG}..${GIT_TAG} | wc -l)
+        LAST_TAG=$(git describe --tags --abbrev=0 HEAD^1)
+        NUM_COMMITS=$(git log --format='format:%h' ${LAST_TAG}..HEAD | wc -l)
 
         csplit site/docs/try/releases.md '%##%' {0} '/##/' {0} '%##%' {*} -f ${DIR}/release-highlights -b '-%d.txt' > /dev/null
 
@@ -277,19 +277,19 @@ jobs:
         ## Try it
 
         The attached executable file
-        [`nessie-quarkus-${RELEASE_VERSION}-runner`](https://github.com/projectnessie/nessie/releases/download/nessie-${RELEASE_VERSION}/nessie-quarkus-${RELEASE_VERSION}-runner)
+        [\`nessie-quarkus-${RELEASE_VERSION}-runner\`](https://github.com/projectnessie/nessie/releases/download/nessie-${RELEASE_VERSION}/nessie-quarkus-${RELEASE_VERSION}-runner)
         is a native binary image built on $(lsb_release -sd) $(uname -p) and only works on
         compatible Linux environments.
 
         The attached uber-jar
-        [`nessie-quarkus-${RELEASE_VERSION}-runner.jar`](https://github.com/projectnessie/nessie/releases/download/nessie-${RELEASE_VERSION}/nessie-quarkus-${RELEASE_VERSION}-runner.jar)
+        [\`nessie-quarkus-${RELEASE_VERSION}-runner.jar\`](https://github.com/projectnessie/nessie/releases/download/nessie-${RELEASE_VERSION}/nessie-quarkus-${RELEASE_VERSION}-runner.jar)
         is a standalone uber-jar file that runs on Java 11 or newer and it is also available via
         [Maven Central](https://search.maven.org/search?q=g:org.projectnessie+AND+a:nessie-quarkus+AND+v:${RELEASE_VERSION}).
         Download and run it (requires Java 11):
-        ```
+        \`\`\`
         wget https://github.com/projectnessie/nessie/releases/download/nessie-${RELEASE_VERSION}/nessie-quarkus-${RELEASE_VERSION}-runner.jar
         java -jar nessie-quarkus-${RELEASE_VERSION}-runner.jar
-        ```
+        \`\`\`
 
         ## Full Changelog (minus dependabot commits):
 


### PR DESCRIPTION
Two issues in the release-publish.yml workflow:
* Finding the previous tag failed - replaced with `git describe --tags --abbrev=0 HEAD^1`)
* The backticks in the shell-script were interpreted as shell-executions - needed to be escaped with a backslash