### PR TITLE
try to fix HEAD^1 issue

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -256,6 +256,8 @@ jobs:
         RELEASE_VERSION: ${{ steps.get_version.outputs.VERSION }}
         GIT_TAG: nessie-${{ steps.get_version.outputs.VERSION }}
       run: |
+        git fetch --tags
+
         DIR=$(mktemp -d)
         NOTES_FILE=${DIR}/release-notes.md
         LAST_TAG=$(git describe --tags --abbrev=0 HEAD^1)


### PR DESCRIPTION
The publish-release workflow [fails](https://github.com/projectnessie/nessie/runs/2830128331?check_suite_focus=true) for the command `git describe --tags --abbrev=0 HEAD^1` with a `fatal: Not a valid object name HEAD^1`. 

We need the previous tag to generate the release-notes with the changes from the previous tag to the released tag.

This probably happens, because the git clone only has the single named ref being checked out, like the checkout action log suggests:
```
  From https://github.com/projectnessie/nessie
   * [new ref]         b1b3ba49fbe30c4ca36ac4ce3c816d34b102ec3a -> nessie-0.7.0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1440)
<!-- Reviewable:end -->
