### PR TITLE
Fix Swagger API example schema for getContents()

### DIFF
--- a/model/src/main/java/org/projectnessie/api/http/HttpContentsApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpContentsApi.java
@@ -24,6 +24,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -74,7 +75,8 @@ public interface HttpContentsApi extends ContentsApi {
   Contents getContents(
       @Parameter(
               description = "object name to search for",
-              examples = {@ExampleObject(ref = "ContentsKeyGet")})
+              examples = {@ExampleObject(ref = "ContentsKeyGet")},
+              schema = @Schema(type = SchemaType.STRING))
           @PathParam("key")
           ContentsKey key,
       @Parameter(

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -64,7 +64,7 @@ components:
         name: "exampleTag"
 
     ContentsKeyGet:
-      value: "this.is.the.example.key"
+      value: "example.key"
 
     ContentsKey:
       value:


### PR DESCRIPTION
The swagger api example is partially fixed with https://github.com/projectnessie/nessie/pull/2545. However, the example wasn't executing because the schema was set to that of ContentsKey; resulting in a - not a valid json error"

This change attempts to
a. Use String type as Key @schema to allow execution from swagger.
b. Reset example key as "example.key" as it aligns with other examples in there.