### PR TITLE
Change VersionStore.getValues to return a map rather than a list

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -16,7 +16,9 @@
 package org.projectnessie.versioned.persist.adapter;
 
 import com.google.protobuf.ByteString;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.ToIntFunction;
@@ -94,8 +96,9 @@ public interface DatabaseAdapter {
    * @return Ordered stream
    * @throws ReferenceNotFoundException if {@code commit} does not exist.
    */
-  Stream<Optional<ContentsAndState<ByteString>>> values(
-      Hash commit, List<Key> keys, KeyFilterPredicate keyFilter) throws ReferenceNotFoundException;
+  Map<Key, ContentsAndState<ByteString>> values(
+      Hash commit, Collection<Key> keys, KeyFilterPredicate keyFilter)
+      throws ReferenceNotFoundException;
 
   /**
    * Retrieve the commit-log starting at the commit referenced by {@code offset}.

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -29,6 +29,7 @@ import com.google.protobuf.UnsafeByteOperations;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -807,7 +808,7 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
    * commitSha}. Non-existing keys must not be present in the returned map.
    */
   protected Map<Key, ContentsAndState<ByteString>> fetchValues(
-      OP_CONTEXT ctx, Hash refHead, List<Key> keys, KeyFilterPredicate keyFilter)
+      OP_CONTEXT ctx, Hash refHead, Collection<Key> keys, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
     Set<Key> remainingKeys = new HashSet<>(keys);
 

--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -222,17 +222,16 @@ public class CommitBench {
   private void doCommit(
       BenchmarkParam bp, BranchName branch, List<Key> keys, Map<Key, String> contentsIds)
       throws Exception {
-    List<Optional<String>> contents = bp.versionStore.getValues(branch, keys);
+    Map<Key, String> contents = bp.versionStore.getValues(branch, keys);
 
     try {
       List<Operation<String>> operations = new ArrayList<>(bp.tablesPerCommit);
       for (int i = 0; i < bp.tablesPerCommit; i++) {
         Key key = keys.get(i);
-        String value =
-            contents
-                .get(i)
-                .orElseThrow(
-                    () -> new RuntimeException("no value for key " + key + " in " + branch));
+        String value = contents.get(key);
+        if (value == null) {
+          throw new RuntimeException("no value for key " + key + " in " + branch);
+        }
         String currentState = value.split("\\|")[0];
         String newGlobalState = Integer.toString(Integer.parseInt(currentState) + 1);
         String contentsId = contentsIds.get(key);

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -32,6 +32,7 @@ import static org.projectnessie.versioned.persist.adapter.spi.TryLoopState.newTr
 import static org.projectnessie.versioned.persist.nontx.NonTransactionalOperationContext.NON_TRANSACTIONAL_OPERATION_CONTEXT;
 
 import com.google.protobuf.ByteString;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -101,12 +102,10 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   @Override
-  public Stream<Optional<ContentsAndState<ByteString>>> values(
-      Hash commit, List<Key> keys, KeyFilterPredicate keyFilter) throws ReferenceNotFoundException {
-    Map<Key, ContentsAndState<ByteString>> result =
-        fetchValues(NON_TRANSACTIONAL_OPERATION_CONTEXT, commit, keys, keyFilter);
-
-    return keys.stream().map(result::get).map(Optional::ofNullable);
+  public Map<Key, ContentsAndState<ByteString>> values(
+      Hash commit, Collection<Key> keys, KeyFilterPredicate keyFilter)
+      throws ReferenceNotFoundException {
+    return fetchValues(NON_TRANSACTIONAL_OPERATION_CONTEXT, commit, keys, keyFilter);
   }
 
   @Override

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
@@ -17,8 +17,10 @@ package org.projectnessie.versioned.persist.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -129,14 +131,15 @@ public abstract class AbstractManyCommits {
       throw new RuntimeException(e);
     }
 
-    try (Stream<Optional<ContentsAndState<ByteString>>> x =
-        databaseAdapter.values(
-            commit, Collections.singletonList(key), KeyFilterPredicate.ALLOW_ALL)) {
+    try {
+      Map<Key, ContentsAndState<ByteString>> values =
+          databaseAdapter.values(
+              commit, Collections.singletonList(key), KeyFilterPredicate.ALLOW_ALL);
       ByteString expectValue = ByteString.copyFromUtf8("value for #" + i + " of " + numCommits);
       ByteString expectState =
           ByteString.copyFromUtf8("state for #" + (numCommits - 1) + " of " + numCommits);
       ContentsAndState<ByteString> expect = ContentsAndState.of(expectValue, expectState);
-      assertThat(x).containsExactly(Optional.of(expect));
+      assertThat(values).containsExactly(Maps.immutableEntry(key, expect));
     } catch (ReferenceNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -38,6 +38,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -117,12 +118,12 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  public Stream<Optional<ContentsAndState<ByteString>>> values(
-      Hash commit, List<Key> keys, KeyFilterPredicate keyFilter) throws ReferenceNotFoundException {
+  public Map<Key, ContentsAndState<ByteString>> values(
+      Hash commit, Collection<Key> keys, KeyFilterPredicate keyFilter)
+      throws ReferenceNotFoundException {
     Connection conn = borrowConnection();
     try {
-      Map<Key, ContentsAndState<ByteString>> result = fetchValues(conn, commit, keys, keyFilter);
-      return keys.stream().map(result::get).map(Optional::ofNullable);
+      return fetchValues(conn, commit, keys, keyFilter);
     } finally {
       releaseConnection(conn);
     }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -22,7 +22,9 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Sample;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -151,7 +153,7 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
-  public List<Optional<VALUE>> getValues(Ref ref, List<Key> keys)
+  public Map<Key, VALUE> getValues(Ref ref, Collection<Key> keys)
       throws ReferenceNotFoundException {
     return delegate1Ex("getvalues", () -> delegate.getValues(ref, keys));
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -25,7 +25,9 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.util.GlobalTracer;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -197,7 +199,7 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
-  public List<Optional<VALUE>> getValues(Ref ref, List<Key> keys)
+  public Map<Key, VALUE> getValues(Ref ref, Collection<Key> keys)
       throws ReferenceNotFoundException {
     return callWithOneException(
         "GetValues",

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -15,7 +15,9 @@
  */
 package org.projectnessie.versioned;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -251,7 +253,7 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * @return A parallel list of values.
    * @throws ReferenceNotFoundException if {@code ref} is not present in the store
    */
-  List<Optional<VALUE>> getValues(Ref ref, List<Key> keys) throws ReferenceNotFoundException;
+  Map<Key, VALUE> getValues(Ref ref, Collection<Key> keys) throws ReferenceNotFoundException;
 
   /**
    * Get list of diffs between two refs.

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -173,7 +173,7 @@ class TestMetricsVersionStore {
                     vs.getValues(
                         BranchName.of("mock-branch"),
                         Collections.singletonList(Key.of("some", "key"))),
-                () -> Collections.singletonList(Optional.empty()),
+                Collections::emptyMap,
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "getdiffs",

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -195,7 +195,7 @@ class TestTracingVersionStore {
                             vs.getValues(
                                 BranchName.of("mock-branch"),
                                 Collections.singletonList(Key.of("some", "key"))),
-                        () -> Collections.singletonList(Optional.empty())),
+                        Collections::emptyMap),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "GetDiffs", refNotFoundThrows)
                     .tag("nessie.version-store.from", "BranchName{name=mock-branch}")

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractITVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractITVersionStore.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -389,14 +390,19 @@ public abstract class AbstractITVersionStore {
                 .getValues(
                     secondCommit,
                     Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
-        .contains(Optional.of("v1_2"), Optional.empty(), Optional.empty(), Optional.of("v4_1"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(Key.of("t1"), "v1_2", Key.of("t4"), "v4_1"));
 
     assertThat(
             store()
                 .getValues(
                     initialCommit,
                     Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
-        .contains(Optional.of("v1_1"), Optional.of("v2_1"), Optional.of("v3_1"), Optional.empty());
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_1",
+                Key.of("t2"), "v2_1",
+                Key.of("t3"), "v3_1"));
 
     assertThat(store().getValue(branch, Key.of("t1"))).isEqualTo("v1_2");
     assertThat(store().getValue(branch, Key.of("t2"))).isEqualTo("v2_2");
@@ -467,24 +473,45 @@ public abstract class AbstractITVersionStore {
     }
 
     assertThat(store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.of("v1_3"), Optional.of("new_v2_1"), Optional.of("v3_2"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_3",
+                Key.of("t2"), "new_v2_1",
+                Key.of("t3"), "v3_2"));
 
     assertThat(
             store().getValues(newT2Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.of("v1_3"), Optional.of("new_v2_1"), Optional.of("v3_2"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_3",
+                Key.of("t2"), "new_v2_1",
+                Key.of("t3"), "v3_2"));
 
     assertThat(
             store().getValues(extraCommit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.of("v1_3"), Optional.empty(), Optional.of("v3_2"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_3",
+                Key.of("t3"), "v3_2"));
 
     assertThat(store().getValues(t3Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.of("v1_2"), Optional.empty(), Optional.of("v3_1"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_2",
+                Key.of("t3"), "v3_1"));
 
     assertThat(store().getValues(t2Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.of("v1_2"), Optional.empty(), Optional.of("v3_1"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_2",
+                Key.of("t3"), "v3_1"));
 
     assertThat(store().getValues(t1Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.of("v1_2"), Optional.of("v2_1"), Optional.of("v3_1"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_2",
+                Key.of("t2"), "v2_1",
+                Key.of("t3"), "v3_1"));
   }
 
   /*
@@ -587,7 +614,11 @@ public abstract class AbstractITVersionStore {
 
     assertThat(store().toHash(branch)).isEqualTo(putCommit);
     assertThat(store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.of("v1_3"), Optional.of("v2_2"), Optional.of("v3_2"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_3",
+                Key.of("t2"), "v2_2",
+                Key.of("t3"), "v3_2"));
 
     final Hash unchangedCommit =
         commit("Conflicting Commit")
@@ -597,13 +628,17 @@ public abstract class AbstractITVersionStore {
             .toBranch(branch);
     assertThat(store().toHash(branch)).isEqualTo(unchangedCommit);
     assertThat(store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.of("v1_3"), Optional.of("v2_2"), Optional.of("v3_2"));
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), "v1_3",
+                Key.of("t2"), "v2_2",
+                Key.of("t3"), "v3_2"));
 
     final Hash deleteCommit =
         commit("Conflicting Commit").delete("t1").delete("t2").delete("t3").toBranch(branch);
     assertThat(store().toHash(branch)).isEqualTo(deleteCommit);
     assertThat(store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
-        .contains(Optional.empty(), Optional.empty(), Optional.empty());
+        .isEmpty();
   }
 
   /*
@@ -789,8 +824,11 @@ public abstract class AbstractITVersionStore {
                   .getValues(
                       newBranch,
                       Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
-          .contains(
-              Optional.of("v1_2"), Optional.of("v2_2"), Optional.empty(), Optional.of("v4_1"));
+          .containsExactlyInAnyOrderEntriesOf(
+              ImmutableMap.of(
+                  Key.of("t1"), "v1_2",
+                  Key.of("t2"), "v2_2",
+                  Key.of("t4"), "v4_1"));
     }
 
     @Test
@@ -810,12 +848,12 @@ public abstract class AbstractITVersionStore {
                       newBranch,
                       Arrays.asList(
                           Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"), Key.of("t5"))))
-          .contains(
-              Optional.of("v1_2"),
-              Optional.of("v2_2"),
-              Optional.empty(),
-              Optional.of("v4_1"),
-              Optional.of("v5_1"));
+          .containsExactlyInAnyOrderEntriesOf(
+              ImmutableMap.of(
+                  Key.of("t1"), "v1_2",
+                  Key.of("t2"), "v2_2",
+                  Key.of("t4"), "v4_1",
+                  Key.of("t5"), "v5_1"));
     }
 
     @Test
@@ -851,8 +889,11 @@ public abstract class AbstractITVersionStore {
                   .getValues(
                       newBranch,
                       Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
-          .contains(
-              Optional.of("v1_2"), Optional.of("v2_2"), Optional.empty(), Optional.of("v4_1"));
+          .containsExactlyInAnyOrderEntriesOf(
+              ImmutableMap.of(
+                  Key.of("t1"), "v1_2",
+                  Key.of("t2"), "v2_2",
+                  Key.of("t4"), "v4_1"));
     }
 
     @Test
@@ -898,12 +939,12 @@ public abstract class AbstractITVersionStore {
                       newBranch,
                       Arrays.asList(
                           Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"), Key.of("t5"))))
-          .contains(
-              Optional.of("v1_2"),
-              Optional.of("v2_2"),
-              Optional.empty(),
-              Optional.of("v4_1"),
-              Optional.of("v5_1"));
+          .containsExactlyInAnyOrderEntriesOf(
+              ImmutableMap.of(
+                  Key.of("t1"), "v1_2",
+                  Key.of("t2"), "v2_2",
+                  Key.of("t4"), "v4_1",
+                  Key.of("t5"), "v5_1"));
     }
 
     @Test
@@ -956,7 +997,11 @@ public abstract class AbstractITVersionStore {
               newBranch, Optional.of(initialHash), Arrays.asList(firstCommit, secondCommit));
       assertThat(
               store().getValues(newBranch, Arrays.asList(Key.of("t1"), Key.of("t4"), Key.of("t5"))))
-          .contains(Optional.of("v1_2"), Optional.of("v4_1"), Optional.of("v5_1"));
+          .containsExactlyInAnyOrderEntriesOf(
+              ImmutableMap.of(
+                  Key.of("t1"), "v1_2",
+                  Key.of("t4"), "v4_1",
+                  Key.of("t5"), "v5_1"));
     }
   }
 
@@ -1008,8 +1053,11 @@ public abstract class AbstractITVersionStore {
                   .getValues(
                       newBranch,
                       Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
-          .contains(
-              Optional.of("v1_2"), Optional.of("v2_2"), Optional.empty(), Optional.of("v4_1"));
+          .containsExactlyInAnyOrderEntriesOf(
+              ImmutableMap.of(
+                  Key.of("t1"), "v1_2",
+                  Key.of("t2"), "v2_2",
+                  Key.of("t4"), "v4_1"));
 
       assertThat(store().toHash(newBranch)).isEqualTo(thirdCommit);
     }
@@ -1027,12 +1075,12 @@ public abstract class AbstractITVersionStore {
                       newBranch,
                       Arrays.asList(
                           Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"), Key.of("t5"))))
-          .contains(
-              Optional.of("v1_2"),
-              Optional.of("v2_2"),
-              Optional.empty(),
-              Optional.of("v4_1"),
-              Optional.of("v5_1"));
+          .containsExactlyInAnyOrderEntriesOf(
+              ImmutableMap.of(
+                  Key.of("t1"), "v1_2",
+                  Key.of("t2"), "v2_2",
+                  Key.of("t4"), "v4_1",
+                  Key.of("t5"), "v5_1"));
 
       final List<WithHash<String>> commits = commitsList(newBranch);
       assertThat(commits).hasSize(5);
@@ -1075,12 +1123,12 @@ public abstract class AbstractITVersionStore {
                       newBranch,
                       Arrays.asList(
                           Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"), Key.of("t5"))))
-          .contains(
-              Optional.of("v1_2"),
-              Optional.of("v2_2"),
-              Optional.empty(),
-              Optional.of("v4_1"),
-              Optional.of("v5_1"));
+          .containsExactlyInAnyOrderEntriesOf(
+              ImmutableMap.of(
+                  Key.of("t1"), "v1_2",
+                  Key.of("t2"), "v2_2",
+                  Key.of("t4"), "v4_1",
+                  Key.of("t5"), "v5_1"));
 
       final List<WithHash<String>> commits = commitsList(newBranch);
       assertThat(commits).hasSize(5);


### PR DESCRIPTION
Previous `VersionStore.getValues()` implementations returned a `Stream<Optional<VALUE>>` with the
"contract" that the index of an element in the stream is related to the index of the request key.
This is counter-intuitive. It also complicates things.

This change refactors the mentioned method and related functionality.