### PR TITLE
SQL extensions: SHOW LOG & SHOW REF need to point to the previously configured Hash

### DIFF
--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AssignReferenceExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AssignReferenceExec.scala
@@ -54,7 +54,8 @@ case class AssignReferenceExec(
       )
     }
 
-    val ref = nessieClient.getTreeApi.getReferenceByName(branch)
+    val ref = NessieUtils.calculateRef(branch, Some(assignToHash), nessieClient)
+    NessieUtils.setCurrentRefForSpark(currentCatalog, catalog, ref)
 
     Seq(
       InternalRow(

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeBranchExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeBranchExec.scala
@@ -36,7 +36,7 @@ case class MergeBranchExec(
     val from = nessieClient.getTreeApi
       .getReferenceByName(
         branch.getOrElse(
-          NessieUtils.getCurrentRef(currentCatalog, catalog).getName
+          NessieUtils.getCurrentRefAtHead(currentCatalog, catalog).getName
         )
       )
     nessieClient.getTreeApi.mergeRefIntoBranch(

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowReferenceExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowReferenceExec.scala
@@ -32,7 +32,7 @@ case class ShowReferenceExec(
       nessieClient: NessieClient
   ): Seq[InternalRow] = {
 
-    val ref = NessieUtils.getCurrentRef(currentCatalog, catalog)
+    val ref = NessieUtils.getCurrentRefAtConfiguredHash(currentCatalog, catalog)
     // todo have to figure out if this is delta or iceberg and extract the ref accordingly
     Seq(
       InternalRow(


### PR DESCRIPTION
ASSIGN and USE REFERENCE both provide a way to use a specific Hash. Once
a user then uses SHOW LOG / SHOW REF, then both those commands need to
use the specified Hash.