### PR TITLE
TVS/TX: Bugfixes

### DIFF
--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -1091,6 +1091,9 @@ public abstract class TxDatabaseAdapter
    * Transaction Retry Error Reference</a>, and Postgres may return a "deadlock" error.
    */
   protected boolean isRetryTransaction(SQLException e) {
+    if (e.getSQLState() == null) {
+      return false;
+    }
     switch (e.getSQLState()) {
       case DEADLOCK_SQL_STATE_POSTGRES:
       case RETRY_SQL_STATE_COCKROACH:

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
@@ -41,6 +41,11 @@ public class PostgresDatabaseAdapter extends TxDatabaseAdapter {
   }
 
   @Override
+  protected boolean metadataUpperCase() {
+    return false;
+  }
+
+  @Override
   protected boolean batchDDL() {
     // Postgres + Cockroach can perform DDL-batches, but that doesn't always work :(
     return false;


### PR DESCRIPTION
* Postgres stores "metadata" (table names et al) in lower-case, tell the TxDatabaseAdapter, so it does
  not try to create an already existing table.
* Fix NPE in TxDatabaseAdapter.isRetryTransaction (SQLException.getSQLState() can be null)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2025)
<!-- Reviewable:end -->
