### PR TITLE
Split PR workflow into three

### DIFF
--- a/.github/workflows/pull-request-jackson.yml
+++ b/.github/workflows/pull-request-jackson.yml
@@ -1,0 +1,51 @@
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Projectnessie GitHub Pull-Request / Jackson integration tests
+
+name: PR Build Check Jackson
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  jackson-tests:
+    name: ITs
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'pr-jackson')
+    strategy:
+      max-parallel: 4
+      # note the big include entry in matrix is used to ensure we get human readable names for the jobs
+      matrix:
+        include:
+          - jackson-version: 2.6.7
+            target-library: Spark 2.4.4
+            java-version: 11
+          - jackson-version: 2.10.0
+            target-library: Spark 3.0.1
+            java-version: 11
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Java, Maven, Gradle
+        uses: ./.github/actions/dev-tool-java
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Build with Maven ${{ matrix.target-library }}
+        run: |
+          ./mvnw -B install -DskipTests -am -pl :nessie-quarkus -pl :nessie-lambda
+      - name: Jackson Integration Tests ${{ matrix.target-library }}
+        run: |
+          ./mvnw verify -pl :nessie-client -am -Pjackson-tests -Djackson.test.version=${{ matrix.jackson-version }} -Dtest.log.level=WARN

--- a/.github/workflows/pull-request-native.yml
+++ b/.github/workflows/pull-request-native.yml
@@ -1,0 +1,46 @@
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Projectnessie GitHub Pull-Request / Native-image tests
+
+name: PR Build Check Native
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  java:
+    name: Java/Maven Native
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'pr-native')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup runner
+      uses: ./.github/actions/setup-runner
+    - name: Setup Java, Maven, Gradle
+      uses: ./.github/actions/dev-tool-java
+
+    - name: Build with Maven
+      run: |
+        ./mvnw -B install -DskipTests -am -pl :nessie-quarkus -pl :nessie-lambda
+
+    - name: Native tests
+      run: |
+        # No code-coverage here
+        ./mvnw -B install --file pom.xml -Pnative -Dtest.log.level=WARN -pl :nessie-quarkus -pl :nessie-lambda -Dquarkus.native.native-image-xmx=6g
+
+    - name: Capture Results
+      uses: ./.github/actions/ci-results

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,8 +1,25 @@
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Projectnessie GitHub Pull-Request / Default CI
+
 name: PR Build Check
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 # NOTE: using paths-ignore here doesn't play well with "Require status checks to pass before merging"
 # due to https://github.community/t/feature-request-conditional-required-checks/16761
 #    paths-ignore:
@@ -20,8 +37,6 @@ jobs:
   java:
     name: Java/Maven
     runs-on: ubuntu-latest
-    outputs:
-      CI_WITH_JACKSON: ${{ steps.ci_options.outputs.CI_WITH_JACKSON }}
 
     steps:
     - uses: actions/checkout@v2
@@ -30,22 +45,11 @@ jobs:
     - name: Setup Java, Maven, Gradle
       uses: ./.github/actions/dev-tool-java
 
-    - name: Build/test options
-      id: ci_options
-      run: |
-        echo ::set-output name=CI_WITH_NATIVE::$(jq 'any(.pull_request.labels[]; .name == "pr-native")' < $GITHUB_EVENT_PATH)
-        echo ::set-output name=CI_WITH_JACKSON::$(jq 'any(.pull_request.labels[]; .name == "pr-jackson")' < $GITHUB_EVENT_PATH)
-
     - name: Build with Maven
       env:
         SPARK_LOCAL_IP: localhost
       run: |
         ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage -Dtest.log.level=WARN
-    - name: Build with Maven / Native tests
-      if: ${{ steps.ci_options.outputs.CI_WITH_NATIVE == 'true' }}
-      run: |
-        # No code-coverage here
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pnative -Dtest.log.level=WARN -pl :nessie-quarkus -pl :nessie-lambda -Dquarkus.native.native-image-xmx=6g
 
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build
@@ -53,31 +57,6 @@ jobs:
 
     - name: Capture Results
       uses: ./.github/actions/ci-results
-
-  jackson-tests:
-    name: Jackson Integration Tests
-    needs: java
-    if: ${{ needs.java.outputs.CI_WITH_JACKSON == 'true' }}
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      # note the big include entry in matrix is used to ensure we get human readable names for the jobs
-      matrix:
-        include:
-          - jackson-version: 2.6.7
-            target-library: Spark 2.4.4
-            java-version: 11
-          - jackson-version: 2.10.0
-            target-library: Spark 3.0.1
-            java-version: 11
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java, Maven, Gradle
-        uses: ./.github/actions/dev-tool-java
-        with:
-          java-version: ${{ matrix.java-version }}
-      - name: Jackson Integration Tests ${{ matrix.target-library }}
-        run: mvn verify -pl :nessie-client -am -Pjackson-tests -Djackson.test.version=${{ matrix.jackson-version }} -Dtest.log.level=WARN
 
   python:
     name: Python


### PR DESCRIPTION
Currently, CI runs are triggered for every addition or removal of any label.
This causes PRs created by dependabot to trigger 3 CI runs:
* one for the PR creation (type `opened`)
* one for the addition of the `dependencies` label (type `labeled`)
* one for the addition of the package-type label (type `labeled`)

It would be ideal to have a filter for the workflow-triggers `labeled` and
`unlabeled`, but that does not exist.

It feels possible that splitting the `pull-request.yml` workflow into
three workflows could solve the problem. The current one is run for
the types `opened`, `synchronize`, `reopened`. The two new ones, one
for "native tests" and one for "jackson tests", get additionally triggered
for the type `labeled`. `if:` conditions on the jobs in the new workflows
ensure that the jobs only run when the appropriate label is present.

A "fresh" PR is created as usual, but has two checks that are initially
marked as "Skipped":

* `PR Build Check Native / Java/Maven Native (pull_request)` - if the `pr-native` label is added, this job will be triggered
* `PR Build Check Jackson / ITs (pull_request)` - if the `pr-jackson` label is added, this matrix-job will be triggered

Slightly annoying is that adding another `pr-*` label will restart the other jobs for other `pr-*` labels. This cannot really be avoided.

Keeping one workflow doesn't really work (see #2080)

Fixes #2079

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2081)
<!-- Reviewable:end -->
