### PR TITLE
Include openapi.yaml/json in nessie-model.jar file

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -90,6 +90,26 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-open-api-maven-plugin</artifactId>
+        <configuration>
+          <scanPackages>org.projectnessie.api,org.projectnessie.model</scanPackages>
+          <outputDirectory>${project.build.directory}/classes/META-INF/openapi</outputDirectory>
+          <operationIdStrategy>METHOD</operationIdStrategy>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-schema</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/model/src/main/java/org/projectnessie/api/ContentsApi.java
+++ b/model/src/main/java/org/projectnessie/api/ContentsApi.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -55,7 +56,11 @@ public interface ContentsApi {
     @APIResponse(
         responseCode = "200",
         description = "Information for table",
-        content = @Content(examples = {@ExampleObject(ref = "iceberg")})),
+        content =
+            @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                examples = {@ExampleObject(ref = "iceberg")},
+                schema = @Schema(implementation = Contents.class))),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "404", description = "Table not found on ref")
   })
@@ -80,7 +85,13 @@ public interface ContentsApi {
   @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Get multiple objects' content")
   @APIResponses({
-    @APIResponse(responseCode = "200", description = "Retrieved successfully."),
+    @APIResponse(
+        responseCode = "200",
+        description = "Retrieved successfully.",
+        content =
+            @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(implementation = MultiGetContentsResponse.class))),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "404", description = "Provided ref doesn't exists")
   })

--- a/model/src/main/java/org/projectnessie/api/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/TreeApi.java
@@ -30,8 +30,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -55,7 +57,15 @@ public interface TreeApi {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Operation(summary = "Get all references")
-  @APIResponses({@APIResponse(responseCode = "200", description = "Returned references.")})
+  @APIResponses({
+    @APIResponse(
+        responseCode = "200",
+        description = "Returned references.",
+        content =
+            @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(type = SchemaType.ARRAY, implementation = Reference.class)))
+  })
   List<Reference> getAllReferences();
 
   /** Get details for the default reference. */
@@ -66,7 +76,11 @@ public interface TreeApi {
   @APIResponses({
     @APIResponse(
         responseCode = "200",
-        description = "Returns name and latest hash of the default branch."),
+        description = "Returns name and latest hash of the default branch.",
+        content =
+            @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(implementation = Branch.class))),
     @APIResponse(responseCode = "404", description = "Default branch not found.")
   })
   Branch getDefaultBranch() throws NessieNotFoundException;
@@ -79,7 +93,12 @@ public interface TreeApi {
     @APIResponse(
         responseCode = "200",
         description = "Created successfully.",
-        content = {@Content(examples = {@ExampleObject(ref = "refObj")})}),
+        content = {
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              examples = {@ExampleObject(ref = "refObj")},
+              schema = @Schema(implementation = Reference.class))
+        }),
     @APIResponse(responseCode = "409", description = "Reference already exists")
   })
   Reference createReference(
@@ -87,7 +106,11 @@ public interface TreeApi {
           @NotNull
           @RequestBody(
               description = "Reference to create.",
-              content = {@Content(examples = {@ExampleObject(ref = "refObj")})})
+              content = {
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    examples = {@ExampleObject(ref = "refObj")})
+              })
           Reference reference)
       throws NessieNotFoundException, NessieConflictException;
 
@@ -100,7 +123,12 @@ public interface TreeApi {
     @APIResponse(
         responseCode = "200",
         description = "Found and returned reference.",
-        content = {@Content(examples = {@ExampleObject(ref = "refObj")})}),
+        content = {
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              examples = {@ExampleObject(ref = "refObj")},
+              schema = @Schema(implementation = Reference.class))
+        }),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "404", description = "Ref not found")
   })
@@ -163,7 +191,12 @@ public interface TreeApi {
   @APIResponses({
     @APIResponse(
         description = "all objects for a reference",
-        content = {@Content(examples = {@ExampleObject(ref = "entriesResponse")})}),
+        content = {
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              examples = {@ExampleObject(ref = "entriesResponse")},
+              schema = @Schema(implementation = EntriesResponse.class))
+        }),
     @APIResponse(responseCode = "200", description = "Returned successfully."),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "404", description = "Ref not found")
@@ -246,7 +279,12 @@ public interface TreeApi {
     @APIResponse(
         responseCode = "200",
         description = "Returned commits.",
-        content = {@Content(examples = {@ExampleObject(ref = "logResponse")})}),
+        content = {
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              examples = {@ExampleObject(ref = "logResponse")},
+              schema = @Schema(implementation = LogResponse.class))
+        }),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "404", description = "Ref doesn't exists")
   })
@@ -312,7 +350,10 @@ public interface TreeApi {
           @NotNull
           @RequestBody(
               description = "New tag content",
-              content = @Content(examples = {@ExampleObject(ref = "tagObj")}))
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON,
+                      examples = {@ExampleObject(ref = "tagObj")}))
           Tag tag)
       throws NessieNotFoundException, NessieConflictException;
 
@@ -371,7 +412,10 @@ public interface TreeApi {
           @NotNull
           @RequestBody(
               description = "New branch content",
-              content = @Content(examples = {@ExampleObject(ref = "refObj")}))
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON,
+                      examples = {@ExampleObject(ref = "refObj")}))
           Branch branch)
       throws NessieNotFoundException, NessieConflictException;
 
