### PR TITLE
Revert "Bump pyspark from 3.0.2 to 3.1.2 in /python"

### DIFF
--- a/python/demo/requirements.txt
+++ b/python/demo/requirements.txt
@@ -1,6 +1,6 @@
 pynessie==0.6.1
 jupyterlab==3.0.16
 findspark==1.4.2
-pyspark==3.1.2
+pyspark==3.0.2
 pandas==1.2.4
 pyarrow==4.0.0


### PR DESCRIPTION
Reverts projectnessie/nessie#1329

I saw the build passed and didn't realise this was Spark. Iceberg doesn't support Spark 3.1.x yet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1331)
<!-- Reviewable:end -->
