### PR TITLE
Add named-ref parameters to API

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/AssignBranchBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/AssignBranchBuilder.java
@@ -19,7 +19,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.Branch;
+import org.projectnessie.model.Reference;
 
 /**
  * Request builder for "assign branch".
@@ -27,7 +27,7 @@ import org.projectnessie.model.Branch;
  * @since Nessie API {@link NessieApiVersion#V_1}
  */
 public interface AssignBranchBuilder extends OnBranchBuilder<AssignBranchBuilder> {
-  AssignBranchBuilder assignTo(@Valid @NotNull Branch assignTo);
+  AssignBranchBuilder assignTo(@Valid @NotNull Reference assignTo);
 
   void submit() throws NessieNotFoundException, NessieConflictException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/AssignTagBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/AssignTagBuilder.java
@@ -19,7 +19,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.Tag;
+import org.projectnessie.model.Reference;
 
 /**
  * Request builder for "assign tag".
@@ -27,7 +27,7 @@ import org.projectnessie.model.Tag;
  * @since Nessie API {@link NessieApiVersion#V_1}
  */
 public interface AssignTagBuilder extends OnTagBuilder<AssignTagBuilder> {
-  AssignTagBuilder assignTo(@Valid @NotNull Tag assignTo);
+  AssignTagBuilder assignTo(@Valid @NotNull Reference assignTo);
 
   void submit() throws NessieNotFoundException, NessieConflictException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/CreateReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/CreateReferenceBuilder.java
@@ -17,9 +17,11 @@ package org.projectnessie.client.api;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.Validation;
 
 /**
  * Request builder for "create reference".
@@ -27,6 +29,10 @@ import org.projectnessie.model.Reference;
  * @since Nessie API {@link NessieApiVersion#V_1}
  */
 public interface CreateReferenceBuilder {
+  CreateReferenceBuilder sourceRefName(
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+          String sourceRefName);
+
   CreateReferenceBuilder reference(@Valid @NotNull Reference reference);
 
   Reference submit() throws NessieNotFoundException, NessieConflictException;

--- a/clients/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
@@ -16,8 +16,10 @@
 package org.projectnessie.client.api;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Validation;
 
 /**
  * Request builder for "merge reference".
@@ -26,6 +28,10 @@ import org.projectnessie.error.NessieNotFoundException;
  */
 public interface MergeReferenceBuilder extends OnBranchBuilder<MergeReferenceBuilder> {
   MergeReferenceBuilder fromHash(@NotBlank String fromHash);
+
+  MergeReferenceBuilder sourceRefName(
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+          String sourceRefName);
 
   void submit() throws NessieNotFoundException, NessieConflictException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
@@ -19,6 +19,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
 import org.projectnessie.model.Validation;
 
 /**
@@ -29,9 +30,17 @@ import org.projectnessie.model.Validation;
 public interface MergeReferenceBuilder extends OnBranchBuilder<MergeReferenceBuilder> {
   MergeReferenceBuilder fromHash(@NotBlank String fromHash);
 
-  MergeReferenceBuilder sourceRefName(
+  MergeReferenceBuilder fromRefName(
       @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-          String sourceRefName);
+          String fromRefName);
+
+  /**
+   * Convenience for {@link #fromRefName(String) fromRefName(fromRef.getName())}{@code .}{@link
+   * #fromHash(String) fromHash(fromRef.getHash())}.
+   */
+  default MergeReferenceBuilder fromRef(Reference fromRef) {
+    return fromRefName(fromRef.getName()).fromHash(fromRef.getHash());
+  }
 
   void submit() throws NessieNotFoundException, NessieConflictException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/TransplantCommitsBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/TransplantCommitsBuilder.java
@@ -31,9 +31,9 @@ import org.projectnessie.model.Validation;
 public interface TransplantCommitsBuilder extends OnBranchBuilder<TransplantCommitsBuilder> {
   TransplantCommitsBuilder message(String message);
 
-  TransplantCommitsBuilder sourceRefName(
+  TransplantCommitsBuilder fromRefName(
       @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-          String sourceRefName);
+          String fromRefName);
 
   TransplantCommitsBuilder hashesToTransplant(
       @NotNull @Size(min = 1) List<String> hashesToTransplant);

--- a/clients/client/src/main/java/org/projectnessie/client/api/TransplantCommitsBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/TransplantCommitsBuilder.java
@@ -17,9 +17,11 @@ package org.projectnessie.client.api;
 
 import java.util.List;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Validation;
 
 /**
  * Request builder for "transplant commits".
@@ -28,6 +30,10 @@ import org.projectnessie.error.NessieNotFoundException;
  */
 public interface TransplantCommitsBuilder extends OnBranchBuilder<TransplantCommitsBuilder> {
   TransplantCommitsBuilder message(String message);
+
+  TransplantCommitsBuilder sourceRefName(
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+          String sourceRefName);
 
   TransplantCommitsBuilder hashesToTransplant(
       @NotNull @Size(min = 1) List<String> hashesToTransplant);

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
@@ -30,7 +30,6 @@ import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Merge;
 import org.projectnessie.model.Operations;
 import org.projectnessie.model.Reference;
-import org.projectnessie.model.Tag;
 import org.projectnessie.model.Transplant;
 
 class HttpTreeClient implements HttpTreeApi {
@@ -50,9 +49,14 @@ class HttpTreeClient implements HttpTreeApi {
   }
 
   @Override
-  public Reference createReference(@NotNull Reference reference)
+  public Reference createReference(String sourceRefName, @NotNull Reference reference)
       throws NessieNotFoundException, NessieConflictException {
-    return client.newRequest().path("trees/tree").post(reference).readEntity(Reference.class);
+    return client
+        .newRequest()
+        .path("trees/tree")
+        .queryParam("sourceRefName", sourceRefName)
+        .post(reference)
+        .readEntity(Reference.class);
   }
 
   @Override
@@ -66,14 +70,15 @@ class HttpTreeClient implements HttpTreeApi {
   }
 
   @Override
-  public void assignTag(@NotNull String tagName, @NotNull String expectedHash, @NotNull Tag tag)
+  public void assignTag(
+      @NotNull String tagName, @NotNull String expectedHash, @NotNull Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
     client
         .newRequest()
         .path("trees/tag/{tagName}")
         .resolveTemplate("tagName", tagName)
         .queryParam("expectedHash", expectedHash)
-        .put(tag);
+        .put(assignTo);
   }
 
   @Override
@@ -89,14 +94,14 @@ class HttpTreeClient implements HttpTreeApi {
 
   @Override
   public void assignBranch(
-      @NotNull String branchName, @NotNull String expectedHash, @NotNull Branch branch)
+      @NotNull String branchName, @NotNull String expectedHash, @NotNull Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
     client
         .newRequest()
         .path("trees/branch/{branchName}")
         .resolveTemplate("branchName", branchName)
         .queryParam("expectedHash", expectedHash)
-        .put(branch);
+        .put(assignTo);
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
@@ -19,18 +19,18 @@ import org.projectnessie.client.api.AssignBranchBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.Branch;
+import org.projectnessie.model.Reference;
 
 final class HttpAssignBranch extends BaseHttpOnBranchRequest<AssignBranchBuilder>
     implements AssignBranchBuilder {
-  private Branch assignTo;
+  private Reference assignTo;
 
   HttpAssignBranch(NessieApiClient client) {
     super(client);
   }
 
   @Override
-  public AssignBranchBuilder assignTo(Branch assignTo) {
+  public AssignBranchBuilder assignTo(Reference assignTo) {
     this.assignTo = assignTo;
     return this;
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
@@ -19,19 +19,19 @@ import org.projectnessie.client.api.AssignTagBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.Tag;
+import org.projectnessie.model.Reference;
 
 final class HttpAssignTag extends BaseHttpOnTagRequest<AssignTagBuilder>
     implements AssignTagBuilder {
 
-  private Tag assignTo;
+  private Reference assignTo;
 
   HttpAssignTag(NessieApiClient client) {
     super(client);
   }
 
   @Override
-  public AssignTagBuilder assignTo(Tag assignTo) {
+  public AssignTagBuilder assignTo(Reference assignTo) {
     this.assignTo = assignTo;
     return this;
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateReference.java
@@ -24,9 +24,16 @@ import org.projectnessie.model.Reference;
 final class HttpCreateReference extends BaseHttpRequest implements CreateReferenceBuilder {
 
   private Reference reference;
+  private String sourceRefName;
 
   HttpCreateReference(NessieApiClient client) {
     super(client);
+  }
+
+  @Override
+  public CreateReferenceBuilder sourceRefName(String sourceRefName) {
+    this.sourceRefName = sourceRefName;
+    return this;
   }
 
   @Override
@@ -37,6 +44,6 @@ final class HttpCreateReference extends BaseHttpRequest implements CreateReferen
 
   @Override
   public Reference submit() throws NessieNotFoundException, NessieConflictException {
-    return client.getTreeApi().createReference(reference);
+    return client.getTreeApi().createReference(sourceRefName, reference);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
@@ -31,8 +31,8 @@ final class HttpMergeReference extends BaseHttpOnBranchRequest<MergeReferenceBui
   }
 
   @Override
-  public MergeReferenceBuilder sourceRefName(String sourceRefName) {
-    merge.sourceRefName(sourceRefName);
+  public MergeReferenceBuilder fromRefName(String fromRefName) {
+    merge.fromRefName(fromRefName);
     return this;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
@@ -31,6 +31,12 @@ final class HttpMergeReference extends BaseHttpOnBranchRequest<MergeReferenceBui
   }
 
   @Override
+  public MergeReferenceBuilder sourceRefName(String sourceRefName) {
+    merge.sourceRefName(sourceRefName);
+    return this;
+  }
+
+  @Override
   public MergeReferenceBuilder fromHash(String fromHash) {
     merge.fromHash(fromHash);
     return this;

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
@@ -39,8 +39,8 @@ final class HttpTransplantCommits extends BaseHttpOnBranchRequest<TransplantComm
   }
 
   @Override
-  public TransplantCommitsBuilder sourceRefName(String sourceRefName) {
-    transplant.sourceRefName(sourceRefName);
+  public TransplantCommitsBuilder fromRefName(String fromRefName) {
+    transplant.fromRefName(fromRefName);
     return this;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
@@ -39,6 +39,12 @@ final class HttpTransplantCommits extends BaseHttpOnBranchRequest<TransplantComm
   }
 
   @Override
+  public TransplantCommitsBuilder sourceRefName(String sourceRefName) {
+    transplant.sourceRefName(sourceRefName);
+    return this;
+  }
+
+  @Override
   public TransplantCommitsBuilder hashesToTransplant(List<String> hashesToTransplant) {
     transplant.addAllHashesToTransplant(hashesToTransplant);
     return this;

--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLog.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLog.java
@@ -78,7 +78,8 @@ class ITDeltaLog extends AbstractSparkTest {
     Reference devBranch =
         nessieClient
             .getTreeApi()
-            .createReference(Branch.of("testMultipleBranches", mainBranch.getHash()));
+            .createReference(
+                mainBranch.getName(), Branch.of("testMultipleBranches", mainBranch.getHash()));
 
     spark.sparkContext().conf().set("spark.sql.catalog.spark_catalog.ref", devBranch.getName());
 
@@ -123,7 +124,8 @@ class ITDeltaLog extends AbstractSparkTest {
     Reference devBranch =
         nessieClient
             .getTreeApi()
-            .createReference(Branch.of("testCommitRetry", mainBranch.getHash()));
+            .createReference(
+                mainBranch.getName(), Branch.of("testCommitRetry", mainBranch.getHash()));
 
     spark.sparkContext().conf().set("spark.sql.catalog.spark_catalog.ref", devBranch.getName());
 
@@ -133,12 +135,18 @@ class ITDeltaLog extends AbstractSparkTest {
     Dataset<Row> count2 = spark.sql("SELECT COUNT(*) FROM test_commit_retry");
     Assertions.assertEquals(30L, count2.collectAsList().get(0).getLong(0));
 
-    String toHash = nessieClient.getTreeApi().getReferenceByName("main").getHash();
-    String fromHash = nessieClient.getTreeApi().getReferenceByName("testCommitRetry").getHash();
+    Reference to = nessieClient.getTreeApi().getReferenceByName("main");
+    Reference from = nessieClient.getTreeApi().getReferenceByName("testCommitRetry");
 
     nessieClient
         .getTreeApi()
-        .mergeRefIntoBranch("main", toHash, ImmutableMerge.builder().fromHash(fromHash).build());
+        .mergeRefIntoBranch(
+            to.getName(),
+            to.getHash(),
+            ImmutableMerge.builder()
+                .sourceRefName(from.getName())
+                .fromHash(from.getHash())
+                .build());
 
     spark.sparkContext().conf().set("spark.sql.catalog.spark_catalog.ref", "main");
 

--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLog.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLog.java
@@ -143,10 +143,7 @@ class ITDeltaLog extends AbstractSparkTest {
         .mergeRefIntoBranch(
             to.getName(),
             to.getHash(),
-            ImmutableMerge.builder()
-                .sourceRefName(from.getName())
-                .fromHash(from.getHash())
-                .build());
+            ImmutableMerge.builder().fromRefName(from.getName()).fromHash(from.getHash()).build());
 
     spark.sparkContext().conf().set("spark.sql.catalog.spark_catalog.ref", "main");
 

--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
@@ -87,9 +87,10 @@ class ITDeltaLogBranches extends AbstractSparkTest {
     // write some data to table
     targetTable.write().format("delta").save(tempPath.getAbsolutePath());
     // create test at the point where there is only 1 commit
+    Branch sourceRef = client.getTreeApi().getDefaultBranch();
     client
         .getTreeApi()
-        .createReference(Branch.of("test", client.getTreeApi().getDefaultBranch().getHash()));
+        .createReference(sourceRef.getName(), Branch.of("test", sourceRef.getHash()));
     // add some more data to main
     targetTable.write().format("delta").mode("append").save(tempPath.getAbsolutePath());
 

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateReferenceExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateReferenceExec.scala
@@ -36,13 +36,15 @@ case class CreateReferenceExec(
   override protected def runInternal(
       nessieClient: NessieClient
   ): Seq[InternalRow] = {
-    val hash = createdFrom
+    val sourceRef = createdFrom
       .map(nessieClient.getTreeApi.getReferenceByName)
       .orElse(Option(nessieClient.getTreeApi.getDefaultBranch))
-      .map(x => x.getHash)
       .orNull
-    val ref = if (isBranch) Branch.of(branch, hash) else Tag.of(branch, hash)
+    val ref =
+      if (isBranch) Branch.of(branch, sourceRef.getHash)
+      else Tag.of(branch, sourceRef.getHash)
     try {
+      // TODO !!! nessieClient.getTreeApi.createReference(sourceRef.getName, ref)
       nessieClient.getTreeApi.createReference(ref)
     } catch {
       case e: NessieConflictException =>

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeBranchExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeBranchExec.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.unsafe.types.UTF8String
 import org.projectnessie.client.NessieClient
-import org.projectnessie.model.{Branch, ImmutableMerge}
+import org.projectnessie.model.ImmutableMerge
 
 case class MergeBranchExec(
     output: Seq[Attribute],
@@ -33,21 +33,20 @@ case class MergeBranchExec(
   override protected def runInternal(
       nessieClient: NessieClient
   ): Seq[InternalRow] = {
+    val from = nessieClient.getTreeApi
+      .getReferenceByName(
+        branch.getOrElse(
+          NessieUtils.getCurrentRef(currentCatalog, catalog).getName
+        )
+      )
     nessieClient.getTreeApi.mergeRefIntoBranch(
       toRefName.getOrElse(nessieClient.getTreeApi.getDefaultBranch.getName),
       toRefName
         .map(r => nessieClient.getTreeApi.getReferenceByName(r).getHash)
         .getOrElse(nessieClient.getTreeApi.getDefaultBranch.getHash),
       ImmutableMerge.builder
-        .fromHash(
-          nessieClient.getTreeApi
-            .getReferenceByName(
-              branch.getOrElse(
-                NessieUtils.getCurrentRef(currentCatalog, catalog).getName
-              )
-            )
-            .getHash
-        )
+        .fromHash(from.getHash)
+        // TODO !! .sourceRefName(from.getName)
         .build
     )
     val ref = nessieClient.getTreeApi.getReferenceByName(

--- a/clients/spark-extensions/src/test/java/org/projectnessie/spark/extensions/ITNessieStatements.java
+++ b/clients/spark-extensions/src/test/java/org/projectnessie/spark/extensions/ITNessieStatements.java
@@ -24,7 +24,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.tests.AbstractSparkTest;
-import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -46,6 +44,7 @@ import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.ImmutableOperations;
 import org.projectnessie.model.Operation;
 import org.projectnessie.model.Operations;
+import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
 
 public class ITNessieStatements extends AbstractSparkTest {
@@ -66,15 +65,15 @@ public class ITNessieStatements extends AbstractSparkTest {
 
   @AfterEach
   void removeBranches() throws NessieConflictException, NessieNotFoundException {
-    for (String s : Arrays.asList(refName, "main")) {
-      try {
-        nessieClient
-            .getTreeApi()
-            .deleteBranch(s, nessieClient.getTreeApi().getReferenceByName(s).getHash());
-      } catch (BaseNessieClientServerException e) {
-        // pass
+    for (Reference ref : nessieClient.getTreeApi().getAllReferences()) {
+      if (ref instanceof Branch) {
+        nessieClient.getTreeApi().deleteBranch(ref.getName(), ref.getHash());
+      }
+      if (ref instanceof Tag) {
+        nessieClient.getTreeApi().deleteTag(ref.getName(), ref.getHash());
       }
     }
+    // TODO !! nessieClient.getTreeApi().createReference(null, Branch.of("main", null));
     nessieClient.getTreeApi().createReference(Branch.of("main", null));
   }
 

--- a/model/src/main/java/org/projectnessie/api/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/TreeApi.java
@@ -16,6 +16,7 @@
 package org.projectnessie.api;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -29,7 +30,6 @@ import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Merge;
 import org.projectnessie.model.Operations;
 import org.projectnessie.model.Reference;
-import org.projectnessie.model.Tag;
 import org.projectnessie.model.Transplant;
 import org.projectnessie.model.Validation;
 
@@ -41,8 +41,24 @@ public interface TreeApi {
   /** Get details for the default reference. */
   Branch getDefaultBranch() throws NessieNotFoundException;
 
-  /** Create a new reference. */
-  Reference createReference(@Valid @NotNull Reference reference)
+  /**
+   * Create a new reference.
+   *
+   * <p>The type of {@code reference}, which can be either a {@link Branch} or {@link
+   * org.projectnessie.model.Tag}, determines the type of the reference to be created.
+   *
+   * <p>{@link Reference#getName()} defines the the name of the reference to be created, {@link
+   * Reference#getHash()} is the hash of the created reference, the HEAD of the created reference.
+   * {@code sourceRefName} is the name of the reference which contains {@link Reference#getHash()},
+   * and must be present if {@link Reference#getHash()} is present.
+   *
+   * <p>Specifying no {@link Reference#getHash()} means that the new reference will be created "at
+   * the beginning of time".
+   */
+  Reference createReference(
+      @Nullable @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+          String sourceRefName,
+      @Valid @NotNull Reference reference)
       throws NessieNotFoundException, NessieConflictException;
 
   /** Get details of a particular ref, if it exists. */
@@ -109,7 +125,7 @@ public interface TreeApi {
           String tagName,
       @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String oldHash,
-      @Valid @NotNull Tag tag)
+      @Valid @NotNull Reference assignTo)
       throws NessieNotFoundException, NessieConflictException;
 
   /** Delete a tag. */
@@ -125,7 +141,7 @@ public interface TreeApi {
           String branchName,
       @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String oldHash,
-      @Valid @NotNull Branch branch)
+      @Valid @NotNull Reference assignTo)
       throws NessieNotFoundException, NessieConflictException;
 
   /** Delete a branch. */

--- a/model/src/main/java/org/projectnessie/api/http/HttpContentsApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpContentsApi.java
@@ -51,7 +51,16 @@ public interface HttpContentsApi extends ContentsApi {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("{key}")
-  @Operation(summary = "Get object content associated with key")
+  @Operation(
+      summary = "Get object content associated with a key.",
+      description =
+          "This operation returns the contents-value for a contents-key in a named-reference "
+              + "(a branch or tag).\n"
+              + "\n"
+              + "If the table-metadata is tracked globally (Iceberg), "
+              + "Nessie returns a 'Contents' object, that contains the most up-to-date part for "
+              + "the globally tracked part (Iceberg: table-metadata) plus the "
+              + "per-Nessie-reference/hash specific part (Iceberg: snapshot-ID).")
   @APIResponses({
     @APIResponse(
         responseCode = "200",
@@ -92,7 +101,17 @@ public interface HttpContentsApi extends ContentsApi {
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
-  @Operation(summary = "Get multiple objects' content")
+  @Operation(
+      summary = "Get multiple objects' content.",
+      description =
+          "Similar to 'getContents', but takes multiple 'ContentKey's and returns the "
+              + "contents-values for the one or more contents-keys in a named-reference "
+              + "(a branch or tag).\n"
+              + "\n"
+              + "If the table-metadata is tracked globally (Iceberg), "
+              + "Nessie returns a 'Contents' object, that contains the most up-to-date part for "
+              + "the globally tracked part (Iceberg: table-metadata) plus the "
+              + "per-Nessie-reference/hash specific part (Iceberg: snapshot-ID).")
   @APIResponses({
     @APIResponse(
         responseCode = "200",

--- a/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
@@ -35,7 +35,8 @@ public class CommitLogParams {
   @Nullable
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
   @Parameter(
-      description = "a particular hash on the given ref to start from",
+      description =
+          "Hash on the given ref to start from (in chronological sense), the 'far' end of the commit log, returned 'late' in the result.",
       examples = {@ExampleObject(ref = "nullHash"), @ExampleObject(ref = "hash")})
   @QueryParam("startHash")
   private String startHash;
@@ -43,7 +44,8 @@ public class CommitLogParams {
   @Nullable
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
   @Parameter(
-      description = "a particular hash on the given ref to end at",
+      description =
+          "Hash on the given ref to end at (in chronological sense), the 'near' end of the commit log, returned 'early' in the result.",
       examples = {@ExampleObject(ref = "nullHash"), @ExampleObject(ref = "hash")})
   @QueryParam("endHash")
   private String endHash;

--- a/model/src/main/java/org/projectnessie/model/Merge.java
+++ b/model/src/main/java/org/projectnessie/model/Merge.java
@@ -20,7 +20,7 @@ import static org.projectnessie.model.Validation.validateHash;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
@@ -39,11 +39,11 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableMerge.class)
 public interface Merge {
 
-  @Nullable
+  @NotBlank
   @JsonFormat(pattern = Validation.HASH_REGEX)
   String getFromHash();
 
-  @Nullable
+  @NotBlank
   @JsonFormat(pattern = Validation.REF_NAME_REGEX)
   String getSourceRefName();
 

--- a/model/src/main/java/org/projectnessie/model/Merge.java
+++ b/model/src/main/java/org/projectnessie/model/Merge.java
@@ -31,7 +31,7 @@ import org.immutables.value.Value;
     title = "Merge Operation",
     // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
     properties = {
-      @SchemaProperty(name = "sourceRefName", pattern = Validation.REF_NAME_REGEX),
+      @SchemaProperty(name = "fromRefName", pattern = Validation.REF_NAME_REGEX),
       @SchemaProperty(name = "fromHash", pattern = Validation.HASH_REGEX)
     })
 @Value.Immutable(prehash = true)
@@ -45,7 +45,7 @@ public interface Merge {
 
   @NotBlank
   @JsonFormat(pattern = Validation.REF_NAME_REGEX)
-  String getSourceRefName();
+  String getFromRefName();
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateHash(String)}

--- a/model/src/main/java/org/projectnessie/model/Merge.java
+++ b/model/src/main/java/org/projectnessie/model/Merge.java
@@ -20,7 +20,7 @@ import static org.projectnessie.model.Validation.validateHash;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import javax.validation.constraints.NotBlank;
+import javax.annotation.Nullable;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
@@ -30,15 +30,22 @@ import org.immutables.value.Value;
     type = SchemaType.OBJECT,
     title = "Merge Operation",
     // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
-    properties = {@SchemaProperty(name = "fromHash", pattern = Validation.HASH_REGEX)})
+    properties = {
+      @SchemaProperty(name = "sourceRefName", pattern = Validation.REF_NAME_REGEX),
+      @SchemaProperty(name = "fromHash", pattern = Validation.HASH_REGEX)
+    })
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableMerge.class)
 @JsonDeserialize(as = ImmutableMerge.class)
 public interface Merge {
 
-  @NotBlank
+  @Nullable
   @JsonFormat(pattern = Validation.HASH_REGEX)
   String getFromHash();
+
+  @Nullable
+  @JsonFormat(pattern = Validation.REF_NAME_REGEX)
+  String getSourceRefName();
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateHash(String)}

--- a/model/src/main/java/org/projectnessie/model/Transplant.java
+++ b/model/src/main/java/org/projectnessie/model/Transplant.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
-import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -46,7 +46,7 @@ public interface Transplant {
   @Size(min = 1)
   List<String> getHashesToTransplant();
 
-  @Nullable
+  @NotBlank
   @JsonFormat(pattern = Validation.REF_NAME_REGEX)
   String getSourceRefName();
 

--- a/model/src/main/java/org/projectnessie/model/Transplant.java
+++ b/model/src/main/java/org/projectnessie/model/Transplant.java
@@ -34,7 +34,7 @@ import org.immutables.value.Value;
     title = "Transplant",
     // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
     properties = {
-      @SchemaProperty(name = "sourceRefName", pattern = Validation.REF_NAME_REGEX),
+      @SchemaProperty(name = "fromRefName", pattern = Validation.REF_NAME_REGEX),
       @SchemaProperty(name = "hashesToTransplant", uniqueItems = true)
     })
 @Value.Immutable(prehash = true)
@@ -48,7 +48,7 @@ public interface Transplant {
 
   @NotBlank
   @JsonFormat(pattern = Validation.REF_NAME_REGEX)
-  String getSourceRefName();
+  String getFromRefName();
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateHash(String)}

--- a/model/src/main/java/org/projectnessie/model/Transplant.java
+++ b/model/src/main/java/org/projectnessie/model/Transplant.java
@@ -17,9 +17,11 @@ package org.projectnessie.model;
 
 import static org.projectnessie.model.Validation.validateHash;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -30,7 +32,11 @@ import org.immutables.value.Value;
 @Schema(
     type = SchemaType.OBJECT,
     title = "Transplant",
-    properties = {@SchemaProperty(name = "hashesToTransplant", uniqueItems = true)})
+    // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
+    properties = {
+      @SchemaProperty(name = "sourceRefName", pattern = Validation.REF_NAME_REGEX),
+      @SchemaProperty(name = "hashesToTransplant", uniqueItems = true)
+    })
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableTransplant.class)
 @JsonDeserialize(as = ImmutableTransplant.class)
@@ -39,6 +45,10 @@ public interface Transplant {
   @NotNull
   @Size(min = 1)
   List<String> getHashesToTransplant();
+
+  @Nullable
+  @JsonFormat(pattern = Validation.REF_NAME_REGEX)
+  String getSourceRefName();
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateHash(String)}

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CreateManyBranchesSimulation.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CreateManyBranchesSimulation.scala
@@ -59,6 +59,7 @@ class CreateManyBranchesSimulation extends Simulation {
           val branchName = s"branch-${session.userId}-$branchNum"
           client
             .createReference()
+            .sourceRefName(defaultBranch.getName)
             .reference(Branch.of(branchName, defaultBranch.getHash))
             .submit()
           session

--- a/python/docs/branch.rst
+++ b/python/docs/branch.rst
@@ -18,19 +18,32 @@
 	
 	      nessie branch -> list all branches
 	
-	      nessie branch main -> create branch main at current head
+	      nessie branch new_branch -> create new branch named 'new_branch' at
+	      current HEAD of the default branch
 	
-	      nessie branch main test -> create branch main at head of test
+	      nessie branch new_branch test -> create new branch named 'new_branch' at
+	      head of reference named 'test'
 	
-	      nessie branch -f main test -> assign main to head of test
+	      nessie branch -o 12345678abcdef new_branch test -> create new branch named
+	      'new_branch' at hash 12345678abcdef on reference named 'test'
+	
+	      nessie branch -f existing_branch test -> assign branch named
+	      'existing_branch' to head of reference named 'test'
+	
+	      nessie branch -o 12345678abcdef -f existing_branch test -> assign branch
+	      named 'existing_branch' to hash 12345678abcdef on reference named 'test'
 	
 	Options:
-	  -l, --list            list branches
-	  -d, --delete          delete a branch
-	  -f, --force           force branch assignment
-	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
-	                        currently points to condition.
-	  --help                Show this message and exit.
+	  -l, --list              list branches
+	  -d, --delete            delete a branch
+	  -f, --force             force branch assignment
+	  -o, --hash-on-ref TEXT  Hash on source-reference for 'create' and 'assign'
+	                          operations, if the branch shall not point to the HEAD
+	                          of the given source-reference.
+	  -c, --condition TEXT    Conditional Hash. Only perform the action if the
+	                          branch currently points to the hash specified by this
+	                          option.
+	  --help                  Show this message and exit.
 	
 	
 

--- a/python/docs/cherry-pick.rst
+++ b/python/docs/cherry-pick.rst
@@ -5,12 +5,14 @@
 	  Transplant HASHES onto current branch.
 	
 	Options:
-	  -b, --branch TEXT     branch to cherry-pick onto. If not supplied the default
-	                        branch from config is used
-	  -f, --force           force branch assignment
-	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
-	                        currently points to condition.
-	  --help                Show this message and exit.
+	  -b, --branch TEXT      branch to cherry-pick onto. If not supplied the default
+	                         branch from config is used
+	  -f, --force            force branch assignment
+	  -c, --condition TEXT   Conditional Hash. Only perform the action if branch
+	                         currently points to condition.
+	  -s, --source-ref TEXT  Name of the reference used to read the hashes from.
+	                         [required]
+	  --help                 Show this message and exit.
 	
 	
 

--- a/python/docs/merge.rst
+++ b/python/docs/merge.rst
@@ -5,12 +5,13 @@
 	  Merge FROM_BRANCH into current branch. FROM_BRANCH can be a hash or branch.
 	
 	Options:
-	  -b, --branch TEXT     branch to merge onto. If not supplied the default branch
-	                        from config is used
-	  -f, --force           force branch assignment
-	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
-	                        currently points to condition.
-	  --help                Show this message and exit.
+	  -b, --branch TEXT       branch to merge onto. If not supplied the default
+	                          branch from config is used
+	  -f, --force             force branch assignment
+	  -c, --condition TEXT    Conditional Hash. Only perform the action if branch
+	                          currently points to condition.
+	  -o, --hash-on-ref TEXT  Hash on merge-from-reference
+	  --help                  Show this message and exit.
 	
 	
 

--- a/python/docs/tag.rst
+++ b/python/docs/tag.rst
@@ -18,19 +18,31 @@
 	
 	      nessie tag -> list all tags
 	
-	      nessie tag main -> create tag xxx at current head
+	      nessie tag new_tag -> create new tag named 'new_tag' at current HEAD of
+	      the default branch
 	
-	      nessie tag main test -> create tag xxx at head of test
+	      nessie tag new_tag test -> create new tag named 'new_tag' at head of
+	      reference named 'test'
 	
-	      nessie tag -f main test -> assign xxx to head of test
+	      nessie tag -o 12345678abcdef new_tag test -> create new tag named
+	      'new_tag' at hash 12345678abcdef on reference named 'test'
+	
+	      nessie tag -f existing_tag test -> assign tag named 'existing_tag' to head
+	      of reference named 'test'
+	
+	      nessie tag -o 12345678abcdef -f existing_tag test -> assign tag named
+	      'existing_tag' to hash 12345678abcdef on reference named 'test'
 	
 	Options:
-	  -l, --list            list branches
-	  -d, --delete          delete a branches
-	  -f, --force           force branch assignment
-	  -c, --condition TEXT  Conditional Hash. Only perform the action if branch
-	                        currently points to condition.
-	  --help                Show this message and exit.
+	  -l, --list              list branches
+	  -d, --delete            delete a branches
+	  -f, --force             force branch assignment
+	  -o, --hash-on-ref TEXT  Hash on source-reference for 'create' and 'assign'
+	                          operations, if the tag shall not point to the HEAD of
+	                          the given source-reference.
+	  -c, --condition TEXT    Conditional Hash. Only perform the action if the tag
+	                          currently points to the hash specified by this option.
+	  --help                  Show this message and exit.
 	
 	
 

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -164,7 +164,7 @@ class Reference:
     """Dataclass for Nessie Reference."""
 
     name: str = desert.ib(fields.Str())
-    hash_: Optional[str] = desert.ib(fields.Str(data_key="hash"))
+    hash_: Optional[str] = attr.ib(default=None, metadata=desert.metadata(fields.Str(data_key="hash", allow_none=True)))
 
 
 @attr.dataclass
@@ -285,6 +285,7 @@ LogResponseSchema = desert.schema_class(LogResponse)
 class Transplant:
     """Dataclass for Transplant operation."""
 
+    source_ref_name: str = attr.ib(metadata=desert.metadata(fields.Str(data_key="sourceRefName")))
     hashes_to_transplant: List[str] = attr.ib(metadata=desert.metadata(fields.List(fields.Str(), data_key="hashesToTransplant")))
 
 
@@ -295,6 +296,7 @@ TransplantSchema = desert.schema_class(Transplant)
 class Merge:
     """Dataclass for Merge operation."""
 
+    source_ref_name: str = attr.ib(metadata=desert.metadata(fields.Str(data_key="sourceRefName")))
     from_hash: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(data_key="fromHash")))
 
 

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -285,7 +285,7 @@ LogResponseSchema = desert.schema_class(LogResponse)
 class Transplant:
     """Dataclass for Transplant operation."""
 
-    source_ref_name: str = attr.ib(metadata=desert.metadata(fields.Str(data_key="sourceRefName")))
+    from_ref_name: str = attr.ib(metadata=desert.metadata(fields.Str(data_key="fromRefName")))
     hashes_to_transplant: List[str] = attr.ib(metadata=desert.metadata(fields.List(fields.Str(), data_key="hashesToTransplant")))
 
 
@@ -296,7 +296,7 @@ TransplantSchema = desert.schema_class(Transplant)
 class Merge:
     """Dataclass for Merge operation."""
 
-    source_ref_name: str = attr.ib(metadata=desert.metadata(fields.Str(data_key="sourceRefName")))
+    from_ref_name: str = attr.ib(metadata=desert.metadata(fields.Str(data_key="fromRefName")))
     from_hash: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(data_key="fromHash")))
 
 

--- a/python/pynessie/nessie_client.py
+++ b/python/pynessie/nessie_client.py
@@ -191,7 +191,9 @@ class NessieClient(object):
         if not old_hash:
             old_hash = self.get_reference(onto_branch).hash_
         assert old_hash is not None
-        merge_json = MergeSchema().dump(Merge(from_branch, from_hash or self.get_reference(from_branch).hash_))
+        if not from_hash:
+            from_hash = self.get_reference(from_branch).hash_
+        merge_json = MergeSchema().dump(Merge(from_branch, str(from_hash)))
         merge(self._base_url, self._auth, onto_branch, merge_json, old_hash, self._ssl_verify)
 
     def cherry_pick(self: "NessieClient", branch: str, from_ref: str, old_hash: Optional[str] = None, *hashes: str) -> None:

--- a/python/pynessie/nessie_client.py
+++ b/python/pynessie/nessie_client.py
@@ -191,9 +191,7 @@ class NessieClient(object):
         if not old_hash:
             old_hash = self.get_reference(onto_branch).hash_
         assert old_hash is not None
-        if not from_hash:
-            from_hash = self.get_reference(from_branch).hash_
-        merge_json = MergeSchema().dump(Merge(from_branch, from_hash))
+        merge_json = MergeSchema().dump(Merge(from_branch, from_hash or self.get_reference(from_branch).hash_))
         merge(self._base_url, self._auth, onto_branch, merge_json, old_hash, self._ssl_verify)
 
     def cherry_pick(self: "NessieClient", branch: str, from_ref: str, old_hash: Optional[str] = None, *hashes: str) -> None:

--- a/python/pynessie/nessie_client.py
+++ b/python/pynessie/nessie_client.py
@@ -84,15 +84,16 @@ class NessieClient(object):
         ref = ReferenceSchema().load(ref_obj)
         return ref
 
-    def create_branch(self: "NessieClient", branch: str, ref: str = None) -> Branch:
+    def create_branch(self: "NessieClient", branch: str, ref: Optional[str] = None, hash_on_ref: Optional[str] = None) -> Branch:
         """Create a branch.
 
-        :param branch: name of new branch
-        :param ref: ref to fork from
+        :param branch: name of new branch to create
+        :param ref: name of the reference via which 'hash_on_ref' is reachable
+        :param hash_on_ref: hash to assign 'branch' to
         :return: Nessie branch object
         """
-        ref_json = ReferenceSchema().dump(Branch(branch, ref))
-        ref_obj = create_reference(self._base_url, self._auth, ref_json, self._ssl_verify)
+        ref_json = ReferenceSchema().dump(Branch(branch, hash_on_ref) if hash_on_ref else Branch(branch))
+        ref_obj = create_reference(self._base_url, self._auth, ref_json, ref, self._ssl_verify)
         return cast(Branch, ReferenceSchema().load(ref_obj))
 
     def delete_branch(self: "NessieClient", branch: str, hash_: str) -> None:
@@ -103,15 +104,16 @@ class NessieClient(object):
         """
         delete_branch(self._base_url, self._auth, branch, hash_, self._ssl_verify)
 
-    def create_tag(self: "NessieClient", tag: str, ref: str = None) -> Tag:
+    def create_tag(self: "NessieClient", tag: str, ref: str, hash_on_ref: Optional[str] = None) -> Tag:
         """Create a tag.
 
-        :param tag: name of new tag
-        :param ref: ref to fork from
+        :param tag: name of new tag to create
+        :param ref: name of the reference via which 'hash_on_ref' is reachable
+        :param hash_on_ref: hash to assign 'branch' to
         :return: Nessie tag object
         """
-        ref_json = ReferenceSchema().dump(Tag(tag, ref))
-        ref_obj = create_reference(self._base_url, self._auth, ref_json, self._ssl_verify)
+        ref_json = ReferenceSchema().dump(Tag(tag, hash_on_ref) if hash_on_ref else Tag(tag))
+        ref_obj = create_reference(self._base_url, self._auth, ref_json, ref, self._ssl_verify)
         return cast(Tag, ReferenceSchema().load(ref_obj))
 
     def delete_tag(self: "NessieClient", tag: str, hash_: str) -> None:
@@ -125,6 +127,7 @@ class NessieClient(object):
     def list_keys(
         self: "NessieClient",
         ref: str,
+        hash_on_ref: str = None,
         max_result_hint: Optional[int] = None,
         page_token: Optional[str] = None,
         query_expression: Optional[str] = None,
@@ -132,22 +135,26 @@ class NessieClient(object):
         """Fetch a list of all tables from a known branch.
 
         :param ref: name of branch
+        :param hash_on_ref: hash on reference
         :param entity_types: list of types to filter keys on
         :param query_expression: A CEL expression that allows advanced filtering capabilities
         :return: list of Nessie table names
         """
         return EntriesSchema().load(
-            list_tables(self._base_url, self._auth, ref, max_result_hint, page_token, query_expression, self._ssl_verify)
+            list_tables(self._base_url, self._auth, ref, hash_on_ref, max_result_hint, page_token, query_expression, self._ssl_verify)
         )
 
-    def get_values(self: "NessieClient", ref: str, *tables: str) -> Generator[Contents, Any, None]:
+    def get_values(self: "NessieClient", ref: str, *tables: str, hash_on_ref: Optional[str] = None) -> Generator[Contents, Any, None]:
         """Fetch a table from a known ref.
 
         :param ref: name of ref
+        :param hash_on_ref: hash on reference
         :param tables: tables to fetch
         :return: Nessie Table
         """
-        return (ContentsSchema().load(get_table(self._base_url, self._auth, ref, _format_key(i), self._ssl_verify)) for i in tables)
+        return (
+            ContentsSchema().load(get_table(self._base_url, self._auth, ref, _format_key(i), hash_on_ref, self._ssl_verify)) for i in tables
+        )
 
     def commit(
         self: "NessieClient", branch: str, old_hash: str, reason: Optional[str] = None, author: Optional[str] = None, *ops: Operation
@@ -159,41 +166,45 @@ class NessieClient(object):
         ref_obj = commit(self._base_url, self._auth, branch, MultiContentsSchema().dumps(MultiContents(meta, list(ops))), old_hash)
         return cast(Branch, ReferenceSchema().load(ref_obj))
 
-    def assign_branch(self: "NessieClient", branch: str, to_ref: str, old_hash: Optional[str] = None) -> None:
+    def assign_branch(
+        self: "NessieClient", branch: str, to_ref: str, to_ref_hash: Optional[str] = None, old_hash: Optional[str] = None
+    ) -> None:
         """Assign a hash to a branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
         assert old_hash is not None
-        branch_json = ReferenceSchema().dumps(Branch(branch, self.get_reference(to_ref).hash_))
-        assign_branch(self._base_url, self._auth, branch, branch_json, old_hash, self._ssl_verify)
+        ref_json = ReferenceSchema().dumps(Branch(to_ref, to_ref_hash) if to_ref_hash else Branch(to_ref))
+        assign_branch(self._base_url, self._auth, branch, ref_json, old_hash, self._ssl_verify)
 
-    def assign_tag(self: "NessieClient", tag: str, to_ref: str, old_hash: Optional[str] = None) -> None:
+    def assign_tag(self: "NessieClient", tag: str, to_ref: str, to_ref_hash: Optional[str] = None, old_hash: Optional[str] = None) -> None:
         """Assign a hash to a tag."""
         if not old_hash:
             old_hash = self.get_reference(tag).hash_
         assert old_hash is not None
-        tag_json = ReferenceSchema().dumps(Tag(tag, self.get_reference(to_ref).hash_))
-        assign_tag(self._base_url, self._auth, tag, tag_json, old_hash, self._ssl_verify)
+        ref_json = ReferenceSchema().dumps(Tag(to_ref, to_ref_hash) if to_ref_hash else Tag(to_ref))
+        assign_tag(self._base_url, self._auth, tag, ref_json, old_hash, self._ssl_verify)
 
-    def merge(self: "NessieClient", from_branch: str, onto_branch: str, old_hash: Optional[str] = None) -> None:
+    def merge(
+        self: "NessieClient", from_branch: str, onto_branch: str, from_hash: Optional[str] = None, old_hash: Optional[str] = None
+    ) -> None:
         """Merge a branch into another branch."""
         if not old_hash:
             old_hash = self.get_reference(onto_branch).hash_
         assert old_hash is not None
-        from_hash = self.get_reference(from_branch).hash_
-        assert from_hash is not None
-        merge_json = MergeSchema().dump(Merge(from_hash))
+        merge_json = MergeSchema().dump(Merge(from_branch, from_hash) if from_hash else Merge(from_branch))
         merge(self._base_url, self._auth, onto_branch, merge_json, old_hash, self._ssl_verify)
 
-    def cherry_pick(self: "NessieClient", branch: str, old_hash: Optional[str] = None, *hashes: str) -> None:
+    def cherry_pick(self: "NessieClient", branch: str, from_ref: str, old_hash: Optional[str] = None, *hashes: str) -> None:
         """Cherry pick a list of hashes to a branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
         assert old_hash is not None
-        transplant_json = TransplantSchema().dump(Transplant(list(hashes)))
+        transplant_json = TransplantSchema().dump(Transplant(from_ref, list(hashes)))
         cherry_pick(self._base_url, self._auth, branch, transplant_json, old_hash, self._ssl_verify)
 
-    def get_log(self: "NessieClient", start_ref: str, **filtering_args: Any) -> Generator[CommitMeta, Any, None]:
+    def get_log(
+        self: "NessieClient", start_ref: str, hash_on_ref: Optional[str] = None, **filtering_args: Any
+    ) -> Generator[CommitMeta, Any, None]:
         """Fetch all logs starting at start_ref.
 
         start_ref can be any ref.
@@ -208,7 +219,14 @@ class NessieClient(object):
             if token:
                 filtering_args["pageToken"] = token
 
-            fetched_logs = list_logs(base_url=self._base_url, auth=self._auth, ref=start_ref, ssl_verify=self._ssl_verify, **filtering_args)
+            fetched_logs = list_logs(
+                base_url=self._base_url,
+                auth=self._auth,
+                hash_on_ref=hash_on_ref,
+                ref=start_ref,
+                ssl_verify=self._ssl_verify,
+                **filtering_args
+            )
             log_schema = LogResponseSchema().load(fetched_logs)
             return log_schema
 

--- a/python/pynessie/nessie_client.py
+++ b/python/pynessie/nessie_client.py
@@ -191,7 +191,9 @@ class NessieClient(object):
         if not old_hash:
             old_hash = self.get_reference(onto_branch).hash_
         assert old_hash is not None
-        merge_json = MergeSchema().dump(Merge(from_branch, from_hash) if from_hash else Merge(from_branch))
+        if not from_hash:
+            from_hash = self.get_reference(from_branch).hash_
+        merge_json = MergeSchema().dump(Merge(from_branch, from_hash))
         merge(self._base_url, self._auth, onto_branch, merge_json, old_hash, self._ssl_verify)
 
     def cherry_pick(self: "NessieClient", branch: str, from_ref: str, old_hash: Optional[str] = None, *hashes: str) -> None:

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -1,11 +1,13 @@
 interactions:
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -34,6 +36,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -43,7 +47,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -61,6 +65,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -81,16 +87,18 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
+      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
+      "commitMeta": {"hash": null, "message": "test_message", "committer": null, "authorTime":
+      null, "signedOffBy": null, "email": null, "author": null, "properties": null,
+      "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -103,7 +111,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -119,6 +127,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -127,7 +137,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -137,12 +147,14 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -152,7 +164,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56
   response:
     body:
       string: ''
@@ -167,6 +179,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -176,8 +190,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}
+        \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}
         ]"
     headers:
       Content-Length:
@@ -194,6 +208,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -219,6 +235,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -227,7 +245,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -237,13 +255,15 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89",
-      "type": "TAG"}'
+    body: '{"hash": "9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -256,7 +276,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -272,6 +292,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -281,9 +303,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}, {\n
-        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n},
-        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}
+        \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}
         ]"
     headers:
       Content-Length:
@@ -300,6 +322,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -308,7 +332,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -318,12 +342,14 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": null, "type": "TAG"}'
+    body: '{"hash": null, "name": "dev", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -333,7 +359,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041
   response:
     body:
       string: ''
@@ -348,6 +374,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -357,9 +385,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}, {\n
-        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n},
-        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}
+        \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}
         ]"
     headers:
       Content-Length:
@@ -376,6 +404,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -384,7 +414,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -400,6 +430,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -407,7 +439,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041
   response:
     body:
       string: ''
@@ -422,6 +454,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -430,7 +464,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -446,6 +480,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -453,7 +489,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041
   response:
     body:
       string: ''
@@ -468,6 +504,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -477,10 +515,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\",\n
+        [ {\n    \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:53.536606Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:53.536606Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:43:01.171160Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:43:01.171160Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -497,6 +535,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -516,15 +556,17 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"message": "delete_message", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"hash": null, "message": "delete_message", "committer": null,
+      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
+      null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -534,10 +576,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"aad52efc4bca47f006053a23e57faf0c150da16c2239b79df8253f6797c118c7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5d8f928da63f1a6355012eb41e4961cfb92ea02cf6c051d02e1a5ec8ecb4c712\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -553,6 +595,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -561,7 +605,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"aad52efc4bca47f006053a23e57faf0c150da16c2239b79df8253f6797c118c7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5d8f928da63f1a6355012eb41e4961cfb92ea02cf6c051d02e1a5ec8ecb4c712\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -577,6 +621,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -584,7 +630,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=aad52efc4bca47f006053a23e57faf0c150da16c2239b79df8253f6797c118c7
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=5d8f928da63f1a6355012eb41e4961cfb92ea02cf6c051d02e1a5ec8ecb4c712
   response:
     body:
       string: ''
@@ -593,12 +639,14 @@ interactions:
       code: 204
       message: No Content
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -18,8 +18,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -43,10 +42,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '247'
@@ -70,9 +69,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=dev
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -82,11 +81,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "contents": {"id":
-      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "test_message", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -104,8 +103,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -129,8 +127,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -140,33 +137,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "main", "hash": "180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b",
-      "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -175,13 +146,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '110'
+      - '47'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582
   response:
     body:
       string: ''
@@ -204,10 +175,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}
+        ]"
     headers:
       Content-Length:
       - '247'
@@ -231,8 +202,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"message\" : \"Unable to find reference [v1.0].\",\n  \"status\"\
-        \ : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Unable to find reference [v1.0].\",\n  \"status\"
+        : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
       - '125'
@@ -256,8 +227,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -267,7 +237,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b",
+    body: '{"name": "v1.0", "hash": "4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89",
       "type": "TAG"}'
     headers:
       Accept:
@@ -283,11 +253,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/tree
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        \n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -311,11 +280,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\n},\
-        \ {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        \n}, {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}
+        ]"
     headers:
       Content-Length:
       - '367'
@@ -339,8 +308,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        \n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -350,33 +318,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "v1.0", "hash": "180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b",
-      "type": "TAG"}'
+    body: '{"name": "dev", "hash": null, "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -385,13 +327,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '107'
+      - '44'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89
   response:
     body:
       string: ''
@@ -414,11 +356,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\n},\
-        \ {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        \n}, {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}
+        ]"
     headers:
       Content-Length:
       - '367'
@@ -442,8 +384,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -466,7 +407,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89
   response:
     body:
       string: ''
@@ -489,8 +430,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        \n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -513,7 +453,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89
   response:
     body:
       string: ''
@@ -536,12 +476,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:18.601676Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:18.601676Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:53.536606Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:53.536606Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '372'
@@ -565,8 +505,8 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"\
-        \ : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
+        : \"/a/b/c\"\n}"
     headers:
       Content-Length:
       - '80'
@@ -576,10 +516,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "delete_message", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "delete_message", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -594,11 +534,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=180d3c71a5122f41243428f59b104acf553028c64f1a860cd1f62fabb26b303b
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=4ea334a5267893cac4aa9a7d0b3a13954a6b922de0867e5527b87c1fb57c4a89
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        a3956d16cde831e9caf3e12c20b264204e88c075d8b5443b25c4bc090579618b\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"aad52efc4bca47f006053a23e57faf0c150da16c2239b79df8253f6797c118c7\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -622,8 +561,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        a3956d16cde831e9caf3e12c20b264204e88c075d8b5443b25c4bc090579618b\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"aad52efc4bca47f006053a23e57faf0c150da16c2239b79df8253f6797c118c7\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -646,7 +584,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=a3956d16cde831e9caf3e12c20b264204e88c075d8b5443b25c4bc090579618b
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=aad52efc4bca47f006053a23e57faf0c150da16c2239b79df8253f6797c118c7
   response:
     body:
       string: ''
@@ -673,8 +611,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '121'

--- a/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
@@ -14,9 +14,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
     headers:
       Content-Length:
       - '125'

--- a/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
@@ -6,6 +6,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:

--- a/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
@@ -1,11 +1,13 @@
 interactions:
 - request:
-    body: '{"name": "contents_listing_dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "contents_listing_dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -35,6 +37,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -62,6 +66,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -82,16 +88,18 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message1", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["this",
-      "is", "iceberg", "foo"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
+      "type": "ICEBERG_TABLE"}, "key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "type": "PUT"}], "commitMeta": {"hash": null, "message": "test_message1", "committer":
+      null, "authorTime": null, "signedOffBy": null, "email": null, "author": null,
+      "properties": null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -105,7 +113,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"a1172b52b4a0338fdd1785cc75794cec2c70222153b129760393cd0a4bdd4ddd\"\n}"
+        \ \"hash\" : \"6d3f00abff8deb17af46ab68b6fb02b40344f03d42617f1a0ff0bbda3e2f26ba\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -121,6 +129,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -130,7 +140,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"a1172b52b4a0338fdd1785cc75794cec2c70222153b129760393cd0a4bdd4ddd\"\n},
+        \ \"hash\" : \"6d3f00abff8deb17af46ab68b6fb02b40344f03d42617f1a0ff0bbda3e2f26ba\"\n},
         {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -148,6 +158,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -168,17 +180,19 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message2", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["this",
-      "is", "delta", "bar"]}, "contents": {"metadataLocationHistory": ["asd"], "checkpointLocationHistory":
+    body: '{"operations": [{"contents": {"metadataLocationHistory": ["asd"], "checkpointLocationHistory":
       ["def"], "id": "uuid2", "lastCheckpoint": "x", "type": "DELTA_LAKE_TABLE"},
-      "type": "PUT"}]}'
+      "key": {"elements": ["this", "is", "delta", "bar"]}, "type": "PUT"}], "commitMeta":
+      {"hash": null, "message": "test_message2", "committer": null, "authorTime":
+      null, "signedOffBy": null, "email": null, "author": null, "properties": null,
+      "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -188,11 +202,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=a1172b52b4a0338fdd1785cc75794cec2c70222153b129760393cd0a4bdd4ddd
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=6d3f00abff8deb17af46ab68b6fb02b40344f03d42617f1a0ff0bbda3e2f26ba
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"23e4118b9228da94ce88857bb3c5aafd140d568e4bef768cbf26494eda6d64c9\"\n}"
+        \ \"hash\" : \"7d60bba3165f1425ecf3102e7bfda632fa1d1c8110f77f6dbd1c290f9dc2bad3\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -208,6 +222,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -217,7 +233,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"23e4118b9228da94ce88857bb3c5aafd140d568e4bef768cbf26494eda6d64c9\"\n},
+        \ \"hash\" : \"7d60bba3165f1425ecf3102e7bfda632fa1d1c8110f77f6dbd1c290f9dc2bad3\"\n},
         {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -235,6 +251,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -255,16 +273,18 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message3", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["this",
-      "is", "sql", "baz"]}, "contents": {"sqlText": "SELECT * FROM foo", "id": "uuid3",
-      "dialect": "SPARK", "type": "VIEW"}, "type": "PUT"}]}'
+    body: '{"operations": [{"contents": {"sqlText": "SELECT * FROM foo", "dialect":
+      "SPARK", "id": "uuid3", "type": "VIEW"}, "key": {"elements": ["this", "is",
+      "sql", "baz"]}, "type": "PUT"}], "commitMeta": {"hash": null, "message": "test_message3",
+      "committer": null, "authorTime": null, "signedOffBy": null, "email": null, "author":
+      null, "properties": null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -274,11 +294,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=23e4118b9228da94ce88857bb3c5aafd140d568e4bef768cbf26494eda6d64c9
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=7d60bba3165f1425ecf3102e7bfda632fa1d1c8110f77f6dbd1c290f9dc2bad3
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"fcecfcbbfa469e99975d840fdc194eaa7c8e777d4165ad34c83ff2063ec16fc3\"\n}"
+        \ \"hash\" : \"5b7ee352a8aca498f9450c17805e4408af348e89e42b0492c6334bf259e6b718\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -294,6 +314,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -319,6 +341,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -345,6 +369,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -371,6 +397,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -397,6 +425,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -423,6 +453,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -451,6 +483,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -477,6 +511,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -507,6 +543,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -516,7 +554,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"fcecfcbbfa469e99975d840fdc194eaa7c8e777d4165ad34c83ff2063ec16fc3\"\n}"
+        \ \"hash\" : \"5b7ee352a8aca498f9450c17805e4408af348e89e42b0492c6334bf259e6b718\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -532,6 +570,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -539,7 +579,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev?expectedHash=fcecfcbbfa469e99975d840fdc194eaa7c8e777d4165ad34c83ff2063ec16fc3
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev?expectedHash=5b7ee352a8aca498f9450c17805e4408af348e89e42b0492c6334bf259e6b718
   response:
     body:
       string: ''

--- a/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
@@ -18,9 +18,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\"\
-        ,\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\
-        \n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
+        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -44,10 +43,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\"\
-        ,\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\
-        \n}, {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
+        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '264'
@@ -71,9 +70,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_listing_dev
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -83,11 +82,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "contents": {"id": "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}], "commitMeta": {"signedOffBy": null, "email": null, "properties":
-      null, "message": "test_message1", "authorTime": null, "hash": null, "author":
-      null, "commitTime": null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message1", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["this",
+      "is", "iceberg", "foo"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -105,9 +104,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\"\
-        ,\n  \"hash\" : \"0a28d82695ed303cbf5f085b1bfc86f4e69a856f9244749e30ee399ebd0acfbd\"\
-        \n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
+        \ \"hash\" : \"a1172b52b4a0338fdd1785cc75794cec2c70222153b129760393cd0a4bdd4ddd\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -131,10 +129,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\"\
-        ,\n  \"hash\" : \"0a28d82695ed303cbf5f085b1bfc86f4e69a856f9244749e30ee399ebd0acfbd\"\
-        \n}, {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
+        \ \"hash\" : \"a1172b52b4a0338fdd1785cc75794cec2c70222153b129760393cd0a4bdd4ddd\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '264'
@@ -158,9 +156,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_listing_dev
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -170,12 +168,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "delta", "bar"]}, "contents":
-      {"id": "uuid2", "lastCheckpoint": "x", "checkpointLocationHistory": ["def"],
-      "metadataLocationHistory": ["asd"], "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "test_message2", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message2", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["this",
+      "is", "delta", "bar"]}, "contents": {"metadataLocationHistory": ["asd"], "checkpointLocationHistory":
+      ["def"], "id": "uuid2", "lastCheckpoint": "x", "type": "DELTA_LAKE_TABLE"},
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -190,12 +188,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=0a28d82695ed303cbf5f085b1bfc86f4e69a856f9244749e30ee399ebd0acfbd
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=a1172b52b4a0338fdd1785cc75794cec2c70222153b129760393cd0a4bdd4ddd
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\"\
-        ,\n  \"hash\" : \"532d07bcdc76a141ed2132c6958c1b9eb1c271f6025dec9d73567b6943443c14\"\
-        \n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
+        \ \"hash\" : \"23e4118b9228da94ce88857bb3c5aafd140d568e4bef768cbf26494eda6d64c9\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -219,10 +216,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\"\
-        ,\n  \"hash\" : \"532d07bcdc76a141ed2132c6958c1b9eb1c271f6025dec9d73567b6943443c14\"\
-        \n}, {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
+        \ \"hash\" : \"23e4118b9228da94ce88857bb3c5aafd140d568e4bef768cbf26494eda6d64c9\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '264'
@@ -246,9 +243,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.sql.baz?ref=contents_listing_dev
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -258,11 +255,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "sql", "baz"]}, "contents":
-      {"dialect": "SPARK", "id": "uuid3", "sqlText": "SELECT * FROM foo", "type": "VIEW"},
-      "type": "PUT"}], "commitMeta": {"signedOffBy": null, "email": null, "properties":
-      null, "message": "test_message3", "authorTime": null, "hash": null, "author":
-      null, "commitTime": null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message3", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["this",
+      "is", "sql", "baz"]}, "contents": {"sqlText": "SELECT * FROM foo", "id": "uuid3",
+      "dialect": "SPARK", "type": "VIEW"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -271,18 +268,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '369'
+      - '370'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=532d07bcdc76a141ed2132c6958c1b9eb1c271f6025dec9d73567b6943443c14
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=23e4118b9228da94ce88857bb3c5aafd140d568e4bef768cbf26494eda6d64c9
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\"\
-        ,\n  \"hash\" : \"4a048b8b9c121d9d513eb4d91286348337251726380eb7a53d2ef09e038edd53\"\
-        \n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
+        \ \"hash\" : \"fcecfcbbfa469e99975d840fdc194eaa7c8e777d4165ad34c83ff2063ec16fc3\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -306,8 +302,8 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_listing_dev
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"\
-        \ : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
+        : \"/a/b/c\"\n}"
     headers:
       Content-Length:
       - '80'
@@ -331,9 +327,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_listing_dev
   response:
     body:
-      string: "{\n  \"type\" : \"DELTA_LAKE_TABLE\",\n  \"id\" : \"uuid2\",\n  \"\
-        metadataLocationHistory\" : [ \"asd\" ],\n  \"checkpointLocationHistory\"\
-        \ : [ \"def\" ],\n  \"lastCheckpoint\" : \"x\"\n}"
+      string: "{\n  \"type\" : \"DELTA_LAKE_TABLE\",\n  \"id\" : \"uuid2\",\n  \"metadataLocationHistory\"
+        : [ \"asd\" ],\n  \"checkpointLocationHistory\" : [ \"def\" ],\n  \"lastCheckpoint\"
+        : \"x\"\n}"
     headers:
       Content-Length:
       - '161'
@@ -357,9 +353,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n\
-        \    \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :\
-        \ [ \"this\", \"is\", \"iceberg\", \"foo\" ]\n    }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n
+        \   \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :
+        [ \"this\", \"is\", \"iceberg\", \"foo\" ]\n    }\n  } ]\n}"
     headers:
       Content-Length:
       - '171'
@@ -383,9 +379,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev/entries?query_expression=entry.contentType+in+%5B%27DELTA_LAKE_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n\
-        \    \"type\" : \"DELTA_LAKE_TABLE\",\n    \"name\" : {\n      \"elements\"\
-        \ : [ \"this\", \"is\", \"delta\", \"bar\" ]\n    }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n
+        \   \"type\" : \"DELTA_LAKE_TABLE\",\n    \"name\" : {\n      \"elements\"
+        : [ \"this\", \"is\", \"delta\", \"bar\" ]\n    }\n  } ]\n}"
     headers:
       Content-Length:
       - '172'
@@ -409,9 +405,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev/entries?query_expression=entry.contentType+%3D%3D+%27ICEBERG_TABLE%27
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n\
-        \    \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :\
-        \ [ \"this\", \"is\", \"iceberg\", \"foo\" ]\n    }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n
+        \   \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :
+        [ \"this\", \"is\", \"iceberg\", \"foo\" ]\n    }\n  } ]\n}"
     headers:
       Content-Length:
       - '171'
@@ -435,11 +431,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%2C+%27DELTA_LAKE_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n\
-        \    \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :\
-        \ [ \"this\", \"is\", \"iceberg\", \"foo\" ]\n    }\n  }, {\n    \"type\"\
-        \ : \"DELTA_LAKE_TABLE\",\n    \"name\" : {\n      \"elements\" : [ \"this\"\
-        , \"is\", \"delta\", \"bar\" ]\n    }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n
+        \   \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :
+        [ \"this\", \"is\", \"iceberg\", \"foo\" ]\n    }\n  }, {\n    \"type\" :
+        \"DELTA_LAKE_TABLE\",\n    \"name\" : {\n      \"elements\" : [ \"this\",
+        \"is\", \"delta\", \"bar\" ]\n    }\n  } ]\n}"
     headers:
       Content-Length:
       - '284'
@@ -463,9 +459,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev/entries?query_expression=entry.namespace.startsWith%28%27this.is.del%27%29
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n\
-        \    \"type\" : \"DELTA_LAKE_TABLE\",\n    \"name\" : {\n      \"elements\"\
-        \ : [ \"this\", \"is\", \"delta\", \"bar\" ]\n    }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n
+        \   \"type\" : \"DELTA_LAKE_TABLE\",\n    \"name\" : {\n      \"elements\"
+        : [ \"this\", \"is\", \"delta\", \"bar\" ]\n    }\n  } ]\n}"
     headers:
       Content-Length:
       - '172'
@@ -489,13 +485,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev/entries?query_expression=entry.namespace.startsWith%28%27this.is%27%29
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n\
-        \    \"type\" : \"VIEW\",\n    \"name\" : {\n      \"elements\" : [ \"this\"\
-        , \"is\", \"sql\", \"baz\" ]\n    }\n  }, {\n    \"type\" : \"ICEBERG_TABLE\"\
-        ,\n    \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"iceberg\"\
-        , \"foo\" ]\n    }\n  }, {\n    \"type\" : \"DELTA_LAKE_TABLE\",\n    \"name\"\
-        \ : {\n      \"elements\" : [ \"this\", \"is\", \"delta\", \"bar\" ]\n   \
-        \ }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n
+        \   \"type\" : \"VIEW\",\n    \"name\" : {\n      \"elements\" : [ \"this\",
+        \"is\", \"sql\", \"baz\" ]\n    }\n  }, {\n    \"type\" : \"ICEBERG_TABLE\",\n
+        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"iceberg\", \"foo\"
+        ]\n    }\n  }, {\n    \"type\" : \"DELTA_LAKE_TABLE\",\n    \"name\" : {\n
+        \     \"elements\" : [ \"this\", \"is\", \"delta\", \"bar\" ]\n    }\n  }
+        ]\n}"
     headers:
       Content-Length:
       - '383'
@@ -519,9 +515,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\"\
-        ,\n  \"hash\" : \"4a048b8b9c121d9d513eb4d91286348337251726380eb7a53d2ef09e038edd53\"\
-        \n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
+        \ \"hash\" : \"fcecfcbbfa469e99975d840fdc194eaa7c8e777d4165ad34c83ff2063ec16fc3\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -544,7 +539,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev?expectedHash=4a048b8b9c121d9d513eb4d91286348337251726380eb7a53d2ef09e038edd53
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev?expectedHash=fcecfcbbfa469e99975d840fdc194eaa7c8e777d4165ad34c83ff2063ec16fc3
   response:
     body:
       string: ''

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -6,6 +6,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -31,6 +33,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -56,6 +60,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -76,16 +82,18 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message", "hash": null, "author": "nessie_user1",
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
+      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
+      "commitMeta": {"hash": null, "message": "test_message", "committer": null, "authorTime":
+      null, "signedOffBy": null, "email": null, "author": "nessie_user1", "properties":
+      null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -98,7 +106,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -114,6 +122,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -139,6 +149,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -148,10 +160,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        [ {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -168,19 +180,21 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        [ {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -197,6 +211,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -223,6 +239,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -242,15 +260,17 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"message": "delete_message", "hash": null, "author": "nessie_user2",
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"hash": null, "message": "delete_message", "committer": null,
+      "authorTime": null, "signedOffBy": null, "email": null, "author": "nessie_user2",
+      "properties": null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -260,10 +280,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -279,6 +299,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -288,14 +310,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -312,19 +334,21 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582&endHash=9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56&endHash=c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        [ {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -341,6 +365,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -350,14 +376,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -374,6 +400,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -383,10 +411,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        [ {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -403,6 +431,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -412,10 +442,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -432,6 +462,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -441,14 +473,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -465,6 +497,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -474,14 +508,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -498,6 +532,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -507,10 +543,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -527,6 +563,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -536,14 +574,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -14,8 +14,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ ]\n}"
     headers:
       Content-Length:
       - '63'
@@ -39,9 +39,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -65,9 +64,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -77,11 +76,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "contents": {"id":
-      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "test_message", "authorTime": null, "hash": null, "author": "nessie_user1",
-      "commitTime": null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message", "hash": null, "author": "nessie_user1",
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -99,8 +98,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -124,8 +122,8 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"\
-        \ : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
+        : \"/a/b/c\"\n}"
     headers:
       Content-Length:
       - '80'
@@ -149,12 +147,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '384'
@@ -175,15 +173,15 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '384'
@@ -207,9 +205,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/entries
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n\
-        \    \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :\
-        \ [ \"foo\", \"bar\" ]\n    }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n
+        \   \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :
+        [ \"foo\", \"bar\" ]\n    }\n  } ]\n}"
     headers:
       Content-Length:
       - '153'
@@ -233,8 +231,8 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"\
-        \ : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
+        : \"/a/b/c\"\n}"
     headers:
       Content-Length:
       - '80'
@@ -244,10 +242,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "delete_message", "authorTime": null, "hash": null, "author": "nessie_user2",
-      "commitTime": null, "committer": null}}'
+    body: '{"commitMeta": {"message": "delete_message", "hash": null, "author": "nessie_user2",
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -262,11 +260,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -290,16 +287,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"\
-        2021-07-19T11:59:15.665506Z\",\n    \"authorTime\" : \"2021-07-19T11:59:15.665506Z\"\
-        ,\n    \"properties\" : { }\n  }, {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
@@ -320,15 +317,15 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a&endHash=1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582&endHash=9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '384'
@@ -352,16 +349,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"\
-        2021-07-19T11:59:15.665506Z\",\n    \"authorTime\" : \"2021-07-19T11:59:15.665506Z\"\
-        ,\n    \"properties\" : { }\n  }, {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
@@ -385,12 +382,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user1%27
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '384'
@@ -414,12 +411,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user2%27
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"\
-        2021-07-19T11:59:15.665506Z\",\n    \"authorTime\" : \"2021-07-19T11:59:15.665506Z\"\
-        ,\n    \"properties\" : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '386'
@@ -443,16 +440,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28commit.author%3D%3D%27nessie_user2%27+%7C%7C+commit.author%3D%3D%27nessie_user1%27%29
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"\
-        2021-07-19T11:59:15.665506Z\",\n    \"authorTime\" : \"2021-07-19T11:59:15.665506Z\"\
-        ,\n    \"properties\" : { }\n  }, {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
@@ -476,16 +473,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.committer%3D%3D%27%27
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"\
-        2021-07-19T11:59:15.665506Z\",\n    \"authorTime\" : \"2021-07-19T11:59:15.665506Z\"\
-        ,\n    \"properties\" : { }\n  }, {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'
@@ -509,12 +506,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author+%3D%3D+%27nessie_user2%27+%7C%7C+commit.author+%3D%3D+%27non_existing%27
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"\
-        2021-07-19T11:59:15.665506Z\",\n    \"authorTime\" : \"2021-07-19T11:59:15.665506Z\"\
-        ,\n    \"properties\" : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '386'
@@ -538,16 +535,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28timestamp%28commit.commitTime%29+%3E+timestamp%28%272001-01-01T00%3A00%3A00%2B00%3A00%27%29+%26%26+timestamp%28commit.commitTime%29+%3C+timestamp%28%272999-12-30T23%3A00%3A00%2B00%3A00%27%29%29
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"\
-        2021-07-19T11:59:15.665506Z\",\n    \"authorTime\" : \"2021-07-19T11:59:15.665506Z\"\
-        ,\n    \"properties\" : { }\n  }, {\n    \"hash\" : \"1f4487f7b9b3012bdddb176b6034961c085bac49f98ff3a993e4240a8d2d9813\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:15.311235Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:15.311235Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.842483Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.842483Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"9ff1a8f164d303374665116096f0c6ca2e06ad9ee6ef2c822aae876161edb363\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:50.680906Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:50.680906Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '708'

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -18,8 +18,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -43,10 +42,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '247'
@@ -70,9 +69,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=dev
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -82,11 +81,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "contents": {"id":
-      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "test_message", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -104,8 +103,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -129,10 +127,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}
+        ]"
     headers:
       Content-Length:
       - '247'
@@ -142,32 +140,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fromHash": "b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6"}'
+    body: '{"fromHash": null, "sourceRefName": "dev"}'
     headers:
       Accept:
       - '*/*'
@@ -176,7 +149,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '80'
+      - '42'
       Content-Type:
       - application/json
       User-Agent:
@@ -205,10 +178,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}
+        ]"
     headers:
       Content-Length:
       - '247'
@@ -232,8 +205,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -256,7 +228,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a
   response:
     body:
       string: ''
@@ -279,12 +251,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:20.591161Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:20.591161Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:55.944472Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:55.944472Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '372'
@@ -308,8 +280,8 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"\
-        \ : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
+        : \"/a/b/c\"\n}"
     headers:
       Content-Length:
       - '80'
@@ -319,10 +291,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "delete_message", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "delete_message", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -337,11 +309,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=b18206032e1b4df61110b2f8f8628f3720f909e0d08be286fc2d34a2d64023a6
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        cf88d143eee994d79dfbbef497d4765ef011c4f77f4e9607b7c1b56b547e05af\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"501814cd75cbdfeacc74183fc15a23a291f42b6d5adf24d38f206e1f12d4ec1c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -365,8 +336,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        cf88d143eee994d79dfbbef497d4765ef011c4f77f4e9607b7c1b56b547e05af\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"501814cd75cbdfeacc74183fc15a23a291f42b6d5adf24d38f206e1f12d4ec1c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -389,7 +359,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=cf88d143eee994d79dfbbef497d4765ef011c4f77f4e9607b7c1b56b547e05af
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=501814cd75cbdfeacc74183fc15a23a291f42b6d5adf24d38f206e1f12d4ec1c
   response:
     body:
       string: ''
@@ -416,8 +386,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '121'

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -1,11 +1,13 @@
 interactions:
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -34,6 +36,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -61,6 +65,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -81,16 +87,18 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
+      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
+      "commitMeta": {"hash": null, "message": "test_message", "committer": null, "authorTime":
+      null, "signedOffBy": null, "email": null, "author": null, "properties": null,
+      "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -103,7 +111,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -119,6 +127,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -129,7 +139,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}
         ]"
     headers:
       Content-Length:
@@ -140,16 +150,45 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": null, "sourceRefName": "dev"}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/dev
+  response:
+    body:
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}"
+    headers:
+      Content-Length:
+      - '120'
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fromHash": "dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d",
+      "fromRefName": "dev"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
-      - '42'
+      - '102'
       Content-Type:
       - application/json
       User-Agent:
@@ -170,6 +209,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -179,8 +220,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}
+        \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}
         ]"
     headers:
       Content-Length:
@@ -197,6 +238,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -205,7 +248,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -221,6 +264,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -228,7 +273,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d
   response:
     body:
       string: ''
@@ -243,6 +288,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -252,10 +299,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a\",\n
+        [ {\n    \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:55.944472Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:55.944472Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:43:03.584094Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:43:03.584094Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -272,6 +319,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -291,15 +340,17 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"message": "delete_message", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"hash": null, "message": "delete_message", "committer": null,
+      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
+      null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -309,10 +360,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=65e5c0d606bc234409d58e8508ad0354d993ac6c894e04c9d8472e7500d8986a
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"501814cd75cbdfeacc74183fc15a23a291f42b6d5adf24d38f206e1f12d4ec1c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"76116bf83f896e253df9b74db39437d5873b2f7d0ee3f98f82d126fdd0e01770\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -328,6 +379,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -336,7 +389,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"501814cd75cbdfeacc74183fc15a23a291f42b6d5adf24d38f206e1f12d4ec1c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"76116bf83f896e253df9b74db39437d5873b2f7d0ee3f98f82d126fdd0e01770\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -352,6 +405,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -359,7 +414,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=501814cd75cbdfeacc74183fc15a23a291f42b6d5adf24d38f206e1f12d4ec1c
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=76116bf83f896e253df9b74db39437d5873b2f7d0ee3f98f82d126fdd0e01770
   response:
     body:
       string: ''
@@ -368,12 +423,14 @@ interactions:
       code: 204
       message: No Content
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:

--- a/python/tests/cassettes/test_nessie_cli/test_ref.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_ref.yaml
@@ -14,9 +14,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -44,8 +43,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -69,10 +67,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '247'
@@ -96,8 +94,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
     body:
-      string: "{\n  \"message\" : \"Unable to find reference [etl].\",\n  \"status\"\
-        \ : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Unable to find reference [etl].\",\n  \"status\"
+        : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
       - '124'
@@ -121,8 +119,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -132,7 +129,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl", "hash": "a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a",
+    body: '{"name": "etl", "hash": "421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582",
       "type": "BRANCH"}'
     headers:
       Accept:
@@ -148,11 +145,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/tree
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -176,11 +172,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        \n}, {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '369'
@@ -204,8 +200,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -228,7 +223,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a
+    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582
   response:
     body:
       string: ''
@@ -251,8 +246,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -298,9 +292,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n} ]"
     headers:
       Content-Length:
       - '125'

--- a/python/tests/cassettes/test_nessie_cli/test_ref.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_ref.yaml
@@ -6,6 +6,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -15,7 +17,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n} ]"
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -25,12 +27,14 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -59,6 +63,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -68,7 +74,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -86,6 +92,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -111,6 +119,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -119,7 +129,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -129,13 +139,15 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl", "hash": "421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582",
-      "type": "BRANCH"}'
+    body: '{"hash": "6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56",
+      "name": "etl", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -148,7 +160,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -164,6 +176,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -173,8 +187,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n},
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n},
         {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -192,6 +206,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -200,7 +216,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -216,6 +232,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -223,7 +241,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582
+    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56
   response:
     body:
       string: ''
@@ -238,6 +256,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -262,6 +282,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -284,6 +306,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -293,7 +317,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n} ]"
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n} ]"
     headers:
       Content-Length:
       - '125'

