### PR TITLE
Github commit-status-checks in workflow should ignore the "skipped" conclusion

### DIFF
--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Check commit status
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-        gh api repos/projectnessie/nessie/commits/${SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") or startswith("Report ") | not ) | .conclusion // "pending" ] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
+        gh api repos/projectnessie/nessie/commits/${SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") or startswith("Report ") | not ) | select(.conclusion != "skipped") | .conclusion // "pending" ] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
 
     - name: Set up JDK 11
       uses: actions/setup-java@v1

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Check commit status
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-        gh api repos/projectnessie/nessie/commits/${GITHUB_SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") or startswith("Report ") | not ) | .conclusion // "pending" ] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
+        gh api repos/projectnessie/nessie/commits/${GITHUB_SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") or startswith("Report ") | not ) | select(.conclusion != "skipped") | .conclusion // "pending" ] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
 
     ### BEGIN runner setup
     - name: Checkout


### PR DESCRIPTION
For example [this run](https://github.com/projectnessie/nessie/runs/3194995316?check_suite_focus=true) 

A `gh api repos/projectnessie/nessie/commits/${SHA}/check-runs --jq '[.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") or startswith("Report ") | not ) | { name, conclusion }  ]'` on that SHA (ee1dc659e24d8d7202dea6c37db225213962d047) reports:
```
[
  {
    "conclusion": "skipped",
    "name": "Jackson Integration Tests"
  },
  {
    "conclusion": "success",
    "name": "Python (3.9)"
  },
...
```

In other words: the Jackson-tests in #1660 were not enabled and the check skipped and caused the status-check to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1672)
<!-- Reviewable:end -->
