### PR TITLE
Align Chart version with Nessie version

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -136,7 +136,7 @@ jobs:
       working-directory: ./helm/nessie
       run: |
         cp Chart.yaml /tmp/nessie-Chart.yaml
-        cat /tmp/nessie-Chart.yaml | sed "s/^appVersion: [0-9.]*$/appVersion: ${RELEASE_VERSION}/" > Chart.yaml
+        cat /tmp/nessie-Chart.yaml | sed "s/^version: [0-9.]*$/version: ${RELEASE_VERSION}/" > Chart.yaml
 
     - name: Bump UI release version ${{ github.event.inputs.releaseVersion }}
       working-directory: ./ui

--- a/helm/README.md
+++ b/helm/README.md
@@ -21,7 +21,7 @@ The following table lists the configurable parameters of the Nessie chart and th
 | image | Nessie Image settings | |
 | image.repository | The nessie image to use | `projectnessie/nessie` |
 | image.pullPolicy | Image pull policy, such as `IfNotPresent` / `Always` / `Never` | `IfNotPresent` |
-| image.tag | Overrides the image tag whose default is the chart appVersion | `appVersion` from `Chart.yaml` |
+| image.tag | Overrides the image tag whose default is the chart version | `version` from `Chart.yaml` |
 | versionStoreType | Version store to use: `JGIT` / `INMEMORY` / `DYNAMO`. `JGIT` is best for local testing, `DYNAMO` preferred for production | `INMEMORY` |
 | dynamodb | Configuration specific to `versionStoreType: DYNAMO` | |
 | dynamodb.region | The region to configure for Dynamo | `us-west-2` |

--- a/helm/nessie/Chart.yaml
+++ b/helm/nessie/Chart.yaml
@@ -1,23 +1,5 @@
 apiVersion: v2
 name: nessie
 description: A Helm chart for Nessie
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.8.3
+version: 0.8.3

--- a/helm/nessie/templates/_helpers.tpl
+++ b/helm/nessie/templates/_helpers.tpl
@@ -36,9 +36,7 @@ Common labels
 {{- define "nessie.labels" -}}
 helm.sh/chart: {{ include "nessie.chart" . }}
 {{ include "nessie.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: NESSIE_VERSION_STORE_TYPE

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: projectnessie/nessie
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag whose default is the chart version.
   tag: ""
 
 # which type of version store to use: JGIT, INMEMORY, DYNAMO. JGIT is best for local testing, DYNAMO preferred for production


### PR DESCRIPTION
We don't need to track the Helm chart independently from the Nessie
version, thus having a 1:1 mapping of Helm version & Nessie version makes sense here

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1704)
<!-- Reviewable:end -->