--- a/python/tests/cassettes/test_nessie_cli/test_remote.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_remote.yaml
@@ -14,8 +14,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -39,9 +38,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
     headers:
       Content-Length:
       - '125'

--- a/python/tests/cassettes/test_nessie_cli/test_remote.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_remote.yaml
@@ -6,6 +6,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -30,6 +32,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -14,9 +14,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -40,8 +39,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
     body:
-      string: "{\n  \"message\" : \"Unable to find reference [dev-tag].\",\n  \"status\"\
-        \ : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Unable to find reference [dev-tag].\",\n  \"status\"
+        : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
       - '128'
@@ -65,8 +64,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -76,7 +74,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev-tag", "hash": "a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a",
+    body: '{"name": "dev-tag", "hash": "421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582",
       "type": "TAG"}'
     headers:
       Accept:
@@ -92,11 +90,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/tree
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -120,10 +117,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}
+        ]"
     headers:
       Content-Length:
       - '248'
@@ -147,8 +144,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
     body:
-      string: "{\n  \"message\" : \"Unable to find reference [etl-tag].\",\n  \"status\"\
-        \ : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Unable to find reference [etl-tag].\",\n  \"status\"
+        : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
       - '128'
@@ -172,8 +169,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -183,7 +179,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl-tag", "hash": "a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a",
+    body: '{"name": "etl-tag", "hash": "421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582",
       "type": "TAG"}'
     headers:
       Accept:
