### PR TITLE
release-workflow: don't let commit-status-check if no checks were run

### DIFF
--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Check commit status
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-        gh api repos/projectnessie/nessie/commits/${SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") or startswith("Report ") | not ) | select(.conclusion != "skipped") | .conclusion // "pending" ] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
+        gh api repos/projectnessie/nessie/commits/${SHA}/check-runs --jq 'if (([.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") or startswith("Report ") | not ) | select(.conclusion != "skipped") | .conclusion // "pending" ]) + ["success"] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
 
     - name: Set up JDK 11
       uses: actions/setup-java@v1


### PR DESCRIPTION
Running the "Create Release" WF against 3c6a442faa5cdee947b5b622b68b9b83007f7111 failed ([see result](https://github.com/projectnessie/nessie/actions/runs/1171431728)), because the commit-status-check reports "not ok", because there were no check runs.,

This PR adds a "dummy success" to work around that one.

Alternatively we might remove all `paths-ignore` from `main.yml`, which might be the better alternative.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1852)
<!-- Reviewable:end -->
