### PR TITLE
Remove 'paths-ignore' for PRs due to mismatch with 'required status checks to pass'

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,16 +2,18 @@ name: PR Build Check
 
 on:
   pull_request:
-    paths-ignore:
-      - 'LICENSE'
-      - 'NOTICE'
-      - '**.md'
-      - '!site/**'
-      - '.github/dependabot.yml'
-      - '.github/workflows/release*.yml'
-      - '.github/workflows/check*.yml'
-      - '.idea/**'
-      - '.editorconfig'
+# NOTE: using paths-ignore here doesn't play well with "Require status checks to pass before merging"
+# due to https://github.community/t/feature-request-conditional-required-checks/16761
+#    paths-ignore:
+#      - 'LICENSE'
+#      - 'NOTICE'
+#      - '**.md'
+#      - '!site/**'
+#      - '.github/dependabot.yml'
+#      - '.github/workflows/release*.yml'
+#      - '.github/workflows/check*.yml'
+#      - '.idea/**'
+#      - '.editorconfig'
 
 jobs:
   java:


### PR DESCRIPTION
Problem: Users opening PRs that only update ignored files, such as a .md
file end up having PRs that can't be merged because we have `Require status checks to pass before merging`
enabled for the `main` branch.
This is a known GH issue as reported at https://github.community/t/feature-request-conditional-required-checks/16761.
There seem to be a few workarounds mentioned on the ticket, however we
don't want to invest time currently in fixing this on our side as it
seems cheaper to run CI for those "ignored" files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1706)
<!-- Reviewable:end -->
