### PR TITLE
Specify version of smallrye-open-api-maven-plugin to fix Maven warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -742,6 +742,11 @@
           <version>${quarkus.version}</version>
         </plugin>
         <plugin>
+          <groupId>io.smallrye</groupId>
+          <artifactId>smallrye-open-api-maven-plugin</artifactId>
+          <version>2.1.9</version>
+        </plugin>
+        <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
           <version>0.6.1</version>


### PR DESCRIPTION
Maven complains about this as can be seen below:
```
2021-08-19T07:08:33.8778965Z [WARNING] Some problems were encountered while building the effective model for org.projectnessie:nessie-model:jar:0.9.1-SNAPSHOT
2021-08-19T07:08:33.8794382Z [WARNING] 'build.plugins.plugin.version' for io.smallrye:smallrye-open-api-maven-plugin is missing. @ line 103, column 15
2021-08-19T07:08:33.8797646Z [WARNING]
2021-08-19T07:08:33.8805829Z [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
2021-08-19T07:08:33.8808291Z [WARNING]
2021-08-19T07:08:33.8816626Z [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1794)
<!-- Reviewable:end -->
