### PR TITLE
Fix client.nessie.version for Iceberg 0.12.0 using Nessie 0.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <bouncycastle.version>1.66</bouncycastle.version>
     <cel.version>0.2.0</cel.version>
     <!-- to fix circular dependencies with NessieClient, certain projects need to use the same Nessie version as Iceberg/Delta has -->
-    <client.nessie.version>0.9.0</client.nessie.version>
+    <client.nessie.version>0.8.3</client.nessie.version>
     <deltalake.version>1.0.0-nessie</deltalake.version>
     <dynamodb.version>1.12.0</dynamodb.version>
     <flapdoodle.version>3.0.0</flapdoodle.version>


### PR DESCRIPTION
See [here](https://github.com/apache/iceberg/blob/apache-iceberg-0.12.0/versions.props#L21)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1847)
<!-- Reviewable:end -->