@@ -199,11 +195,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/tree
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -227,11 +222,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\
-        \n}, {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n} ]"
+      string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}
+        ]"
     headers:
       Content-Length:
       - '371'
@@ -255,8 +250,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -279,7 +273,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a
+    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582
   response:
     body:
       string: ''
@@ -302,8 +296,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"\
-        a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -326,7 +319,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a
+    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582
   response:
     body:
       string: ''
@@ -349,9 +342,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"a615031ae80f9e42ffaaeeba5ac67e1dddaa86fecbc20a14b91aac19f1fa748a\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -360,34 +352,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: '{"name": "v1.0", "hash": null, "type": "TAG"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '45'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree
-  response:
-    body:
-      string: "{\n  \"message\" : \"Cannot create an unassigned tag reference\",\n\
-        \  \"status\" : 400,\n  \"reason\" : \"Bad Request\",\n  \"serverStackTrace\"\
-        \ : null\n}"
-    headers:
-      Content-Length:
-      - '136'
-      Content-Type:
-      - application/json
-    status:
-      code: 400
-      message: Bad Request
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -6,6 +6,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -15,7 +17,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n} ]"
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -31,6 +33,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -56,6 +60,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -64,7 +70,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -74,13 +80,15 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev-tag", "hash": "421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582",
-      "type": "TAG"}'
+    body: '{"hash": "6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56",
+      "name": "dev-tag", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -93,7 +101,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -109,6 +117,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -118,8 +128,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}
         ]"
     headers:
       Content-Length:
@@ -136,6 +146,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -161,6 +173,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -169,7 +183,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -179,13 +193,15 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl-tag", "hash": "421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582",
-      "type": "TAG"}'
+    body: '{"hash": "6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56",
+      "name": "etl-tag", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -198,7 +214,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -214,6 +230,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -223,9 +241,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n},
-        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}
         ]"
     headers:
       Content-Length:
@@ -242,6 +260,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -250,7 +270,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -266,6 +286,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -273,7 +295,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582
+    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56
   response:
     body:
       string: ''
@@ -288,6 +310,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -296,7 +320,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -312,6 +336,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -319,7 +345,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582
+    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56
   response:
     body:
       string: ''
@@ -334,6 +360,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -343,7 +371,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"421f058e45c70919575da66b0d3620271c40dc1dcd90dc3050b5bf01ed616582\"\n} ]"
+        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n} ]"
     headers:
       Content-Length:
       - '125'

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -1,11 +1,13 @@
 interactions:
 - request:
-    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -34,6 +36,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -61,6 +65,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -81,16 +87,18 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
+      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
+      "commitMeta": {"hash": null, "message": "test_message", "committer": null, "authorTime":
+      null, "signedOffBy": null, "email": null, "author": null, "properties": null,
+      "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -103,7 +111,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f4fa2082cebb0bc339259b31f6f6f7bb0819f3e2039786f1d8e323ba7ac06e75\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e7b22b3488ea9e65b281dcef5935926ab01a9d157554b8e5de5f66d9cb40a675\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -119,6 +127,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -139,16 +149,18 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message2", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["bar",
-      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
+      "type": "ICEBERG_TABLE"}, "key": {"elements": ["bar", "bar"]}, "type": "PUT"}],
+      "commitMeta": {"hash": null, "message": "test_message2", "committer": null,
+      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
+      null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -161,7 +173,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -177,6 +189,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -197,16 +211,18 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"message": "test_message3", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "baz"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
+      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "baz"]}, "type": "PUT"}],
+      "commitMeta": {"hash": null, "message": "test_message3", "committer": null,
+      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
+      null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -219,7 +235,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b42f9c0954fa098b51e68604bf51e137653ee23eed68594eaf557cef282b6136\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e83ab3e7d2f2f2c5082deb7cffa16e2651cae434ec55656fc05664328728aa92\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -235,6 +251,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -244,8 +262,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"b42f9c0954fa098b51e68604bf51e137653ee23eed68594eaf557cef282b6136\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933\"\n}
+        \"e83ab3e7d2f2f2c5082deb7cffa16e2651cae434ec55656fc05664328728aa92\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3\"\n}
         ]"
     headers:
       Content-Length:
