### PR TITLE
Experiment w/ jacoco-reports to fix code-coverage issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
       with:
         flags: java
         files: |
-          **/target/site/jacoco-aggregate-all/jacoco.xml
+          code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
     - name: Push Docker images
       run: |
           echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,8 @@ jobs:
     - uses: codecov/codecov-action@v1
       with:
         flags: java
+        files: |
+          **/target/site/jacoco-aggregate-all/jacoco.xml
     - name: Push Docker images
       run: |
           echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -108,6 +108,8 @@ jobs:
     - uses: codecov/codecov-action@v1
       with:
         flags: java
+        files: |
+          **/target/site/jacoco-aggregate-all/jacoco.xml
   python:
     name: Python
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         flags: java
         files: |
-          **/target/site/jacoco-aggregate-all/jacoco.xml
+          code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
   python:
     name: Python
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,11 @@ Follow the instructions for [Eclipse](https://github.com/google/google-java-form
 [IntelliJ](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides),
 note the required manual actions for IntelliJ.
 
+#### Code coverage
+
+Code coverage is measured using jacoco plus codecov. The [aggregator-project](./code-coverage)
+contains all modules that shall be measured. New modules must be added there as a dependency as well.
+
 ### Submitting a pull request
 
 Upon submission of a pull request you will be asked to sign our contributor license agreement. We use [Reviewable.io](https://reviewable.io/) for reviews.

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -29,6 +29,7 @@
   <packaging>pom</packaging>
 
   <name>Nessie - Code Coverage</name>
+  <description>Aggregates all code-projects for Nessie for a consolidated code-coverage report.</description>
 
   <dependencies>
     <dependency>

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie</artifactId>
+    <version>0.7.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-code-coverage</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Nessie - Code Coverage</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-apprunner-maven-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-deltalake-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-deltalake-spark2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-deltalake-spark3</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-hms-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-hms-hive2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-hms-hive3</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-perftest-gatling</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-lambda</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-quarkus</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-services</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-server-store</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-gc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-jgit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-memory</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tiered-dynamodb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tiered-gc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tiered-mongodb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tiered-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-tiered-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-aggregate-report-all</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <configuration>
+              <dataFileIncludes>
+                <dataFileInclude>**/jacoco.exec</dataFileInclude>
+                <dataFileInclude>**/jacoco-it.exec</dataFileInclude>
+              </dataFileIncludes>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate-all</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -173,8 +173,7 @@
             </goals>
             <configuration>
               <dataFileIncludes>
-                <dataFileInclude>**/jacoco.exec</dataFileInclude>
-                <dataFileInclude>**/jacoco-it.exec</dataFileInclude>
+                <dataFileInclude>**/jacoco*.exec</dataFileInclude>
               </dataFileIncludes>
               <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate-all</outputDirectory>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
     <module>perftest</module>
     <module>servers</module>
     <module>tools</module>
-    <module>code-coverage</module>
   </modules>
 
   <scm>
@@ -1090,6 +1089,9 @@ limitations under the License.
   <profiles>
     <profile>
       <id>code-coverage</id>
+      <modules>
+        <module>code-coverage</module>
+      </modules>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1151,6 +1151,20 @@ limitations under the License.
                   <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate-it</outputDirectory>
                 </configuration>
               </execution>
+              <execution>
+                <id>default-aggregate-report-all</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+                <configuration>
+                  <dataFileIncludes>
+                    <dataFileInclude>**/jacoco.exec</dataFileInclude>
+                    <dataFileInclude>**/jacoco-it.exec</dataFileInclude>
+                  </dataFileIncludes>
+                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate-all</outputDirectory>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <module>perftest</module>
     <module>servers</module>
     <module>tools</module>
+    <module>code-coverage</module>
   </modules>
 
   <scm>
@@ -1106,64 +1107,6 @@ limitations under the License.
                 <goals>
                   <goal>prepare-agent-integration</goal>
                 </goals>
-              </execution>
-              <execution>
-                <id>default-report</id>
-                <goals>
-                  <goal>report</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-report-integration</id>
-                <goals>
-                  <goal>report-integration</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-aggregate-report</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>report-aggregate</goal>
-                </goals>
-                <configuration>
-                  <dataFileIncludes>
-                    <dataFileInclude>**/jacoco.exec</dataFileInclude>
-                  </dataFileIncludes>
-                  <excludes>
-                    <exclude>org.projectnessie.versioned.tests.AbstractITVersionStore</exclude>
-                    <exclude>org.projectnessie.versioned.impl.AbstractITTieredVersionStore</exclude>
-                    <exclude>org.projectnessie.versioned.impl.AbstractTestStore</exclude>
-                    <exclude>org.projectnessie.versioned.impl.AbstractTieredStoreFixture</exclude>
-                  </excludes>
-                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
-                </configuration>
-              </execution>
-              <execution>
-                <id>default-aggregate-report-integration</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>report-aggregate</goal>
-                </goals>
-                <configuration>
-                  <dataFileIncludes>
-                    <dataFileInclude>**/jacoco-it.exec</dataFileInclude>
-                  </dataFileIncludes>
-                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate-it</outputDirectory>
-                </configuration>
-              </execution>
-              <execution>
-                <id>default-aggregate-report-all</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>report-aggregate</goal>
-                </goals>
-                <configuration>
-                  <dataFileIncludes>
-                    <dataFileInclude>**/jacoco.exec</dataFileInclude>
-                    <dataFileInclude>**/jacoco-it.exec</dataFileInclude>
-                  </dataFileIncludes>
-                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate-all</outputDirectory>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
We generate two aggregate reports: `jacoco-aggregate` and `jacoco-aggregate-it`.
Both contain information for the same classes, but with _different_ values for
hits/misses.

This experiment generates another report `jacoco-aggregate-all` and only pushes
that one to codecov.

Crossing fingers, that this helps...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1468)
<!-- Reviewable:end -->
