### PR TITLE
Bump Delta to 1.0.0

### DIFF
--- a/clients/deltalake/src/main/scala/org/projectnessie/deltalake/NessieLogFileMetaParser.scala
+++ b/clients/deltalake/src/main/scala/org/projectnessie/deltalake/NessieLogFileMetaParser.scala
@@ -17,7 +17,7 @@ package org.projectnessie.deltalake
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.delta.storage.LogStore
-import org.apache.spark.sql.delta.{LogFileMeta, LogFileMetaParser}
+import org.apache.spark.sql.delta.storage.{LogFileMeta, LogFileMetaParser}
 
 class NessieLogFileMetaParser(val logStore: LogStore)
     extends LogFileMetaParser(logStore = logStore) {

--- a/clients/deltalake/src/main/scala/org/projectnessie/deltalake/NessieLogStore.scala
+++ b/clients/deltalake/src/main/scala/org/projectnessie/deltalake/NessieLogStore.scala
@@ -46,11 +46,8 @@ import org.apache.spark.sql.delta.util.FileNames.{
   deltaFile,
   getFileVersion
 }
-import org.apache.spark.sql.delta.{
-  CheckpointMetaData,
-  DeltaFileType,
-  LogFileMeta
-}
+import org.apache.spark.sql.delta.CheckpointMetaData
+import org.apache.spark.sql.delta.storage.{DeltaFileType, LogFileMeta}
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.projectnessie.model.Operation.Put

--- a/pom.xml
+++ b/pom.xml
@@ -160,10 +160,8 @@
     <scala2.13.version>2.13.6</scala2.13.version>
     <serverless.version>1.5</serverless.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <spark2.jackson.version>2.8.8</spark2.jackson.version>
-    <spark2.version>2.4.2</spark2.version>
     <spark3.jackson.version>2.10.2</spark3.jackson.version>
-    <spark3.version>3.0.3</spark3.version>
+    <spark3.version>3.1.1</spark3.version>
     <sqlite.version>1.0.392</sqlite.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <weld.version>3.1.7.Final</weld.version>
@@ -484,6 +482,10 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <cel.version>0.2.0</cel.version>
     <!-- to fix circular dependencies with NessieClient, certain projects need to use the same Nessie version as Iceberg/Delta has -->
     <client.nessie.version>0.9.0</client.nessie.version>
-    <deltalake.version>0.8.0-nessie</deltalake.version>
+    <deltalake.version>1.0.0-nessie</deltalake.version>
     <dynamodb.version>1.12.0</dynamodb.version>
     <flapdoodle.version>3.0.0</flapdoodle.version>
     <gatling.maven.version>3.1.2</gatling.maven.version>

--- a/versioned/gc/iceberg/src/test/java/org/projectnessie/versioned/gc/ITTestIdentifyUnreferencedAssetsIceberg.java
+++ b/versioned/gc/iceberg/src/test/java/org/projectnessie/versioned/gc/ITTestIdentifyUnreferencedAssetsIceberg.java
@@ -226,7 +226,9 @@ class ITTestIdentifyUnreferencedAssetsIceberg {
 
     // create a new table on a different branch, commit then delete the branch.
     createTable(TABLE_IDENTIFIER2, catalogDeleteBranch);
+    SparkSession.setActiveSession(sparkDeleteBranch);
     addFile(sparkDeleteBranch, TABLE_IDENTIFIER2);
+    SparkSession.setActiveSession(spark);
     client
         .getTreeApi()
         .deleteBranch(


### PR DESCRIPTION
Delta 1.0.0 is spark3.1 only so this simultaneously bumps the tested version to spark 3.1

* Iceberg supports both 3.0 and 3.1 so testing against either is fine from icebergs perspective
* Previous delta only supported 3.0 so we had to do both bumps in 1 PR :-(
* the only change to support 3.1 is to make sure the session is set correctly when operating on multiple refs
* the only change required for delta is to change the package for a few classes that moved between 0.8 and 1.0