@@ -262,6 +280,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -271,14 +291,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933\",\n
+        [ {\n    \"hash\" : \"3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-08-20T07:21:00.301107Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:21:00.301107Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"f4fa2082cebb0bc339259b31f6f6f7bb0819f3e2039786f1d8e323ba7ac06e75\",\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-08-31T16:43:07.941153Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:43:07.941153Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"e7b22b3488ea9e65b281dcef5935926ab01a9d157554b8e5de5f66d9cb40a675\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:58.222934Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:58.222934Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:43:05.871006Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:43:05.871006Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -289,24 +309,25 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hashesToTransplant": ["f4fa2082cebb0bc339259b31f6f6f7bb0819f3e2039786f1d8e323ba7ac06e75",
-      "ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933"], "sourceRefName":
-      "dev"}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["e7b22b3488ea9e65b281dcef5935926ab01a9d157554b8e5de5f66d9cb40a675",
+      "3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3"]}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
-      - '184'
+      - '182'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=b42f9c0954fa098b51e68604bf51e137653ee23eed68594eaf557cef282b6136
+    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=e83ab3e7d2f2f2c5082deb7cffa16e2651cae434ec55656fc05664328728aa92
   response:
     body:
       string: ''
@@ -321,6 +342,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -330,18 +353,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"84aa54a4d8b27ae6507f0bf2618f159c769295a390c2a4a7a69c39c035db387e\",\n
+        [ {\n    \"hash\" : \"0771bc1a44d3c2ea8a9775d663110d4236fdc6dc95c6198bd297bad8f0079a3c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-08-20T07:21:00.301107Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:21:00.301107Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"517e1a8601d5cda6349a5e408eb66b6fa909572d598d23b8c3812db04e2970d9\",\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-08-31T16:43:07.941153Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:43:07.941153Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"1c1ca8893c9a49caa58773e8fe6ac918fada55ed7b729305db3b28070be3ff34\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:58.222934Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:20:58.222934Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"b42f9c0954fa098b51e68604bf51e137653ee23eed68594eaf557cef282b6136\",\n
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:43:05.871006Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:43:05.871006Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"e83ab3e7d2f2f2c5082deb7cffa16e2651cae434ec55656fc05664328728aa92\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-08-20T07:21:02.384654Z\",\n
-        \   \"authorTime\" : \"2021-08-20T07:21:02.384654Z\",\n    \"properties\"
+        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-08-31T16:43:10.018072Z\",\n
+        \   \"authorTime\" : \"2021-08-31T16:43:10.018072Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -358,6 +381,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -377,15 +402,17 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"message": "delete_message", "hash": null, "author": null,
-      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
-      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
-      "bar"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"hash": null, "message": "delete_message", "committer": null,
+      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
+      null, "commitTime": null}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -395,10 +422,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=84aa54a4d8b27ae6507f0bf2618f159c769295a390c2a4a7a69c39c035db387e
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=0771bc1a44d3c2ea8a9775d663110d4236fdc6dc95c6198bd297bad8f0079a3c
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"7b571fc0fc6beef87b78433f4df2a0ad3b9633a5a07721e7aa78c09d27731fc6\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"fafdc0827ab4f24d8ca9acb397dac692b8ebe101180aa618bb87d2bd6f7d08ed\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -414,6 +441,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -422,7 +451,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -438,6 +467,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -445,7 +476,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3
   response:
     body:
       string: ''
@@ -460,6 +491,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -468,7 +501,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"7b571fc0fc6beef87b78433f4df2a0ad3b9633a5a07721e7aa78c09d27731fc6\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"fafdc0827ab4f24d8ca9acb397dac692b8ebe101180aa618bb87d2bd6f7d08ed\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -484,6 +517,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -491,7 +526,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=7b571fc0fc6beef87b78433f4df2a0ad3b9633a5a07721e7aa78c09d27731fc6
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=fafdc0827ab4f24d8ca9acb397dac692b8ebe101180aa618bb87d2bd6f7d08ed
   response:
     body:
       string: ''
@@ -500,12 +535,14 @@ interactions:
       code: 204
       message: No Content
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -18,8 +18,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -43,10 +42,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '247'
@@ -70,9 +69,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=dev
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -82,11 +81,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "contents": {"id":
-      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "test_message", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -104,8 +103,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        0c4c8a75836bfca937a37ba71b758050c3f95bad66773889f53c3aedd502f26c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f4fa2082cebb0bc339259b31f6f6f7bb0819f3e2039786f1d8e323ba7ac06e75\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -129,9 +127,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/bar.bar?ref=dev
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -141,11 +139,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["bar", "bar"]}, "contents": {"id":
-      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "test_message2", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message2", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["bar",
+      "bar"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -163,8 +161,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        4e87163e88b4c69632c529ce42e9e48169935a2677ea9a593adf164da5f05193\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -188,9 +185,9 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.baz?ref=main
   response:
     body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified\
-        \ reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"\
-        serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Requested contents do not exist for specified
+        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '149'
@@ -200,11 +197,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "baz"]}, "contents": {"id":
-      "uuid", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "test_message3", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "test_message3", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "baz"]}, "contents": {"metadataLocation": "/a/b/c", "id": "uuid", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -222,8 +219,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        909020306995d718291fd5e3dddb057a17982bd718f22abefb396341845f8132\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b42f9c0954fa098b51e68604bf51e137653ee23eed68594eaf557cef282b6136\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -247,10 +243,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"909020306995d718291fd5e3dddb057a17982bd718f22abefb396341845f8132\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4e87163e88b4c69632c529ce42e9e48169935a2677ea9a593adf164da5f05193\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"b42f9c0954fa098b51e68604bf51e137653ee23eed68594eaf557cef282b6136\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933\"\n}
+        ]"
     headers:
       Content-Length:
       - '247'
