### PR TITLE
Python test cleanup

### DIFF
--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,11 +130,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["assign",
-      "foo", "bar"]}, "contents": {"idGenerators": "xyz", "id": "test_assign", "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta": {"commitTime":
-      null, "committer": null, "author": "nessie test", "properties": null, "signedOffBy":
-      null, "message": "test message", "authorTime": null, "hash": null}}'
+    body: '{"operations": [{"contents": {"id": "test_assign", "metadataLocation":
+      "/a/b/c", "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements":
+      ["assign", "foo", "bar"]}, "expectedContents": null, "type": "PUT"}], "commitMeta":
+      {"author": "nessie test", "properties": null, "committer": null, "signedOffBy":
+      null, "hash": null, "commitTime": null, "message": "test message", "authorTime":
+      null}}'
     headers:
       Accept:
       - '*/*'
@@ -152,7 +153,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -176,7 +177,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -186,8 +187,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": "250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121",
-      "type": "BRANCH"}'
+    body: '{"hash": "f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7",
+      "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -240,8 +241,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121",
-      "type": "BRANCH"}'
+    body: '{"hash": "f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -280,8 +281,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}
+        \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}
         ]"
     headers:
       Content-Length:
@@ -306,7 +307,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -316,8 +317,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121",
-      "type": "TAG"}'
+    body: '{"hash": "f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -335,7 +336,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -360,9 +361,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n},
-        {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}
+        \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}
         ]"
     headers:
       Content-Length:
@@ -387,7 +388,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -397,8 +398,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121",
-      "type": "TAG"}'
+    body: '{"hash": "f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -441,7 +442,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -451,8 +452,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121",
-      "type": "TAG"}'
+    body: '{"hash": "f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7",
+      "name": "dev", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -467,7 +468,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7
   response:
     body:
       string: ''
@@ -491,288 +492,13 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n},
-        {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}
+        \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"f584f63f1b837134c8063e5339900b6245669c82639e421819abd98c358163b7\"\n}
         ]"
     headers:
       Content-Length:
       - '367'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/v1.0
-  response:
-    body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
-    headers:
-      Content-Length:
-      - '118'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log
-  response:
-    body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:35.206913Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:35.206913Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
-    headers:
-      Content-Length:
-      - '383'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/contents/assign.foo.bar?ref=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_assign\",\n  \"metadataLocation\"
-        : \"/a/b/c\",\n  \"idGenerators\" : \"xyz\"\n}"
-    headers:
-      Content-Length:
-      - '113'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"operations": [{"key": {"elements": ["assign", "foo", "bar"]}, "type":
-      "DELETE"}], "commitMeta": {"commitTime": null, "committer": null, "author":
-      null, "properties": null, "signedOffBy": null, "message": "delete_message",
-      "authorTime": null, "hash": null}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '258'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=250c12f8e22b0e5bf0ccae57254c1b99fa3013c47a2a0e1d636bf36014443121
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"51740ceaed0b3d82d22a602f2f99f39b7c1c58f9167914bcad0baf1720d8a83a\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"51740ceaed0b3d82d22a602f2f99f39b7c1c58f9167914bcad0baf1720d8a83a\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=51740ceaed0b3d82d22a602f2f99f39b7c1c58f9167914bcad0baf1720d8a83a
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
       Content-Type:
       - application/json
     status:

--- a/python/tests/cassettes/test_nessie_cli/test_branch.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_branch.yaml
@@ -73,8 +73,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -153,8 +153,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "etl", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/cassettes/test_nessie_cli/test_commit_no_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_commit_no_expected_state.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,13 +130,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["commit",
-      "expected", "contents"]}, "contents": {"metadataLocationHistory": ["asd111"],
-      "id": "test_commit_no_expected_state", "checkpointLocationHistory": ["def"],
-      "lastCheckpoint": "x", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}], "commitMeta":
-      {"commitTime": null, "committer": null, "author": "nessie test", "properties":
-      null, "signedOffBy": null, "message": "commit 1", "authorTime": null, "hash":
-      null}}'
+    body: '{"operations": [{"contents": {"id": "test_commit_no_expected_state", "checkpointLocationHistory":
+      ["def"], "metadataLocationHistory": ["asd111"], "lastCheckpoint": "x", "type":
+      "DELTA_LAKE_TABLE"}, "key": {"elements": ["commit", "expected", "contents"]},
+      "expectedContents": null, "type": "PUT"}], "commitMeta": {"author": "nessie
+      test", "properties": null, "committer": null, "signedOffBy": null, "hash": null,
+      "commitTime": null, "message": "commit 1", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -154,7 +153,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"902d633d055966bc00eb36b536b01170cbb378d363c08bc6eb08d42e48e3fb08\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"13326c835719419906534171b1a8b651bd1a686d3fb2cd98d78d93b353cbc65a\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -180,7 +179,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"902d633d055966bc00eb36b536b01170cbb378d363c08bc6eb08d42e48e3fb08\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"13326c835719419906534171b1a8b651bd1a686d3fb2cd98d78d93b353cbc65a\"\n}
         ]"
     headers:
       Content-Length:
@@ -217,13 +216,12 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["commit",
-      "expected", "contents"]}, "contents": {"metadataLocationHistory": ["asd222"],
-      "id": "test_commit_no_expected_state", "checkpointLocationHistory": ["def"],
-      "lastCheckpoint": "x", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}], "commitMeta":
-      {"commitTime": null, "committer": null, "author": "nessie test", "properties":
-      null, "signedOffBy": null, "message": "commit 2", "authorTime": null, "hash":
-      null}}'
+    body: '{"operations": [{"contents": {"id": "test_commit_no_expected_state", "checkpointLocationHistory":
+      ["def"], "metadataLocationHistory": ["asd222"], "lastCheckpoint": "x", "type":
+      "DELTA_LAKE_TABLE"}, "key": {"elements": ["commit", "expected", "contents"]},
+      "expectedContents": null, "type": "PUT"}], "commitMeta": {"author": "nessie
+      test", "properties": null, "committer": null, "signedOffBy": null, "hash": null,
+      "commitTime": null, "message": "commit 2", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -238,10 +236,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=902d633d055966bc00eb36b536b01170cbb378d363c08bc6eb08d42e48e3fb08
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=13326c835719419906534171b1a8b651bd1a686d3fb2cd98d78d93b353cbc65a
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"55c561467dc61e13c38c9bdb7e0a9cfeb43fd45ad91b59b643409b06e964ad60\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"18ba05ff14ce6eb31cfe141db58f818e327cf9ec3fb657d08f323ecf553ebe16\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -250,129 +248,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"55c561467dc61e13c38c9bdb7e0a9cfeb43fd45ad91b59b643409b06e964ad60\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=55c561467dc61e13c38c9bdb7e0a9cfeb43fd45ad91b59b643409b06e964ad60
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"message\" : \"Named reference 'main' already exists.\",\n  \"status\"
-        : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\" : null\n}"
-    headers:
-      Content-Length:
-      - '130'
-      Content-Type:
-      - application/json
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_commit_with_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_commit_with_expected_state.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,12 +130,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["commit",
-      "expected", "contents"]}, "contents": {"idGenerators": "xyz", "id": "test_expected_contents",
-      "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta":
-      {"commitTime": null, "committer": null, "author": "nessie test", "properties":
-      null, "signedOffBy": null, "message": "commit 1", "authorTime": null, "hash":
-      null}}'
+    body: '{"operations": [{"contents": {"id": "test_expected_contents", "metadataLocation":
+      "/a/b/c", "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements":
+      ["commit", "expected", "contents"]}, "expectedContents": null, "type": "PUT"}],
+      "commitMeta": {"author": "nessie test", "properties": null, "committer": null,
+      "signedOffBy": null, "hash": null, "commitTime": null, "message": "commit 1",
+      "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -153,7 +153,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"185f6fbc781d6ae29e9b15e8e9acfab2c56888562cf7ffac87d8a9a485efae8d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1b80e34098fab4883e48c66a953f0b20f2fb7c3d0146548cfd98af3e45a7ac71\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -179,7 +179,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"185f6fbc781d6ae29e9b15e8e9acfab2c56888562cf7ffac87d8a9a485efae8d\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1b80e34098fab4883e48c66a953f0b20f2fb7c3d0146548cfd98af3e45a7ac71\"\n}
         ]"
     headers:
       Content-Length:
