### PR TITLE
Global-states: API changes (non-intrusive)

### DIFF
--- a/model/src/main/java/org/projectnessie/api/http/HttpContentsApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpContentsApi.java
@@ -47,7 +47,21 @@ import org.projectnessie.model.Validation;
 @Path("contents")
 public interface HttpContentsApi extends ContentsApi {
 
-  /** Get the properties of an object. */
+  /**
+   * This operation returns the {@link Contents} for a {@link ContentsKey} in a named-reference (a
+   * {@link org.projectnessie.model.Branch} or {@link org.projectnessie.model.Tag}).
+   *
+   * <p>If the table-metadata is tracked globally (Iceberg), Nessie returns a {@link Contents}
+   * object, that contains the most up-to-date part for the globally tracked part (Iceberg:
+   * table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-ID).
+   *
+   * @param key the {@link ContentsKey}s to retrieve
+   * @param ref named-reference to retrieve the contents for
+   * @param hashOnRef hash on {@code ref} to retrieve the contents for, translates to {@code HEAD},
+   *     if missing/{@code null}
+   * @return list of {@link org.projectnessie.model.MultiGetContentsResponse.ContentsWithKey}s
+   * @throws NessieNotFoundException if {@code ref} or {@code hashOnRef} does not exist
+   */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("{key}")
@@ -99,6 +113,23 @@ public interface HttpContentsApi extends ContentsApi {
           String hashOnRef)
       throws NessieNotFoundException;
 
+  /**
+   * Similar to {@link #getContents(ContentsKey, String, String)}, but takes multiple {@link
+   * ContentsKey}s and returns the {@link Contents} for the one or more {@link ContentsKey}s in a
+   * named-reference (a {@link org.projectnessie.model.Branch} or {@link
+   * org.projectnessie.model.Tag}).
+   *
+   * <p>If the table-metadata is tracked globally (Iceberg), Nessie returns a {@link Contents}
+   * object, that contains the most up-to-date part for the globally tracked part (Iceberg:
+   * table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-ID).
+   *
+   * @param ref named-reference to retrieve the contents for
+   * @param hashOnRef hash on {@code ref} to retrieve the contents for, translates to {@code HEAD},
+   *     if missing/{@code null}
+   * @param request the {@link ContentsKey}s to retrieve
+   * @return list of {@link org.projectnessie.model.MultiGetContentsResponse.ContentsWithKey}s
+   * @throws NessieNotFoundException if {@code ref} or {@code hashOnRef} does not exist
+   */
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   @Operation(

--- a/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
@@ -571,6 +571,19 @@ public interface HttpTreeApi extends TreeApi {
           Merge merge)
       throws NessieNotFoundException, NessieConflictException;
 
+  /**
+   * Commit multiple operations against the given branch expecting that branch to have the given
+   * hash as its latest commit. The hash in the successful response contains the hash of the commit
+   * that contains the operations of the invocation.
+   *
+   * @param branchName Branch to change, defaults to default branch.
+   * @param hash Expected hash of branch.
+   * @param operations {@link Operations} to apply
+   * @return updated {@link Branch} objects with the hash of the new HEAD
+   * @throws NessieNotFoundException if {@code branchName} could not be found
+   * @throws NessieConflictException if the operations could not be applied to some conflict, which
+   *     is either caused by a conflicting commit or concurrent commits.
+   */
   @POST
   @Path("branch/{branchName}/commit")
   @Consumes(MediaType.APPLICATION_JSON)

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -18,21 +18,80 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 
+/**
+ * Represents the state of an Iceberg table in Nessie. An Iceberg table is globally identified via
+ * its {@link Contents#getId() unique ID}.
+ *
+ * <p>The Iceberg-table-state consists of the location to the table-metadata and the snapshot-ID.
+ *
+ * <p>The table-metadata-location is managed globally within Nessie, which means that all versions
+ * of the same table share the table-metadata across all named-references (branches and tags). There
+ * is only one version, the current version, of Iceberg's table-metadata.
+ *
+ * <p>Within each named-reference (branch or tag), the (current) Iceberg-snapshot-ID will be
+ * different. In other words: changes to an Iceberg table update the snapshot-ID.
+ *
+ * <p>When adding a new table (aka contents-object identified by a contents-id), use a {@link
+ * org.projectnessie.model.Operation.Put} without an expected-value. In all other cases (updating an
+ * existing table). always pass the last known version of {@link IcebergTable} as the expected-value
+ * within the put-operation.
+ */
+@Schema(
+    type = SchemaType.OBJECT,
+    title = "Iceberg table global state",
+    description =
+        "Represents the global state of an Iceberg table in Nessie. An Iceberg table is globally "
+            + "identified via its unique 'Contents.id'.\n"
+            + "\n"
+            + "A Nessie commit-operation, performed via 'TreeApi.commitMultipleOperations', for Iceberg "
+            + "for Iceberg consists of a 'Operation.Put' with an 'IcebergTable' and an "
+            + "'IcebergTableGlobal' as the expected-global-state via 'Operation.PutGlobal' using the "
+            + "same 'ContentsKey' and 'Contents.id'.\n"
+            + "\n"
+            + "During a commit-operation, Nessie checks whether the known global state of the "
+            + "Iceberg table is compatible (think: equal) to 'Operation.PutGlobal.expectedContents'.")
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableIcebergTable.class)
 @JsonDeserialize(as = ImmutableIcebergTable.class)
 @JsonTypeName("ICEBERG_TABLE")
 public abstract class IcebergTable extends Contents {
 
+  /**
+   * Location where Iceberg stored its {@code TableMetadata} file. The location depends on the
+   * (implementation of) Iceberg's {@code FileIO} configured for the particular Iceberg table.
+   */
   @NotNull
   @NotBlank
   public abstract String getMetadataLocation();
 
+  /** ID of the current Iceberg snapshot. This value is not present, if there is no snapshot. */
+  @Nullable // TODO to be removed with PR#1923
+  public abstract Long getSnapshotId();
+
+  // TODO to be removed with PR#1923
   public static IcebergTable of(String metadataLocation) {
     return ImmutableIcebergTable.builder().metadataLocation(metadataLocation).build();
+  }
+
+  public static IcebergTable of(String metadataLocation, long snapshotId) {
+    return ImmutableIcebergTable.builder()
+        .metadataLocation(metadataLocation)
+        .snapshotId(snapshotId)
+        .build();
+  }
+
+  public static IcebergTable of(String metadataLocation, long snapshotId, String contentsId) {
+    return ImmutableIcebergTable.builder()
+        .metadataLocation(metadataLocation)
+        .snapshotId(snapshotId)
+        .id(contentsId)
+        .build();
   }
 }

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -51,12 +51,11 @@ import org.immutables.value.Value;
             + "identified via its unique 'Contents.id'.\n"
             + "\n"
             + "A Nessie commit-operation, performed via 'TreeApi.commitMultipleOperations', for Iceberg "
-            + "for Iceberg consists of a 'Operation.Put' with an 'IcebergTable' and an "
-            + "'IcebergTableGlobal' as the expected-global-state via 'Operation.PutGlobal' using the "
-            + "same 'ContentsKey' and 'Contents.id'.\n"
+            + "for Iceberg consists of a 'Operation.Put' with an 'IcebergTable' as in the 'contents' "
+            + "field and the previous value of 'IcebergTable' in the 'expectedContetns' field.\n"
             + "\n"
             + "During a commit-operation, Nessie checks whether the known global state of the "
-            + "Iceberg table is compatible (think: equal) to 'Operation.PutGlobal.expectedContents'.")
+            + "Iceberg table is compatible (think: equal) to 'Operation.Put.expectedContents'.")
 @Value.Immutable(prehash = true)
 @JsonSerialize(as = ImmutableIcebergTable.class)
 @JsonDeserialize(as = ImmutableIcebergTable.class)

