### PR TITLE
Bump google-java-format from 1.10.0 to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1354,7 +1354,7 @@ limitations under the License.
               </formats>
               <java>
                 <google-java-format>
-                  <version>1.10.0</version>
+                  <version>1.11.0</version>
                 </google-java-format>
                 <licenseHeader>
                   <file>${maven.multiModuleProjectDirectory}/codestyle/copyright-header-java.txt</file>


### PR DESCRIPTION
dependabot doesn't know how to update the version for the google-java-format dependency via the spottless-plugin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1899)
<!-- Reviewable:end -->
