### PR TITLE
Do not let CI fail on forks

### DIFF
--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -30,6 +30,7 @@ jobs:
   report-upload:
     name: Report Upload
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'projectnessie/nessie' }}
 
     env:
       WEB_DIR: ${{ github.event.workflow_run.event }}/${{ github.event.workflow_run.head_branch }}/${{ github.event.workflow_run.head_sha }}/gatling

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,12 +90,19 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Maven
-      run: ./mvnw -B deploy --file pom.xml -Pcode-coverage,jdk8-tests,native,release -DdeployAtEnd=true -Dtest.log.level=WARN
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
         MAVEN_OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         SPARK_LOCAL_IP: localhost
+      if: ${{ env.MAVEN_USERNAME }}
+      run: ./mvnw -B deploy --file pom.xml -Pcode-coverage,jdk8-tests,native,release -DdeployAtEnd=true -Dtest.log.level=WARN
+    - name: Build with Maven (Fork)
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
+        SPARK_LOCAL_IP: localhost
+      if: ${{ ! env.MAVEN_USERNAME }}
+      run: ./mvnw -B install --file pom.xml -Pcode-coverage,jdk8-tests,native -Dtest.log.level=WARN
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build
       working-directory: ./tools/apprunner-gradle-plugin
@@ -129,6 +136,9 @@ jobs:
         files: |
           code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
     - name: Push Docker images
+      env:
+        DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      if: ${{ env.DOCKER_TOKEN }}
       run: |
           echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
           docker images --filter 'reference=projectnessie/nessie' --format '{{.ID}}\t{{.Tag}}' |

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,6 +10,7 @@ jobs:
   site:
     name: Build & Deploy Website
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'projectnessie/nessie' }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
Github workflow runs currently fail on forks, because the configured relevant
workflows require secrets to deploy e.g. snapshot artifacts or push a docker image.

This change adds some `if: ${{ github.repository == 'projectnessie/nessie' }}`
conditions to the relevant workflows and steps so the workflows are happy on
Nessie-forks as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1574)
<!-- Reviewable:end -->
