### PR TITLE
Fix Swagger API example for getContents()

### DIFF
--- a/model/src/main/java/org/projectnessie/api/http/HttpContentsApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpContentsApi.java
@@ -74,7 +74,7 @@ public interface HttpContentsApi extends ContentsApi {
   Contents getContents(
       @Parameter(
               description = "object name to search for",
-              examples = {@ExampleObject(ref = "ContentsKey")})
+              examples = {@ExampleObject(ref = "ContentsKeyGet")})
           @PathParam("key")
           ContentsKey key,
       @Parameter(

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -63,6 +63,9 @@ components:
         hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
         name: "exampleTag"
 
+    ContentsKeyGet:
+      value: "this.is.the.example.key"
+
     ContentsKey:
       value:
         elements:


### PR DESCRIPTION
The current example generates a Request of the form 
`http://localhost:19120/api/v1/contents/elements,deltatable,key?hashOnRef=b53925421f56fb8d1522e12f69d1fb939eaba71d110bf9b8b91516d06e6ff8d0&ref=dev`, but it should be `http://localhost:19120/api/v1/contents/deltatable.key?hashOnRef=b53925421f56fb8d1522e12f69d1fb939eaba71d110bf9b8b91516d06e6ff8d0&ref=dev`