### PR TITLE
Run all quarkus tests in the same JVM.

### DIFF
--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -231,7 +231,6 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <reuseForks>false</reuseForks>
           <systemPropertyVariables>
             <maven.home>${maven.home}</maven.home>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>


### PR DESCRIPTION
Forking tests is not necessary in Quarkus 2.2.1+

----

Forking tests was originally added in #1777, but it is not necessary after Quarkus PR https://github.com/quarkusio/quarkus/pull/19715

Fixes #1862

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1910)
<!-- Reviewable:end -->
