### PR TITLE
TVS/non-tx: Fix paging for global-states-log

### DIFF
--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -630,7 +630,6 @@ public abstract class NonTransactionalDatabaseAdapter<CONFIG extends DatabaseAda
           Stream.concat(
               newParents,
               currentEntry.getParentsList().stream()
-                  .skip(1)
                   .limit(config.getParentsPerCommit() - 1)
                   .map(Hash::of));
     }


### PR DESCRIPTION
The intention of `List GlobalStateLogEntry.parents` is to track a list of parent-hashes and benefit from fetching
multiple keys at once when traversing the global-state-log.

However, `NonTransactionalDatabaseAdapter.writeGlobalCommit()` has a bug that actually hard-limited the number of
parent hashes to exactly 1. This is a preformance issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1989)
<!-- Reviewable:end -->
