### PR TITLE
Fix ITNativeNessieError

### DIFF
--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
@@ -53,7 +53,7 @@ public class ITNativeNessieError {
     ContentsKey k = ContentsKey.of("a");
     IcebergTable t = IcebergTable.of("path1");
     assertEquals(
-        "Bad Request (HTTP/400): setContents.hash: must not be null",
+        "Bad Request (HTTP/400): commitMultipleOperations.hash: must not be null",
         assertThrows(
                 NessieBadRequestException.class,
                 () ->


### PR DESCRIPTION
Fix CI error introduced by #1522 

```
org.opentest4j.AssertionFailedError: expected: <Bad Request (HTTP/400): setContents.hash: must not be null> but was: <Bad Request (HTTP/400): commitMultipleOperations.hash: must not be null>
	at org.projectnessie.server.error.ITNativeNessieError.testNullParamViolation(ITNativeNessieError.java:55)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1529)
<!-- Reviewable:end -->
