### PR TITLE
TVS2: Cleanup DatabaseAdapter interface methods

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -19,7 +19,6 @@ import com.google.protobuf.ByteString;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.BranchName;
@@ -257,16 +256,6 @@ public interface DatabaseAdapter extends AutoCloseable {
    *
    * <p>This operation is primarily used by Nessie-GC and must not be exposed via a public API.
    */
-  Stream<ContentsIdAndBytes> globalLog(
-      Set<ContentsIdWithType> keys, ToIntFunction<ByteString> contentsTypeExtractor);
-
-  /**
-   * Retrieve all distinct contents from all named references for the given key. This operation is
-   * used to collect the "reachable" contents during Nessie-GC. For Iceberg, this operation is used
-   * to find the "reachable" snapshot-IDs.
-   *
-   * <p>This operation is primarily used by Nessie-GC and must not be exposed via a public API.
-   */
-  Stream<KeyWithBytes> allContents(
-      BiFunction<NamedRef, CommitLogEntry, Boolean> continueOnRefPredicate);
+  Stream<ContentsIdAndBytes> globalContents(
+      Set<ContentsId> keys, ToIntFunction<ByteString> contentsTypeExtractor);
 }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
@@ -30,7 +30,6 @@ import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentsAndState;
 import org.projectnessie.versioned.persist.adapter.ContentsId;
 import org.projectnessie.versioned.persist.adapter.ContentsIdAndBytes;
-import org.projectnessie.versioned.persist.adapter.ContentsIdWithType;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
@@ -82,8 +81,7 @@ public abstract class AbstractManyCommits {
       commits[i] = hash;
 
       try (Stream<ContentsIdAndBytes> globals =
-          databaseAdapter.globalLog(
-              Collections.singleton(ContentsIdWithType.of(fixed, (byte) 0)), bs -> (byte) 0)) {
+          databaseAdapter.globalContents(Collections.singleton(fixed), bs -> (byte) 0)) {
         assertThat(globals)
             .containsExactly(
                 ContentsIdAndBytes.of(


### PR DESCRIPTION
`DatabaseAdapter.allContents` is not needed, `DatabaseAdapter.globalLog` should be named `globalContents` and take a set of `ContentsId`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1892)
<!-- Reviewable:end -->