@@ -215,13 +215,13 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"expectedContents": {"idGenerators": "xyz", "id": "test_expected_contents",
-      "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "key": {"elements":
-      ["commit", "expected", "contents"]}, "contents": {"idGenerators": "xyz", "id":
-      "test_expected_contents", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}], "commitMeta": {"commitTime": null, "committer": null, "author":
-      "nessie test", "properties": null, "signedOffBy": null, "message": "commit 2",
-      "authorTime": null, "hash": null}}'
+    body: '{"operations": [{"contents": {"id": "test_expected_contents", "metadataLocation":
+      "/a/b/c", "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements":
+      ["commit", "expected", "contents"]}, "expectedContents": {"id": "test_expected_contents",
+      "metadataLocation": "/a/b/c", "idGenerators": "xyz", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}], "commitMeta": {"author": "nessie test", "properties": null,
+      "committer": null, "signedOffBy": null, "hash": null, "commitTime": null, "message":
+      "commit 2", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -236,10 +236,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=185f6fbc781d6ae29e9b15e8e9acfab2c56888562cf7ffac87d8a9a485efae8d
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=1b80e34098fab4883e48c66a953f0b20f2fb7c3d0146548cfd98af3e45a7ac71
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e8703b6e1d465df68d7215d6cbbd1a674f6159172fa58712917ced81f8c6480f\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"cab302a07d613f23241c4425f594fc84ca3ca3fbecacd52860241651f4813c60\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -248,129 +248,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e8703b6e1d465df68d7215d6cbbd1a674f6159172fa58712917ced81f8c6480f\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=e8703b6e1d465df68d7215d6cbbd1a674f6159172fa58712917ced81f8c6480f
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"message\" : \"Named reference 'main' already exists.\",\n  \"status\"
-        : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\" : null\n}"
-    headers:
-      Content-Length:
-      - '130'
-      Content-Type:
-      - application/json
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "contents_listing_dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "contents_listing_dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["this",
-      "is", "iceberg", "foo"]}, "contents": {"idGenerators": "xyz", "id": "test_contents_listing",
-      "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta":
-      {"commitTime": null, "committer": null, "author": "nessie test", "properties":
-      null, "signedOffBy": null, "message": "test message", "authorTime": null, "hash":
-      null}}'
+    body: '{"operations": [{"contents": {"id": "test_contents_listing", "metadataLocation":
+      "/a/b/c", "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements":
+      ["this", "is", "iceberg", "foo"]}, "expectedContents": null, "type": "PUT"}],
+      "commitMeta": {"author": "nessie test", "properties": null, "committer": null,
+      "signedOffBy": null, "hash": null, "commitTime": null, "message": "test message",
+      "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"4fb8aacec2cb5c6b6bed5ddc5ee2cc97d05c10f697fd6c7fd082f7b318635ab1\"\n}"
+        \ \"hash\" : \"6233a0f88765a7da04276bfe6d47694d4ac6dc8454a86a681c5adc73e8031b24\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -183,7 +183,7 @@ interactions:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n  \"hash\"
-        : \"4fb8aacec2cb5c6b6bed5ddc5ee2cc97d05c10f697fd6c7fd082f7b318635ab1\"\n}
+        : \"6233a0f88765a7da04276bfe6d47694d4ac6dc8454a86a681c5adc73e8031b24\"\n}
         ]"
     headers:
       Content-Length:
@@ -220,12 +220,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["this",
-      "is", "delta", "bar"]}, "contents": {"metadataLocationHistory": ["asd"], "id":
-      "uuid2", "checkpointLocationHistory": ["def"], "lastCheckpoint": "x", "type":
-      "DELTA_LAKE_TABLE"}, "type": "PUT"}], "commitMeta": {"commitTime": null, "committer":
-      null, "author": "nessie test", "properties": null, "signedOffBy": null, "message":
-      "test message", "authorTime": null, "hash": null}}'
+    body: '{"operations": [{"contents": {"id": "uuid2", "checkpointLocationHistory":
+      ["def"], "metadataLocationHistory": ["asd"], "lastCheckpoint": "x", "type":
+      "DELTA_LAKE_TABLE"}, "key": {"elements": ["this", "is", "delta", "bar"]}, "expectedContents":
+      null, "type": "PUT"}], "commitMeta": {"author": "nessie test", "properties":
+      null, "committer": null, "signedOffBy": null, "hash": null, "commitTime": null,
+      "message": "test message", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -240,11 +240,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=4fb8aacec2cb5c6b6bed5ddc5ee2cc97d05c10f697fd6c7fd082f7b318635ab1
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=6233a0f88765a7da04276bfe6d47694d4ac6dc8454a86a681c5adc73e8031b24
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"e4730fe85f06f85abe8a18d259dca5fd15f6010fa0244a36db265095b2f509e7\"\n}"
+        \ \"hash\" : \"a8b576c59a491b10c57365ea22df4e4c76f3e1f05210a1c53dc410c9234be547\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -271,7 +271,7 @@ interactions:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n  \"hash\"
-        : \"e4730fe85f06f85abe8a18d259dca5fd15f6010fa0244a36db265095b2f509e7\"\n}
+        : \"a8b576c59a491b10c57365ea22df4e4c76f3e1f05210a1c53dc410c9234be547\"\n}
         ]"
     headers:
       Content-Length:
