### PR TITLE
Prepare code for global-states

### DIFF
--- a/clients/spark-extensions/src/test/java/org/projectnessie/spark/extensions/ITNessieStatements.java
+++ b/clients/spark-extensions/src/test/java/org/projectnessie/spark/extensions/ITNessieStatements.java
@@ -145,7 +145,7 @@ public class ITNessieStatements extends AbstractSparkTest {
     List<Object[]> listResult = new ArrayList<>();
     listResult.add(row("Branch", "main", hash));
     listResult.add(row("Tag", refName, hash));
-    assertEquals("created branch", listResult, result);
+    assertThat(result).as("created branch").containsExactlyInAnyOrderElementsOf(listResult);
     result = sql("DROP TAG %s IN nessie", refName);
     assertEquals("deleted tag", row("OK"), result);
     assertThatThrownBy(() -> nessieClient.getTreeApi().getReferenceByName(refName))

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -18,7 +18,6 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -71,13 +70,7 @@ public abstract class IcebergTable extends Contents {
   public abstract String getMetadataLocation();
 
   /** ID of the current Iceberg snapshot. This value is not present, if there is no snapshot. */
-  @Nullable // TODO to be removed with PR#1923
-  public abstract Long getSnapshotId();
-
-  // TODO to be removed with PR#1923
-  public static IcebergTable of(String metadataLocation) {
-    return ImmutableIcebergTable.builder().metadataLocation(metadataLocation).build();
-  }
+  public abstract long getSnapshotId();
 
   public static IcebergTable of(String metadataLocation, long snapshotId) {
     return ImmutableIcebergTable.builder()

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -26,10 +26,11 @@ class IcebergTable(Contents):
     """Dataclass for Nessie Contents."""
 
     metadata_location: str = desert.ib(fields.Str(data_key="metadataLocation"))
+    snapshot_id: int = desert.ib(fields.Int(data_key="snapshotId"))
 
     def pretty_print(self: "IcebergTable") -> str:
         """Print out for cli."""
-        return "Iceberg table:\n\t{}".format(self.metadata_location)
+        return "Iceberg table:\n\t{}\n\tsnapshot-id:{}".format(self.metadata_location, self.snapshot_id)
 
 
 IcebergTableSchema = desert.schema_class(IcebergTable)

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -30,7 +30,7 @@ class IcebergTable(Contents):
 
     def pretty_print(self: "IcebergTable") -> str:
         """Print out for cli."""
-        return "Iceberg table:\n\t{}\n\tsnapshot-id:{}".format(self.metadata_location, self.snapshot_id)
+        return "Iceberg table:\n\tmetadata-location:{}\n\tsnapshot-id:{}".format(self.metadata_location, self.snapshot_id)
 
 
 IcebergTableSchema = desert.schema_class(IcebergTable)

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -47,7 +47,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -72,7 +72,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=dev
+    uri: http://localhost:19120/api/v1/contents/assign.foo.bar?ref=dev
   response:
     body:
       string: "{\n  \"message\" : \"Requested contents do not exist for specified
@@ -87,11 +87,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"hash": null, "message": "test_message", "committer": null, "authorTime":
-      null, "signedOffBy": null, "email": null, "author": null, "properties": null,
-      "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["assign", "foo", "bar"]}, "contents":
+      {"snapshotId": 42, "metadataLocation": "/a/b/c", "id": "test_assign", "type":
+      "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta": {"committer": null, "author":
+      null, "authorTime": null, "email": null, "commitTime": null, "message": "test_message",
+      "properties": null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -102,7 +102,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '341'
+      - '376'
       Content-Type:
       - application/json
       User-Agent:
@@ -111,7 +111,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -137,7 +137,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -147,7 +147,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -164,7 +164,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c
   response:
     body:
       string: ''
@@ -190,8 +190,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}
+        \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}
         ]"
     headers:
       Content-Length:
@@ -218,11 +218,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"message\" : \"Unable to find reference [v1.0].\",\n  \"status\"
-        : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Ref 'v1.0' does not exist\",\n  \"status\" : 404,\n
+        \ \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
-      - '125'
+      - '118'
       Content-Type:
       - application/json
     status:
@@ -245,7 +245,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -255,8 +255,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041",
-      "name": "v1.0", "type": "TAG"}'
+    body: '{"name": "v1.0", "hash": "9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -276,7 +276,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -303,9 +303,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}, {\n
-        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n},
-        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}
+        \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}
         ]"
     headers:
       Content-Length:
@@ -332,7 +332,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -342,7 +342,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": null, "name": "dev", "type": "TAG"}'
+    body: '{"name": "dev", "hash": null, "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -359,7 +359,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7
   response:
     body:
       string: ''
@@ -385,9 +385,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}, {\n
-        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n},
-        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}
+        \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}, {\n
+        \ \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n},
+        {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}
         ]"
     headers:
       Content-Length:
@@ -414,7 +414,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -439,7 +439,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7
   response:
     body:
       string: ''
@@ -464,7 +464,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -489,7 +489,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7
   response:
     body:
       string: ''
@@ -515,10 +515,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041\",\n
+        [ {\n    \"hash\" : \"9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:43:01.171160Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:43:01.171160Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:58.850270Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:58.850270Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -542,24 +542,24 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
+    uri: http://localhost:19120/api/v1/contents/assign.foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
-        : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_assign\",\n  \"metadataLocation\"
+        : \"/a/b/c\",\n  \"snapshotId\" : 42\n}"
     headers:
       Content-Length:
-      - '80'
+      - '108'
       Content-Type:
       - application/json
     status:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"hash": null, "message": "delete_message", "committer": null,
-      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
-      null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["assign", "foo", "bar"]}, "type":
+      "DELETE"}], "commitMeta": {"committer": null, "author": null, "authorTime":
+      null, "email": null, "commitTime": null, "message": "delete_message", "properties":
+      null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -570,16 +570,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '263'
+      - '273'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=9665282012f37acca33573b10ec3b508dbeaa50a3edf57f263036d2d8a72e041
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=9ae3b3bd9fa9f48a948952e2348c5a288668a59986a26c7ab5381c403ccdd1f7
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5d8f928da63f1a6355012eb41e4961cfb92ea02cf6c051d02e1a5ec8ecb4c712\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"1199102352d7c7edaf16d4b5fcfdcea3f5fc94a166b0e2d2776312ebc00c2403\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -605,7 +605,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5d8f928da63f1a6355012eb41e4961cfb92ea02cf6c051d02e1a5ec8ecb4c712\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"1199102352d7c7edaf16d4b5fcfdcea3f5fc94a166b0e2d2776312ebc00c2403\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -630,7 +630,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=5d8f928da63f1a6355012eb41e4961cfb92ea02cf6c051d02e1a5ec8ecb4c712
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=1199102352d7c7edaf16d4b5fcfdcea3f5fc94a166b0e2d2776312ebc00c2403
   response:
     body:
       string: ''
@@ -639,7 +639,7 @@ interactions:
       code: 204
       message: No Content
 - request:
-    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
+    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"hash": null, "name": "contents_listing_dev", "type": "BRANCH"}'
+    body: '{"name": "contents_listing_dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -88,11 +88,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "type": "PUT"}], "commitMeta": {"hash": null, "message": "test_message1", "committer":
-      null, "authorTime": null, "signedOffBy": null, "email": null, "author": null,
-      "properties": null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "contents": {"snapshotId": 42, "metadataLocation": "/a/b/c", "id": "test_contents_listing",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta": {"committer": null,
+      "author": null, "authorTime": null, "email": null, "commitTime": null, "message":
+      "test_message1", "properties": null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -103,7 +103,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '360'
+      - '395'
       Content-Type:
       - application/json
       User-Agent:
@@ -113,7 +113,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"6d3f00abff8deb17af46ab68b6fb02b40344f03d42617f1a0ff0bbda3e2f26ba\"\n}"
+        \ \"hash\" : \"3f986f455b424a467497625f2d7e74b8a3defcce0c1cdf38b777ccd08f8ae23e\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -140,7 +140,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"6d3f00abff8deb17af46ab68b6fb02b40344f03d42617f1a0ff0bbda3e2f26ba\"\n},
+        \ \"hash\" : \"3f986f455b424a467497625f2d7e74b8a3defcce0c1cdf38b777ccd08f8ae23e\"\n},
         {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -180,12 +180,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocationHistory": ["asd"], "checkpointLocationHistory":
-      ["def"], "id": "uuid2", "lastCheckpoint": "x", "type": "DELTA_LAKE_TABLE"},
-      "key": {"elements": ["this", "is", "delta", "bar"]}, "type": "PUT"}], "commitMeta":
-      {"hash": null, "message": "test_message2", "committer": null, "authorTime":
-      null, "signedOffBy": null, "email": null, "author": null, "properties": null,
-      "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "delta", "bar"]}, "contents":
+      {"lastCheckpoint": "x", "metadataLocationHistory": ["asd"], "id": "uuid2", "checkpointLocationHistory":
+      ["def"], "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}], "commitMeta": {"committer":
+      null, "author": null, "authorTime": null, "email": null, "commitTime": null,
+      "message": "test_message2", "properties": null, "hash": null, "signedOffBy":
+      null}}'
     headers:
       Accept:
       - '*/*'
