### PR TITLE
Fix running quarkus:dev

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -185,6 +185,29 @@
           </execution>
         </executions>
       </plugin>
+      <!-- since quarkus 2.4.0.Final quarkus:dev expects the META-INF/resources folder under target -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <resources>
+                <resource>
+                  <targetPath>META-INF/resources</targetPath>
+                  <directory>build</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
since quarkus 2.4.0.Final quarkus:dev expects the META-INF/resources
folder under target.

The issue is happening because of this line: https://github.com/quarkusio/quarkus/pull/20500/files#diff-dbfecb8ead57f5ad197c876b824b224ea62a3711ba4a3d2c0bb07da027aa11d1R708

Previously it was doing this via `localProject.getSourcesDir().toAbsolutePath()` but now it is checking `module.getMainResources().iterator().next().getDestinationDir().toPath().toAbsolutePath()`.

Since our `META-INF/resources` directory is basically pointing to the `build` dir as defined in https://github.com/projectnessie/nessie/blob/1d9e32e47c573f9c0906a264f83066f6a45dde03/ui/pom.xml#L33-L39 the actual `META-INF/resources` directory doesn't exist under `target`, thus `quarkus:dev` complains