### PR TITLE
Fix Gatling-Report for 'main'

### DIFF
--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         cd ${SIMULATION_LOG_DIR}
         for run_id in $(gh api 'repos/projectnessie/nessie/actions/runs?branch=main&per_page=20' --jq '.workflow_runs[] | .id'); do
-          gh run download ${REF_RUN_ID} --repo projectnessie/nessie -n gatling-logs || true
+          gh run download ${run_id} --repo projectnessie/nessie -n gatling-logs || true
         done
 
     - name: Generate Gatling reports


### PR DESCRIPTION
The workflow tried to pull the simulation-logs for the last commit 20 times, instead
of pulling the simulation-logs for the last 20 runs...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1467)
<!-- Reviewable:end -->
