### PR TITLE
Update Spotless/license-header rule to work for files w/o `package`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1334,14 +1334,14 @@ limitations under the License.
                 </google-java-format>
                 <licenseHeader>
                   <file>${maven.multiModuleProjectDirectory}/codestyle/copyright-header-java.txt</file>
-                  <delimiter>package </delimiter>
+                  <delimiter>(package|import) </delimiter>
                 </licenseHeader>
               </java>
               <scala>
                 <scalafmt/>
                 <licenseHeader>
                   <file>${maven.multiModuleProjectDirectory}/codestyle/copyright-header-java.txt</file>
-                  <delimiter>package </delimiter>
+                  <delimiter>(package|import) </delimiter>
                 </licenseHeader>
               </scala>
             </configuration>


### PR DESCRIPTION
Java+Scala classes in the default package (i.e. classes without the `package ` line) currently fail the spotless check for the license header, because it looks for the regex `^package `, which just doesn't exist.

(Found while working on #940)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1443)
<!-- Reviewable:end -->
