### PR TITLE
Hide the "never ending" & toggling warning messaged about FlushCommand

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -50,6 +50,8 @@ quarkus.log.console.level=INFO
 quarkus.log.file.level=INFO
 quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
 quarkus.log.category."io.netty".level=WARN
+# Don't log toggling warnings about "FlushCommand errors" + "FlushCommand working again" - see https://github.com/projectnessie/nessie/issues/1500
+quarkus.log.category."io.jaegertracing.internal.reporters".level=ERROR
 # Effectively disable HTTP request logging to the console (HTTP access logs happen at INFO level)
 quarkus.log.category."io.quarkus.http.access-log".level=${HTTP_ACCESS_LOG_LEVEL:INFO}
 


### PR DESCRIPTION
This change just changes the log settings so these warnings don't get logged.

See #1500

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1661)
<!-- Reviewable:end -->
