### PR TITLE
Clean up and improve `nessie log` cli command experience

### DIFF
--- a/python/docs/log.rst
+++ b/python/docs/log.rst
@@ -1,19 +1,36 @@
 .. code-block:: bash
 
-	Usage: cli log [OPTIONS] [REVISION_RANGE] [PATHS]...
+	Usage: cli log [OPTIONS] [REF]
 	
 	  Show commit log.
 	
-	  REVISION_RANGE optional hash to start viewing log from. If of the form
-	  <start_hash>..<end_hash> only show log for given range on the particular ref
-	  that was provided
+	  REF name of branch or tag to use to show the commit logs
 	
-	  PATHS optional list of paths. If given, only show commits which affected the
-	  given paths
+	  Examples:
+	
+	      nessie log -> show commit logs using the configured default branch
+	
+	      nessie log dev -> show commit logs for 'dev' branch
+	
+	      nessie log -n 5 dev -> show commit logs for 'dev' branch limited by 5
+	      commits
+	
+	      nessie log --revision-range 12345678abcdef..12345678efghj dev -> show
+	      commit logs in range of hash '12345678abcdef' and '12345678efghj' in 'dev'
+	      branch
+	
+	      nessie log --author nessie.user dev -> show commit logs for user
+	      'nessie.user' in 'dev' branch
+	
+	      nessie log --query "commit.author == 'nessie_user2' || commit.author ==
+	      'non_existing'" dev -> show commit logs using query in 'dev' branch
+	
+	      nessie log --after "2019-01-01T00:00:00+00:00" --before
+	      "2021-01-01T00:00:00+00:00" dev -> show commit logs between
+	      "2019-01-01T00:00:00+00:00" and "2021-01-01T00:00:00+00:00" in 'dev'
+	      branch
 	
 	Options:
-	  -r, --ref TEXT                  branch to list from. If not supplied the
-	                                  default branch from config is used
 	  -n, --number INTEGER            number of log entries to return
 	  --since, --after TEXT           Only include commits newer than specific date,
 	                                  such as '2001-01-01T00:00:00+00:00'
@@ -26,6 +43,11 @@
 	                                  the logged in user/account who performed the
 	                                  commit). Supports specifying multiple
 	                                  committers to filter by.
+	  -r, --revision-range TEXT       Hash to start viewing log from. If of the form
+	                                  '<start_hash>'..'<end_hash>' only show log for
+	                                  given range on the particular ref that was
+	                                  provided, the '<end_hash>' is inclusive and
+	                                  '<start_hash>' is exclusive.
 	  --query, --query-expression TEXT
 	                                  Allows advanced filtering using the Common
 	                                  Expression Language (CEL). An intro to CEL can

--- a/python/pynessie/cli.py
+++ b/python/pynessie/cli.py
@@ -186,7 +186,7 @@ def set_head(ctx: ContextObject, head: str, delete: bool) -> None:
 
 
 @cli.command("log")
-@click.option("-r", "--ref", help="branch to list from. If not supplied the default branch from config is used")
+@click.argument("ref", nargs=1, required=False)
 @click.option("-n", "--number", help="number of log entries to return", type=int)
 @click.option("--since", "--after", help="Only include commits newer than specific date, such as '2001-01-01T00:00:00+00:00'")
 @click.option("--until", "--before", help="Only include commits older than specific date, such as '2999-12-30T23:00:00+00:00'")
@@ -201,8 +201,13 @@ def set_head(ctx: ContextObject, head: str, delete: bool) -> None:
     help="Limit commits to a specific committer (this is the logged in user/account who performed the commit). "
     "Supports specifying multiple committers to filter by.",
 )
