### PR TITLE
Do not let surefire trim stack traces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,7 @@
           <version>${surefire.version}</version>
           <configuration>
             <argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>
+            <trimStackTrace>false</trimStackTrace>
             <systemProperties>
               <user.language>en</user.language>
               <user.country>US</user.country>
@@ -639,6 +640,7 @@
           <version>${surefire.version}</version>
           <configuration>
             <argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>
+            <trimStackTrace>false</trimStackTrace>
             <systemProperties>
               <user.language>en</user.language>
               <user.country>US</user.country>


### PR DESCRIPTION
`maven-surefire-plugin` + `maven-failsafe-plugin` have a parameter `trimStackTrace` which defaults to `true`. Stacktraces emitted for test failures are shortened so that it is hard to determine the actual reason for a failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1918)
<!-- Reviewable:end -->
