### PR TITLE
Specified sort order  in Spark extension tests

### DIFF
--- a/clients/spark-extensions/src/test/java/org/projectnessie/spark/extensions/ITNessieStatements.java
+++ b/clients/spark-extensions/src/test/java/org/projectnessie/spark/extensions/ITNessieStatements.java
@@ -299,6 +299,7 @@ public class ITNessieStatements extends AbstractSparkTest {
                 "committerTime")
             .pivot("key")
             .agg(functions.first("value"))
+            .orderBy(functions.desc("committerTime"))
             .collectAsList()
             .stream()
             .map(AbstractSparkTest::toJava)


### PR DESCRIPTION
Sort order wasn't specified in tests. This resulted in a flaky test. We have set the spark sort order now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1624)
<!-- Reviewable:end -->
