### PR TITLE
UI: Prevent warning for unspecified React version

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -40,6 +40,11 @@ module.exports = {
     "eslint-plugin-prettier",
     "@typescript-eslint",
   ],
+  settings: {
+    "react": {
+      "version": "detect"
+    }
+  },
   rules: {
     "prettier/prettier": "error",
     "@typescript-eslint/adjacent-overload-signatures": "error",


### PR DESCRIPTION
Eliminate the "React version not specified..." warning

```
[INFO] --- frontend-maven-plugin:1.12.0:npm (typescript lint) @ nessie-ui ---
[INFO] Running 'npm run lint' in /home/snazy/devel/projectnessie/nessie/master/ui
[INFO]
[INFO] > nessie-ui@0.12.2-snapshot lint
[INFO] > eslint src/**/*.{ts,tsx} --fix
[INFO]
[INFO] Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
```