--- a/model/src/main/java/org/projectnessie/model/Operation.java
+++ b/model/src/main/java/org/projectnessie/model/Operation.java
@@ -55,8 +55,7 @@ public interface Operation {
       description =
           "Add or replace (put) a 'Contents' object for a 'ContentsKey'. "
               + "If the actual table type tracks the 'global state' of individual tables (Iceberg "
-              + "as of today), every 'Put' must be accompanied by a 'PutGlobal' to update the global "
-              + "state.")
+              + "as of today), every 'Put'-operation must contain a non-null value for 'expectedContents'.")
   @Value.Immutable(prehash = true)
   @JsonSerialize(as = ImmutablePut.class)
   @JsonDeserialize(as = ImmutablePut.class)

--- a/model/src/main/java/org/projectnessie/model/Operation.java
+++ b/model/src/main/java/org/projectnessie/model/Operation.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
@@ -48,6 +49,14 @@ public interface Operation {
   @NotNull
   ContentsKey getKey();
 
+  @Schema(
+      type = SchemaType.OBJECT,
+      title = "Put-'Contents'-operation for a 'ContentsKey'.",
+      description =
+          "Add or replace (put) a 'Contents' object for a 'ContentsKey'. "
+              + "If the actual table type tracks the 'global state' of individual tables (Iceberg "
+              + "as of today), every 'Put' must be accompanied by a 'PutGlobal' to update the global "
+              + "state.")
   @Value.Immutable(prehash = true)
   @JsonSerialize(as = ImmutablePut.class)
   @JsonDeserialize(as = ImmutablePut.class)
@@ -56,8 +65,19 @@ public interface Operation {
     @NotNull
     Contents getContents();
 
+    @Nullable
+    Contents getExpectedContents();
+
     public static Put of(ContentsKey key, Contents contents) {
       return ImmutablePut.builder().key(key).contents(contents).build();
+    }
+
+    public static Put of(ContentsKey key, Contents contents, Contents expectedContents) {
+      return ImmutablePut.builder()
+          .key(key)
+          .contents(contents)
+          .expectedContents(expectedContents)
+          .build();
     }
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/rest/TreeResourceWithAuthorizationChecks.java
+++ b/servers/services/src/main/java/org/projectnessie/services/rest/TreeResourceWithAuthorizationChecks.java
@@ -100,7 +100,6 @@ public class TreeResourceWithAuthorizationChecks extends TreeResource {
   @Override
   public Reference createReference(@Nullable String sourceRefName, Reference reference)
       throws NessieNotFoundException, NessieConflictException {
-    // TODO remove after Iceberg > 0.12
     if (sourceRefName == null) {
       sourceRefName = getConfig().getDefaultBranch();
     }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Put.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Put.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /** Setting a new value. Can optionally declare whether the prior hash must match. */
@@ -29,8 +30,15 @@ public interface Put<V> extends Operation<V> {
    */
   V getValue();
 
+  @Nullable
+  V getExpectedValue();
+
   /**
-   * Creates a put operation for the given key and value.
+   * Creates a put-operation for the given key and value without an expected-value so the returned
+   * put-operation is unconditional.
+   *
+   * <p>Unconditional put-operations must be used for contents-types that do not support
+   * global-state and for those that do support global-state when a new contents object is added.
    *
    * @param <V> the store value type
    * @param key the key impacted by the operation
@@ -40,5 +48,24 @@ public interface Put<V> extends Operation<V> {
   @Nonnull
   public static <V> Put<V> of(@Nonnull Key key, @Nonnull V value) {
     return ImmutablePut.<V>builder().key(key).value(value).build();
+  }
+
+  /**
+   * Creates a conditional put-operation for the given key and value with an expected-value so the
+   * returned put-operation will check whether the current state in Nessie matches the expected
+   * state in {@code expectedValue}.
+   *
+   * <p>Using a conditional put-operation for a contents-type that does not support global-state
+   * results in an error.
+   *
+   * @param <V> the store value type
+   * @param key the key impacted by the operation
+   * @param value the new value associated with the key
+   * @param expectedValue the expected value associated with the key
+   * @return a put operation for the key and value
+   */
+  @Nonnull
+  public static <V> Put<V> of(@Nonnull Key key, @Nonnull V value, @Nonnull V expectedValue) {
+    return ImmutablePut.<V>builder().key(key).value(value).expectedValue(expectedValue).build();
   }
 }


### PR DESCRIPTION
This PR only adds API+model changes, but does **not** change any behavior. Actual behavior changes and
implementations for global-state are subject to a follow-up PR.

Introduces the model changes for global-state.

* `IcebergTable` gets a new attribute `snapshotId`. The already existing `metadataLocation` will represent
  the "global state" and `snapshotId` the "per-reference state`

Operations:

* `Put` updates the `IcebergTable` for a key and gets a new attribute `expectedValue`. When updating an
  Iceberg table, clients pass the "last known" version of `IcebergTable` as the `expectedValue`. The server
  side automatically extracts the global-state from that `expectedValue`.
* No put-global operation.

No other API changes.

The initial version for global-states looked similar to this one. An intermediate version of this change
did model the global-state and on-reference-state as separate object types - on-reference-states were
updated using `Put` and global-states updated using an added `PutGlobal` operation. The latter approach
distinguished the meaning of the individual objects more clearly, but was much more difficult to implement
and use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1922)
<!-- Reviewable:end -->
