### PR TITLE
Use an automatically activated profile for Java version > 11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ for more information. Small changes don't require an issue. However, it is good 
 larger changes. If you are unsure of where to start ask on the slack channel or look at [existing issues](https://github.com/projectnessie/nessie/issues).
 The [good first issue](https://github.com/projectnessie/nessie/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label marks issues that are particularly good for people new to the codebase.
 
-For the tests to run, you need to update your `~/.m2/toolchains.xml` to contain a reference to Java 11. 
+For the Spark tests to run with Java 16 or newer, you need to update your `~/.m2/toolchains.xml` to contain a reference to Java 11. 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <toolchains>

--- a/clients/deltalake/pom.xml
+++ b/clients/deltalake/pom.xml
@@ -240,9 +240,6 @@
           <systemPropertyVariables>
             <quarkus.http.test-port>${quarkus.http.test-port}</quarkus.http.test-port>
           </systemPropertyVariables>
-          <jdkToolchain>
-            <version>11</version>
-          </jdkToolchain>
         </configuration>
         <executions>
           <execution>
@@ -257,6 +254,25 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>spark-test-java</id>
+      <activation>
+        <jdk>[16,20)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <jdkToolchain>
+                <version>11</version>
+              </jdkToolchain>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -179,9 +179,6 @@
             ${project.build.directory}/test-sources
           </additionalClasspathElements>
           <failIfNoTests>true</failIfNoTests>
-          <jdkToolchain>
-            <version>11</version>
-          </jdkToolchain>
         </configuration>
         <executions>
           <execution>
@@ -193,49 +190,68 @@
         </executions>
       </plugin>
       <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-shade-plugin</artifactId>
-      <configuration>
-        <filters>
-          <!-- filter to address "Invalid signature file" issue - see https://stackoverflow.com/a/6743609/589215 -->
-          <filter>
-            <artifact>*:*</artifact>
-            <excludes>
-              <exclude>META-INF/*.SF</exclude>
-              <exclude>META-INF/*.DSA</exclude>
-              <exclude>META-INF/*.RSA</exclude>
-              <exclude>META-INF/jandex.idx</exclude>
-              <exclude>META-INF/LICENSE</exclude>
-              <exclude>LICENSE</exclude>
-              <exclude>META-INF/LICENSE.md</exclude>
-              <exclude>META-INF/LICENSE.txt</exclude>
-              <exclude>META-INF/NOTIC*</exclude>
-              <exclude>META-INF/DEPENDENCIES</exclude>
-            </excludes>
-          </filter>
-        </filters>
-        <transformers>
-          <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-        </transformers>
-        <artifactSet>
-          <includes>
-            <include>org.projectnessie</include>
-          </includes>
-        </artifactSet>
-      </configuration>
-      <executions>
-        <execution>
-          <phase>package</phase>
-          <goals>
-            <goal>shade</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <filters>
+            <!-- filter to address "Invalid signature file" issue - see https://stackoverflow.com/a/6743609/589215 -->
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/jandex.idx</exclude>
+                <exclude>META-INF/LICENSE</exclude>
+                <exclude>LICENSE</exclude>
+                <exclude>META-INF/LICENSE.md</exclude>
+                <exclude>META-INF/LICENSE.txt</exclude>
+                <exclude>META-INF/NOTIC*</exclude>
+                <exclude>META-INF/DEPENDENCIES</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+          </transformers>
+          <artifactSet>
+            <includes>
+              <include>org.projectnessie</include>
+            </includes>
+          </artifactSet>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
+    <profile>
+      <id>spark-test-java</id>
+      <activation>
+        <jdk>[16,20)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <jdkToolchain>
+                <version>11</version>
+              </jdkToolchain>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/versioned/gc/spark/pom.xml
+++ b/versioned/gc/spark/pom.xml
@@ -78,17 +78,25 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <jdkToolchain>
-            <version>11</version>
-          </jdkToolchain>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <profile>
+      <id>spark-test-java</id>
+      <activation>
+        <jdk>[16,20)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <jdkToolchain>
+                <version>11</version>
+              </jdkToolchain>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/versioned/tiered/gc/pom.xml
+++ b/versioned/tiered/gc/pom.xml
@@ -170,15 +170,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <jdkToolchain>
-            <version>11</version>
-          </jdkToolchain>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <!-- Nessie PR https://github.com/projectnessie/nessie/pull/1922 introduces breaking changes as a clear cut to Nessie before 1.0 -->
@@ -195,4 +186,26 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>spark-test-java</id>
+      <activation>
+        <jdk>[16,20)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <jdkToolchain>
+                <version>11</version>
+              </jdkToolchain>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Fixes #2096

Note: Moving the activation of the profile into the top-level pom.xml doesn't work. Although Maven says that the profile is activated and active in all projects, Maven ignores the definition in the projects - so the activation is scattered around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2118)
<!-- Reviewable:end -->
