### PR TITLE
Add more Operations/Contents.Type test cases to TestRest

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -39,6 +39,8 @@ public abstract class Namespace {
   static final String ERROR_MSG_TEMPLATE =
       "'%s' is not a valid namespace identifier (should not end with '.')";
 
+  public static final ImmutableNamespace EMPTY = ImmutableNamespace.builder().name("").build();
+
   @JsonValue
   public abstract String name();
 
@@ -57,7 +59,7 @@ public abstract class Namespace {
   public static Namespace of(String... elements) {
     Objects.requireNonNull(elements, "elements must be non-null");
     if (elements.length == 0) {
-      return ImmutableNamespace.builder().name("").build();
+      return EMPTY;
     }
 
     if (DOT.equals(elements[elements.length - 1])) {


### PR DESCRIPTION
`TestRest` (and `ITNativeRest`) have very low coverage of the various different
`Contents.Type` and `Operations`. This change adds some tests to improve that
coverage. (Inspired by the recent Quarkus 2.0.1 issue https://github.com/quarkusio/quarkus/issues/18486)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1564)
<!-- Reviewable:end -->
