### PR TITLE
TVS2 allow nested key-lists

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
@@ -53,15 +53,25 @@ public interface CommitLogEntry {
   List<Key> getDeletes();
 
   /**
-   * List of all "reachable" or "known" {@link Key}s up to this commit-log-entry's <em>parent</em>
-   * commit.
+   * The list of all "reachable" or "known" {@link org.projectnessie.versioned.Key}s up to this
+   * commit-log-entry's <em>parent</em> commit consists of all entries in this {@link
+   * org.projectnessie.versioned.persist.adapter.KeyList} plus the {@link
+   * org.projectnessie.versioned.persist.adapter.KeyListEntity}s via {@link #getKeyListsIds()}.
    *
    * <p>This key-list checkpoint, if present, does <em>not</em> contain the key-changes in this
    * entry in {@link #getPuts()} and {@link #getDeletes()}.
    */
   @Nullable
-  EmbeddedKeyList getKeyList();
+  KeyList getKeyList();
 
+  /**
+   * IDs of for the linked {@link org.projectnessie.versioned.persist.adapter.KeyListEntity} that,
+   * together with {@link #getKeyList()} make the complete {@link org.projectnessie.versioned.Key}
+   * for this commit.
+   */
+  List<Hash> getKeyListsIds();
+
+  /** Number of commits since the last complete key-list. */
   int getKeyListDistance();
 
   static CommitLogEntry of(
@@ -73,7 +83,8 @@ public interface CommitLogEntry {
       List<Key> unchanged,
       List<Key> deletes,
       int keyListDistance,
-      EmbeddedKeyList keyList) {
+      KeyList keyList,
+      List<Hash> keyListIds) {
     return ImmutableCommitLogEntry.builder()
         .createdTime(createdTime)
         .hash(hash)
@@ -84,6 +95,7 @@ public interface CommitLogEntry {
         .deletes(deletes)
         .keyListDistance(keyListDistance)
         .keyList(keyList)
+        .addAllKeyListsIds(keyListIds)
         .build();
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
@@ -32,7 +32,7 @@ public interface DatabaseAdapterConfig {
 
   int DEFAULT_PARENTS_PER_COMMIT = 20;
   int DEFAULT_KEY_LIST_DISTANCE = 20;
-  int DEFAULT_MAX_KEY_LIST_SIZE = Integer.MAX_VALUE;
+  int DEFAULT_MAX_KEY_LIST_SIZE = 250_000;
   int DEFAULT_COMMIT_TIMEOUT = 500;
   int DEFAULT_COMMIT_RETRIES = Integer.MAX_VALUE;
 
@@ -86,7 +86,7 @@ public interface DatabaseAdapterConfig {
    * org.projectnessie.versioned.persist.adapter.CommitLogEntry#getKeyListsIds()},
    * database-serialization overhead and similar.
    *
-   * <p>Values {@code <=0} are illegal, defaults to "unlimited".
+   * <p>Values {@code <=0} are illegal, defaults to {@link #getDefaultMaxKeyListSize()}.
    */
   @Value.Default
   default int getMaxKeyListSize() {
@@ -104,6 +104,8 @@ public interface DatabaseAdapterConfig {
    * leave enough room for a somewhat large-ish list via {@link
    * org.projectnessie.versioned.persist.adapter.CommitLogEntry#getKeyListsIds()},
    * database-serialization overhead * and similar.
+   *
+   * <p>Defaults to {@value #DEFAULT_MAX_KEY_LIST_SIZE}.
    */
   default int getDefaultMaxKeyListSize() {
     return DEFAULT_MAX_KEY_LIST_SIZE;

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
@@ -32,6 +32,7 @@ public interface DatabaseAdapterConfig {
 
   int DEFAULT_PARENTS_PER_COMMIT = 20;
   int DEFAULT_KEY_LIST_DISTANCE = 20;
+  int DEFAULT_MAX_KEY_LIST_SIZE = Integer.MAX_VALUE;
   int DEFAULT_COMMIT_TIMEOUT = 500;
   int DEFAULT_COMMIT_RETRIES = Integer.MAX_VALUE;
 
@@ -61,7 +62,7 @@ public interface DatabaseAdapterConfig {
   /**
    * Each {@code n}-th {@link org.projectnessie.versioned.persist.adapter.CommitLogEntry}, where
    * {@code n ==} value of this parameter, will contain a "full" {@link
-   * org.projectnessie.versioned.persist.adapter.EmbeddedKeyList}. Defaults to {@value
+   * org.projectnessie.versioned.persist.adapter.KeyList}. Defaults to {@value
    * #DEFAULT_KEY_LIST_DISTANCE}.
    */
   @Value.Default
@@ -70,6 +71,43 @@ public interface DatabaseAdapterConfig {
   }
 
   DatabaseAdapterConfig withKeyListDistance(int keyListDistance);
+
+  /**
+   * Maximum size of a database object/row.
+   *
+   * <p>This parameter is respected for {@link
+   * org.projectnessie.versioned.persist.adapter.CommitLogEntry} with an {@link
+   * org.projectnessie.versioned.persist.adapter.KeyList}.
+   *
+   * <p>Not all kinds of databases have hard limits on the maximum size of a database object/row.
+   *
+   * <p>This value must not be "on the edge" - means: it must leave enough room for a somewhat
+   * large-ish list via {@link
+   * org.projectnessie.versioned.persist.adapter.CommitLogEntry#getKeyListsIds()},
+   * database-serialization overhead and similar.
+   *
+   * <p>Values {@code <=0} are illegal, defaults to "unlimited".
+   */
+  @Value.Default
+  default int getMaxKeyListSize() {
+    return getDefaultMaxKeyListSize();
+  }
+
+  DatabaseAdapterConfig withMaxKeyListSize(int maxKeyListSize);
+
+  /**
+   * Database adapter implementations that actually do have a hard technical or highly recommended
+   * limit on a maximum db-object / db-row size limitation should override this method and return a
+   * "good" value.
+   *
+   * <p>As for {@link #getMaxKeyListSize()}, this value must not be "on the edge" - means: it must
+   * leave enough room for a somewhat large-ish list via {@link
+   * org.projectnessie.versioned.persist.adapter.CommitLogEntry#getKeyListsIds()},
+   * database-serialization overhead * and similar.
+   */
+  default int getDefaultMaxKeyListSize() {
+    return DEFAULT_MAX_KEY_LIST_SIZE;
+  }
 
   /**
    * Timeout for CAS-like operations in milliseconds. Default is {@value #DEFAULT_COMMIT_TIMEOUT}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
@@ -21,16 +21,12 @@ import java.util.List;
 import org.immutables.value.Value;
 
 /**
- * Contains/references the complete list of keys that are "visible" from a specific {@link
+ * Contains/references a list of keys that are "visible" from a specific {@link
  * org.projectnessie.versioned.persist.adapter.CommitLogEntry}.
  */
 @Value.Immutable(lazyhash = true)
-@JsonSerialize(as = ImmutableEmbeddedKeyList.class)
-@JsonDeserialize(as = ImmutableEmbeddedKeyList.class)
-public interface EmbeddedKeyList {
+@JsonSerialize(as = ImmutableKeyList.class)
+@JsonDeserialize(as = ImmutableKeyList.class)
+public interface KeyList {
   List<KeyWithType> getKeys();
-
-  // TODO add a List<Hash> here that points to a new KeyList-entity to support an arbitrary number
-  //  of keys
-  // List<Hash> getKeyListsIds();
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntity.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntity.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.Hash;
+
+/**
+ * Persistable entity with a list of keys for {@link
+ * org.projectnessie.versioned.persist.adapter.CommitLogEntry#getKeyListsIds()}.
+ */
+@Value.Immutable(lazyhash = true)
+@JsonSerialize(as = ImmutableKeyListEntity.class)
+@JsonDeserialize(as = ImmutableKeyListEntity.class)
+public interface KeyListEntity {
+  Hash getId();
+
+  KeyList getKeys();
+
+  static KeyListEntity of(Hash id, KeyList keys) {
+    return ImmutableKeyListEntity.builder().id(id).keys(keys).build();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -762,7 +762,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
                       Stream.of(e.getKeyListsIds())
                           .flatMap(ids -> fetchKeyLists(ctx, ids))
                           .map(KeyListEntity::getKeys)
-                          .flatMap(k -> k.getKeys().stream()));
+                          .flatMap(k -> k.getKeys().stream())
+                          .filter(kt -> seen.add(kt.getKey())));
             }
           }
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.adapter.spi;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.hashKey;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.hashNotFound;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.newHasher;
+import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.randomHash;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.takeUntilExcludeLast;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.takeUntilIncludeLast;
 
@@ -60,10 +61,11 @@ import org.projectnessie.versioned.persist.adapter.ContentsAndState;
 import org.projectnessie.versioned.persist.adapter.ContentsId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
-import org.projectnessie.versioned.persist.adapter.EmbeddedKeyList;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitLogEntry;
-import org.projectnessie.versioned.persist.adapter.ImmutableEmbeddedKeyList;
+import org.projectnessie.versioned.persist.adapter.ImmutableKeyList;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
+import org.projectnessie.versioned.persist.adapter.KeyList;
+import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 import org.projectnessie.versioned.persist.adapter.KeyWithType;
 
@@ -130,10 +132,15 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
    * @param ctx technical operation-context
    * @param commitAttempt commit parameters
    * @param branchHead current HEAD of {@code branch}
+   * @param newKeyLists consumer for optimistically written {@link KeyListEntity}s
    * @return optimistically written commit-log-entry
    */
   protected CommitLogEntry commitAttempt(
-      OP_CONTEXT ctx, long timeInMicros, Hash branchHead, CommitAttempt commitAttempt)
+      OP_CONTEXT ctx,
+      long timeInMicros,
+      Hash branchHead,
+      CommitAttempt commitAttempt,
+      Consumer<Hash> newKeyLists)
       throws ReferenceNotFoundException, ReferenceConflictException {
     List<String> mismatches = new ArrayList<>();
 
@@ -165,7 +172,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
             commitAttempt.getPuts(),
             commitAttempt.getUnchanged(),
             commitAttempt.getDeletes(),
-            currentBranchEntry != null ? currentBranchEntry.getKeyListDistance() : 0);
+            currentBranchEntry != null ? currentBranchEntry.getKeyListDistance() : 0,
+            newKeyLists);
     writeIndividualCommit(ctx, newBranchCommit);
     return newBranchCommit;
   }
@@ -178,7 +186,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
    * @param toBranch merge-into reference with expected hash of HEAD
    * @param expectedHead if present, {@code toBranch}'s current HEAD must be equal to this value
    * @param toHead current HEAD of {@code toBranch}
-   * @param individualCommits consumer for the individual commits to merge
+   * @param branchCommits consumer for the individual commits to merge
+   * @param newKeyLists consumer for optimistically written {@link KeyListEntity}s
    * @return hash of the last commit-log-entry written to {@code toBranch}
    */
   protected Hash mergeAttempt(
@@ -188,7 +197,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
       BranchName toBranch,
       Optional<Hash> expectedHead,
       Hash toHead,
-      Consumer<Hash> individualCommits)
+      Consumer<Hash> branchCommits,
+      Consumer<Hash> newKeyLists)
       throws ReferenceNotFoundException, ReferenceConflictException {
 
     // 1. ensure 'expectedHash' is a parent of HEAD-of-'toBranch'
@@ -222,11 +232,11 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
 
     // (no need to verify the global states during a transplant)
     // 6. re-apply commits in 'sequenceToTransplant' onto 'targetBranch'
-    toHead = copyCommits(ctx, timeInMicros, toHead, commitsToMergeChronological);
+    toHead = copyCommits(ctx, timeInMicros, toHead, commitsToMergeChronological, newKeyLists);
 
     // 7. Write commits
 
-    commitsToMergeChronological.stream().map(CommitLogEntry::getHash).forEach(individualCommits);
+    commitsToMergeChronological.stream().map(CommitLogEntry::getHash).forEach(branchCommits);
     writeMultipleCommits(ctx, commitsToMergeChronological);
     return toHead;
   }
@@ -239,7 +249,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
    * @param expectedHead if present, {@code targetBranch}'s current HEAD must be equal to this value
    * @param targetHead current HEAD of {@code targetBranch}
    * @param sequenceToTransplant sequential list of commits to transplant from {@code source}
-   * @param individualCommits consumer for the individual commits to merge
+   * @param branchCommits consumer for the individual commits to merge
+   * @param newKeyLists consumer for optimistically written {@link KeyListEntity}s
    * @return hash of the last commit-log-entry written to {@code targetBranch}
    */
   protected Hash transplantAttempt(
@@ -249,7 +260,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
       Optional<Hash> expectedHead,
       Hash targetHead,
       List<Hash> sequenceToTransplant,
-      Consumer<Hash> individualCommits)
+      Consumer<Hash> branchCommits,
+      Consumer<Hash> newKeyLists)
       throws ReferenceNotFoundException, ReferenceConflictException {
     if (sequenceToTransplant.isEmpty()) {
       throw new IllegalArgumentException("No hashes to transplant given.");
@@ -293,13 +305,12 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
 
     // (no need to verify the global states during a transplant)
     // 6. re-apply commits in 'sequenceToTransplant' onto 'targetBranch'
-    targetHead = copyCommits(ctx, timeInMicros, targetHead, commitsToTransplantChronological);
+    targetHead =
+        copyCommits(ctx, timeInMicros, targetHead, commitsToTransplantChronological, newKeyLists);
 
     // 7. Write commits
 
-    commitsToTransplantChronological.stream()
-        .map(CommitLogEntry::getHash)
-        .forEach(individualCommits);
+    commitsToTransplantChronological.stream().map(CommitLogEntry::getHash).forEach(branchCommits);
     writeMultipleCommits(ctx, commitsToTransplantChronological);
     return targetHead;
   }
@@ -491,8 +502,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
   }
 
   /**
-   * Builds a {@link CommitLogEntry} using the given values. This function also includes an {@link
-   * EmbeddedKeyList}, if triggered by the values of {@code currentKeyListDistance} and {@link
+   * Builds a {@link CommitLogEntry} using the given values. This function also includes a {@link
+   * KeyList}, if triggered by the values of {@code currentKeyListDistance} and {@link
    * DatabaseAdapterConfig#getKeyListDistance()}, so read operations may happen.
    */
   protected CommitLogEntry buildIndividualCommit(
@@ -503,7 +514,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
       List<KeyWithBytes> puts,
       List<Key> unchanged,
       List<Key> deletes,
-      int currentKeyListDistance) {
+      int currentKeyListDistance,
+      Consumer<Hash> newKeyLists) {
     Hash commitHash = individualCommitHash(parentHashes, commitMeta, puts, unchanged, deletes);
 
     int keyListDistance = currentKeyListDistance + 1;
@@ -518,10 +530,11 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
             unchanged,
             deletes,
             keyListDistance,
-            null);
+            null,
+            Collections.emptyList());
 
     if (keyListDistance >= config.getKeyListDistance()) {
-      entry = buildKeyList(ctx, entry);
+      entry = buildKeyList(ctx, entry, newKeyLists);
     }
     return entry;
   }
@@ -549,20 +562,129 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
     return Hash.of(UnsafeByteOperations.unsafeWrap(hasher.hash().asBytes()));
   }
 
-  /** Adds a complete key-list to the given {@link CommitLogEntry}, will read from the database. */
-  protected CommitLogEntry buildKeyList(OP_CONTEXT ctx, CommitLogEntry unwrittenEntry) {
+  /** Helper object for {@link #buildKeyList(Object, CommitLogEntry, Consumer)}. */
+  private static class KeyListBuildState {
+    final ImmutableCommitLogEntry.Builder newCommitEntry;
+    /** Builder for {@link CommitLogEntry#getKeyList()}. */
+    ImmutableKeyList.Builder embeddedBuilder = ImmutableKeyList.builder();
+    /** Builder for {@link KeyListEntity}. */
+    ImmutableKeyList.Builder currentKeyList;
+    /** Already built {@link KeyListEntity}s. */
+    List<KeyListEntity> newKeyListEntities = new ArrayList<>();
+
+    /** Flag whether {@link CommitLogEntry#getKeyList()} is being filled. */
+    boolean embedded = true;
+
+    /** Current size of either the {@link CommitLogEntry} or current {@link KeyListEntity}. */
+    int currentSize;
+
+    KeyListBuildState(int initialSize, ImmutableCommitLogEntry.Builder newCommitEntry) {
+      this.currentSize = initialSize;
+      this.newCommitEntry = newCommitEntry;
+    }
+
+    void finishKeyListEntity() {
+      Hash id = randomHash();
+      newKeyListEntities.add(KeyListEntity.of(id, currentKeyList.build()));
+      newCommitEntry.addKeyListsIds(id);
+    }
+
+    void newKeyListEntity() {
+      currentSize = 0;
+      currentKeyList = ImmutableKeyList.builder();
+    }
+
+    void addToKeyListEntity(KeyWithType keyWithType, int keyTypeSize) {
+      currentSize += keyTypeSize;
+      currentKeyList.addKeys(keyWithType);
+    }
+
+    void addToEmbedded(KeyWithType keyWithType, int keyTypeSize) {
+      currentSize += keyTypeSize;
+      embeddedBuilder.addKeys(keyWithType);
+    }
+  }
+
+  /**
+   * Adds a complete key-list to the given {@link CommitLogEntry}, will read from the database.
+   *
+   * <p>The implementation fills {@link CommitLogEntry#getKeyList()} with the most recently updated
+   * {@link Key}s.
+   *
+   * <p>If the calculated size of the database-object/row gets larger than {@link
+   * DatabaseAdapterConfig#getMaxKeyListSize()}, the next {@link Key}s will be added to new {@link
+   * KeyListEntity}s, each with a maximum size of {@link DatabaseAdapterConfig#getMaxKeyListSize()}.
+   *
+   * <p>The current implementation fetches all keys and "blindly" populated {@link
+   * CommitLogEntry#getKeyList()} and nested {@link KeyListEntity} via {@link
+   * CommitLogEntry#getKeyListsIds()}. So this implementation does not yet reuse previous {@link
+   * KeyListEntity}s. A follow-up improvement should check if already existing {@link
+   * KeyListEntity}s contain the same keys. This proposed optimization should be accompanied by an
+   * optimized read of the keys: for example, if the set of changed keys only affects {@link
+   * CommitLogEntry#getKeyList()} but not the keys via {@link KeyListEntity}, it is just unnecessary
+   * to both read and re-write those rows for {@link KeyListEntity}.
+   */
+  protected CommitLogEntry buildKeyList(
+      OP_CONTEXT ctx, CommitLogEntry unwrittenEntry, Consumer<Hash> newKeyLists) {
     // Read commit-log until the previous persisted key-list
 
     Hash startHash = unwrittenEntry.getParents().get(0);
-    ImmutableEmbeddedKeyList.Builder newKeyList = ImmutableEmbeddedKeyList.builder();
-    keysForCommitEntry(ctx, startHash, KeyFilterPredicate.ALLOW_ALL).forEach(newKeyList::addKeys);
 
-    return ImmutableCommitLogEntry.builder()
-        .from(unwrittenEntry)
-        .keyListDistance(0)
-        .keyList(newKeyList.build())
-        .build();
+    // Return the new commit-log-entry with the complete-key-list
+    ImmutableCommitLogEntry.Builder newCommitEntry =
+        ImmutableCommitLogEntry.builder().from(unwrittenEntry).keyListDistance(0);
+
+    KeyListBuildState buildState =
+        new KeyListBuildState(entitySize(unwrittenEntry), newCommitEntry);
+
+    keysForCommitEntry(ctx, startHash)
+        .forEach(
+            keyWithType -> {
+              int keyTypeSize = entitySize(keyWithType);
+              if (buildState.embedded) {
+                // filling the embedded key-list in CommitLogEntry
+
+                if (buildState.currentSize + keyTypeSize < config.getMaxKeyListSize()) {
+                  // CommitLogEntry.keyList still has room
+                  buildState.addToEmbedded(keyWithType, keyTypeSize);
+                } else {
+                  // CommitLogEntry.keyList is "full", switch to the first KeyListEntity
+                  buildState.embedded = false;
+                  buildState.newKeyListEntity();
+                  buildState.addToKeyListEntity(keyWithType, keyTypeSize);
+                }
+              } else {
+                // filling linked key-lists via CommitLogEntry.keyListIds
+
+                if (buildState.currentSize + keyTypeSize > config.getMaxKeyListSize()) {
+                  // current KeyListEntity is "full", switch to a new one
+                  buildState.finishKeyListEntity();
+                  buildState.newKeyListEntity();
+                }
+                buildState.addToKeyListEntity(keyWithType, keyTypeSize);
+              }
+            });
+
+    // If there's an "unfinished" KeyListEntity, build it.
+    if (buildState.currentKeyList != null) {
+      buildState.finishKeyListEntity();
+    }
+
+    // Inform the (CAS)-op-loop about the IDs of the KeyListEntities being optimistically written.
+    buildState.newKeyListEntities.stream().map(KeyListEntity::getId).forEach(newKeyLists);
+
+    // Write the new KeyListEntities
+    writeKeyListEntities(ctx, buildState.newKeyListEntities);
+
+    // Return the new commit-log-entry with the complete-key-list
+    return newCommitEntry.keyList(buildState.embeddedBuilder.build()).build();
   }
+
+  /** Calculate the expected size of the given {@link CommitLogEntry} in the database. */
+  protected abstract int entitySize(CommitLogEntry entry);
+
+  /** Calculate the expected size of the given {@link CommitLogEntry} in the database. */
+  protected abstract int entitySize(KeyWithType entry);
 
   /**
    * If the current HEAD of the target branch for a commit/transplant/merge is not equal to the
@@ -600,34 +722,52 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
   /** Retrieve the contents-keys and their types for the commit-log-entry with the given hash. */
   protected Stream<KeyWithType> keysForCommitEntry(
       OP_CONTEXT ctx, Hash hash, KeyFilterPredicate keyFilter) {
+    return keysForCommitEntry(ctx, hash)
+        .filter(kt -> keyFilter.check(kt.getKey(), kt.getContentsId(), kt.getType()));
+  }
+
+  /** Retrieve the contents-keys and their types for the commit-log-entry with the given hash. */
+  protected Stream<KeyWithType> keysForCommitEntry(OP_CONTEXT ctx, Hash hash) {
     // walk the commit-logs in reverse order - starting with the last persisted key-list
-    Set<KeyWithType> keys = new HashSet<>();
 
-    // Commit log is processed in
     Set<Key> seen = new HashSet<>();
-    Set<Key> removes = new HashSet<>();
-
     Stream<CommitLogEntry> log = commitLogFetcher(ctx, hash);
     log = takeUntilIncludeLast(log, e -> e.getKeyList() != null);
-    log.forEach(
+    return log.flatMap(
         e -> {
-          if (e.getKeyList() != null) {
-            e.getKeyList().getKeys().stream()
-                .filter(kt -> seen.add(kt.getKey()))
-                .filter(kt -> keyFilter.check(kt.getKey(), kt.getContentsId(), kt.getType()))
-                .forEach(keys::add);
-          }
-          e.getPuts().stream()
-              .filter(kt -> seen.add(kt.getKey()))
-              .filter(kt -> keyFilter.check(kt.getKey(), kt.getContentsId(), kt.getType()))
-              .map(KeyWithBytes::asKeyWithType)
-              .forEach(keys::add);
-          // Only have 'Key' in deletes, so map it to a 'KeyWithType' and it can be used to remove
-          // the entry from 'keys'.
-          e.getDeletes().stream().filter(seen::add).forEach(removes::add);
-        });
 
-    return keys.stream().filter(kt -> !removes.contains(kt.getKey()));
+          // Add CommitLogEntry.deletes to "seen" so these keys won't be returned
+          seen.addAll(e.getDeletes());
+
+          // Return from CommitLogEntry.puts first
+          Stream<KeyWithType> stream =
+              e.getPuts().stream()
+                  .filter(kt -> seen.add(kt.getKey()))
+                  .map(KeyWithBytes::asKeyWithType);
+
+          if (e.getKeyList() != null) {
+
+            // Return from CommitLogEntry.keyList after the keys in CommitLogEntry.puts
+            Stream<KeyWithType> embedded =
+                e.getKeyList().getKeys().stream().filter(kt -> seen.add(kt.getKey()));
+
+            stream = Stream.concat(stream, embedded);
+
+            if (!e.getKeyListsIds().isEmpty()) {
+              // If there are nested key-lists, retrieve those and add the keys from these
+              stream =
+                  Stream.concat(
+                      stream,
+                      // "lazily" fetch key-lists
+                      Stream.of(e.getKeyListsIds())
+                          .flatMap(ids -> fetchKeyLists(ctx, ids))
+                          .map(KeyListEntity::getKeys)
+                          .flatMap(k -> k.getKeys().stream()));
+            }
+          }
+
+          return stream;
+        });
   }
 
   /**
@@ -676,6 +816,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
   protected abstract Map<ContentsId, ByteString> fetchGlobalStates(
       OP_CONTEXT ctx, Set<ContentsId> contentIds);
 
+  protected abstract Stream<KeyListEntity> fetchKeyLists(OP_CONTEXT ctx, List<Hash> keyListsIds);
+
   /**
    * Write a new commit-entry, the given commit entry is to be persisted as is. All values of the
    * given {@link CommitLogEntry} can be considered valid and consistent.
@@ -695,6 +837,9 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
    */
   protected abstract void writeMultipleCommits(OP_CONTEXT ctx, List<CommitLogEntry> entries)
       throws ReferenceConflictException;
+
+  protected abstract void writeKeyListEntities(
+      OP_CONTEXT ctx, List<KeyListEntity> newKeyListEntities);
 
   /**
    * Check whether the commits in the range {@code sinceCommitExcluding] .. [upToCommitIncluding}
@@ -836,7 +981,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
       OP_CONTEXT ctx,
       long timeInMicros,
       Hash targetHead,
-      List<CommitLogEntry> commitsChronological) {
+      List<CommitLogEntry> commitsChronological,
+      Consumer<Hash> newKeyLists) {
     int parentsPerCommit = config.getParentsPerCommit();
 
     List<Hash> parents = new ArrayList<>(parentsPerCommit);
@@ -869,7 +1015,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
               sourceCommit.getPuts(),
               sourceCommit.getUnchanged(),
               sourceCommit.getDeletes(),
-              keyListDistance);
+              keyListDistance,
+              newKeyLists);
       keyListDistance = newEntry.getKeyListDistance();
 
       if (!newEntry.getHash().equals(sourceCommit.getHash())) {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
@@ -17,11 +17,13 @@ package org.projectnessie.versioned.persist.adapter.spi;
 
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+import com.google.protobuf.UnsafeByteOperations;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators.AbstractSpliterator;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -42,6 +44,16 @@ public final class DatabaseAdapterUtil {
   @SuppressWarnings("UnstableApiUsage")
   public static Hasher newHasher() {
     return Hashing.sha256().newHasher();
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  public static Hash randomHash() {
+    ThreadLocalRandom rand = ThreadLocalRandom.current();
+    Hasher hasher = newHasher();
+    for (int i = 0; i < 20; i++) {
+      hasher.putInt(rand.nextInt());
+    }
+    return Hash.of(UnsafeByteOperations.unsafeWrap(hasher.hash().asBytes()));
   }
 
   @SuppressWarnings("UnstableApiUsage")


### PR DESCRIPTION
The current implementation aggregates all known content-`Key`s in `CommitLogEntry.keyList`, so a larger amount of content-keys would hit a database's hard (and also highly recommended) limit of a database-object/database-row.

This PR enhances the "embedded key list" `CommitLogEntry.keyList` with "nested" `KeyListEntity`s, so the total number of keys is rather "unlimited".

When a "complete-key-list" is constructed, the total size of both `CommitLogEntry` and `KeyListEntity` is limited to `DatabaseAdapterConfig.getMaxKeyListSize`. The "global default" for this value is unlimited (`Integer.MAX_VALUE`). Databases that do force a hard/highly-recommended limit must override `DatabaseAdapterConfig.getDefaultMaxKeyListSize`, to imply that as the default for the concrete database.

Current tests (not in this PR) exercise against a rather small value for max-key-list-size and pass for the current implementations (not in this PR) for in-memory, rocks-db, h2 + postgres.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1763)
<!-- Reviewable:end -->