@@ -308,11 +308,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["this",
-      "is", "sql", "baz"]}, "contents": {"sqlText": "SELECT * FROM foo", "id": "uuid3",
-      "dialect": "SPARK", "type": "VIEW"}, "type": "PUT"}], "commitMeta": {"commitTime":
-      null, "committer": null, "author": "nessie test", "properties": null, "signedOffBy":
-      null, "message": "test message", "authorTime": null, "hash": null}}'
+    body: '{"operations": [{"contents": {"id": "uuid3", "dialect": "SPARK", "sqlText":
+      "SELECT * FROM foo", "type": "VIEW"}, "key": {"elements": ["this", "is", "sql",
+      "baz"]}, "expectedContents": null, "type": "PUT"}], "commitMeta": {"author":
+      "nessie test", "properties": null, "committer": null, "signedOffBy": null, "hash":
+      null, "commitTime": null, "message": "test message", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -327,11 +327,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=e4730fe85f06f85abe8a18d259dca5fd15f6010fa0244a36db265095b2f509e7
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=a8b576c59a491b10c57365ea22df4e4c76f3e1f05210a1c53dc410c9234be547
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"7d0eb6974235804d012de3d6b3fe0905172d2a0b8c381d083466e7781d92df41\"\n}"
+        \ \"hash\" : \"5e2b56e040b7b0aae665ba3c6a09630eb1401d240ad6de9eb644f0e091f4c3e0\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -553,51 +553,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"7d0eb6974235804d012de3d6b3fe0905172d2a0b8c381d083466e7781d92df41\"\n}"
-    headers:
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev?expectedHash=7d0eb6974235804d012de3d6b3fe0905172d2a0b8c381d083466e7781d92df41
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -99,11 +99,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["log",
-      "foo", "bar"]}, "contents": {"idGenerators": "xyz", "id": "test_log", "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta": {"commitTime":
-      null, "committer": null, "author": "nessie_user1", "properties": null, "signedOffBy":
-      null, "message": "test message", "authorTime": null, "hash": null}}'
+    body: '{"operations": [{"contents": {"id": "test_log", "metadataLocation": "/a/b/c",
+      "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements": ["log",
+      "foo", "bar"]}, "expectedContents": null, "type": "PUT"}], "commitMeta": {"author":
+      "nessie_user1", "properties": null, "committer": null, "signedOffBy": null,
+      "hash": null, "commitTime": null, "message": "test message", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -121,7 +121,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -145,7 +145,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -194,7 +194,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -218,10 +218,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -246,7 +246,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -267,13 +267,13 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -298,7 +298,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -360,9 +360,9 @@ interactions:
       message: OK
 - request:
     body: '{"operations": [{"key": {"elements": ["log", "foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"commitTime": null, "committer": null, "author": "nessie_user2",
-      "properties": null, "signedOffBy": null, "message": "delete_message", "authorTime":
-      null, "hash": null}}'
+      "commitMeta": {"author": "nessie_user2", "properties": null, "committer": null,
+      "signedOffBy": null, "hash": null, "commitTime": null, "message": "delete_message",
+      "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -377,10 +377,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -404,7 +404,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -428,11 +428,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?max=1
   response:
     body:
-      string: "{\n  \"token\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
-        \ \"operations\" : [ {\n    \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\",\n
+      string: "{\n  \"token\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
+        \ \"operations\" : [ {\n    \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.783900Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.783900Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.965875Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.965875Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : true\n}"
     headers:
       Content-Length:
@@ -457,7 +457,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -481,14 +481,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.783900Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.783900Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.965875Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.965875Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -513,7 +513,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -534,13 +534,13 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70&endHash=e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c&endHash=27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -565,7 +565,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -589,14 +589,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.783900Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.783900Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.965875Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.965875Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -621,7 +621,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -645,10 +645,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user1%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -673,7 +673,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -697,10 +697,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user2%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.783900Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.783900Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.965875Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.965875Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -725,7 +725,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -749,14 +749,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28commit.author%3D%3D%27nessie_user2%27+%7C%7C+commit.author%3D%3D%27nessie_user1%27%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.783900Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.783900Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.965875Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.965875Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -781,7 +781,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -805,14 +805,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.committer%3D%3D%27%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.783900Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.783900Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.965875Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.965875Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -837,7 +837,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -861,10 +861,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author+%3D%3D+%27nessie_user2%27+%7C%7C+commit.author+%3D%3D+%27non_existing%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.783900Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.783900Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.965875Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.965875Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -889,7 +889,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -913,14 +913,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28timestamp%28commit.commitTime%29+%3E+timestamp%28%272001-01-01T00%3A00%3A00%2B00%3A00%27%29+%26%26+timestamp%28commit.commitTime%29+%3C+timestamp%28%272999-12-30T23%3A00%3A00%2B00%3A00%27%29%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9ce05713b85afcb796b8f1c2dd751a48bf8223c3d53b76add3f97728d8e3b34c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.783900Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.783900Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"e3dcdefc29ca929e290ebd6438a87ce1d6dbc45a9005bd60321e470915e18c6a\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.965875Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.965875Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"27bfa790a3feb0dd60b24dad0dc37c785562f39a7bd8ae18e4a694ee746eb11c\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:33.551351Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:33.551351Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:30.815544Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:30.815544Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -930,83 +930,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"message\" : \"Named reference 'main' already exists.\",\n  \"status\"
-        : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\" : null\n}"
-    headers:
-      Content-Length:
-      - '130'
-      Content-Type:
-      - application/json
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=9f17b9fb59a0738c0d979d481e6b0b2e764d6ad969f623f58c7708cd4efdef70
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,11 +130,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["merge",
-      "foo", "bar"]}, "contents": {"idGenerators": "xyz", "id": "test_merge", "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta": {"commitTime":
-      null, "committer": null, "author": "nessie test", "properties": null, "signedOffBy":
-      null, "message": "test message", "authorTime": null, "hash": null}}'
+    body: '{"operations": [{"contents": {"id": "test_merge", "metadataLocation": "/a/b/c",
+      "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements": ["merge",
+      "foo", "bar"]}, "expectedContents": null, "type": "PUT"}], "commitMeta": {"author":
+      "nessie test", "properties": null, "committer": null, "signedOffBy": null, "hash":
+      null, "commitTime": null, "message": "test message", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -152,7 +152,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ec0a4087ae772bf872812ded5868bdf7dbf1cb3642cc88f20ec6f9dfbf13396e\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -178,7 +178,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ec0a4087ae772bf872812ded5868bdf7dbf1cb3642cc88f20ec6f9dfbf13396e\"\n}
         ]"
     headers:
       Content-Length:
@@ -227,7 +227,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ec0a4087ae772bf872812ded5868bdf7dbf1cb3642cc88f20ec6f9dfbf13396e\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -237,8 +237,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41",
-      "fromRefName": "dev"}'
+    body: '{"fromRefName": "dev", "fromHash": "ec0a4087ae772bf872812ded5868bdf7dbf1cb3642cc88f20ec6f9dfbf13396e"}'
     headers:
       Accept:
       - '*/*'
@@ -277,241 +276,12 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41\"\n}
+        \"ec0a4087ae772bf872812ded5868bdf7dbf1cb3642cc88f20ec6f9dfbf13396e\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ec0a4087ae772bf872812ded5868bdf7dbf1cb3642cc88f20ec6f9dfbf13396e\"\n}
         ]"
     headers:
       Content-Length:
       - '247'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log
