### PR TITLE
Bump Quarkus version from 2.4.0.Final to 2.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <openapi.version>2.0</openapi.version>
     <prometheus.version>0.9.0</prometheus.version>
     <protobuf.version>3.19.1</protobuf.version>
-    <quarkus.version>2.4.0.Final</quarkus.version>
+    <quarkus.version>2.4.1.Final</quarkus.version>
     <reactor.version>2020.0.12</reactor.version>
     <rocksdb.version>6.25.3</rocksdb.version>
     <scala2.12.version>2.12.13</scala2.12.version>

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.server.config;
 
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
 /** Configuration for Nessie authentication settings. */
+@StaticInitSafe
 @ConfigMapping(prefix = "nessie.server.authentication")
 public interface QuarkusNessieAuthenticationConfig {
 

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthorizationConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthorizationConfig.java
@@ -15,12 +15,14 @@
  */
 package org.projectnessie.server.config;
 
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import java.util.Map;
 
 /** Configuration for Nessie authorization settings. */
+@StaticInitSafe
 @ConfigMapping(prefix = "nessie.server.authorization")
 public interface QuarkusNessieAuthorizationConfig {
 

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusServerConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusServerConfig.java
@@ -15,19 +15,24 @@
  */
 package org.projectnessie.server.config;
 
-import io.quarkus.arc.config.ConfigProperties;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import io.quarkus.runtime.annotations.StaticInitSafe;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 import org.projectnessie.services.config.ServerConfig;
 
 /** Nessie server config for Quarkus. */
-@ConfigProperties(prefix = "nessie.server")
+@StaticInitSafe
+@ConfigMapping(prefix = "nessie.server")
 public interface QuarkusServerConfig extends ServerConfig {
 
-  @ConfigProperty(name = "default-branch", defaultValue = "main")
   @Override
+  @WithName("default-branch")
+  @WithDefault("main")
   String getDefaultBranch();
 
-  @ConfigProperty(name = "send-stacktrace-to-client", defaultValue = "false")
   @Override
+  @WithName("send-stacktrace-to-client")
+  @WithDefault("false")
   boolean sendStacktraceToClient();
 }

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusVersionStoreAdvancedConfig.java
@@ -16,6 +16,7 @@
 package org.projectnessie.server.config;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithConverter;
@@ -34,6 +35,7 @@ import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
  * <p>This interface overrides all getters to assign explicit Quarkus configuration names and
  * default values to them.
  */
+@StaticInitSafe
 @ConfigMapping(prefix = "nessie.version.store.advanced")
 @RegisterForReflection(targets = TrimmedStringConverter.class)
 public interface QuarkusVersionStoreAdvancedConfig

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/VersionStoreConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/VersionStoreConfig.java
@@ -16,11 +16,13 @@
 package org.projectnessie.server.config;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
 /** Version store configuration. */
+@StaticInitSafe
 @ConfigMapping(prefix = "nessie.version.store")
 public interface VersionStoreConfig {
 
@@ -49,6 +51,7 @@ public interface VersionStoreConfig {
   @WithDefault("true")
   boolean isMetricsEnabled();
 
+  @StaticInitSafe
   @ConfigMapping(prefix = "nessie.version.store.rocks")
   interface RocksVersionStoreConfig {
     @WithName("db-path")

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/DynamoDatabaseAdapterBuilder.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/DynamoDatabaseAdapterBuilder.java
@@ -19,11 +19,11 @@ import static org.projectnessie.server.config.VersionStoreConfig.VersionStoreTyp
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.projectnessie.server.config.QuarkusVersionStoreAdvancedConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.dynamodb.DynamoDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.dynamodb.DynamoDatabaseClient;
 import org.projectnessie.versioned.persist.dynamodb.ProvidedDynamoClientConfig;
+import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 /** DynamoDB version store factory. */
@@ -31,7 +31,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 @Dependent
 public class DynamoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject DynamoDbClient dynamoConfig;
-  @Inject QuarkusVersionStoreAdvancedConfig config;
+  @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
   public DatabaseAdapter newDatabaseAdapter() {

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/InmemoryDatabaseAdapterBuilder.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/InmemoryDatabaseAdapterBuilder.java
@@ -19,16 +19,16 @@ import static org.projectnessie.server.config.VersionStoreConfig.VersionStoreTyp
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.projectnessie.server.config.QuarkusVersionStoreAdvancedConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.inmem.InmemoryStore;
+import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 
 /** In-memory version store factory. */
 @StoreType(INMEMORY)
 @Dependent
 public class InmemoryDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
-  @Inject QuarkusVersionStoreAdvancedConfig config;
+  @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
   public DatabaseAdapter newDatabaseAdapter() {

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/MongoDatabaseAdapterBuilder.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/MongoDatabaseAdapterBuilder.java
@@ -24,11 +24,11 @@ import io.quarkus.mongodb.runtime.MongoClients;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.projectnessie.server.config.QuarkusVersionStoreAdvancedConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.mongodb.MongoClientConfig;
 import org.projectnessie.versioned.persist.mongodb.MongoDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.mongodb.MongoDatabaseClient;
+import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 
 /** Version store factory for the MongoDB Database Adapter. */
 @StoreType(MONGO)
@@ -38,7 +38,7 @@ public class MongoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @ConfigProperty(name = "quarkus.mongodb.database")
   String databaseName;
 
-  @Inject QuarkusVersionStoreAdvancedConfig config;
+  @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
   public DatabaseAdapter newDatabaseAdapter() {

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/RocksDatabaseAdapterBuilder.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/RocksDatabaseAdapterBuilder.java
@@ -19,9 +19,9 @@ import static org.projectnessie.server.config.VersionStoreConfig.VersionStoreTyp
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.projectnessie.server.config.QuarkusVersionStoreAdvancedConfig;
 import org.projectnessie.server.config.VersionStoreConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.rocks.ImmutableRocksDbConfig;
 import org.projectnessie.versioned.persist.rocks.RocksDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.rocks.RocksDbInstance;
@@ -31,7 +31,7 @@ import org.projectnessie.versioned.persist.rocks.RocksDbInstance;
 @Dependent
 public class RocksDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject VersionStoreConfig.RocksVersionStoreConfig rocksConfig;
-  @Inject QuarkusVersionStoreAdvancedConfig config;
+  @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
   public DatabaseAdapter newDatabaseAdapter() {


### PR DESCRIPTION
Contains the code-changes to revert the workarounds added in #2438

Quarkus 2.4.1.Final seems to have https://github.com/quarkusio/quarkus/pull/20940 to fix https://github.com/quarkusio/quarkus/issues/20916 and https://github.com/quarkusio/quarkus/issues/20917
