### PR TITLE
Do not let CI fail on forks

### DIFF
--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -30,7 +30,7 @@ jobs:
   report-upload:
     name: Report Upload
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'projectnessie/nessie' }}
+    if: ${{ secrets.CI_REPORTS_TOKEN }}
 
     env:
       WEB_DIR: ${{ github.event.workflow_run.event }}/${{ github.event.workflow_run.head_branch }}/${{ github.event.workflow_run.head_sha }}/gatling

--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -30,6 +30,7 @@ jobs:
   report-upload:
     name: Report Upload
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'projectnessie/nessie' }}
 
     env:
       WEB_DIR: ${{ github.event.workflow_run.event }}/${{ github.event.workflow_run.head_branch }}/${{ github.event.workflow_run.head_sha }}/gatling

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,10 +91,15 @@ jobs:
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Maven
       run: ./mvnw -B deploy --file pom.xml -Pcode-coverage,jdk8-tests,native,release -DdeployAtEnd=true -Dtest.log.level=WARN
+      if: ${{ github.repository == 'projectnessie/nessie' }}
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
         MAVEN_OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        SPARK_LOCAL_IP: localhost
+    - name: Build with Maven (Fork)
+      run: ./mvnw -B install --file pom.xml -Pcode-coverage,jdk8-tests,native -Dtest.log.level=WARN
+      env:
         SPARK_LOCAL_IP: localhost
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build
@@ -129,6 +134,7 @@ jobs:
         files: |
           code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
     - name: Push Docker images
+      if: ${{ github.repository == 'projectnessie/nessie' }}
       run: |
           echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
           docker images --filter 'reference=projectnessie/nessie' --format '{{.ID}}\t{{.Tag}}' |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Maven
       run: ./mvnw -B deploy --file pom.xml -Pcode-coverage,jdk8-tests,native,release -DdeployAtEnd=true -Dtest.log.level=WARN
-      if: ${{ github.repository == 'projectnessie/nessie' }}
+      if: ${{ secrets.OSSRH_ACCESS_ID }}
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
         MAVEN_OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
@@ -99,6 +99,7 @@ jobs:
         SPARK_LOCAL_IP: localhost
     - name: Build with Maven (Fork)
       run: ./mvnw -B install --file pom.xml -Pcode-coverage,jdk8-tests,native -Dtest.log.level=WARN
+      if: ${{ ! secrets.OSSRH_ACCESS_ID }}
       env:
         SPARK_LOCAL_IP: localhost
     - name: Build with Gradle
@@ -134,7 +135,7 @@ jobs:
         files: |
           code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
     - name: Push Docker images
-      if: ${{ github.repository == 'projectnessie/nessie' }}
+      if: ${{ secrets.DOCKER_TOKEN && secrets.DOCKER_USERNAME }}
       run: |
           echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
           docker images --filter 'reference=projectnessie/nessie' --format '{{.ID}}\t{{.Tag}}' |

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -46,8 +46,6 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'projectnessie/nessie' }}
-
     env:
       GIT_TAG: nessie-${{ github.event.inputs.releaseVersion }}
       RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -46,6 +46,8 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'projectnessie/nessie' }}
+
     env:
       GIT_TAG: nessie-${{ github.event.inputs.releaseVersion }}
       RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,6 +47,7 @@ jobs:
   publish-release:
     name: Publish release
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'projectnessie/nessie' }}
 
     # Runs in the `release` environment, which has the necessary secrets and defines the reviewers.
     # See https://docs.github.com/en/actions/reference/environments

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,7 +47,7 @@ jobs:
   publish-release:
     name: Publish release
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'projectnessie/nessie' }}
+    if: ${{ secrets.OSSRH_ACCESS_ID && secrets.MAVEN_GPG_PASSPHRASE && secrets.PYPI_API_TOKEN && secrets.DOCKER_TOKEN && secrets.GRADLE_PUBLISH_SECRET }}
 
     # Runs in the `release` environment, which has the necessary secrets and defines the reviewers.
     # See https://docs.github.com/en/actions/reference/environments

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,7 +10,7 @@ jobs:
   site:
     name: Build & Deploy Website
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'projectnessie/nessie' }}
+    if: ${{ secrets.NESSIE_SITE_DEPLOY_KEY }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,6 +10,7 @@ jobs:
   site:
     name: Build & Deploy Website
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'projectnessie/nessie' }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
Github workflow runs currently fail on forks, because the configured relevant
workflows require secrets to deploy e.g. snapshot artifacts or push a docker image.

This change adds some `if: ${{ github.repository == 'projectnessie/nessie' }}`
conditions to the relevant workflows and steps so the workflows are happy on
Nessie-forks as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1477)
<!-- Reviewable:end -->