-  response:
-    body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:35.623035Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:35.623035Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
-    headers:
-      Content-Length:
-      - '383'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/contents/merge.foo.bar?ref=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_merge\",\n  \"metadataLocation\"
-        : \"/a/b/c\",\n  \"idGenerators\" : \"xyz\"\n}"
-    headers:
-      Content-Length:
-      - '112'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"operations": [{"key": {"elements": ["merge", "foo", "bar"]}, "type":
-      "DELETE"}], "commitMeta": {"commitTime": null, "committer": null, "author":
-      null, "properties": null, "signedOffBy": null, "message": "delete_message",
-      "authorTime": null, "hash": null}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '257'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=fbd0f7adf0bc7927a2640ad8a3d31d106ee25189c8d6c430e48213c678b19a41
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"3a73464201cf1ef2103f87f4f240c90a13770dc750a91c4598face062691433d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"3a73464201cf1ef2103f87f4f240c90a13770dc750a91c4598face062691433d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=3a73464201cf1ef2103f87f4f240c90a13770dc750a91c4598face062691433d
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
       Content-Type:
       - application/json
     status:

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -49,8 +49,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev-tag", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "TAG"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev-tag", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -129,8 +129,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl-tag", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "TAG"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "etl-tag", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -351,8 +351,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "TAG"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -433,50 +433,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/v1.0
-  response:
-    body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '118'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,11 +130,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["transplant",
-      "foo", "bar"]}, "contents": {"idGenerators": "xyz", "id": "test_transplant_1",
-      "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta":
-      {"commitTime": null, "committer": null, "author": "nessie test", "properties":
-      null, "signedOffBy": null, "message": "test message", "authorTime": null, "hash":
+    body: '{"operations": [{"contents": {"id": "test_transplant_1", "metadataLocation":
+      "/a/b/c", "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements":
+      ["transplant", "foo", "bar"]}, "expectedContents": null, "type": "PUT"}], "commitMeta":
+      {"author": "nessie test", "properties": null, "committer": null, "signedOffBy":
+      null, "hash": null, "commitTime": null, "message": "test message", "authorTime":
       null}}'
     headers:
       Accept:
@@ -153,7 +153,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ed2809449db440abb8f16ed93ea9701b6eef64154185c79e014fcb65795afe35\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"a2f614d231ceb4d66e054e9b0e811e12649d189f55d666e8645cf4baa2a8fba2\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -179,7 +179,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ed2809449db440abb8f16ed93ea9701b6eef64154185c79e014fcb65795afe35\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"a2f614d231ceb4d66e054e9b0e811e12649d189f55d666e8645cf4baa2a8fba2\"\n}
         ]"
     headers:
       Content-Length:
@@ -216,11 +216,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["bar",
-      "bar"]}, "contents": {"idGenerators": "xyz", "id": "test_transplant_2", "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta": {"commitTime":
-      null, "committer": null, "author": "nessie test", "properties": null, "signedOffBy":
-      null, "message": "test message", "authorTime": null, "hash": null}}'
+    body: '{"operations": [{"contents": {"id": "test_transplant_2", "metadataLocation":
+      "/a/b/c", "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements":
+      ["bar", "bar"]}, "expectedContents": null, "type": "PUT"}], "commitMeta": {"author":
+      "nessie test", "properties": null, "committer": null, "signedOffBy": null, "hash":
+      null, "commitTime": null, "message": "test message", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -235,10 +235,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=ed2809449db440abb8f16ed93ea9701b6eef64154185c79e014fcb65795afe35
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=a2f614d231ceb4d66e054e9b0e811e12649d189f55d666e8645cf4baa2a8fba2
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ab1c66c58c6a7dfd81df25014f49401546257ef497cbee9119f2f48218ae1249\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"8a6adfc4063802ccaa0e2e41c8b251c6d9548c91eb73d0b5ce008dbcc3fd6e36\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -264,7 +264,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"ab1c66c58c6a7dfd81df25014f49401546257ef497cbee9119f2f48218ae1249\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"8a6adfc4063802ccaa0e2e41c8b251c6d9548c91eb73d0b5ce008dbcc3fd6e36\"\n}
         ]"
     headers:
       Content-Length:
@@ -301,11 +301,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"expectedContents": null, "key": {"elements": ["foo",
-      "baz"]}, "contents": {"idGenerators": "xyz", "id": "test_transplant_3", "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}], "commitMeta": {"commitTime":
-      null, "committer": null, "author": "nessie test", "properties": null, "signedOffBy":
-      null, "message": "test message", "authorTime": null, "hash": null}}'
+    body: '{"operations": [{"contents": {"id": "test_transplant_3", "metadataLocation":
+      "/a/b/c", "idGenerators": "xyz", "type": "ICEBERG_TABLE"}, "key": {"elements":
+      ["foo", "baz"]}, "expectedContents": null, "type": "PUT"}], "commitMeta": {"author":
+      "nessie test", "properties": null, "committer": null, "signedOffBy": null, "hash":
+      null, "commitTime": null, "message": "test message", "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -320,10 +320,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=ab1c66c58c6a7dfd81df25014f49401546257ef497cbee9119f2f48218ae1249
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=8a6adfc4063802ccaa0e2e41c8b251c6d9548c91eb73d0b5ce008dbcc3fd6e36
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"c76b98683558733257dc969a00d0a5b7588d794daaef1d6cbf37dcd7fa3ccddd\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"012d9e737d9bdbd7a7bda1768ed8d649285d31b562b09e266d6c28d3c2eebf1a\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -349,7 +349,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"c76b98683558733257dc969a00d0a5b7588d794daaef1d6cbf37dcd7fa3ccddd\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"012d9e737d9bdbd7a7bda1768ed8d649285d31b562b09e266d6c28d3c2eebf1a\"\n}
         ]"
     headers:
       Content-Length:
@@ -374,18 +374,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"c76b98683558733257dc969a00d0a5b7588d794daaef1d6cbf37dcd7fa3ccddd\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"012d9e737d9bdbd7a7bda1768ed8d649285d31b562b09e266d6c28d3c2eebf1a\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:35.959664Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:35.959664Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"ab1c66c58c6a7dfd81df25014f49401546257ef497cbee9119f2f48218ae1249\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:32.906627Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:32.906627Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"8a6adfc4063802ccaa0e2e41c8b251c6d9548c91eb73d0b5ce008dbcc3fd6e36\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:35.915210Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:35.915210Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"ed2809449db440abb8f16ed93ea9701b6eef64154185c79e014fcb65795afe35\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:32.864840Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:32.864840Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"a2f614d231ceb4d66e054e9b0e811e12649d189f55d666e8645cf4baa2a8fba2\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:35.870734Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:35.870734Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:32.823631Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:32.823631Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
@@ -420,9 +420,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hashesToTransplant": ["ab1c66c58c6a7dfd81df25014f49401546257ef497cbee9119f2f48218ae1249",
-      "c76b98683558733257dc969a00d0a5b7588d794daaef1d6cbf37dcd7fa3ccddd"], "fromRefName":
-      "dev"}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["8a6adfc4063802ccaa0e2e41c8b251c6d9548c91eb73d0b5ce008dbcc3fd6e36",
+      "012d9e737d9bdbd7a7bda1768ed8d649285d31b562b09e266d6c28d3c2eebf1a"]}'
     headers:
       Accept:
       - '*/*'
