### PR TITLE
Make Nessie build w/ Java 16 + 17, update `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,26 @@ for more information. Small changes don't require an issue. However, it is good 
 larger changes. If you are unsure of where to start ask on the slack channel or look at [existing issues](https://github.com/projectnessie/nessie/issues).
 The [good first issue](https://github.com/projectnessie/nessie/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label marks issues that are particularly good for people new to the codebase.
 
+For the tests to run, you need to update your `~/.m2/toolchains.xml` to contain a reference to Java 11. 
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>11</version>
+      <vendor>sun</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>PATH_TO_YOUR_JAVA_11_HOME</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>
+```
+
 #### Building with Java 17 (and 16)
 
-Due to [JEP 296](https://openjdk.java.net/jeps/396), introduced in Java 16, a couple JVM options are required for
+Due to [JEP 396](https://openjdk.java.net/jeps/396), introduced in Java 16, a couple JVM options are required for
 [google-java-format](https://github.com/google/google-java-format#jdk-16) and [errorprone](https://errorprone.info/docs/installation)
 to work. These options are harmless when using Java 11.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,24 @@ for more information. Small changes don't require an issue. However, it is good 
 larger changes. If you are unsure of where to start ask on the slack channel or look at [existing issues](https://github.com/projectnessie/nessie/issues).
 The [good first issue](https://github.com/projectnessie/nessie/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label marks issues that are particularly good for people new to the codebase.
 
+#### Building with Java 17 (and 16)
+
+Due to [JEP 296](https://openjdk.java.net/jeps/396), introduced in Java 16, a couple JVM options are required for
+[google-java-format](https://github.com/google/google-java-format#jdk-16) and [errorprone](https://errorprone.info/docs/installation)
+to work. These options are harmless when using Java 11.
+
+Apache Spark does **only** work with Java 11 (or 8), so all tests using Spark use the Maven toolchain mechanism
+to force Java 11 for the execution of those tests.
+
+```bash
+export MAVEN_OPTS="--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
+```
+
+If you are using [mvnd](https://github.com/mvndaemon/mvnd), update your `mvnd.properties` (user location: `~/.m2/mvnd.properties`):
+```
+mvnd.jvmArgs = --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+```
+
 ### Style guide
 
 Changes must adhere to the style guide and this will be verified by the continuous integration build.

--- a/clients/deltalake/pom.xml
+++ b/clients/deltalake/pom.xml
@@ -240,6 +240,9 @@
           <systemPropertyVariables>
             <quarkus.http.test-port>${quarkus.http.test-port}</quarkus.http.test-port>
           </systemPropertyVariables>
+          <jdkToolchain>
+            <version>11</version>
+          </jdkToolchain>
         </configuration>
         <executions>
           <execution>

--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -179,6 +179,9 @@
             ${project.build.directory}/test-sources
           </additionalClasspathElements>
           <failIfNoTests>true</failIfNoTests>
+          <jdkToolchain>
+            <version>11</version>
+          </jdkToolchain>
         </configuration>
         <executions>
           <execution>

--- a/versioned/gc/spark/pom.xml
+++ b/versioned/gc/spark/pom.xml
@@ -77,4 +77,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <jdkToolchain>
+            <version>11</version>
+          </jdkToolchain>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/versioned/tiered/gc/pom.xml
+++ b/versioned/tiered/gc/pom.xml
@@ -170,6 +170,15 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <jdkToolchain>
+            <version>11</version>
+          </jdkToolchain>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <!-- Nessie PR https://github.com/projectnessie/nessie/pull/1922 introduces breaking changes as a clear cut to Nessie before 1.0 -->


### PR DESCRIPTION
This was an experiment a couple days ago. It makes Nessie build using any Java version >= 11, just requires Java 11 for tests against Spark (really, just Spark - Scala's not the offender in this case I think).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2021)
<!-- Reviewable:end -->