-@click.argument("revision_range", nargs=1, required=False)
-@click.argument("paths", nargs=-1, type=click.Path(exists=False), required=False)
+@click.option(
+    "-r",
+    "--revision-range",
+    help="Hash to start viewing log from. If of the form '<start_hash>'..'<end_hash>' "
+    "only show log for given range on the particular ref that was provided, the '<end_hash>' "
+    "is inclusive and '<start_hash>' is exclusive.",
+)
 @click.option(
     "--query",
     "--query-expression",
@@ -229,15 +234,31 @@ def log(  # noqa: C901
     author: List[str],
     committer: List[str],
     revision_range: str,
-    paths: Tuple[click.Path],
     query_expression: str,
 ) -> None:
     """Show commit log.
 
-    REVISION_RANGE optional hash to start viewing log from. If of the form <start_hash>..<end_hash> only show log
-    for given range on the particular ref that was provided
+    REF name of branch or tag to use to show the commit logs
 
-    PATHS optional list of paths. If given, only show commits which affected the given paths
+    Examples:
+
+        nessie log -> show commit logs using the configured default branch
+
+        nessie log dev -> show commit logs for 'dev' branch
+
+        nessie log -n 5 dev -> show commit logs for 'dev' branch limited by 5 commits
+
+        nessie log --revision-range 12345678abcdef..12345678efghj dev -> show commit logs in range of hash
+    '12345678abcdef' and '12345678efghj' in 'dev' branch
+
+        nessie log --author nessie.user dev -> show commit logs for user 'nessie.user' in 'dev' branch
+
+        nessie log --query "commit.author == 'nessie_user2' || commit.author == 'non_existing'" dev ->
+    show commit logs using query in 'dev' branch
+
+        nessie log --after "2019-01-01T00:00:00+00:00" --before "2021-01-01T00:00:00+00:00" dev ->
+    show commit logs between "2019-01-01T00:00:00+00:00" and "2021-01-01T00:00:00+00:00" in 'dev' branch
+
     """
     if not ref:
         ref = ctx.nessie.get_default_branch()
@@ -263,14 +284,23 @@ def log(  # noqa: C901
     if ctx.json:
         click.echo(CommitMetaSchema().dumps(log_result, many=True))
     else:
-        click.echo_via_pager(_format_log_result(x) for x in log_result)
+        click.echo_via_pager(_format_log_result(x, ref, index) for index, x in enumerate(log_result))
 
 
-def _format_log_result(x: CommitMeta) -> str:
-    result = click.style("commit {}\n".format(x.hash_), fg="yellow")
+def _format_log_result(x: CommitMeta, ref: str, index: int) -> str:
+    result = _format_commit_log_string(x.hash_, ref, index)
     result += click.style("Author: {}\n".format(x.author))
     result += click.style("Date: {}\n".format(_format_time(x.commitTime)))
     result += click.style("\n\t{}\n\n".format(x.message))
+    return result
+
+
+def _format_commit_log_string(commit_hash: str, ref: str, index: int) -> str:
+    result = click.style("commit {}".format(commit_hash), fg="yellow")
+    if index == 0:
+        result += click.style(" ({})\n".format(ref), fg="green")
+    else:
+        result += "\n"
     return result
 
 

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -59,16 +59,183 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees
+    uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n} ]"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '125'
+      - '121'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/main
+  response:
+    body:
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '121'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev_test_log", "type": "BRANCH"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
+  response:
+    body:
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev_test_log\",\n  \"hash\"
+        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '129'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev_test_log\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}
+        ]"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '256'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/contents/log.foo.dev?ref=dev_test_log
+  response:
+    body:
+      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
+        : \"Could not find contents for key 'log.foo.dev' in reference 'dev_test_log'.\",\n
+        \ \"errorCode\" : \"CONTENTS_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '205'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"commitMeta": {"commitTime": null, "hash": null, "author": "nessie_user1",
+      "properties": null, "signedOffBy": null, "message": "test message", "committer":
+      null, "authorTime": null}, "operations": [{"contents": {"id": "test_log_dev",
+      "idGenerators": "xyz", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"},
+      "key": {"elements": ["log", "foo", "dev"]}, "expectedContents": null, "type":
+      "PUT"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '400'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/branch/dev_test_log/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+  response:
+    body:
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev_test_log\",\n  \"hash\"
+        : \"4bb49247b353837cbd86ea44d2dc2d1dfee4042ddc177f15cc31b8c14b895329\"\n}"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '129'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
+        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev_test_log\",\n  \"hash\" : \"4bb49247b353837cbd86ea44d2dc2d1dfee4042ddc177f15cc31b8c14b895329\"\n}
+        ]"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '256'
     status:
       code: 200
       message: OK
@@ -99,11 +266,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"author": "nessie_user1", "commitTime": null, "committer":
-      null, "properties": null, "message": "test message", "hash": null, "signedOffBy":
-      null, "authorTime": null}, "operations": [{"expectedContents": null, "contents":
-      {"metadataLocation": "/a/b/c", "id": "test_log", "idGenerators": "xyz", "type":
-      "ICEBERG_TABLE"}, "key": {"elements": ["log", "foo", "bar"]}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"commitTime": null, "hash": null, "author": "nessie_user1",
+      "properties": null, "signedOffBy": null, "message": "test message", "committer":
+      null, "authorTime": null}, "operations": [{"contents": {"id": "test_log", "idGenerators":
+      "xyz", "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "key": {"elements":
+      ["log", "foo", "bar"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -121,7 +288,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -145,7 +312,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -194,7 +361,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -218,10 +385,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -246,7 +413,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -267,13 +434,13 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -298,7 +465,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -359,8 +526,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"author": "nessie_user2", "commitTime": null, "committer":
-      null, "properties": null, "message": "delete_message", "hash": null, "signedOffBy":
+    body: '{"commitMeta": {"commitTime": null, "hash": null, "author": "nessie_user2",
+      "properties": null, "signedOffBy": null, "message": "delete_message", "committer":
       null, "authorTime": null}, "operations": [{"key": {"elements": ["log", "foo",
       "bar"]}, "type": "DELETE"}]}'
     headers:
@@ -377,10 +544,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -404,7 +571,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -428,11 +595,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?max=1
   response:
     body:
-      string: "{\n  \"token\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
-        \ \"operations\" : [ {\n    \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\",\n
+      string: "{\n  \"token\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
+        \ \"operations\" : [ {\n    \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.336356Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.336356Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.401548Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.401548Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : true\n}"
     headers:
       Content-Type:
@@ -454,93 +621,13 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree
+    uri: http://localhost:19120/api/v1/trees/tree/dev_test_log/log
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '121'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log
-  response:
-    body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.336356Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.336356Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"4bb49247b353837cbd86ea44d2dc2d1dfee4042ddc177f15cc31b8c14b895329\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '708'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '121'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634&endHash=482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1
-  response:
-    body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.170562Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.170562Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -565,7 +652,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -589,14 +676,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.336356Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.336356Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.401548Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.401548Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -621,7 +708,115 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '121'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea&endHash=d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731
+  response:
+    body:
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
+        : { }\n  } ],\n  \"hasMore\" : false\n}"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '384'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree
+  response:
+    body:
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '121'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/main/log
+  response:
+    body:
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.401548Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.401548Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
+        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
+        : { }\n  } ],\n  \"hasMore\" : false\n}"
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '708'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree
+  response:
+    body:
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -645,10 +840,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user1%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -673,7 +868,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -697,10 +892,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user2%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.336356Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.336356Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.401548Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.401548Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -725,7 +920,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -749,14 +944,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28commit.author%3D%3D%27nessie_user2%27+%7C%7C+commit.author%3D%3D%27nessie_user1%27%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.336356Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.336356Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.401548Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.401548Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -781,7 +976,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -805,14 +1000,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.committer%3D%3D%27%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.336356Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.336356Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.401548Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.401548Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -837,7 +1032,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -861,10 +1056,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author+%3D%3D+%27nessie_user2%27+%7C%7C+commit.author+%3D%3D+%27non_existing%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.336356Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.336356Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.401548Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.401548Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -889,7 +1084,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -913,14 +1108,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28timestamp%28commit.commitTime%29+%3E+timestamp%28%272001-01-01T00%3A00%3A00%2B00%3A00%27%29+%26%26+timestamp%28commit.commitTime%29+%3C+timestamp%28%272999-12-30T23%3A00%3A00%2B00%3A00%27%29%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"46a1f67b4c8a701dc86319bbc1016b39f931167e22373f18a1180eb8850a5634\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.336356Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.336356Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"482225db9fd902729f5f1b400a64a6aea40ed01ac5dc4547e3923f61273bd5b1\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.401548Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.401548Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-25T15:52:27.161671Z\",\n
-        \   \"authorTime\" : \"2021-10-25T15:52:27.161671Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-27T15:39:16.240153Z\",\n
+        \   \"authorTime\" : \"2021-10-27T15:39:16.240153Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -88,6 +88,9 @@ def test_log() -> None:
     """Test log and log filtering."""
     logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 0