@@ -460,7 +459,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"cd21ff6755a6061b66dddce329a36457ae3ffc63b472e0f30da68fb0a0eaf6e2\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"27e97c3848ae972e7e1aa688ce53ded88efa656424c61280476a3cd7dc1df6aa\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -484,196 +483,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"cd21ff6755a6061b66dddce329a36457ae3ffc63b472e0f30da68fb0a0eaf6e2\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"27e97c3848ae972e7e1aa688ce53ded88efa656424c61280476a3cd7dc1df6aa\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:35.959664Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:35.959664Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"9c5b1119011e2a6caf7b9e849520e89e81f86555f71abfcb9a64b1c7a7592a35\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:32.906627Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:32.906627Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"84bd622edc5f43e37c0719702b85f2e2a79bcf511468d44d31c967c8e418ef94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T13:48:35.915210Z\",\n
-        \   \"authorTime\" : \"2021-10-19T13:48:35.915210Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-19T20:45:32.864840Z\",\n
+        \   \"authorTime\" : \"2021-10-19T20:45:32.864840Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Length:
       - '704'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/contents/transplant.foo.bar?ref=main
-  response:
-    body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified
-        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
-        : null\n}"
-    headers:
-      Content-Length:
-      - '149'
-      Content-Type:
-      - application/json
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: '{"operations": [{"key": {"elements": ["transplant", "foo", "bar"]}, "type":
-      "DELETE"}], "commitMeta": {"commitTime": null, "committer": null, "author":
-      null, "properties": null, "signedOffBy": null, "message": "delete_message",
-      "authorTime": null, "hash": null}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '262'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=cd21ff6755a6061b66dddce329a36457ae3ffc63b472e0f30da68fb0a0eaf6e2
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"cd3bdbfe778e91a555a1eadb39794a464cf1403e205dcdb39577f4c8d845e852\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"c76b98683558733257dc969a00d0a5b7588d794daaef1d6cbf37dcd7fa3ccddd\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=c76b98683558733257dc969a00d0a5b7588d794daaef1d6cbf37dcd7fa3ccddd
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"cd3bdbfe778e91a555a1eadb39794a464cf1403e205dcdb39577f4c8d845e852\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=cd3bdbfe778e91a555a1eadb39794a464cf1403e205dcdb39577f4c8d845e852
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
       Content-Type:
       - application/json
     status:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -4,10 +4,25 @@
 import os
 import shutil
 import tempfile
+from typing import List
+from typing import Optional
 
 import pytest
+from _pytest.fixtures import FixtureRequest
+from assertpy import assert_that
+from click.testing import CliRunner
+from click.testing import Result
 from pytest import Session
+from vcr.request import Request
 
+from pynessie import cli
+from pynessie.model import ReferenceSchema
+
+# Per-test Nessie config directly
+nessie_config_dir: str
+
+# Helper variable to control VCR recording in test fixtures
+nessie_cleanup: bool = False
 
 def pytest_configure(config):  # noqa
     """Configure pytest."""
@@ -16,11 +31,91 @@ def pytest_configure(config):  # noqa
 
 def pytest_sessionstart(session: "Session") -> None:
     """Setup a fresh temporary config directory for tests."""
-    pytest.nessie_config_dir = tempfile.mkdtemp() + "/"
+    global nessie_config_dir
+    nessie_config_dir = tempfile.mkdtemp() + "/"
     # Instruct Confuse to keep Nessie config file in the temp location:
-    os.environ["NESSIEDIR"] = pytest.nessie_config_dir
+    os.environ["NESSIEDIR"] = nessie_config_dir
 
 
 def pytest_sessionfinish(session: "Session", exitstatus: int) -> None:
     """Remove temporary config directory."""
