### PR TITLE
Add a bunch of constraints to OpenAPI definition

### DIFF
--- a/model/src/main/java/org/projectnessie/model/CommitMeta.java
+++ b/model/src/main/java/org/projectnessie/model/CommitMeta.java
@@ -29,12 +29,19 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
-@Schema(type = SchemaType.OBJECT, title = "CommitMeta")
+@Schema(
+    type = SchemaType.OBJECT,
+    title = "CommitMeta",
+    // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
+    properties = {@SchemaProperty(name = "hash", pattern = Validation.HASH_REGEX)})
 @JsonSerialize(as = ImmutableCommitMeta.class)
 @JsonDeserialize(as = ImmutableCommitMeta.class)
 public abstract class CommitMeta {
@@ -78,6 +85,7 @@ public abstract class CommitMeta {
    *
    * <p>Like github if this message is in markdown it may be displayed cleanly in the UI.
    */
+  @NotBlank
   public abstract String getMessage();
 
   /** Commit time in UTC. Set by the server. */
@@ -98,6 +106,7 @@ public abstract class CommitMeta {
    * <p>examples are spark id, the client type (eg iceberg, delta etc), application or job names,
    * hostnames etc
    */
+  @NotNull
   public abstract Map<String, String> getProperties();
 
   public ImmutableCommitMeta.Builder toBuilder() {

--- a/model/src/main/java/org/projectnessie/model/ContentsKey.java
+++ b/model/src/main/java/org/projectnessie/model/ContentsKey.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import org.immutables.value.Value;
 
 /**
@@ -39,6 +41,8 @@ public abstract class ContentsKey {
   private static final char ZERO_BYTE = '\u0000';
   private static final String ZERO_BYTE_STRING = Character.toString(ZERO_BYTE);
 
+  @NotNull
+  @Size(min = 1)
   public abstract List<String> getElements();
 
   /**

--- a/model/src/main/java/org/projectnessie/model/DeltaLakeTable.java
+++ b/model/src/main/java/org/projectnessie/model/DeltaLakeTable.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
@@ -28,8 +29,10 @@ import org.immutables.value.Value;
 @JsonTypeName("DELTA_LAKE_TABLE")
 public abstract class DeltaLakeTable extends Contents {
 
+  @NotNull
   public abstract List<String> getMetadataLocationHistory();
 
+  @NotNull
   public abstract List<String> getCheckpointLocationHistory();
 
   @Nullable

--- a/model/src/main/java/org/projectnessie/model/EntriesResponse.java
+++ b/model/src/main/java/org/projectnessie/model/EntriesResponse.java
@@ -18,6 +18,7 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
@@ -29,6 +30,7 @@ public interface EntriesResponse extends PaginatedResponse {
     return ImmutableEntriesResponse.builder();
   }
 
+  @NotNull
   List<Entry> getEntries();
 
   @Value.Immutable(prehash = true)
@@ -40,8 +42,10 @@ public interface EntriesResponse extends PaginatedResponse {
       return ImmutableEntry.builder();
     }
 
+    @NotNull
     Contents.Type getType();
 
+    @NotNull
     ContentsKey getName();
   }
 }

--- a/model/src/main/java/org/projectnessie/model/HiveDatabase.java
+++ b/model/src/main/java/org/projectnessie/model/HiveDatabase.java
@@ -18,6 +18,7 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.Size;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
@@ -26,5 +27,6 @@ import org.immutables.value.Value;
 @JsonTypeName("HIVE_DATABASE")
 public abstract class HiveDatabase extends Contents {
 
+  @Size(min = 1)
   public abstract byte[] getDatabaseDefinition();
 }

--- a/model/src/main/java/org/projectnessie/model/HiveTable.java
+++ b/model/src/main/java/org/projectnessie/model/HiveTable.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
@@ -29,8 +31,10 @@ import org.immutables.value.Value;
 @JsonTypeName("HIVE_TABLE")
 public abstract class HiveTable extends Contents {
 
+  @Size(min = 1)
   public abstract byte[] getTableDefinition();
 
+  @NotNull
   public abstract List<byte[]> getPartitions();
 
   /**

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -18,6 +18,8 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
@@ -26,6 +28,8 @@ import org.immutables.value.Value;
 @JsonTypeName("ICEBERG_TABLE")
 public abstract class IcebergTable extends Contents {
 
+  @NotNull
+  @NotBlank
   public abstract String getMetadataLocation();
 
   public static IcebergTable of(String metadataLocation) {

--- a/model/src/main/java/org/projectnessie/model/LogResponse.java
+++ b/model/src/main/java/org/projectnessie/model/LogResponse.java
@@ -18,6 +18,7 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -28,5 +29,6 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableLogResponse.class)
 public interface LogResponse extends PaginatedResponse {
 
+  @NotNull
   List<CommitMeta> getOperations();
 }

--- a/model/src/main/java/org/projectnessie/model/Merge.java
+++ b/model/src/main/java/org/projectnessie/model/Merge.java
@@ -17,18 +17,27 @@ package org.projectnessie.model;
 
 import static org.projectnessie.model.Validation.validateHash;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.NotBlank;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
 import org.immutables.value.Value;
 
-@Schema(type = SchemaType.OBJECT, title = "Merge Operation")
+@Schema(
+    type = SchemaType.OBJECT,
+    title = "Merge Operation",
+    // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
+    properties = {@SchemaProperty(name = "fromHash", pattern = Validation.HASH_REGEX)})
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableMerge.class)
 @JsonDeserialize(as = ImmutableMerge.class)
 public interface Merge {
 
+  @NotBlank
+  @JsonFormat(pattern = Validation.HASH_REGEX)
   String getFromHash();
 
   /**

--- a/model/src/main/java/org/projectnessie/model/MultiGetContentsRequest.java
+++ b/model/src/main/java/org/projectnessie/model/MultiGetContentsRequest.java
@@ -18,6 +18,8 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -28,6 +30,8 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableMultiGetContentsRequest.class)
 public interface MultiGetContentsRequest {
 
+  @NotNull
+  @Size(min = 1)
   List<ContentsKey> getRequestedKeys();
 
   static ImmutableMultiGetContentsRequest.Builder builder() {

--- a/model/src/main/java/org/projectnessie/model/MultiGetContentsResponse.java
+++ b/model/src/main/java/org/projectnessie/model/MultiGetContentsResponse.java
@@ -18,6 +18,7 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -28,6 +29,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableMultiGetContentsResponse.class)
 public interface MultiGetContentsResponse {
 
+  @NotNull
   List<ContentsWithKey> getContents();
 
   static MultiGetContentsResponse of(List<ContentsWithKey> items) {
@@ -39,8 +41,10 @@ public interface MultiGetContentsResponse {
   @JsonDeserialize(as = ImmutableContentsWithKey.class)
   interface ContentsWithKey {
 
+    @NotNull
     ContentsKey getKey();
 
+    @NotNull
     Contents getContents();
 
     static ContentsWithKey of(ContentsKey key, Contents contents) {

--- a/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
+import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
 
 /**
@@ -42,6 +43,7 @@ public abstract class Namespace {
   public static final ImmutableNamespace EMPTY = ImmutableNamespace.builder().name("").build();
 
   @JsonValue
+  @NotNull
   public abstract String name();
 
   public boolean isEmpty() {

--- a/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
+++ b/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import org.immutables.value.Value;
 
 /** configuration object to tell a client how a server is configured. */
@@ -30,9 +32,11 @@ public abstract class NessieConfiguration {
   @JsonIgnore private static final String CURRENT_VERSION = "1.0";
 
   @Nullable
+  @Size(min = 1)
   public abstract String getDefaultBranch();
 
   @Value.Default
+  @NotNull
   public String getVersion() {
     return CURRENT_VERSION;
   }

--- a/model/src/main/java/org/projectnessie/model/Operation.java
+++ b/model/src/main/java/org/projectnessie/model/Operation.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -44,6 +45,7 @@ import org.immutables.value.Value;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface Operation {
 
+  @NotNull
   ContentsKey getKey();
 
   @Value.Immutable(prehash = true)
@@ -51,6 +53,7 @@ public interface Operation {
   @JsonDeserialize(as = ImmutablePut.class)
   @JsonTypeName("PUT")
   interface Put extends Operation {
+    @NotNull
     Contents getContents();
 
     public static Put of(ContentsKey key, Contents contents) {

--- a/model/src/main/java/org/projectnessie/model/Operations.java
+++ b/model/src/main/java/org/projectnessie/model/Operations.java
@@ -18,6 +18,8 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -28,7 +30,10 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableOperations.class)
 public interface Operations {
 
+  @NotNull
   CommitMeta getCommitMeta();
 
+  @NotNull
+  @Size(min = 1)
   List<Operation> getOperations();
 }

--- a/model/src/main/java/org/projectnessie/model/PaginatedResponse.java
+++ b/model/src/main/java/org/projectnessie/model/PaginatedResponse.java
@@ -16,6 +16,7 @@
 package org.projectnessie.model;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.Size;
 import org.immutables.value.Value.Default;
 
 public interface PaginatedResponse {
@@ -43,5 +44,6 @@ public interface PaginatedResponse {
    *     {@code true}. Undefined, if {@link #hasMore()} is {@code false}.
    */
   @Nullable
+  @Size(min = 1)
   String getToken();
 }

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -17,13 +17,16 @@ package org.projectnessie.model;
 
 import static org.projectnessie.model.Validation.validateHash;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
 import org.immutables.value.Value;
 
 @Schema(
@@ -35,15 +38,23 @@ import org.immutables.value.Value;
       @DiscriminatorMapping(value = "BRANCH", schema = Branch.class),
       @DiscriminatorMapping(value = "HASH", schema = Hash.class)
     },
-    discriminatorProperty = "type")
+    discriminatorProperty = "type",
+    // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
+    properties = {
+      @SchemaProperty(name = "name", pattern = Validation.REF_NAME_REGEX),
+      @SchemaProperty(name = "hash", pattern = Validation.HASH_REGEX)
+    })
 @JsonSubTypes({@Type(Branch.class), @Type(Tag.class), @Type(Hash.class)})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface Reference extends Base {
   /** Human readable reference name. */
+  @NotBlank
+  @JsonFormat(pattern = Validation.REF_NAME_REGEX)
   String getName();
 
   /** backend system id. Usually the 32-byte hash of the commit this reference points to. */
   @Nullable
+  @JsonFormat(pattern = Validation.HASH_REGEX)
   String getHash();
 
   /**

--- a/model/src/main/java/org/projectnessie/model/SqlView.java
+++ b/model/src/main/java/org/projectnessie/model/SqlView.java
@@ -18,6 +18,8 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
 
 @Value.Immutable(prehash = true)
@@ -33,8 +35,10 @@ public abstract class SqlView extends Contents {
     PRESTO
   }
 
+  @NotBlank
   public abstract String getSqlText();
 
+  @NotNull
   public abstract Dialect getDialect();
 
   // Schema getSchema();

--- a/model/src/main/java/org/projectnessie/model/Transplant.java
+++ b/model/src/main/java/org/projectnessie/model/Transplant.java
@@ -20,16 +20,24 @@ import static org.projectnessie.model.Validation.validateHash;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
 import org.immutables.value.Value;
 
-@Schema(type = SchemaType.OBJECT, title = "Transplant")
+@Schema(
+    type = SchemaType.OBJECT,
+    title = "Transplant",
+    properties = {@SchemaProperty(name = "hashesToTransplant", uniqueItems = true)})
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableTransplant.class)
 @JsonDeserialize(as = ImmutableTransplant.class)
 public interface Transplant {
 
+  @NotNull
+  @Size(min = 1)
   List<String> getHashesToTransplant();
 
   /**

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -931,14 +931,18 @@ class TestRest {
     MultiGetContentsRequest mgReq = MultiGetContentsRequest.of(key);
     Tag tag = Tag.of("valid", validHash);
 
+    String opsCountMsg = "commitMultipleOperations.operations.operations: size must be between 1 and 2147483647";
+
     assertAll(
         () ->
-            assertEquals(
-                "Bad Request (HTTP/400): commitMultipleOperations.branchName: " + REF_NAME_MESSAGE,
-                assertThrows(
-                        NessieBadRequestException.class,
-                        () -> tree.commitMultipleOperations(invalidBranchName, validHash, ops))
-                    .getMessage()),
+            assertThat(
+                    assertThrows(
+                            NessieBadRequestException.class,
+                            () -> tree.commitMultipleOperations(invalidBranchName, validHash, ops))
+                        .getMessage())
+                .contains("Bad Request (HTTP/400): ")
+                .contains("commitMultipleOperations.branchName: " + REF_NAME_MESSAGE)
+                .contains(opsCountMsg),
         () ->
             assertEquals(
                 "Bad Request (HTTP/400): deleteBranch.branchName: " + REF_NAME_MESSAGE,
@@ -1032,14 +1036,18 @@ class TestRest {
     Contents cts = IcebergTable.of("moo");
     Tag tag = Tag.of("valid", validHash);
 
+    String opsCountMsg = "commitMultipleOperations.operations.operations: size must be between 1 and 2147483647";
+
     assertAll(
         () ->
-            assertEquals(
-                "Bad Request (HTTP/400): commitMultipleOperations.hash: " + HASH_MESSAGE,
-                assertThrows(
-                        NessieBadRequestException.class,
-                        () -> tree.commitMultipleOperations(validBranchName, invalidHash, ops))
-                    .getMessage()),
+            assertThat(
+                    assertThrows(
+                            NessieBadRequestException.class,
+                            () -> tree.commitMultipleOperations(validBranchName, invalidHash, ops))
+                        .getMessage())
+                .contains("Bad Request (HTTP/400): ")
+                .contains("commitMultipleOperations.hash: " + HASH_MESSAGE)
+                .contains(opsCountMsg),
         () ->
             assertEquals(
                 "Bad Request (HTTP/400): deleteBranch.hash: " + HASH_MESSAGE,

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRest.java
@@ -931,7 +931,8 @@ class TestRest {
     MultiGetContentsRequest mgReq = MultiGetContentsRequest.of(key);
     Tag tag = Tag.of("valid", validHash);
 
-    String opsCountMsg = "commitMultipleOperations.operations.operations: size must be between 1 and 2147483647";
+    String opsCountMsg =
+        "commitMultipleOperations.operations.operations: size must be between 1 and 2147483647";
 
     assertAll(
         () ->
@@ -1036,7 +1037,8 @@ class TestRest {
     Contents cts = IcebergTable.of("moo");
     Tag tag = Tag.of("valid", validHash);
 
-    String opsCountMsg = "commitMultipleOperations.operations.operations: size must be between 1 and 2147483647";
+    String opsCountMsg =
+        "commitMultipleOperations.operations.operations: size must be between 1 and 2147483647";
 
     assertAll(
         () ->


### PR DESCRIPTION
Adds properties to populate the OpenAPI schema property constraints: "nullable", "min", "pattern" and similarly simple ones.

Sadly, smallrye doesn't really support all possible constructs and does not process "all annotations" - e.g. `javax.validation.constraints.Pattern` is missing. See https://github.com/smallrye/smallrye-open-api/blob/eb5fa87c1766fd49580d29c4b189fc79add566fb/core/src/main/java/io/smallrye/openapi/runtime/scanner/dataobject/BeanValidationScanner.java

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1565)
<!-- Reviewable:end -->
