### PR TITLE
Bump to Quarkus 2.3.1.Final and replace ConfigProperties with ConfigMappings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <openapi.version>2.0</openapi.version>
     <prometheus.version>0.9.0</prometheus.version>
     <protobuf.version>3.18.1</protobuf.version>
-    <quarkus.version>2.2.3.Final</quarkus.version>
+    <quarkus.version>2.3.1.Final</quarkus.version>
     <reactor.version>2020.0.12</reactor.version>
     <rocksdb.version>6.22.1.1</rocksdb.version>
     <scala2.12.version>2.12.13</scala2.12.version>

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.server.config;
 
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
 /** Configuration for Nessie authentication settings. */
+@StaticInitSafe
 @ConfigMapping(prefix = "nessie.server.authentication")
 public interface QuarkusNessieAuthenticationConfig {
 

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthorizationConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthorizationConfig.java
@@ -15,12 +15,14 @@
  */
 package org.projectnessie.server.config;
 
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import java.util.Map;
 
 /** Configuration for Nessie authorization settings. */
+@StaticInitSafe
 @ConfigMapping(prefix = "nessie.server.authorization")
 public interface QuarkusNessieAuthorizationConfig {
 

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusServerConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusServerConfig.java
@@ -15,19 +15,24 @@
  */
 package org.projectnessie.server.config;
 
-import io.quarkus.arc.config.ConfigProperties;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import io.quarkus.runtime.annotations.StaticInitSafe;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 import org.projectnessie.services.config.ServerConfig;
 
 /** Nessie server config for Quarkus. */
-@ConfigProperties(prefix = "nessie.server")
+@StaticInitSafe
+@ConfigMapping(prefix = "nessie.server")
 public interface QuarkusServerConfig extends ServerConfig {
 
-  @ConfigProperty(name = "default-branch", defaultValue = "main")
   @Override
+  @WithName("default-branch")
+  @WithDefault("main")
   String getDefaultBranch();
 
-  @ConfigProperty(name = "send-stacktrace-to-client", defaultValue = "false")
   @Override
+  @WithName("send-stacktrace-to-client")
+  @WithDefault("false")
   boolean sendStacktraceToClient();
 }

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusVersionStoreAdvancedConfig.java
@@ -16,6 +16,7 @@
 package org.projectnessie.server.config;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithConverter;
@@ -34,6 +35,7 @@ import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
  * <p>This interface overrides all getters to assign explicit Quarkus configuration names and
  * default values to them.
  */
+@StaticInitSafe
 @ConfigMapping(prefix = "nessie.version.store.advanced")
 @RegisterForReflection(targets = TrimmedStringConverter.class)
 public interface QuarkusVersionStoreAdvancedConfig

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/VersionStoreConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/VersionStoreConfig.java
@@ -16,11 +16,13 @@
 package org.projectnessie.server.config;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
 /** Version store configuration. */
+@StaticInitSafe
 @ConfigMapping(prefix = "nessie.version.store")
 public interface VersionStoreConfig {
 
@@ -49,6 +51,7 @@ public interface VersionStoreConfig {
   @WithDefault("true")
   boolean isMetricsEnabled();
 
+  @StaticInitSafe
   @ConfigMapping(prefix = "nessie.version.store.rocks")
   interface RocksVersionStoreConfig {
     @WithName("db-path")


### PR DESCRIPTION
Fixes https://github.com/projectnessie/nessie/issues/2188 which was fixed by https://github.com/quarkusio/quarkus/pull/20103

Reverts: https://github.com/projectnessie/nessie/pull/1967

Note now `StaticInitSafe` is used now to mark a config safe to be initialized during static init phase (upon Quarkus startup).