@@ -202,11 +202,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=6d3f00abff8deb17af46ab68b6fb02b40344f03d42617f1a0ff0bbda3e2f26ba
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=3f986f455b424a467497625f2d7e74b8a3defcce0c1cdf38b777ccd08f8ae23e
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"7d60bba3165f1425ecf3102e7bfda632fa1d1c8110f77f6dbd1c290f9dc2bad3\"\n}"
+        \ \"hash\" : \"040d17a809a957037bcc50536cce195a5f007eb65c35b13ae8147ee71a62b421\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -233,7 +233,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"7d60bba3165f1425ecf3102e7bfda632fa1d1c8110f77f6dbd1c290f9dc2bad3\"\n},
+        \ \"hash\" : \"040d17a809a957037bcc50536cce195a5f007eb65c35b13ae8147ee71a62b421\"\n},
         {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -273,11 +273,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"sqlText": "SELECT * FROM foo", "dialect":
-      "SPARK", "id": "uuid3", "type": "VIEW"}, "key": {"elements": ["this", "is",
-      "sql", "baz"]}, "type": "PUT"}], "commitMeta": {"hash": null, "message": "test_message3",
-      "committer": null, "authorTime": null, "signedOffBy": null, "email": null, "author":
-      null, "properties": null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "sql", "baz"]}, "contents":
+      {"id": "uuid3", "dialect": "SPARK", "sqlText": "SELECT * FROM foo", "type":
+      "VIEW"}, "type": "PUT"}], "commitMeta": {"committer": null, "author": null,
+      "authorTime": null, "email": null, "commitTime": null, "message": "test_message3",
+      "properties": null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -294,11 +294,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=7d60bba3165f1425ecf3102e7bfda632fa1d1c8110f77f6dbd1c290f9dc2bad3
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=040d17a809a957037bcc50536cce195a5f007eb65c35b13ae8147ee71a62b421
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"5b7ee352a8aca498f9450c17805e4408af348e89e42b0492c6334bf259e6b718\"\n}"
+        \ \"hash\" : \"3bc901cd7a70e9c6ca83d04733f2974e57d2e512525b51da9df7575659baf3c2\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -324,11 +324,11 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_listing_dev
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
-        : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_contents_listing\",\n
+        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42\n}"
     headers:
       Content-Length:
-      - '80'
+      - '118'
       Content-Type:
       - application/json
     status:
@@ -554,7 +554,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"5b7ee352a8aca498f9450c17805e4408af348e89e42b0492c6334bf259e6b718\"\n}"
+        \ \"hash\" : \"3bc901cd7a70e9c6ca83d04733f2974e57d2e512525b51da9df7575659baf3c2\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -579,7 +579,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev?expectedHash=5b7ee352a8aca498f9450c17805e4408af348e89e42b0492c6334bf259e6b718
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev?expectedHash=3bc901cd7a70e9c6ca83d04733f2974e57d2e512525b51da9df7575659baf3c2
   response:
     body:
       string: ''

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
+    uri: http://localhost:19120/api/v1/contents/log.foo.bar?ref=main
   response:
     body:
       string: "{\n  \"message\" : \"Requested contents do not exist for specified
@@ -82,11 +82,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"hash": null, "message": "test_message", "committer": null, "authorTime":
-      null, "signedOffBy": null, "email": null, "author": "nessie_user1", "properties":
-      null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["log", "foo", "bar"]}, "contents":
+      {"snapshotId": 42, "metadataLocation": "/a/b/c", "id": "test_log", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}], "commitMeta": {"committer": null, "author": "nessie_user1",
+      "authorTime": null, "email": null, "commitTime": null, "message": "test_message",
+      "properties": null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -97,7 +97,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '351'
+      - '380'
       Content-Type:
       - application/json
       User-Agent:
@@ -106,7 +106,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -129,14 +129,14 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
+    uri: http://localhost:19120/api/v1/contents/log.foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
-        : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_log\",\n  \"metadataLocation\"
+        : \"/a/b/c\",\n  \"snapshotId\" : 42\n}"
     headers:
       Content-Length:
-      - '80'
+      - '105'
       Content-Type:
       - application/json
     status:
@@ -160,10 +160,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        [ {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -187,14 +187,14 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        [ {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -223,10 +223,10 @@ interactions:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"entries\" : [ {\n
         \   \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\" :
-        [ \"foo\", \"bar\" ]\n    }\n  } ]\n}"
+        [ \"log\", \"foo\", \"bar\" ]\n    }\n  } ]\n}"
     headers:
       Content-Length:
-      - '153'
+      - '160'
       Content-Type:
       - application/json
     status:
@@ -246,24 +246,24 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
+    uri: http://localhost:19120/api/v1/contents/log.foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
-        : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_log\",\n  \"metadataLocation\"
+        : \"/a/b/c\",\n  \"snapshotId\" : 42\n}"
     headers:
       Content-Length:
-      - '80'
+      - '105'
       Content-Type:
       - application/json
     status:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"hash": null, "message": "delete_message", "committer": null,
-      "authorTime": null, "signedOffBy": null, "email": null, "author": "nessie_user2",
-      "properties": null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["log", "foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"committer": null, "author": "nessie_user2", "authorTime": null,
+      "email": null, "commitTime": null, "message": "delete_message", "properties":
+      null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -274,16 +274,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '273'
+      - '280'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -310,14 +310,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
+        [ {\n    \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-09-13T18:43:56.086906Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:56.086906Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -341,14 +341,14 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56&endHash=c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c&endHash=969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        [ {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -376,14 +376,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
+        [ {\n    \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-09-13T18:43:56.086906Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:56.086906Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -411,10 +411,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        [ {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -442,10 +442,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
+        [ {\n    \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-09-13T18:43:56.086906Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:56.086906Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -473,14 +473,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
+        [ {\n    \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-09-13T18:43:56.086906Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:56.086906Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -508,14 +508,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
+        [ {\n    \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-09-13T18:43:56.086906Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:56.086906Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -543,10 +543,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
+        [ {\n    \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-09-13T18:43:56.086906Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:56.086906Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -574,14 +574,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\",\n
+        [ {\n    \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.464585Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.464585Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"c09b636040a7836a93492abd63eae7a6ace020d7149d4d410688124b22b77456\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-09-13T18:43:56.086906Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:56.086906Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"969eb21acfb967d4aac66aaf0121855ba76677ff959715ece918d4bd8bc9167c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:42:58.308643Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:42:58.308643Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:43:55.929411Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:43:55.929411Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -72,7 +72,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=dev
+    uri: http://localhost:19120/api/v1/contents/merge.foo.bar?ref=dev
   response:
     body:
       string: "{\n  \"message\" : \"Requested contents do not exist for specified
@@ -87,11 +87,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"hash": null, "message": "test_message", "committer": null, "authorTime":
-      null, "signedOffBy": null, "email": null, "author": null, "properties": null,
-      "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["merge", "foo", "bar"]}, "contents":
+      {"snapshotId": 42, "metadataLocation": "/a/b/c", "id": "test_merge", "type":
+      "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta": {"committer": null, "author":
+      null, "authorTime": null, "email": null, "commitTime": null, "message": "test_message",
+      "properties": null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -102,7 +102,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '341'
+      - '374'
       Content-Type:
       - application/json
       User-Agent:
@@ -111,7 +111,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -139,7 +139,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65\"\n}
         ]"
     headers:
       Content-Length:
@@ -166,7 +166,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -176,8 +176,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d",
-      "fromRefName": "dev"}'
+    body: '{"fromRefName": "dev", "fromHash": "2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65"}'
     headers:
       Accept:
       - '*/*'
@@ -220,8 +219,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}
+        \"2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65\"\n}
         ]"
     headers:
       Content-Length:
@@ -248,7 +247,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -273,7 +272,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65
   response:
     body:
       string: ''
@@ -299,10 +298,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d\",\n
+        [ {\n    \"hash\" : \"2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:43:03.584094Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:43:03.584094Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:44:01.248587Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:44:01.248587Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -326,24 +325,24 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
+    uri: http://localhost:19120/api/v1/contents/merge.foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
-        : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_merge\",\n  \"metadataLocation\"
+        : \"/a/b/c\",\n  \"snapshotId\" : 42\n}"
     headers:
       Content-Length:
-      - '80'
+      - '107'
       Content-Type:
       - application/json
     status:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"hash": null, "message": "delete_message", "committer": null,
-      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
-      null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["merge", "foo", "bar"]}, "type":
+      "DELETE"}], "commitMeta": {"committer": null, "author": null, "authorTime":
+      null, "email": null, "commitTime": null, "message": "delete_message", "properties":
+      null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -354,16 +353,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '263'
+      - '272'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=dfe9026d9115440be5d98e80f9d52a13f74417ca9dd219350ef29a7ed1007f3d
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2d268e677ed9f0bec4940d3c06e85afee173ee2fb28bbdc169e9cdfaa2036d65
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"76116bf83f896e253df9b74db39437d5873b2f7d0ee3f98f82d126fdd0e01770\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"0984bd1dac6657af4b1f81df536644cfd11bf7901f34bbd75ad815c7b9120c2a\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -389,7 +388,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"76116bf83f896e253df9b74db39437d5873b2f7d0ee3f98f82d126fdd0e01770\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"0984bd1dac6657af4b1f81df536644cfd11bf7901f34bbd75ad815c7b9120c2a\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -414,7 +413,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=76116bf83f896e253df9b74db39437d5873b2f7d0ee3f98f82d126fdd0e01770
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=0984bd1dac6657af4b1f81df536644cfd11bf7901f34bbd75ad815c7b9120c2a
   response:
     body:
       string: ''
@@ -423,7 +422,7 @@ interactions:
       code: 204
       message: No Content
 - request:
-    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
+    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/cassettes/test_nessie_cli/test_ref.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_ref.yaml
@@ -17,7 +17,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n} ]"
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -27,7 +27,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -74,7 +74,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -102,11 +102,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
     body:
-      string: "{\n  \"message\" : \"Unable to find reference [etl].\",\n  \"status\"
-        : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
+      string: "{\n  \"message\" : \"Ref 'etl' does not exist\",\n  \"status\" : 404,\n
+        \ \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
-      - '124'
+      - '117'
       Content-Type:
       - application/json
     status:
@@ -129,7 +129,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -139,8 +139,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56",
-      "name": "etl", "type": "BRANCH"}'
+    body: '{"name": "etl", "hash": "8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -160,7 +160,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -187,8 +187,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n},
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n},
         {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
         ]"
     headers:
@@ -216,7 +216,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -241,7 +241,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56
+    uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c
   response:
     body:
       string: ''
@@ -317,7 +317,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n} ]"
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n} ]"
     headers:
       Content-Length:
       - '125'

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -17,7 +17,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n} ]"
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n} ]"
     headers:
       Content-Length:
       - '125'
@@ -43,11 +43,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
     body:
-      string: "{\n  \"message\" : \"Unable to find reference [dev-tag].\",\n  \"status\"
+      string: "{\n  \"message\" : \"Ref 'dev-tag' does not exist\",\n  \"status\"
         : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
-      - '128'
+      - '121'
       Content-Type:
       - application/json
     status:
@@ -70,7 +70,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -80,8 +80,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56",
-      "name": "dev-tag", "type": "TAG"}'
+    body: '{"name": "dev-tag", "hash": "8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -101,7 +101,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -128,8 +128,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}
         ]"
     headers:
       Content-Length:
@@ -156,11 +156,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
     body:
-      string: "{\n  \"message\" : \"Unable to find reference [etl-tag].\",\n  \"status\"
+      string: "{\n  \"message\" : \"Ref 'etl-tag' does not exist\",\n  \"status\"
         : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
-      - '128'
+      - '121'
       Content-Type:
       - application/json
     status:
@@ -183,7 +183,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -193,8 +193,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56",
-      "name": "etl-tag", "type": "TAG"}'
+    body: '{"name": "etl-tag", "hash": "8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -214,7 +214,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -241,9 +241,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n},
-        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}
         ]"
     headers:
       Content-Length:
@@ -270,7 +270,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -295,7 +295,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56
+    uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c
   response:
     body:
       string: ''
@@ -320,7 +320,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -345,7 +345,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56
+    uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c
   response:
     body:
       string: ''
@@ -371,7 +371,7 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"6bb3d05a95b9f091eabaddd4beeb849e1fc7ff81b82329bf664acdd5639dca56\"\n} ]"
+        \"8fc184b3829fe5499b474c4d4d05131ab229d9536fdfc4173f0e764925b5ef3c\"\n} ]"
     headers:
       Content-Length:
       - '125'

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"hash": null, "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -72,7 +72,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=dev
+    uri: http://localhost:19120/api/v1/contents/transplant.foo.bar?ref=dev
   response:
     body:
       string: "{\n  \"message\" : \"Requested contents do not exist for specified
@@ -87,11 +87,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"hash": null, "message": "test_message", "committer": null, "authorTime":
-      null, "signedOffBy": null, "email": null, "author": null, "properties": null,
-      "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["transplant", "foo", "bar"]}, "contents":
+      {"snapshotId": 42, "metadataLocation": "/a/b/c", "id": "uuid1", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}], "commitMeta": {"committer": null, "author": null, "authorTime":
+      null, "email": null, "commitTime": null, "message": "test_message", "properties":
+      null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -102,7 +102,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '341'
+      - '374'
       Content-Type:
       - application/json
       User-Agent:
@@ -111,7 +111,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e7b22b3488ea9e65b281dcef5935926ab01a9d157554b8e5de5f66d9cb40a675\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4814fecdb01be53336fe3dfd3f7644f7213891ab1a60973536c80bec4769e68b\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -149,11 +149,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["bar", "bar"]}, "type": "PUT"}],
-      "commitMeta": {"hash": null, "message": "test_message2", "committer": null,
-      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
-      null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["bar", "bar"]}, "contents": {"snapshotId":
+      42, "metadataLocation": "/a/b/c", "id": "uuid2", "type": "ICEBERG_TABLE"}, "type":
+      "PUT"}], "commitMeta": {"committer": null, "author": null, "authorTime": null,
+      "email": null, "commitTime": null, "message": "test_message2", "properties":
+      null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -164,7 +164,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '342'
+      - '361'
       Content-Type:
       - application/json
       User-Agent:
@@ -173,7 +173,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"717547666512e0d77b339e488c832d516ec60df7df35f55a876bbc807a246136\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -211,11 +211,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"metadataLocation": "/a/b/c", "id": "uuid",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["foo", "baz"]}, "type": "PUT"}],
-      "commitMeta": {"hash": null, "message": "test_message3", "committer": null,
-      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
-      null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["foo", "baz"]}, "contents": {"snapshotId":
+      42, "metadataLocation": "/a/b/c", "id": "uuid3", "type": "ICEBERG_TABLE"}, "type":
+      "PUT"}], "commitMeta": {"committer": null, "author": null, "authorTime": null,
+      "email": null, "commitTime": null, "message": "test_message3", "properties":
+      null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -226,7 +226,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '342'
+      - '361'
       Content-Type:
       - application/json
       User-Agent:
@@ -235,7 +235,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e83ab3e7d2f2f2c5082deb7cffa16e2651cae434ec55656fc05664328728aa92\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"82b183d04c56f32f74f7f161c73d7205a0811516985a814490c0e9dbc5c5d81e\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -262,8 +262,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"e83ab3e7d2f2f2c5082deb7cffa16e2651cae434ec55656fc05664328728aa92\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3\"\n}
+        \"82b183d04c56f32f74f7f161c73d7205a0811516985a814490c0e9dbc5c5d81e\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"717547666512e0d77b339e488c832d516ec60df7df35f55a876bbc807a246136\"\n}
         ]"
     headers:
       Content-Length:
@@ -291,14 +291,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3\",\n
+        [ {\n    \"hash\" : \"717547666512e0d77b339e488c832d516ec60df7df35f55a876bbc807a246136\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-08-31T16:43:07.941153Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:43:07.941153Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"e7b22b3488ea9e65b281dcef5935926ab01a9d157554b8e5de5f66d9cb40a675\",\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-09-13T18:44:05.609513Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:44:05.609513Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"4814fecdb01be53336fe3dfd3f7644f7213891ab1a60973536c80bec4769e68b\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:43:05.871006Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:43:05.871006Z\",\n    \"properties\"
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:44:03.533309Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:44:03.533309Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -309,8 +309,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromRefName": "dev", "hashesToTransplant": ["e7b22b3488ea9e65b281dcef5935926ab01a9d157554b8e5de5f66d9cb40a675",
-      "3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3"]}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["4814fecdb01be53336fe3dfd3f7644f7213891ab1a60973536c80bec4769e68b",
+      "717547666512e0d77b339e488c832d516ec60df7df35f55a876bbc807a246136"]}'
     headers:
       Accept:
       - '*/*'
