### PR TITLE
DRAFT: Validate client/server version on the REST API level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ venv/
 
 # Maven flatten plugin
 .flattened-pom.xml
+
+# UI / generated from gen-src/
+ui/src/utils/version-numbers.tsx

--- a/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieHttpClient.java
@@ -34,7 +34,6 @@ import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
-import javax.ws.rs.WebApplicationException;
 import org.projectnessie.api.ConfigApi;
 import org.projectnessie.api.ContentsApi;
 import org.projectnessie.api.TreeApi;
@@ -42,11 +41,9 @@ import org.projectnessie.client.auth.AwsAuth;
 import org.projectnessie.client.auth.BasicAuthFilter;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.HttpClientException;
-import org.projectnessie.client.http.RequestContext;
 import org.projectnessie.client.http.RequestFilter;
-import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.rest.NessieHttpResponseFilter;
-import org.projectnessie.common.NessieVersion;
+import org.projectnessie.client.rest.NessieVersionFilters;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 
@@ -91,7 +88,7 @@ class NessieHttpClient implements NessieClient {
       addTracing(client);
     }
     authFilter(client, authType, username, password);
-    addNessieVersionFilter(client);
+    NessieVersionFilters.register(client);
     client.register(new NessieHttpResponseFilter(mapper));
     contents = wrap(ContentsApi.class, new ClientContentsApi(client));
     tree = wrap(TreeApi.class, new ClientTreeApi(client));
@@ -144,31 +141,6 @@ class NessieHttpClient implements NessieClient {
                 }
               });
     }
