### PR TITLE
Fix for missing scala javadoc+source artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
         MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
         SPARK_LOCAL_IP: localhost
       if: ${{ ! env.MAVEN_USERNAME }}
-      run: ./mvnw -B install --file pom.xml -Pcode-coverage,jdk8-tests,native -Dtest.log.level=WARN
+      run: ./mvnw -B install --file pom.xml -Pcode-coverage,jdk8-tests,native,release -DskipGpg -Dtest.log.level=WARN
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build
       working-directory: ./tools/apprunner-gradle-plugin

--- a/clients/deltalake/core/pom.xml
+++ b/clients/deltalake/core/pom.xml
@@ -50,6 +50,12 @@
               <goal>add-source</goal>
             </goals>
           </execution>
+          <execution>
+            <id>attach-javadocs</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -234,7 +234,39 @@
         </execution>
       </executions>
     </plugin>
-
-  </plugins>
+    </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>doc-jar</goal>
+                </goals>
+                <configuration>
+                  <scalaVersion>${scala2.12.version}</scalaVersion>
+                  <additionalDependencies>
+                    <!-- Hack to let scaladoc pick up the generated code -->
+                    <dependency>
+                      <groupId>${project.groupId}</groupId>
+                      <artifactId>${project.artifactId}</artifactId>
+                      <version>${project.version}</version>
+                    </dependency>
+                  </additionalDependencies>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/NessieSparkSqlExtensionsParser.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/NessieSparkSqlExtensionsParser.scala
@@ -220,8 +220,8 @@ case object NessieParseErrorListener extends BaseErrorListener {
 
 /**
   * Copied from Apache Spark
-  * A [[ParseException]] is an [[AnalysisException]] that is thrown during the parse process. It
-  * contains fields and an extended error message that make reporting and diagnosing errors easier.
+  * A [[NessieParseException]] is an `AnalysisException` that is thrown during the parse process.
+  * It contains fields and an extended error message that make reporting and diagnosing errors easier.
   */
 class NessieParseException(
     val command: Option[String],

--- a/perftest/gatling/pom.xml
+++ b/perftest/gatling/pom.xml
@@ -59,7 +59,17 @@
         <artifactId>scala-maven-plugin</artifactId>
         <executions>
           <execution>
+            <id>attach-javadocs</id>
             <goals>
+              <goal>doc-jar</goal>
+            </goals>
+            <configuration>
+              <scalaVersion>${scala2.13.version}</scalaVersion>
+            </configuration>
+          </execution>
+          <execution>
+            <goals>
+              <goal>add-source</goal>
               <goal>compile</goal>
               <goal>testCompile</goal>
             </goals>

--- a/perftest/simulations/pom.xml
+++ b/perftest/simulations/pom.xml
@@ -101,6 +101,7 @@
         <executions>
           <execution>
             <goals>
+              <goal>add-source</goal>
               <goal>compile</goal>
               <goal>testCompile</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1211,6 +1211,21 @@ limitations under the License.
             </executions>
           </plugin>
           <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>doc-jar</goal>
+                </goals>
+                <configuration>
+                  <scalaVersion>${scala2.12.version}</scalaVersion>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <executions>
@@ -1232,6 +1247,7 @@ limitations under the License.
                   <goal>sign</goal>
                 </goals>
                 <configuration>
+                  <skip>${skipGpg}</skip>
                   <gpgArguments>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nessie-ui",
-      "version": "0.8.1-snapshot",
+      "version": "0.8.2-snapshot",
       "dependencies": {
         "@material-ui/core": "^4.12.1",
         "@material-ui/icons": "^4.11.2",


### PR DESCRIPTION
Also adds a `skipGpg` property, so you can run with `-Prelease` without having a gpg key.

The [issue](https://github.com/davidB/scala-maven-plugin/issues/46) that the `scala-maven-plugin` does not pick up _generated_ sources for docs requires the hack in `clients/spark-extensions/pom.xml`.

Since the nessie-deltalake-core module doesn't actually compile anything, the doc-part needs to be skipped there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1607)
<!-- Reviewable:end -->
