### PR TITLE
Remove circular dependency to NessieClient in GC modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,8 @@
     <guava.version>30.1.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <iceberg.version>0.12.0</iceberg.version>
+    <!-- to fix circular dependencies with NessieClient, certain projects need to use the same Nessie version as Iceberg has -->
+    <iceberg.nessie.version>0.9.0</iceberg.nessie.version>
     <immutables.version>2.8.9-ea-1</immutables.version>
     <jackson.version>2.12.4</jackson.version>
     <javax.version>4.0.1</javax.version>

--- a/versioned/gc/iceberg-actions/pom.xml
+++ b/versioned/gc/iceberg-actions/pom.xml
@@ -30,11 +30,20 @@
 
   <name>Nessie - Versioned - GC for Spark - Iceberg - Actions</name>
 
-  <properties>
-    <iceberg.nessie.version>${project.version}</iceberg.nessie.version>
-  </properties>
-
   <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client</artifactId>
+      <version>${iceberg.nessie.version}</version>
+      <scope>test</scope>
+      <!-- we need to exclude this here so that we run the code with the same model classes that ship with iceberg's nessie version -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.projectnessie</groupId>
+          <artifactId>nessie-model</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-gc-iceberg</artifactId>

--- a/versioned/gc/iceberg/pom.xml
+++ b/versioned/gc/iceberg/pom.xml
@@ -30,11 +30,20 @@
 
   <name>Nessie - Versioned - GC for Spark - Iceberg</name>
 
-  <properties>
-    <iceberg.nessie.version>${project.version}</iceberg.nessie.version>
-  </properties>
-
   <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client</artifactId>
+      <version>${iceberg.nessie.version}</version>
+      <scope>test</scope>
+      <!-- we need to exclude this here so that we run the code with the same model classes that ship with iceberg's nessie version -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.projectnessie</groupId>
+          <artifactId>nessie-model</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-gc</artifactId>


### PR DESCRIPTION
The circular dependecy is fixed by introducing the same NessieClient
version that Iceberg uses.

Note that we need to exclude nessie-model from the GC modules so that we
run the code with the same model classes that ship with iceberg's nessie
version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1818)
<!-- Reviewable:end -->
