### PR TITLE
TVS2: Serialization for database-adapters

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -216,6 +216,11 @@
       </dependency>
       <dependency>
         <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-persist-serialize</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
         <artifactId>nessie-versioned-persist-tests</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -164,6 +164,11 @@
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-serialize</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-persist-tests</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/versioned/persist/adapter/pom.xml
+++ b/versioned/persist/adapter/pom.xml
@@ -36,18 +36,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.versioned.persist.adapter;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.protobuf.ByteString;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -26,8 +24,6 @@ import org.projectnessie.versioned.Key;
 
 /** Represents a commit-log-entry stored in the database. */
 @Value.Immutable(lazyhash = true)
-@JsonSerialize(as = ImmutableCommitLogEntry.class)
-@JsonDeserialize(as = ImmutableCommitLogEntry.class)
 public interface CommitLogEntry {
   /** Creation timestamp in microseconds since epoch. */
   long getCreatedTime();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentsIdAndBytes.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentsIdAndBytes.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.versioned.persist.adapter;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.protobuf.ByteString;
 import org.immutables.value.Value;
 
@@ -25,8 +23,6 @@ import org.immutables.value.Value;
  * managed contents. Composite of contents-id, contents-type and contents.
  */
 @Value.Immutable(lazyhash = true)
-@JsonSerialize(as = ImmutableContentsIdAndBytes.class)
-@JsonDeserialize(as = ImmutableContentsIdAndBytes.class)
 public interface ContentsIdAndBytes {
   ContentsId getContentsId();
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentsIdWithType.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentsIdWithType.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.versioned.persist.adapter;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 /**
@@ -24,8 +22,6 @@ import org.immutables.value.Value;
  * managed contents. Composite of contents-id and contents-type.
  */
 @Value.Immutable(lazyhash = true)
-@JsonSerialize(as = ImmutableContentsIdWithType.class)
-@JsonDeserialize(as = ImmutableContentsIdWithType.class)
 public interface ContentsIdWithType {
   ContentsId getContentsId();
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.versioned.persist.adapter;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import org.immutables.value.Value;
 
@@ -25,8 +23,10 @@ import org.immutables.value.Value;
  * org.projectnessie.versioned.persist.adapter.CommitLogEntry}.
  */
 @Value.Immutable(lazyhash = true)
-@JsonSerialize(as = ImmutableKeyList.class)
-@JsonDeserialize(as = ImmutableKeyList.class)
 public interface KeyList {
   List<KeyWithType> getKeys();
+
+  static KeyList of(List<KeyWithType> keys) {
+    return ImmutableKeyList.builder().keys(keys).build();
+  }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntity.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntity.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.versioned.persist.adapter;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 import org.projectnessie.versioned.Hash;
 
@@ -25,8 +23,6 @@ import org.projectnessie.versioned.Hash;
  * org.projectnessie.versioned.persist.adapter.CommitLogEntry#getKeyListsIds()}.
  */
 @Value.Immutable(lazyhash = true)
-@JsonSerialize(as = ImmutableKeyListEntity.class)
-@JsonDeserialize(as = ImmutableKeyListEntity.class)
 public interface KeyListEntity {
   Hash getId();
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyWithBytes.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyWithBytes.java
@@ -15,16 +15,12 @@
  */
 package org.projectnessie.versioned.persist.adapter;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.protobuf.ByteString;
 import org.immutables.value.Value;
 import org.projectnessie.versioned.Key;
 
 /** Composite of key, contents-id, contents-type and contents. */
 @Value.Immutable(lazyhash = true)
-@JsonSerialize(as = ImmutableKeyWithBytes.class)
-@JsonDeserialize(as = ImmutableKeyWithBytes.class)
 public interface KeyWithBytes {
   Key getKey();
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyWithType.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyWithType.java
@@ -15,15 +15,11 @@
  */
 package org.projectnessie.versioned.persist.adapter;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 import org.projectnessie.versioned.Key;
 
 /** Composite of key, contents-id, contents-type. */
 @Value.Immutable(lazyhash = true)
-@JsonSerialize(as = ImmutableKeyWithType.class)
-@JsonDeserialize(as = ImmutableKeyWithType.class)
 public interface KeyWithType {
   Key getKey();
 

--- a/versioned/persist/pom.xml
+++ b/versioned/persist/pom.xml
@@ -32,6 +32,7 @@
 
   <modules>
     <module>adapter</module>
+    <module>serialize</module>
     <module>tests</module>
   </modules>
 </project>

--- a/versioned/persist/serialize/pom.xml
+++ b/versioned/persist/serialize/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie-versioned-persist</artifactId>
+    <version>0.9.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-versioned-persist-serialize</artifactId>
+
+  <name>Nessie - Versioned - Persist - Serialization</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>protobuf-java</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/serialize/ProtoSerialization.java
+++ b/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/serialize/ProtoSerialization.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.serialize;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ContentsId;
+import org.projectnessie.versioned.persist.adapter.ContentsIdAndBytes;
+import org.projectnessie.versioned.persist.adapter.ContentsIdWithType;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ImmutableKeyList;
+import org.projectnessie.versioned.persist.adapter.KeyList;
+import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+import org.projectnessie.versioned.persist.adapter.KeyWithType;
+
+public class ProtoSerialization {
+  public static AdapterTypes.CommitLogEntry toProto(CommitLogEntry entry) {
+    AdapterTypes.CommitLogEntry.Builder proto =
+        AdapterTypes.CommitLogEntry.newBuilder()
+            .setCreatedTime(entry.getCreatedTime())
+            .setHash(entry.getHash().asBytes())
+            .setMetadata(entry.getMetadata())
+            .setKeyListDistance(entry.getKeyListDistance());
+
+    entry.getParents().forEach(p -> proto.addParents(p.asBytes()));
+    entry.getPuts().forEach(p -> proto.addPuts(toProto(p)));
+    entry.getUnchanged().forEach(p -> proto.addUnchanged(keyToProto(p)));
+    entry.getDeletes().forEach(p -> proto.addDeletes(keyToProto(p)));
+
+    if (entry.getKeyList() != null) {
+      entry.getKeyList().getKeys().forEach(k -> proto.addKeyList(toProto(k)));
+    }
+    entry.getKeyListsIds().forEach(k -> proto.addKeyListIds(k.asBytes()));
+
+    return proto.build();
+  }
+
+  public static CommitLogEntry protoToCommitLogEntry(byte[] bytes) {
+    try {
+      if (bytes == null) {
+        return null;
+      }
+
+      AdapterTypes.CommitLogEntry proto = AdapterTypes.CommitLogEntry.parseFrom(bytes);
+      ImmutableCommitLogEntry.Builder entry =
+          ImmutableCommitLogEntry.builder()
+              .createdTime(proto.getCreatedTime())
+              .hash(Hash.of(proto.getHash()))
+              .metadata(proto.getMetadata())
+              .keyListDistance(proto.getKeyListDistance());
+
+      proto.getParentsList().forEach(p -> entry.addParents(Hash.of(p)));
+      proto.getPutsList().forEach(p -> entry.addPuts(protoToKeyWithBytes(p)));
+      proto.getUnchangedList().forEach(p -> entry.addUnchanged(protoToKey(p)));
+      proto.getDeletesList().forEach(p -> entry.addDeletes(protoToKey(p)));
+      if (!proto.getKeyListList().isEmpty()) {
+        ImmutableKeyList.Builder kl = ImmutableKeyList.builder();
+        proto.getKeyListList().forEach(kle -> kl.addKeys(protoToKeyWithType(kle)));
+        entry.keyList(kl.build());
+      }
+      proto.getKeyListIdsList().forEach(p -> entry.addKeyListsIds(Hash.of(p)));
+
+      return entry.build();
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static AdapterTypes.ContentsIdWithBytes toProto(ContentsIdAndBytes x) {
+    return AdapterTypes.ContentsIdWithBytes.newBuilder()
+        .setContentsId(AdapterTypes.ContentsId.newBuilder().setId(x.getContentsId().getId()))
+        .setType(x.getType())
+        .setValue(x.getValue())
+        .build();
+  }
+
+  public static ContentsIdAndBytes protoToContentsIdAndBytes(
+      AdapterTypes.ContentsIdWithBytes proto) {
+    return ContentsIdAndBytes.of(
+        ContentsId.of(proto.getContentsId().getId()), (byte) proto.getType(), proto.getValue());
+  }
+
+  public static AdapterTypes.ContentsIdWithType toProto(ContentsIdWithType x) {
+    return AdapterTypes.ContentsIdWithType.newBuilder()
+        .setContentsId(AdapterTypes.ContentsId.newBuilder().setId(x.getContentsId().getId()))
+        .setType(x.getType())
+        .build();
+  }
+
+  public static ContentsIdWithType protoToContentsIdWithType(
+      AdapterTypes.ContentsIdWithType proto) {
+    return ContentsIdWithType.of(
+        ContentsId.of(proto.getContentsId().getId()), (byte) proto.getType());
+  }
+
+  public static AdapterTypes.KeyList toProto(KeyList x) {
+    AdapterTypes.KeyList.Builder keyList = AdapterTypes.KeyList.newBuilder();
+    for (KeyWithType key : x.getKeys()) {
+      keyList.addKeys(toProto(key));
+    }
+    return keyList.build();
+  }
+
+  public static KeyList protoToKeyList(byte[] bytes) {
+    try {
+      AdapterTypes.KeyList proto = AdapterTypes.KeyList.parseFrom(bytes);
+      ImmutableKeyList.Builder keyList = ImmutableKeyList.builder();
+      for (AdapterTypes.KeyWithType key : proto.getKeysList()) {
+        keyList.addKeys(protoToKeyWithType(key));
+      }
+      return keyList.build();
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static AdapterTypes.KeyWithBytes toProto(KeyWithBytes x) {
+    return AdapterTypes.KeyWithBytes.newBuilder()
+        .setKey(keyToProto(x.getKey()))
+        .setContentsId(AdapterTypes.ContentsId.newBuilder().setId(x.getContentsId().getId()))
+        .setType(x.getType())
+        .setValue(x.getValue())
+        .build();
+  }
+
+  public static KeyWithBytes protoToKeyWithBytes(AdapterTypes.KeyWithBytes proto) {
+    return KeyWithBytes.of(
+        Key.of(proto.getKey().getElementList().toArray(new String[0])),
+        ContentsId.of(proto.getContentsId().getId()),
+        (byte) proto.getType(),
+        proto.getValue());
+  }
+
+  public static AdapterTypes.KeyWithType toProto(KeyWithType x) {
+    return AdapterTypes.KeyWithType.newBuilder()
+        .setKey(keyToProto(x.getKey()))
+        .setContentsId(AdapterTypes.ContentsId.newBuilder().setId(x.getContentsId().getId()))
+        .setType(x.getType())
+        .build();
+  }
+
+  public static KeyWithType protoToKeyWithType(AdapterTypes.KeyWithType proto) {
+    return KeyWithType.of(
+        protoToKey(proto.getKey()),
+        ContentsId.of(proto.getContentsId().getId()),
+        (byte) proto.getType());
+  }
+
+  public static AdapterTypes.Key keyToProto(Key key) {
+    return AdapterTypes.Key.newBuilder().addAllElement(key.getElements()).build();
+  }
+
+  public static Key protoToKey(AdapterTypes.Key key) {
+    return Key.of(key.getElementList().toArray(new String[0]));
+  }
+}

--- a/versioned/persist/serialize/src/main/proto/persist.proto
+++ b/versioned/persist/serialize/src/main/proto/persist.proto
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+package nessie.persist;
+
+option java_package = "org.projectnessie.versioned.persist.serialize";
+option java_outer_classname = "AdapterTypes";
+option java_generate_equals_and_hash = true;
+
+message CommitLogEntry {
+  int64 createdTime = 1;
+  bytes hash = 2;
+  repeated bytes parents = 3;
+  bytes metadata = 4;
+  repeated KeyWithBytes puts = 5;
+  repeated Key unchanged = 6;
+  repeated Key deletes = 7;
+  int32 key_list_distance = 8;
+  repeated KeyWithType key_list = 9;
+  repeated bytes key_list_ids = 10;
+}
+
+message Key {
+  repeated string element = 1;
+}
+
+message KeyWithType {
+  Key key = 1;
+  ContentsId contents_id = 2;
+  int32 type = 3;
+}
+
+message KeyWithBytes {
+  Key key = 1;
+  ContentsId contents_id = 2;
+  int32 type = 3;
+  bytes value = 4;
+}
+
+message KeyList {
+  repeated KeyWithType keys = 1;
+}
+
+message ContentsId {
+  string id = 1;
+}
+
+message ContentsIdWithType {
+  ContentsId contents_id = 2;
+  int32 type = 3;
+}
+
+message ContentsIdWithBytes {
+  ContentsId contents_id = 2;
+  int32 type = 3;
+  bytes value = 4;
+}
+
+// Used by non-transactional database-adapters
+message GlobalStateLogEntry {
+  int64 createdTime = 1;
+  bytes id = 2;
+  repeated bytes parents = 3;
+  repeated ContentsIdWithBytes puts = 4;
+}
+
+// Used by non-transactional database-adapters
+message GlobalStatePointer {
+  bytes global_id = 1;
+  map<string, RefPointer> named_references = 2;
+}
+
+// Used by non-transactional database-adapters
+message RefPointer {
+  enum Type {
+    Branch = 0;
+    Tag = 1;
+  }
+  Type type = 1;
+  bytes hash = 2;
+}

--- a/versioned/persist/serialize/src/main/proto/persist.proto
+++ b/versioned/persist/serialize/src/main/proto/persist.proto
@@ -59,14 +59,14 @@ message ContentsId {
 }
 
 message ContentsIdWithType {
-  ContentsId contents_id = 2;
-  int32 type = 3;
+  ContentsId contents_id = 1;
+  int32 type = 2;
 }
 
 message ContentsIdWithBytes {
-  ContentsId contents_id = 2;
-  int32 type = 3;
-  bytes value = 4;
+  ContentsId contents_id = 1;
+  int32 type = 2;
+  bytes value = 3;
 }
 
 // Used by non-transactional database-adapters

--- a/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/serialize/TestSerialization.java
+++ b/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/serialize/TestSerialization.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.serialize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.toProto;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.UnsafeByteOperations;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ContentsId;
+import org.projectnessie.versioned.persist.adapter.ContentsIdAndBytes;
+import org.projectnessie.versioned.persist.adapter.ContentsIdWithType;
+import org.projectnessie.versioned.persist.adapter.KeyList;
+import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
+
+/** (Re-)serialization tests using random data for relevant types. */
+class TestSerialization {
+
+  public static class SerializationParam {
+    final Supplier<Object> generator;
+    final Class<?> type;
+    final Function<Object, byte[]> serializer;
+    final Function<byte[], Object> deserializer;
+
+    public SerializationParam(
+        Supplier<Object> generator,
+        Class<?> type,
+        Function<Object, byte[]> serializer,
+        Function<byte[], Object> deserializer) {
+      this.generator = generator;
+      this.type = type;
+      this.serializer = serializer;
+      this.deserializer = deserializer;
+    }
+
+    @Override
+    public String toString() {
+      return type.getSimpleName();
+    }
+  }
+
+  public static Supplier<Stream<SerializationParam>> params =
+      () ->
+          Stream.of(
+              new SerializationParam(
+                  TestSerialization::createEntry,
+                  CommitLogEntry.class,
+                  o -> toProto((CommitLogEntry) o).toByteArray(),
+                  ProtoSerialization::protoToCommitLogEntry),
+              new SerializationParam(
+                  TestSerialization::createGlobalEntry,
+                  GlobalStateLogEntry.class,
+                  o -> ((GlobalStateLogEntry) o).toByteArray(),
+                  b -> {
+                    try {
+                      return GlobalStateLogEntry.parseFrom(b);
+                    } catch (InvalidProtocolBufferException e) {
+                      throw new RuntimeException(e);
+                    }
+                  }),
+              new SerializationParam(
+                  TestSerialization::createGlobalState,
+                  GlobalStatePointer.class,
+                  o -> ((GlobalStatePointer) o).toByteArray(),
+                  b -> {
+                    try {
+                      return GlobalStatePointer.parseFrom(b);
+                    } catch (InvalidProtocolBufferException e) {
+                      throw new RuntimeException(e);
+                    }
+                  }));
+
+  public static Stream<SerializationParam> params() {
+    return params.get();
+  }
+
+  @ParameterizedTest
+  @MethodSource("params")
+  @Disabled("exists to compare serialized sizes of different implementations")
+  public void entries(SerializationParam ser) {
+    Object value = ser.generator.get();
+    byte[] serialized = ser.serializer.apply(value);
+    System.err.printf("%s serialized size: %s%n", ser, serialized.length);
+
+    Object deserialized = ser.deserializer.apply(serialized);
+    assertThat(deserialized).isEqualTo(value);
+  }
+
+  @ParameterizedTest
+  @MethodSource("params")
+  public void serialize1k(SerializationParam ser) {
+    Object value = ser.generator.get();
+    for (int i = 0; i < 1_000; i++) {
+      @SuppressWarnings("unused")
+      byte[] serialized = ser.serializer.apply(value);
+
+      Object deserialized = ser.deserializer.apply(serialized);
+      assertThat(deserialized).isEqualTo(value);
+      byte[] reserialized = ser.serializer.apply(deserialized);
+      assertThat(serialized).isEqualTo(reserialized);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("params")
+  public void deserialize1k(SerializationParam ser) {
+    Object value = ser.generator.get();
+    byte[] serialized = ser.serializer.apply(value);
+
+    for (int i = 0; i < 1_000; i++) {
+      @SuppressWarnings("unused")
+      Object deserialized = ser.deserializer.apply(serialized);
+      assertThat(deserialized).isEqualTo(value);
+      byte[] reserialized = ser.serializer.apply(deserialized);
+      assertThat(serialized).isEqualTo(reserialized);
+    }
+  }
+
+  static class TypeSerialization<A, P> {
+    final Class<A> apiType;
+    final Class<P> protoType;
+    final Supplier<A> generator;
+    final Function<A, P> toProto;
+    final Function<byte[], P> parseProto;
+    final Function<byte[], A> parseApi;
+
+    TypeSerialization(
+        Class<A> apiType,
+        Class<P> protoType,
+        Supplier<A> generator,
+        Function<A, P> toProto,
+        Function<byte[], P> parseProto,
+        Function<byte[], A> parseApi) {
+      this.apiType = apiType;
+      this.protoType = protoType;
+      this.generator = generator;
+      this.toProto = toProto;
+      this.parseProto = parseProto;
+      this.parseApi = parseApi;
+    }
+
+    @Override
+    public String toString() {
+      return apiType.getSimpleName();
+    }
+  }
+
+  @SuppressWarnings("rawtypes")
+  static List<TypeSerialization> typeSerialization() {
+    List<TypeSerialization> params = new ArrayList<>();
+    params.add(
+        new TypeSerialization<>(
+            CommitLogEntry.class,
+            AdapterTypes.CommitLogEntry.class,
+            TestSerialization::createEntry,
+            ProtoSerialization::toProto,
+            v -> {
+              try {
+                return AdapterTypes.CommitLogEntry.parseFrom(v);
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            ProtoSerialization::protoToCommitLogEntry));
+
+    params.add(
+        new TypeSerialization<>(
+            ContentsIdAndBytes.class,
+            AdapterTypes.ContentsIdWithBytes.class,
+            TestSerialization::createContentsIdWithBytes,
+            ProtoSerialization::toProto,
+            v -> {
+              try {
+                return AdapterTypes.ContentsIdWithBytes.parseFrom(v);
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            v -> {
+              try {
+                return ProtoSerialization.protoToContentsIdAndBytes(
+                    AdapterTypes.ContentsIdWithBytes.parseFrom(v));
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }));
+    params.add(
+        new TypeSerialization<>(
+            ContentsIdWithType.class,
+            AdapterTypes.ContentsIdWithType.class,
+            TestSerialization::createContentsIdWithType,
+            ProtoSerialization::toProto,
+            v -> {
+              try {
+                return AdapterTypes.ContentsIdWithType.parseFrom(v);
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            v -> {
+              try {
+                return ProtoSerialization.protoToContentsIdWithType(
+                    AdapterTypes.ContentsIdWithType.parseFrom(v));
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }));
+    params.add(
+        new TypeSerialization<>(
+            KeyWithBytes.class,
+            AdapterTypes.KeyWithBytes.class,
+            TestSerialization::createKeyWithBytes,
+            ProtoSerialization::toProto,
+            v -> {
+              try {
+                return AdapterTypes.KeyWithBytes.parseFrom(v);
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            v -> {
+              try {
+                return ProtoSerialization.protoToKeyWithBytes(
+                    AdapterTypes.KeyWithBytes.parseFrom(v));
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }));
+    params.add(
+        new TypeSerialization<>(
+            KeyWithType.class,
+            AdapterTypes.KeyWithType.class,
+            TestSerialization::createKeyWithType,
+            ProtoSerialization::toProto,
+            v -> {
+              try {
+                return AdapterTypes.KeyWithType.parseFrom(v);
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            v -> {
+              try {
+                return ProtoSerialization.protoToKeyWithType(AdapterTypes.KeyWithType.parseFrom(v));
+              } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+              }
+            }));
+    return params;
+  }
+
+  @ParameterizedTest
+  @MethodSource("typeSerialization")
+  public <A, P extends MessageLite> void typeSerialization(TypeSerialization<A, P> param) {
+    for (int i = 0; i < 500; i++) {
+      A entry = param.generator.get();
+
+      P proto = param.toProto.apply(entry);
+      byte[] serialized = proto.toByteArray();
+      P deserialized = param.parseProto.apply(serialized);
+
+      assertThat(proto).isEqualTo(deserialized);
+
+      A deserializedEntry = param.parseApi.apply(serialized);
+      assertThat(entry).isEqualTo(deserializedEntry);
+    }
+  }
+
+  public static ContentsId randomId() {
+    return ContentsId.of(UUID.randomUUID().toString());
+  }
+
+  public static Key randomKey() {
+    ThreadLocalRandom r = ThreadLocalRandom.current();
+    return Key.of("some" + r.nextInt(10000), "other" + r.nextInt(10000));
+  }
+
+  public static Hash randomHash() {
+    return Hash.of(randomBytes(16));
+  }
+
+  public static ByteString randomBytes(int num) {
+    byte[] raw = new byte[num];
+    ThreadLocalRandom.current().nextBytes(raw);
+    return UnsafeByteOperations.unsafeWrap(raw);
+  }
+
+  public static String randomString(int num) {
+    StringBuilder sb = new StringBuilder(num);
+    for (int i = 0; i < num; i++) {
+      sb.append((char) ThreadLocalRandom.current().nextInt(32, 126));
+    }
+    return sb.toString();
+  }
+
+  static GlobalStateLogEntry createGlobalEntry() {
+    GlobalStateLogEntry.Builder entry =
+        GlobalStateLogEntry.newBuilder().setCreatedTime(System.nanoTime() / 1000L);
+    for (int i = 0; i < 20; i++) {
+      entry.addParents(randomBytes(32));
+    }
+    for (int i = 0; i < 20; i++) {
+      entry.addPuts(
+          AdapterTypes.ContentsIdWithBytes.newBuilder()
+              .setContentsId(AdapterTypes.ContentsId.newBuilder().setId(randomString(64)).build())
+              .setType(2)
+              .setValue(randomBytes(120))
+              .build());
+    }
+    return entry.build();
+  }
+
+  static GlobalStatePointer createGlobalState() {
+    GlobalStatePointer.Builder state = GlobalStatePointer.newBuilder().setGlobalId(randomBytes(32));
+    for (int i = 0; i < 50; i++) {
+      state.putNamedReferences(
+          randomString(32),
+          RefPointer.newBuilder().setType(RefPointer.Type.Branch).setHash(randomBytes(32)).build());
+    }
+    return state.build();
+  }
+
+  static CommitLogEntry createEntry() {
+    return CommitLogEntry.of(
+        System.nanoTime() / 1000L,
+        randomHash(),
+        Arrays.asList(
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash(),
+            randomHash()),
+        randomBytes(256),
+        Arrays.asList(
+            KeyWithBytes.of(randomKey(), randomId(), (byte) 1, randomBytes(32)),
+            KeyWithBytes.of(randomKey(), randomId(), (byte) 1, randomBytes(32)),
+            KeyWithBytes.of(randomKey(), randomId(), (byte) 1, randomBytes(32)),
+            KeyWithBytes.of(randomKey(), randomId(), (byte) 1, randomBytes(32)),
+            KeyWithBytes.of(randomKey(), randomId(), (byte) 1, randomBytes(32)),
+            KeyWithBytes.of(randomKey(), randomId(), (byte) 1, randomBytes(32)),
+            KeyWithBytes.of(randomKey(), randomId(), (byte) 1, randomBytes(32))),
+        Arrays.asList(randomKey(), randomKey(), randomKey(), randomKey(), randomKey()),
+        Arrays.asList(randomKey(), randomKey()),
+        42,
+        KeyList.of(
+            IntStream.range(0, 20)
+                .mapToObj(
+                    i -> KeyWithType.of(randomKey(), ContentsId.of(randomString(60)), (byte) 0))
+                .collect(Collectors.toList())),
+        IntStream.range(0, 20).mapToObj(i -> randomHash()).collect(Collectors.toList()));
+  }
+
+  static KeyWithType createKeyWithType() {
+    return KeyWithType.of(
+        randomKey(),
+        ContentsId.of(randomString(64)),
+        (byte) ThreadLocalRandom.current().nextInt(0, 127));
+  }
+
+  static KeyWithBytes createKeyWithBytes() {
+    return KeyWithBytes.of(
+        randomKey(),
+        ContentsId.of(randomString(64)),
+        (byte) ThreadLocalRandom.current().nextInt(0, 127),
+        randomBytes(120));
+  }
+
+  static ContentsIdWithType createContentsIdWithType() {
+    return ContentsIdWithType.of(
+        ContentsId.of(randomString(64)), (byte) ThreadLocalRandom.current().nextInt(0, 127));
+  }
+
+  static ContentsIdAndBytes createContentsIdWithBytes() {
+    return ContentsIdAndBytes.of(
+        ContentsId.of(randomString(64)),
+        (byte) ThreadLocalRandom.current().nextInt(0, 127),
+        randomBytes(120));
+  }
+}


### PR DESCRIPTION
Some `DatabaseAdapter` implementations, for example RocksDB, store certain entities in their serialized form.

Introduces a new artifact `nessie-versioned-persist-serialize` that contains protobuf based serialization.

Objects that are exposed via the `DatabaseAdapter` interface are still based on "immutables" and not protobuf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1765)
<!-- Reviewable:end -->