-  }
-
-  private void addNessieVersionFilter(HttpClient client) {
-    client.register(
-        (RequestContext c) -> {
-          c.putHeader("Nessie-Version", NessieVersion.NESSIE_VERSION.toString());
-        });
-    client.register(
-        (ResponseContext r) -> {
-          String remoteNessieVersion = r.getHeader("Nessie-Version");
-          if (remoteNessieVersion == null) {
-            throw new WebApplicationException(
-                "Response from Nessie-Server misses the Nessie-Version header, "
-                    + "considering server as incompatible");
-          }
-          if (!NessieVersion.isApiCompatible(remoteNessieVersion)) {
-            throw new WebApplicationException(
-                String.format(
-                    "Response Nessie-Server version %s is incompatible "
-                        + "with local client version %s, requires server version %s",
-                    remoteNessieVersion,
-                    NessieVersion.NESSIE_VERSION,
-                    NessieVersion.NESSIE_MIN_API_VERSION));
-          }
-        });
   }
 
   private void authFilter(HttpClient client, AuthType authType, String username, String password) {

--- a/clients/client/src/main/java/org/projectnessie/client/http/ResponseContextImpl.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/ResponseContextImpl.java
@@ -27,6 +27,10 @@ class ResponseContextImpl implements ResponseContext {
     this.connection = connection;
   }
 
+  public String getHeader(String header) {
+    return connection.getRequestProperty(header);
+  }
+
   public Status getResponseCode() throws IOException {
     return Status.fromCode(connection.getResponseCode());
   }

--- a/clients/client/src/main/java/org/projectnessie/client/rest/NessieVersionFilters.java
+++ b/clients/client/src/main/java/org/projectnessie/client/rest/NessieVersionFilters.java
@@ -1,0 +1,2 @@
+package org.projectnessie.client.rest;public class NessieVersionFilters {
+}

--- a/clients/client/src/main/java/org/projectnessie/client/rest/NessieVersionFilters.java
+++ b/clients/client/src/main/java/org/projectnessie/client/rest/NessieVersionFilters.java
@@ -1,2 +1,50 @@
-package org.projectnessie.client.rest;public class NessieVersionFilters {
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.rest;
+
+import javax.ws.rs.WebApplicationException;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.RequestContext;
+import org.projectnessie.client.http.ResponseContext;
+import org.projectnessie.common.NessieVersion;
+
+public class NessieVersionFilters {
+
+  public static void register(HttpClient client) {
+    client.register(
+        (RequestContext c) -> {
+          c.putHeader("Nessie-Version", NessieVersion.NESSIE_VERSION.toString());
+        });
+    client.register(
+        (ResponseContext r) -> {
+          String remoteNessieVersion = r.getHeader("Nessie-Version");
+          if (remoteNessieVersion == null) {
+            throw new WebApplicationException(
+                "Response from Nessie-Server misses the Nessie-Version header, "
+                    + "considering server as incompatible");
+          }
+          if (!NessieVersion.isApiCompatible(remoteNessieVersion)) {
+            throw new WebApplicationException(
+                String.format(
+                    "Response Nessie-Server version %s is incompatible "
+                        + "with local client version %s, requires server version %s",
+                    remoteNessieVersion,
+                    NessieVersion.NESSIE_VERSION,
+                    NessieVersion.NESSIE_MIN_API_VERSION));
+          }
+        });
+  }
 }

--- a/clients/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/clients/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -91,6 +91,12 @@ public class TestResponseFilter {
             public InputStream getErrorStream() {
               return new StringInputStream("this will fail");
             }
+
+            @Override
+            public String getHeader(String header) {
+              Assertions.fail();
+              return null;
+            }
           },
           MAPPER);
     } catch (NessieServiceException e) {
@@ -161,6 +167,12 @@ public class TestResponseFilter {
       }
       String value = MAPPER.writeValueAsString(error);
       return new StringInputStream(value);
+    }
+
+    @Override
+    public String getHeader(String header) {
+      Assertions.fail();
+      return null;
     }
   }
 }

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -92,4 +92,29 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/classes</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/unprocessed-resources</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/model/src/main/java/org/projectnessie/common/NessieVersion.java
+++ b/model/src/main/java/org/projectnessie/common/NessieVersion.java
@@ -34,7 +34,7 @@ public class NessieVersion {
       try (InputStream in = nessieInfo.openConnection().getInputStream()) {
         properties.load(in);
 
-        NESSIE_VERSION = Version.parse(properties.getProperty("nessie.version"));
+        NESSIE_VERSION = Version.parse(properties.getProperty("nessie.version")).removeSnapshot();
         NESSIE_MIN_API_VERSION = Version.parse(properties.getProperty("nessie.min-remote-version"));
       }
     } catch (Exception e) {
@@ -51,6 +51,6 @@ public class NessieVersion {
    * @return {@code true}, if "API compatible", {@code false} otherwise
    */
   public static boolean isApiCompatible(String otherVersion) {
-    return Version.parse(otherVersion).compareTo(NESSIE_MIN_API_VERSION) >= 0;
+    return Version.parse(otherVersion).removeSnapshot().compareTo(NESSIE_MIN_API_VERSION) >= 0;
   }
 }

--- a/model/src/main/java/org/projectnessie/common/NessieVersion.java
+++ b/model/src/main/java/org/projectnessie/common/NessieVersion.java
@@ -35,7 +35,7 @@ public class NessieVersion {
         properties.load(in);
 
         NESSIE_VERSION = Version.parse(properties.getProperty("nessie.version"));
-        NESSIE_MIN_API_VERSION = Version.parse(properties.getProperty("nessie.min-api-version"));
+        NESSIE_MIN_API_VERSION = Version.parse(properties.getProperty("nessie.min-remote-version"));
       }
     } catch (Exception e) {
       throw new RuntimeException("Failed to load nessie.properties", e);
@@ -44,7 +44,7 @@ public class NessieVersion {
 
   /**
    * Verifies that the given Nessie version is "API compatible", which means that the given version
-   * is greater than or equal to the value of the property {@code nessie.min-api-version} in the
+   * is greater than or equal to the value of the property {@code nessie.min-remote-version} in the
    * {@code nessie.properties} file.
    *
    * @param otherVersion version to check

--- a/model/src/main/java/org/projectnessie/common/NessieVersion.java
+++ b/model/src/main/java/org/projectnessie/common/NessieVersion.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.common;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+/** Helper class for Nessie version related functionality. */
+public class NessieVersion {
+  public static final Version NESSIE_VERSION;
+  public static final Version NESSIE_MIN_API_VERSION;
+
+  static {
+    URL nessieInfo = NessieVersion.class.getResource("nessie.properties");
+    Properties properties = new Properties();
+    try {
+      if (nessieInfo == null) {
+        throw new Exception("nessie.properties resource not found");
+      }
+      try (InputStream in = nessieInfo.openConnection().getInputStream()) {
+        properties.load(in);
+
+        NESSIE_VERSION = Version.parse(properties.getProperty("nessie.version"));
+        NESSIE_MIN_API_VERSION = Version.parse(properties.getProperty("nessie.min-api-version"));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load nessie.properties", e);
+    }
+  }
+
+  /**
+   * Verifies that the given Nessie version is "API compatible", which means that the given version
+   * is greater than or equal to the value of the property {@code nessie.min-api-version} in the
+   * {@code nessie.properties} file.
+   *
+   * @param otherVersion version to check
+   * @return {@code true}, if "API compatible", {@code false} otherwise
+   */
+  public static boolean isApiCompatible(String otherVersion) {
+    return Version.parse(otherVersion).compareTo(NessieVersion.NESSIE_MIN_API_VERSION) >= 0;
+  }
+}

--- a/model/src/main/java/org/projectnessie/common/NessieVersion.java
+++ b/model/src/main/java/org/projectnessie/common/NessieVersion.java
@@ -51,6 +51,6 @@ public class NessieVersion {
    * @return {@code true}, if "API compatible", {@code false} otherwise
    */
   public static boolean isApiCompatible(String otherVersion) {
-    return Version.parse(otherVersion).compareTo(NessieVersion.NESSIE_MIN_API_VERSION) >= 0;
+    return Version.parse(otherVersion).compareTo(NESSIE_MIN_API_VERSION) >= 0;
   }
 }

--- a/model/src/main/java/org/projectnessie/common/Version.java
+++ b/model/src/main/java/org/projectnessie/common/Version.java
@@ -122,4 +122,8 @@ public class Version implements Comparable<Version> {
     }
     return Integer.compare(this.snapshot ? 0 : 1, o.snapshot ? 0 : 1);
   }
+
+  public Version removeSnapshot() {
+    return this.snapshot ? new Version(major, minor, patch, false) : this;
+  }
 }

--- a/model/src/main/java/org/projectnessie/common/Version.java
+++ b/model/src/main/java/org/projectnessie/common/Version.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.common;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Container for a version number. */
+public class Version implements Comparable<Version> {
+
+  private static final Pattern PARSE_PATTERN =
+      Pattern.compile("^([0-9]+)([.]([0-9]+)([.]([0-9]+))?)?(-SNAPSHOT)?");
+
+  private final int major;
+  private final int minor;
+  private final int patch;
+  private final boolean snapshot;
+  private final String str;
+
+  /**
+   * Construct a new version instance.
+   *
+   * @param major major version number
+   * @param minor minor version number
+   * @param patch patch version number
+   * @param snapshot snapshot-version flag
+   */
+  public Version(int major, int minor, int patch, boolean snapshot) {
+    this.major = major;
+    this.minor = minor;
+    this.patch = patch;
+    this.snapshot = snapshot;
+    this.str = String.format("%d.%d.%d%s", major, minor, patch, snapshot ? "-SNAPSHOT" : "");
+  }
+
+  /**
+   * Parses a version string that matches the pattern {@link #PARSE_PATTERN}.
+   *
+   * @param version version string to parse
+   * @return parsed version
+   * @throws IllegalArgumentException if {@code version} is not a valid version string
+   */
+  public static Version parse(String version) {
+    if (version == null) {
+      throw new NullPointerException("null version argument");
+    }
+
+    Matcher m = PARSE_PATTERN.matcher(version);
+    if (!m.matches()) {
+      throw new IllegalArgumentException("Not a valid version string: " + version);
+    }
+
+    String strMajor = m.group(1);
+    String strMinor = m.group(3);
+    String strPatch = m.group(5);
+    String strSnapshot = m.group(6);
+
+    try {
+      int major = Integer.parseInt(strMajor);
+      int minor = strMinor != null ? Integer.parseInt(strMinor) : 0;
+      int patch = strPatch != null ? Integer.parseInt(strPatch) : 0;
+      boolean snapshot = "-SNAPSHOT".equals(strSnapshot);
+
+      return new Version(major, minor, patch, snapshot);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Not a valid version string: " + version, e);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return str;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Version version = (Version) o;
+    return major == version.major
+        && minor == version.minor
+        && patch == version.patch
+        && snapshot == version.snapshot;
+  }
+
+  @Override
+  public int hashCode() {
+    return str.hashCode();
+  }
+
+  @Override
+  public int compareTo(Version o) {
+    int r;
+    r = Integer.compare(this.major, o.major);
+    if (r != 0) {
+      return r;
+    }
+    r = Integer.compare(this.minor, o.minor);
+    if (r != 0) {
+      return r;
+    }
+    r = Integer.compare(this.patch, o.patch);
+    if (r != 0) {
+      return r;
+    }
+    return Integer.compare(this.snapshot ? 0 : 1, o.snapshot ? 0 : 1);
+  }
+}

--- a/model/src/test/java/org/projectnessie/common/TestNessieVersion.java
+++ b/model/src/test/java/org/projectnessie/common/TestNessieVersion.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+
+class TestNessieVersion {
+  @Test
+  void checkNessieVersion() throws Exception {
+    URL url =
+        Thread.currentThread()
+            .getContextClassLoader()
+            .getResource("org/projectnessie/common/nessie.properties");
+    assertThat(url).isNotNull();
+
+    Properties props = new Properties();
+    try (InputStream in = url.openConnection().getInputStream()) {
+      props.load(in);
+    }
+
+    assertThat(props).extractingByKey("nessie.version").isNotNull();
+    assertThat(Version.parse(props.getProperty("nessie.version")))
+        .isGreaterThan(Version.parse("0.6.1"));
+
+    assertThat(props).extractingByKey("nessie.min-api-version").isNotNull();
+    assertThat(Version.parse(props.getProperty("nessie.min-api-version")))
+        .isGreaterThanOrEqualTo(Version.parse("0.6.0"));
+
+    assertThat(props.getProperty("nessie.version"))
+        .is(new Condition<>(NessieVersion::isApiCompatible, "api compatible"));
+    assertThat("0.5.1").isNot(new Condition<>(NessieVersion::isApiCompatible, "api compatible"));
+    assertThatThrownBy(() -> NessieVersion.isApiCompatible(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("null version argument");
+  }
+}

--- a/model/src/test/java/org/projectnessie/common/TestNessieVersion.java
+++ b/model/src/test/java/org/projectnessie/common/TestNessieVersion.java
@@ -40,11 +40,11 @@ class TestNessieVersion {
 
     assertThat(props).extractingByKey("nessie.version").isNotNull();
     assertThat(Version.parse(props.getProperty("nessie.version")))
-        .isGreaterThan(Version.parse("0.6.1"));
+        .isGreaterThan(Version.parse("0.7.0"));
 
-    assertThat(props).extractingByKey("nessie.min-api-version").isNotNull();
-    assertThat(Version.parse(props.getProperty("nessie.min-api-version")))
-        .isGreaterThanOrEqualTo(Version.parse("0.6.0"));
+    assertThat(props).extractingByKey("nessie.min-remote-version").isNotNull();
+    assertThat(Version.parse(props.getProperty("nessie.min-remote-version")))
+        .isGreaterThanOrEqualTo(Version.parse("0.7.1"));
 
     assertThat(props.getProperty("nessie.version"))
         .is(new Condition<>(NessieVersion::isApiCompatible, "api compatible"));

--- a/model/src/test/java/org/projectnessie/common/TestVersion.java
+++ b/model/src/test/java/org/projectnessie/common/TestVersion.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import org.junit.jupiter.api.Test;
+
+class TestVersion {
+  @Test
+  void version() {
+    assertThat(Version.parse("0.0.0").toString()).isEqualTo("0.0.0");
+    assertThat(Version.parse("0.0").toString()).isEqualTo("0.0.0");
+    assertThat(Version.parse("0").toString()).isEqualTo("0.0.0");
+    assertThat(Version.parse("0.0.0-SNAPSHOT").toString()).isEqualTo("0.0.0-SNAPSHOT");
+    assertThat(Version.parse("0.0-SNAPSHOT").toString()).isEqualTo("0.0.0-SNAPSHOT");
+    assertThat(Version.parse("0-SNAPSHOT").toString()).isEqualTo("0.0.0-SNAPSHOT");
+
+    assertThat(Version.parse("1.2.3").toString()).isEqualTo("1.2.3");
+    assertThat(Version.parse("1.2").toString()).isEqualTo("1.2.0");
+    assertThat(Version.parse("1").toString()).isEqualTo("1.0.0");
+    assertThat(Version.parse("1.2.3-SNAPSHOT").toString()).isEqualTo("1.2.3-SNAPSHOT");
+    assertThat(Version.parse("1.2-SNAPSHOT").toString()).isEqualTo("1.2.0-SNAPSHOT");
+    assertThat(Version.parse("1-SNAPSHOT").toString()).isEqualTo("1.0.0-SNAPSHOT");
+
+    assertThat(Version.parse("1.2.3")).isEqualTo(new Version(1, 2, 3, false));
+    assertThat(Version.parse("1.2")).isEqualTo(new Version(1, 2, 0, false));
+    assertThat(Version.parse("1")).isEqualTo(new Version(1, 0, 0, false));
+    assertThat(Version.parse("1.2.3-SNAPSHOT")).isEqualTo(new Version(1, 2, 3, true));
+    assertThat(Version.parse("1.2-SNAPSHOT")).isEqualTo(new Version(1, 2, 0, true));
+    assertThat(Version.parse("1-SNAPSHOT")).isEqualTo(new Version(1, 0, 0, true));
+
+    assertThat(Version.parse("1.2.3")).isGreaterThan(Version.parse("1"));
+    assertThat(Version.parse("1.2.3")).isGreaterThan(Version.parse("1.2"));
+    assertThat(Version.parse("1.2.3")).isGreaterThan(Version.parse("1.2.3-SNAPSHOT"));
+    assertThat(Version.parse("1.2.3-SNAPSHOT")).isGreaterThan(Version.parse("1"));
+    assertThat(Version.parse("1.2.3-SNAPSHOT")).isGreaterThan(Version.parse("1.2"));
+    assertThat(Version.parse("1.2.3-SNAPSHOT"))
+        .isEqualByComparingTo(Version.parse("1.2.3-SNAPSHOT"));
+
+    assertThat(
+            new HashSet<>(
+                Arrays.asList(
+                    Version.parse("1"),
+                    Version.parse("1.0"),
+                    Version.parse("1.0.0"),
+                    Version.parse("1.2"),
+                    Version.parse("1.2.0"),
+                    Version.parse("1.2.3"),
+                    Version.parse("1-SNAPSHOT"),
+                    Version.parse("1.0-SNAPSHOT"),
+                    Version.parse("1.0.0-SNAPSHOT"),
+                    Version.parse("1.2-SNAPSHOT"),
+                    Version.parse("1.2.3-SNAPSHOT"))))
+        .containsAll(
+            Arrays.asList(
+                Version.parse("1"),
+                Version.parse("1.2"),
+                Version.parse("1.2.3"),
+                Version.parse("1-SNAPSHOT"),
+                Version.parse("1.2-SNAPSHOT"),
+                Version.parse("1.2.3-SNAPSHOT")))
+        .hasSize(6);
+
+    assertThatThrownBy(() -> Version.parse(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("null version argument");
+    assertThatThrownBy(() -> Version.parse("x.y.z"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Not a valid version string: x.y.z");
+  }
+}

--- a/model/src/test/java/org/projectnessie/common/TestVersion.java
+++ b/model/src/test/java/org/projectnessie/common/TestVersion.java
@@ -39,6 +39,14 @@ class TestVersion {
     assertThat(Version.parse("1.2-SNAPSHOT").toString()).isEqualTo("1.2.0-SNAPSHOT");
     assertThat(Version.parse("1-SNAPSHOT").toString()).isEqualTo("1.0.0-SNAPSHOT");
 
+    assertThat(Version.parse("0.1.3-SNAPSHOT")).extracting("snapshot").isEqualTo(true);
+    assertThat(Version.parse("0.1.3-SNAPSHOT").removeSnapshot())
+        .extracting("snapshot")
+        .isEqualTo(false);
+    assertThat(Version.parse("0.1.3").removeSnapshot()).extracting("snapshot").isEqualTo(false);
+    assertThat(Version.parse("0.1.3-SNAPSHOT").removeSnapshot()).isEqualTo(Version.parse("0.1.3"));
+    assertThat(Version.parse("0.1.3")).isEqualTo(Version.parse("0.1.3-SNAPSHOT").removeSnapshot());
+
     assertThat(Version.parse("1.2.3")).isEqualTo(new Version(1, 2, 3, false));
     assertThat(Version.parse("1.2")).isEqualTo(new Version(1, 2, 0, false));
     assertThat(Version.parse("1")).isEqualTo(new Version(1, 0, 0, false));

--- a/model/src/test/java/org/projectnessie/common/TestVersion.java
+++ b/model/src/test/java/org/projectnessie/common/TestVersion.java
@@ -54,6 +54,8 @@ class TestVersion {
     assertThat(Version.parse("1.2.3-SNAPSHOT"))
         .isEqualByComparingTo(Version.parse("1.2.3-SNAPSHOT"));
 
+    assertThat(Version.parse("1.2.3")).isGreaterThanOrEqualTo(Version.parse("1.2.3-SNAPSHOT"));
+
     assertThat(
             new HashSet<>(
                 Arrays.asList(

--- a/model/src/unprocessed-resources/org/projectnessie/common/nessie.properties
+++ b/model/src/unprocessed-resources/org/projectnessie/common/nessie.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+nessie.version=${project.version}
+nessie.min-api-version=${nessie.min-api-compatibility}

--- a/model/src/unprocessed-resources/org/projectnessie/common/nessie.properties
+++ b/model/src/unprocessed-resources/org/projectnessie/common/nessie.properties
@@ -15,4 +15,4 @@
 #
 
 nessie.version=${project.version}
-nessie.min-api-version=${nessie.min-api-compatibility}
+nessie.min-remote-version=${nessie.min-remote-version}

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>8</maven.compiler.release>
     <argLine />
-    <nessie.min-api-compatibility>0.6.0</nessie.min-api-compatibility>
+    <nessie.min-api-compatibility>0.7.1</nessie.min-api-compatibility>
 
     <!-- 3rd party repositories -->
     <dynamodb-local.repository.url>https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release</dynamodb-local.repository.url>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>8</maven.compiler.release>
     <argLine />
-    <nessie.min-api-compatibility>0.7.1</nessie.min-api-compatibility>
+    <nessie.min-remote-version>0.7.1</nessie.min-remote-version>
 
     <!-- 3rd party repositories -->
     <dynamodb-local.repository.url>https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release</dynamodb-local.repository.url>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>8</maven.compiler.release>
     <argLine />
+    <nessie.min-api-compatibility>0.6.0</nessie.min-api-compatibility>
 
     <!-- 3rd party repositories -->
     <dynamodb-local.repository.url>https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release</dynamodb-local.repository.url>

--- a/python/docs/branch.rst
+++ b/python/docs/branch.rst
@@ -30,7 +30,6 @@
 	  -f, --force           force branch assignment
 	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
 	                        currently points to condition.
-	
 	  --help                Show this message and exit.
 	
 	

--- a/python/docs/cherry-pick.rst
+++ b/python/docs/cherry-pick.rst
@@ -7,11 +7,9 @@
 	Options:
 	  -b, --branch TEXT     branch to cherry-pick onto. If not supplied the default
 	                        branch from config is used
-	
 	  -f, --force           force branch assignment
 	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
 	                        currently points to condition.
-	
 	  --help                Show this message and exit.
 	
 	

--- a/python/docs/config.rst
+++ b/python/docs/config.rst
@@ -11,7 +11,6 @@
 	  --unset TEXT  unset config parameter
 	  --type TEXT   type to interpret config value to set or get. Allowed options:
 	                bool, int
-	
 	  -h, --help    Show this message and exit.
 	
 	

--- a/python/docs/contents.rst
+++ b/python/docs/contents.rst
@@ -1,24 +1,25 @@
 .. code-block:: bash
 
 	Usage: cli contents [OPTIONS] [KEY]...
-
+	
 	  Contents operations.
-
-	  KEY name of object to view, delete. If listing the key will limit by
-	  namespace what is included.
-
+	
+	  KEY name of object to view, delete. If listing the key will limit by namespace
+	  what is included.
+	
 	Options:
 	  -l, --list            list tables
 	  -d, --delete          delete a table
 	  -s, --set             modify a table
 	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
 	                        currently points to condition.
-
 	  -r, --ref TEXT        branch to list from. If not supplied the default branch
 	                        from config is used
-
 	  -m, --message TEXT    commit message
 	  -t, --type TEXT       entity types to filter on, if no entity types are passed
 	                        then all types are returned
-
+	  --author TEXT         The author to use for the commit
 	  --help                Show this message and exit.
+	
+	
+

--- a/python/docs/log.rst
+++ b/python/docs/log.rst
@@ -12,9 +12,14 @@
 	
 	Options:
 	  -n, --number INTEGER    number of log entries to return
-	  --since, --after TEXT   Commits more recent than specific date
-	  --until, --before TEXT  Commits older than specific date
-	  --author, --committer   limit commits to specific committer
+	  --since, --after TEXT   Only include commits newer than specific date
+	  --until, --before TEXT  Only include commits older than specific date
+	  --author TEXT           Limit commits to a specific author (this is the
+	                          original committer). Supports specifying multiple
+	                          authors to filter by.
+	  --committer TEXT        Limit commits to a specific committer (this is the
+	                          logged in user/account who performed the commit).
+	                          Supports specifying multiple committers to filter by.
 	  --help                  Show this message and exit.
 	
 	

--- a/python/docs/main.rst
+++ b/python/docs/main.rst
@@ -19,7 +19,7 @@
 	  config       Set and view config.
 	  contents     Contents operations.
 	  log          Show commit log.
-	  merge        Merge BRANCH into current branch.
+	  merge        Merge FROM_BRANCH into current branch.
 	  remote       Set and view remote endpoint.
 	  tag          Tag operations.
 	

--- a/python/docs/merge.rst
+++ b/python/docs/merge.rst
@@ -1,15 +1,16 @@
 .. code-block:: bash
 
 	Usage: cli merge [OPTIONS] [FROM_BRANCH]
-
+	
 	  Merge FROM_BRANCH into current branch. FROM_BRANCH can be a hash or branch.
-
+	
 	Options:
 	  -b, --branch TEXT     branch to merge onto. If not supplied the default branch
 	                        from config is used
-
 	  -f, --force           force branch assignment
 	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
 	                        currently points to condition.
-
 	  --help                Show this message and exit.
+	
+	
+

--- a/python/docs/tag.rst
+++ b/python/docs/tag.rst
@@ -30,7 +30,6 @@
 	  -f, --force           force branch assignment
 	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
 	                        currently points to condition.
-	
 	  --help                Show this message and exit.
 	
 	

--- a/python/pynessie/__init__.py
+++ b/python/pynessie/__init__.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 """Top-level package for Python API and CLI for Nessie."""
 import os
-import re
-from typing import Tuple
 
 import confuse
-from packaging.version import _BaseVersion, Version
+from packaging.version import Version
 
 from .conf import build_config
 from .nessie_client import NessieClient
@@ -13,18 +11,7 @@ from .nessie_client import NessieClient
 __author__ = """Project Nessie"""
 __email__ = "nessie-release-builder@dremio.com"
 __version__ = "0.7.1"
-
-
-def __make_version_range() -> Tuple[_BaseVersion, _BaseVersion]:
-    match = re.match("([0-9]+)[.]([0-9]+)[.].*", __version__)
-    if not match:
-        raise Exception(f"Invalid pynessie package version string {__version__}")
-    major = int(match.group(1))
-    minor = int(match.group(2))
-    return Version(f"{major}.{minor}.0"), Version(f"{major}.{minor + 1}.0")
-
-
-__required_version_range__ = __make_version_range()
+__min_remote_version__ = Version("0.7.1")
 
 
 def get_config(config_dir: str = None, args: dict = None) -> confuse.Configuration:

--- a/python/pynessie/__init__.py
+++ b/python/pynessie/__init__.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """Top-level package for Python API and CLI for Nessie."""
 import os
+import re
+from typing import Tuple
 
 import confuse
+from packaging.version import _BaseVersion, Version
 
 from .conf import build_config
 from .nessie_client import NessieClient
@@ -10,6 +13,18 @@ from .nessie_client import NessieClient
 __author__ = """Project Nessie"""
 __email__ = "nessie-release-builder@dremio.com"
 __version__ = "0.7.1"
+
+
+def __make_version_range() -> Tuple[_BaseVersion, _BaseVersion]:
+    match = re.match("([0-9]+)[.]([0-9]+)[.].*", __version__)
+    if not match:
+        raise Exception(f"Invalid pynessie package version string {__version__}")
+    major = int(match.group(1))
+    minor = int(match.group(2))
+    return Version(f"{major}.{minor}.0"), Version(f"{major}.{minor + 1}.0")
+
+
+__required_version_range__ = __make_version_range()
 
 
 def get_config(config_dir: str = None, args: dict = None) -> confuse.Configuration:

--- a/python/pynessie/_endpoints.py
+++ b/python/pynessie/_endpoints.py
@@ -230,16 +230,16 @@ def assign_tag(base_url: str, tag: str, tag_json: dict, old_hash: str, ssl_verif
 
 
 def _check_nessie_version(self: requests.models.Response) -> None:
-    from . import __required_version_range__
+    from . import __min_remote_version__
 
     if 200 < self.status_code <= 399 and "Nessie-Version" not in self.headers:
         # Ignore missing 'Nessie-Version' header, for HTTP status codes 201...399, because those response codes
         # don't get the Nessie-Version header (REST API restriction/inconvenience :( ).
         return
-    _check_nessie_version_headers(self.headers, __required_version_range__)
+    _check_nessie_version_headers(self.headers, __min_remote_version__)
 
 
-def _check_nessie_version_headers(self: MutableMapping[str, Any], version_range: Tuple[_BaseVersion, _BaseVersion]) -> None:
+def _check_nessie_version_headers(self: MutableMapping[str, Any], min_version: _BaseVersion) -> None:
     from . import __version__
 
     if "Nessie-Version" not in self:
@@ -248,7 +248,7 @@ def _check_nessie_version_headers(self: MutableMapping[str, Any], version_range:
     if len(server_version) == 0:
         raise Exception("Server replied without the required Nessie-Version header. pynessie requires Nessie-Server version >= 0.7.0")
     parsed_version = _LooseVersion(server_version)
-    if parsed_version < version_range[0] or parsed_version > version_range[1]:
+    if parsed_version < min_version:
         raise Exception(f"Nessie-Server is running version {server_version}, which is incompatible to pynessie {__version__}")
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,6 +5,7 @@ confuse==1.4.0
 desert==2020.11.18
 marshmallow==3.12.1
 marshmallow_oneofschema==2.1.0
+packaging>=20.0
 python-dateutil>=2.8.0
 requests==2.25.1
 requests-aws4auth==1.1.1

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,6 +21,7 @@ requirements = [
     "desert",  # features we use are not regularly changing
     "marshmallow",  # features we use are not regularly changing
     "marshmallow_oneofschema",  # features we use are not regularly changing
+    "packaging",  # provides `Version` et al, comes with pip
     "python-dateutil",  # stable
     "requests",  # stable
     "requests-aws4auth",  # stable

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -41,7 +41,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -49,7 +49,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -72,7 +72,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -88,16 +88,16 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": null, "authorTime": null, "email": null, "properties": null, "message":
-      "test_message", "hash": null}, "operations": [{"contents": {"metadataLocation":
-      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
-      "bar"]}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "contents": {"id":
+      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
+      "commitMeta": {"properties": null, "committer": null, "author": null, "signedOffBy":
+      null, "commitTime": null, "hash": null, "authorTime": null, "email": null, "message":
+      "test_message"}}'
     headers:
       Accept:
       - application/json
@@ -110,21 +110,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -138,21 +138,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -166,27 +166,27 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": "e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c",
-      "type": "BRANCH"}'
+    body: '{"hash": "9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527",
+      "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -199,17 +199,17 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -223,7 +223,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -231,8 +231,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}
+        \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}
         ]"
     headers:
       Content-Length:
@@ -240,7 +240,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -254,7 +254,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -269,7 +269,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
@@ -283,27 +283,27 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c",
-      "type": "TAG"}'
+    body: '{"hash": "9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - application/json
@@ -316,21 +316,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}"
     headers:
       Content-Length:
       - '118'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -344,7 +344,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -352,9 +352,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}, {\n
-        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n},
-        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}
+        \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}
         ]"
     headers:
       Content-Length:
@@ -362,7 +362,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -376,21 +376,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}"
     headers:
       Content-Length:
       - '118'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -404,27 +404,27 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c",
-      "type": "TAG"}'
+    body: '{"hash": "9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - application/json
@@ -437,17 +437,17 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -461,7 +461,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -469,9 +469,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}, {\n
-        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n},
-        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}
+        \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}
         ]"
     headers:
       Content-Length:
@@ -479,7 +479,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -493,21 +493,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -523,17 +523,17 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -547,21 +547,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\"\n}"
     headers:
       Content-Length:
       - '118'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -577,17 +577,17 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -601,7 +601,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -609,10 +609,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\",\n
+        [ {\n    \"hash\" : \"9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:02:01.041425Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:02:01.041425Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:16.396575Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:16.396575Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -620,7 +620,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -634,7 +634,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -649,15 +649,15 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": null, "authorTime": null, "email": null, "properties": null, "message":
-      "delete_message", "hash": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"properties": null, "committer": null, "author": null, "signedOffBy":
+      null, "commitTime": null, "hash": null, "authorTime": null, "email": null, "message":
+      "delete_message"}}'
     headers:
       Accept:
       - application/json
@@ -670,21 +670,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=9a79e96a2631fae1292121e0fbaef718d81996638c13274d21f867e32aadf527
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b560bfb47266e4e5e7548ff5c70296efe4dc1401ea9d9306eafcf44bd0669123\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5eea945fc0033cbe572561e0421039386ebb75392a05e5bb92bae0d6d9e372f7\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -698,21 +698,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b560bfb47266e4e5e7548ff5c70296efe4dc1401ea9d9306eafcf44bd0669123\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5eea945fc0033cbe572561e0421039386ebb75392a05e5bb92bae0d6d9e372f7\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -728,22 +728,22 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=b560bfb47266e4e5e7548ff5c70296efe4dc1401ea9d9306eafcf44bd0669123
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=5eea945fc0033cbe572561e0421039386ebb75392a05e5bb92bae0d6d9e372f7
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -770,7 +770,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -12,6 +12,8 @@ interactions:
       - '47'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -24,6 +26,8 @@ interactions:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -36,6 +40,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -43,7 +49,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}, {\n
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -51,6 +57,8 @@ interactions:
       - '247'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -63,6 +71,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -77,18 +87,20 @@ interactions:
       - '149'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"authorTime": null, "author": null, "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "test_message"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": null, "authorTime": null, "email": null, "properties": null, "message":
+      "test_message", "hash": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
+      "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -97,18 +109,22 @@ interactions:
       - '341'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -121,18 +137,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -145,27 +165,31 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": "4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949",
+    body: '{"name": "main", "hash": "e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c",
       "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -174,14 +198,18 @@ interactions:
       - '110'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -194,6 +222,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -201,14 +231,16 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}
+        \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}
         ]"
     headers:
       Content-Length:
       - '247'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -221,6 +253,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -234,6 +268,8 @@ interactions:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
