### PR TITLE
Adjust examples to allow for 200 reposes where possible

### DIFF
--- a/model/src/main/java/org/projectnessie/api/ContentsApi.java
+++ b/model/src/main/java/org/projectnessie/api/ContentsApi.java
@@ -83,7 +83,7 @@ public interface ContentsApi {
           @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           @Parameter(
               description = "a particular hash on the given ref",
-              examples = {@ExampleObject(ref = "hash")})
+              examples = {@ExampleObject(ref = "nullHash"), @ExampleObject(ref = "hash")})
           @QueryParam("hashOnRef")
           String hashOnRef)
       throws NessieNotFoundException;
@@ -116,7 +116,7 @@ public interface ContentsApi {
           @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           @Parameter(
               description = "a particular hash on the given ref",
-              examples = {@ExampleObject(ref = "hash")})
+              examples = {@ExampleObject(ref = "nullHash"), @ExampleObject(ref = "hash")})
           @QueryParam("hashOnRef")
           String hashOnRef,
       @Valid @NotNull @RequestBody(description = "Keys to retrieve.")

--- a/model/src/main/java/org/projectnessie/api/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/TreeApi.java
@@ -83,6 +83,7 @@ public interface TreeApi {
         content =
             @Content(
                 mediaType = MediaType.APPLICATION_JSON,
+                examples = {@ExampleObject(ref = "refObj")},
                 schema = @Schema(implementation = Branch.class))),
     @APIResponse(responseCode = "404", description = "Default branch not found.")
   })
@@ -99,7 +100,7 @@ public interface TreeApi {
         content = {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
-              examples = {@ExampleObject(ref = "refObj")},
+              examples = {@ExampleObject(ref = "refObjNew")},
               schema = @Schema(implementation = Reference.class))
         }),
     @APIResponse(responseCode = "403", description = "Not allowed to create reference"),
@@ -113,7 +114,7 @@ public interface TreeApi {
               content = {
                 @Content(
                     mediaType = MediaType.APPLICATION_JSON,
-                    examples = {@ExampleObject(ref = "refObj")})
+                    examples = {@ExampleObject(ref = "refObjNew")})
               })
           Reference reference)
       throws NessieNotFoundException, NessieConflictException;

--- a/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
@@ -36,7 +36,7 @@ public class CommitLogParams {
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
   @Parameter(
       description = "a particular hash on the given ref to start from",
-      examples = {@ExampleObject(ref = "hash")})
+      examples = {@ExampleObject(ref = "nullHash"), @ExampleObject(ref = "hash")})
   @QueryParam("startHash")
   private String startHash;
 
@@ -44,7 +44,7 @@ public class CommitLogParams {
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
   @Parameter(
       description = "a particular hash on the given ref to end at",
-      examples = {@ExampleObject(ref = "hash")})
+      examples = {@ExampleObject(ref = "nullHash"), @ExampleObject(ref = "hash")})
   @QueryParam("endHash")
   private String endHash;
 

--- a/model/src/main/java/org/projectnessie/api/params/EntriesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/EntriesParams.java
@@ -36,7 +36,7 @@ public class EntriesParams {
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
   @Parameter(
       description = "a particular hash on the given ref",
-      examples = {@ExampleObject(ref = "hash")})
+      examples = {@ExampleObject(ref = "nullHash"), @ExampleObject(ref = "hash")})
   @QueryParam("hashOnRef")
   private String hashOnRef;
 

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -40,13 +40,22 @@ components:
       value: "main"
 
     hash:
-      value: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+      value: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+
+    nullHash:
+      value:
 
     refObj:
       value:
         type: BRANCH
-        hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+        hash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
         name: "main"
+
+    refObjNew:
+      value:
+        type: BRANCH
+        hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+        name: "exampleBranch"
 
     tagObj:
       value:


### PR DESCRIPTION
* Use the hash of the `main` branch from the in-memory store.
  This should match actual behaviour in the default docker
  image.

* Add null "expected" hash examples to methods that allow them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1755)
<!-- Reviewable:end -->
