### PR TITLE
Allow expected global state in commit attempts when none is present in storage

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1085,13 +1085,7 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
     for (Entry<ContentsId, Optional<ByteString>> expectedState :
         commitAttempt.getExpectedStates().entrySet()) {
       ByteString currentState = globalStates.get(expectedState.getKey());
-      if (currentState == null) {
-        if (expectedState.getValue().isPresent()) {
-          mismatches.accept(
-              String.format(
-                  "No current global-state for contents-id '%s'.", expectedState.getKey()));
-        }
-      } else {
+      if (currentState != null) {
         if (!expectedState.getValue().isPresent()) {
           // This happens, when a table's being created on a branch, but that table already exists.
           mismatches.accept(


### PR DESCRIPTION
The basic problem is that if a table used to exist, but is no longer
referenced in a branch, the client that wishes to make a new commit
has no way of knowing whether Nessie Server has some previous global
state for the table or it does not.

Before this commit, the server would reject changes that have an
"expected" global state when the server has none. Conversely the
server would reject changes that do not have an "expected" global
state when the server has some.

It is not feasible for a client to iterate all possible keys in
all possible branches trying to detect whether the table used to
exist. Moreover, the table might no longer be discoverable from
any live references even if it used to exist.

Therefore, this commit relaxes "expected" global state checks and
allows changes that declare an "expected" state when the server has
none.

Clients that (re-)create a table can now always include the best
known "expected" global state and the server will verify it whenever
it has records of prior global state for the contents ID in question.