### PR TITLE
Add GH workflow to work with PR#940

### DIFF
--- a/.github/workflows/pull-request-upload.yml
+++ b/.github/workflows/pull-request-upload.yml
@@ -1,0 +1,95 @@
+name: PR Report Upload
+
+# This workflow runs after a successful run of the "PR Build Check" workflow.
+# It generates HTML and YAML reports from the Gatling simulation-logs and publishes those via
+# github pages. Since pushing contents to a different repo requires access to secrets, the
+# GH-API contents-PUT cannot be performed from the  "PR Build Check" workflow, which is triggered
+# on 'pull_request' and therefore has no access to secrets.
+
+# Required secrets:
+#   CI_REPORTS_TOKEN    a token that can write contents (commit) to the 'CI_REPORTS_REPO'
+
+on:
+  workflow_run:
+    workflows: ["PR Build Check", "Main CI"]
+    types:
+        - completed
+
+env:
+  # Name of the jar in the nessie-ci S3 bucket
+  GATLING_REPORT_JAR: gatling-report-5.1-nessie-1-capsule-fat.jar
+  SIMULATION_LOG_DIR: perftest/simulations/target/gatling
+  REPORT_DIR: perftest/simulations/target/gatling-report
+  # TODO CHANGE THESE!
+  #PUBLIC_BASE: https://projectnessie.github.io/nessie-ci/
+  PUBLIC_BASE: https://snazy.github.io/some-test/
+  CI_REPORTS_REPO: snazy/some-test
+
+jobs:
+
+  # TODO Shall we "permanently archive" the raw simulation-logs as well, so we can re-generate the reports? (archives for workflow runs will be removed)
+  # TODO Or just never re-generate-reports?
+  # (Reports would be re-generated on when the "Main CI" workflow re-runs.)
+
+  # For main-branch pushes & PRs
+  report-upload:
+    name: Main Report Upload
+    runs-on: ubuntu-latest
+    # TODO remove this before actually merging the perf-test-stuff-PR !!!
+    if: ${GITHUB_REF} == "refs/pulls/940/merge"
+
+    env:
+      WEB_DIR: ${{ github.event.workflow_run.event }}/${{ github.event.workflow_run.head_sha }}/gatling
+      REF_RUN_ID: ${{ github.event.workflow_run.id }}
+
+    steps:
+    # Check that the commit has passed CI.
+    - name: Check commit status
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+        gh api repos/projectnessie/nessie/commits/${{ github.event.workflow_run.head_sha }}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") | not ) | .conclusion // "pending" ] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Download gatling-report jar
+      run: |
+        # Jar built from https://github.com/snazy/gatling-report/tree/gatling-3.5-rebased @ 8327f302f1af433150b8bc21789f7bbd4f5d96d5
+        curl -s -o ${GATLING_REPORT_JAR} ${PUBLIC_BASE}/lib/${GATLING_REPORT_JAR}
+
+    - name: Download simulation-logs from PR
+      if: ${{ github.event.workflow_run.event == 'pull_request' }}
+      run: gh run download ${REF_RUN_ID} --repo projectnessie/nessie -n gatling-logs
+
+    - name: Download last 20 simulation-logs for main
+      if: ${{ github.event.workflow_run.event == 'push' }}
+      # TODO this should download the simulation-log for the "current" SHA and the simulation-logs for the preceding commits - not just blindly the most recent N commits
+      run: |
+        for run_id in $(gh api 'repos/projectnessie/nessie/actions/runs?branch=main&per_page=20' --jq '.workflow_runs[] | .id'); do
+          gh run download ${REF_RUN_ID} --repo projectnessie/nessie -n gatling-logs || true
+        done
+
+    - name: Generate reports
+      run: |
+        java -jar ${GATLING_REPORT_JAR} ${SIMULATION_LOG_DIR}/*/simulation.log -o ${REPORT_DIR} -n report.html
+        java -jar ${GATLING_REPORT_JAR} ${SIMULATION_LOG_DIR}/*/simulation.log -o ${REPORT_DIR} -y -f -n report.yaml
+
+    - name: GH Auth
+      run: echo ${{ secrets.CI_REPORTS_TOKEN }} | gh auth login --with-token
+
+    - name: Upload reports
+      env:
+        SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        gh api -X PUT repos/${CI_REPORTS_REPO}/contents/docs/${WEB_DIR}/report.html -f message="add report html" -f content=$(base64 -w0 ${REPORT_DIR}/report.html)
+        gh api -X PUT repos/${CI_REPORTS_REPO}/contents/docs/${WEB_DIR}/report.yaml -f message="add report yaml" -f content=$(base64 -w0 ${REPORT_DIR}/report.yaml)
+
+    - name: GH Auth
+      run: echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+
+    - name: Update commit-status
+      env:
+        SHA: ${{ github.event.workflow_run.head_sha }}
+      run: gh api -X POST repos/projectnessie/nessie/statuses/${SHA} -f target_url=${PUBLIC_BASE}/${WEB_DIR}/report.html -f description='Gatling Report' -f state=success -f context=perf


### PR DESCRIPTION
The PR for #940 shall upload perf-test results as HTML+YAML to present to the developer as a simple HTML page exposed in a commit status.

The idea is to push the HTML+YAML to the `docs/` directory of a separate github repo for now (it's easy and doesn't require us to have a publicly accessible S3 or something like that).

The change adds a new workflow that only runs for #940 (guarded with an `if: ` ), so other builds won't be affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1441)
<!-- Reviewable:end -->
