### PR TITLE
Ignore 'coverage' vulnerability

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -16,7 +16,7 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     flake8 pynessie tests
-    safety check
+    safety check --ignore=41002
     mypy --ignore-missing-imports -p pynessie
 
 [testenv]


### PR DESCRIPTION
```
+==============================================================================+
| coverage                   | 5.5       | <6.0b1                   | 41002    |
+==============================================================================+
| Coverage 6.0b1 starts to use a modern hash algorithm (sha256) when           |
| fingerprinting for high-security environments.                               |
+==============================================================================+

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1687)
<!-- Reviewable:end -->

`tomli` is needed by this newer `coverage` version as described in https://github.com/nedbat/coveragepy/releases/tag/6.0b1