### PR TITLE
TVS throw ref not found + expose hash for "beginning of time"

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -217,11 +217,13 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
 
     // 3. Collect commit-log-entries
     List<CommitLogEntry> toEntriesReverseChronological =
-        takeUntilExcludeLast(readCommitLogStream(ctx, toHead), e -> e.getHash().equals(commonAncestor))
+        takeUntilExcludeLast(
+                readCommitLogStream(ctx, toHead), e -> e.getHash().equals(commonAncestor))
             .collect(Collectors.toList());
     Collections.reverse(toEntriesReverseChronological);
     List<CommitLogEntry> commitsToMergeChronological =
-        takeUntilExcludeLast(readCommitLogStream(ctx, from), e -> e.getHash().equals(commonAncestor))
+        takeUntilExcludeLast(
+                readCommitLogStream(ctx, from), e -> e.getHash().equals(commonAncestor))
             .collect(Collectors.toList());
 
     if (commitsToMergeChronological.isEmpty()) {
@@ -459,9 +461,9 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
   }
 
   /**
-   * Like {@link #readCommitLogStream(Object, Hash)}, but only returns the {@link Hash commit-log-entry
-   * hashes}, which can be taken from {@link CommitLogEntry#getParents()}, thus no need to perform a
-   * read-operation against every hash.
+   * Like {@link #readCommitLogStream(Object, Hash)}, but only returns the {@link Hash
+   * commit-log-entry hashes}, which can be taken from {@link CommitLogEntry#getParents()}, thus no
+   * need to perform a read-operation against every hash.
    */
   private Stream<Hash> readCommitLogHashesStream(OP_CONTEXT ctx, Hash initialHash) {
     return logFetcher(
@@ -935,8 +937,10 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
     //  max number of "to"-commits to fetch, max number of "from"-commits to fetch,
     //  both impact the cost (CPU, memory, I/O) of a merge operation.
 
-    Iterator<Hash> toLog = Spliterators.iterator(readCommitLogHashesStream(ctx, toHead).spliterator());
-    Iterator<Hash> fromLog = Spliterators.iterator(readCommitLogHashesStream(ctx, from).spliterator());
+    Iterator<Hash> toLog =
+        Spliterators.iterator(readCommitLogHashesStream(ctx, toHead).spliterator());
+    Iterator<Hash> fromLog =
+        Spliterators.iterator(readCommitLogHashesStream(ctx, from).spliterator());
     Set<Hash> toCommitHashes = new HashSet<>();
     List<Hash> fromCommitHashes = new ArrayList<>();
     while (true) {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
@@ -77,6 +77,10 @@ public final class DatabaseAdapterUtil {
         String.format("Named reference '%s' not found", ref.getName()));
   }
 
+  public static ReferenceNotFoundException referenceNotFound(Hash hash) {
+    return new ReferenceNotFoundException(String.format("Commit '%s' not found", hash.asString()));
+  }
+
   public static ReferenceAlreadyExistsException referenceAlreadyExists(NamedRef ref) {
     return new ReferenceAlreadyExistsException(
         String.format("Named reference '%s' already exists.", ref.getName()));


### PR DESCRIPTION
Current `DatabaseAdapter` API returns an empty stream if a ref could not be found, which is a left-over from the removal of all the added `NamedRef`s. `DatabaseAdapter` should throw `ReferenceNotFoundException`s instread.

Also exposes a function to return the hash for "beginning of time", which will become useful in following PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1776)
<!-- Reviewable:end -->
