### PR TITLE
Fix static init in AbstractTieredCommitsTest

### DIFF
--- a/versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/TestTieredCommitsInmemory.java
+++ b/versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/TestTieredCommitsInmemory.java
@@ -15,12 +15,13 @@
  */
 package org.projectnessie.versioned.persist.inmem;
 
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.junit.jupiter.api.BeforeAll;
 import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
 
-public class TestTieredCommitsInmemory extends AbstractTieredCommitsTest<DatabaseAdapterConfig> {
-  @Override
-  protected String adapterName() {
-    return "In-Memory";
+public class TestTieredCommitsInmemory extends AbstractTieredCommitsTest {
+
+  @BeforeAll
+  static void configureAdapter() {
+    createAdapter("In-Memory", c -> c);
   }
 }

--- a/versioned/persist/rocks/src/test/java/org/projectnessie/versioned/persist/rocks/TestTieredCommitsRocks.java
+++ b/versioned/persist/rocks/src/test/java/org/projectnessie/versioned/persist/rocks/TestTieredCommitsRocks.java
@@ -17,27 +17,27 @@ package org.projectnessie.versioned.persist.rocks;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
 
-public class TestTieredCommitsRocks extends AbstractTieredCommitsTest<RocksDatabaseAdapterConfig> {
+public class TestTieredCommitsRocks extends AbstractTieredCommitsTest {
   @TempDir static Path rocksDir;
 
   static RocksDbInstance instance;
 
-  @Override
-  protected String adapterName() {
-    return "RocksDB";
-  }
+  @BeforeAll
+  static void configureDatabaseAdapter() {
+    instance = new RocksDbInstance();
+    instance.setDbPath(rocksDir.toString());
 
-  @Override
-  protected RocksDatabaseAdapterConfig configureDatabaseAdapter(RocksDatabaseAdapterConfig config) {
-    if (instance == null) {
-      instance = new RocksDbInstance();
-      instance.setDbPath(rocksDir.toString());
-    }
-
-    return ImmutableRocksDatabaseAdapterConfig.builder().from(config).dbInstance(instance).build();
+    createAdapter(
+        "RocksDB",
+        config ->
+            ImmutableRocksDatabaseAdapterConfig.builder()
+                .from(config)
+                .dbInstance(instance)
+                .build());
   }
 
   @AfterAll

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/h2/TestTieredCommitsH2.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/h2/TestTieredCommitsH2.java
@@ -15,23 +15,23 @@
  */
 package org.projectnessie.versioned.persist.tx.h2;
 
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory.Builder;
+import org.junit.jupiter.api.BeforeAll;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
 import org.projectnessie.versioned.persist.tx.local.ImmutableDefaultLocalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.tx.local.LocalDatabaseAdapterConfig;
 
-public class TestTieredCommitsH2 extends AbstractTieredCommitsTest<LocalDatabaseAdapterConfig> {
-  @Override
-  protected String adapterName() {
-    return "H2";
-  }
+public class TestTieredCommitsH2 extends AbstractTieredCommitsTest {
 
-  @Override
-  protected Builder<LocalDatabaseAdapterConfig> createAdapterBuilder() {
-    return super.createAdapterBuilder()
-        .withConfig(
-            ImmutableDefaultLocalDatabaseAdapterConfig.builder()
-                .jdbcUrl("jdbc:h2:mem:nessie")
-                .build());
+  @BeforeAll
+  static void configureAdapter() {
+    createAdapter(
+        DatabaseAdapterFactory.<LocalDatabaseAdapterConfig>loadFactoryByName("H2")
+            .newBuilder()
+            .withConfig(
+                ImmutableDefaultLocalDatabaseAdapterConfig.builder()
+                    .jdbcUrl("jdbc:h2:mem:nessie")
+                    .build()),
+        c -> c);
   }
 }

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsCockroach.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsCockroach.java
@@ -18,40 +18,29 @@ package org.projectnessie.versioned.persist.tx.postgres;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory.Builder;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
 import org.projectnessie.versioned.persist.tx.local.ImmutableDefaultLocalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.tx.local.LocalDatabaseAdapterConfig;
 
 @EnabledIfSystemProperty(named = "it.nessie.dbs", matches = ".*cockroach.*")
-public class ITTieredCommitsCockroach
-    extends AbstractTieredCommitsTest<LocalDatabaseAdapterConfig> {
+public class ITTieredCommitsCockroach extends AbstractTieredCommitsTest {
   static ContainerFixture container =
       new ContainerFixture("cockroachdb/cockroach", "v21.1.6", "it.nessie.container.cockroach.tag");
 
   @BeforeAll
   static void startContainer() {
     container.setup();
+
+    createAdapter(
+        DatabaseAdapterFactory.<LocalDatabaseAdapterConfig>loadFactoryByName("PostgreSQL")
+            .newBuilder()
+            .withConfig(ImmutableDefaultLocalDatabaseAdapterConfig.builder().build()),
+        config -> container.configureDatabaseAdapter(config));
   }
 
   @AfterAll
   static void stopContainer() {
     container.stop();
-  }
-
-  @Override
-  protected String adapterName() {
-    return "PostgreSQL";
-  }
-
-  @Override
-  protected Builder<LocalDatabaseAdapterConfig> createAdapterBuilder() {
-    return super.createAdapterBuilder()
-        .withConfig(ImmutableDefaultLocalDatabaseAdapterConfig.builder().build());
-  }
-
-  @Override
-  protected LocalDatabaseAdapterConfig configureDatabaseAdapter(LocalDatabaseAdapterConfig config) {
-    return container.configureDatabaseAdapter(config);
   }
 }

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsPostgres.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITTieredCommitsPostgres.java
@@ -18,39 +18,29 @@ package org.projectnessie.versioned.persist.tx.postgres;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory.Builder;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
 import org.projectnessie.versioned.persist.tx.local.ImmutableDefaultLocalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.tx.local.LocalDatabaseAdapterConfig;
 
 @EnabledIfSystemProperty(named = "it.nessie.dbs", matches = ".*postgres.*")
-public class ITTieredCommitsPostgres extends AbstractTieredCommitsTest<LocalDatabaseAdapterConfig> {
+public class ITTieredCommitsPostgres extends AbstractTieredCommitsTest {
   static ContainerFixture container =
       new ContainerFixture("postgres", "9.6.22", "it.nessie.container.postgres.tag");
 
   @BeforeAll
   static void startContainer() {
     container.setup();
+
+    createAdapter(
+        DatabaseAdapterFactory.<LocalDatabaseAdapterConfig>loadFactoryByName("PostgreSQL")
+            .newBuilder()
+            .withConfig(ImmutableDefaultLocalDatabaseAdapterConfig.builder().build()),
+        config -> container.configureDatabaseAdapter(config));
   }
 
   @AfterAll
   static void stopContainer() {
     container.stop();
-  }
-
-  @Override
-  protected String adapterName() {
-    return "PostgreSQL";
-  }
-
-  @Override
-  protected Builder<LocalDatabaseAdapterConfig> createAdapterBuilder() {
-    return super.createAdapterBuilder()
-        .withConfig(ImmutableDefaultLocalDatabaseAdapterConfig.builder().build());
-  }
-
-  @Override
-  protected LocalDatabaseAdapterConfig configureDatabaseAdapter(LocalDatabaseAdapterConfig config) {
-    return container.configureDatabaseAdapter(config);
   }
 }


### PR DESCRIPTION
Initialize the static adapter instance in static JUnit 5
lifecycle methods.

This is to allow running/debugging individual (nested) test
methods in an IDE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1936)
<!-- Reviewable:end -->
