### PR TITLE
Revert "Bump dependency-check-maven from 6.3.1 to 6.3.2 (#2200)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -771,7 +771,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>6.3.2</version>
+          <version>6.3.1</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This reverts commit abe8d6b1be57d7e4b3f3fd2cdfe376b86d69585f.


Reason (happened after merge into `main`):
```
Error:  Failed to execute goal org.owasp:dependency-check-maven:6.3.2:aggregate (default-cli) on project nessie: Execution default-cli of goal org.owasp:dependency-check-maven:6.3.2:aggregate failed.: NullPointerException -> [Help 1]
1550
```