### PR TITLE
Fix perf-test-trend generation

### DIFF
--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -69,7 +69,7 @@ jobs:
       # TODO this should download the simulation-log for the "current" SHA and the simulation-logs for the preceding commits - not just blindly the most recent N commits
       run: |
         cd ${SIMULATION_LOG_DIR}
-        for run_id in $(gh api 'repos/projectnessie/nessie/actions/runs?branch=main&per_page=20' --jq '.workflow_runs[] | .id'); do
+        for run_id in $(gh api 'repos/projectnessie/nessie/actions/runs?branch=main&event=push&per_page=50' --jq 'limit(20; .workflow_runs[] | select(.name=="Main CI") | .id)'); do
           gh run download ${run_id} --repo projectnessie/nessie -n gatling-logs || true
         done
 


### PR DESCRIPTION
The "Check Results Upload" workflow step to fetch the latest workflow-runs on `main`
currently fetches too many (wrong) workflow runs. The goal was to have at max 20
sets gatling-perf-test-logs from that amount of "Main CI" runs, but the `jq` expression
in the "Download Gatling simulation-logs from the last 20 main CI runs" workflow-step
is too broad.

This patch actually fetches the last 50 workflow runs triggered by a "push" event,
filters out the "Main CI" runs and limits the result to 20.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1549)
<!-- Reviewable:end -->
