### PR TITLE
Prefer explict args over env. vars in python CLI

### DIFF
--- a/python/pynessie/conf/config_parser.py
+++ b/python/pynessie/conf/config_parser.py
@@ -19,9 +19,9 @@ def _get_env_args() -> dict:
 def build_config(args: dict = None) -> confuse.Configuration:
     """Build configuration object from input params, env variables and yaml file."""
     config = confuse.Configuration("nessie", __name__)
-    if args:
-        config.set_args(args, dots=True)
     env_args = _get_env_args()
     config.set_args(env_args, dots=True)
+    if args:
+        config.set_args(args, dots=True)
     config["auth"]["password"].redact = True
     return config

--- a/python/tests/test_config_parser.py
+++ b/python/tests/test_config_parser.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Tests for `config_parser.py`."""
+
+import os
+
+from assertpy import assert_that
+
+from pynessie.conf.config_parser import build_config
+
+
+def test_config_from_env() -> None:
+    """Makes sure NESSIE environment variables are resolved automatically."""
+    os.environ["NESSIE_TEST1_TEST2_TEST3"] = "test_val"
+    config = build_config()
+    assert_that(config["test1"]["test2"]["test3"].get()).is_equal_to("test_val")
+
+
+def test_config_from_args() -> None:
+    """Makes sure explicit config args are respected."""
+    config = build_config({"abc.def": "test_val"})
+    assert_that(config["abc"]["def"].get()).is_equal_to("test_val")
+
+
+def test_args_take_precedence_over_env() -> None:
+    """Makes sure explicit config args take precedence over environment variables."""
+    os.environ["NESSIE_TEST1_TEST2_TEST3"] = "env_val"
+    config = build_config({"test1.test2.test3": "arg_val"})
+    assert_that(config["test1"]["test2"]["test3"].get()).is_equal_to("arg_val")


### PR DESCRIPTION
Values given as explicit command line parameters
should take precedence over env. variables for
the same configuration property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/projectnessie/nessie/2147)
<!-- Reviewable:end -->
