### PR TITLE
Bump to GraalVM 21.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>8</maven.compiler.release>
     <argLine />
+    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-native-image:21.3-java11</quarkus.native.builder-image>
 
     <!-- Version properties -->
     <antlr.version>4.8</antlr.version>


### PR DESCRIPTION
Benefits (on my machine):

| GraalVM version | Native image build time (local) | Native image build time (CI) | Image size |
| --------------- | ----------------------- | ---------- | ---------- |
| 21.2            | 200s                    | 700s | 177MB |
| 21.3            | 130s                    | 600s | 169MB |

Fixes #2441