### PR TITLE
Do not let DB-adapter implementations throw NPE for uninitialized key-prefix

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -102,7 +102,6 @@
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.33.0",
-        "@typescript-eslint/eslint-plugin-tslint": "^5.3.0",
         "@typescript-eslint/parser": "^4.33.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
@@ -4222,131 +4221,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin-tslint": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.3.0.tgz",
-      "integrity": "sha512-zvK4yBbOTKLD4GCCCzXDqg3DhCoVxoRksCT4Jhv6PJ8l6F9E7lMG4uzrZqFZEOQVtSZaJu7PLEP8Fat0E80nOQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.3.0",
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "tslint": "^5.0.0 || ^6.0.0",
-        "typescript": "*"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin-tslint/node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
-      "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.3.0",
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/typescript-estree": "5.3.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin-tslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
-      "integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/visitor-keys": "5.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin-tslint/node_modules/@typescript-eslint/types": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
-      "integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin-tslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
-      "integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/visitor-keys": "5.3.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin-tslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
-      "integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.3.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin-tslint/node_modules/eslint-visitor-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-      "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -7909,16 +7783,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/diff-sequences": {
       "version": "27.0.6",
@@ -21957,78 +21821,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
-    "node_modules/tslint": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-      "deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.3",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.13.0",
-        "tsutils": "^2.29.0"
-      },
-      "bin": {
-        "tslint": "bin/tslint"
-      },
-      "engines": {
-        "node": ">=4.8.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
-      }
-    },
-    "node_modules/tslint/node_modules/builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tslint/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/tslint/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/tslint/node_modules/tsutils": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
-      }
-    },
     "node_modules/tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -26850,79 +26642,6 @@
         }
       }
     },
-    "@typescript-eslint/eslint-plugin-tslint": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.3.0.tgz",
-      "integrity": "sha512-zvK4yBbOTKLD4GCCCzXDqg3DhCoVxoRksCT4Jhv6PJ8l6F9E7lMG4uzrZqFZEOQVtSZaJu7PLEP8Fat0E80nOQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "5.3.0",
-        "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
-          "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "@typescript-eslint/scope-manager": "5.3.0",
-            "@typescript-eslint/types": "5.3.0",
-            "@typescript-eslint/typescript-estree": "5.3.0",
-            "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0"
-          }
-        },
-        "@typescript-eslint/scope-manager": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
-          "integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.3.0",
-            "@typescript-eslint/visitor-keys": "5.3.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
-          "integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
-          "integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.3.0",
-            "@typescript-eslint/visitor-keys": "5.3.0",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
-          "integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.3.0",
-            "eslint-visitor-keys": "^3.0.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-          "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
-          "dev": true
-        }
-      }
-    },
     "@typescript-eslint/experimental-utils": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
@@ -29660,13 +29379,6 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "peer": true
     },
     "diff-sequences": {
       "version": "27.0.6",
@@ -40279,61 +39991,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "tslint": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.3",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.13.0",
-        "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "peer": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true,
-          "peer": true
-        },
-        "tsutils": {
-          "version": "2.29.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
-      }
     },
     "tsutils": {
       "version": "3.21.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -122,7 +122,6 @@
   "proxy": "http://localhost:19120",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.33.0",
-    "@typescript-eslint/eslint-plugin-tslint": "^5.3.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -377,6 +377,26 @@ public abstract class AbstractDatabaseAdapterTest {
   }
 
   @Test
+  void nonExistentKeyPrefixTest(
+      @NessieDbAdapter(initializeRepo = false)
+          @NessieDbAdapterConfigItem(name = "key.prefix", value = "non-existent")
+          DatabaseAdapter nonExistent) {
+    assertAll(
+        () -> {
+          try (Stream<WithHash<NamedRef>> r = nonExistent.namedRefs()) {
+            assertThat(r).isEmpty();
+          }
+        },
+        () ->
+            assertThatThrownBy(
+                    () -> nonExistent.hashOnReference(BranchName.of("main"), Optional.empty()))
+                .isInstanceOf(ReferenceNotFoundException.class),
+        () ->
+            assertThatThrownBy(() -> nonExistent.toHash(BranchName.of("main")))
+                .isInstanceOf(ReferenceNotFoundException.class));
+  }
+
+  @Test
   void keyPrefixBasic(
       @NessieDbAdapter @NessieDbAdapterConfigItem(name = "key.prefix", value = "foo")
           DatabaseAdapter foo,

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbAdapter.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbAdapter.java
@@ -53,4 +53,7 @@ public @interface NessieDbAdapter {
    * </code></pre>
    */
   String configMethod() default "";
+
+  /** Whether to initialize the adapter, defaults to {@code true}. */
+  boolean initializeRepo() default true;
 }


### PR DESCRIPTION
Currently the non-transactional database adapters throw an NPE when a key-prefix
isn't initialized. Such cases are hard to catch on the client side. This change
makes both the non-tx and tx implementations behave the same in such cases, as the
tx implementation just returns nothing (e.g. get-named-refs) or throws the correct
exceptions (e.g. get-hash-for-ref).