### PR TITLE
Increase swap for release-publish (as done for main-CI)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -74,6 +74,21 @@ jobs:
         fi
 
     ### BEGIN runner setup
+    - name: Memory report
+      run: |
+        echo "Memory and swap:"
+        free
+        echo
+        swapon --show
+        echo
+        echo "Available storage:"
+        df -h
+        echo
+    - name: Add 6G more swap for native-image build
+      run: |
+        sudo dd if=/dev/zero of=/mnt/swapfile-2 bs=1MiB count=$((6*1024))
+        sudo mkswap /mnt/swapfile-2
+        sudo swapon /mnt/swapfile-2
     - name: Checkout
       uses: actions/checkout@v2
       if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
The release-publish workflow also builds a native image, so give it more "memory" as well, to be safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1609)
<!-- Reviewable:end -->
