### PR TITLE
More flexible CI for PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -111,14 +111,25 @@ jobs:
         echo ::set-output name=CI_WITH_JACKSON::$(jq 'any(.pull_request.labels[]; .name == "pr-jackson")' < $GITHUB_EVENT_PATH)
     - name: Build with Maven
       env:
-        CI_WITH_NATIVE: ${{ steps.ci_options.outputs.CI_WITH_NATIVE }}
-        CI_WITH_JDK8: ${{ steps.ci_options.outputs.CI_WITH_JDK8 }}
         SPARK_LOCAL_IP: localhost
       run: |
-        PROFILES="-Pcode-coverage"
-        [[ $CI_WITH_JDK8 == "true" ]] && PROFILES="$PROFILES,jdk8-tests"
-        [[ $CI_WITH_NATIVE == "true" ]] && PROFILES="$PROFILES,native"
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml $PROFILES -Dtest.log.level=WARN
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage -Dtest.log.level=WARN
+    - name: Build with Maven / JDK8 tests
+      if: ${{ steps.ci_options.outputs.CI_WITH_JDK8 == 'true' }}
+      env:
+        SPARK_LOCAL_IP: localhost
+      run: |
+        # No code-coverage here
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pjdk8-tests" -Dtest.log.level=WARN \
+          -pl :nessie-hms-hive2 \
+          -pl :nessie-hms-hive3
+    - name: Build with Maven / Native tests
+      if: ${{ steps.ci_options.outputs.CI_WITH_NATIVE == 'true' }}
+      run: |
+        # No code-coverage here
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pnative -Dtest.log.level=WARN \
+          -pl :nessie-quarkus \
+          -pl :nessie-lambda
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build
       working-directory: ./tools/apprunner-gradle-plugin
@@ -142,6 +153,7 @@ jobs:
         flags: java
         files: |
           code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
+
   jackson-tests:
     name: Jackson Integration Tests
     needs: java
@@ -181,6 +193,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Jackson Integration Tests ${{ matrix.target-library }}
         run: mvn verify -pl :nessie-client -am -Pjackson-tests -Djackson.test.version=${{ matrix.jackson-version }} -Dtest.log.level=WARN
+
   python:
     name: Python
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,8 @@ jobs:
   java:
     name: Java/Maven
     runs-on: ubuntu-latest
+    outputs:
+      CI_WITH_JACKSON: ${{ steps.ci_options.outputs.CI_WITH_JACKSON }}
 
     steps:
     - uses: actions/checkout@v2
@@ -85,10 +87,22 @@ jobs:
           ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
+    - name: Build/test options
+      id: ci_options
+      run: |
+        echo ::set-output name=CI_WITH_NATIVE::$(jq 'any(.pull_request.labels[]; .name == "pr-native")' < $GITHUB_EVENT_PATH)
+        echo ::set-output name=CI_WITH_JDK8::$(jq 'any(.pull_request.labels[]; .name == "pr-jdk8")' < $GITHUB_EVENT_PATH)
+        echo ::set-output name=CI_WITH_JACKSON::$(jq 'any(.pull_request.labels[]; .name == "pr-jackson")' < $GITHUB_EVENT_PATH)
     - name: Build with Maven
-      run: ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage,jdk8-tests -Dtest.log.level=WARN
       env:
+        CI_WITH_NATIVE: ${{ steps.ci_options.outputs.CI_WITH_NATIVE }}
+        CI_WITH_JDK8: ${{ steps.ci_options.outputs.CI_WITH_JDK8 }}
         SPARK_LOCAL_IP: localhost
+      run: |
+        PROFILES="-Pcode-coverage"
+        [[ $CI_WITH_JDK8 == "true" ]] && PROFILES="$PROFILES,jdk8-tests"
+        [[ $CI_WITH_NATIVE == "true" ]] && PROFILES="$PROFILES,native"
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml $PROFILES -Dtest.log.level=WARN
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build
       working-directory: ./tools/apprunner-gradle-plugin
