### PR TITLE
Fix to allow re-creating the default branch

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -125,13 +125,21 @@ public abstract class AbstractTestRest {
   }
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     init(URI.create("http://localhost:19121/api/v1"));
   }
 
   @AfterEach
   public void tearDown() {
     api.close();
+  }
+
+  @Test
+  void createRecreateDefaultBranch() throws NessieConflictException, NessieNotFoundException {
+    api.deleteBranch().branch(api.getDefaultBranch()).delete();
+
+    api.createReference().reference(Branch.of("main", null)).create();
+    api.getReference().refName("main").get();
   }
 
   @Test


### PR DESCRIPTION
Fixes Iceberg tests, otherwise [this line](https://github.com/apache/iceberg/blob/master/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java#L83) never works.