### PR TITLE
Nessie-API: Split out Http-API-interfaces

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/NessieApiClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/NessieApiClient.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http;
+
+import java.io.Closeable;
+import org.projectnessie.api.http.HttpConfigApi;
+import org.projectnessie.api.http.HttpContentsApi;
+import org.projectnessie.api.http.HttpTreeApi;
+
+public class NessieApiClient implements Closeable {
+  private final HttpConfigApi config;
+  private final HttpTreeApi tree;
+  private final HttpContentsApi contents;
+
+  public NessieApiClient(HttpConfigApi config, HttpTreeApi tree, HttpContentsApi contents) {
+    this.config = config;
+    this.tree = tree;
+    this.contents = contents;
+  }
+
+  public HttpTreeApi getTreeApi() {
+    return tree;
+  }
+
+  public HttpContentsApi getContentsApi() {
+    return contents;
+  }
+
+  public HttpConfigApi getConfigApi() {
+    return config;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/BaseHttpOnBranchRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/BaseHttpOnBranchRequest.java
@@ -16,14 +16,14 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.OnBranchBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 
 abstract class BaseHttpOnBranchRequest<R extends OnBranchBuilder<R>> extends BaseHttpRequest
     implements OnBranchBuilder<R> {
   protected String branchName;
   protected String hash;
 
-  BaseHttpOnBranchRequest(NessieHttpClient client) {
+  BaseHttpOnBranchRequest(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/BaseHttpOnReferenceRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/BaseHttpOnReferenceRequest.java
@@ -16,14 +16,14 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.OnReferenceBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 
 abstract class BaseHttpOnReferenceRequest<R extends OnReferenceBuilder<R>> extends BaseHttpRequest
     implements OnReferenceBuilder<R> {
   protected String refName;
   protected String hashOnRef;
 
-  BaseHttpOnReferenceRequest(NessieHttpClient client) {
+  BaseHttpOnReferenceRequest(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/BaseHttpOnTagRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/BaseHttpOnTagRequest.java
@@ -16,14 +16,14 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.OnTagBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 
 abstract class BaseHttpOnTagRequest<R extends OnTagBuilder<R>> extends BaseHttpRequest
     implements OnTagBuilder<R> {
   protected String tagName;
   protected String hash;
 
-  BaseHttpOnTagRequest(NessieHttpClient client) {
+  BaseHttpOnTagRequest(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/BaseHttpRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/BaseHttpRequest.java
@@ -15,13 +15,13 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 
 abstract class BaseHttpRequest {
 
-  protected final NessieHttpClient client;
+  protected final NessieApiClient client;
 
-  BaseHttpRequest(NessieHttpClient client) {
+  BaseHttpRequest(NessieApiClient client) {
     this.client = client;
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
@@ -30,16 +30,16 @@ import org.projectnessie.client.api.MergeReferenceBuilder;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.api.NessieApiVersion;
 import org.projectnessie.client.api.TransplantCommitsBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.NessieConfiguration;
 
 public final class HttpApiV1 implements NessieApiV1 {
 
-  private final NessieHttpClient client;
+  private final NessieApiClient client;
 
-  public HttpApiV1(NessieHttpClient client) {
+  public HttpApiV1(NessieApiClient client) {
     this.client = client;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
@@ -16,7 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.AssignBranchBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -25,7 +25,7 @@ final class HttpAssignBranch extends BaseHttpOnBranchRequest<AssignBranchBuilder
     implements AssignBranchBuilder {
   private Branch assignTo;
 
-  HttpAssignBranch(NessieHttpClient client) {
+  HttpAssignBranch(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
@@ -16,7 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.AssignTagBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Tag;
@@ -26,7 +26,7 @@ final class HttpAssignTag extends BaseHttpOnTagRequest<AssignTagBuilder>
 
   private Tag assignTo;
 
-  HttpAssignTag(NessieHttpClient client) {
+  HttpAssignTag(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCommitMultipleOperations.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCommitMultipleOperations.java
@@ -17,7 +17,7 @@ package org.projectnessie.client.http.v1api;
 
 import java.util.List;
 import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -31,7 +31,7 @@ final class HttpCommitMultipleOperations
 
   private final ImmutableOperations.Builder operations = ImmutableOperations.builder();
 
-  HttpCommitMultipleOperations(NessieHttpClient client) {
+  HttpCommitMultipleOperations(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateReference.java
@@ -16,7 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.CreateReferenceBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
@@ -25,7 +25,7 @@ final class HttpCreateReference extends BaseHttpRequest implements CreateReferen
 
   private Reference reference;
 
-  HttpCreateReference(NessieHttpClient client) {
+  HttpCreateReference(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteBranch.java
@@ -16,13 +16,13 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.DeleteBranchBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 
 final class HttpDeleteBranch extends BaseHttpOnBranchRequest<DeleteBranchBuilder>
     implements DeleteBranchBuilder {
-  HttpDeleteBranch(NessieHttpClient client) {
+  HttpDeleteBranch(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteTag.java
@@ -16,14 +16,14 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.DeleteTagBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 
 final class HttpDeleteTag extends BaseHttpOnTagRequest<DeleteTagBuilder>
     implements DeleteTagBuilder {
 
-  HttpDeleteTag(NessieHttpClient client) {
+  HttpDeleteTag(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
@@ -17,12 +17,12 @@ package org.projectnessie.client.http.v1api;
 
 import java.util.List;
 import org.projectnessie.client.api.GetAllReferencesBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.model.Reference;
 
 final class HttpGetAllReferences extends BaseHttpRequest implements GetAllReferencesBuilder {
 
-  HttpGetAllReferences(NessieHttpClient client) {
+  HttpGetAllReferences(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetCommitLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetCommitLog.java
@@ -17,7 +17,7 @@ package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.CommitLogParams;
 import org.projectnessie.client.api.GetCommitLogBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.LogResponse;
 
@@ -26,7 +26,7 @@ final class HttpGetCommitLog extends BaseHttpOnReferenceRequest<GetCommitLogBuil
 
   private final CommitLogParams.Builder params = CommitLogParams.builder();
 
-  HttpGetCommitLog(NessieHttpClient client) {
+  HttpGetCommitLog(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetContents.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetContents.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.projectnessie.client.api.GetContentsBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Contents;
 import org.projectnessie.model.ContentsKey;
@@ -32,10 +32,8 @@ final class HttpGetContents extends BaseHttpOnReferenceRequest<GetContentsBuilde
 
   private final ImmutableMultiGetContentsRequest.Builder request =
       ImmutableMultiGetContentsRequest.builder();
-  private String refName;
-  private String hashOnRef;
 
-  HttpGetContents(NessieHttpClient client) {
+  HttpGetContents(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
@@ -17,7 +17,7 @@ package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.EntriesParams;
 import org.projectnessie.client.api.GetEntriesBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.EntriesResponse;
 
@@ -26,7 +26,7 @@ final class HttpGetEntries extends BaseHttpOnReferenceRequest<GetEntriesBuilder>
 
   private final EntriesParams.Builder params = EntriesParams.builder();
 
-  HttpGetEntries(NessieHttpClient client) {
+  HttpGetEntries(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetReference.java
@@ -16,7 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.GetReferenceBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
@@ -24,7 +24,7 @@ final class HttpGetReference extends BaseHttpRequest implements GetReferenceBuil
 
   private String refName;
 
-  HttpGetReference(NessieHttpClient client) {
+  HttpGetReference(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
@@ -16,7 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.MergeReferenceBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.ImmutableMerge;
@@ -26,7 +26,7 @@ final class HttpMergeReference extends BaseHttpOnBranchRequest<MergeReferenceBui
 
   private final ImmutableMerge.Builder merge = ImmutableMerge.builder();
 
-  HttpMergeReference(NessieHttpClient client) {
+  HttpMergeReference(NessieApiClient client) {
     super(client);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
@@ -17,7 +17,7 @@ package org.projectnessie.client.http.v1api;
 
 import java.util.List;
 import org.projectnessie.client.api.TransplantCommitsBuilder;
-import org.projectnessie.client.http.NessieHttpClient;
+import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.ImmutableTransplant;
@@ -28,7 +28,7 @@ final class HttpTransplantCommits extends BaseHttpOnBranchRequest<TransplantComm
   private final ImmutableTransplant.Builder transplant = ImmutableTransplant.builder();
   private String message;
 
-  HttpTransplantCommits(NessieHttpClient client) {
+  HttpTransplantCommits(NessieApiClient client) {
     super(client);
   }
 


### PR DESCRIPTION
Move the references to `Http*Api` interface implementations into a separate class to allow testing of
API functionality without an HTTP server.

This helps when building tests that mock `Http*Api` or `versionStore` interfaces and allows using the Nessie-API w/o an HTTP server like this:
```
    HttpTreeApi treeApi = new TreeResource(serverConfig, versionStore, null);
    HttpApiV1 api = new HttpApiV1(new NessieApiClient(null, treeApi, null));
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1893)
<!-- Reviewable:end -->