@@ -327,7 +327,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=e83ab3e7d2f2f2c5082deb7cffa16e2651cae434ec55656fc05664328728aa92
+    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=82b183d04c56f32f74f7f161c73d7205a0811516985a814490c0e9dbc5c5d81e
   response:
     body:
       string: ''
@@ -353,18 +353,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"0771bc1a44d3c2ea8a9775d663110d4236fdc6dc95c6198bd297bad8f0079a3c\",\n
+        [ {\n    \"hash\" : \"5d4b165d97fd2214bc5aea3c68b72859fc1c6bf765035ec08d1464e2642d4fd1\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-08-31T16:43:07.941153Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:43:07.941153Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"1c1ca8893c9a49caa58773e8fe6ac918fada55ed7b729305db3b28070be3ff34\",\n
+        \   \"message\" : \"test_message2\",\n    \"commitTime\" : \"2021-09-13T18:44:05.609513Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:44:05.609513Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"2227d73dff0a580222e8aad4694a480ff703cd2624b4fbb99c13a91fa0e678d9\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-08-31T16:43:05.871006Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:43:05.871006Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"e83ab3e7d2f2f2c5082deb7cffa16e2651cae434ec55656fc05664328728aa92\",\n
+        \   \"message\" : \"test_message\",\n    \"commitTime\" : \"2021-09-13T18:44:03.533309Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:44:03.533309Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"82b183d04c56f32f74f7f161c73d7205a0811516985a814490c0e9dbc5c5d81e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"\",\n    \"signedOffBy\" : null,\n
-        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-08-31T16:43:10.018072Z\",\n
-        \   \"authorTime\" : \"2021-08-31T16:43:10.018072Z\",\n    \"properties\"
+        \   \"message\" : \"test_message3\",\n    \"commitTime\" : \"2021-09-13T18:44:07.691051Z\",\n
+        \   \"authorTime\" : \"2021-09-13T18:44:07.691051Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -388,24 +388,24 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.bar?ref=main
+    uri: http://localhost:19120/api/v1/contents/transplant.foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid\",\n  \"metadataLocation\"
-        : \"/a/b/c\"\n}"
+      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"uuid1\",\n  \"metadataLocation\"
+        : \"/a/b/c\",\n  \"snapshotId\" : 42\n}"
     headers:
       Content-Length:
-      - '80'
+      - '102'
       Content-Type:
       - application/json
     status:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"hash": null, "message": "delete_message", "committer": null,
-      "authorTime": null, "signedOffBy": null, "email": null, "author": null, "properties":
-      null, "commitTime": null}}'
+    body: '{"operations": [{"key": {"elements": ["transplant", "foo", "bar"]}, "type":
+      "DELETE"}], "commitMeta": {"committer": null, "author": null, "authorTime":
+      null, "email": null, "commitTime": null, "message": "delete_message", "properties":
+      null, "hash": null, "signedOffBy": null}}'
     headers:
       Accept:
       - '*/*'