-    shutil.rmtree(pytest.nessie_config_dir)
+    global nessie_config_dir
+    shutil.rmtree(nessie_config_dir)
+
+
+def _run(args: List[str], input: Optional[str] = None, ret_val: int = 0) -> Result:
+    result = CliRunner().invoke(cli.cli, args, input=input)
+    if result.exit_code != ret_val:
+        print(result.output)
+        print(result)
+    assert_that(result.exit_code).is_equal_to(ret_val)
+    return result
+
+
+def _cli(args: List[str], input: Optional[str] = None, ret_val: int = 0) -> str:
+    return _run(args, input, ret_val).output
+
+
+def reset_nessie_server_state() -> None:
+    """Resets the Nessie Server to an initial, clean state for testing."""
+    # Delete all branches
+    branches = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
+    for branch in branches:
+        _cli(["branch", "-d", branch.name])
+
+    # Delete all tags
+    tags = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
+    for tag in tags:
+        _cli(["tag", "-d", tag.name])
+
+    # Note: This hash should match the java constant AbstractDatabaseAdapter.NO_ANCESTOR
+    no_ancestor_hash = "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+
+    # Re-create the main branch from the "root" (a.k.a. no ancestor) hash
+    _cli(["branch", "--force", "-o", no_ancestor_hash, "main", "main"])
+
+    # Verify the re-created main branch
+    branches = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
+    assert_that(branches).is_length(1)
+    assert_that(branches[0].name).is_equal_to("main")
+    assert_that(branches[0].hash_).is_equal_to(no_ancestor_hash)
+
+
+def before_record_cb(request: Request) -> Optional[Request]:
+    """VCR callback that instructs it to not record our "cleanup" requests."""
+    if nessie_cleanup:
+        return None
+    return request
+
+
+@pytest.fixture(scope="module")
+def vcr_config() -> dict:
+    """VCR config that adds a custom before_record_request callback."""
+    pytest.nessie_cleanup = False
+    return {
+        "before_record_request": before_record_cb,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_nessie_session_marker(request: "FixtureRequest", record_mode: str) -> None:
+    """This pytest fixture is invoked for all test methods and cleans up the Nessie Server state.
+
+    :param request Request object provided by the pytest framework
+    :param record_mode Recording mode provided by the VCR plugin
+    """
+    # Cleaning the Nessie Server state is meaningful only when we are recording,
+    # i.e. when the tests are running against a real server, not against VCR cassettes.
+    # Consequently, when the tests will run against VCR cassettes, the pre-recorded
+    # responses will simulate a "clean" server.
+    if record_mode is None or record_mode == "none":
+        return
+
+    # Clean the server state for tests that have the @pytest.mark.clean_nessie_session annotation
+    if request.node.get_closest_marker("vcr"):
+        global nessie_cleanup
+        try:
+            nessie_cleanup = True
+            reset_nessie_server_state()
+        finally:
+            nessie_cleanup = False

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -4,18 +4,13 @@
 import itertools
 import os
 from pathlib import Path
-from typing import List
-from typing import Optional
 
 import confuse
 import pytest
 import simplejson
 from assertpy import assert_that
-from click.testing import CliRunner
-from click.testing import Result
 
 from pynessie import __version__
-from pynessie import cli
 from pynessie.model import Branch
 from pynessie.model import Contents
 from pynessie.model import ContentsSchema
@@ -24,28 +19,17 @@ from pynessie.model import EntrySchema
 from pynessie.model import IcebergTable
 from pynessie.model import ReferenceSchema
 from pynessie.model import SqlView
-
-
-def _run(runner: CliRunner, args: List[str], input: Optional[str] = None, ret_val: int = 0) -> Result:
-    result = runner.invoke(cli.cli, args, input=input)
-    if result.exit_code != ret_val:
-        print(result.output)
-    assert result.exit_code == ret_val
-    return result
+from .conftest import _cli
+from .conftest import _run
 
 
 @pytest.mark.vcr
 def test_command_line_interface() -> None:
     """Test the CLI."""
-    runner = CliRunner()
-    result = _run(runner, list())
-    assert "Usage: cli" in result.output
-    help_result = _run(runner, ["--help"])
-    assert "Usage: cli" in help_result.output
-    help_result = _run(runner, ["--version"])
-    assert __version__ in help_result.output
-    help_result = _run(runner, ["--json", "branch", "-l"])
-    references = ReferenceSchema().loads(help_result.output, many=True)
+    assert "Usage: cli" in _cli(list())
+    assert "Usage: cli" in _cli(["--help"])
+    assert __version__ in _cli(["--version"])
+    references = ReferenceSchema().loads(_cli(["--json", "branch", "-l"]), many=True)
     assert len(references) == 1
     assert references[0].name == "main"
     assert isinstance(references[0], Branch)
@@ -53,41 +37,32 @@ def test_command_line_interface() -> None:
 
 def test_config_options() -> None:
     """Ensure config cli option is consistent."""
-    runner = CliRunner()
-    result = _run(runner, ["config"])
-    assert "Usage: cli" in result.output
+    assert "Usage: cli" in _cli(["config"])
     vars = ["--add x", "--get x", "--list", "--unset x"]
     for i in itertools.permutations(vars, 2):
-        result = _run(runner, ["config"] + [*i[0].split(" "), *i[1].split(" ")], ret_val=2)
-        assert "Error: Illegal usage: " in result.output
+        assert "Error: Illegal usage: " in _cli(["config"] + [*i[0].split(" "), *i[1].split(" ")], ret_val=2)
 
-    _run(runner, ["config", "x", "--add", "x"])
+    _cli(["config", "x", "--add", "x"])
 
 
 def test_set_unset() -> None:
     """Test config set/unset/list."""
-    runner = CliRunner()
-    _run(runner, ["config", "--add", "test.data", "123", "--type", "int"])
-    result = _run(runner, ["config", "test.data", "--type", "int"])
-    assert result.output == "123\n"
-    _run(runner, ["config", "--unset", "test.data"])
-    result = _run(runner, ["config", "--list"])
-    assert "123" not in result.output
+    _cli(["config", "--add", "test.data", "123", "--type", "int"])
+    assert _cli(["config", "test.data", "--type", "int"]) == "123\n"
+    _cli(["config", "--unset", "test.data"])
+    assert "123" not in _cli(["config", "--list"])
 
 
 @pytest.mark.vcr
 def test_remote() -> None:
     """Test setting and viewing remote."""
-    runner = CliRunner()
-    _run(runner, ["remote", "add", "http://test.url"])
-    _run(runner, ["remote", "add", "http://localhost:19120/api/v1"])
-    result = _run(runner, ["--json", "remote", "show"])
-    assert "main" in result.output
-    _run(runner, ["remote", "set-head", "dev"])
-    result = _run(runner, ["config", "default_branch"])
-    assert result.output == "dev\n"
-    _run(runner, ["remote", "set-head", "dev", "-d"])
-    result = _run(runner, ["config", "default_branch"], ret_val=1)
+    _cli(["remote", "add", "http://test.url"])
+    _cli(["remote", "add", "http://localhost:19120/api/v1"])
+    assert "main" in _cli(["--json", "remote", "show"])
+    _cli(["remote", "set-head", "dev"])
+    assert _cli(["config", "default_branch"]) == "dev\n"
+    _cli(["remote", "set-head", "dev", "-d"])
+    result = _run(["config", "default_branch"], ret_val=1)
     assert result.output == ""
     assert isinstance(result.exception, confuse.exceptions.ConfigTypeError)
 
@@ -98,49 +73,33 @@ def _new_table(table_id: str) -> IcebergTable:
 
 def _make_commit(
     key: str, table: Contents, branch: str, head_hash: str = None, message: str = "test message", author: str = "nessie test"
-) -> IcebergTable:
+) -> None:
     if not head_hash:
-        result = _run(CliRunner(), ["--json", "branch"])
-        refs = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
+        refs = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)}
         head_hash = refs[branch]
