### PR TITLE
Bump error_prone_core from 2.7.1 to 2.9.0, errorprone-slf4j from 0.1.3 to 0.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1200,12 +1200,12 @@ limitations under the License.
                 <path>
                   <groupId>com.google.errorprone</groupId>
                   <artifactId>error_prone_core</artifactId>
-                  <version>2.7.1</version>
+                  <version>2.9.0</version>
                 </path>
                 <path>
                   <groupId>jp.skypencil.errorprone.slf4j</groupId>
                   <artifactId>errorprone-slf4j</artifactId>
-                  <version>0.1.3</version>
+                  <version>0.1.4</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>


### PR DESCRIPTION
dependabot seems to ignore the dependencies in `maven-compiler-plugin` -> `configuration`/`annotationProcessorPaths`/`path`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1898)
<!-- Reviewable:end -->