+    _cli(["branch", "dev_test_log"])
+    table = _new_table("test_log_dev")
+    _make_commit("log.foo.dev", table, "dev_test_log", author="nessie_user1")
     table = _new_table("test_log")
     _make_commit("log.foo.bar", table, "main", author="nessie_user1")
     tables = ContentsSchema().loads(_cli(["--json", "contents", "log.foo.bar"]), many=True)
@@ -95,7 +98,7 @@ def test_log() -> None:
     assert tables[0] == table
     logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 1
-    logs = simplejson.loads(_cli(["--json", "log", logs[0]["hash"]]))
+    logs = simplejson.loads(_cli(["--json", "log", "--revision-range", logs[0]["hash"]]))
     assert len(logs) == 1
     entries = EntrySchema().loads(_cli(["--json", "contents", "--list"]), many=True)
     assert len(entries) == 1
@@ -117,9 +120,11 @@ def test_log() -> None:
     )
     logs = simplejson.loads(_cli(["--json", "log", "-n", 1]))
     assert len(logs) == 1
+    logs = simplejson.loads(_cli(["--json", "log", "dev_test_log"]))
+    assert len(logs) == 1
     logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 2
-    logs = simplejson.loads(_cli(["--json", "log", "{}..{}".format(logs[0]["hash"], logs[1]["hash"])]))
+    logs = simplejson.loads(_cli(["--json", "log", "--revision-range", "{}..{}".format(logs[0]["hash"], logs[1]["hash"])]))
     assert len(logs) == 1
     logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 2
