### PR TITLE
Explicitly define behavior of multiple operations for the same key in a commit

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestCommitLog.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestCommitLog.java
@@ -478,7 +478,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                                 ContentKey.of("key" + i),
                                 IcebergTable.of("meta" + i, i, i, i, i, c2.apply(i))))
                         .operation(Delete.of(ContentKey.of("delete" + i)))
-                        .operation(Unchanged.of(ContentKey.of("key" + i)))
+                        .operation(Unchanged.of(ContentKey.of("unchanged" + i)))
                         .commitMeta(CommitMeta.fromMessage("Commit #" + i))
                         .branchName(branch)
                         .hash(head)

--- a/site/docs/develop/spec.md
+++ b/site/docs/develop/spec.md
@@ -139,8 +139,27 @@ recorded within the [_Put Operation_](#put-operation) of a Nessie commit.
 
 ## Operations in a Nessie commit
 
-Each Nessie commit carries one or more operations. Each operation contains the Content Key and
-comes in one of the following variations.
+Each Nessie commit carries one or more operations. Each operation contains the
+[Content Key](#content-key) and is either a [Put](#put-operation), [Delete](#delete-operation) or
+[Unmodified](#unmodified-operation) operation.
+
+One [Content Key](#content-key) must only occur once in a Nessie commit.
+
+Operations present in a commit are passed into Nessie as a list of operations.
+
+### Mapping SQL DDL to Nessie commit operations
+
+A `CREATE TABLE` is mapped to one _Put operation_.
+
+An `ALTER TABLE RENAME` is mapped to a _Delete operation_ using the Content Key for the table
+being renamed plus at least one _Put operation_ using the Content Key of the table's new name,
+using the Content Id of the table being renamed.
+
+A `DROP TABLE` is represented as a Nessie _Delete operation_ (without a _Put operation_ for the
+same Content Id).
+
+A `DROP TABLE` + `CREATE TABLE` using the same table name (Content Key) in a single commit are
+mapped to one _Put operation_ with a different Content Id.
 
 ### Put operation
 
@@ -158,15 +177,14 @@ definition (think: SQL DDL) or data (think: SQL DML).
 A _Delete operation_ does not carry any Content object and is used to indicate that a Content
 object is no longer referenced using the Content Key of the _Delete operation_.
 
-Example for a Nessie _Delete operation_ is an SQL `DROP TABLE`. An `ALTER TABLE RENAME` is mapped
-to a _Delete operation_ plus a _Put operation_.
-
 ### Unmodified operation
 
 An _Unmodified operation_ does not represent any change of the data, but can be included in a
 Nessie commit operation to enforce strict serializable transactions. The presence of an
 _Unmodified operation_ means that the Content object referred to via the operation's Content Key
 must not have been modified since the Nessie commit's `expectedHash`.
+
+The _Unmodified operation_ is not persisted.
 
 ## Version Store
 

--- a/site/docs/develop/spec.md
+++ b/site/docs/develop/spec.md
@@ -143,7 +143,7 @@ Each Nessie commit carries one or more operations. Each operation contains the
 [Content Key](#content-key) and is either a [Put](#put-operation), [Delete](#delete-operation) or
 [Unmodified](#unmodified-operation) operation.
 
-One [Content Key](#content-key) must only occur once in a Nessie commit.
+A [Content Key](#content-key) must only occur once in a Nessie commit.
 
 Operations present in a commit are passed into Nessie as a list of operations.
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
@@ -42,4 +42,9 @@ public interface ContentAndState<CONTENT> {
         .globalState(globalState)
         .build();
   }
+
+  @Nonnull
+  static <CONTENT> ContentAndState<CONTENT> of(@Nonnull CONTENT refState) {
+    return ImmutableContentAndState.<CONTENT>builder().refState(refState).build();
+  }
 }

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -139,20 +139,20 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
             expectedValue = Optional.empty();
           }
 
-          // Handle the case when there are multiple operations against the same contents-id.
+          // Handle the case when there are multiple operations against the same content-id.
           if (!expectedStates.containsKey(contentId)) {
-            // First occurrence of contentsId in this commit.
+            // First occurrence of contentId in this commit.
             commitAttempt.putExpectedStates(contentId, expectedValue);
             expectedStates.put(contentId, expectedValue);
           } else {
-            // Consecutive occurrence of contentsId in this commit.
+            // Consecutive occurrence of contentId in this commit.
             if (expectedValue.isPresent()) {
               // Operation expects a certain global, compare against the previous global-value
               // from this commit.
               if (!globals.get(contentId).equals(expectedValue.get())) {
                 // Value not equal - aka not expected -> report conflict.
                 throw new ReferenceConflictException(
-                    String.format("Mismatch in global-state for contents-id '%s'.", contentId));
+                    String.format("Mismatch in global-state for content-id '%s'.", contentId));
               }
             }
           }


### PR DESCRIPTION
While thinking about how Nessie could actually squash multiple commits, I realized
that this can result in multiple commit-operations for the same content-key.

While commit-operations are ordered on the (REST) API level (list of `Operation`s),
database adapters split those into separate collections of delete and put operations,
which makes it impossible to determine the original order of the squashed operations.

The Nessie spec does not define the behavior of a Nessie commit with multiple
operations for the same key in one commit.

The spec now clearly states that there must be no more than operation (put / delete)
for each content key.

This commit updates the spec and also adds tests on the `DatabaseAdapter` and
`VersionStore` levels and includes related fixes to `AbstractDatabaseAdapter`
and `PersistVersionStore`.
