### PR TITLE
Improve circular dependency handling to NessieClient

### DIFF
--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -33,7 +33,19 @@
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
-      <version>${project.version}</version>
+      <version>${iceberg.nessie.version}</version>
+      <!-- we need to exclude this here so that we run the code with the same model classes that ship with iceberg's nessie version -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.projectnessie</groupId>
+          <artifactId>nessie-model</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-model</artifactId>
+      <version>${iceberg.nessie.version}</version>
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
@@ -136,10 +148,10 @@
       <plugin>
         <groupId>org.projectnessie</groupId>
         <artifactId>nessie-apprunner-maven-plugin</artifactId>
-        <version>${project.version}</version>
+        <version>${iceberg.nessie.version}</version>
         <configuration>
           <skip>${skipTests}</skip>
-          <appArtifactId>org.projectnessie:nessie-quarkus:${project.version}</appArtifactId>
+          <appArtifactId>org.projectnessie:nessie-quarkus:${iceberg.nessie.version}</appArtifactId>
           <applicationProperties>
             <quarkus.http.test-port>0</quarkus.http.test-port>
           </applicationProperties>
@@ -151,7 +163,7 @@
           <dependency>
             <groupId>org.projectnessie</groupId>
             <artifactId>nessie-quarkus</artifactId>
-            <version>${project.version}</version>
+            <version>${iceberg.nessie.version}</version>
           </dependency>
         </dependencies>
         <executions>

--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -34,18 +34,7 @@
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
       <version>${client.nessie.version}</version>
-      <!-- we need to exclude this here so that we run the code with the same model classes that ship with iceberg's nessie version -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.projectnessie</groupId>
-          <artifactId>nessie-model</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-model</artifactId>
-      <version>${client.nessie.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>

--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
-      <version>${iceberg.nessie.version}</version>
+      <version>${client.nessie.version}</version>
       <!-- we need to exclude this here so that we run the code with the same model classes that ship with iceberg's nessie version -->
       <exclusions>
         <exclusion>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-model</artifactId>
-      <version>${iceberg.nessie.version}</version>
+      <version>${client.nessie.version}</version>
     </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
@@ -148,10 +148,10 @@
       <plugin>
         <groupId>org.projectnessie</groupId>
         <artifactId>nessie-apprunner-maven-plugin</artifactId>
-        <version>${iceberg.nessie.version}</version>
+        <version>${client.nessie.version}</version>
         <configuration>
           <skip>${skipTests}</skip>
-          <appArtifactId>org.projectnessie:nessie-quarkus:${iceberg.nessie.version}</appArtifactId>
+          <appArtifactId>org.projectnessie:nessie-quarkus:${client.nessie.version}</appArtifactId>
           <applicationProperties>
             <quarkus.http.test-port>0</quarkus.http.test-port>
           </applicationProperties>
@@ -163,7 +163,7 @@
           <dependency>
             <groupId>org.projectnessie</groupId>
             <artifactId>nessie-quarkus</artifactId>
-            <version>${iceberg.nessie.version}</version>
+            <version>${client.nessie.version}</version>
           </dependency>
         </dependencies>
         <executions>

--- a/clients/tests/pom.xml
+++ b/clients/tests/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
-      <version>${project.version}</version>
+      <version>${iceberg.nessie.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/clients/tests/pom.xml
+++ b/clients/tests/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
-      <version>${iceberg.nessie.version}</version>
+      <version>${client.nessie.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,8 @@
     <awssdk.version>2.17.25</awssdk.version>
     <bouncycastle.version>1.66</bouncycastle.version>
     <cel.version>0.2.0</cel.version>
+    <!-- to fix circular dependencies with NessieClient, certain projects need to use the same Nessie version as Iceberg/Delta has -->
+    <client.nessie.version>0.9.0</client.nessie.version>
     <deltalake2.version>0.6.2-nessie</deltalake2.version>
     <deltalake3.version>0.8.0-nessie</deltalake3.version>
     <dynamodb.version>1.12.0</dynamodb.version>
@@ -139,8 +141,6 @@
     <guava.version>30.1.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <iceberg.version>0.12.0</iceberg.version>
-    <!-- to fix circular dependencies with NessieClient, certain projects need to use the same Nessie version as Iceberg has -->
-    <iceberg.nessie.version>0.9.0</iceberg.nessie.version>
     <immutables.version>2.8.9-ea-1</immutables.version>
     <jackson.version>2.12.4</jackson.version>
     <javax.version>4.0.1</javax.version>

--- a/versioned/gc/iceberg-actions/pom.xml
+++ b/versioned/gc/iceberg-actions/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
-      <version>${iceberg.nessie.version}</version>
+      <version>${client.nessie.version}</version>
       <scope>test</scope>
       <!-- we need to exclude this here so that we run the code with the same model classes that ship with iceberg's nessie version -->
       <exclusions>
@@ -258,10 +258,10 @@
       <plugin>
         <groupId>org.projectnessie</groupId>
         <artifactId>nessie-apprunner-maven-plugin</artifactId>
-        <version>${iceberg.nessie.version}</version>
+        <version>${client.nessie.version}</version>
         <configuration>
           <skip>${skipTests}</skip>
-          <appArtifactId>org.projectnessie:nessie-quarkus:${iceberg.nessie.version}</appArtifactId>
+          <appArtifactId>org.projectnessie:nessie-quarkus:${client.nessie.version}</appArtifactId>
           <applicationProperties>
             <quarkus.http.test-port>0</quarkus.http.test-port>
             <nessie.version.store.dynamo.initialize>true</nessie.version.store.dynamo.initialize>
@@ -281,7 +281,7 @@
           <dependency>
             <groupId>org.projectnessie</groupId>
             <artifactId>nessie-quarkus</artifactId>
-            <version>${iceberg.nessie.version}</version>
+            <version>${client.nessie.version}</version>
           </dependency>
         </dependencies>
         <executions>

--- a/versioned/gc/iceberg/pom.xml
+++ b/versioned/gc/iceberg/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-client</artifactId>
-      <version>${iceberg.nessie.version}</version>
+      <version>${client.nessie.version}</version>
       <scope>test</scope>
       <!-- we need to exclude this here so that we run the code with the same model classes that ship with iceberg's nessie version -->
       <exclusions>
@@ -250,10 +250,10 @@
       <plugin>
         <groupId>org.projectnessie</groupId>
         <artifactId>nessie-apprunner-maven-plugin</artifactId>
-        <version>${iceberg.nessie.version}</version>
+        <version>${client.nessie.version}</version>
         <configuration>
           <skip>${skipTests}</skip>
-          <appArtifactId>org.projectnessie:nessie-quarkus:${iceberg.nessie.version}</appArtifactId>
+          <appArtifactId>org.projectnessie:nessie-quarkus:${client.nessie.version}</appArtifactId>
           <applicationProperties>
             <quarkus.http.test-port>0</quarkus.http.test-port>
             <nessie.version.store.dynamo.initialize>true</nessie.version.store.dynamo.initialize>
@@ -273,7 +273,7 @@
           <dependency>
             <groupId>org.projectnessie</groupId>
             <artifactId>nessie-quarkus</artifactId>
-            <version>${iceberg.nessie.version}</version>
+            <version>${client.nessie.version}</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
The circular dependecy is fixed by introducing the same NessieClient version that Iceberg uses.

This also moves NessieClient instantiation into subclasses of AbstractSparkTest so that each subclass can control how to instantiate the NessieClient (depending on the Nessie version they pull in)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1783)
<!-- Reviewable:end -->
