### PR TITLE
Disable MongoDB devservices

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -69,6 +69,8 @@ nessie.version.store.type=INMEMORY
 ## MongoDB version store specific configuration
 quarkus.mongodb.database=nessie
 #quarkus.mongodb.connection-string=mongodb://localhost:27017
+# fixed at buildtime
+quarkus.mongodb.devservices.enabled=false
 
 ## Dynamo
 quarkus.dynamodb.aws.region=us-west-2


### PR DESCRIPTION
With #2472 running MongoDB devservices is no longer necessary.

Nessie's tests do not use the MongoDB test container managed by Quarkus.