### PR TITLE
Add database-adapter test-jar artifacts to bom for proper version management

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -142,17 +142,11 @@
       <dependency>
         <groupId>org.projectnessie</groupId>
         <artifactId>nessie-versioned-persist-in-memory</artifactId>
-        <type>test-jar</type>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.projectnessie</groupId>
         <artifactId>nessie-versioned-persist-in-memory</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.projectnessie</groupId>
-        <artifactId>nessie-versioned-persist-rocks</artifactId>
         <type>test-jar</type>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
When other projects need to run integration tests against (different) database-adapters and use the junit5 extension, they need the test-jars for those - i.e. those artifacts need to be present in the bom as well.