### PR TITLE
Add noop-BackwardsCompatibleVersionStore / prepare global-states PR

### DIFF
--- a/servers/jax-rs/src/main/java/org/projectnessie/versioned/VersionStoreExtension.java
+++ b/servers/jax-rs/src/main/java/org/projectnessie/versioned/VersionStoreExtension.java
@@ -37,10 +37,12 @@ public class VersionStoreExtension implements Extension {
   public void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager bm) {
     final TableCommitMetaStoreWorker storeWorker = new TableCommitMetaStoreWorker();
     final VersionStore<Contents, CommitMeta, Type> store =
-        InMemoryVersionStore.<Contents, CommitMeta, Type>builder()
-            .valueSerializer(storeWorker.getValueSerializer())
-            .metadataSerializer(storeWorker.getMetadataSerializer())
-            .build();
+        new BackwardsCompatibleVersionStore<>(
+            InMemoryVersionStore.<Contents, CommitMeta, Type>builder()
+                .valueSerializer(storeWorker.getValueSerializer())
+                .metadataSerializer(storeWorker.getMetadataSerializer())
+                .build(),
+            storeWorker.getValueSerializer());
 
     try {
       store.create(BranchName.of(SERVER_CONFIG.getDefaultBranch()), Optional.empty());

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
@@ -113,7 +113,7 @@ public class ConfigurableVersionStoreFactory {
       LOGGER.info("Using {} Version store", versionStoreType);
       VersionStore<Contents, CommitMeta, Contents.Type> versionStore;
       try {
-        versionStore = factory.newStore(new TableCommitMetaStoreWorker());
+        versionStore = factory.newStore(new TableCommitMetaStoreWorker(), serverConfig);
       } catch (IOException e) {
         throw new IOError(e);
       }

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/InMemoryVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/InMemoryVersionStoreFactory.java
@@ -19,6 +19,8 @@ import static org.projectnessie.server.config.VersionStoreConfig.VersionStoreTyp
 
 import java.io.IOException;
 import javax.enterprise.context.Dependent;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.versioned.BackwardsCompatibleVersionStore;
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.memory.InMemoryVersionStore;
@@ -30,10 +32,13 @@ public class InMemoryVersionStoreFactory implements VersionStoreFactory {
   @Override
   public <VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYPE>>
       VersionStore<VALUE, METADATA, VALUE_TYPE> newStore(
-          StoreWorker<VALUE, METADATA, VALUE_TYPE> worker) throws IOException {
-    return InMemoryVersionStore.<VALUE, METADATA, VALUE_TYPE>builder()
-        .metadataSerializer(worker.getMetadataSerializer())
-        .valueSerializer(worker.getValueSerializer())
-        .build();
+          StoreWorker<VALUE, METADATA, VALUE_TYPE> worker, ServerConfig serverConfig)
+          throws IOException {
+    return new BackwardsCompatibleVersionStore<>(
+        InMemoryVersionStore.<VALUE, METADATA, VALUE_TYPE>builder()
+            .metadataSerializer(worker.getMetadataSerializer())
+            .valueSerializer(worker.getValueSerializer())
+            .build(),
+        worker.getValueSerializer());
   }
 }

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/JGitVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/JGitVersionStoreFactory.java
@@ -27,6 +27,8 @@ import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
 import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
 import org.eclipse.jgit.lib.Repository;
 import org.projectnessie.server.config.JGitVersionStoreConfig;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.versioned.BackwardsCompatibleVersionStore;
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.jgit.JGitVersionStore;
@@ -49,9 +51,11 @@ public class JGitVersionStoreFactory implements VersionStoreFactory {
   @Override
   public <VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYPE>>
       VersionStore<VALUE, METADATA, VALUE_TYPE> newStore(
-          StoreWorker<VALUE, METADATA, VALUE_TYPE> worker) throws IOException {
+          StoreWorker<VALUE, METADATA, VALUE_TYPE> worker, ServerConfig serverConfig)
+          throws IOException {
     final Repository repository = newRepository();
-    return new JGitVersionStore<>(repository, worker);
+    return new BackwardsCompatibleVersionStore<>(
+        new JGitVersionStore<>(repository, worker), worker.getValueSerializer());
   }
 
   private Repository newRepository() throws IOException {

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/VersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/VersionStoreFactory.java
@@ -16,6 +16,7 @@
 package org.projectnessie.server.providers;
 
 import java.io.IOException;
+import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.VersionStore;
 
@@ -34,5 +35,6 @@ public interface VersionStoreFactory {
    */
   <VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYPE>>
       VersionStore<VALUE, METADATA, VALUE_TYPE> newStore(
-          StoreWorker<VALUE, METADATA, VALUE_TYPE> worker) throws IOException;
+          StoreWorker<VALUE, METADATA, VALUE_TYPE> worker, ServerConfig serverConfig)
+          throws IOException;
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/BackwardsCompatibleVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/BackwardsCompatibleVersionStore.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+
+public class BackwardsCompatibleVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYPE>>
+    implements VersionStore<VALUE, METADATA, VALUE_TYPE> {
+  private final VersionStore<VALUE, METADATA, VALUE_TYPE> delegate;
+  private final SerializerWithPayload<VALUE, VALUE_TYPE> valueSerializer;
+
+  public BackwardsCompatibleVersionStore(
+      VersionStore<VALUE, METADATA, VALUE_TYPE> delegate,
+      SerializerWithPayload<VALUE, VALUE_TYPE> valueSerializer) {
+    this.valueSerializer = valueSerializer;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Hash commit(
+      @Nonnull BranchName branch,
+      @Nonnull Optional<Hash> referenceHash,
+      @Nonnull METADATA metadata,
+      @Nonnull List<Operation<VALUE>> operations)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    // TODO fleshed out with global-states PR
+    return delegate.commit(branch, referenceHash, metadata, operations);
+  }
+
+  @Override
+  public Stream<WithType<Key, VALUE_TYPE>> getKeys(Ref ref) throws ReferenceNotFoundException {
+    return delegate.getKeys(ref).map(this::mapKey);
+  }
+
+  @Override
+  public VALUE getValue(Ref ref, Key key) throws ReferenceNotFoundException {
+    return mapValue(delegate.getValue(ref, key));
+  }
+
+  @Override
+  public List<Optional<VALUE>> getValues(Ref ref, List<Key> keys)
+      throws ReferenceNotFoundException {
+    return delegate.getValues(ref, keys).stream()
+        .map(v -> v.map(this::mapValue))
+        .collect(Collectors.toList());
+  }
+
+  protected VALUE mapValue(VALUE value) {
+    return value; // TODO updated later w/ global-states-PR
+  }
+
+  private WithType<Key, VALUE_TYPE> mapKey(WithType<Key, VALUE_TYPE> keyWithType) {
+    return keyWithType; // TODO updated later w/ global-states-PR
+  }
+
+  //
+
+  @Override
+  public Hash hashOnReference(NamedRef namedReference, Optional<Hash> hashOnReference)
+      throws ReferenceNotFoundException {
+    return delegate.hashOnReference(namedReference, hashOnReference);
+  }
+
+  @Override
+  @Nonnull
+  public Hash noAncestorHash() {
+    return delegate.noAncestorHash();
+  }
+
+  @Override
+  @Nonnull
+  public Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException {
+    return delegate.toHash(ref);
+  }
+
+  @Override
+  public WithHash<Ref> toRef(@Nonnull String refOfUnknownType) throws ReferenceNotFoundException {
+    return delegate.toRef(refOfUnknownType);
+  }
+
+  @Override
+  public void transplant(
+      BranchName targetBranch, Optional<Hash> referenceHash, List<Hash> sequenceToTransplant)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    delegate.transplant(targetBranch, referenceHash, sequenceToTransplant);
+  }
+
+  @Override
+  public void merge(Hash fromHash, BranchName toBranch, Optional<Hash> expectedHash)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    delegate.merge(fromHash, toBranch, expectedHash);
+  }
+
+  @Override
+  public void assign(NamedRef ref, Optional<Hash> expectedHash, Hash targetHash)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    delegate.assign(ref, expectedHash, targetHash);
+  }
+
+  @Override
+  public Hash create(NamedRef ref, Optional<Hash> targetHash)
+      throws ReferenceNotFoundException, ReferenceAlreadyExistsException {
+    return delegate.create(ref, targetHash);
+  }
+
+  @Override
+  public void delete(NamedRef ref, Optional<Hash> hash)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    delegate.delete(ref, hash);
+  }
+
+  @Override
+  public Stream<WithHash<NamedRef>> getNamedRefs() {
+    return delegate.getNamedRefs();
+  }
+
+  @Override
+  public Stream<WithHash<METADATA>> getCommits(Ref ref) throws ReferenceNotFoundException {
+    return delegate.getCommits(ref);
+  }
+
+  @Override
+  public Stream<Diff<VALUE>> getDiffs(Ref from, Ref to) throws ReferenceNotFoundException {
+    return delegate.getDiffs(from, to);
+  }
+
+  @Override
+  public Collector collectGarbage() {
+    return delegate.collectGarbage();
+  }
+}


### PR DESCRIPTION
The global-states-PR will introduce a new operation type (`PutGlobal`) and change contents (make `IcebergTable` a
global-state + introduce `IcebergSnapshot`). While we have the jgit + in-memory + dynamo version-stores in the
code base, a "translation layer" is needed to map the global-state-ish operations + contents to those version-store
implementations.

This PR only introduces `BackwardsCompatibleVersionStore`, which will be fleshed out with the actual global-states-PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1921)
<!-- Reviewable:end -->