@@ -246,27 +282,31 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949",
+    body: '{"name": "v1.0", "hash": "e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c",
       "type": "TAG"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -275,18 +315,22 @@ interactions:
       - '107'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
     headers:
       Content-Length:
       - '118'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -299,6 +343,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -306,15 +352,17 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}, {\n
-        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n},
-        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}
+        \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}
         ]"
     headers:
       Content-Length:
       - '367'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -327,18 +375,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
     headers:
       Content-Length:
       - '118'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -351,27 +403,31 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949",
+    body: '{"name": "v1.0", "hash": "e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c",
       "type": "TAG"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -380,14 +436,18 @@ interactions:
       - '107'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -400,6 +460,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -407,15 +469,17 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}, {\n
-        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n},
-        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}
+        \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}
         ]"
     headers:
       Content-Length:
       - '367'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -428,18 +492,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -454,14 +522,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -474,18 +546,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\"\n}"
     headers:
       Content-Length:
       - '118'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -500,14 +576,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -520,6 +600,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -527,16 +609,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949\",\n
+        [ {\n    \"hash\" : \"e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:14.376886Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:14.376886Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:02:01.041425Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:02:01.041425Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '372'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -549,6 +633,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -562,17 +648,19 @@ interactions:
       - '80'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"authorTime": null, "author": null, "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "delete_message"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": null, "authorTime": null, "email": null, "properties": null, "message":
+      "delete_message", "hash": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -581,18 +669,22 @@ interactions:
       - '263'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=4b0044dbcce64fddd6629bc85b7bc42c0fe89b8b4a0e77fa738348fda1afc949
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=e1b2fbc5c24ec400b25c72c4572d9a1dbab71528d07694751fb8c4ed7e86173c
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"da7d70b345bbe837b80f9408f66828dfd56ecdeca196e9d7cc4c5821bf2241b7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b560bfb47266e4e5e7548ff5c70296efe4dc1401ea9d9306eafcf44bd0669123\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -605,18 +697,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"da7d70b345bbe837b80f9408f66828dfd56ecdeca196e9d7cc4c5821bf2241b7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b560bfb47266e4e5e7548ff5c70296efe4dc1401ea9d9306eafcf44bd0669123\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -631,14 +727,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=da7d70b345bbe837b80f9408f66828dfd56ecdeca196e9d7cc4c5821bf2241b7
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=b560bfb47266e4e5e7548ff5c70296efe4dc1401ea9d9306eafcf44bd0669123
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -646,7 +746,7 @@ interactions:
     body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -655,6 +755,8 @@ interactions:
       - '48'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -667,6 +769,8 @@ interactions:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
@@ -8,6 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -21,6 +23,8 @@ interactions:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -38,7 +38,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -53,7 +53,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -83,16 +83,16 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": "nessie_user1", "authorTime": null, "email": null, "properties": null,
-      "message": "test_message", "hash": null}, "operations": [{"contents": {"metadataLocation":
-      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
-      "bar"]}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "contents": {"id":
+      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
+      "commitMeta": {"properties": null, "committer": null, "author": "nessie_user1",
+      "signedOffBy": null, "commitTime": null, "hash": null, "authorTime": null, "email":
+      null, "message": "test_message"}}'
     headers:
       Accept:
       - application/json
@@ -105,21 +105,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -133,7 +133,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -148,7 +148,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -162,7 +162,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -170,10 +170,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
+        [ {\n    \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.829180Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.829180Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -195,18 +195,18 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339/log
+    uri: http://localhost:19120/api/v1/trees/tree/29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33/log
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
+        [ {\n    \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.829180Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.829180Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -214,7 +214,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -228,7 +228,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -244,7 +244,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -258,7 +258,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -273,15 +273,15 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": "nessie_user2", "authorTime": null, "email": null, "properties": null,
-      "message": "delete_message", "hash": null}, "operations": [{"key": {"elements":
-      ["foo", "bar"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"properties": null, "committer": null, "author": "nessie_user2",
+      "signedOffBy": null, "commitTime": null, "hash": null, "authorTime": null, "email":
+      null, "message": "delete_message"}}'
     headers:
       Accept:
       - application/json
@@ -294,21 +294,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -322,7 +322,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -330,14 +330,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
+        [ {\n    \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.906766Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.906766Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.829180Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.829180Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -345,7 +345,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -359,22 +359,22 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2/log
+    uri: http://localhost:19120/api/v1/trees/tree/ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14/log
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
+        [ {\n    \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.906766Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.906766Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.829180Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.829180Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -382,7 +382,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -396,7 +396,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -404,14 +404,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
+        [ {\n    \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.906766Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.906766Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.829180Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.829180Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -433,7 +433,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -441,10 +441,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
+        [ {\n    \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.829180Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.829180Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -466,7 +466,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -474,10 +474,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
+        [ {\n    \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.906766Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.906766Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -499,7 +499,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -507,14 +507,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
+        [ {\n    \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.906766Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.906766Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.829180Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.829180Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -522,7 +522,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -536,7 +536,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -544,14 +544,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
+        [ {\n    \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.906766Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.906766Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"29aeeff7636f6bbe977e8bd029971321087c2d3ba159e742fd9f30bc199c8b33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:13.829180Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:13.829180Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -559,7 +559,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -8,6 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -21,6 +23,8 @@ interactions:
       - '63'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -33,6 +37,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -46,6 +52,8 @@ interactions:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -58,6 +66,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -72,18 +82,20 @@ interactions:
       - '149'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"authorTime": null, "author": "nessie_user1", "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "test_message"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": "nessie_user1", "authorTime": null, "email": null, "properties": null,
+      "message": "test_message", "hash": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
+      "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -92,18 +104,22 @@ interactions:
       - '351'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -116,6 +132,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -129,6 +147,8 @@ interactions:
       - '80'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -141,6 +161,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -148,16 +170,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\",\n
+        [ {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.854094Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.854094Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '384'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -170,23 +194,27 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72/log
+    uri: http://localhost:19120/api/v1/trees/tree/5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339/log
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\",\n
+        [ {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.854094Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.854094Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '384'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -199,6 +227,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -213,6 +243,8 @@ interactions:
       - '153'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -225,6 +257,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -238,17 +272,19 @@ interactions:
       - '80'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"authorTime": null, "author": "nessie_user2", "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "delete_message"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": "nessie_user2", "authorTime": null, "email": null, "properties": null,
+      "message": "delete_message", "hash": null}, "operations": [{"key": {"elements":
+      ["foo", "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -257,18 +293,22 @@ interactions:
       - '273'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -281,6 +321,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -288,20 +330,22 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\",\n
+        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.957606Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.957606Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.854094Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.854094Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -314,27 +358,31 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed/log
+    uri: http://localhost:19120/api/v1/trees/tree/a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2/log
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\",\n
+        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.957606Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.957606Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.854094Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.854094Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -347,6 +395,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -354,20 +404,22 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\",\n
+        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.957606Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.957606Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.854094Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.854094Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -380,6 +432,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -387,16 +441,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\",\n
+        [ {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.854094Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.854094Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '384'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -409,6 +465,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -416,16 +474,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\",\n
+        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.957606Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.957606Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '386'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -438,6 +498,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -445,20 +507,22 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\",\n
+        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.957606Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.957606Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.854094Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.854094Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -471,6 +535,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -478,20 +544,22 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\",\n
+        [ {\n    \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.957606Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.957606Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"05f32d5203ac67270401d817512e19a3ebb3dc9a0ba8737c76e20b3b5726de72\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.357796Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.357796Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"5d74ed4c5ebc1f8a4d9aa06e65c0dcb898f3e42b5cc3b9522dbcb89dc97c3339\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:13.854094Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:13.854094Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:01:58.222181Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:01:58.222181Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -12,6 +12,8 @@ interactions:
       - '47'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -24,6 +26,8 @@ interactions:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -36,6 +40,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -51,6 +57,8 @@ interactions:
       - '247'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -63,6 +71,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -77,18 +87,20 @@ interactions:
       - '149'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"authorTime": null, "author": null, "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "test_message"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": null, "authorTime": null, "email": null, "properties": null, "message":
+      "test_message", "hash": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
+      "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -97,18 +109,22 @@ interactions:
       - '341'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -121,6 +137,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -129,13 +147,15 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}
         ]"
     headers:
       Content-Length:
       - '247'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -148,26 +168,30 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb"}'
+    body: '{"fromHash": "1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -176,6 +200,8 @@ interactions:
       - '80'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -183,7 +209,9 @@ interactions:
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -196,6 +224,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -203,14 +233,16 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb\"\n}
+        \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}
         ]"
     headers:
       Content-Length:
       - '247'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -223,18 +255,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -249,14 +285,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -269,6 +309,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -276,16 +318,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb\",\n
+        [ {\n    \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:14.660340Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:14.660340Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:02:03.553226Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:02:03.553226Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '372'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -298,6 +342,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -311,17 +357,19 @@ interactions:
       - '80'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"authorTime": null, "author": null, "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "delete_message"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": null, "authorTime": null, "email": null, "properties": null, "message":
+      "delete_message", "hash": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -330,18 +378,22 @@ interactions:
       - '263'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2b8316c4a2fd84bb070093aa6d6f72882836135dfcb32168056eabbdc30e9dfb
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"cdbce4764bb05c2cee7b0df4b69d17e0677595f16cc97184215f44f4167d1a56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9bb1025c0ccad9b7243c63c5fdec2cc7ed3597dd3e751ac76366ebcfb79d685a\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -354,18 +406,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"cdbce4764bb05c2cee7b0df4b69d17e0677595f16cc97184215f44f4167d1a56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9bb1025c0ccad9b7243c63c5fdec2cc7ed3597dd3e751ac76366ebcfb79d685a\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -380,14 +436,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=cdbce4764bb05c2cee7b0df4b69d17e0677595f16cc97184215f44f4167d1a56
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=9bb1025c0ccad9b7243c63c5fdec2cc7ed3597dd3e751ac76366ebcfb79d685a
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -395,7 +455,7 @@ interactions:
     body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -404,6 +464,8 @@ interactions:
       - '48'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -416,6 +478,8 @@ interactions:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -41,7 +41,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -72,7 +72,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -88,16 +88,16 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": null, "authorTime": null, "email": null, "properties": null, "message":
-      "test_message", "hash": null}, "operations": [{"contents": {"metadataLocation":
-      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
-      "bar"]}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "contents": {"id":
+      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
+      "commitMeta": {"properties": null, "committer": null, "author": null, "signedOffBy":
+      null, "commitTime": null, "hash": null, "authorTime": null, "email": null, "message":
+      "test_message"}}'
     headers:
       Accept:
       - application/json
@@ -110,21 +110,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -138,7 +138,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -147,7 +147,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c\"\n}
         ]"
     headers:
       Content-Length:
@@ -155,7 +155,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -169,26 +169,26 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d"}'
+    body: '{"fromHash": "91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c"}'
     headers:
       Accept:
       - application/json
@@ -201,7 +201,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -211,7 +211,7 @@ interactions:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -225,7 +225,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -233,8 +233,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}
+        \"91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c\"\n}
         ]"
     headers:
       Content-Length:
@@ -242,7 +242,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -256,21 +256,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -286,17 +286,17 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -310,7 +310,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -318,10 +318,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d\",\n
+        [ {\n    \"hash\" : \"91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:02:03.553226Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:02:03.553226Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:18.802976Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:18.802976Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -329,7 +329,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -343,7 +343,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -358,15 +358,15 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": null, "authorTime": null, "email": null, "properties": null, "message":
-      "delete_message", "hash": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"properties": null, "committer": null, "author": null, "signedOffBy":
+      null, "commitTime": null, "hash": null, "authorTime": null, "email": null, "message":
+      "delete_message"}}'
     headers:
       Accept:
       - application/json
@@ -379,21 +379,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=1ed6f13719c24243a9827c864872d321ee113c713452b0afba9dfcf0e593ff6d
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=91fb0e38196b41f26da3c77bbf1d75a2d0210f62c452900598af88114097260c
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9bb1025c0ccad9b7243c63c5fdec2cc7ed3597dd3e751ac76366ebcfb79d685a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5e5a5f5514c8433c77893674bb8e09636f897fdba8faf5bd6a0e1883a12d6c17\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -407,21 +407,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9bb1025c0ccad9b7243c63c5fdec2cc7ed3597dd3e751ac76366ebcfb79d685a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5e5a5f5514c8433c77893674bb8e09636f897fdba8faf5bd6a0e1883a12d6c17\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -437,22 +437,22 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=9bb1025c0ccad9b7243c63c5fdec2cc7ed3597dd3e751ac76366ebcfb79d685a
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=5e5a5f5514c8433c77893674bb8e09636f897fdba8faf5bd6a0e1883a12d6c17
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -465,7 +465,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -479,7 +479,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_ref.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_ref.yaml
@@ -8,6 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -15,12 +17,14 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n} ]"
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n} ]"
     headers:
       Content-Length:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -28,7 +32,7 @@ interactions:
     body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -37,6 +41,8 @@ interactions:
       - '47'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -49,6 +55,8 @@ interactions:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -61,6 +69,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -68,7 +78,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}, {\n
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -76,6 +86,8 @@ interactions:
       - '247'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -88,6 +100,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -101,6 +115,8 @@ interactions:
       - '124'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
@@ -113,27 +129,31 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl", "hash": "b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed",
+    body: '{"name": "etl", "hash": "a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2",
       "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -142,18 +162,22 @@ interactions:
       - '109'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -166,6 +190,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -173,8 +199,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n},
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n},
         {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -182,6 +208,8 @@ interactions:
       - '369'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -194,18 +222,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -220,14 +252,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed
+    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -240,6 +276,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -252,6 +290,8 @@ interactions:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -266,6 +306,8 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
@@ -273,7 +315,9 @@ interactions:
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -286,6 +330,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -293,12 +339,14 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n} ]"
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n} ]"
     headers:
       Content-Length:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_ref.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_ref.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -17,19 +17,19 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n} ]"
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n} ]"
     headers:
       Content-Length:
       - '125'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -42,7 +42,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -56,7 +56,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -70,7 +70,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -78,7 +78,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -87,7 +87,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -101,7 +101,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
@@ -130,27 +130,27 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl", "hash": "a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2",
-      "type": "BRANCH"}'
+    body: '{"hash": "ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14",
+      "name": "etl", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -163,21 +163,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -191,7 +191,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -199,8 +199,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n},
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n},
         {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -209,7 +209,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -223,21 +223,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -253,17 +253,17 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2
+    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -277,7 +277,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -291,7 +291,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -307,7 +307,7 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
@@ -317,7 +317,7 @@ interactions:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -331,7 +331,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -339,14 +339,14 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n} ]"
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n} ]"
     headers:
       Content-Length:
       - '125'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_remote.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_remote.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -23,7 +23,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -37,7 +37,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -52,7 +52,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_remote.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_remote.yaml
@@ -8,6 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -20,6 +22,8 @@ interactions:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -32,6 +36,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -45,6 +51,8 @@ interactions:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -17,14 +17,14 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n} ]"
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n} ]"
     headers:
       Content-Length:
       - '125'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -38,7 +38,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -53,7 +53,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
@@ -67,27 +67,27 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev-tag", "hash": "a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2",
-      "type": "TAG"}'
+    body: '{"hash": "ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14",
+      "name": "dev-tag", "type": "TAG"}'
     headers:
       Accept:
       - application/json
@@ -100,21 +100,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -128,7 +128,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -136,8 +136,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}
         ]"
     headers:
       Content-Length:
@@ -145,7 +145,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -159,7 +159,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -174,7 +174,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
@@ -188,27 +188,27 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl-tag", "hash": "a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2",
-      "type": "TAG"}'
+    body: '{"hash": "ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14",
+      "name": "etl-tag", "type": "TAG"}'
     headers:
       Accept:
       - application/json
@@ -221,21 +221,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -249,7 +249,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -257,9 +257,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n},
-        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}
         ]"
     headers:
       Content-Length:
@@ -267,7 +267,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -281,21 +281,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -311,17 +311,17 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2
+    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -335,21 +335,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -365,17 +365,17 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2
+    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -389,7 +389,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -397,19 +397,19 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n} ]"
+        \"ba120663e1d212f358fb8de1da2c8621a32d6cc80d5afbad20e4a9e91ac05e14\"\n} ]"
     headers:
       Content-Length:
       - '125'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": null, "type": "TAG"}'
+    body: '{"hash": null, "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - application/json
@@ -422,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -438,7 +438,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 400
       message: Bad Request

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -8,6 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -15,12 +17,14 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n} ]"
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n} ]"
     headers:
       Content-Length:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -33,6 +37,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -46,6 +52,8 @@ interactions:
       - '128'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
@@ -58,27 +66,31 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev-tag", "hash": "b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed",
+    body: '{"name": "dev-tag", "hash": "a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2",
       "type": "TAG"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -87,18 +99,22 @@ interactions:
       - '110'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -111,6 +127,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -118,14 +136,16 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}
         ]"
     headers:
       Content-Length:
       - '248'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -138,6 +158,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -151,6 +173,8 @@ interactions:
       - '128'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
