### PR TITLE
Make error handling more robust in python client

### DIFF
--- a/python/pynessie/error.py
+++ b/python/pynessie/error.py
@@ -26,7 +26,15 @@ class NessieException(Exception):
             parsed_response = response.json()
 
         except:  # NOQA
-            parsed_response = dict()
+            # If we did not get a JSON response for a 500 error, use a generic message.
+            # In this case the HTML response contents are likely not user-friendly anyway.
+            if 500 <= response.status_code <= 599:
+                parsed_response = {
+                    "message": "Internal Server Error",
+                    "status": response.status_code,
+                }
+            else:
+                parsed_response = dict()
 
         self.status_code = response.status_code
         self.server_message = parsed_response.get("message", response.text)

--- a/python/tests/cassettes/test_nessie_cli_error/test_server_error_html.yaml
+++ b/python/tests/cassettes/test_nessie_cli_error/test_server_error_html.yaml
@@ -1,0 +1,26 @@
+interactions:
+    - request:
+          body: null
+          headers:
+              Accept:
+                  - application/json
+              Accept-Encoding:
+                  - gzip, deflate
+              Connection:
+                  - keep-alive
+              User-Agent:
+                  - python-requests/2.26.0
+          method: GET
+          uri: http://localhost:19120/api/v1/trees/tree
+      response:
+          body:
+              string: "<html/>"
+          headers:
+              Content-Length:
+                  - '7'
+              Content-Type:
+                  - text/html
+          status:
+              code: 500
+              message: Internal Server Error
+version: 1

--- a/python/tests/cassettes/test_nessie_cli_error/test_server_error_json.yaml
+++ b/python/tests/cassettes/test_nessie_cli_error/test_server_error_json.yaml
@@ -1,0 +1,28 @@
+interactions:
+    - request:
+          body: null
+          headers:
+              Accept:
+                  - application/json
+              Accept-Encoding:
+                  - gzip, deflate
+              Connection:
+                  - keep-alive
+              User-Agent:
+                  - python-requests/2.26.0
+          method: GET
+          uri: http://localhost:19120/api/v1/trees/tree
+      response:
+          body:
+              string: "{\n  \"message\" : \"java.lang.IllegalStateException: Default branch
+        isn't a branch\",\n  \"status\" : 500,\n  \"reason\" : \"Internal Server Error\",\n
+        \ \"serverStackTrace\" : null\n}"
+          headers:
+              Content-Length:
+                  - '167'
+              Content-Type:
+                  - application/json
+          status:
+              code: 500
+              message: Internal Server Error
+version: 1

--- a/python/tests/test_nessie_cli_error.py
+++ b/python/tests/test_nessie_cli_error.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Authentication tests for Nessi CLI."""
+#  Copyright (C) 2020 Dremio
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from click.testing import CliRunner
+
+from .test_nessie_cli import _run
+
+
+# Note: tests in this file use custom VCR files for error server responses.
+# Running these tests in recording mode will likely NOT produce the expected
+# server responses. The related VCR files need to be reviewed and corrected
+# manually.
+
+
+@pytest.mark.vcr
+def test_server_error_html() -> None:
+    """Test the handling of 500 responses with HTML payload (unexpected, but possible)."""
+    runner = CliRunner()
+    result = _run(runner, ["--json", "remote", "show"], ret_val=1)
+    assert "Internal Server Error" in result.output
+    assert "500" in result.output
+
+
+@pytest.mark.vcr
+def test_server_error_json() -> None:
+    """Test the handling of 500 responses with JSON payload."""
+    runner = CliRunner()
+    result = _run(runner, ["--json", "remote", "show"], ret_val=1)
+    assert "Default branch isn't a branch" in result.output
+    assert "500" in result.output


### PR DESCRIPTION
* Use a generic user-facing error message when a 500
  response body cannot be parsed as JSON

Related to #1838

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2009)
<!-- Reviewable:end -->