@@ -416,16 +416,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '263'
+      - '277'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=0771bc1a44d3c2ea8a9775d663110d4236fdc6dc95c6198bd297bad8f0079a3c
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=5d4b165d97fd2214bc5aea3c68b72859fc1c6bf765035ec08d1464e2642d4fd1
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"fafdc0827ab4f24d8ca9acb397dac692b8ebe101180aa618bb87d2bd6f7d08ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"bc78743b0b43dccce0a2cc78ed99af9b45aa96640cfb8befbee1dc43960c6f51\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -451,7 +451,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"717547666512e0d77b339e488c832d516ec60df7df35f55a876bbc807a246136\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -476,7 +476,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=3b05dede5986cb96f0615a6760bd0816457df7d74b24d81c578cb34d0bd82cb3
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=717547666512e0d77b339e488c832d516ec60df7df35f55a876bbc807a246136
   response:
     body:
       string: ''
@@ -501,7 +501,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"fafdc0827ab4f24d8ca9acb397dac692b8ebe101180aa618bb87d2bd6f7d08ed\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"bc78743b0b43dccce0a2cc78ed99af9b45aa96640cfb8befbee1dc43960c6f51\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -526,7 +526,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=fafdc0827ab4f24d8ca9acb397dac692b8ebe101180aa618bb87d2bd6f7d08ed
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=bc78743b0b43dccce0a2cc78ed99af9b45aa96640cfb8befbee1dc43960c6f51
   response:
     body:
       string: ''
@@ -535,7 +535,7 @@ interactions:
       code: 204
       message: No Content
 - request:
-    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
+    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -27,7 +27,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
+    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -47,20 +47,19 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"message\" : \"A reference of name [main] already exists.\",\n
-        \ \"status\" : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\"
-        : null\n}"
+      string: "{\n  \"message\" : \"branch 'main' already exists\",\n  \"status\"
+        : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\" : null\n}"
     headers:
       Content-Length:
-      - '134'
+      - '120'
       Content-Type:
       - application/json
     status:
       code: 409
       message: Conflict
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "test", "type": "BRANCH"}'
+    body: '{"name": "test", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -152,7 +152,7 @@ public abstract class AbstractTestRest {
                             .submit())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("Cannot create an unassigned tag reference"),
