### PR TITLE
UI: remove `@types/http-proxy-middleware`

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -20,7 +20,6 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/bootstrap": "^5.1.6",
         "@types/history": "^4.7.9",
-        "@types/http-proxy-middleware": "^1.0.0",
         "@types/material-ui": "^0.21.12",
         "@types/ramda": "^0.27.46",
         "@types/react": "^17.0.34",
@@ -3889,15 +3888,6 @@
       "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/http-proxy-middleware": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy-middleware/-/http-proxy-middleware-1.0.0.tgz",
-      "integrity": "sha512-/s8lFX6rT43hSPqjjD8KNuu0SkPKY7uIdR6u9DCxVqCRhAvfKxGbVOixJsAT2mdpSnCyrGFAGoB39KFh6tmRxw==",
-      "deprecated": "This is a stub types definition. http-proxy-middleware provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "http-proxy-middleware": "*"
       }
     },
     "node_modules/@types/invariant": {
@@ -26536,14 +26526,6 @@
       "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/http-proxy-middleware": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy-middleware/-/http-proxy-middleware-1.0.0.tgz",
-      "integrity": "sha512-/s8lFX6rT43hSPqjjD8KNuu0SkPKY7uIdR6u9DCxVqCRhAvfKxGbVOixJsAT2mdpSnCyrGFAGoB39KFh6tmRxw==",
-      "requires": {
-        "http-proxy-middleware": "*"
       }
     },
     "@types/invariant": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,6 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/bootstrap": "^5.1.6",
     "@types/history": "^4.7.9",
-    "@types/http-proxy-middleware": "^1.0.0",
     "@types/material-ui": "^0.21.12",
     "@types/ramda": "^0.27.46",
     "@types/react": "^17.0.34",


### PR DESCRIPTION
Fixes this warning during build:
```
npm WARN deprecated @types/http-proxy-middleware@1.0.0: This is a stub types definition. http-proxy-middleware provides its own type definitions, so you do not need this installed.
```