### PR TITLE
TVS: add microbenchmark base

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -246,6 +246,11 @@
       </dependency>
       <dependency>
         <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-versioned-persist-bench</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectnessie</groupId>
         <artifactId>nessie-perf-test</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
     <jetty.version>9.4.31.v20200723</jetty.version>
     <jgit.version>5.13.0.202109080827-r</jgit.version>
     <jjwt.version>0.11.2</jjwt.version>
+    <jmh.version>1.32</jmh.version>
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>5.8.0</junit.version>
     <logback.version>1.2.6</logback.version>
@@ -450,6 +451,16 @@
         <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${jmh.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>${jmh.version}</version>
       </dependency>
       <dependency>
         <groupId>org.immutables</groupId>

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterFactory.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterFactory.java
@@ -66,7 +66,7 @@ public interface DatabaseAdapterFactory<CONFIG extends DatabaseAdapterConfig<?>>
 
   static <CONFIG extends DatabaseAdapterConfig<?>> DatabaseAdapterFactory<CONFIG> loadFactoryByName(
       String name) {
-    return loadFactory(f -> f.getName().equals(name));
+    return loadFactory(f -> f.getName().equalsIgnoreCase(name));
   }
 
   static <CONFIG extends DatabaseAdapterConfig<?>> DatabaseAdapterFactory<CONFIG> loadFactory(

--- a/versioned/persist/bench/README.md
+++ b/versioned/persist/bench/README.md
@@ -1,0 +1,159 @@
+# Nessie Tiered Version Store Microbenchmarks
+
+**DISCLAIMER** THIS IS NOT A BENCHMARK TOOL FOR PRODUCTION WORKLOADS!!!
+
+The JMH based microbenchmarks exist to get an idea of the potential commit-performance of a
+database-adapter with a specific configuration. These microbenchmarks do neither validate
+linearizability nor the commit-contents-model, but focus on the pure "commit performance" to find
+bottlenecks.
+
+## Usage
+
+JMH code parameter defaults:
+
+* number of threads: 4
+* number of forks: 1
+* warmups: 2 x 2s
+* iterations: 3 * 5s
+
+Benchmark defaults:
+
+* exercised database adapters via `adapter`: H2, In-Memory, RocksDB
+* tables per commit via `tablesPerCommi`: 1, 3, 5
+
+Benchmarks:
+
+* `CommitBench.singleBranchSharedKeys`: threads use a single branch and shared content-keys,
+  contention on the branch, contention on the content-keys
+* `CommitBench.branchPerThreadSharedKeys`: threads use their own branch and own content-keys, no
+  contention on the branch, contention on the content-keys
+* `CommitBench.singleBranchUnsharedKeys`: threads use a single branch and shared content-keys,
+  contention on the branch, no contention on the content-keys
+* `CommitBench.branchPerThreadUnsharedKeys`: threads use their own branch and own content-keys, no
+  contention on the branch, no contention on the content-keys
+
+## Database-adapter configuration options
+
+Some database-adapters need extra configuration. These options are "injected" via
+[SystemPropertiesConfigurer](../adapter/src/main/java/org/projectnessie/versioned/persist/adapter/SystemPropertiesConfigurer.java)
+.
+
+Basically all database-adapters, except those intended for testing, require configuration options
+provided via system properties.
+
+* RocksDB:
+  * `nessie.store.db.path`, the path where the RocksDB is persisted.
+    Example: `-Dnessie.store.db.path=/tmp/rocks-nessie-jmh`
+* MongoDB:
+  * `nessie.store.connection.string`, the MongoDB connection URL.
+    Example: `-Dnessie.store.connection.string=mongodb://localhost:1234`
+  * `nessie.store.database.name`, the Mongo database name.
+* JDBC based database-adapters:
+  * `nessie.store.jdbc.url`, the JDBC URL
+  * `nessie.store.jdbc.user`, the JDBC username
+  * `nessie.store.jdbc.pass`, the JDBC password
+
+The "In-Memory" and "H2" database adapters do not require additional configuration, because those
+are mainly intended for testing purposes.
+
+## Running the microbenchmarks
+
+Running microbenchmarks against in-memory, RocksDB and H2-in-memory do not require an external
+process/service to be started, so those work "out of the box".
+
+Other database adapters like Mongo, Postgres or Cockroach need a running database service. The
+following sections shall help to start a database locally. Please refer to the official docs of the
+projects/vendors how to install a "production grade" database, if needed.
+
+The snippets below assume that you have built Nessie from source. If not, run
+```bash
+./mvnw package -am -pl :nessie-versioned-persist-bench -DskipTests
+```
+
+### In-Memory
+
+```bash
+java \
+  -jar versioned/persist/bench/target/nessie-versioned-persist-bench-0.9.3-SNAPSHOT-jmh.jar \
+  -p adapter=in-memory
+```
+
+### RocksDB
+
+```bash
+java \
+  -jar versioned/persist/bench/target/nessie-versioned-persist-bench-0.9.3-SNAPSHOT-jmh.jar \
+  -p adapter=RocksDB
+```
+
+### MongoDB
+
+```bash
+docker run -d \
+  --name nessie-mongodb-bench \
+  -p 27017:27017 \
+  mongo:latest
+
+java \
+  -Dnessie.store.connection.string=mongodb://localhost:27017 \
+  -Dnessie.store.database.name=nessie-mongodb \
+  -jar versioned/persist/bench/target/nessie-versioned-persist-bench-0.9.3-SNAPSHOT-jmh.jar \
+  -p adapter=MongoDB
+```
+
+### H2 / In-Memory
+
+```bash
+java \
+  -Dnessie.store.jdbc.url=jdbc:h2:mem:nessie \
+  -jar versioned/persist/bench/target/nessie-versioned-persist-bench-0.9.3-SNAPSHOT-jmh.jar \
+  -p adapter=H2:h2
+```
+
+### H2 / Remote
+
+(There does not seem to be an officially maintained Docker image for H2.)
+
+```bash
+java \
+  -Dnessie.store.jdbc.url=<JDBC_URL_HERE> \
+  -jar versioned/persist/bench/target/nessie-versioned-persist-bench-0.9.3-SNAPSHOT-jmh.jar \
+  -p adapter=H2:generic
+```
+
+### PostgreSQL
+
+```bash
+docker run -d \
+  -e POSTGRES_PASSWORD=nessie-bench \
+  --name nessie-postgres-bench \
+  -p 5432:5432 \
+  postgres:latest
+
+java \
+  -Dnessie.store.jdbc.url=jdbc:postgresql://localhost:5432/postgres \
+  -Dnessie.store.jdbc.user=postgres \
+  -Dnessie.store.jdbc.pass=nessie-bench \
+  -jar versioned/persist/bench/target/nessie-versioned-persist-bench-0.9.3-SNAPSHOT-jmh.jar \
+  -p adapter=PostgreSQL
+```
+
+### Cockroach
+
+```bash
+docker run -d \
+  --name nessie-cockroach-bench \
+  -p 26257:26257 -p 8080:8080 \
+  cockroachdb/cockroach:latest \
+  start-single-node \
+  --insecure
+
+java \
+  -Dnessie.store.jdbc.url=jdbc:postgresql://localhost:26257/postgres \
+  -Dnessie.store.jdbc.user=root \
+  -Dnessie.store.jdbc.pass= \
+  -jar versioned/persist/bench/target/nessie-versioned-persist-bench-0.9.3-SNAPSHOT-jmh.jar \
+  -p adapter=PostgreSQL
+```
+
+Docs: [Cockroach](https://www.cockroachlabs.com/docs/stable/start-a-local-cluster-in-docker-linux.html)

--- a/versioned/persist/bench/README.md
+++ b/versioned/persist/bench/README.md
@@ -19,7 +19,7 @@ JMH code parameter defaults:
 Benchmark defaults:
 
 * exercised database adapters via `adapter`: H2, In-Memory, RocksDB
-* tables per commit via `tablesPerCommi`: 1, 3, 5
+* tables per commit via `tablesPerCommit`: 1, 3, 5
 
 Benchmarks:
 

--- a/versioned/persist/bench/README.md
+++ b/versioned/persist/bench/README.md
@@ -25,9 +25,9 @@ Benchmarks:
 
 * `CommitBench.singleBranchSharedKeys`: threads use a single branch and shared content-keys,
   contention on the branch, contention on the content-keys
-* `CommitBench.branchPerThreadSharedKeys`: threads use their own branch and own content-keys, no
+* `CommitBench.branchPerThreadSharedKeys`: threads use their own branch and shared content-keys, no
   contention on the branch, contention on the content-keys
-* `CommitBench.singleBranchUnsharedKeys`: threads use a single branch and shared content-keys,
+* `CommitBench.singleBranchUnsharedKeys`: threads use a single branch and own content-keys,
   contention on the branch, no contention on the content-keys
 * `CommitBench.branchPerThreadUnsharedKeys`: threads use their own branch and own content-keys, no
   contention on the branch, no contention on the content-keys

--- a/versioned/persist/bench/pom.xml
+++ b/versioned/persist/bench/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie-versioned-persist</artifactId>
+    <version>0.9.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-versioned-persist-bench</artifactId>
+
+  <name>Nessie - Versioned - Persist - Benchmarks</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-store</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-in-memory</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-in-memory</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-rocks</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-rocks</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-mongodb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-mongodb</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-transactional</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-transactional</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-pool</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.children="append">
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>org.openjdk.jmh</groupId>
+              <artifactId>jmh-generator-annprocess</artifactId>
+              <version>${jmh.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-${project.version}-jmh</finalName>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.benchmarks;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.Operation;
+import org.projectnessie.versioned.Put;
+import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceRetryFailureException;
+import org.projectnessie.versioned.StringStoreWorker;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+import org.projectnessie.versioned.persist.store.PersistVersionStore;
+import org.projectnessie.versioned.persist.tests.SystemPropertiesConfigurer;
+import org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource;
+
+@Warmup(iterations = 2, time = 2000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 5000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@Threads(4)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class CommitBench {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkParam {
+
+    @Param({"1", "3", "5"})
+    public int tablesPerCommit;
+
+    @Param({"H2:h2", "In-Memory", "RocksDB"})
+    public String adapter;
+
+    final AtomicInteger retryFailures = new AtomicInteger();
+    final AtomicInteger conflictsFailures = new AtomicInteger();
+    final AtomicInteger success = new AtomicInteger();
+    DatabaseConnectionProvider<?> connectionProvider;
+    DatabaseAdapter databaseAdapter;
+    PersistVersionStore<String, String, StringStoreWorker.TestEnum> versionStore;
+    List<Key> keys;
+    Map<Key, String> contentsIds;
+    BranchName branch = BranchName.of("main");
+
+    @Setup
+    public void init() throws Exception {
+      databaseAdapter = adapterByName();
+
+      databaseAdapter.reinitializeRepo(branch.getName());
+
+      versionStore = new PersistVersionStore<>(databaseAdapter, StringStoreWorker.INSTANCE);
+
+      keys = new ArrayList<>(tablesPerCommit);
+
+      for (int i = 0; i < tablesPerCommit; i++) {
+        Key key = Key.of("my", "table", "num" + i);
+        keys.add(key);
+      }
+
+      contentsIds =
+          keys.stream().collect(Collectors.toMap(k -> k, k -> UUID.randomUUID().toString()));
+
+      versionStore.commit(
+          branch,
+          Optional.empty(),
+          "initial commit meta",
+          initialOperations(this, keys, contentsIds));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private DatabaseAdapter adapterByName() {
+      String adapterName =
+          (adapter.indexOf(':') <= 0) ? adapter : adapter.substring(0, adapter.indexOf(':'));
+      DatabaseAdapterFactory<DatabaseAdapterConfig<DatabaseConnectionProvider<?>>> factory =
+          DatabaseAdapterFactory.loadFactory(f -> f.getName().equalsIgnoreCase(adapterName));
+
+      return factory
+          .newBuilder()
+          .configure(SystemPropertiesConfigurer::configureAdapterFromSystemProperties)
+          .configure(
+              c -> {
+                String providerSpec =
+                    adapter.indexOf(':') == -1
+                        ? null
+                        : adapter.substring(adapter.indexOf(':') + 1).toLowerCase(Locale.ROOT);
+                TestConnectionProviderSource<DatabaseConnectionConfig> providerSource =
+                    TestConnectionProviderSource.findCompatibleProviderSource(
+                        c, factory, providerSpec);
+                providerSource.configureConnectionProviderConfigFromDefaults(
+                    SystemPropertiesConfigurer::configureConnectionFromSystemProperties);
+                try {
+                  providerSource.start();
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
+                }
+                c = providerSource.updateConfig((DatabaseAdapterConfig) c);
+                connectionProvider = c.getConnectionProvider();
+                return c;
+              })
+          .build();
+    }
+
+    @TearDown
+    public void close() throws Exception {
+      int retries = retryFailures.get();
+      int conflicts = conflictsFailures.get();
+      int successes = success.get();
+      int total = retries + conflicts + successes;
+      double retryRate = retries;
+      retryRate /= total;
+      retryRate *= 100;
+      double conflictRate = conflicts;
+      conflictRate /= total;
+      conflictRate *= 100;
+      double successRate = successes;
+      successRate /= total;
+      successRate *= 100;
+      System.out.printf(
+          "(%.02f%% retries (%d), %.02f%% conflicts (%d), %.02f%% success (%d))",
+          retryRate, retries, conflictRate, conflicts, successRate, successes);
+      connectionProvider.close();
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class ThreadParam {
+    BranchName branch;
+    List<Key> keys;
+    Map<Key, String> contentsIds;
+
+    @Setup
+    public void createBranch(BenchmarkParam bp) throws Exception {
+      branch = BranchName.of("thread-" + Thread.currentThread().getId());
+
+      keys = new ArrayList<>(bp.tablesPerCommit);
+      for (int i = 0; i < bp.tablesPerCommit; i++) {
+        Key key = Key.of("per-thread", Long.toString(Thread.currentThread().getId()), "num" + i);
+        keys.add(key);
+      }
+
+      contentsIds = new HashMap<>(bp.contentsIds);
+      keys.forEach(k -> contentsIds.put(k, UUID.randomUUID().toString()));
+
+      bp.versionStore.commit(
+          bp.branch,
+          Optional.empty(),
+          "initial commit meta " + Thread.currentThread().getId(),
+          initialOperations(bp, keys, contentsIds));
+
+      Hash hash = bp.versionStore.toHash(bp.branch);
+
+      bp.versionStore.create(branch, Optional.of(hash));
+    }
+  }
+
+  @Benchmark
+  public void singleBranchSharedKeys(BenchmarkParam bp) throws Exception {
+    doCommit(bp, bp.branch, bp.keys, bp.contentsIds);
+  }
+
+  @Benchmark
+  public void branchPerThreadSharedKeys(BenchmarkParam bp, ThreadParam tp) throws Exception {
+    doCommit(bp, tp.branch, bp.keys, bp.contentsIds);
+  }
+
+  @Benchmark
+  public void singleBranchUnsharedKeys(BenchmarkParam bp, ThreadParam tp) throws Exception {
+    doCommit(bp, bp.branch, tp.keys, tp.contentsIds);
+  }
+
+  @Benchmark
+  public void branchPerThreadUnsharedKeys(BenchmarkParam bp, ThreadParam tp) throws Exception {
+    doCommit(bp, tp.branch, tp.keys, tp.contentsIds);
+  }
+
+  private void doCommit(
+      BenchmarkParam bp, BranchName branch, List<Key> keys, Map<Key, String> contentsIds)
+      throws Exception {
+    List<Optional<String>> contents = bp.versionStore.getValues(branch, keys);
+
+    try {
+      List<Operation<String>> operations = new ArrayList<>(bp.tablesPerCommit);
+      for (int i = 0; i < bp.tablesPerCommit; i++) {
+        Key key = keys.get(i);
+        String value =
+            contents
+                .get(i)
+                .orElseThrow(
+                    () -> new RuntimeException("no value for key " + key + " in " + branch));
+        String currentState = value.split("\\|")[0];
+        String newGlobalState = Integer.toString(Integer.parseInt(currentState) + 1);
+        String contentsId = contentsIds.get(key);
+        operations.add(
+            Put.of(
+                key,
+                // Must add randomness here, otherwise concurrent threads will compute the same
+                // hashes, because parent, "contents", key are a all the same.
+                StringStoreWorker.withStateAndId(
+                    newGlobalState,
+                    "commit value " + ThreadLocalRandom.current().nextLong(),
+                    contentsId),
+                StringStoreWorker.withStateAndId(currentState, "foo", contentsId)));
+      }
+
+      bp.versionStore.commit(branch, Optional.empty(), "commit meta data", operations);
+
+      bp.success.incrementAndGet();
+    } catch (ReferenceRetryFailureException e) {
+      bp.retryFailures.incrementAndGet();
+    } catch (ReferenceConflictException e) {
+      bp.conflictsFailures.incrementAndGet();
+    }
+  }
+
+  static List<Operation<String>> initialOperations(
+      BenchmarkParam bp, List<Key> keys, Map<Key, String> contentsIds) {
+    List<Operation<String>> operations = new ArrayList<>(bp.tablesPerCommit);
+    for (Key key : keys) {
+      String contentsId = contentsIds.get(key);
+      operations.add(
+          Put.of(
+              key, StringStoreWorker.withStateAndId("0", "initial commit contents", contentsId)));
+    }
+    return operations;
+  }
+}

--- a/versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/InmemoryTestConnectionProviderSource.java
+++ b/versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/InmemoryTestConnectionProviderSource.java
@@ -16,32 +16,25 @@
 package org.projectnessie.versioned.persist.inmem;
 
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
-import org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.tests.extension.AbstractTestConnectionProviderSource;
 
 public class InmemoryTestConnectionProviderSource
-    implements TestConnectionProviderSource<InmemoryStore> {
-
-  private InmemoryStore store;
+    extends AbstractTestConnectionProviderSource<InmemoryConfig> {
 
   @Override
-  public DatabaseAdapterConfig<InmemoryStore> updateConfig(
-      DatabaseAdapterConfig<InmemoryStore> config) {
-    return config.withConnectionProvider(store);
+  public boolean isCompatibleWith(
+      DatabaseAdapterConfig<?> adapterConfig, DatabaseAdapterFactory<?> databaseAdapterFactory) {
+    return adapterConfig instanceof InmemoryDatabaseAdapterConfig;
   }
 
   @Override
-  public void start() {
-    store = new InmemoryStore();
+  public InmemoryConfig createDefaultConnectionProviderConfig() {
+    return ImmutableInmemoryConfig.builder().build();
   }
 
   @Override
-  public void stop() {
-    try {
-      if (store != null) {
-        store.close();
-      }
-    } finally {
-      store = null;
-    }
+  public InmemoryStore createConnectionProvider() {
+    return new InmemoryStore();
   }
 }

--- a/versioned/persist/inmem/src/test/resources/META-INF/services/org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource
+++ b/versioned/persist/inmem/src/test/resources/META-INF/services/org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource
@@ -1,0 +1,1 @@
+org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource

--- a/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/FlapdoodleMongoTestConnectionProviderSource.java
+++ b/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/FlapdoodleMongoTestConnectionProviderSource.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.flapdoodle.embed.mongo.Command;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodProcessOutputConfig;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.config.io.ProcessOutput;
+import de.flapdoodle.embed.process.io.StreamProcessor;
+import de.flapdoodle.embed.process.runtime.Network;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
+
+/**
+ * MongoDB test connection-provider source using a locally spawned MongoDB instance via
+ * "flapdoodle".
+ */
+public class FlapdoodleMongoTestConnectionProviderSource extends MongoTestConnectionProviderSource {
+  private static final Pattern LISTEN_ON_PORT_PATTERN =
+      Pattern.compile(
+          ".*NETWORK ([^\\n]*) waiting for connections on port ([0-9]+)\\n.*",
+          Pattern.MULTILINE | Pattern.DOTALL);
+
+  private final AtomicInteger port = new AtomicInteger();
+  private MongodExecutable mongo;
+
+  @Override
+  public boolean isCompatibleWith(
+      DatabaseAdapterConfig<?> adapterConfig, DatabaseAdapterFactory<?> databaseAdapterFactory) {
+    return adapterConfig instanceof MongoDatabaseAdapterConfig;
+  }
+
+  @Override
+  public MongoClientConfig createDefaultConnectionProviderConfig() {
+    return ImmutableMongoClientConfig.builder().build();
+  }
+
+  @Override
+  public MongoDatabaseClient createConnectionProvider() {
+    return new MongoDatabaseClient();
+  }
+
+  @Override
+  public void start() throws Exception {
+    if (mongo != null) {
+      throw new IllegalStateException("Already started");
+    }
+
+    ProcessOutput defaultOutput = MongodProcessOutputConfig.getDefaultInstance(Command.MongoD);
+    StreamProcessor capturedStdout =
+        new StreamProcessor() {
+          private final StringBuilder buffer = new StringBuilder();
+
+          @Override
+          public void process(String block) {
+            if (port.get() == 0) {
+              buffer.append(block);
+              Matcher matcher = LISTEN_ON_PORT_PATTERN.matcher(buffer);
+              if (matcher.matches()) {
+                String portString = matcher.group(2);
+                port.set(Integer.parseInt(portString));
+              }
+            }
+            defaultOutput.getOutput().process(block);
+          }
+
+          @Override
+          public void onProcessed() {
+            defaultOutput.getOutput().onProcessed();
+          }
+        };
+
+    MongodStarter starter =
+        MongodStarter.getInstance(
+            Defaults.runtimeConfigFor(Command.MongoD)
+                .processOutput(
+                    new ProcessOutput(
+                        capturedStdout, defaultOutput.getError(), defaultOutput.getCommands()))
+                .build());
+
+    MongodConfig mongodConfig =
+        MongodConfig.builder()
+            .version(Version.Main.PRODUCTION)
+            .net(new Net(0, Network.localhostIsIPv6()))
+            .build();
+
+    mongo = starter.prepare(mongodConfig);
+    mongo.start();
+
+    assertThat(port).hasPositiveValue();
+
+    String connectionString = String.format("mongodb://localhost:%d", port.get());
+    String databaseName = "test";
+
+    configureConnectionProviderConfigFromDefaults(
+        c -> c.withConnectionString(connectionString).withDatabaseName(databaseName));
+
+    super.start();
+  }
+
+  @Override
+  public void stop() throws Exception {
+    try {
+      super.stop();
+    } finally {
+      try {
+        if (mongo != null) {
+          mongo.stop();
+        }
+      } finally {
+        mongo = null;
+      }
+    }
+  }
+}

--- a/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/TestMongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/TestMongoDatabaseAdapter.java
@@ -18,5 +18,5 @@ package org.projectnessie.versioned.persist.mongodb;
 import org.projectnessie.versioned.persist.tests.AbstractTieredCommitsTest;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
-@NessieExternalDatabase(MongoTestConnectionProviderSource.class)
+@NessieExternalDatabase(FlapdoodleMongoTestConnectionProviderSource.class)
 public class TestMongoDatabaseAdapter extends AbstractTieredCommitsTest {}

--- a/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/TestVersionStoreMongo.java
+++ b/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/TestVersionStoreMongo.java
@@ -18,5 +18,5 @@ package org.projectnessie.versioned.persist.mongodb;
 import org.projectnessie.versioned.persist.tests.AbstractVersionStoreTest;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
-@NessieExternalDatabase(MongoTestConnectionProviderSource.class)
+@NessieExternalDatabase(FlapdoodleMongoTestConnectionProviderSource.class)
 class TestVersionStoreMongo extends AbstractVersionStoreTest {}

--- a/versioned/persist/mongodb/src/test/resources/META-INF/services/org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource
+++ b/versioned/persist/mongodb/src/test/resources/META-INF/services/org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource
@@ -1,0 +1,1 @@
+org.projectnessie.versioned.persist.mongodb.MongoTestConnectionProviderSource

--- a/versioned/persist/pom.xml
+++ b/versioned/persist/pom.xml
@@ -40,5 +40,6 @@
     <module>tx</module>
     <module>store</module>
     <module>tests</module>
+    <module>bench</module>
   </modules>
 </project>

--- a/versioned/persist/rocks/src/test/resources/META-INF/services/org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource
+++ b/versioned/persist/rocks/src/test/resources/META-INF/services/org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource
@@ -1,0 +1,1 @@
+org.projectnessie.versioned.persist.rocks.RocksTestConnectionProviderSource

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/AbstractTestConnectionProviderSource.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/AbstractTestConnectionProviderSource.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests.extension;
+
+import java.util.function.Function;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+
+public abstract class AbstractTestConnectionProviderSource<
+        CONN_CONFIG extends DatabaseConnectionConfig>
+    implements TestConnectionProviderSource<CONN_CONFIG> {
+  private CONN_CONFIG config;
+  private DatabaseConnectionProvider<CONN_CONFIG> connectionProvider;
+
+  @Override
+  public void configureConnectionProviderConfigFromDefaults(
+      Function<CONN_CONFIG, CONN_CONFIG> configurer) {
+    CONN_CONFIG config = createDefaultConnectionProviderConfig();
+    config = configurer.apply(config);
+    setConnectionProviderConfig(config);
+  }
+
+  @Override
+  public void setConnectionProviderConfig(CONN_CONFIG connectionProviderConfig) {
+    this.config = connectionProviderConfig;
+  }
+
+  @Override
+  public DatabaseAdapterConfig<DatabaseConnectionProvider<CONN_CONFIG>> updateConfig(
+      DatabaseAdapterConfig<DatabaseConnectionProvider<CONN_CONFIG>> config) {
+    return config.withConnectionProvider(connectionProvider);
+  }
+
+  @Override
+  public void start() throws Exception {
+    if (connectionProvider != null) {
+      throw new IllegalStateException("Already started");
+    }
+    connectionProvider = createConnectionProvider();
+    connectionProvider.configure(config);
+    connectionProvider.initialize();
+  }
+
+  @Override
+  public void stop() throws Exception {
+    try {
+      if (connectionProvider != null) {
+        connectionProvider.close();
+      }
+    } finally {
+      connectionProvider = null;
+    }
+  }
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
@@ -208,7 +208,7 @@ public class DatabaseAdapterExtension
     builder
         .configure(
             c ->
-                SystemPropertiesConfigurer.configureFromProperties(
+                SystemPropertiesConfigurer.configureAdapterFromProperties(
                     c,
                     property -> {
                       List<NessieDbAdapterConfigItem> configs = new ArrayList<>();

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/TestConnectionProviderSource.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/TestConnectionProviderSource.java
@@ -37,7 +37,8 @@ import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
  *       NessieExternalDatabase} annotation.
  *   <li>Via {@link #findCompatibleProviderSource(DatabaseAdapterConfig, DatabaseAdapterFactory,
  *       String)}, usually from within a {@link DatabaseAdapterFactory.Builder#configure(Function)}
- *       function using a code snippet like this: <code><pre> .configure(c -> {
+ *       function using a code snippet like this:
+ *       <pre><code> .configure(c -&gt; {
  *   String providerSpec =
  *       adapter.indexOf(':') == -1
  *           ? null
@@ -58,7 +59,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
  *   c = providerSource.updateConfig(c);
  *   connectionProvider = c.getConnectionProvider();
  *   return c;
- * })</pre></code>
+ * })</code></pre>
  * </ol>
  */
 public interface TestConnectionProviderSource<CONN_CONFIG extends DatabaseConnectionConfig> {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/TestConnectionProviderSource.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/TestConnectionProviderSource.java
@@ -15,14 +15,78 @@
  */
 package org.projectnessie.versioned.persist.tests.extension;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.ServiceLoader;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
 
 /**
  * Manages all external resources (Docker containers, processes) and "internal" resources (network
  * connections and pools) required for tests.
+ *
+ * <p>There are two ways to choose a {@link TestConnectionProviderSource} implementation:
+ *
+ * <ol>
+ *   <li>In JUnit tests, reference the implementation class directly using the {@link
+ *       NessieExternalDatabase} annotation.
+ *   <li>Via {@link #findCompatibleProviderSource(DatabaseAdapterConfig, DatabaseAdapterFactory,
+ *       String)}, usually from within a {@link DatabaseAdapterFactory.Builder#configure(Function)}
+ *       function using a code snippet like this: <code><pre> .configure(c -> {
+ *   String providerSpec =
+ *       adapter.indexOf(':') == -1
+ *           ? null
+ *           : adapter.substring(adapter.indexOf(':') + 1)
+ *               .toLowerCase(Locale.ROOT);
+ *   TestConnectionProviderSource&lt;DatabaseConnectionConfig&gt; providerSource =
+ *       findCompatibleProviderSource(
+ *           c, factory, providerSpec);
+ *   providerSource
+ *       .configureConnectionProviderConfigFromDefaults(
+ *           SystemPropertiesConfigurer
+ *               ::configureConnectionFromSystemProperties);
+ *   try {
+ *     providerSource.start();
+ *   } catch (Exception e) {
+ *     throw new RuntimeException(e);
+ *   }
+ *   c = providerSource.updateConfig(c);
+ *   connectionProvider = c.getConnectionProvider();
+ *   return c;
+ * })</pre></code>
+ * </ol>
  */
-public interface TestConnectionProviderSource<T extends DatabaseConnectionProvider<?>> {
+public interface TestConnectionProviderSource<CONN_CONFIG extends DatabaseConnectionConfig> {
+
+  boolean isCompatibleWith(
+      DatabaseAdapterConfig<?> adapterConfig, DatabaseAdapterFactory<?> databaseAdapterFactory);
+
+  /** Creates the default {@link DatabaseConnectionConfig}. */
+  CONN_CONFIG createDefaultConnectionProviderConfig();
+
+  /**
+   * A shortcut for {@link #setConnectionProviderConfig(DatabaseConnectionConfig)} using a
+   * configuration received from {@link #createDefaultConnectionProviderConfig()} and passed through
+   * the given function.
+   */
+  void configureConnectionProviderConfigFromDefaults(Function<CONN_CONFIG, CONN_CONFIG> configurer);
+
+  /**
+   * Set the configuration for the {@link DatabaseConnectionProvider} to create via {@link
+   * #createConnectionProvider()}.
+   */
+  void setConnectionProviderConfig(CONN_CONFIG connectionProviderConfig);
+
+  /**
+   * Creates the {@link DatabaseConnectionProvider} using the configuration set earlier via {@link
+   * #setConnectionProviderConfig(DatabaseConnectionConfig)}.
+   */
+  DatabaseConnectionProvider<CONN_CONFIG> createConnectionProvider();
 
   /**
    * Updates the given {@code config} with the {@link DatabaseConnectionProvider} via {@link
@@ -31,7 +95,8 @@ public interface TestConnectionProviderSource<T extends DatabaseConnectionProvid
    * @param config the current configuration
    * @return {@code config} with a valid {@link DatabaseConnectionProvider} instance.
    */
-  DatabaseAdapterConfig<T> updateConfig(DatabaseAdapterConfig<T> config);
+  DatabaseAdapterConfig<DatabaseConnectionProvider<CONN_CONFIG>> updateConfig(
+      DatabaseAdapterConfig<DatabaseConnectionProvider<CONN_CONFIG>> config);
 
   /**
    * Initialize/start the connection provider.
@@ -48,4 +113,51 @@ public interface TestConnectionProviderSource<T extends DatabaseConnectionProvid
    * external processes.
    */
   void stop() throws Exception;
+
+  /**
+   * Tries to find a {@link TestConnectionProviderSource} implementation that returns {@code true}
+   * for {@link #isCompatibleWith(DatabaseAdapterConfig, DatabaseAdapterFactory)} for the given
+   * arguments using Java's {@link ServiceLoader} mechanism.
+   *
+   * @param databaseAdapterConfig database-adapter configuration, passed to {@link
+   *     #isCompatibleWith(DatabaseAdapterConfig, DatabaseAdapterFactory)}
+   * @param databaseAdapterFactory database-adapter-factory, passed to {@link
+   *     #isCompatibleWith(DatabaseAdapterConfig, DatabaseAdapterFactory)}
+   * @param providerSpec optional string, if non-{@code null} the lower-case class-name of the
+   *     {@link TestConnectionProviderSource} implementation must contain this string
+   * @return {@link TestConnectionProviderSource} implementation
+   * @throws IllegalStateException if no matching {@link TestConnectionProviderSource}
+   *     implementation could be found
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  static <CONN_CONFIG extends DatabaseConnectionConfig>
+      TestConnectionProviderSource<CONN_CONFIG> findCompatibleProviderSource(
+          DatabaseAdapterConfig<?> databaseAdapterConfig,
+          DatabaseAdapterFactory<?> databaseAdapterFactory,
+          String providerSpec) {
+    List<TestConnectionProviderSource> providerSources = new ArrayList<>();
+    for (TestConnectionProviderSource ps : ServiceLoader.load(TestConnectionProviderSource.class)) {
+      if (ps.isCompatibleWith(databaseAdapterConfig, databaseAdapterFactory)) {
+        providerSources.add(ps);
+      }
+    }
+
+    if (providerSources.isEmpty()) {
+      throw new IllegalStateException(
+          "No matching TestConnectionProviderSource found for " + databaseAdapterConfig);
+    }
+
+    if (providerSpec != null) {
+      providerSources.removeIf(
+          ps -> !ps.getClass().getName().toLowerCase(Locale.ROOT).contains(providerSpec));
+    }
+
+    if (providerSources.size() != 1) {
+      throw new IllegalStateException(
+          "Too many TestConnectionProviderSource instances matched: "
+              + providerSources.stream().map(Object::toString).collect(Collectors.joining(", ")));
+    }
+
+    return providerSources.get(0);
+  }
 }

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/local/GenericJdbcTestConnectionProviderSource.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/local/GenericJdbcTestConnectionProviderSource.java
@@ -13,33 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.mongodb;
+package org.projectnessie.versioned.persist.tx.local;
 
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.tests.extension.AbstractTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
 
 /**
- * MongoDB test connection-provider source using an external MongoDB instance/cluster.
+ * Generic JDBC test connection-provider source.
  *
- * <p>See {@link MongoClientConfig} for configuration options.
+ * <p>See {@link LocalTxConnectionConfig} for configuration options.
  */
-public class MongoTestConnectionProviderSource
-    extends AbstractTestConnectionProviderSource<MongoClientConfig> {
+public class GenericJdbcTestConnectionProviderSource
+    extends AbstractTestConnectionProviderSource<LocalTxConnectionConfig> {
+
+  @Override
+  public LocalTxConnectionConfig createDefaultConnectionProviderConfig() {
+    return ImmutableLocalTxConnectionConfig.builder().build();
+  }
+
+  @Override
+  public LocalConnectionProvider createConnectionProvider() {
+    return new LocalConnectionProvider();
+  }
 
   @Override
   public boolean isCompatibleWith(
       DatabaseAdapterConfig<?> adapterConfig, DatabaseAdapterFactory<?> databaseAdapterFactory) {
-    return adapterConfig instanceof MongoDatabaseAdapterConfig;
-  }
-
-  @Override
-  public MongoClientConfig createDefaultConnectionProviderConfig() {
-    return ImmutableMongoClientConfig.builder().build();
-  }
-
-  @Override
-  public MongoDatabaseClient createConnectionProvider() {
-    return new MongoDatabaseClient();
+    return adapterConfig instanceof TxDatabaseAdapterConfig;
   }
 }

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/CockroachTestConnectionProviderSource.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/CockroachTestConnectionProviderSource.java
@@ -15,10 +15,21 @@
  */
 package org.projectnessie.versioned.persist.tx.postgres;
 
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
 import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
+/** CockroachDB test connection-provider source using a Docker container running CockroachDB. */
 public class CockroachTestConnectionProviderSource extends ContainerTestConnectionProviderSource {
+
+  @Override
+  public boolean isCompatibleWith(
+      DatabaseAdapterConfig<?> adapterConfig, DatabaseAdapterFactory<?> databaseAdapterFactory) {
+    return adapterConfig instanceof TxDatabaseAdapterConfig
+        && databaseAdapterFactory instanceof PostgresDatabaseAdapterFactory;
+  }
 
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/PostgresTestConnectionProviderSource.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/PostgresTestConnectionProviderSource.java
@@ -15,10 +15,21 @@
  */
 package org.projectnessie.versioned.persist.tx.postgres;
 
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 
+/** PostgreSQL test connection-provider source using a Docker container running PostgreSQL. */
 public class PostgresTestConnectionProviderSource extends ContainerTestConnectionProviderSource {
+
+  @Override
+  public boolean isCompatibleWith(
+      DatabaseAdapterConfig<?> adapterConfig, DatabaseAdapterFactory<?> databaseAdapterFactory) {
+    return adapterConfig instanceof TxDatabaseAdapterConfig
+        && databaseAdapterFactory instanceof PostgresDatabaseAdapterFactory;
+  }
 
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {

--- a/versioned/persist/tx/src/test/resources/META-INF/services/org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource
+++ b/versioned/persist/tx/src/test/resources/META-INF/services/org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource
@@ -1,0 +1,5 @@
+org.projectnessie.versioned.persist.tx.local.GenericJdbcTestConnectionProviderSource
+org.projectnessie.versioned.persist.tx.h2.H2TestConnectionProviderSource
+# Note: The CockroachTestConnectionProviderSource + PostgresTestConnectionProviderSource are
+# intentionally not discoverable via ServiceLoader, because those start up Docker containers,
+# which should only happen in integration tests, but not in microbenchmarks or simple unit tests.


### PR DESCRIPTION
Adds a first JMH based microbenchmark against database-adapters.
Microbenchmarks are not run during CI though.

This PR also introduces a change to `TestConnectionProviderSource` so a suitable instance can be discovered and configured without adding database-adapter-specific code to each microbenchmark. That code can later be reused for the Gatling based tests. Goal of that change is that is should be sufficient to provide a database-adapter name plus system-properties to configure the connection-provider and database-adapter instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2084)
<!-- Reviewable:end -->
