### PR TITLE
Exclude CI for non-code-changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,16 @@ name: Main CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'LICENSE'
+      - 'NOTICE'
+      - '*.md'
+      - '**/README.md'
+      - '.github/dependabot.yml'
+      - '.github/workflows/release*.yml'
+      - '.github/workflows/check*.yml'
+      - '.idea/**'
+      - '.editorconfig'
 
 jobs:
   java:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,16 @@ name: PR Build Check
 
 on:
   pull_request:
+    paths-ignore:
+      - 'LICENSE'
+      - 'NOTICE'
+      - '*.md'
+      - '**/README.md'
+      - '.github/dependabot.yml'
+      - '.github/workflows/release*.yml'
+      - '.github/workflows/check*.yml'
+      - '.idea/**'
+      - '.editorconfig'
 
 jobs:
   java:


### PR DESCRIPTION
We just don't need to run CI for changes in files that are "not code" (for example README.md or IntelliJ configs or GH workflows that aren't run during CI).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1465)
<!-- Reviewable:end -->
