### PR TITLE
loosen pins for client install on python cli

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -11,8 +11,21 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-with open("requirements.txt") as fp:
-    requirements = fp.read()
+# here we have listed all dependencies w/o explicit pins to enable flexibility in client installs.
+# we use `requirements.txt` in this directory when testing to ensure a stable test in CI.
+requirements = [
+    "attrs",  # features we use are not regularly changing
+    "botocore",  # features we use are not regularly changing
+    "Click<9.0.0,>6.0.0",  # pinning to 7.x or 8.x as we have used w/ both
+    "confuse==1.4.0",  # important for config so don't change w/o testing
+    "desert",  # features we use are not regularly changing
+    "marshmallow",  # features we use are not regularly changing
+    "marshmallow_oneofschema",  # features we use are not regularly changing
+    "python-dateutil",  # stable
+    "requests",  # stable
+    "requests-aws4auth",  # stable
+    "simplejson",  # stable
+]
 
 setup_requirements = ["pytest-runner", "pip"]
 


### PR DESCRIPTION
`setup.py` has changed to list all dependencies w/o explicit pins to enable flexibility in client installs.

we continue to use `requirements.txt` in the `python` directory when testing to ensure a stable test in CI.

fixes #1137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1332)
<!-- Reviewable:end -->
