### PR TITLE
Extend pre-commit usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,34 @@
+#
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 21.6b0
     hooks:
     - id: black
       language_version: python3
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.3.0
+    rev: v2.5.0
     hooks:
     - id: reorder-python-imports
       args:
           - --py3-plus
           - --application-directories=pynessie:tests:python/pynessie:python:tests
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+    rev: v4.0.1
     hooks:
     - id: trailing-whitespace
     - id: check-added-large-files
@@ -35,3 +51,14 @@ repos:
       pass_filenames: false
       types: [text]
       verbose: true
+-   repo: https://github.com/ejba/pre-commit-maven
+    rev: v0.3.0
+    hooks:
+    - id: maven
+      args: ['tidy:pom', 'license:format']
+    - id: maven-checkstyle
+    - id: maven-spotless-apply
+-   repo: https://github.com/kynan/nbstripout
+    rev: 0.4.0
+    hooks:
+    - id: nbstripout


### PR DESCRIPTION
We were already using [pre-commit](https://pre-commit.com/) in our python sub-repo. This change extends it to the entire repo.

Things it was already doing:
* detecting security issues via aws private keys, talisman, etc
* ensuring file encoding is set
* ensuring the correct line endings
* formatting and reordering python
* ensuring we don't have dumb python errors

This change adds:
* license format in maven
* pom tidy format in maven
* checkstyle check
* spotless apply
* strip output from notebooks

All the existing pre-commit checks were only done on changed/staged files in the pre-commit check. This differs from previous as it executes maven on the entire repo. So it adds ~15 seconds delay on commits.

These checks can be skipped using the `-n` flag on the CLI or through a setting in your IDE commit window.

To install and configure (if you haven't already):
```
pip install pre-commit
pre-commit install
```
It will now run as a pre-commit hook. You can run against the entire repo with `pre-commit run`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1439)
<!-- Reviewable:end -->
