### PR TITLE
Exclude tcnative from performance tests and fix a regression in performance tests

### DIFF
--- a/perftest/gatling/pom.xml
+++ b/perftest/gatling/pom.xml
@@ -44,6 +44,12 @@
       <groupId>io.gatling.highcharts</groupId>
       <artifactId>gatling-charts-highcharts</artifactId>
       <version>${gatling.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
@@ -78,8 +78,7 @@ class CommitToBranchSimulation extends Simulation {
               CommitMeta.fromMessage(s"test-commit $userId $commitNum")
             )
             .operation(op)
-
-          updatedBranch.commit()
+            .commit()
 
           session.set("branch", updatedBranch)
         }


### PR DESCRIPTION
It will exclude `netty-tcnative-boringssl-static` from `gatling-charts-highcharts` as it seems [it is not recommended](https://github.com/quarkusio/quarkus/pull/20684#issuecomment-942990746) to use it in Java 11+, [perhaps due to the performance plenty](https://stackoverflow.com/a/66759725) in Java 11+ with OpenSSL, BoringSSL.. etc?

Also there was a regression in the performance tests where there were `org.projectnessie.client.http.v1api.HttpCommitMultipleOperation` casting errors, it should be fixed now.