-    _run(
-        CliRunner(),
+    _cli(
         ["contents", "--set", "--stdin", key, "--ref", branch, "-m", message, "-c", head_hash, "--author", author],
         input=ContentsSchema().dumps(table),
     )
 
 
-def _reset_main() -> None:
-    # Note: This hash should match the java constant AbstractDatabaseAdapter.NO_ANCESTOR
-    no_ancestor_hash = "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
-    # Re-create branch main from the root hash (assuming in-memory store)
-    _run(CliRunner(), ["branch", "--force", "-o", no_ancestor_hash, "main", "main"])
-
-
 @pytest.mark.vcr
 def test_log() -> None:
     """Test log and log filtering."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 0
     table = _new_table("test_log")
     _make_commit("log.foo.bar", table, "main", author="nessie_user1")
-    result = _run(runner, ["--json", "contents", "log.foo.bar"])
-    tables = ContentsSchema().loads(result.output, many=True)
+    tables = ContentsSchema().loads(_cli(["--json", "contents", "log.foo.bar"]), many=True)
     assert len(tables) == 1
     assert tables[0] == table
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "log", logs[0]["hash"]])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", logs[0]["hash"]]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "contents", "--list"])
-    entries = EntrySchema().loads(result.output, many=True)
+    entries = EntrySchema().loads(_cli(["--json", "contents", "--list"]), many=True)
     assert len(entries) == 1
-    _run(
-        runner,
+    _cli(
         [
             "--json",
             "contents",
@@ -156,111 +115,83 @@ def test_log() -> None:
             "nessie_user2",
         ],
     )
-    result = _run(runner, ["--json", "log", "-n", 1])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "-n", 1]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 2
-    result = _run(runner, ["--json", "log", "{}..{}".format(logs[0]["hash"], logs[1]["hash"])])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "{}..{}".format(logs[0]["hash"], logs[1]["hash"])]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 2
-    result = _run(runner, ["--json", "log", "--author", "nessie_user1"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--author", "nessie_user1"]))
     assert len(logs) == 1
     assert_that(logs[0]["author"]).is_equal_to("nessie_user1")
-    result = _run(runner, ["--json", "log", "--author", "nessie_user2"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--author", "nessie_user2"]))
     assert len(logs) == 1
     assert_that(logs[0]["author"]).is_equal_to("nessie_user2")
-    result = _run(runner, ["--json", "log", "--author", "nessie_user2", "--author", "nessie_user1"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--author", "nessie_user2", "--author", "nessie_user1"]))
     assert len(logs) == 2
     # the committer is set on the server-side and is empty if we're not logged
     # in when performing a commit
-    result = _run(runner, ["--json", "log", "--committer", ""])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--committer", ""]))
     assert len(logs) == 2
-    result = _run(runner, ["--json", "log", "--query", "commit.author == 'nessie_user2' || commit.author == 'non_existing'"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--query", "commit.author == 'nessie_user2' || commit.author == 'non_existing'"]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "log", "--after", "2001-01-01T00:00:00+00:00", "--before", "2999-12-30T23:00:00+00:00"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--after", "2001-01-01T00:00:00+00:00", "--before", "2999-12-30T23:00:00+00:00"]))
     assert len(logs) == 2
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_branch() -> None:
     """Test create and assign refs."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "branch"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    references = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     assert len(references) == 1
-    _run(runner, ["branch", "dev"])
-    result = _run(runner, ["--json", "branch"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["branch", "dev"])
+    references = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     assert len(references) == 2
-    _run(runner, ["branch", "etl", "main"])
-    result = _run(runner, ["--json", "branch"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["branch", "etl", "main"])
+    references = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     assert len(references) == 3
-    _run(runner, ["branch", "-d", "etl"])
-    _run(runner, ["branch", "-d", "dev"])
-    result = _run(runner, ["--json", "branch"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["branch", "-d", "etl"])
+    _cli(["branch", "-d", "dev"])
+    references = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     assert len(references) == 1
 
 
 @pytest.mark.vcr
 def test_tag() -> None:
     """Test create and assign refs."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "tag"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    references = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
     assert len(references) == 0
-    _run(runner, ["tag", "dev-tag", "main"])
-    result = _run(runner, ["--json", "tag"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["tag", "dev-tag", "main"])
+    references = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
     assert len(references) == 1
-    _run(runner, ["tag", "etl-tag", "main"])
-    result = _run(runner, ["--json", "tag"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["tag", "etl-tag", "main"])
+    references = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
     assert len(references) == 2
-    _run(runner, ["tag", "-d", "etl-tag"])
-    _run(runner, ["tag", "-d", "dev-tag"])
-    result = _run(runner, ["--json", "tag"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["tag", "-d", "etl-tag"])
+    _cli(["tag", "-d", "dev-tag"])
+    references = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
     assert len(references) == 0
-    _run(runner, ["tag", "v1.0"])
-    result = _run(runner, ["--json", "tag"])
-    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
-    result = _run(runner, ["--json", "branch"])
-    branches = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
+    _cli(["tag", "v1.0"])
+    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)}
+    branches = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)}
     assert tags["v1.0"] == branches["main"]
-    _run(runner, ["tag", "-d", "v1.0"])
 
 
 @pytest.mark.vcr
 def test_commit_with_expected_state() -> None:
     """Test making a commit with some expected Contents, i.e. IcebergTable."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     _make_commit("commit.expected.contents", _new_table("test_expected_contents"), "dev", message="commit 1")
     # the second commit will use the Contents of the first one as "expected contents"
     _make_commit("commit.expected.contents", _new_table("test_expected_contents"), "dev", message="commit 2")
-    _run(runner, ["branch", "-d", "dev"])
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_commit_no_expected_state() -> None:
     """Test making two commit without any expected Contents, i.e. using DeltaLakeTable."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     table1 = DeltaLakeTable(
         id="test_commit_no_expected_state", metadata_location_history=["asd111"], checkpoint_location_history=["def"], last_checkpoint="x"
     )
@@ -270,95 +201,66 @@ def test_commit_no_expected_state() -> None:
     )
     # the second commit will set new contents without the "expected contents" parameter due to using a DeltaLakeTable
     _make_commit("commit.expected.contents", table2, "dev", message="commit 2")
-    _run(runner, ["branch", "-d", "dev"])
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_assign() -> None:
     """Test assign operation."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     _make_commit("assign.foo.bar", _new_table("test_assign"), "dev")
-    _run(runner, ["branch", "main", "dev", "--force"])
-    result = _run(runner, ["--json", "branch"])
-    branches = ReferenceSchema().loads(result.output, many=True)
+    _run(["branch", "main", "dev", "--force"])
+    branches = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     refs = {i.name: i.hash_ for i in branches}
     assert refs["main"] == refs["dev"]
-    _run(runner, ["tag", "v1.0", "main"])
-    result = _run(runner, ["--json", "tag"])
-    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
+    _cli(["tag", "v1.0", "main"])
+    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)}
     assert tags["v1.0"] == refs["main"]
-    _run(runner, ["tag", "v1.0", "dev", "--force"])
-    result = _run(runner, ["--json", "tag"])
-    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
+    _cli(["tag", "v1.0", "dev", "--force"])
+    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)}
     assert tags["v1.0"] == refs["dev"]
-    _run(runner, ["branch", "dev", "--delete"])
-    _run(runner, ["tag", "v1.0", "--delete"])
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
-    _run(runner, ["--json", "contents", "--delete", "assign.foo.bar", "--ref", "main", "-m", "delete_message", "-c", logs[0]["hash"]])
-    _run(runner, ["branch", "main", "--delete"])
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_merge() -> None:
     """Test merge operation."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     _make_commit("merge.foo.bar", _new_table("test_merge"), "dev")
-    refs = ReferenceSchema().loads(_run(runner, ["--json", "branch", "-l", "main"]).output, many=True)
+    refs = ReferenceSchema().loads(_cli(["--json", "branch", "-l", "main"]), many=True)
     main_hash = next(i.hash_ for i in refs if i.name == "main")
-    _run(runner, ["merge", "dev", "-c", main_hash])
-    result = _run(runner, ["--json", "branch"])
-    branches = ReferenceSchema().loads(result.output, many=True)
+    _cli(["merge", "dev", "-c", main_hash])
+    branches = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     refs = {i.name: i.hash_ for i in branches}
     assert refs["main"] == refs["dev"]
-    _run(runner, ["branch", "dev", "--delete"])
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
-    _run(runner, ["--json", "contents", "--delete", "merge.foo.bar", "--ref", "main", "-m", "delete_message", "-c", logs[0]["hash"]])
-    _run(runner, ["branch", "main", "--delete"])
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_transplant() -> None:
     """Test transplant operation."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     _make_commit("transplant.foo.bar", _new_table("test_transplant_1"), "dev")
     _make_commit("bar.bar", _new_table("test_transplant_2"), "dev")
     _make_commit("foo.baz", _new_table("test_transplant_3"), "dev")
-    refs = ReferenceSchema().loads(_run(runner, ["--json", "branch", "-l"]).output, many=True)
+    refs = ReferenceSchema().loads(_cli(["--json", "branch", "-l"]), many=True)
     main_hash = next(i.hash_ for i in refs if i.name == "main")
