### PR TITLE
Separate configuration for # of parents in GlobalLogEntry

### DIFF
--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapterConfig.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapterConfig.java
@@ -16,7 +16,8 @@
 package org.projectnessie.versioned.persist.inmem;
 
 import org.immutables.value.Value;
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 
 @Value.Immutable(lazyhash = true)
-public interface InmemoryDatabaseAdapterConfig extends DatabaseAdapterConfig<InmemoryStore> {}
+public interface InmemoryDatabaseAdapterConfig
+    extends NonTransactionalDatabaseAdapterConfig<InmemoryStore> {}

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapterConfig.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapterConfig.java
@@ -16,7 +16,8 @@
 package org.projectnessie.versioned.persist.mongodb;
 
 import org.immutables.value.Value;
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 
 @Value.Immutable(lazyhash = true)
-public interface MongoDatabaseAdapterConfig extends DatabaseAdapterConfig<MongoDatabaseClient> {}
+public interface MongoDatabaseAdapterConfig
+    extends NonTransactionalDatabaseAdapterConfig<MongoDatabaseClient> {}

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -59,7 +59,6 @@ import org.projectnessie.versioned.persist.adapter.ContentsAndState;
 import org.projectnessie.versioned.persist.adapter.ContentsId;
 import org.projectnessie.versioned.persist.adapter.ContentsIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.ContentsIdWithType;
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
@@ -87,7 +86,8 @@ import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
  *       content-keys, the commit-metadata and a (list of) its parents.
  * </ul>
  */
-public abstract class NonTransactionalDatabaseAdapter<CONFIG extends DatabaseAdapterConfig<?>>
+public abstract class NonTransactionalDatabaseAdapter<
+        CONFIG extends NonTransactionalDatabaseAdapterConfig<?>>
     extends AbstractDatabaseAdapter<NonTransactionalOperationContext, CONFIG> {
 
   protected NonTransactionalDatabaseAdapter(CONFIG config) {
@@ -619,7 +619,7 @@ public abstract class NonTransactionalDatabaseAdapter<CONFIG extends DatabaseAda
           Stream.concat(
               newParents,
               currentEntry.getParentsList().stream()
-                  .limit(config.getParentsPerCommit() - 1)
+                  .limit(config.getParentsPerGlobalCommit() - 1)
                   .map(Hash::of));
     }
 

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.nontx;
+
+import org.immutables.value.Value;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
+
+public interface NonTransactionalDatabaseAdapterConfig<T extends DatabaseConnectionProvider<?>>
+    extends DatabaseAdapterConfig<T> {
+  int DEFAULT_PARENTS_PER_GLOBAL_COMMIT = 50;
+
+  /**
+   * The number of parent-global-commit-hashes stored in {@link
+   * GlobalStateLogEntry#getParentsList()}. Defaults to {@value #DEFAULT_PARENTS_PER_GLOBAL_COMMIT}.
+   */
+  @Value.Default
+  default int getParentsPerGlobalCommit() {
+    return DEFAULT_PARENTS_PER_GLOBAL_COMMIT;
+  }
+
+  NonTransactionalDatabaseAdapterConfig<T> withParentsPerGlobalCommit(int parentsPerGlobalCommit);
+}

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapterConfig.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapterConfig.java
@@ -16,7 +16,8 @@
 package org.projectnessie.versioned.persist.rocks;
 
 import org.immutables.value.Value;
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 
 @Value.Immutable(lazyhash = true)
-public interface RocksDatabaseAdapterConfig extends DatabaseAdapterConfig<RocksDbInstance> {}
+public interface RocksDatabaseAdapterConfig
+    extends NonTransactionalDatabaseAdapterConfig<RocksDbInstance> {}


### PR DESCRIPTION
The implementation is currently reusing the number of parents per CommitLogEntry for
the number of parents in a GlobalLogEntry. The payload sizes for both types are very
different and it makes sense to have different configuration options and different
defaults for both. CommitLogEntry can be assumed to be bigger than GlobalLogEntry.
It also makes sense to have more parents per GlobalLogEntry, because we do not (yet)
aggregate the global-contents-values within the global-log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2132)
<!-- Reviewable:end -->