@@ -163,27 +187,31 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl-tag", "hash": "b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed",
+    body: '{"name": "etl-tag", "hash": "a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2",
       "type": "TAG"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -192,18 +220,22 @@ interactions:
       - '110'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -216,6 +248,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -223,15 +257,17 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n},
-        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}
         ]"
     headers:
       Content-Length:
       - '371'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -244,18 +280,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -270,14 +310,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed
+    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -290,18 +334,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -316,14 +364,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed
+    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -336,6 +388,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -343,12 +397,14 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"b001de3fc1d925b69724a71e7ab81945ba3df3fe4315c0d85fcf004514eff8ed\"\n} ]"
+        \"a7a9dec9e97ad2af974b89e28bb5dfd876cad07c1bd7815ab5c02f74b9b69dd2\"\n} ]"
     headers:
       Content-Length:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -356,7 +412,7 @@ interactions:
     body: '{"name": "v1.0", "hash": null, "type": "TAG"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -365,6 +421,8 @@ interactions:
       - '45'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -379,6 +437,8 @@ interactions:
       - '136'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 400
       message: Bad Request

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -12,6 +12,8 @@ interactions:
       - '47'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -24,6 +26,8 @@ interactions:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -36,6 +40,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -51,6 +57,8 @@ interactions:
       - '247'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -63,6 +71,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -77,18 +87,20 @@ interactions:
       - '149'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"authorTime": null, "author": null, "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "test_message"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": null, "authorTime": null, "email": null, "properties": null, "message":
+      "test_message", "hash": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
+      "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -97,18 +109,22 @@ interactions:
       - '341'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f5eb6a9e898c84644c5793a7565e07b9c7dacfb7900f67fe28cd71e41048860b\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2b1de4637250d944942eb56e08d64eef39540d8502bd52a34541d40ea3d734db\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -121,6 +137,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -135,18 +153,20 @@ interactions:
       - '149'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["bar", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"authorTime": null, "author": null, "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "test_message2"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": null, "authorTime": null, "email": null, "properties": null, "message":
+      "test_message2", "hash": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["bar",
+      "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -155,18 +175,22 @@ interactions:
       - '342'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a0777ff4d4535c426b6e572f65a9b029a8e0a542b37d9d5fc2130cfae081e50\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -179,6 +203,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -193,18 +219,20 @@ interactions:
       - '149'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "baz"]}, "type": "PUT"}],
-      "commitMeta": {"authorTime": null, "author": null, "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "test_message3"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": null, "authorTime": null, "email": null, "properties": null, "message":
+      "test_message3", "hash": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
+      "baz"]}, "type": "PUT"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -213,18 +241,22 @@ interactions:
       - '342'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"45f65d4cf86f7a33e707ed81ed9746ccb6a6cc1bfd0be82f1ad548c96a380f27\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"3c7b73e9648d0ebc2cc1697d5678b304d0e31be3c184318f518271e3686b7c5d\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -237,6 +269,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -244,14 +278,16 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"45f65d4cf86f7a33e707ed81ed9746ccb6a6cc1bfd0be82f1ad548c96a380f27\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a0777ff4d4535c426b6e572f65a9b029a8e0a542b37d9d5fc2130cfae081e50\"\n}
+        \"3c7b73e9648d0ebc2cc1697d5678b304d0e31be3c184318f518271e3686b7c5d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68\"\n}
         ]"
     headers:
       Content-Length:
       - '247'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -264,6 +300,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -271,29 +309,31 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"9a0777ff4d4535c426b6e572f65a9b029a8e0a542b37d9d5fc2130cfae081e50\",\n