@@ -274,16 +270,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev/log
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"4e87163e88b4c69632c529ce42e9e48169935a2677ea9a593adf164da5f05193\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-07-19T11:59:22.359192Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:22.359192Z\",\n    \"properties\"\
-        \ : { }\n  }, {\n    \"hash\" : \"0c4c8a75836bfca937a37ba71b758050c3f95bad66773889f53c3aedd502f26c\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:22.026259Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:22.026259Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-08-20T07:21:00.301107Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:21:00.301107Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"f4fa2082cebb0bc339259b31f6f6f7bb0819f3e2039786f1d8e323ba7ac06e75\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:58.222934Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:58.222934Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '683'
@@ -293,8 +289,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hashesToTransplant": ["0c4c8a75836bfca937a37ba71b758050c3f95bad66773889f53c3aedd502f26c",
-      "4e87163e88b4c69632c529ce42e9e48169935a2677ea9a593adf164da5f05193"]}'
+    body: '{"hashesToTransplant": ["f4fa2082cebb0bc339259b31f6f6f7bb0819f3e2039786f1d8e323ba7ac06e75",
+      "ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933"], "sourceRefName":
+      "dev"}'
     headers:
       Accept:
       - '*/*'
@@ -303,13 +300,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '160'
+      - '184'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=909020306995d718291fd5e3dddb057a17982bd718f22abefb396341845f8132
+    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=b42f9c0954fa098b51e68604bf51e137653ee23eed68594eaf557cef282b6136
   response:
     body:
       string: ''
