### PR TITLE
Bump Iceberg from 0.12.0 to 0.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <gatling.version>3.6.1</gatling.version>
     <guava.version>31.0.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
-    <iceberg.version>0.12.0</iceberg.version>
+    <iceberg.version>0.12.1</iceberg.version>
     <immutables.version>2.8.9-ea-1</immutables.version>
     <jackson.version>2.13.0</jackson.version>
     <javax.version>4.0.1</javax.version>


### PR DESCRIPTION
Uses currently 0.13.0-SNAPSHOT until 0.12.1 is actually released