+        [ {\n    \"hash\" : \"59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-06-07T16:04:14.879324Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:14.879324Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"f5eb6a9e898c84644c5793a7565e07b9c7dacfb7900f67fe28cd71e41048860b\",\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-06-15T12:02:07.973542Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:02:07.973542Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"2b1de4637250d944942eb56e08d64eef39540d8502bd52a34541d40ea3d734db\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:14.841306Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:14.841306Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:02:05.885257Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:02:05.885257Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '683'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hashesToTransplant": ["f5eb6a9e898c84644c5793a7565e07b9c7dacfb7900f67fe28cd71e41048860b",
-      "9a0777ff4d4535c426b6e572f65a9b029a8e0a542b37d9d5fc2130cfae081e50"]}'
+    body: '{"hashesToTransplant": ["2b1de4637250d944942eb56e08d64eef39540d8502bd52a34541d40ea3d734db",
+      "59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68"]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -302,14 +342,18 @@ interactions:
       - '160'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=45f65d4cf86f7a33e707ed81ed9746ccb6a6cc1bfd0be82f1ad548c96a380f27
+    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=3c7b73e9648d0ebc2cc1697d5678b304d0e31be3c184318f518271e3686b7c5d
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -322,6 +366,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -329,24 +375,26 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"bf1dd91fd18300d250048baa6b540bf7f0384ae8712122cc62ea6027ec46afc7\",\n
+        [ {\n    \"hash\" : \"163f6e6177201f27f2f5df5fa96e5f62608ab5897cd7cfc599d2ee4fd1bffa02\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-06-07T16:04:14.879324Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:14.879324Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"2b7dc8808c91bf452fe7d3d0506b69c67221064e612fda768e978e56344cd0ee\",\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-06-15T12:02:07.973542Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:02:07.973542Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"d17dae368dfaed5fa2983cbbef2fe18e38838516775cb85c8779ac24fcb0f09a\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-07T16:04:14.841306Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:14.841306Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"45f65d4cf86f7a33e707ed81ed9746ccb6a6cc1bfd0be82f1ad548c96a380f27\",\n
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:02:05.885257Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:02:05.885257Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"3c7b73e9648d0ebc2cc1697d5678b304d0e31be3c184318f518271e3686b7c5d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-06-07T16:04:14.917590Z\",\n
-        \   \"authorTime\" : \"2021-06-07T16:04:14.917590Z\",\n    \"properties\"
+        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-06-15T12:02:10.067234Z\",\n
+        \   \"authorTime\" : \"2021-06-15T12:02:10.067234Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '994'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -359,6 +407,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -372,17 +422,19 @@ interactions:
       - '80'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"authorTime": null, "author": null, "hash": null, "commitTime":
-      null, "signedOffBy": null, "email": null, "properties": null, "committer": null,
-      "message": "delete_message"}}'
+    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
+      "author": null, "authorTime": null, "email": null, "properties": null, "message":
+      "delete_message", "hash": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -391,18 +443,22 @@ interactions:
       - '263'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=bf1dd91fd18300d250048baa6b540bf7f0384ae8712122cc62ea6027ec46afc7
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=163f6e6177201f27f2f5df5fa96e5f62608ab5897cd7cfc599d2ee4fd1bffa02
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e23e2b9103fa45ed624b5dbcf038cef0f3c8b19fdbbe5a151766e268c41108ae\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"15bc667121467da875532778fd5601a1bceb0a27587d48cf32cbf804bed6529f\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -415,18 +471,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9a0777ff4d4535c426b6e572f65a9b029a8e0a542b37d9d5fc2130cfae081e50\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -441,14 +501,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=9a0777ff4d4535c426b6e572f65a9b029a8e0a542b37d9d5fc2130cfae081e50
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -461,18 +525,22 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e23e2b9103fa45ed624b5dbcf038cef0f3c8b19fdbbe5a151766e268c41108ae\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"15bc667121467da875532778fd5601a1bceb0a27587d48cf32cbf804bed6529f\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -487,14 +555,18 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=e23e2b9103fa45ed624b5dbcf038cef0f3c8b19fdbbe5a151766e268c41108ae
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=15bc667121467da875532778fd5601a1bceb0a27587d48cf32cbf804bed6529f
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -502,7 +574,7 @@ interactions:
     body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -511,6 +583,8 @@ interactions:
       - '48'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -523,6 +597,8 @@ interactions:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -41,7 +41,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -72,7 +72,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -88,16 +88,16 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": null, "authorTime": null, "email": null, "properties": null, "message":
-      "test_message", "hash": null}, "operations": [{"contents": {"metadataLocation":
-      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
-      "bar"]}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "contents": {"id":
+      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
+      "commitMeta": {"properties": null, "committer": null, "author": null, "signedOffBy":
+      null, "commitTime": null, "hash": null, "authorTime": null, "email": null, "message":
+      "test_message"}}'
     headers:
       Accept:
       - application/json
@@ -110,21 +110,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2b1de4637250d944942eb56e08d64eef39540d8502bd52a34541d40ea3d734db\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"a1e95f1704f85a8581940a7f8b71c2781b6fe880cd6e667317030db15ee9e81f\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -138,7 +138,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -154,16 +154,16 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": null, "authorTime": null, "email": null, "properties": null, "message":
-      "test_message2", "hash": null}, "operations": [{"contents": {"metadataLocation":
-      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["bar",
-      "bar"]}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["bar", "bar"]}, "contents": {"id":
+      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
+      "commitMeta": {"properties": null, "committer": null, "author": null, "signedOffBy":
+      null, "commitTime": null, "hash": null, "authorTime": null, "email": null, "message":
+      "test_message2"}}'
     headers:
       Accept:
       - application/json
@@ -176,21 +176,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"909fab6b36fac1b166a526012240017050bcc45d2ebe2af769c85d671ae2abfe\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -204,7 +204,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -220,16 +220,16 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": null, "authorTime": null, "email": null, "properties": null, "message":
-      "test_message3", "hash": null}, "operations": [{"contents": {"metadataLocation":
-      "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo",
-      "baz"]}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "baz"]}, "contents": {"id":
+      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
+      "commitMeta": {"properties": null, "committer": null, "author": null, "signedOffBy":
+      null, "commitTime": null, "hash": null, "authorTime": null, "email": null, "message":
+      "test_message3"}}'
     headers:
       Accept:
       - application/json
@@ -242,21 +242,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"3c7b73e9648d0ebc2cc1697d5678b304d0e31be3c184318f518271e3686b7c5d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"69ac0c6be1f718f94603d142dafb6d3b48308fcd20d97c8292d04899c0745e4e\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -270,7 +270,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -278,8 +278,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"3c7b73e9648d0ebc2cc1697d5678b304d0e31be3c184318f518271e3686b7c5d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68\"\n}
+        \"69ac0c6be1f718f94603d142dafb6d3b48308fcd20d97c8292d04899c0745e4e\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"909fab6b36fac1b166a526012240017050bcc45d2ebe2af769c85d671ae2abfe\"\n}
         ]"
     headers:
       Content-Length:
@@ -287,7 +287,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -301,7 +301,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -309,14 +309,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68\",\n
+        [ {\n    \"hash\" : \"909fab6b36fac1b166a526012240017050bcc45d2ebe2af769c85d671ae2abfe\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-06-15T12:02:07.973542Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:02:07.973542Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"2b1de4637250d944942eb56e08d64eef39540d8502bd52a34541d40ea3d734db\",\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-06-18T13:57:23.161559Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:23.161559Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"a1e95f1704f85a8581940a7f8b71c2781b6fe880cd6e667317030db15ee9e81f\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:02:05.885257Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:02:05.885257Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:21.078420Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:21.078420Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -324,13 +324,13 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hashesToTransplant": ["2b1de4637250d944942eb56e08d64eef39540d8502bd52a34541d40ea3d734db",
-      "59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68"]}'
+    body: '{"hashesToTransplant": ["a1e95f1704f85a8581940a7f8b71c2781b6fe880cd6e667317030db15ee9e81f",
+      "909fab6b36fac1b166a526012240017050bcc45d2ebe2af769c85d671ae2abfe"]}'
     headers:
       Accept:
       - application/json
@@ -343,17 +343,17 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=3c7b73e9648d0ebc2cc1697d5678b304d0e31be3c184318f518271e3686b7c5d
+    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=69ac0c6be1f718f94603d142dafb6d3b48308fcd20d97c8292d04899c0745e4e
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -367,7 +367,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -375,18 +375,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"163f6e6177201f27f2f5df5fa96e5f62608ab5897cd7cfc599d2ee4fd1bffa02\",\n
+        [ {\n    \"hash\" : \"9e450844028d4ff347c3cbd9768ba93f0d2826a294f8b4b98898a83d674ec089\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-06-15T12:02:07.973542Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:02:07.973542Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"d17dae368dfaed5fa2983cbbef2fe18e38838516775cb85c8779ac24fcb0f09a\",\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-06-18T13:57:23.161559Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:23.161559Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"37cb1f2641b6767100600632910712455e84d877b3a66cb1315b079fe70824c3\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-15T12:02:05.885257Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:02:05.885257Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"3c7b73e9648d0ebc2cc1697d5678b304d0e31be3c184318f518271e3686b7c5d\",\n
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-06-18T13:57:21.078420Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:21.078420Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"69ac0c6be1f718f94603d142dafb6d3b48308fcd20d97c8292d04899c0745e4e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-06-15T12:02:10.067234Z\",\n
-        \   \"authorTime\" : \"2021-06-15T12:02:10.067234Z\",\n    \"properties\"
+        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-06-18T13:57:25.254685Z\",\n
+        \   \"authorTime\" : \"2021-06-18T13:57:25.254685Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -394,7 +394,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -408,7 +408,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -423,15 +423,15 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"signedOffBy": null, "commitTime": null, "committer": null,
-      "author": null, "authorTime": null, "email": null, "properties": null, "message":
-      "delete_message", "hash": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"properties": null, "committer": null, "author": null, "signedOffBy":
+      null, "commitTime": null, "hash": null, "authorTime": null, "email": null, "message":
+      "delete_message"}}'
     headers:
       Accept:
       - application/json
@@ -444,21 +444,21 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=163f6e6177201f27f2f5df5fa96e5f62608ab5897cd7cfc599d2ee4fd1bffa02
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=9e450844028d4ff347c3cbd9768ba93f0d2826a294f8b4b98898a83d674ec089
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"15bc667121467da875532778fd5601a1bceb0a27587d48cf32cbf804bed6529f\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9db45de39f2d041e801bd1bc1afb6f77667dde7db69fe7c8f77098913b173c31\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -472,21 +472,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"909fab6b36fac1b166a526012240017050bcc45d2ebe2af769c85d671ae2abfe\"\n}"
     headers:
       Content-Length:
       - '120'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -502,17 +502,17 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=59a44281373311ba02a2b2dbd794208ffc77605dd8e167068a06982f8bd63a68
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=909fab6b36fac1b166a526012240017050bcc45d2ebe2af769c85d671ae2abfe
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -526,21 +526,21 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"15bc667121467da875532778fd5601a1bceb0a27587d48cf32cbf804bed6529f\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9db45de39f2d041e801bd1bc1afb6f77667dde7db69fe7c8f77098913b173c31\"\n}"
     headers:
       Content-Length:
       - '121'
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -556,22 +556,22 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=15bc667121467da875532778fd5601a1bceb0a27587d48cf32cbf804bed6529f
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=9db45de39f2d041e801bd1bc1afb6f77667dde7db69fe7c8f77098913b173c31
   response:
     body:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -584,7 +584,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -598,7 +598,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -24,12 +24,12 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -42,7 +42,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -58,13 +58,13 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 409
       message: Conflict
 - request:
-    body: '{"name": "test", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "test", "type": "BRANCH"}'
     headers:
       Accept:
       - application/json
@@ -77,7 +77,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -105,7 +105,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -122,7 +122,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -136,7 +136,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -150,7 +150,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -164,7 +164,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -178,7 +178,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -194,7 +194,7 @@ interactions:
       Content-Length:
       - '0'
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
@@ -204,7 +204,7 @@ interactions:
       string: ''
     headers:
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -218,7 +218,7 @@ interactions:
       Connection:
       - keep-alive
       Nessie-Version:
-      - 0.6.2
+      - 0.7.1
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -233,7 +233,7 @@ interactions:
       Content-Type:
       - application/json
       Nessie-Version:
-      - 0.6.2-SNAPSHOT
+      - 0.7.1-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -8,6 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -21,6 +23,8 @@ interactions:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -28,7 +32,7 @@ interactions:
     body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -37,6 +41,8 @@ interactions:
       - '48'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -51,6 +57,8 @@ interactions:
       - '134'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 409
       message: Conflict
@@ -59,7 +67,7 @@ interactions:
       "type": "BRANCH"}'
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
@@ -68,6 +76,8 @@ interactions:
       - '110'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: POST
@@ -80,6 +90,8 @@ interactions:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -92,6 +104,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -107,6 +121,8 @@ interactions:
       - '248'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -119,6 +135,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -131,6 +149,8 @@ interactions:
       - '121'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -143,6 +163,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -155,6 +177,8 @@ interactions:
       - '60'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK
@@ -169,6 +193,8 @@ interactions:
       - keep-alive
       Content-Length:
       - '0'
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: DELETE
@@ -176,7 +202,9 @@ interactions:
   response:
     body:
       string: ''
-    headers: {}
+    headers:
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 204
       message: No Content
@@ -189,6 +217,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Nessie-Version:
+      - 0.6.2
       User-Agent:
       - python-requests/2.25.1
     method: GET
@@ -202,6 +232,8 @@ interactions:
       - '125'
       Content-Type:
       - application/json
+      Nessie-Version:
+      - 0.6.2-SNAPSHOT
     status:
       code: 200
       message: OK

--- a/python/tests/test_nessie_client.py
+++ b/python/tests/test_nessie_client.py
@@ -4,7 +4,7 @@
 import pytest
 from packaging.version import Version
 
-from pynessie import __required_version_range__, __version__, init
+from pynessie import __min_remote_version__, __version__, init
 from pynessie._endpoints import _check_nessie_version_headers
 from pynessie.error import NessieConflictException
 from pynessie.model import Branch
@@ -41,46 +41,40 @@ def test_nessie_version() -> None:
     """Test version requirements."""
     # No Nessie-Version header from server
     with pytest.raises(Exception) as e:
-        _check_nessie_version_headers({}, (Version("1.2.3"), Version("1.2.4")))
+        _check_nessie_version_headers({}, Version("1.2.3"))
     assert str(e.value) == "Server replied without the required Nessie-Version header. pynessie requires Nessie-Server version >= 0.7.0"
 
     # Empty Nessie-Version header from server
     with pytest.raises(Exception) as e:
-        _check_nessie_version_headers({"Nessie-Version": ""}, (Version("1.2.3"), Version("1.2.4")))
+        _check_nessie_version_headers({"Nessie-Version": ""}, Version("1.2.3"))
     assert str(e.value) == "Server replied without the required Nessie-Version header. pynessie requires Nessie-Server version >= 0.7.0"
 
     # Nessie-Server version is one patch version too new
-    with pytest.raises(Exception) as e:
-        _check_nessie_version_headers({"Nessie-Version": "88.44.22"}, (Version("88.0.0"), Version("88.44.21")))
-    assert str(e.value) == f"Nessie-Server is running version 88.44.22, which is incompatible to pynessie {__version__}"
+    _check_nessie_version_headers({"Nessie-Version": "88.44.22"}, Version("88.0.0"))
 
     # Nessie-Server version is one patch version too old
     with pytest.raises(Exception) as e:
-        _check_nessie_version_headers({"Nessie-Version": "88.44.22"}, (Version("88.44.23"), Version("88.45.0")))
+        _check_nessie_version_headers({"Nessie-Version": "88.44.22"}, Version("88.44.23"))
     assert str(e.value) == f"Nessie-Server is running version 88.44.22, which is incompatible to pynessie {__version__}"
 
     # Nessie-Server version is one minor version too new
-    with pytest.raises(Exception) as e:
-        _check_nessie_version_headers({"Nessie-Version": "88.45.0"}, (Version("88.0.0"), Version("88.44.999")))
-    assert str(e.value) == f"Nessie-Server is running version 88.45.0, which is incompatible to pynessie {__version__}"
+    _check_nessie_version_headers({"Nessie-Version": "88.45.0"}, Version("88.0.0"))
 
     # Nessie-Server version is one minor version too old
     with pytest.raises(Exception) as e:
-        _check_nessie_version_headers({"Nessie-Version": "88.43.0"}, (Version("88.44.0"), Version("88.45.0")))
+        _check_nessie_version_headers({"Nessie-Version": "88.43.0"}, Version("88.44.0"))
     assert str(e.value) == f"Nessie-Server is running version 88.43.0, which is incompatible to pynessie {__version__}"
 
     # Nessie-Server version is one major version too new
-    with pytest.raises(Exception) as e:
-        _check_nessie_version_headers({"Nessie-Version": "89.0.0"}, (Version("88.0.0"), Version("88.999.999")))
-    assert str(e.value) == f"Nessie-Server is running version 89.0.0, which is incompatible to pynessie {__version__}"
+    _check_nessie_version_headers({"Nessie-Version": "89.0.0"}, Version("88.0.0"))
 
     # Nessie-Server version is one major version too old
     with pytest.raises(Exception) as e:
-        _check_nessie_version_headers({"Nessie-Version": "87.44.22"}, (Version("88.0.0"), Version("999.999.999")))
+        _check_nessie_version_headers({"Nessie-Version": "87.44.22"}, Version("88.0.0"))
     assert str(e.value) == f"Nessie-Server is running version 87.44.22, which is incompatible to pynessie {__version__}"
 
     # Verify that server can safely sent versions with -SNAPSHOT
-    _check_nessie_version_headers({"Nessie-Version": "1.2.3-SNAPSHOT"}, (Version("1.2.3"), Version("1.2.4")))
+    _check_nessie_version_headers({"Nessie-Version": "1.2.3-SNAPSHOT"}, Version("1.2.3"))
 
     # Sanity - check that the pynessie global vars make sense