@@ -332,20 +329,20 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :\
-        \ [ {\n    \"hash\" : \"b9730e2f855582c4ec7b5c570129b30347b847d0e9826a4b032b50664491dec0\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-07-19T11:59:22.359192Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:22.359192Z\",\n    \"properties\"\
-        \ : { }\n  }, {\n    \"hash\" : \"d4d090ff3199d1f13de833b7eb9c85ff94e74a2608ab5ddfb640ae3b3d42087c\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-07-19T11:59:22.026259Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:22.026259Z\",\n    \"properties\"\
-        \ : { }\n  }, {\n    \"hash\" : \"909020306995d718291fd5e3dddb057a17982bd718f22abefb396341845f8132\"\
-        ,\n    \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\"\
-        \ : null,\n    \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-07-19T11:59:22.736729Z\"\
-        ,\n    \"authorTime\" : \"2021-07-19T11:59:22.736729Z\",\n    \"properties\"\
-        \ : { }\n  } ]\n}"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
+        [ {\n    \"hash\" : \"84aa54a4d8b27ae6507f0bf2618f159c769295a390c2a4a7a69c39c035db387e\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-08-20T07:21:00.301107Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:21:00.301107Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"517e1a8601d5cda6349a5e408eb66b6fa909572d598d23b8c3812db04e2970d9\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-20T07:20:58.222934Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:20:58.222934Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"b42f9c0954fa098b51e68604bf51e137653ee23eed68594eaf557cef282b6136\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
+        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-08-20T07:21:02.384654Z\",\n
+        \   \"authorTime\" : \"2021-08-20T07:21:02.384654Z\",\n    \"properties\"
+        : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '994'
@@ -369,8 +366,8 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"\
-        \ : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
+        : \"/a/b/c\"\n}"
     headers:
       Content-Length:
       - '80'
@@ -380,10 +377,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"signedOffBy": null, "email": null, "properties": null, "message":
-      "delete_message", "authorTime": null, "hash": null, "author": null, "commitTime":
-      null, "committer": null}}'
+    body: '{"commitMeta": {"message": "delete_message", "hash": null, "author": null,
+      "committer": null, "signedOffBy": null, "commitTime": null, "properties": null,
+      "email": null, "authorTime": null}, "operations": [{"key": {"elements": ["foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -398,11 +395,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=b9730e2f855582c4ec7b5c570129b30347b847d0e9826a4b032b50664491dec0
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=84aa54a4d8b27ae6507f0bf2618f159c769295a390c2a4a7a69c39c035db387e
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        72b58a87fdd24d25c0c4592fedcec61d461dbcfd587e1379c4fb08d324b87eaa\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"7b571fc0fc6beef87b78433f4df2a0ad3b9633a5a07721e7aa78c09d27731fc6\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -426,8 +422,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"\
-        4e87163e88b4c69632c529ce42e9e48169935a2677ea9a593adf164da5f05193\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -450,7 +445,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=4e87163e88b4c69632c529ce42e9e48169935a2677ea9a593adf164da5f05193
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=ffd91e5a69f41a66e4d1a0aa39e1398c136092d8aef7287a4e11061e65c1b933
   response:
     body:
       string: ''
@@ -473,8 +468,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        72b58a87fdd24d25c0c4592fedcec61d461dbcfd587e1379c4fb08d324b87eaa\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"7b571fc0fc6beef87b78433f4df2a0ad3b9633a5a07721e7aa78c09d27731fc6\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -497,7 +491,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=72b58a87fdd24d25c0c4592fedcec61d461dbcfd587e1379c4fb08d324b87eaa
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=7b571fc0fc6beef87b78433f4df2a0ad3b9633a5a07721e7aa78c09d27731fc6
   response:
     body:
       string: ''
@@ -524,8 +518,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '121'

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -6,6 +6,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -25,12 +27,14 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -55,13 +59,15 @@ interactions:
       code: 409
       message: Conflict
 - request:
-    body: '{"name": "test", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "test", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -90,6 +96,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -117,6 +125,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -141,6 +151,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:
@@ -165,6 +177,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       Content-Length:
@@ -187,6 +201,8 @@ interactions:
       - application/json
       Accept-Encoding:
       - gzip, deflate
+      Authorization:
+      - Basic YWRtaW5fdXNlcjp0ZXN0MTIz
       Connection:
       - keep-alive
       User-Agent:

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -14,9 +14,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -44,9 +43,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"message\" : \"A reference of name [main] already exists.\",\n\
-        \  \"status\" : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\"\
-        \ : null\n}"
+      string: "{\n  \"message\" : \"A reference of name [main] already exists.\",\n
+        \ \"status\" : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\"
+        : null\n}"
     headers:
       Content-Length:
       - '134'
@@ -72,11 +71,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/tree
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"test\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"test\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -100,10 +98,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n},\
-        \ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"test\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\
-        \n} ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"test\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
     headers:
       Content-Length:
       - '248'
@@ -127,8 +125,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/test
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"test\",\n  \"hash\" : \"\
-        2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"test\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -149,11 +146,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/test/entries
+    uri: http://localhost:19120/api/v1/trees/tree/test/entries?hashOnRef=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ ]\n\
-        }"
+      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ ]\n}"
     headers:
       Content-Length:
       - '60'
@@ -199,9 +195,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :\
-        \ \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}\
-        \ ]"
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
     headers:
       Content-Length:
       - '125'

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -350,7 +350,7 @@ def test_transplant() -> None:
     result = _run(runner, ["--json", "log", "--ref", "dev"])
     logs = simplejson.loads(result.output)
     first_hash = [i["hash"] for i in logs]
-    _run(runner, ["cherry-pick", "-c", main_hash, first_hash[1], first_hash[0]])
+    _run(runner, ["cherry-pick", "-c", main_hash, "-s", "dev", first_hash[1], first_hash[0]])
 
     result = _run(runner, ["--json", "log"])
     logs = simplejson.loads(result.output)

--- a/python/tests/test_nessie_client.py
+++ b/python/tests/test_nessie_client.py
@@ -18,17 +18,18 @@ def test_client_interface_e2e() -> None:
     references = client.list_references()
     assert len(references) == 1
     assert references[0] == Branch("main", references[0].hash_)
+    main_name = references[0].name
     main_commit = references[0].hash_
     with pytest.raises(NessieConflictException):
         client.create_branch("main")
-    created_reference = client.create_branch("test", main_commit)
+    created_reference = client.create_branch("test", main_name, main_commit)
     references = client.list_references()
     assert len(references) == 2
     assert next(i for i in references if i.name == "main") == Branch("main", main_commit)
     assert next(i for i in references if i.name == "test") == Branch("test", main_commit)
     reference = client.get_reference("test")
     assert created_reference == reference