@@ -250,7 +255,7 @@ def test_transplant() -> None:
     _make_commit("foo.baz", _new_table("test_transplant_3"), "dev")
     refs = ReferenceSchema().loads(_cli(["--json", "branch", "-l"]), many=True)
     main_hash = next(i.hash_ for i in refs if i.name == "main")
-    logs = simplejson.loads(_cli(["--json", "log", "--ref", "dev"]))
+    logs = simplejson.loads(_cli(["--json", "log", "dev"]))
     first_hash = [i["hash"] for i in logs]
     _cli(["cherry-pick", "-c", main_hash, "-s", "dev", first_hash[1], first_hash[0]])
 


### PR DESCRIPTION
Fixes https://github.com/projectnessie/nessie/issues/2298. 

This is some clean up for `nessie log` command in the cli. Now the reference will be taken as argument and the revision range as an option (`-r` or `--revision-range`) in order to allow some consistent with other commands as well. As well, adding the branch name (in green color) in the first commit similar to `git log <branch>` command, example:
```
$ nessie log dev

commit 8a262495712e48cc9814708f605273b403df4987dde72f8f4dab06509858d6ea (dev)
Author: nessie_user2
Date: Wed Oct 27 17:39:16 2021 +0200

        delete_message

commit d221d931e5f3cc793d9035de4d1578fabd3f5f77a5d8f28c44214f1618777731
Author: nessie_user1
Date: Wed Oct 27 17:39:16 2021 +0200

        test message

```