@@ -436,7 +480,10 @@ public interface TreeApi {
       @Valid
           @RequestBody(
               description = "Hashes to transplant",
-              content = @Content(examples = {@ExampleObject(ref = "transplant")}))
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON,
+                      examples = {@ExampleObject(ref = "transplant")}))
           Transplant transplant)
       throws NessieNotFoundException, NessieConflictException;
 
@@ -470,7 +517,10 @@ public interface TreeApi {
           @NotNull
           @RequestBody(
               description = "Merge operation",
-              content = @Content(examples = {@ExampleObject(ref = "merge")}))
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON,
+                      examples = {@ExampleObject(ref = "merge")}))
           Merge merge)
       throws NessieNotFoundException, NessieConflictException;
 
@@ -486,7 +536,12 @@ public interface TreeApi {
     @APIResponse(
         responseCode = "200",
         description = "Updated successfully.",
-        content = {@Content(examples = {@ExampleObject(ref = "refObj")})}),
+        content = {
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              examples = {@ExampleObject(ref = "refObj")},
+              schema = @Schema(implementation = Branch.class))
+        }),
     @APIResponse(responseCode = "400", description = "Invalid input, ref/hash name not valid"),
     @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "Update conflict")
@@ -510,7 +565,10 @@ public interface TreeApi {
           @NotNull
           @RequestBody(
               description = "Operations",
-              content = @Content(examples = {@ExampleObject(ref = "operations")}))
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON,
+                      examples = {@ExampleObject(ref = "operations")}))
           Operations operations)
       throws NessieNotFoundException, NessieConflictException;
 }

--- a/model/src/main/java/org/projectnessie/api/package-info.java
+++ b/model/src/main/java/org/projectnessie/api/package-info.java
@@ -19,7 +19,7 @@
     info =
         @Info(
             title = "Nessie API",
-            version = "0.6.0",
+            version = "0.8.0",
             contact = @Contact(name = "Project Nessie", url = "https://projectnessie.org"),
             license =
                 @License(

--- a/model/src/main/java/org/projectnessie/model/Branch.java
+++ b/model/src/main/java/org/projectnessie/model/Branch.java
@@ -20,10 +20,13 @@ import static org.projectnessie.model.Validation.validateReferenceName;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 
 /** Api representation of an Nessie Tag/Branch. This object is akin to a Ref in Git terminology. */
 @Value.Immutable(prehash = true)
+@Schema(type = SchemaType.OBJECT, title = "Branch")
 @JsonSerialize(as = ImmutableBranch.class)
 @JsonDeserialize(as = ImmutableBranch.class)
 @JsonTypeName("BRANCH")

--- a/model/src/main/java/org/projectnessie/model/CommitMeta.java
+++ b/model/src/main/java/org/projectnessie/model/CommitMeta.java
@@ -29,9 +29,12 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
+@Schema(type = SchemaType.OBJECT, title = "CommitMeta")
 @JsonSerialize(as = ImmutableCommitMeta.class)
 @JsonDeserialize(as = ImmutableCommitMeta.class)
 public abstract class CommitMeta {

--- a/model/src/main/java/org/projectnessie/model/Hash.java
+++ b/model/src/main/java/org/projectnessie/model/Hash.java
@@ -18,11 +18,14 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Derived;
 
 /** Api representation of an Nessie Tag/Branch. This object is akin to a Ref in Git terminology. */
 @Value.Immutable(prehash = true)
+@Schema(type = SchemaType.OBJECT, title = "Hash")
 @JsonSerialize(as = ImmutableHash.class)
 @JsonDeserialize(as = ImmutableHash.class)
 @JsonTypeName("HASH")

--- a/model/src/main/java/org/projectnessie/model/LogResponse.java
+++ b/model/src/main/java/org/projectnessie/model/LogResponse.java
@@ -18,9 +18,12 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
+@Schema(type = SchemaType.OBJECT, title = "LogResponse")
 @JsonSerialize(as = ImmutableLogResponse.class)
 @JsonDeserialize(as = ImmutableLogResponse.class)
 public interface LogResponse extends PaginatedResponse {

--- a/model/src/main/java/org/projectnessie/model/Tag.java
+++ b/model/src/main/java/org/projectnessie/model/Tag.java
@@ -20,10 +20,13 @@ import static org.projectnessie.model.Validation.validateReferenceName;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 
 /** Api representation of an Nessie Tag/Branch. This object is akin to a Ref in Git terminology. */
 @Value.Immutable(prehash = true)
+@Schema(type = SchemaType.OBJECT, title = "Tag")
 @JsonSerialize(as = ImmutableTag.class)
 @JsonDeserialize(as = ImmutableTag.class)
 @JsonTypeName("TAG")


### PR DESCRIPTION
With this change, other modules can generate their OpenAPI client libraries using the
OpenAPI yaml/json files without having to start a Nessie-Quarkus-server.

Also add missing OpenAPI annotations like schema + media-type for the responses.

The paths in the generated openapi files do _not_ have the `/api/v1` prefix, because
that is configured in Quarkus' `application.properties` file, so it's a server
specific setting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1523)
<!-- Reviewable:end -->