-    tables = client.list_keys(reference.name)
+    tables = client.list_keys(reference.name, reference.hash_)
     assert isinstance(tables, Entries)
     assert len(tables.entries) == 0
     client.delete_branch("test", main_commit)

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -258,7 +258,7 @@ public abstract class AbstractTestRest {
     tree.mergeRefIntoBranch(
         branchName2,
         branchHash2,
-        ImmutableMerge.builder().sourceRefName(branchName).fromHash(newHash).build());
+        ImmutableMerge.builder().fromRefName(branchName).fromHash(newHash).build());
 
     tree.deleteTag(tagName, newHash);
     tree.deleteBranch(branchName, newHash);

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
@@ -88,7 +88,8 @@ public class ConfigurableVersionStoreFactory {
       if (!str.findFirst().isPresent()) {
         // if this is a new database, create a branch with the default branch name.
         try {
-          store.create(BranchName.of(serverConfig.getDefaultBranch()), Optional.empty());
+          store.create(
+              BranchName.of(serverConfig.getDefaultBranch()), Optional.empty(), Optional.empty());
         } catch (ReferenceNotFoundException | ReferenceAlreadyExistsException e) {
           LOGGER.warn("Failed to create default branch of {}.", serverConfig.getDefaultBranch(), e);
         }

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
@@ -88,8 +88,7 @@ public class ConfigurableVersionStoreFactory {
       if (!str.findFirst().isPresent()) {
         // if this is a new database, create a branch with the default branch name.
         try {
-          store.create(
-              BranchName.of(serverConfig.getDefaultBranch()), Optional.empty(), Optional.empty());
+          store.create(BranchName.of(serverConfig.getDefaultBranch()), Optional.empty());
         } catch (ReferenceNotFoundException | ReferenceAlreadyExistsException e) {
           LOGGER.warn("Failed to create default branch of {}.", serverConfig.getDefaultBranch(), e);
         }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/RestGitTest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/RestGitTest.java
@@ -178,7 +178,12 @@ public class RestGitTest {
     Assertions.assertEquals(table, returned);
 
     Branch b3 = rest().get("trees/tree/test").as(Branch.class);
-    rest().body(Tag.of("tagtest", b3.getHash())).post("trees/tree").then().statusCode(200);
+    rest()
+        .body(Tag.of("tagtest", b3.getHash()))
+        .queryParam("sourceRefName", b3.getName())
+        .post("trees/tree")
+        .then()
+        .statusCode(200);
 
     assertThat(
             rest()

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -188,14 +188,14 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   private void createBranch(Branch branch, String role, boolean shouldFail)
       throws NessieConflictException, NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> tree.createReference(null, branch))
+      assertThatThrownBy(() -> tree.createReference("main", branch))
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(
               String.format(
                   "'CREATE_REFERENCE' is not allowed for role '%s' on reference '%s'",
                   role, branch.getName()));
     } else {
-      tree.createReference(null, branch);
+      tree.createReference("main", branch);
     }
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -95,9 +95,12 @@ class TestAuthorizationRules extends BaseClientAuthTest {
             .build();
     addContent(branch, createOps, role, shouldFail);
 
-    getCommitLog(branchName, role, shouldFail);
-    getEntriesFor(branchName, role, shouldFail);
-    readContent(branchName, key, role, shouldFail);
+    if (!shouldFail) {
+      // These requests cannot succeed, because "disallowedBranchForTestUser" could not be created
+      getCommitLog(branchName, role, shouldFail);
+      getEntriesFor(branchName, role, shouldFail);
+      readContent(branchName, key, role, shouldFail);
+    }
 
     branch = shouldFail ? branchWithInvalidHash : retrieveBranch(branchName, role, shouldFail);
 
@@ -185,14 +188,14 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   private void createBranch(Branch branch, String role, boolean shouldFail)
       throws NessieConflictException, NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> tree.createReference(branch))
+      assertThatThrownBy(() -> tree.createReference(null, branch))
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(
               String.format(
                   "'CREATE_REFERENCE' is not allowed for role '%s' on reference '%s'",
                   role, branch.getName()));
     } else {
-      tree.createReference(branch);
+      tree.createReference(null, branch);
     }
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicOperations.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicOperations.java
@@ -61,7 +61,7 @@ class TestBasicOperations {
     tree = client.getTreeApi();
     contents = client.getContentsApi();
     if (branch != null) {
-      tree.createReference(Branch.of(branch, null));
+      tree.createReference(null, Branch.of(branch, null));
     }
   }
 
@@ -95,7 +95,8 @@ class TestBasicOperations {
 
     Branch master = (Branch) tree.getReferenceByName("testx");
     Branch test = ImmutableBranch.builder().hash(master.getHash()).name("testy").build();
-    tryEndpointPass(() -> tree.createReference(Branch.of(test.getName(), test.getHash())));
+    tryEndpointPass(
+        () -> tree.createReference(master.getName(), Branch.of(test.getName(), test.getHash())));
     Branch test2 = (Branch) tree.getReferenceByName("testy");
     tryEndpointPass(() -> tree.deleteBranch(test2.getName(), test2.getHash()));
     tryEndpointPass(

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicOperations.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicOperations.java
@@ -61,7 +61,7 @@ class TestBasicOperations {
     tree = client.getTreeApi();
     contents = client.getContentsApi();
     if (branch != null) {
-      tree.createReference(null, Branch.of(branch, null));
+      tree.createReference("main", Branch.of(branch, null));
     }
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/rest/BaseResource.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/BaseResource.java
@@ -17,7 +17,6 @@ package org.projectnessie.services.rest;
 
 import java.security.Principal;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -31,7 +30,6 @@ import org.projectnessie.services.authz.ServerAccessContext;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
-import org.projectnessie.versioned.Ref;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.WithHash;
@@ -55,15 +53,6 @@ abstract class BaseResource {
     this.config = config;
     this.store = store;
     this.accessChecker = accessChecker;
-  }
-
-  Optional<WithHash<Ref>> getRefWithHash(String ref) {
-    try {
-      WithHash<Ref> whr = store.toRef(Optional.ofNullable(ref).orElse(config.getDefaultBranch()));
-      return Optional.of(whr);
-    } catch (ReferenceNotFoundException e) {
-      return Optional.empty();
-    }
   }
 
   WithHash<NamedRef> namedRefWithHashOrThrow(String namedRef, @Nullable String hashOnRef)
@@ -93,7 +82,7 @@ abstract class BaseResource {
     }
 
     try {
-      if (null == hashOnRef) {
+      if (null == hashOnRef || store.noAncestorHash().asString().equals(hashOnRef)) {
         return namedRefWithHash;
       }
 

--- a/servers/services/src/main/java/org/projectnessie/services/rest/TreeResource.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/TreeResource.java
@@ -289,7 +289,7 @@ public class TreeResource extends BaseResource implements HttpTreeApi {
     try {
       getStore()
           .merge(
-              toHash(merge.getSourceRefName(), merge.getFromHash(), true).get(),
+              toHash(merge.getFromRefName(), merge.getFromHash(), true).get(),
               BranchName.of(branchName),
               toHash(hash, true));
     } catch (ReferenceNotFoundException e) {

--- a/servers/services/src/main/java/org/projectnessie/services/rest/TreeResourceWithAuthorizationChecks.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/TreeResourceWithAuthorizationChecks.java
@@ -100,6 +100,11 @@ public class TreeResourceWithAuthorizationChecks extends TreeResource {
   @Override
   public Reference createReference(@Nullable String sourceRefName, Reference reference)
       throws NessieNotFoundException, NessieConflictException {
+    // TODO remove after Iceberg > 0.12
+    if (sourceRefName == null) {
+      sourceRefName = getConfig().getDefaultBranch();
+    }
+
     if (reference instanceof Branch) {
       getAccessChecker()
           .canCreateReference(createAccessContext(), BranchName.of(reference.getName()));

--- a/servers/services/src/main/java/org/projectnessie/services/rest/TreeResourceWithAuthorizationChecks.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/TreeResourceWithAuthorizationChecks.java
@@ -20,7 +20,9 @@ import static org.projectnessie.model.Operation.Put;
 
 import java.security.AccessControlException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
@@ -43,7 +45,10 @@ import org.projectnessie.services.authz.AccessChecker;
 import org.projectnessie.services.authz.ServerAccessContext;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.Ref;
+import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.VersionStore;
 
@@ -93,22 +98,64 @@ public class TreeResourceWithAuthorizationChecks extends TreeResource {
   }
 
   @Override
-  public Reference createReference(Reference reference)
+  public Reference createReference(@Nullable String sourceRefName, Reference reference)
       throws NessieNotFoundException, NessieConflictException {
     if (reference instanceof Branch) {
       getAccessChecker()
           .canCreateReference(createAccessContext(), BranchName.of(reference.getName()));
     } else if (reference instanceof Tag) {
       getAccessChecker().canCreateReference(createAccessContext(), TagName.of(reference.getName()));
+    } else {
+      throw new IllegalArgumentException("Only tag and branch references can be created.");
     }
-    return super.createReference(reference);
+
+    checkHashOnRef(sourceRefName, reference.getHash());
+    return super.createReference(sourceRefName, reference);
+  }
+
+  protected void checkHashOnRef(String refName, String hash) throws NessieNotFoundException {
+    if (refName == null) {
+      refName = getConfig().getDefaultBranch();
+    }
+
+    try {
+      NamedRef sourceRef;
+      try {
+        Ref ref = getStore().toRef(refName).getValue();
+        if (!(ref instanceof NamedRef)) {
+          throw new ReferenceNotFoundException(
+              String.format("Named reference '%s' not found", refName));
+        }
+        sourceRef = (NamedRef) ref;
+      } catch (ReferenceNotFoundException e) {
+        // Special case, mostly for tests:
+        // When the default branch is deleted, we cannot verify whether the branch already exists
+        // (it does not, so the check would fail).
+        if (refName.equals(getConfig().getDefaultBranch()) && hash == null
+            || hash.equals(getStore().noAncestorHash().asString())) {
+          // prevent the "hash-on-ref" check, but still do the "can-view" check
+          hash = null;
+          return;
+        } else {
+          throw e;
+        }
+      }
+      getAccessChecker().canViewReference(createAccessContext(), sourceRef);
+      if (hash != null) {
+        getStore().hashOnReference(sourceRef, Optional.of(Hash.of(hash)));
+      }
+    } catch (ReferenceNotFoundException e) {
+      throw new NessieNotFoundException(e.getMessage());
+    }
   }
 
   @Override
-  protected void assignReference(NamedRef ref, String oldHash, String newHash)
+  protected void assignReference(NamedRef ref, String oldHash, Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
+    checkHashOnRef(assignTo.getName(), assignTo.getHash());
+
     getAccessChecker().canAssignRefToHash(createAccessContext(), ref);
-    super.assignReference(ref, oldHash, newHash);
+    super.assignReference(ref, oldHash, assignTo);
   }
 
   @Override
@@ -145,6 +192,12 @@ public class TreeResourceWithAuthorizationChecks extends TreeResource {
   public void transplantCommitsIntoBranch(
       String branchName, String hash, String message, Transplant transplant)
       throws NessieNotFoundException, NessieConflictException {
+    if (transplant.getHashesToTransplant().isEmpty()) {
+      throw new IllegalArgumentException("No hashes given to transplant.");
+    }
+    checkHashOnRef(
+        transplant.getSourceRefName(),
+        transplant.getHashesToTransplant().get(transplant.getHashesToTransplant().size() - 1));
     getAccessChecker()
         .canCommitChangeAgainstReference(createAccessContext(), BranchName.of(branchName));
     super.transplantCommitsIntoBranch(branchName, hash, message, transplant);

--- a/servers/services/src/main/java/org/projectnessie/services/rest/TreeResourceWithAuthorizationChecks.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/TreeResourceWithAuthorizationChecks.java
@@ -201,7 +201,7 @@ public class TreeResourceWithAuthorizationChecks extends TreeResource {
       throw new IllegalArgumentException("No hashes given to transplant.");
     }
     checkHashOnRef(
-        transplant.getSourceRefName(),
+        transplant.getFromRefName(),
         transplant.getHashesToTransplant().get(transplant.getHashesToTransplant().size() - 1));
     getAccessChecker()
         .canCommitChangeAgainstReference(createAccessContext(), BranchName.of(branchName));

--- a/versioned/jgit/src/main/java/org/projectnessie/versioned/jgit/JGitVersionStore.java
+++ b/versioned/jgit/src/main/java/org/projectnessie/versioned/jgit/JGitVersionStore.java
@@ -123,6 +123,12 @@ public class JGitVersionStore<TABLE, METADATA, TABLE_TYPE extends Enum<TABLE_TYP
 
   @Nonnull
   @Override
+  public Hash noAncestorHash() {
+    return Hash.of(emptyObject.name());
+  }
+
+  @Nonnull
+  @Override
   public Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException {
     repository.getRefDatabase().refresh();
     final org.eclipse.jgit.lib.Ref jgitRef;

--- a/versioned/memory/src/main/java/org/projectnessie/versioned/memory/InMemoryVersionStore.java
+++ b/versioned/memory/src/main/java/org/projectnessie/versioned/memory/InMemoryVersionStore.java
@@ -125,6 +125,12 @@ public class InMemoryVersionStore<ValueT, MetadataT, EnumT extends Enum<EnumT>>
     return new Builder<>();
   }
 
+  @Nonnull
+  @Override
+  public Hash noAncestorHash() {
+    return NO_ANCESTOR;
+  }
+
   @Override
   @Nonnull
   public Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -60,6 +60,19 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
+  public Hash hashOnReference(NamedRef namedReference, Optional<Hash> hashOnReference)
+      throws ReferenceNotFoundException {
+    return delegate1Ex(
+        "hashonreference", () -> delegate.hashOnReference(namedReference, hashOnReference));
+  }
+
+  @Nonnull
+  @Override
+  public Hash noAncestorHash() {
+    return delegate.noAncestorHash();
+  }
+
+  @Override
   @Nonnull
   public Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException {
     return delegate1Ex("tohash", () -> delegate.toHash(ref));

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -68,6 +68,23 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
+  public Hash hashOnReference(NamedRef namedReference, Optional<Hash> hashOnReference)
+      throws ReferenceNotFoundException {
+    return callWithOneException(
+        "HashOnReference",
+        b ->
+            b.withTag(TAG_REF, safeRefName(namedReference))
+                .withTag(TAG_HASH, safeToString(hashOnReference)),
+        () -> delegate.hashOnReference(namedReference, hashOnReference));
+  }
+
+  @Nonnull
+  @Override
+  public Hash noAncestorHash() {
+    return delegate.noAncestorHash();
+  }
+
+  @Override
   @Nonnull
   public Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException {
     return callWithOneException(

--- a/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/impl/TieredVersionStore.java
+++ b/versioned/tiered/tiered-impl/src/main/java/org/projectnessie/versioned/impl/TieredVersionStore.java
@@ -139,6 +139,12 @@ public class TieredVersionStore<DATA, METADATA, DATA_TYPE extends Enum<DATA_TYPE
             .register(registry);
   }
 
+  @Nonnull
+  @Override
+  public Hash noAncestorHash() {
+    return Id.EMPTY.toHash();
+  }
+
   @Override
   public Hash create(NamedRef ref, Optional<Hash> targetHash)
       throws ReferenceNotFoundException, ReferenceAlreadyExistsException {

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractTieredStoreFixture.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractTieredStoreFixture.java
@@ -78,6 +78,18 @@ public abstract class AbstractTieredStoreFixture<S extends Store, C>
   }
 
   @Override
+  public Hash hashOnReference(NamedRef namedReference, Optional<Hash> hashOnReference)
+      throws ReferenceNotFoundException {
+    return versionStore.hashOnReference(namedReference, hashOnReference);
+  }
+
+  @Nonnull
+  @Override
+  public Hash noAncestorHash() {
+    return versionStore.noAncestorHash();
+  }
+
+  @Override
   @Nonnull
   public Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException {
     return versionStore.toHash(ref);


### PR DESCRIPTION
For authz to work properly, to ensure that a provided hash is really accessible to the caller,
a bunch of changes had to be applied to the API calls.

* Doc-changes in CommitLogParam (no functional changes)
* Doc-changes in ContentsApi (no functional changes)
* `TreeApi.createReference`: new parameter `sourceRef` (reference name)
* `TreeApi.assignTag`+`assignBranch`: type change of source-ref to `Reference` (bugfix)
* `TreeApi.merge`: `Merge` object: new field/parameter `sourceRef` (reference name)
* `TreeApi.transplant`: `Transplant` object: new field/parameter `sourceRef` (reference name)

---

* Propagate the named-ref parameters downstream to `VersionStore` interface
* Introduce a new `LegacyVersionStore` class that implements the REST-API changes in
  `VersionStore` and delegates using the "old version-store SPI" to the legacy
  version-store implementation. Benefit: No major change in the legacy implementations.

---

* Related changes to `pynessie`

---

* Bunch of boring test-code changes + generated code (python cassettes+docs, ui)

---

Related Iceberg branch: https://github.com/snazy/iceberg/tree/nessie-api-with-named-refs



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1693)
<!-- Reviewable:end -->