-    result = _run(runner, ["--json", "log", "--ref", "dev"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--ref", "dev"]))
     first_hash = [i["hash"] for i in logs]
-    _run(runner, ["cherry-pick", "-c", main_hash, "-s", "dev", first_hash[1], first_hash[0]])
+    _cli(["cherry-pick", "-c", main_hash, "-s", "dev", first_hash[1], first_hash[0]])
 
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 2  # two commits were transplanted into an empty `main`
-    _run(runner, ["--json", "contents", "--delete", "transplant.foo.bar", "--ref", "main", "-m", "delete_message", "-c", logs[0]["hash"]])
-    _run(runner, ["branch", "dev", "--delete"])
-    _run(runner, ["branch", "main", "--delete"])
-    _reset_main()
 
 
 @pytest.mark.doc
 def test_all_help_options() -> None:
     """Write out all help options to std out."""
-    runner = CliRunner()
     args = ["", "config", "branch", "tag", "remote", "log", "merge", "cherry-pick", "contents"]
 
     for i in args:
-        result = _run(runner, [x for x in [i] if x] + ["--help"])
+        result = _cli([x for x in [i] if x] + ["--help"])
         cwd = os.getcwd()
         with open(Path(Path(cwd), "docs", "{}.rst".format(i if i else "main")), "w") as f:
             f.write(".. code-block:: bash\n\n\t")
-            for line in result.output.split("\n"):
+            for line in result.split("\n"):
                 f.write(line + "\n\t")
             f.write("\n\n")
 
@@ -366,9 +268,8 @@ def test_all_help_options() -> None:
 @pytest.mark.vcr
 def test_contents_listing() -> None:
     """Test contents listing and filtering."""
-    runner = CliRunner()
     branch = "contents_listing_dev"
-    _run(runner, ["branch", branch])
+    _cli(["branch", branch])
 
     iceberg_table = IcebergTable(id="test_contents_listing", metadata_location="/a/b/c", id_generators="xyz")
     delta_lake_table = DeltaLakeTable(
@@ -380,47 +281,40 @@ def test_contents_listing() -> None:
     _make_commit("this.is.delta.bar", delta_lake_table, branch)
     _make_commit("this.is.sql.baz", sql_view, branch)
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "this.is.iceberg.foo"])
-    tables = ContentsSchema().loads(result.output, many=True)
+    tables = ContentsSchema().loads(_cli(["--json", "contents", "--ref", branch, "this.is.iceberg.foo"]), many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0]).is_equal_to(iceberg_table)
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "this.is.delta.bar"])
-    tables = ContentsSchema().loads(result.output, many=True)
+    tables = ContentsSchema().loads(_cli(["--json", "contents", "--ref", branch, "this.is.delta.bar"]), many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0]).is_equal_to(delta_lake_table)
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--type", "ICEBERG_TABLE"])
-    tables = EntrySchema().loads(result.output, many=True)
+    tables = EntrySchema().loads(_cli(["--json", "contents", "--ref", branch, "--list", "--type", "ICEBERG_TABLE"]), many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0].kind).is_equal_to("ICEBERG_TABLE")
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--type", "DELTA_LAKE_TABLE"])
-    tables = EntrySchema().loads(result.output, many=True)
+    tables = EntrySchema().loads(_cli(["--json", "contents", "--ref", branch, "--list", "--type", "DELTA_LAKE_TABLE"]), many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0].kind).is_equal_to("DELTA_LAKE_TABLE")
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--query", "entry.contentType == 'ICEBERG_TABLE'"])
-    tables = EntrySchema().loads(result.output, many=True)
+    result = _cli(["--json", "contents", "--ref", branch, "--list", "--query", "entry.contentType == 'ICEBERG_TABLE'"])
+    tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0].kind).is_equal_to("ICEBERG_TABLE")
 
-    result = _run(
-        runner,
-        ["--json", "contents", "--ref", branch, "--list", "--query", "entry.contentType in ['ICEBERG_TABLE', 'DELTA_LAKE_TABLE']"],
+    result = _cli(
+        ["--json", "contents", "--ref", branch, "--list", "--query", "entry.contentType in ['ICEBERG_TABLE', 'DELTA_LAKE_TABLE']"]
     )
-    tables = EntrySchema().loads(result.output, many=True)
+    tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(2)
     assert_that(set(t.kind for t in tables)).is_equal_to({"DELTA_LAKE_TABLE", "ICEBERG_TABLE"})
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--query", "entry.namespace.startsWith('this.is.del')"])
-    tables = EntrySchema().loads(result.output, many=True)
+    result = _cli(["--json", "contents", "--ref", branch, "--list", "--query", "entry.namespace.startsWith('this.is.del')"])
+    tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0].kind).is_equal_to("DELTA_LAKE_TABLE")
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--query", "entry.namespace.startsWith('this.is')"])
-    tables = EntrySchema().loads(result.output, many=True)
+    result = _cli(["--json", "contents", "--ref", branch, "--list", "--query", "entry.namespace.startsWith('this.is')"])
+    tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(3)
     assert_that(set(i.kind for i in tables)).is_equal_to({"ICEBERG_TABLE", "VIEW", "DELTA_LAKE_TABLE"})
-
-    _run(runner, ["branch", branch, "--delete"])

--- a/python/tests/test_nessie_cli_auth.py
+++ b/python/tests/test_nessie_cli_auth.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Authentication tests for Nessi CLI."""
 import pytest
-from click.testing import CliRunner
 
-from .test_nessie_cli import _run
+from .conftest import _cli
 
 
 @pytest.fixture(scope="module")
@@ -15,14 +14,11 @@ def vcr_config() -> dict:
 @pytest.mark.vcr
 def test_bearer_auth() -> None:
     """Test the "remote show" command with bearer authentication."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "--auth-token", "test_token_123", "remote", "show"])
-    assert "main" in result.output
+    assert "main" in _cli(["--json", "--auth-token", "test_token_123", "remote", "show"])
 
 
 @pytest.mark.vcr
 def test_bearer_auth_invalid() -> None:
     """Test any command with an invalid bearer authentication token."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "--auth-token", "invalid", "remote", "show"], ret_val=1)
-    assert "401 Client Error: Unauthorized" in result.output
+    result = _cli(["--json", "--auth-token", "invalid", "remote", "show"], ret_val=1)
+    assert "401 Client Error: Unauthorized" in result

--- a/python/tests/test_nessie_cli_error.py
+++ b/python/tests/test_nessie_cli_error.py
@@ -15,9 +15,8 @@
 #  limitations under the License.
 
 import pytest
-from click.testing import CliRunner
 
-from .test_nessie_cli import _run
+from .conftest import _cli
 
 
 # Note: tests in this file use custom VCR files for error server responses.
@@ -29,16 +28,14 @@ from .test_nessie_cli import _run
 @pytest.mark.vcr
 def test_server_error_html() -> None:
     """Test the handling of 500 responses with HTML payload (unexpected, but possible)."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "remote", "show"], ret_val=1)
-    assert "Internal Server Error" in result.output
-    assert "500" in result.output
+    result = _cli(["--json", "remote", "show"], ret_val=1)
+    assert "Internal Server Error" in result
+    assert "500" in result
 
 
 @pytest.mark.vcr
 def test_server_error_json() -> None:
     """Test the handling of 500 responses with JSON payload."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "remote", "show"], ret_val=1)
-    assert "Default branch isn't a branch" in result.output
-    assert "500" in result.output
+    result = _cli(["--json", "remote", "show"], ret_val=1)
+    assert "Default branch isn't a branch" in result
+    assert "500" in result


### PR DESCRIPTION
* Add pytest fixtures to clean test branches up in the Nessie
  server before VCR tests.

* Add utility method _cli(...) to automatically unwrap CLI output

* Move global helper variables from the `pytest` scope to local scope