@@ -112,6 +126,45 @@ jobs:
         flags: java
         files: |
           code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
+  jackson-tests:
+    name: Jackson Integration Tests
+    needs: java
+    if: ${{ needs.java.outputs.CI_WITH_JACKSON == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      # note the big include entry in matrix is used to ensure we get human readable names for the jobs
+      matrix:
+        include:
+          - jackson-version: 2.6.5
+            target-library: Hive 2.3.7
+            java-version: 11
+          - jackson-version: 2.9.5
+            target-library: Hive 3.1.2
+            java-version: 11
+          - jackson-version: 2.6.7
+            target-library: Spark 2.4.4
+            java-version: 11
+          - jackson-version: 2.10.0
+            target-library: Spark 3.0.1
+            java-version: 11
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/projectnessie
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Jackson Integration Tests ${{ matrix.target-library }}
+        run: mvn verify -pl :nessie-client -am -Pjackson-tests -Djackson.test.version=${{ matrix.jackson-version }} -Dtest.log.level=WARN
   python:
     name: Python
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,6 @@ jobs:
       id: ci_options
       run: |
         echo ::set-output name=CI_WITH_NATIVE::$(jq 'any(.pull_request.labels[]; .name == "pr-native")' < $GITHUB_EVENT_PATH)
-        echo ::set-output name=CI_WITH_JDK8::$(jq 'any(.pull_request.labels[]; .name == "pr-jdk8")' < $GITHUB_EVENT_PATH)
         echo ::set-output name=CI_WITH_JACKSON::$(jq 'any(.pull_request.labels[]; .name == "pr-jackson")' < $GITHUB_EVENT_PATH)
     - name: Memory report
       run: |
@@ -113,13 +112,8 @@ jobs:
     - name: Build with Maven
       env:
         SPARK_LOCAL_IP: localhost
-        CI_WITH_JDK8: ${{ steps.ci_options.outputs.CI_WITH_JDK8 }}
       run: |
-        PROFILES="-Pcode-coverage"
-        if [[ ${CI_WITH_JDK8} == "true" ]]; then
-          PROFILES="${PROFILES},jdk8-tests"
-        fi
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml ${PROFILES} -Dtest.log.level=WARN
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage,jdk8-tests -Dtest.log.level=WARN
     - name: Build with Maven / Native tests
       if: ${{ steps.ci_options.outputs.CI_WITH_NATIVE == 'true' }}
       run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: PR Build Check
 
 on:
   pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
 # NOTE: using paths-ignore here doesn't play well with "Require status checks to pass before merging"
 # due to https://github.community/t/feature-request-conditional-required-checks/16761
 #    paths-ignore:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,6 +24,12 @@ jobs:
       CI_WITH_JACKSON: ${{ steps.ci_options.outputs.CI_WITH_JACKSON }}
 
     steps:
+    - name: Build/test options
+      id: ci_options
+      run: |
+        echo ::set-output name=CI_WITH_NATIVE::$(jq 'any(.pull_request.labels[]; .name == "pr-native")' < $GITHUB_EVENT_PATH)
+        echo ::set-output name=CI_WITH_JDK8::$(jq 'any(.pull_request.labels[]; .name == "pr-jdk8")' < $GITHUB_EVENT_PATH)
+        echo ::set-output name=CI_WITH_JACKSON::$(jq 'any(.pull_request.labels[]; .name == "pr-jackson")' < $GITHUB_EVENT_PATH)
     - name: Memory report
       run: |
         echo "Memory and swap:"
@@ -35,6 +41,7 @@ jobs:
         df -h
         echo
     - name: Add 6G more swap for native-image build
+      if: ${{ steps.ci_options.outputs.CI_WITH_NATIVE == 'true' }}
       run: |
         sudo dd if=/dev/zero of=/mnt/swapfile-2 bs=1MiB count=$((6*1024))
         sudo mkswap /mnt/swapfile-2
@@ -103,12 +110,6 @@ jobs:
           ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
-    - name: Build/test options
-      id: ci_options
-      run: |
-        echo ::set-output name=CI_WITH_NATIVE::$(jq 'any(.pull_request.labels[]; .name == "pr-native")' < $GITHUB_EVENT_PATH)
-        echo ::set-output name=CI_WITH_JDK8::$(jq 'any(.pull_request.labels[]; .name == "pr-jdk8")' < $GITHUB_EVENT_PATH)
-        echo ::set-output name=CI_WITH_JACKSON::$(jq 'any(.pull_request.labels[]; .name == "pr-jackson")' < $GITHUB_EVENT_PATH)
     - name: Build with Maven
       env:
         SPARK_LOCAL_IP: localhost

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -113,24 +113,18 @@ jobs:
     - name: Build with Maven
       env:
         SPARK_LOCAL_IP: localhost
+        CI_WITH_JDK8: ${{ steps.ci_options.outputs.CI_WITH_JDK8 }}
       run: |
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage -Dtest.log.level=WARN
-    - name: Build with Maven / JDK8 tests
-      if: ${{ steps.ci_options.outputs.CI_WITH_JDK8 == 'true' }}
-      env:
-        SPARK_LOCAL_IP: localhost
-      run: |
-        # No code-coverage here
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pjdk8-tests" -Dtest.log.level=WARN \
-          -pl :nessie-hms-hive2 \
-          -pl :nessie-hms-hive3
+        PROFILES="-Pcode-coverage"
+        if [[ ${CI_WITH_JDK8} == "true" ]]; then
+          PROFILES="${PROFILES},jdk8-tests"
+        fi
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml ${PROFILES} -Dtest.log.level=WARN
     - name: Build with Maven / Native tests
       if: ${{ steps.ci_options.outputs.CI_WITH_NATIVE == 'true' }}
       run: |
         # No code-coverage here
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pnative -Dtest.log.level=WARN \
-          -pl :nessie-quarkus \
-          -pl :nessie-lambda
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pnative -Dtest.log.level=WARN -pl :nessie-quarkus -pl :nessie-lambda
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build
       working-directory: ./tools/apprunner-gradle-plugin

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,6 +24,21 @@ jobs:
       CI_WITH_JACKSON: ${{ steps.ci_options.outputs.CI_WITH_JACKSON }}
 
     steps:
+    - name: Memory report
+      run: |
+        echo "Memory and swap:"
+        free
+        echo
+        swapon --show
+        echo
+        echo "Available storage:"
+        df -h
+        echo
+    - name: Add 6G more swap for native-image build
+      run: |
+        sudo dd if=/dev/zero of=/mnt/swapfile-2 bs=1MiB count=$((6*1024))
+        sudo mkswap /mnt/swapfile-2
+        sudo swapon /mnt/swapfile-2
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,14 @@ Upon submission of a pull request you will be asked to sign our contributor lice
 Anyone can take part in the review process and once the community is happy and the build actions are passing a Pull Request will be merged. Support 
 must be unanimous for a change to be merged.
 
+All pull-requests automatically trigger CI runs. Two long-running parts of the CI workflow are
+skipped for PRs by default, but can be enabled using "labels" on the PR.
+* Quarkus native image generation + tests against the native image. The label `pr-native` label enables this.
+  The label `pr-native` label enables this, CI results do not appear as a separate job, because
+  those run as part of the "Java/Maven" workflow job.
+* Nessie-client tests against various combinations of Jackson versions.
+  The label `pr-jackson` label enables this and CI result will appear as a separate check.
+
 ### Reporting security issues
 
 Please see our [Security Policy](SECURITY.md)


### PR DESCRIPTION
Proposal for three new labels:
* `pr-native` - triggers CI with `native` Maven profile (disabled by default)
* `pr-jdk8` - triggers CI with `jdk8-tests` Maven profile (disabled by default)
* `pr-jackson` - triggers CI with Jackson-client-test matrix (disabled by default)

Fixes #1575

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1660)
<!-- Reviewable:end -->
