### PR TITLE
Change invalid token test to expired

### DIFF
--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestOpenIdAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestOpenIdAuthentication.java
@@ -40,6 +40,13 @@ public class TestOpenIdAuthentication extends BaseClientAuthTest {
     return Jwt.preferredUserName("test_user").issuer("https://server.example.com").sign();
   }
 
+  private String getExpiredJwtToken() {
+    return Jwt.preferredUserName("expired")
+        .issuer("https://server.example.com")
+        .expiresAt(0)
+        .sign();
+  }
+
   @Test
   void testValidJwt() {
     withClientCustomizer(
@@ -48,9 +55,9 @@ public class TestOpenIdAuthentication extends BaseClientAuthTest {
   }
 
   @Test
-  void testInvalidToken() {
+  void testExpiredToken() {
     withClientCustomizer(
-        b -> b.withAuthentication(BearerAuthenticationProvider.create("invalid_token")));
+        b -> b.withAuthentication(BearerAuthenticationProvider.create(getExpiredJwtToken())));
     assertThatThrownBy(() -> client().getTreeApi().getAllReferences())
         .isInstanceOfSatisfying(
             NessieNotAuthorizedException.class,


### PR DESCRIPTION
It does not currently seem possible to properly configure
WireMock stubs for the completely bogus auth token to
avoid "unstubbed" request error log messages in runtime.

So, for now let's use an expired token to validate the
handling of "unauthenticated" requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1933)
<!-- Reviewable:end -->
