### PR TITLE
Disable global state assertion in AbstractConcurrency

### DIFF
--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
@@ -265,7 +265,11 @@ public abstract class AbstractConcurrency {
             ContentsId contentsId = keyToContentsId.get(key);
             csExpected.add(ContentsAndState.of(onRef.get(key), globalStates.get(contentsId)));
           }
-          assertThat(csList).describedAs("For branch %s", branch).isEqualTo(csExpected);
+          // There is a race between test threads (code above) updating the maps that store
+          // per-branch and global state in this test class. Random delays in the execution
+          // of test threads can cause false positive assertion failure in the below line...
+          // Disabling this assertion for now so as not to destabilize CI.
+          // TODO: assertThat(csList).describedAs("For branch %s", branch).isEqualTo(csExpected);
         }
       }
 


### PR DESCRIPTION
As discovered in #2026, the commented assertion can cause spurious test failures.

The problem is local to the test code and applies to all adapters (with different probability, obviously).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2109)
<!-- Reviewable:end -->
