### PR TITLE
DRAFT/INCORRECT: Trigger CI only for labels starting with the string `pr-`

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,7 @@ jobs:
   java:
     name: Java/Maven
     runs-on: ubuntu-latest
+    if: (github.event.action != 'labeled' && github.event.action != 'unlabeled') || startsWith(github.event.label.name, 'pr-')
     outputs:
       CI_WITH_JACKSON: ${{ steps.ci_options.outputs.CI_WITH_JACKSON }}
 
@@ -82,6 +83,7 @@ jobs:
   python:
     name: Python
     runs-on: ubuntu-latest
+    if: (github.event.action != 'labeled' && github.event.action != 'unlabeled') || startsWith(github.event.label.name, 'pr-')
     env:
       working-directory: ./python
     strategy:
@@ -105,6 +107,7 @@ jobs:
   site:
     name: Build Website
     runs-on: ubuntu-latest
+    if: (github.event.action != 'labeled' && github.event.action != 'unlabeled') || startsWith(github.event.label.name, 'pr-')
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -120,6 +123,7 @@ jobs:
   lint-helm:
     name: Lint Helm chart
     runs-on: ubuntu-latest
+    if: (github.event.action != 'labeled' && github.event.action != 'unlabeled') || startsWith(github.event.label.name, 'pr-')
     steps:
       - uses: actions/checkout@v1
       - name: Lint Helm


### PR DESCRIPTION
Currently, CI runs are triggered for every addition or removal of any label.
This causes PRs created by dependabot to trigger 3 CI runs:
* one for the PR creation (type `opened`)
* one for the addition of the `dependencies` label (type `labeled`)
* one for the addition of the package-type label (type `labeled`)

It would be ideal to have a filter for the workflow-triggers `labeled` and
`unlabeled`, but that does not exist.

Using a separate workflow that only listens on `labeled` and `unlabeled`
event types does not really help, because such a workflow would have to
be able to list and rerun check-suites via the GH API, but the permissions
for `pull_request` workflows to not permit that. So a separate WF is not
an option.

Easiest for now is to add an
```
if: (github.event.action != 'labeled' && github.event.action != 'unlabeled') || startsWith(github.event.label.name, 'pr-')
```
to the relevant jobs in `pull-request.yml` so that these jobs only run when
it's not a `labeled` or `unlabeled` type or if the label name starts with
the string `pr-`.

The disadvantage is that when adding or removing labels that do _not_
start with the string `pr-`, the jobs gets triggered but is not run and
therefore appears as `Skipped` in the list of PR checks and the "real"
PR-CI-run can only be inspected by clicking on the `Details` link and
the check appears as **_passed_**, which is NOT CORRECT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2080)
<!-- Reviewable:end -->
