### PR TITLE
Fix circular dependency to NessieClient in gc modules

### DIFF
--- a/versioned/gc/iceberg-actions/pom.xml
+++ b/versioned/gc/iceberg-actions/pom.xml
@@ -36,6 +36,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-spark3-runtime</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-gc-iceberg</artifactId>
       <version>${project.version}</version>
@@ -141,11 +145,6 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>DynamoDBLocal</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.iceberg</groupId>
-      <artifactId>iceberg-spark3-runtime</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/versioned/gc/iceberg/pom.xml
+++ b/versioned/gc/iceberg/pom.xml
@@ -36,6 +36,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-spark3-runtime</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-gc</artifactId>
       <version>${project.version}</version>
@@ -45,11 +49,6 @@
       <artifactId>nessie-server-store</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.iceberg</groupId>
-      <artifactId>iceberg-spark3-runtime</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
We remove the circular dependency by directly depending on the
NessieClient version that comes with the `iceberg-spark3-runtime`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1785)
<!-- Reviewable:end -->
