### PR TITLE
Build the Docker image with the Quarkus native image

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -188,7 +188,7 @@ jobs:
         ./mvnw -B ${GOALS} --file pom.xml ${PROFILES} ${NEXUS_ARGS} ${BUILD_ARGS}
 
         # Build the native-image, it's not released to Maven Central anyway
-        PROFILES="-Pnative"
+        PROFILES="-Pnative -Pdocker"
         BUILD_ARGS="-DskipTests"
         if [[ -n ${ACT} ]] ; then
           BUILD_ARGS="${BUILD_ARGS} -Dquarkus.native.remote-container-build=true -Dquarkus.native.container-build=false"

--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -332,12 +332,5 @@
         <quarkus.container-image.build>true</quarkus.container-image.build>
       </properties>
     </profile>
-    <profile>
-      <!-- Profile "release" is rather exclusively used by CI -->
-      <id>release</id>
-      <properties>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-      </properties>
-    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Change the GH workflow to use the `docker` profile when building the Quarkus native image.

Remove the Docker image build from the `release` profile, because that would build the
Docker image with the uber-jar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1431)
<!-- Reviewable:end -->