+                .hasMessageContaining("Tag-creation requires a target named-reference and hash."),
         // legit Tag with name + hash
         () -> {
           Reference refTag1 =

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ErrorTestService.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ErrorTestService.java
@@ -35,8 +35,7 @@ import javax.ws.rs.core.MediaType;
 import org.mockito.Mockito;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.versioned.BackendLimitExceededException;
-import org.projectnessie.versioned.StoreWorker;
-import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.impl.ImmutableTieredVersionStoreConfig;
 import org.projectnessie.versioned.impl.TieredVersionStore;
 import org.projectnessie.versioned.store.Store;
@@ -136,9 +135,9 @@ public class ErrorTestService {
     Store store = Mockito.mock(Store.class);
     Mockito.when(store.getValues(ValueType.REF)).thenThrow(ex);
 
-    TieredVersionStore<String, String, StringSerializer.TestEnum> tvs =
+    TieredVersionStore<String, String, StringStoreWorker.TestEnum> tvs =
         new TieredVersionStore<>(
-            StoreWorker.of(StringSerializer.getInstance(), StringSerializer.getInstance()),
+            StringStoreWorker.INSTANCE,
             store,
             ImmutableTieredVersionStoreConfig.builder().waitOnCollapse(true).build());
     tvs.getNamedRefs().forEach(ref -> {});

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
@@ -51,7 +51,7 @@ public class ITNativeNessieError {
   @Test
   void testNullParamViolation() {
     ContentsKey k = ContentsKey.of("a");
-    IcebergTable t = IcebergTable.of("path1");
+    IcebergTable t = IcebergTable.of("path1", -1L);
     assertEquals(
         "Bad Request (HTTP/400): commitMultipleOperations.hash: must not be null",
         assertThrows(

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -20,18 +20,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
+import java.util.Optional;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Contents;
+import org.projectnessie.model.Contents.Type;
 import org.projectnessie.model.DeltaLakeTable;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.ImmutableDeltaLakeTable;
 import org.projectnessie.model.ImmutableDeltaLakeTable.Builder;
-import org.projectnessie.model.ImmutableIcebergTable;
 import org.projectnessie.model.ImmutableSqlView;
 import org.projectnessie.model.SqlView;
 import org.projectnessie.model.SqlView.Dialect;
 import org.projectnessie.store.ObjectTypes;
+import org.projectnessie.store.ObjectTypes.IcebergTableMetadata;
 import org.projectnessie.versioned.Serializer;
 import org.projectnessie.versioned.SerializerWithPayload;
 import org.projectnessie.versioned.StoreWorker;
@@ -45,7 +47,142 @@ public class TableCommitMetaStoreWorker
   private final Serializer<CommitMeta> metaSerializer = new MetadataSerializer();
 
   @Override
-  public SerializerWithPayload<Contents, Contents.Type> getValueSerializer() {
+  public ByteString toStoreOnReferenceState(Contents contents) {
+    ObjectTypes.Contents.Builder builder =
+        ObjectTypes.Contents.newBuilder().setId(contents.getId());
+    if (contents instanceof IcebergTable) {
+      IcebergTable state = (IcebergTable) contents;
+      ObjectTypes.IcebergSnapshot.Builder stateBuilder =
+          ObjectTypes.IcebergSnapshot.newBuilder().setSnapshotId(state.getSnapshotId());
+      builder.setIcebergSnapshot(stateBuilder);
+
+    } else if (contents instanceof DeltaLakeTable) {
+      ObjectTypes.DeltaLakeTable.Builder table =
+          ObjectTypes.DeltaLakeTable.newBuilder()
+              .addAllMetadataLocationHistory(
+                  ((DeltaLakeTable) contents).getMetadataLocationHistory())
+              .addAllCheckpointLocationHistory(
+                  ((DeltaLakeTable) contents).getCheckpointLocationHistory());
+      String lastCheckpoint = ((DeltaLakeTable) contents).getLastCheckpoint();
+      if (lastCheckpoint != null) {
+        table.setLastCheckpoint(lastCheckpoint);
+      }
+      builder.setDeltaLakeTable(table);
+
+    } else if (contents instanceof SqlView) {
+      SqlView view = (SqlView) contents;
+      builder.setSqlView(
+          ObjectTypes.SqlView.newBuilder()
+              .setDialect(view.getDialect().name())
+              .setSqlText(view.getSqlText()));
+    } else {
+      throw new IllegalArgumentException("Unknown type " + contents);
+    }
+
+    return builder.build().toByteString();
+  }
+
+  @Override
+  public ByteString toStoreGlobalState(Contents contents) {
+    ObjectTypes.Contents.Builder builder =
+        ObjectTypes.Contents.newBuilder().setId(contents.getId());
+    if (contents instanceof IcebergTable) {
+      IcebergTable state = (IcebergTable) contents;
+      ObjectTypes.IcebergTableMetadata.Builder stateBuilder =
+          ObjectTypes.IcebergTableMetadata.newBuilder()
+              .setMetadataLocation(state.getMetadataLocation());
+      builder.setIcebergTableMetadata(stateBuilder);
+    } else {
+      throw new IllegalArgumentException("Unknown type " + contents);
+    }
+
+    return builder.build().toByteString();
+  }
+
+  @Override
+  public Contents valueFromStore(ByteString onReferenceValue, Optional<ByteString> globalState) {
+    ObjectTypes.Contents contents = parse(onReferenceValue);
+    Optional<ObjectTypes.Contents> globalContents =
+        globalState.map(TableCommitMetaStoreWorker::parse);
+    switch (contents.getObjectTypeCase()) {
+      case DELTA_LAKE_TABLE:
+        Builder builder =
+            ImmutableDeltaLakeTable.builder()
+                .id(contents.getId())
+                .addAllMetadataLocationHistory(
+                    contents.getDeltaLakeTable().getMetadataLocationHistoryList())
+                .addAllCheckpointLocationHistory(
+                    contents.getDeltaLakeTable().getCheckpointLocationHistoryList());
+        if (contents.getDeltaLakeTable().getLastCheckpoint() != null) {
+          builder.lastCheckpoint(contents.getDeltaLakeTable().getLastCheckpoint());
+        }
+        return builder.build();
+
+      case ICEBERG_SNAPSHOT:
+        return IcebergTable.of(
+            globalContents
+                .map(ObjectTypes.Contents::getIcebergTableMetadata)
+                .map(IcebergTableMetadata::getMetadataLocation)
+                .orElseThrow(IllegalStateException::new),
+            contents.getIcebergSnapshot().getSnapshotId(),
+            contents.getId());
+
+      case SQL_VIEW:
+        ObjectTypes.SqlView view = contents.getSqlView();
+        return ImmutableSqlView.builder()
+            .dialect(Dialect.valueOf(view.getDialect()))
+            .sqlText(view.getSqlText())
+            .id(contents.getId())
+            .build();
+
+      case OBJECTTYPE_NOT_SET:
+      default:
+        throw new IllegalArgumentException("Unknown type " + contents.getObjectTypeCase());
+    }
+  }
+
+  @Override
+  public String getId(Contents contents) {
+    return contents.getId();
+  }
+
+  @Override
+  public Byte getPayload(Contents contents) {
+    if (contents instanceof IcebergTable) {
+      return (byte) Contents.Type.ICEBERG_TABLE.ordinal();
+    } else if (contents instanceof DeltaLakeTable) {
+      return (byte) Contents.Type.DELTA_LAKE_TABLE.ordinal();
+    } else if (contents instanceof SqlView) {
+      return (byte) Contents.Type.VIEW.ordinal();
+    } else {
+      throw new IllegalArgumentException("Unknown type " + contents);
+    }
+  }
+
+  @Override
+  public Type getType(Byte payload) {
+    if (payload == null || payload > Contents.Type.values().length || payload < 0) {
+      throw new IllegalArgumentException(
+          String.format("Cannot create type from payload. Payload %d does not exist", payload));
+    }
+    return Contents.Type.values()[payload];
+  }
+
+  @Override
+  public boolean requiresState(Contents contents) {
+    return contents instanceof IcebergTable;
+  }
+
+  private static ObjectTypes.Contents parse(ByteString onReferenceValue) {
+    try {
+      return ObjectTypes.Contents.parseFrom(onReferenceValue);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException("Failure parsing data", e);
+    }
+  }
+
+  @Override
+  public SerializerWithPayload<Contents, Type> getValueSerializer() {
     return tableSerializer;
   }
 
@@ -54,14 +191,15 @@ public class TableCommitMetaStoreWorker
     return metaSerializer;
   }
 
+  @Deprecated // TODO this class is going to be removed
   private static class TableValueSerializer
       implements SerializerWithPayload<Contents, Contents.Type> {
     @Override
     public ByteString toBytes(Contents value) {
       ObjectTypes.Contents.Builder builder = ObjectTypes.Contents.newBuilder().setId(value.getId());
       if (value instanceof IcebergTable) {
-        builder.setIcebergTable(
-            ObjectTypes.IcebergTable.newBuilder()
+        builder.setIcebergTableMetadata(
+            ObjectTypes.IcebergTableMetadata.newBuilder()
                 .setMetadataLocation(((IcebergTable) value).getMetadataLocation()));
 
       } else if (value instanceof DeltaLakeTable) {
@@ -84,7 +222,7 @@ public class TableCommitMetaStoreWorker
                 .setDialect(view.getDialect().name())
                 .setSqlText(view.getSqlText()));
       } else {
-        throw new IllegalArgumentException("Unknown type" + value);
+        throw new IllegalArgumentException("Unknown type " + value);
       }
 
       return builder.build().toByteString();
@@ -92,12 +230,7 @@ public class TableCommitMetaStoreWorker
 
     @Override
     public Contents fromBytes(ByteString bytes) {
-      ObjectTypes.Contents contents;
-      try {
-        contents = ObjectTypes.Contents.parseFrom(bytes);
-      } catch (InvalidProtocolBufferException e) {
-        throw new RuntimeException("Failure parsing data", e);
-      }
+      ObjectTypes.Contents contents = parse(bytes);
       switch (contents.getObjectTypeCase()) {
         case DELTA_LAKE_TABLE:
           Builder builder =
@@ -112,11 +245,9 @@ public class TableCommitMetaStoreWorker
           }
           return builder.build();
 
-        case ICEBERG_TABLE:
-          return ImmutableIcebergTable.builder()
-              .metadataLocation(contents.getIcebergTable().getMetadataLocation())
-              .id(contents.getId())
-              .build();
+        case ICEBERG_TABLE_METADATA:
+          return IcebergTable.of(
+              contents.getIcebergTableMetadata().getMetadataLocation(), -1L, contents.getId());
 
         case SQL_VIEW:
           ObjectTypes.SqlView view = contents.getSqlView();
@@ -128,7 +259,7 @@ public class TableCommitMetaStoreWorker
 
         case OBJECTTYPE_NOT_SET:
         default:
-          throw new IllegalArgumentException("Unknown type" + contents.getObjectTypeCase());
+          throw new IllegalArgumentException("Unknown type " + contents.getObjectTypeCase());
       }
     }
 
@@ -141,7 +272,7 @@ public class TableCommitMetaStoreWorker
       } else if (value instanceof SqlView) {
         return (byte) Contents.Type.VIEW.ordinal();
       } else {
-        throw new IllegalArgumentException("Unknown type" + value);
+        throw new IllegalArgumentException("Unknown type " + value);
       }
     }
 

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -169,7 +169,7 @@ public class TableCommitMetaStoreWorker
   }
 
   @Override
-  public boolean requiresState(Contents contents) {
+  public boolean requiresGlobalState(Contents contents) {
     return contents instanceof IcebergTable;
   }
 

--- a/servers/store/src/main/proto/table.proto
+++ b/servers/store/src/main/proto/table.proto
@@ -22,15 +22,20 @@ option java_generate_equals_and_hash = true;
 
 message Contents {
   oneof object_type {
-    IcebergTable iceberg_table = 1;
-    SqlView sql_view = 2;
-    DeltaLakeTable delta_lake_table = 3;
+    IcebergTableMetadata iceberg_table_metadata = 1;
+    IcebergSnapshot iceberg_snapshot = 2;
+    SqlView sql_view = 3;
+    DeltaLakeTable delta_lake_table = 4;
   }
-  string id = 6;
+  string id = 5;
 }
 
-message IcebergTable {
+message IcebergTableMetadata {
   string metadata_location = 1;
+}
+
+message IcebergSnapshot {
+  int64 snapshot_id = 1;
 }
 
 message SqlView {

--- a/versioned/gc/iceberg-actions/pom.xml
+++ b/versioned/gc/iceberg-actions/pom.xml
@@ -169,48 +169,11 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.bazaarvoice.maven.plugins</groupId>
-        <artifactId>process-exec-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>start</id>
-            <phase>pre-integration-test</phase>
-            <goals><goal>start</goal></goals>
-            <configuration>
-              <name>dynamolocal</name>
-              <waitAfterLaunch>1</waitAfterLaunch>
-              <workingDir>${project.basedir}</workingDir>
-              <arguments>
-                <argument>java</argument>
-                <argument>-Djava.library.path=${project.build.directory}/native-libraries</argument>
-                <argument>-classpath</argument>
-                <argument>${project.build.directory}/dynamo-libraries/*</argument>
-                <argument>com.amazonaws.services.dynamodbv2.local.main.ServerRunner</argument>
-                <argument>-port</argument>
-                <argument>8000</argument>
-                <argument>-inMemory</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>stop-all</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>stop-all</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${quarkus.http.test-port}</quarkus.http.test-port>
-            <aws.accessKeyId>xxx</aws.accessKeyId>
-            <aws.secretAccessKey>xxx</aws.secretAccessKey>
-            <sqlite4java.library.path>${project.build.directory}/native-libraries</sqlite4java.library.path>
-          </systemPropertyVariables>
+          <!-- Nessie PR https://github.com/projectnessie/nessie/pull/1922 introduces breaking changes as a clear cut to Nessie before 1.0 -->
+          <skip>true</skip>
         </configuration>
         <executions>
           <execution>
@@ -221,127 +184,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-native-libraries</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/native-libraries</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeTypes>dll,so,dylib</includeTypes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-dynamo-libraries</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/dynamo-libraries</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeGroupIds>com.amazonaws,com.google.guava,commons-cli,org.apache.commons,org.eclipse.jetty,org.apache.logging.log4j,com.fasterxml,com.almworks,org.antlr</includeGroupIds>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.projectnessie</groupId>
-        <artifactId>nessie-apprunner-maven-plugin</artifactId>
-        <version>${client.nessie.version}</version>
-        <configuration>
-          <skip>${skipTests}</skip>
-          <appArtifactId>org.projectnessie:nessie-quarkus:${client.nessie.version}</appArtifactId>
-          <applicationProperties>
-            <quarkus.http.test-port>0</quarkus.http.test-port>
-            <nessie.version.store.dynamo.initialize>true</nessie.version.store.dynamo.initialize>
-            <nessie.version.store.type>DYNAMO</nessie.version.store.type>
-            <quarkus.dynamodb.endpoint.override>http://localhost:8000</quarkus.dynamodb.endpoint.override>
-            <quarkus.dynamodb.aws.region>us-west-2</quarkus.dynamodb.aws.region>
-          </applicationProperties>
-          <systemProperties>
-            <aws.accessKeyId>xxx</aws.accessKeyId>
-            <aws.secretAccessKey>xxx</aws.secretAccessKey>
-          </systemProperties>
-          <outputProperties>
-            <quarkus.http.test-port>quarkus.http.test-port</quarkus.http.test-port>
-          </outputProperties>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.projectnessie</groupId>
-            <artifactId>nessie-quarkus</artifactId>
-            <version>${client.nessie.version}</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>start</id>
-            <phase>pre-integration-test</phase>
-            <goals><goal>start</goal></goals>
-          </execution>
-          <execution>
-            <id>stop</id>
-            <phase>post-integration-test</phase>
-            <goals><goal>stop</goal></goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <activation>
-        <os><family>unix</family></os>
-      </activation>
-      <id>linux</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>libsqlite4java-linux-amd64</artifactId>
-          <type>so</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <activation>
-        <os><family>mac</family></os>
-      </activation>
-      <id>mac</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>libsqlite4java-osx</artifactId>
-          <type>dylib</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <activation>
-        <os><family>windows</family></os>
-      </activation>
-      <id>windows</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>sqlite4java-win32-x64</artifactId>
-          <type>dll</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/versioned/gc/iceberg/pom.xml
+++ b/versioned/gc/iceberg/pom.xml
@@ -161,48 +161,11 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.bazaarvoice.maven.plugins</groupId>
-        <artifactId>process-exec-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>start</id>
-            <phase>pre-integration-test</phase>
-            <goals><goal>start</goal></goals>
-            <configuration>
-              <name>dynamolocal</name>
-              <waitAfterLaunch>1</waitAfterLaunch>
-              <workingDir>${project.basedir}</workingDir>
-              <arguments>
-                <argument>java</argument>
-                <argument>-Djava.library.path=${project.build.directory}/native-libraries</argument>
-                <argument>-classpath</argument>
-                <argument>${project.build.directory}/dynamo-libraries/*</argument>
-                <argument>com.amazonaws.services.dynamodbv2.local.main.ServerRunner</argument>
-                <argument>-port</argument>
-                <argument>8000</argument>
-                <argument>-inMemory</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>stop-all</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>stop-all</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${quarkus.http.test-port}</quarkus.http.test-port>
-            <aws.accessKeyId>xxx</aws.accessKeyId>
-            <aws.secretAccessKey>xxx</aws.secretAccessKey>
-            <sqlite4java.library.path>${project.build.directory}/native-libraries</sqlite4java.library.path>
-          </systemPropertyVariables>
+          <!-- Nessie PR https://github.com/projectnessie/nessie/pull/1922 introduces breaking changes as a clear cut to Nessie before 1.0 -->
+          <skip>true</skip>
         </configuration>
         <executions>
           <execution>
@@ -210,82 +173,6 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-native-libraries</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/native-libraries</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeTypes>dll,so,dylib</includeTypes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-dynamo-libraries</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/dynamo-libraries</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeGroupIds>com.amazonaws,com.google.guava,commons-cli,org.apache.commons,org.eclipse.jetty,org.apache.logging.log4j,com.fasterxml,com.almworks,org.antlr</includeGroupIds>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.projectnessie</groupId>
-        <artifactId>nessie-apprunner-maven-plugin</artifactId>
-        <version>${client.nessie.version}</version>
-        <configuration>
-          <skip>${skipTests}</skip>
-          <appArtifactId>org.projectnessie:nessie-quarkus:${client.nessie.version}</appArtifactId>
-          <applicationProperties>
-            <quarkus.http.test-port>0</quarkus.http.test-port>
-            <nessie.version.store.dynamo.initialize>true</nessie.version.store.dynamo.initialize>
-            <nessie.version.store.type>DYNAMO</nessie.version.store.type>
-            <quarkus.dynamodb.endpoint.override>http://localhost:8000</quarkus.dynamodb.endpoint.override>
-            <quarkus.dynamodb.aws.region>us-west-2</quarkus.dynamodb.aws.region>
-          </applicationProperties>
-          <systemProperties>
-            <aws.accessKeyId>xxx</aws.accessKeyId>
-            <aws.secretAccessKey>xxx</aws.secretAccessKey>
-          </systemProperties>
-          <outputProperties>
-            <quarkus.http.test-port>quarkus.http.test-port</quarkus.http.test-port>
-          </outputProperties>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.projectnessie</groupId>
-            <artifactId>nessie-quarkus</artifactId>
-            <version>${client.nessie.version}</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>start</id>
-            <phase>pre-integration-test</phase>
-            <goals><goal>start</goal></goals>
-          </execution>
-          <execution>
-            <id>stop</id>
-            <phase>post-integration-test</phase>
-            <goals><goal>stop</goal></goals>
           </execution>
         </executions>
       </plugin>
@@ -303,49 +190,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <activation>
-        <os><family>unix</family></os>
-      </activation>
-      <id>linux</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>libsqlite4java-linux-amd64</artifactId>
-          <type>so</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <activation>
-        <os><family>mac</family></os>
-      </activation>
-      <id>mac</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>libsqlite4java-osx</artifactId>
-          <type>dylib</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <activation>
-        <os><family>windows</family></os>
-      </activation>
-      <id>windows</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>sqlite4java-win32-x64</artifactId>
-          <type>dll</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/versioned/gc/iceberg/src/test/java/org/projectnessie/versioned/gc/ITIcebergAssetKeyReader.java
+++ b/versioned/gc/iceberg/src/test/java/org/projectnessie/versioned/gc/ITIcebergAssetKeyReader.java
@@ -188,7 +188,8 @@ public class ITIcebergAssetKeyReader {
       IcebergAssetKeyConverter akr, Table table, ImmutableMap<String, Long> expected) {
     Set<AssetKey> fileList =
         akr.apply(
-                IcebergTable.of(((BaseTable) table).operations().current().metadataFileLocation()))
+                IcebergTable.of(
+                    ((BaseTable) table).operations().current().metadataFileLocation(), -1L))
             .collect(Collectors.toSet());
 
     Multimap<String, AssetKey> unreferencedItems =

--- a/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/AbstractITJGitVersionStore.java
+++ b/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/AbstractITJGitVersionStore.java
@@ -19,18 +19,14 @@ import java.io.IOException;
 import org.eclipse.jgit.lib.Repository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
-import org.projectnessie.versioned.StoreWorker;
-import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.VersionStoreException;
 import org.projectnessie.versioned.tests.AbstractITVersionStore;
 
 public abstract class AbstractITJGitVersionStore extends AbstractITVersionStore {
   protected Repository repository;
-  protected VersionStore<String, String, StringSerializer.TestEnum> store;
-
-  protected static final StoreWorker<String, String, StringSerializer.TestEnum> WORKER =
-      StoreWorker.of(StringSerializer.getInstance(), StringSerializer.getInstance());
+  protected VersionStore<String, String, StringStoreWorker.TestEnum> store;
 
   abstract void setUp() throws IOException;
 
@@ -45,7 +41,7 @@ public abstract class AbstractITJGitVersionStore extends AbstractITVersionStore 
   }
 
   @Override
-  protected VersionStore<String, String, StringSerializer.TestEnum> store() {
+  protected VersionStore<String, String, StringStoreWorker.TestEnum> store() {
     return store;
   }
 }

--- a/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/ITJGitInMemoryVersionStore.java
+++ b/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/ITJGitInMemoryVersionStore.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
 import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.projectnessie.versioned.StringStoreWorker;
 
 public class ITJGitInMemoryVersionStore extends AbstractITJGitVersionStore {
 
@@ -28,6 +29,6 @@ public class ITJGitInMemoryVersionStore extends AbstractITJGitVersionStore {
         new InMemoryRepository.Builder()
             .setRepositoryDescription(new DfsRepositoryDescription())
             .build();
-    store = new JGitVersionStore<>(repository, WORKER);
+    store = new JGitVersionStore<>(repository, StringStoreWorker.INSTANCE);
   }
 }

--- a/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/ITJGitOnDiskVersionStore.java
+++ b/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/ITJGitOnDiskVersionStore.java
@@ -21,6 +21,7 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
+import org.projectnessie.versioned.StringStoreWorker;
 
 public class ITJGitOnDiskVersionStore extends AbstractITJGitVersionStore {
 
@@ -33,6 +34,6 @@ public class ITJGitOnDiskVersionStore extends AbstractITJGitVersionStore {
     } catch (GitAPIException e) {
       throw new IOException(e);
     }
-    store = new JGitVersionStore<>(repository, WORKER);
+    store = new JGitVersionStore<>(repository, StringStoreWorker.INSTANCE);
   }
 }

--- a/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/TestJGitVersionStore.java
+++ b/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/TestJGitVersionStore.java
@@ -57,8 +57,7 @@ import org.projectnessie.versioned.Ref;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
-import org.projectnessie.versioned.StoreWorker;
-import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.Unchanged;
 import org.projectnessie.versioned.VersionStore;
@@ -120,7 +119,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void createAndDeleteTag(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     impl.create(BranchName.of("bar"), Optional.empty());
     Optional<Hash> baseCommit = Optional.of(impl.toHash(BranchName.of("bar")));
@@ -162,7 +161,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void unknownRef(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     BranchName branch = BranchName.of("bar");
     impl.create(branch, Optional.empty());
@@ -181,7 +180,7 @@ class TestJGitVersionStore {
   }
 
   private void testRefMatchesToRef(
-      JGitVersionStore<String, String, StringSerializer.TestEnum> impl,
+      JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl,
       Ref ref,
       Hash hash,
       String name)
@@ -195,7 +194,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void createAndDeleteBranch(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     BranchName branch = BranchName.of("foo");
 
@@ -247,7 +246,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void conflictingCommit(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     BranchName branch = BranchName.of("foo");
     impl.create(branch, Optional.empty());
@@ -290,7 +289,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void checkRefs(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     impl.create(BranchName.of("b1"), Optional.empty());
     Optional<Hash> baseCommit = Optional.of(impl.toHash(BranchName.of("b1")));
@@ -308,7 +307,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void checkCommits(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     BranchName branch = BranchName.of("foo");
     impl.create(branch, Optional.empty());
@@ -345,7 +344,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void assignments(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     BranchName branch = BranchName.of("foo");
     final Key k1 = Key.of("p1");
@@ -382,7 +381,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void delete(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     BranchName branch = BranchName.of("foo");
     final Key k1 = Key.of("p1");
@@ -399,7 +398,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void unchangedOperation(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
     BranchName branch = BranchName.of("foo");
     impl.create(branch, Optional.empty());
@@ -445,7 +444,7 @@ class TestJGitVersionStore {
   @EnumSource(RepoType.class)
   void checkEmptyHistory(
       @ConvertWith(RepositoryConverter.class)
-          JGitVersionStore<String, String, StringSerializer.TestEnum> impl)
+          JGitVersionStore<String, String, StringStoreWorker.TestEnum> impl)
       throws Exception {
 
     BranchName branch = BranchName.of("foo");
@@ -456,8 +455,8 @@ class TestJGitVersionStore {
   @ParameterizedTest
   @EnumSource(RepoType.class)
   void completeFlow(RepoType repoType) throws Exception {
-    VersionStore<String, String, StringSerializer.TestEnum> impl =
-        new JGitVersionStore<>(repository(repoType), WORKER);
+    VersionStore<String, String, StringStoreWorker.TestEnum> impl =
+        new JGitVersionStore<>(repository(repoType), StringStoreWorker.INSTANCE);
     final BranchName branch = ImmutableBranchName.builder().name("main").build();
     final BranchName branch2 = ImmutableBranchName.builder().name("b2").build();
     final TagName tag = ImmutableTagName.builder().name("t1").build();
@@ -527,9 +526,6 @@ class TestJGitVersionStore {
     assertEquals(v1, impl.getValue(branch2, p1));
   }
 
-  private static final StoreWorker<String, String, StringSerializer.TestEnum> WORKER =
-      StoreWorker.of(StringSerializer.getInstance(), StringSerializer.getInstance());
-
   /** convert RepoType to VersionStore for each parameterised test. */
   private static class RepositoryConverter implements ArgumentConverter {
 
@@ -538,7 +534,7 @@ class TestJGitVersionStore {
         throws ArgumentConversionException {
       if (source instanceof RepoType) {
         try {
-          return new JGitVersionStore<>(repository((RepoType) source), WORKER);
+          return new JGitVersionStore<>(repository((RepoType) source), StringStoreWorker.INSTANCE);
         } catch (IOException e) {
           throw new RuntimeException("couldn't build repo", e);
         }

--- a/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/TestTreeBuilder.java
+++ b/versioned/jgit/src/test/java/org/projectnessie/versioned/jgit/TestTreeBuilder.java
@@ -37,7 +37,7 @@ import org.projectnessie.versioned.Delete;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.SerializerWithPayload;
-import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.Unchanged;
 
 class TestTreeBuilder {
@@ -57,8 +57,8 @@ class TestTreeBuilder {
     } catch (IOException e) {
       throw new RuntimeException();
     }
-    SerializerWithPayload<String, StringSerializer.TestEnum> serializer =
-        new SerializerWithPayload<String, StringSerializer.TestEnum>() {
+    SerializerWithPayload<String, StringStoreWorker.TestEnum> serializer =
+        new SerializerWithPayload<String, StringStoreWorker.TestEnum>() {
           @Override
           public ByteString toBytes(String value) {
             return ByteString.copyFrom(value.getBytes());
@@ -75,8 +75,8 @@ class TestTreeBuilder {
           }
 
           @Override
-          public StringSerializer.TestEnum getType(Byte payload) {
-            return StringSerializer.TestEnum.NO;
+          public StringStoreWorker.TestEnum getType(Byte payload) {
+            return StringStoreWorker.TestEnum.NO;
           }
         };
 

--- a/versioned/memory/src/main/java/org/projectnessie/versioned/memory/InMemoryVersionStore.java
+++ b/versioned/memory/src/main/java/org/projectnessie/versioned/memory/InMemoryVersionStore.java
@@ -468,7 +468,7 @@ public class InMemoryVersionStore<ValueT, MetadataT, EnumT extends Enum<EnumT>>
       throws ReferenceNotFoundException, ReferenceAlreadyExistsException {
     Preconditions.checkArgument(
         ref instanceof BranchName || targetHash.isPresent(),
-        "Cannot create an unassigned tag reference");
+        "Tag-creation requires a target named-reference and hash.");
 
     return compute(
         namedReferences,

--- a/versioned/memory/src/test/java/org/projectnessie/versioned/memory/ITInMemoryVersionStore.java
+++ b/versioned/memory/src/test/java/org/projectnessie/versioned/memory/ITInMemoryVersionStore.java
@@ -31,21 +31,22 @@ import org.projectnessie.versioned.ImmutablePut;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.VersionStoreException;
 import org.projectnessie.versioned.tests.AbstractITVersionStore;
 
 public class ITInMemoryVersionStore extends AbstractITVersionStore {
-  private static final InMemoryVersionStore.Builder<String, String, StringSerializer.TestEnum>
+  private static final InMemoryVersionStore.Builder<String, String, StringStoreWorker.TestEnum>
       BUILDER =
-          InMemoryVersionStore.<String, String, StringSerializer.TestEnum>builder()
+          InMemoryVersionStore.<String, String, StringStoreWorker.TestEnum>builder()
               .valueSerializer(StringSerializer.getInstance())
               .metadataSerializer(StringSerializer.getInstance());
 
-  private VersionStore<String, String, StringSerializer.TestEnum> store;
+  private VersionStore<String, String, StringStoreWorker.TestEnum> store;
 
   @Override
-  protected VersionStore<String, String, StringSerializer.TestEnum> store() {
+  protected VersionStore<String, String, StringStoreWorker.TestEnum> store() {
     return store;
   }
 
@@ -57,8 +58,8 @@ public class ITInMemoryVersionStore extends AbstractITVersionStore {
 
   @Test
   void clearUnsafe() throws Exception {
-    InMemoryVersionStore<String, String, StringSerializer.TestEnum> inMemoryVersionStore =
-        (InMemoryVersionStore<String, String, StringSerializer.TestEnum>) store;
+    InMemoryVersionStore<String, String, StringStoreWorker.TestEnum> inMemoryVersionStore =
+        (InMemoryVersionStore<String, String, StringStoreWorker.TestEnum>) store;
 
     BranchName fooBranch = BranchName.of("foo");
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/SerializerWithPayload.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/SerializerWithPayload.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned;
 
 /** Extension of Serializable that includes a single byte payload. */
+@Deprecated // TODO this interface is going to be removed
 public interface SerializerWithPayload<V, T extends Enum<T>> extends Serializer<V> {
 
   Byte getPayload(V value);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
@@ -39,7 +39,7 @@ public interface StoreWorker<CONTENTS, COMMIT_METADATA, CONTENTS_TYPE extends En
 
   Byte getPayload(CONTENTS contents);
 
-  boolean requiresState(CONTENTS contents);
+  boolean requiresGlobalState(CONTENTS contents);
 
   CONTENTS_TYPE getType(Byte payload);
 

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/StringSerializer.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/StringSerializer.java
@@ -20,20 +20,16 @@ import static org.mockito.Mockito.spy;
 
 import com.google.protobuf.ByteString;
 import javax.annotation.Nonnull;
+import org.projectnessie.versioned.StringStoreWorker.TestEnum;
 
 /**
  * ValueWorker implementation for {@code String class}. Can also be used as simple {@link
  * Serializer}.
  */
-public class StringSerializer implements SerializerWithPayload<String, StringSerializer.TestEnum> {
+@Deprecated // TODO this class is going to be removed
+public class StringSerializer implements SerializerWithPayload<String, TestEnum> {
   private static final SerializerWithPayload<String, TestEnum> INSTANCE =
       spy(new StringSerializer());
-
-  public enum TestEnum {
-    YES,
-    NO,
-    NULL;
-  }
 
   private StringSerializer() {}
 
@@ -65,8 +61,8 @@ public class StringSerializer implements SerializerWithPayload<String, StringSer
   @Override
   public TestEnum getType(Byte payload) {
     if (payload == null) {
-      return TestEnum.NULL;
+      return StringStoreWorker.TestEnum.NULL;
     }
-    return payload > 60 ? TestEnum.YES : TestEnum.NO;
+    return payload > 60 ? StringStoreWorker.TestEnum.YES : StringStoreWorker.TestEnum.NO;
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/StringStoreWorker.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/StringStoreWorker.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.protobuf.ByteString;
+import java.util.Optional;
+import org.projectnessie.versioned.StringStoreWorker.TestEnum;
+
+public final class StringStoreWorker implements StoreWorker<String, String, TestEnum> {
+
+  public enum TestEnum {
+    YES,
+    NO,
+    NULL
+  }
+
+  public static final StringStoreWorker INSTANCE = new StringStoreWorker();
+
+  private static final Serializer<String> METADATA =
+      new Serializer<String>() {
+        @Override
+        public String fromBytes(ByteString bytes) {
+          return bytes.toString(UTF_8);
+        }
+
+        @Override
+        public ByteString toBytes(String value) {
+          return ByteString.copyFrom(value, UTF_8);
+        }
+      };
+
+  private StringStoreWorker() {}
+
+  public static String withStateAndId(String state, String value, String contentsId) {
+    return state + '|' + value + '@' + contentsId;
+  }
+
+  public static String withId(String value, String contentsId) {
+    return value + '@' + contentsId;
+  }
+
+  @Override
+  public ByteString toStoreOnReferenceState(String contents) {
+    int i = contents.indexOf('|');
+    if (i != -1) {
+      contents = contents.substring(i + 1);
+    }
+    return ByteString.copyFromUtf8(contents);
+  }
+
+  @Override
+  public ByteString toStoreGlobalState(String contents) {
+    int i = contents.indexOf('@');
+    String cid = contents.substring(i);
+    i = contents.indexOf('|');
+    if (i != -1) {
+      contents = contents.substring(0, i) + cid;
+    }
+    return ByteString.copyFromUtf8(contents);
+  }
+
+  @Override
+  public String valueFromStore(ByteString onReferenceValue, Optional<ByteString> globalState) {
+    return globalState
+        .map(bytes -> stripContentsId(bytes.toStringUtf8()) + '|' + onReferenceValue.toStringUtf8())
+        .orElseGet(onReferenceValue::toStringUtf8);
+  }
+
+  @Override
+  public String getId(String contents) {
+    int i = contents.indexOf('@');
+    return i != -1 ? contents.substring(i + 1) : "FIXED";
+  }
+
+  @Override
+  public Byte getPayload(String contents) {
+    return getValueSerializer().getPayload(contents);
+  }
+
+  @Override
+  public TestEnum getType(Byte payload) {
+    return getValueSerializer().getType(payload);
+  }
+
+  @Override
+  public boolean requiresState(String contents) {
+    return contents.indexOf('|') != -1 || contents.indexOf('@') != -1;
+  }
+
+  @Override
+  public SerializerWithPayload<String, TestEnum> getValueSerializer() {
+    return StringSerializer.getInstance();
+  }
+
+  @Override
+  public Serializer<String> getMetadataSerializer() {
+    return METADATA;
+  }
+
+  private static String stripContentsId(String s) {
+    int i = s.indexOf('@');
+    return i == -1 ? s : s.substring(0, i);
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/StringStoreWorker.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/StringStoreWorker.java
@@ -98,7 +98,7 @@ public final class StringStoreWorker implements StoreWorker<String, String, Test
   }
 
   @Override
-  public boolean requiresState(String contents) {
+  public boolean requiresGlobalState(String contents) {
     return contents.indexOf('|') != -1 || contents.indexOf('@') != -1;
   }
 

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractITVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractITVersionStore.java
@@ -50,6 +50,7 @@ import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.Unchanged;
 import org.projectnessie.versioned.VersionStore;
@@ -60,7 +61,7 @@ import org.projectnessie.versioned.WithType;
 /** Base class used for integration tests against version store implementations. */
 public abstract class AbstractITVersionStore {
 
-  protected abstract VersionStore<String, String, StringSerializer.TestEnum> store();
+  protected abstract VersionStore<String, String, StringStoreWorker.TestEnum> store();
 
   /** Use case simulation: single branch, multiple users, each user updating a separate table. */
   @Test
@@ -1221,7 +1222,7 @@ public abstract class AbstractITVersionStore {
     store().create(branch, Optional.empty());
 
     // have to do this here as tiered store stores payload at commit time
-    Mockito.doReturn(StringSerializer.TestEnum.NO)
+    Mockito.doReturn(StringStoreWorker.TestEnum.NO)
         .when(StringSerializer.getInstance())
         .getType("world");
     store()
@@ -1234,24 +1235,24 @@ public abstract class AbstractITVersionStore {
     assertTrue(values.get(0).isPresent());
 
     // have to do this here as non-tiered store reads payload when getKeys is called
-    Mockito.doReturn(StringSerializer.TestEnum.NO)
+    Mockito.doReturn(StringStoreWorker.TestEnum.NO)
         .when(StringSerializer.getInstance())
         .getType("world");
-    List<WithType<Key, StringSerializer.TestEnum>> keys;
-    try (Stream<WithType<Key, StringSerializer.TestEnum>> k = store().getKeys(branch)) {
+    List<WithType<Key, StringStoreWorker.TestEnum>> keys;
+    try (Stream<WithType<Key, StringStoreWorker.TestEnum>> k = store().getKeys(branch)) {
       keys = k.collect(Collectors.toList());
     }
 
     assertEquals(1, keys.size());
     assertEquals(Key.of("hi"), keys.get(0).getValue());
-    assertEquals(StringSerializer.TestEnum.NO, keys.get(0).getType());
+    assertEquals(StringStoreWorker.TestEnum.NO, keys.get(0).getType());
   }
 
-  protected CommitBuilder<String, String, StringSerializer.TestEnum> forceCommit(String message) {
+  protected CommitBuilder<String, String, StringStoreWorker.TestEnum> forceCommit(String message) {
     return new CommitBuilder<>(store()).withMetadata(message);
   }
 
-  protected CommitBuilder<String, String, StringSerializer.TestEnum> commit(String message) {
+  protected CommitBuilder<String, String, StringStoreWorker.TestEnum> commit(String message) {
     return new CommitBuilder<>(store()).withMetadata(message).fromLatest();
   }
 

--- a/versioned/tiered/dynamodb/src/test/java/org/projectnessie/versioned/impl/ITDynamoVersionStore.java
+++ b/versioned/tiered/dynamodb/src/test/java/org/projectnessie/versioned/impl/ITDynamoVersionStore.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
-import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.VersionStoreException;
 import org.projectnessie.versioned.dynamodb.LocalDynamoDB;
@@ -46,7 +46,7 @@ public class ITDynamoVersionStore extends AbstractITVersionStore {
   }
 
   @Override
-  protected VersionStore<String, String, StringSerializer.TestEnum> store() {
+  protected VersionStore<String, String, StringStoreWorker.TestEnum> store() {
     return fixture;
   }
 

--- a/versioned/tiered/gc/pom.xml
+++ b/versioned/tiered/gc/pom.xml
@@ -172,11 +172,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
-            <aws.accessKeyId>xxx</aws.accessKeyId>
-            <aws.secretAccessKey>xxx</aws.secretAccessKey>
-            <sqlite4java.library.path>${project.build.directory}/native-libraries</sqlite4java.library.path>
-          </systemPropertyVariables>
+          <!-- Nessie PR https://github.com/projectnessie/nessie/pull/1922 introduces breaking changes as a clear cut to Nessie before 1.0 -->
+          <skip>true</skip>
         </configuration>
         <executions>
           <execution>
@@ -187,71 +184,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-native-libraries</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/native-libraries</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeTypes>dll,so,dylib</includeTypes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <activation>
-        <os><family>unix</family></os>
-      </activation>
-      <id>linux</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>libsqlite4java-linux-amd64</artifactId>
-          <type>so</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <activation>
-        <os><family>mac</family></os>
-      </activation>
-      <id>mac</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>libsqlite4java-osx</artifactId>
-          <type>dylib</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <activation>
-        <os><family>windows</family></os>
-      </activation>
-      <id>windows</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.almworks.sqlite4java</groupId>
-          <artifactId>sqlite4java-win32-x64</artifactId>
-          <type>dll</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/versioned/tiered/gc/src/test/java/org/projectnessie/versioned/tiered/gc/ITTestIdentifyUnreferencedAssets.java
+++ b/versioned/tiered/gc/src/test/java/org/projectnessie/versioned/tiered/gc/ITTestIdentifyUnreferencedAssets.java
@@ -260,7 +260,7 @@ public class ITTestIdentifyUnreferencedAssets {
     }
 
     @Override
-    public boolean requiresState(DummyValue contents) {
+    public boolean requiresGlobalState(DummyValue contents) {
       return false;
     }
 

--- a/versioned/tiered/mongodb/src/test/java/org/projectnessie/versioned/mongodb/TestMongoDBVersionStore.java
+++ b/versioned/tiered/mongodb/src/test/java/org/projectnessie/versioned/mongodb/TestMongoDBVersionStore.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
-import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.VersionStoreException;
 import org.projectnessie.versioned.tests.AbstractITVersionStore;
@@ -56,7 +56,7 @@ public class TestMongoDBVersionStore extends AbstractITVersionStore {
   }
 
   @Override
-  protected VersionStore<String, String, StringSerializer.TestEnum> store() {
+  protected VersionStore<String, String, StringStoreWorker.TestEnum> store() {
     return fixture;
   }
 

--- a/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractTieredStoreFixture.java
+++ b/versioned/tiered/tiered-tests/src/main/java/org/projectnessie/versioned/impl/AbstractTieredStoreFixture.java
@@ -31,22 +31,19 @@ import org.projectnessie.versioned.Ref;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
-import org.projectnessie.versioned.StoreWorker;
-import org.projectnessie.versioned.StringSerializer;
+import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.WithHash;
 import org.projectnessie.versioned.WithType;
 import org.projectnessie.versioned.store.Store;
 
 public abstract class AbstractTieredStoreFixture<S extends Store, C>
-    implements VersionStore<String, String, StringSerializer.TestEnum>, AutoCloseable {
-  protected static final StoreWorker<String, String, StringSerializer.TestEnum> WORKER =
-      StoreWorker.of(StringSerializer.getInstance(), StringSerializer.getInstance());
+    implements VersionStore<String, String, StringStoreWorker.TestEnum>, AutoCloseable {
 
   private final C config;
 
   private final S store;
-  private final VersionStore<String, String, StringSerializer.TestEnum> versionStore;
+  private final VersionStore<String, String, StringStoreWorker.TestEnum> versionStore;
 
   /** Create a new fixture. */
   protected AbstractTieredStoreFixture(C config) {
@@ -56,9 +53,9 @@ public abstract class AbstractTieredStoreFixture<S extends Store, C>
 
     store = spy(storeImpl);
 
-    VersionStore<String, String, StringSerializer.TestEnum> versionStoreImpl =
+    VersionStore<String, String, StringStoreWorker.TestEnum> versionStoreImpl =
         new TieredVersionStore<>(
-            WORKER,
+            StringStoreWorker.INSTANCE,
             store,
             ImmutableTieredVersionStoreConfig.builder()
                 .enableTracing(true)
@@ -147,7 +144,7 @@ public abstract class AbstractTieredStoreFixture<S extends Store, C>
   }
 
   @Override
-  public Stream<WithType<Key, StringSerializer.TestEnum>> getKeys(Ref ref)
+  public Stream<WithType<Key, StringStoreWorker.TestEnum>> getKeys(Ref ref)
       throws ReferenceNotFoundException {
     return versionStore.getKeys(ref);
   }


### PR DESCRIPTION
Builds upon #1922 and prepares the code base for being able to use global-state to prepare adding the version-store-implementation for the database-adapters.

* Enhances the `StoreWorker` interface to be able to serialize e.g. `IcebergTable` to the global and on-reference representations and vice versa
* Deprecates `StringSerializer` and its base interface for removal
* Adds new `StringStoreWorker`
* makes `IcebergTable.snapshotId` mandatory
* Updates tests according to the above changes
* Disables tests for the three existing GC-modules (breaking change w/ snapshotId)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1923)
<!-- Reviewable:end -->
