### PR TITLE
TVS2: New tiered-version-store / databaser-adapters for Postgres + H2

### DIFF
--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxConnectionProvider.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxConnectionProvider.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter.SqlDataType;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter.NessieSqlDataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +49,9 @@ public abstract class TxConnectionProvider implements AutoCloseable {
         boolean metadataUpperCase = adapter.metadataUpperCase();
         String catalog = config.getCatalog();
         String schema = config.getSchema();
-        Map<SqlDataType, String> dataTypes = adapter.databaseSqlFormatParameters();
+        Map<NessieSqlDataType, String> dataTypes = adapter.databaseSqlFormatParameters();
         Object[] formatParamsArray =
-            Arrays.stream(SqlDataType.values()).map(dataTypes::get).toArray();
+            Arrays.stream(NessieSqlDataType.values()).map(dataTypes::get).toArray();
 
         Stream<String> ddls =
             adapter.allCreateTableDDL().entrySet().stream()

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxConnectionProvider.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxConnectionProvider.java
@@ -20,10 +20,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter.SqlDataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +49,9 @@ public abstract class TxConnectionProvider implements AutoCloseable {
         boolean metadataUpperCase = adapter.metadataUpperCase();
         String catalog = config.getCatalog();
         String schema = config.getSchema();
-        Object[] formatParamsArray = adapter.databaseSqlFormatParameters().toArray();
+        Map<SqlDataType, String> dataTypes = adapter.databaseSqlFormatParameters();
+        Object[] formatParamsArray =
+            Arrays.stream(SqlDataType.values()).map(dataTypes::get).toArray();
 
         Stream<String> ddls =
             adapter.allCreateTableDDL().entrySet().stream()

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -1146,21 +1146,27 @@ public abstract class TxDatabaseAdapter
         .build();
   }
 
-  /**
-   * Get database-specific 'strings' like column definitions for 'BLOB' column types.
-   *
-   * <ul>
-   *   <li>Index #0: column-type string for a 'BLOB' column.
-   *   <li>Index #1: column-type string for the string representation of a {@link Hash}
-   *   <li>Index #2: column-type string for key-prefix
-   *   <li>Index #3: column-type string for the string representation of a {@link Key}
-   *   <li>Index #4: column-type string for the string representation of a {@link NamedRef}
-   *   <li>Index #5: column-type string for the named-reference-type (single char)
-   *   <li>Index #6: column-type string for the contents-id
-   *   <li>Index #7: column-type string for an integer
-   * </ul>
-   */
-  protected abstract List<String> databaseSqlFormatParameters();
+  /** Get database-specific 'strings' like column definitions for 'BLOB' column types. */
+  protected abstract Map<SqlDataType, String> databaseSqlFormatParameters();
+
+  protected enum SqlDataType {
+    /** Column-type string for a 'BLOB' column. */
+    BLOB,
+    /** Column-type string for the string representation of a {@link Hash}. */
+    HASH,
+    /** Column-type string for key-prefix. */
+    KEY_PREFIX,
+    /** Column-type string for the string representation of a {@link Key}. */
+    KEY,
+    /** Column-type string for the string representation of a {@link NamedRef}. */
+    NAMED_REF,
+    /** Column-type string for the named-reference-type (single char). */
+    NAMED_REF_TYPE,
+    /** Column-type string for the contents-id. */
+    CONTENTS_ID,
+    /** Column-type string for an integer. */
+    INTEGER
+  }
 
   /** Whether the database/JDBC-driver require schema-metadata-queries require upper-case names. */
   protected boolean metadataUpperCase() {

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -1128,6 +1128,13 @@ public abstract class TxDatabaseAdapter
    *
    * <p>Names of the tables are defined by the constants defined in this class that start with
    * {@code TABLE_}, for example {@link SqlStatements#TABLE_COMMIT_LOG}.
+   *
+   * <p>The DDL statements in the returned map's value are formatted using {@link
+   * java.text.MessageFormat} using the enum map from {@link #databaseSqlFormatParameters()}, where
+   * the ordinal of the {@link NessieSqlDataType} enum is used as the index.
+   *
+   * @see NessieSqlDataType
+   * @see #databaseSqlFormatParameters() ()
    */
   protected Map<String, List<String>> allCreateTableDDL() {
     return ImmutableMap.<String, List<String>>builder()
@@ -1146,10 +1153,24 @@ public abstract class TxDatabaseAdapter
         .build();
   }
 
-  /** Get database-specific 'strings' like column definitions for 'BLOB' column types. */
-  protected abstract Map<SqlDataType, String> databaseSqlFormatParameters();
+  /**
+   * Get database-specific 'strings' like column definitions for 'BLOB' column types. Used as
+   * placeholders to format the DDL statements from {@link #allCreateTableDDL()}.
+   *
+   * @see NessieSqlDataType
+   * @see #allCreateTableDDL()
+   */
+  protected abstract Map<NessieSqlDataType, String> databaseSqlFormatParameters();
 
-  protected enum SqlDataType {
+  /**
+   * Defines the types of Nessie data types used to map to SQL datatypes via {@link
+   * #databaseSqlFormatParameters()}. For example, the SQL datatype used to store a {@link #BLOB}
+   * might be a {@code BLOB} in a specific database and {@code BYTEA} in another.
+   *
+   * @see #databaseSqlFormatParameters()
+   * @see #allCreateTableDDL()
+   */
+  protected enum NessieSqlDataType {
     /** Column-type string for a 'BLOB' column. */
     BLOB,
     /** Column-type string for the string representation of a {@link Hash}. */

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
@@ -15,8 +15,8 @@
  */
 package org.projectnessie.versioned.persist.tx.h2;
 
-import java.util.Arrays;
-import java.util.List;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
 
@@ -27,23 +27,16 @@ public class H2DatabaseAdapter extends TxDatabaseAdapter {
   }
 
   @Override
-  protected List<String> databaseSqlFormatParameters() {
-    return Arrays.asList(
-        // BLOB column
-        "VARBINARY(390000)",
-        // Hash
-        "VARCHAR",
-        // key-prefix
-        "VARCHAR",
-        // Key
-        "VARCHAR",
-        // NamedRef
-        "VARCHAR",
-        // named-reference type
-        "VARCHAR",
-        // contents-id
-        "VARCHAR",
-        // integer
-        "BIGINT");
+  protected Map<SqlDataType, String> databaseSqlFormatParameters() {
+    return ImmutableMap.<SqlDataType, String>builder()
+        .put(SqlDataType.BLOB, "VARBINARY(390000)")
+        .put(SqlDataType.HASH, "VARCHAR")
+        .put(SqlDataType.KEY_PREFIX, "VARCHAR")
+        .put(SqlDataType.KEY, "VARCHAR")
+        .put(SqlDataType.NAMED_REF, "VARCHAR")
+        .put(SqlDataType.NAMED_REF_TYPE, "VARCHAR")
+        .put(SqlDataType.CONTENTS_ID, "VARCHAR")
+        .put(SqlDataType.INTEGER, "BIGINT")
+        .build();
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx.h2;
+
+import java.util.Arrays;
+import java.util.List;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
+
+public class H2DatabaseAdapter extends TxDatabaseAdapter {
+
+  public H2DatabaseAdapter(TxDatabaseAdapterConfig config) {
+    super(config);
+  }
+
+  @Override
+  protected List<String> databaseSqlFormatParameters() {
+    return Arrays.asList(
+        // BLOB column
+        "VARBINARY(390000)",
+        // Hash
+        "VARCHAR",
+        // key-prefix
+        "VARCHAR",
+        // Key
+        "VARCHAR",
+        // NamedRef
+        "VARCHAR",
+        // named-reference type
+        "VARCHAR",
+        // contents-id
+        "VARCHAR",
+        // integer
+        "BIGINT");
+  }
+}

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
@@ -27,16 +27,16 @@ public class H2DatabaseAdapter extends TxDatabaseAdapter {
   }
 
   @Override
-  protected Map<SqlDataType, String> databaseSqlFormatParameters() {
-    return ImmutableMap.<SqlDataType, String>builder()
-        .put(SqlDataType.BLOB, "VARBINARY(390000)")
-        .put(SqlDataType.HASH, "VARCHAR")
-        .put(SqlDataType.KEY_PREFIX, "VARCHAR")
-        .put(SqlDataType.KEY, "VARCHAR")
-        .put(SqlDataType.NAMED_REF, "VARCHAR")
-        .put(SqlDataType.NAMED_REF_TYPE, "VARCHAR")
-        .put(SqlDataType.CONTENTS_ID, "VARCHAR")
-        .put(SqlDataType.INTEGER, "BIGINT")
+  protected Map<NessieSqlDataType, String> databaseSqlFormatParameters() {
+    return ImmutableMap.<NessieSqlDataType, String>builder()
+        .put(NessieSqlDataType.BLOB, "VARBINARY(390000)")
+        .put(NessieSqlDataType.HASH, "VARCHAR")
+        .put(NessieSqlDataType.KEY_PREFIX, "VARCHAR")
+        .put(NessieSqlDataType.KEY, "VARCHAR")
+        .put(NessieSqlDataType.NAMED_REF, "VARCHAR")
+        .put(NessieSqlDataType.NAMED_REF_TYPE, "VARCHAR")
+        .put(NessieSqlDataType.CONTENTS_ID, "VARCHAR")
+        .put(NessieSqlDataType.INTEGER, "BIGINT")
         .build();
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapterFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx.h2;
+
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.tx.ImmutableDefaultTxDatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
+
+public class H2DatabaseAdapterFactory implements DatabaseAdapterFactory<TxDatabaseAdapterConfig> {
+
+  @Override
+  public String getName() {
+    return "H2";
+  }
+
+  @Override
+  public Builder<TxDatabaseAdapterConfig> newBuilder() {
+    return new Builder<TxDatabaseAdapterConfig>() {
+      @Override
+      protected TxDatabaseAdapterConfig getDefaultConfig() {
+        return ImmutableDefaultTxDatabaseAdapterConfig.builder().build();
+      }
+
+      @Override
+      public DatabaseAdapter build() {
+        return new H2DatabaseAdapter(getConfig());
+      }
+    };
+  }
+}

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx.postgres;
+
+import java.util.Arrays;
+import java.util.List;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
+
+public class PostgresDatabaseAdapter extends TxDatabaseAdapter {
+
+  public PostgresDatabaseAdapter(TxDatabaseAdapterConfig config) {
+    super(config);
+  }
+
+  @Override
+  protected List<String> databaseSqlFormatParameters() {
+    return Arrays.asList(
+        // BLOB column
+        "BYTEA",
+        // Hash
+        "VARCHAR",
+        // key-prefix
+        "VARCHAR",
+        // Key
+        "VARCHAR",
+        // NamedRef
+        "VARCHAR",
+        // named-reference type
+        "VARCHAR",
+        // contents-id
+        "VARCHAR",
+        // integer
+        "BIGINT");
+  }
+
+  @Override
+  protected boolean batchDDL() {
+    // Postgres + Cockroach can perform DDL-batches, but that doesn't always work :(
+    return false;
+  }
+}

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
@@ -15,8 +15,8 @@
  */
 package org.projectnessie.versioned.persist.tx.postgres;
 
-import java.util.Arrays;
-import java.util.List;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
 
@@ -27,24 +27,17 @@ public class PostgresDatabaseAdapter extends TxDatabaseAdapter {
   }
 
   @Override
-  protected List<String> databaseSqlFormatParameters() {
-    return Arrays.asList(
-        // BLOB column
-        "BYTEA",
-        // Hash
-        "VARCHAR",
-        // key-prefix
-        "VARCHAR",
-        // Key
-        "VARCHAR",
-        // NamedRef
-        "VARCHAR",
-        // named-reference type
-        "VARCHAR",
-        // contents-id
-        "VARCHAR",
-        // integer
-        "BIGINT");
+  protected Map<SqlDataType, String> databaseSqlFormatParameters() {
+    return ImmutableMap.<SqlDataType, String>builder()
+        .put(SqlDataType.BLOB, "BYTEA")
+        .put(SqlDataType.HASH, "VARCHAR")
+        .put(SqlDataType.KEY_PREFIX, "VARCHAR")
+        .put(SqlDataType.KEY, "VARCHAR")
+        .put(SqlDataType.NAMED_REF, "VARCHAR")
+        .put(SqlDataType.NAMED_REF_TYPE, "VARCHAR")
+        .put(SqlDataType.CONTENTS_ID, "VARCHAR")
+        .put(SqlDataType.INTEGER, "BIGINT")
+        .build();
   }
 
   @Override

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
@@ -27,16 +27,16 @@ public class PostgresDatabaseAdapter extends TxDatabaseAdapter {
   }
 
   @Override
-  protected Map<SqlDataType, String> databaseSqlFormatParameters() {
-    return ImmutableMap.<SqlDataType, String>builder()
-        .put(SqlDataType.BLOB, "BYTEA")
-        .put(SqlDataType.HASH, "VARCHAR")
-        .put(SqlDataType.KEY_PREFIX, "VARCHAR")
-        .put(SqlDataType.KEY, "VARCHAR")
-        .put(SqlDataType.NAMED_REF, "VARCHAR")
-        .put(SqlDataType.NAMED_REF_TYPE, "VARCHAR")
-        .put(SqlDataType.CONTENTS_ID, "VARCHAR")
-        .put(SqlDataType.INTEGER, "BIGINT")
+  protected Map<NessieSqlDataType, String> databaseSqlFormatParameters() {
+    return ImmutableMap.<NessieSqlDataType, String>builder()
+        .put(NessieSqlDataType.BLOB, "BYTEA")
+        .put(NessieSqlDataType.HASH, "VARCHAR")
+        .put(NessieSqlDataType.KEY_PREFIX, "VARCHAR")
+        .put(NessieSqlDataType.KEY, "VARCHAR")
+        .put(NessieSqlDataType.NAMED_REF, "VARCHAR")
+        .put(NessieSqlDataType.NAMED_REF_TYPE, "VARCHAR")
+        .put(NessieSqlDataType.CONTENTS_ID, "VARCHAR")
+        .put(NessieSqlDataType.INTEGER, "BIGINT")
         .build();
   }
 

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx.postgres;
+
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.tx.ImmutableDefaultTxDatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
+
+public class PostgresDatabaseAdapterFactory
+    implements DatabaseAdapterFactory<TxDatabaseAdapterConfig> {
+
+  @Override
+  public String getName() {
+    return "Postgres";
+  }
+
+  @Override
+  public Builder<TxDatabaseAdapterConfig> newBuilder() {
+    return new Builder<TxDatabaseAdapterConfig>() {
+      @Override
+      protected TxDatabaseAdapterConfig getDefaultConfig() {
+        return ImmutableDefaultTxDatabaseAdapterConfig.builder().build();
+      }
+
+      @Override
+      public DatabaseAdapter build() {
+        return new PostgresDatabaseAdapter(getConfig());
+      }
+    };
+  }
+}

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
@@ -25,7 +25,7 @@ public class PostgresDatabaseAdapterFactory
 
   @Override
   public String getName() {
-    return "Postgres";
+    return "PostgreSQL";
   }
 
   @Override

--- a/versioned/persist/tx/src/main/resources/META-INF/services/org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory
+++ b/versioned/persist/tx/src/main/resources/META-INF/services/org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory
@@ -1,0 +1,2 @@
+org.projectnessie.versioned.persist.tx.h2.H2DatabaseAdapterFactory
+org.projectnessie.versioned.persist.tx.postgres.PostgresDatabaseAdapterFactory

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/h2/TestTieredCommitsH2.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/h2/TestTieredCommitsH2.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx.h2;
+
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory.Builder;
+import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
+import org.projectnessie.versioned.persist.tx.local.ImmutableDefaultLocalDatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.tx.local.LocalDatabaseAdapterConfig;
+
+public class TestTieredCommitsH2 extends AbstractTieredCommitsTest<LocalDatabaseAdapterConfig> {
+  @Override
+  protected String adapterName() {
+    return "H2";
+  }
+
+  @Override
+  protected Builder<LocalDatabaseAdapterConfig> createAdapterBuilder() {
+    return super.createAdapterBuilder()
+        .withConfig(
+            ImmutableDefaultLocalDatabaseAdapterConfig.builder()
+                .jdbcUrl("jdbc:h2:mem:nessie")
+                .build());
+  }
+}

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ContainerFixture.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ContainerFixture.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx.postgres;
+
+import java.util.Locale;
+import org.projectnessie.versioned.persist.tx.local.LocalDatabaseAdapterConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+final class ContainerFixture {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ContainerFixture.class);
+
+  static JdbcDatabaseContainer<?> container;
+
+  private final String imageName;
+  private final String version;
+
+  ContainerFixture(String imageName, String version, String versionPropertyName) {
+    this.imageName = imageName;
+    this.version = System.getProperty(versionPropertyName, version);
+  }
+
+  void setup() {
+    if (imageName.toLowerCase(Locale.ROOT).contains("postgres")) {
+      container = new PostgreSQLContainer(imageName + ":" + version);
+    }
+    if (imageName.toLowerCase(Locale.ROOT).contains("cockroach")) {
+      container = new CockroachContainer(imageName + ":" + version);
+    }
+    container.withLogConsumer(new Slf4jLogConsumer(LOGGER)).start();
+  }
+
+  void stop() {
+    try {
+      container.stop();
+    } finally {
+      container = null;
+    }
+  }
+
+  LocalDatabaseAdapterConfig configureDatabaseAdapter(LocalDatabaseAdapterConfig config) {
+    return config
+        .withJdbcUrl(container.getJdbcUrl())
+        .withJdbcUser(container.getUsername())
+        .withJdbcPass(container.getPassword());
+  }
+}

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsCockroach.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsCockroach.java
@@ -41,7 +41,7 @@ public class ITTieredCommitsCockroach
 
   @Override
   protected String adapterName() {
-    return "Postgres";
+    return "PostgreSQL";
   }
 
   @Override

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsCockroach.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsCockroach.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx.postgres;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory.Builder;
+import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
+import org.projectnessie.versioned.persist.tx.local.ImmutableDefaultLocalDatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.tx.local.LocalDatabaseAdapterConfig;
+
+@EnabledIfSystemProperty(named = "it.nessie.dbs", matches = ".*cockroach.*")
+public class ITTieredCommitsCockroach
+    extends AbstractTieredCommitsTest<LocalDatabaseAdapterConfig> {
+  static ContainerFixture container =
+      new ContainerFixture("cockroachdb/cockroach", "v21.1.6", "it.nessie.container.cockroach.tag");
+
+  @BeforeAll
+  static void startContainer() {
+    container.setup();
+  }
+
+  @AfterAll
+  static void stopContainer() {
+    container.stop();
+  }
+
+  @Override
+  protected String adapterName() {
+    return "Postgres";
+  }
+
+  @Override
+  protected Builder<LocalDatabaseAdapterConfig> createAdapterBuilder() {
+    return super.createAdapterBuilder()
+        .withConfig(ImmutableDefaultLocalDatabaseAdapterConfig.builder().build());
+  }
+
+  @Override
+  protected LocalDatabaseAdapterConfig configureDatabaseAdapter(LocalDatabaseAdapterConfig config) {
+    return container.configureDatabaseAdapter(config);
+  }
+}

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsPostgres.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsPostgres.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx.postgres;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory.Builder;
+import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
+import org.projectnessie.versioned.persist.tx.local.ImmutableDefaultLocalDatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.tx.local.LocalDatabaseAdapterConfig;
+
+@EnabledIfSystemProperty(named = "it.nessie.dbs", matches = ".*postgres.*")
+public class ITTieredCommitsPostgres extends AbstractTieredCommitsTest<LocalDatabaseAdapterConfig> {
+  static ContainerFixture container =
+      new ContainerFixture("postgres", "9.6.22", "it.nessie.container.postgres.tag");
+
+  @BeforeAll
+  static void startContainer() {
+    container.setup();
+  }
+
+  @AfterAll
+  static void stopContainer() {
+    container.stop();
+  }
+
+  @Override
+  protected String adapterName() {
+    return "Postgres";
+  }
+
+  @Override
+  protected Builder<LocalDatabaseAdapterConfig> createAdapterBuilder() {
+    return super.createAdapterBuilder()
+        .withConfig(ImmutableDefaultLocalDatabaseAdapterConfig.builder().build());
+  }
+
+  @Override
+  protected LocalDatabaseAdapterConfig configureDatabaseAdapter(LocalDatabaseAdapterConfig config) {
+    return container.configureDatabaseAdapter(config);
+  }
+}

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsPostgres.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsPostgres.java
@@ -40,7 +40,7 @@ public class ITTieredCommitsPostgres extends AbstractTieredCommitsTest<LocalData
 
   @Override
   protected String adapterName() {
-    return "Postgres";
+    return "PostgreSQL";
   }
 
   @Override


### PR DESCRIPTION
Add transactional/relational database-adapters for:
* Postgres + Cockroach
* H2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1907)
<!-- Reviewable:end -->
