### PR TITLE
main+pr builds: maven/gradle build order fix, test-logs-artifact fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,12 +80,28 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Maven
-      run: mvn -B deploy --file pom.xml -Pcode-coverage,jdk8-tests,native,release -DdeployAtEnd=true -Dtest.log.level=WARN
+      run: ./mvnw -B deploy --file pom.xml -Pcode-coverage,jdk8-tests,native,release -DdeployAtEnd=true -Dtest.log.level=WARN
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
         MAVEN_OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         SPARK_LOCAL_IP: localhost
+    - name: Build with Gradle
+      run: ./gradlew --rerun-tasks --no-daemon --info build
+      working-directory: ./tools/apprunner-gradle-plugin
+    - name: Capture test results
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: test-results
+        path: |
+          **/target/surefire-reports/*
+          **/target/failsafe-reports/*
+          **/build/reports/*
+          **/build/test-results/*
+    - uses: codecov/codecov-action@v1
+      with:
+        flags: java
     - name: Push Docker images
       run: |
           echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
@@ -94,19 +110,6 @@ jobs:
             docker tag "$IMAGE_ID" "projectnessie/nessie-unstable:${IMAGE_TAG%-snapshot}"
             docker push "projectnessie/nessie-unstable:${IMAGE_TAG%-snapshot}"
           done
-    - name: Capture test results
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results
-        path: |
-          **/target/surefire-reports/*
-          **/target/failsafe-reports/*
-    - uses: codecov/codecov-action@v1
-      with:
-        flags: java
-    - name: Build with Gradle
-      run: ./gradlew build
-      working-directory: ./tools/apprunner-gradle-plugin
   jackson-tests:
     name: Jackson Integration Tests
     needs: java

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -74,22 +74,25 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Maven
-      run: mvn -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage,jdk8-tests -Dtest.log.level=WARN
+      run: ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage,jdk8-tests -Dtest.log.level=WARN
       env:
         SPARK_LOCAL_IP: localhost
+    - name: Build with Gradle
+      run: ./gradlew --rerun-tasks --no-daemon --info build
+      working-directory: ./tools/apprunner-gradle-plugin
     - name: Capture test results
       uses: actions/upload-artifact@v2
+      if: failure()
       with:
         name: test-results
         path: |
           **/target/surefire-reports/*
           **/target/failsafe-reports/*
+          **/build/reports/*
+          **/build/test-results/*
     - uses: codecov/codecov-action@v1
       with:
         flags: java
-    - name: Build with Gradle
-      run: ./gradlew build
-      working-directory: ./tools/apprunner-gradle-plugin
   python:
     name: Python
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run the Gradle build immediately after the Maven build.

Include Gradle test-reports in the test-logs-artifact.

Publish test-logs-artifacts on failure, not on success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1345)
<!-- Reviewable:end -->
