### PR TITLE
Fix Quarkus artifact relocation warning (quarkus-vertx-web -> quarkus-reactive-routes)

### DIFF
--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -119,7 +119,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-vertx-web</artifactId>
+      <artifactId>quarkus-reactive-routes</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Fixes the following warning:
`[WARNING] The artifact io.quarkus:quarkus-vertx-web:jar:2.3.1.Final has been relocated to io.quarkus:quarkus-reactive-routes:jar:2.3.1.Final`