-    _check_nessie_version_headers({"Nessie-Version": f"{__version__}"}, __required_version_range__)
+    _check_nessie_version_headers({"Nessie-Version": f"{__version__}"}, __min_remote_version__)

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/RestGitTest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/RestGitTest.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.common.NessieVersion;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Contents;
@@ -205,7 +206,11 @@ public class RestGitTest {
   }
 
   private static RequestSpecification rest() {
-    return given().when().basePath("/api/v1/").contentType(ContentType.JSON);
+    return given()
+        .when()
+        .basePath("/api/v1/")
+        .contentType(ContentType.JSON)
+        .header("Nessie-Version", NessieVersion.NESSIE_VERSION.toString());
   }
 
   private Branch commit(Branch branch, String contentsKey, String metadataUrl) {

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -126,9 +126,8 @@ class TestRest {
   }
 
   @Test
-  void nessieVersion() throws Exception {
+  void noNessieVersionFromClient() throws Exception {
     URLConnection conn1 = uri.resolve("config").toURL().openConnection();
-    conn1.getInputStream().close(); // needs to pass
     assertThatThrownBy(() -> conn1.getInputStream().close())
         .isInstanceOf(IOException.class)
         .extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
@@ -136,19 +135,28 @@ class TestRest {
             "Server returned HTTP response code: " + Status.BAD_REQUEST.getCode()); // must fail
     assertThat(conn1.getHeaderField("Nessie-Version"))
         .isEqualTo(NessieVersion.NESSIE_VERSION.toString());
+  }
 
+  @Test
+  void nessieVersionFromProduct() throws Exception {
     URLConnection conn2 = uri.resolve("config").toURL().openConnection();
     conn2.setRequestProperty("Nessie-Version", NessieVersion.NESSIE_VERSION.toString());
     conn2.getInputStream().close(); // needs to pass
     assertThat(conn2.getHeaderField("Nessie-Version"))
         .isEqualTo(NessieVersion.NESSIE_VERSION.toString());
+  }
 
+  @Test
+  void nessieVersionFromMinVersion() throws Exception {
     URLConnection conn3 = uri.resolve("config").toURL().openConnection();
     conn3.setRequestProperty("Nessie-Version", NessieVersion.NESSIE_MIN_API_VERSION.toString());
     conn3.getInputStream().close(); // needs to pass
     assertThat(conn3.getHeaderField("Nessie-Version"))
         .isEqualTo(NessieVersion.NESSIE_VERSION.toString());
+  }
 
+  @Test
+  void nessieVersionTooOld() throws Exception {
     URLConnection conn4 = uri.resolve("config").toURL().openConnection();
     conn4.setRequestProperty("Nessie-Version", "0.5.1");
     assertThatThrownBy(() -> conn4.getInputStream().close())

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -65,6 +65,7 @@ import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.client.http.Status;
 import org.projectnessie.client.rest.NessieBadRequestException;
 import org.projectnessie.client.rest.NessieHttpResponseFilter;
+import org.projectnessie.client.rest.NessieVersionFilters;
 import org.projectnessie.common.NessieVersion;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -115,6 +116,7 @@ class TestRest {
             .enable(SerializationFeature.INDENT_OUTPUT)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     httpClient = HttpClient.builder().setBaseUri(uri).setObjectMapper(mapper).build();
+    NessieVersionFilters.register(httpClient);
     httpClient.register(new NessieHttpResponseFilter(mapper));
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -35,6 +35,7 @@ import org.projectnessie.client.rest.NessieBackendThrottledException;
 import org.projectnessie.client.rest.NessieBadRequestException;
 import org.projectnessie.client.rest.NessieHttpResponseFilter;
 import org.projectnessie.client.rest.NessieInternalServerException;
+import org.projectnessie.client.rest.NessieVersionFilters;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 
@@ -56,6 +57,7 @@ class TestNessieError {
             .enable(SerializationFeature.INDENT_OUTPUT)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     client = HttpClient.builder().setBaseUri(URI.create(baseURI)).setObjectMapper(mapper).build();
+    NessieVersionFilters.register(client);
     client.register(new NessieHttpResponseFilter(mapper));
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/rest/NessieVersionChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/NessieVersionChecker.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.rest;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.Provider;
+import org.projectnessie.common.NessieVersion;
+
+@Provider
+public class NessieVersionChecker implements ContainerRequestFilter {
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) {
+    String remoteNessieVersion = requestContext.getHeaders().getFirst("Nessie-Version");
+    // Note: no-header means incompatible Nessie-Client
+    if (remoteNessieVersion == null) {
+      // TODO the status reason is always "Bad Request" via Quarkus - seems to be a
+      // Quarkus/Resteasy-bug :(
+      requestContext.abortWith(
+          Response.status(
+                  Status.BAD_REQUEST.getStatusCode(),
+                  String.format(
+                      "Remote Nessie-Client did not sent a version, considering incompatible "
+                          + "with local server version %s, minimum required client version is %s",
+                      NessieVersion.NESSIE_VERSION, NessieVersion.NESSIE_MIN_API_VERSION))
+              .header("Nessie-Version", NessieVersion.NESSIE_VERSION)
+              .build());
+    } else if (!NessieVersion.isApiCompatible(remoteNessieVersion)) {
+      // TODO the status reason is always "Bad Request" via Quarkus - seems to be a
+      // Quarkus/Resteasy-bug :(
+      requestContext.abortWith(
+          Response.status(
+                  Status.BAD_REQUEST.getStatusCode(),
+                  String.format(
+                      "Remote Nessie-Client version %s is incompatible "
+                          + "with local server version %s, minimum required client version is %s",
+                      remoteNessieVersion,
+                      NessieVersion.NESSIE_VERSION,
+                      NessieVersion.NESSIE_MIN_API_VERSION))
+              .header("Nessie-Version", NessieVersion.NESSIE_VERSION)
+              .build());
+    }
+  }
+}

--- a/servers/services/src/main/java/org/projectnessie/services/rest/NessieVersionHeader.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/NessieVersionHeader.java
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.http;
+package org.projectnessie.services.rest;
 
 import java.io.IOException;
-import java.io.InputStream;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+import org.projectnessie.common.NessieVersion;
 
-/** Interface for the important parts of a response. This is created after executing the request. */
-public interface ResponseContext {
+@Provider
+public class NessieVersionHeader implements WriterInterceptor {
 
-  Status getResponseCode() throws IOException;
-
-  InputStream getInputStream() throws IOException;
-
-  InputStream getErrorStream() throws IOException;
-
-  String getHeader(String header);
+  @Override
+  public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+    context.getHeaders().add("Nessie-Version", NessieVersion.NESSIE_VERSION.toString());
+    context.proceed();
+  }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/rest/NessieVersionHeader.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/NessieVersionHeader.java
@@ -15,18 +15,17 @@
  */
 package org.projectnessie.services.rest;
 
-import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Provider;
-import javax.ws.rs.ext.WriterInterceptor;
-import javax.ws.rs.ext.WriterInterceptorContext;
 import org.projectnessie.common.NessieVersion;
 
 @Provider
-public class NessieVersionHeader implements WriterInterceptor {
+public class NessieVersionHeader implements ContainerResponseFilter {
 
   @Override
-  public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+  public void filter(ContainerRequestContext requestContext, ContainerResponseContext context) {
     context.getHeaders().add("Nessie-Version", NessieVersion.NESSIE_VERSION.toString());
-    context.proceed();
   }
 }

--- a/ui/gen-src/utils/version-numbers.tsx
+++ b/ui/gen-src/utils/version-numbers.tsx
@@ -13,16 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {authenticationService} from '../services';
-import {nessieVersion} from "./version-numbers";
 
-export function nessieRequestHeaders() : Record<string, string> {
-  // return authorization header with jwt token
-  const currentUser = authenticationService.currentUserValue;
-  // TODO how can we get the current Nessie version here??
-  if (currentUser && currentUser.token) {
-    return {Authorization: `Bearer ${currentUser.token}`, "Nessie-Version": nessieVersion};
-  } else {
-    return {"Nessie-Version": nessieVersion};
-  }
-}
+// THIS IS A GENERATED FILE - DO NOT EDIT!
+
+export const nessieVersion = "${project.version}";
+export const nessieMinApiVersion = "${nessie.min-api-compatibility}";

--- a/ui/gen-src/utils/version-numbers.tsx
+++ b/ui/gen-src/utils/version-numbers.tsx
@@ -17,4 +17,4 @@
 // THIS IS A GENERATED FILE - DO NOT EDIT!
 
 export const nessieVersion = "${project.version}";
-export const nessieMinApiVersion = "${nessie.min-api-compatibility}";
+export const nessieMinApiVersion = "${nessie.min-remote-version}";

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -57,6 +57,28 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>gen-source</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>src</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>gen-src</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>

--- a/ui/src/services/user.service.ts
+++ b/ui/src/services/user.service.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 import {config} from '../config';
-import {authHeader, handleResponse} from '../utils';
+import {handleResponse, nessieRequestHeaders} from '../utils';
 
 export const userService = {
   getAll
 };
 
 function getAll() {
-  const requestOptions = {method: 'GET', headers: authHeader()};
+  const requestOptions = {method: 'GET', headers: nessieRequestHeaders()};
   return fetch(`${config.apiUrl}/users`, requestOptions).then(handleResponse);
 }

--- a/ui/src/utils/api-wrapper.tsx
+++ b/ui/src/utils/api-wrapper.tsx
@@ -15,7 +15,8 @@
  */
 
 import {Configuration, DefaultApi, ResponseContext} from "./api";
-import {nessieVersion, verifyServerVersion} from "./versions";
+import {nessieVersion} from "./version-numbers";
+import {verifyServerVersion} from "./versions";
 
 function api() {
   return new DefaultApi(new Configuration({

--- a/ui/src/utils/api-wrapper.tsx
+++ b/ui/src/utils/api-wrapper.tsx
@@ -14,11 +14,23 @@
  * limitations under the License.
  */
 
-import {DefaultApi} from "./api/apis";
-import {Configuration} from "./api";
+import {Configuration, DefaultApi, ResponseContext} from "./api";
+import {nessieVersion, verifyServerVersion} from "./versions";
 
 function api() {
-  return new DefaultApi(new Configuration({"basePath": ""}));
+  return new DefaultApi(new Configuration({
+    "basePath": "",
+    "headers": { "Nessie-Version": nessieVersion },
+    "middleware": [ { "post": function(context: ResponseContext): Promise<Response> {
+          let rejected = verifyServerVersion(context.response.headers)
+          if (rejected != null) {
+            return rejected;
+          }
+          return Promise.resolve(context.response)
+        }
+      }
+    ]
+  }));
 }
 
 export {api};

--- a/ui/src/utils/auth-header.tsx
+++ b/ui/src/utils/auth-header.tsx
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 import {authenticationService} from '../services';
+import {nessieVersion} from "./versions";
 
-export function authHeader() : Record<string, string> {
+export function nessieRequestHeaders() : Record<string, string> {
   // return authorization header with jwt token
   const currentUser = authenticationService.currentUserValue;
+  // TODO how can we get the current Nessie version here??
   if (currentUser && currentUser.token) {
-    return {Authorization: `Bearer ${currentUser.token}`};
+    return {Authorization: `Bearer ${currentUser.token}`, "Nessie-Version": nessieVersion};
   } else {
-    return {};
+    return {"Nessie-Version": nessieVersion};
   }
 }

--- a/ui/src/utils/handle-response.tsx
+++ b/ui/src/utils/handle-response.tsx
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 import {authenticationService} from '../services';
+import {verifyServerVersion} from "./versions";
 
 export function handleResponse(response: Response) {
+  let rejected = verifyServerVersion(response.headers)
+  if (rejected != null) {
+    return rejected;
+  }
+
   return response.text().then(text => {
     const data = text && JSON.parse(text);
     if (!response.ok) {

--- a/ui/src/utils/versions.tsx
+++ b/ui/src/utils/versions.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO How to get the current Nessie-version + minimum-server-version here?
+export const nessieVersion = "0.6.2";
+const minServerVersion = parseVersion("0.6.2");
+
+export function verifyServerVersion(headers: Headers) {
+  const serverVersion = headers.get("Nessie-Version")
+  if (serverVersion == null) {
+    return Promise.reject(`Nessie-Server sent no Nessie-Version header`)
+  }
+  if (compareArray(minServerVersion, parseVersion(serverVersion)) > 0) {
+    return Promise.reject(`Nessie-Server version ${serverVersion} is incompatible, minimum required is ${minServerVersion}`)
+  }
+  return null;
+}
+
+function compareArray(arr1: Array<number>, arr2: Array<number>) {
+  let i = 0;
+  console.log(`compare ${arr1} vs ${arr2}`)
+  for (; i < arr1.length && i < arr2.length; i++) {
+    const el1 = arr1[i]
+    const el2 = arr2[i]
+    console.log(`  ${i} -> compare ${el1} vs ${el2}`)
+    if (el1 > el2) {
+      console.log(`  gt`)
+      return 1;
+    }
+    if (el1 < el2) {
+      console.log(`  lt`)
+      return -1;
+    }
+  }
+  if (i < arr1.length) {
+    console.log(`  gt e`)
+    return 1;
+  }
+  if (i < arr2.length) {
+    console.log(`  lt e`)
+    return -1;
+  }
+  console.log(`  eq`)
+  return 0;
+}
+
+function parseVersion(str: string) {
+  return str.replace(/(.*)-SNAPSHOT/, "$1").split(".").map(v => parseInt(v));
+}

--- a/ui/src/utils/versions.tsx
+++ b/ui/src/utils/versions.tsx
@@ -21,6 +21,11 @@ const minServerVersion = parseVersion("0.6.2");
 export function verifyServerVersion(headers: Headers) {
   const serverVersion = headers.get("Nessie-Version")
   if (serverVersion == null) {
+    if (headers.get("Content-Type") == null) {
+      // Ignore missing 'Nessie-Version' header when there's no content, because those
+      // responses don't get the Nessie-Version header (REST API restriction/inconvenience).
+      return null;
+    }
     return Promise.reject(`Nessie-Server sent no Nessie-Version header`)
   }
   if (compareArray(minServerVersion, parseVersion(serverVersion)) > 0) {

--- a/ui/src/utils/versions.tsx
+++ b/ui/src/utils/versions.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-// TODO How to get the current Nessie-version + minimum-server-version here?
-export const nessieVersion = "0.6.2";
-const minServerVersion = parseVersion("0.6.2");
+import {nessieMinApiVersion} from "./version-numbers";
+
+export const minServerVersion = parseVersion(nessieMinApiVersion);
 
 export function verifyServerVersion(headers: Headers) {
   const serverVersion = headers.get("Nessie-Version")
@@ -65,3 +65,4 @@ function compareArray(arr1: Array<number>, arr2: Array<number>) {
 function parseVersion(str: string) {
   return str.replace(/(.*)-SNAPSHOT/, "$1").split(".").map(v => parseInt(v));
 }
+

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -21,6 +21,7 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "src"
+    "src",
+    "target/gen-src"
   ]
 }


### PR DESCRIPTION
Nessie client+server HTTP requests+responses include a new `Nessie-Version` HTTP header indicating the release version.

Clients validate the Nessie server version and the server validates the Nessie client version.

This is still a draft but illustrates the technical possibility.

The Nessie-Server part and the Java+Python+TS clients are implemented.

Open questions:
* I'm not yet sure how to exactly check whether "the other side" is compatible. Either use a "minimum version" that "the other side" must match or consider a version-range as compatible or assume that major+minor is compatible. I tend to the version-range with major+minor as the default.

Not nice:
* The implementation uses a `javax.ws.rs.container.ContainerResponseFilter` to add the `Nessie-Version` header on the server side. However, that filter is *not* called when the response has no content. So for example a HTTP `DELETE` w/o a response doesn't return that header. This behavior is the same when implementing `javax.ws.rs.ext.WriterInterceptor`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1432)
<!-- Reviewable:end -->
