### PR TITLE
Fix dependency issues for `:nessie-deltalake` via `:nessie-client-tests`

### DIFF
--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLog.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLog.java
@@ -65,8 +65,13 @@ class ITDeltaLog extends AbstractSparkTest {
 
   @AfterEach
   void closeClient() {
-    api.close();
-    api = null;
+    try {
+      if (api != null) {
+        api.close();
+      }
+    } finally {
+      api = null;
+    }
   }
 
   @Test

--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
@@ -47,7 +47,7 @@ import scala.Tuple2;
 
 class ITDeltaLogBranches extends AbstractSparkTest {
 
-  static NessieApiV1 api;
+  NessieApiV1 api;
 
   @TempDir File tempPath;
 
@@ -75,8 +75,11 @@ class ITDeltaLogBranches extends AbstractSparkTest {
     if (ref != null) {
       api.deleteBranch().branch((Branch) ref).submit();
     }
-    api.close();
-    api = null;
+    try {
+      api.close();
+    } finally {
+      api = null;
+    }
   }
 
   @Test

--- a/clients/spark-extensions/src/test/java/org/projectnessie/spark/extensions/ITNessieStatements.java
+++ b/clients/spark-extensions/src/test/java/org/projectnessie/spark/extensions/ITNessieStatements.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.client.NessieClient;
 import org.projectnessie.client.tests.AbstractSparkTest;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -51,6 +52,7 @@ public class ITNessieStatements extends AbstractSparkTest {
 
   private String hash;
   private final String refName = "testBranch";
+  protected NessieClient nessieClient;
 
   @BeforeAll
   protected static void createDelta() {
@@ -60,6 +62,7 @@ public class ITNessieStatements extends AbstractSparkTest {
 
   @BeforeEach
   void getHash() throws NessieNotFoundException {
+    nessieClient = NessieClient.builder().withUri(url).build();
     hash = nessieClient.getTreeApi().getDefaultBranch().getHash();
   }
 

--- a/clients/tests/pom.xml
+++ b/clients/tests/pom.xml
@@ -48,12 +48,6 @@
       <version>${spark3.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.projectnessie</groupId>
-      <artifactId>nessie-client</artifactId>
-      <version>${client.nessie.version}</version>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/clients/tests/src/main/java/org/projectnessie/client/tests/AbstractSparkTest.java
+++ b/clients/tests/src/main/java/org/projectnessie/client/tests/AbstractSparkTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,11 +33,8 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
-import org.projectnessie.client.NessieClient;
 
 public abstract class AbstractSparkTest {
-  private static final Object ANY = new Object();
-
   @TempDir File tempFile;
 
   private static final int NESSIE_PORT = Integer.getInteger("quarkus.http.test-port", 19121);
@@ -47,10 +43,8 @@ public abstract class AbstractSparkTest {
   protected static SparkSession spark;
   protected static String url = String.format("http://localhost:%d/api/v1", NESSIE_PORT);
 
-  protected static NessieClient nessieClient;
-
   @BeforeEach
-  protected void create() throws IOException {
+  protected void create() {
     Map<String, String> nessieParams =
         ImmutableMap.of("ref", "main", "uri", url, "warehouse", tempFile.toURI().toString());
 
@@ -67,8 +61,6 @@ public abstract class AbstractSparkTest {
         .set("spark.sql.catalog.nessie", "org.apache.iceberg.spark.SparkCatalog");
     spark = SparkSession.builder().master("local[2]").config(conf).getOrCreate();
     spark.sparkContext().setLogLevel("WARN");
-
-    nessieClient = NessieClient.builder().withUri(url).build();
   }
 
   @AfterAll


### PR DESCRIPTION
Tests _partly_ use `client.nessie.version` (the one that uses `:nessie-client-tests`, some use `project.version`.
Changing the pom to use `client.nessie.version` for the whole module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1932)
<!-- Reviewable:end -->
