### PR TITLE
Use specific `Difference` composite holder in `DatabaseAdapter`

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -236,7 +236,7 @@ public interface DatabaseAdapter extends AutoCloseable {
    *     values that were excluded via {@code keyFilter}
    * @throws ReferenceNotFoundException if {@code from} or {@code to} does not exist.
    */
-  Stream<Diff<ByteString>> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
+  Stream<Difference> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException;
 
   // NOTE: the following is NOT a "proposed" API, just an idea of how the supporting functions

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/Difference.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/Difference.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import com.google.protobuf.ByteString;
+import java.util.Optional;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.Key;
+
+@Value.Immutable(lazyhash = true)
+public interface Difference {
+
+  Key getKey();
+
+  Optional<ByteString> getGlobal();
+
+  Optional<ByteString> getFromValue();
+
+  Optional<ByteString> getToValue();
+
+  static Difference of(
+      Key key, Optional<ByteString> global, Optional<ByteString> from, Optional<ByteString> to) {
+    return ImmutableDifference.builder()
+        .key(key)
+        .global(global)
+        .fromValue(from)
+        .toValue(to)
+        .build();
+  }
+}

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -47,7 +47,6 @@ import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.Diff;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
@@ -64,6 +63,7 @@ import org.projectnessie.versioned.persist.adapter.ContentsId;
 import org.projectnessie.versioned.persist.adapter.ContentsIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.ContentsIdWithType;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyWithType;
@@ -350,7 +350,7 @@ public abstract class NonTransactionalDatabaseAdapter<CONFIG extends DatabaseAda
   }
 
   @Override
-  public Stream<Diff<ByteString>> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
+  public Stream<Difference> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
     return buildDiff(NON_TRANSACTIONAL_OPERATION_CONTEXT, from, to, keyFilter);
   }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTieredCommitsTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTieredCommitsTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.Diff;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
@@ -45,6 +44,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory.Builder;
+import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
@@ -316,7 +316,7 @@ public abstract class AbstractTieredCommitsTest {
       commits[i] = databaseAdapter.commit(commit.build());
     }
 
-    try (Stream<Diff<ByteString>> diff =
+    try (Stream<Difference> diff =
         databaseAdapter.diff(
             databaseAdapter.toHash(main),
             databaseAdapter.hashOnReference(branch, Optional.of(initialHash)),
@@ -325,7 +325,7 @@ public abstract class AbstractTieredCommitsTest {
     }
 
     for (int i = 0; i < commits.length; i++) {
-      try (Stream<Diff<ByteString>> diff =
+      try (Stream<Difference> diff =
           databaseAdapter.diff(
               databaseAdapter.toHash(main),
               databaseAdapter.hashOnReference(branch, Optional.of(commits[i])),
@@ -336,8 +336,9 @@ public abstract class AbstractTieredCommitsTest {
                 IntStream.range(0, 3)
                     .mapToObj(
                         k ->
-                            Diff.of(
+                            Difference.of(
                                 Key.of("key", Integer.toString(k)),
+                                Optional.empty(),
                                 Optional.empty(),
                                 Optional.of(ByteString.copyFromUtf8("value " + c + " for " + k))))
                     .collect(Collectors.toList()));
@@ -345,7 +346,7 @@ public abstract class AbstractTieredCommitsTest {
     }
 
     for (int i = 0; i < commits.length; i++) {
-      try (Stream<Diff<ByteString>> diff =
+      try (Stream<Difference> diff =
           databaseAdapter.diff(
               databaseAdapter.hashOnReference(branch, Optional.of(commits[i])),
               databaseAdapter.toHash(main),
@@ -356,8 +357,9 @@ public abstract class AbstractTieredCommitsTest {
                 IntStream.range(0, 3)
                     .mapToObj(
                         k ->
-                            Diff.of(
+                            Difference.of(
                                 Key.of("key", Integer.toString(k)),
+                                Optional.empty(),
                                 Optional.of(ByteString.copyFromUtf8("value " + c + " for " + k)),
                                 Optional.empty()))
                     .collect(Collectors.toList()));
@@ -365,7 +367,7 @@ public abstract class AbstractTieredCommitsTest {
     }
 
     for (int i = 1; i < commits.length; i++) {
-      try (Stream<Diff<ByteString>> diff =
+      try (Stream<Difference> diff =
           databaseAdapter.diff(
               databaseAdapter.hashOnReference(branch, Optional.of(commits[i - 1])),
               databaseAdapter.hashOnReference(branch, Optional.of(commits[i])),
@@ -376,8 +378,9 @@ public abstract class AbstractTieredCommitsTest {
                 IntStream.range(0, 3)
                     .mapToObj(
                         k ->
-                            Diff.of(
+                            Difference.of(
                                 Key.of("key", Integer.toString(k)),
+                                Optional.empty(),
                                 Optional.of(
                                     ByteString.copyFromUtf8("value " + (c - 1) + " for " + k)),
                                 Optional.of(ByteString.copyFromUtf8("value " + c + " for " + k))))

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -52,7 +52,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.Diff;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
@@ -69,6 +68,7 @@ import org.projectnessie.versioned.persist.adapter.ContentsAndState;
 import org.projectnessie.versioned.persist.adapter.ContentsId;
 import org.projectnessie.versioned.persist.adapter.ContentsIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.ContentsIdWithType;
+import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyWithType;
@@ -368,7 +368,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  public Stream<Diff<ByteString>> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
+  public Stream<Difference> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
     Connection conn = borrowConnection();
     try {


### PR DESCRIPTION
This new `Difference` type is necessary to let the version-store implementation using
`DatabaseAdapter` construct the correct `IcebergTable` (with table-metadata + snapshot-id)
from a `getDiff()` operation.

Preparation for #1923 w/ #1922

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/1993)
<!-- Reviewable:end -->
