### PR TITLE
Simple tool to generate (nonsense) Nessie content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
     <mockito.version>4.0.0</mockito.version>
     <nessie.version>${project.version}</nessie.version>
     <openapi.version>2.0</openapi.version>
+    <picocli.version>4.6.2</picocli.version>
     <prometheus.version>0.9.0</prometheus.version>
     <protobuf.version>3.19.1</protobuf.version>
     <quarkus.version>2.4.1.Final</quarkus.version>

--- a/tools/content-generator/pom.xml
+++ b/tools/content-generator/pom.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie-tools</artifactId>
+    <version>0.12.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-content-generator</artifactId>
+
+  <name>Nessie - Content Generator</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>${picocli.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>info.picocli</groupId>
+              <artifactId>picocli-codegen</artifactId>
+              <version>${picocli.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>tidy-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>validate-pom</id>
+            <phase>generate-resources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <filters>
+            <!-- filter to address "Invalid signature file" issue - see https://stackoverflow.com/a/6743609/589215 -->
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/jandex.idx</exclude>
+                <exclude>META-INF/LICENSE</exclude>
+                <exclude>LICENSE</exclude>
+                <exclude>META-INF/LICENSE.md</exclude>
+                <exclude>META-INF/LICENSE.txt</exclude>
+                <exclude>META-INF/NOTIC*</exclude>
+                <exclude>META-INF/DEPENDENCIES</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <manifestEntries>
+                <Main-Class>org.projectnessie.tools.contentgenerator.cli.NessieContentGenerator</Main-Class>
+              </manifestEntries>
+            </transformer>
+          </transformers>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-apprunner-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <skip>${skipTests}</skip>
+          <appArtifactId>org.projectnessie:nessie-quarkus:${project.version}</appArtifactId>
+          <systemProperties>
+            <!-- disable devservices to stop Quarkus from starting Mongo via testcontainers -->
+            <quarkus.devservices.enabled>false</quarkus.devservices.enabled>
+            <!-- Use INMEMORY version store for testing -->
+            <nessie.version.store.type>INMEMORY</nessie.version.store.type>
+          </systemProperties>
+          <applicationProperties>
+            <quarkus.http.test-port>0</quarkus.http.test-port>
+          </applicationProperties>
+          <outputProperties>
+            <quarkus.http.test-port>quarkus.http.test-port</quarkus.http.test-port>
+          </outputProperties>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.projectnessie</groupId>
+            <artifactId>nessie-quarkus</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>start</id>
+            <phase>pre-integration-test</phase>
+            <goals><goal>start</goal></goals>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <phase>post-integration-test</phase>
+            <goals><goal>stop</goal></goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <quarkus.http.test-port>${quarkus.http.test-port}</quarkus.http.test-port>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/AbstractCommand.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/AbstractCommand.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import java.net.URI;
+import java.util.concurrent.Callable;
+import org.projectnessie.client.NessieClientBuilder;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.http.HttpClientBuilder;
+import org.projectnessie.error.BaseNessieClientServerException;
+import picocli.CommandLine.Option;
+
+public abstract class AbstractCommand implements Callable<Integer> {
+
+  @Option(
+      names = {"-u", "--uri"},
+      description = "Nessie API endpoint URI, defaults to http://localhost:19120/api/v1.")
+  private URI uri = URI.create("http://localhost:19120/api/v1");
+
+  @Option(
+      names = {"-B", "--custom-nessie-client-builder"},
+      hidden = true,
+      description = "Custom implementation of org.projectnessie.client.NessieClientBuilder.")
+  private Class<?> customBuilder;
+
+  public NessieApiV1 createNessieApiInstance() {
+    NessieClientBuilder<?> clientBuilder;
+    if (customBuilder != null) {
+      try {
+        clientBuilder =
+            (NessieClientBuilder<?>) customBuilder.getDeclaredMethod("builder").invoke(null);
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to use custom NessieClientBuilder", e);
+      }
+    } else {
+      clientBuilder = HttpClientBuilder.builder();
+    }
+    clientBuilder.fromSystemProperties();
+    if (uri != null) {
+      clientBuilder.withUri(uri);
+    }
+    return clientBuilder.build(NessieApiV1.class);
+  }
+
+  /** Convenience method declaration that allows to "just throw" Nessie API exceptions. */
+  public abstract void execute() throws BaseNessieClientServerException;
+
+  /**
+   * Implements {@link Callable#call()} that just calls {@link #execute()} and returns {@code 0} for
+   * the process exit code on success.
+   */
+  @Override
+  public final Integer call() throws Exception {
+    execute();
+    return 0;
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.validation.constraints.Min;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.error.BaseNessieClientServerException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ImmutableDeltaLakeTable;
+import org.projectnessie.model.ImmutableIcebergTable;
+import org.projectnessie.model.ImmutableSqlView;
+import org.projectnessie.model.Operation.Put;
+import org.projectnessie.model.SqlView.Dialect;
+import org.projectnessie.model.Tag;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Spec;
+
+@Command(name = "generate", mixinStandardHelpOptions = true, description = "Generate commits")
+public class GenerateContent extends AbstractCommand {
+
+  @Option(
+      names = {"-b", "--num-branches"},
+      defaultValue = "1",
+      description = "Number of branches to use.")
+  private int branchCount;
+
+  @Option(
+      names = {"-T", "--tag-probability"},
+      defaultValue = "0",
+      description = "Probability to create a new tag off the last commit.")
+  private double newTagProbability;
+
+  @Min(value = 1, message = "Must create at least one commit.")
+  @Option(
+      names = {"-n", "--num-commits"},
+      required = true,
+      defaultValue = "100",
+      description = "Number of commits to create.")
+  private int numCommits;
+
+  @Option(
+      names = {"-d", "--duration"},
+      description =
+          "Runtime duration, equally distributed among the number of commits to create. "
+              + "See java.time.Duration for argument format details.")
+  private Duration runtimeDuration;
+
+  @Min(value = 1, message = "Must use at least one table (content-key).")
+  @Option(
+      names = {"-t", "--num-tables"},
+      defaultValue = "1",
+      description = "Number of table names, each commit chooses a random table (content-key).")
+  private int numTables;
+
+  @Option(
+      names = "--type",
+      defaultValue = "ICEBERG_TABLE",
+      description =
+          "Content-types to generate. Defaults to ICEBERG_TABLE. Possible values: "
+              + "ICEBERG_TABLE, DELTA_LAKE_TABLE, VIEW")
+  private Content.Type contentType;
+
+  @Spec private CommandSpec spec;
+
+  @Override
+  public void execute() throws BaseNessieClientServerException {
+    NessieApiV1 api = createNessieApiInstance();
+
+    if (runtimeDuration != null) {
+      if (runtimeDuration.isZero() || runtimeDuration.isNegative()) {
+        throw new ParameterException(
+            spec.commandLine(), "Duration must be absent to greater than zero.");
+      }
+    }
+
+    Duration perCommitDuration =
+        Optional.ofNullable(runtimeDuration).orElse(Duration.ZERO).dividedBy(numCommits);
+
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    String runStartTime =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss").format(LocalDateTime.now());
+
+    List<ContentKey> tableNames =
+        IntStream.range(0, numTables)
+            .mapToObj(
+                i ->
+                    ContentKey.of(
+                        String.format("create-contents-%s", runStartTime),
+                        "contents",
+                        Integer.toString(i)))
+            .collect(Collectors.toList());
+
+    Branch defaultBranch = api.getDefaultBranch();
+
+    List<String> branches = new ArrayList<>();
+    branches.add(defaultBranch.getName());
+    while (branches.size() < branchCount) {
+      // Create a new branch
+      String newBranchName = "branch-" + runStartTime + "_" + (branches.size() - 1);
+      Branch branch = Branch.of(newBranchName, defaultBranch.getHash());
+      spec.commandLine()
+          .getOut()
+          .printf(
+              "Creating branch '%s' from '%s' at %s%n",
+              branch.getName(), defaultBranch.getName(), branch.getHash());
+      api.createReference().reference(branch).sourceRefName(defaultBranch.getName()).create();
+      branches.add(newBranchName);
+    }
+
+    spec.commandLine().getOut().printf("Starting contents generation, %d commits...%n", numCommits);
+
+    for (int i = 0; i < numCommits; i++) {
+      // Choose a random branch to commit to
+      String branchName = branches.get(random.nextInt(branches.size()));
+
+      Branch commitToBranch = (Branch) api.getReference().refName(branchName).get();
+
+      ContentKey tableName = tableNames.get(random.nextInt(tableNames.size()));
+
+      Content tableContents = api.getContent().key(tableName).get().get(tableName);
+      Content newContents = createContents(tableContents, random);
+
+      spec.commandLine()
+          .getOut()
+          .printf(
+              "Committing content-key '%s' to branch '%s' at %s%n",
+              tableName, commitToBranch.getName(), commitToBranch.getHash());
+
+      Branch newHead =
+          api.commitMultipleOperations()
+              .branch(commitToBranch)
+              .commitMeta(
+                  CommitMeta.builder()
+                      .message(
+                          String.format(
+                              "%s table %s on %s, commit #%d of %d",
+                              tableContents != null ? "Update" : "Create",
+                              tableName,
+                              branchName,
+                              i,
+                              numCommits))
+                      .author(System.getProperty("user.name"))
+                      .authorTime(Instant.now())
+                      .build())
+              .operation(Put.of(tableName, newContents, tableContents))
+              .commit();
+
+      if (random.nextDouble() < newTagProbability) {
+        Tag tag = Tag.of("new-tag-" + random.nextLong(), newHead.getHash());
+        spec.commandLine()
+            .getOut()
+            .printf(
+                "Creating tag '%s' from '%s' at %s%n", tag.getName(), branchName, tag.getHash());
+        api.createReference().reference(tag).sourceRefName(branchName).create();
+      }
+
+      try {
+        TimeUnit.NANOSECONDS.sleep(perCommitDuration.toNanos());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+    }
+
+    spec.commandLine().getOut().printf("Done creating contents.%n");
+  }
+
+  private Content createContents(Content currentContents, ThreadLocalRandom random) {
+    switch (contentType) {
+      case ICEBERG_TABLE:
+        ImmutableIcebergTable.Builder icebergBuilder =
+            ImmutableIcebergTable.builder()
+                .idGenerators("ids " + random.nextLong())
+                .metadataLocation("metadata " + random.nextLong());
+        if (currentContents != null) {
+          icebergBuilder.id(currentContents.getId());
+        }
+        return icebergBuilder.build();
+      case DELTA_LAKE_TABLE:
+        ImmutableDeltaLakeTable.Builder deltaBuilder =
+            ImmutableDeltaLakeTable.builder()
+                .lastCheckpoint("Last checkpoint foo bar " + random.nextLong())
+                .addMetadataLocationHistory("metadata location history " + random.nextLong());
+        if (currentContents != null) {
+          deltaBuilder.id(currentContents.getId());
+        }
+        return deltaBuilder.build();
+      case VIEW:
+        ImmutableSqlView.Builder viewBuilder =
+            ImmutableSqlView.builder().dialect(Dialect.SPARK).sqlText("SELECT blah FROM meh;");
+        if (currentContents != null) {
+          viewBuilder.id(currentContents.getId());
+        }
+        return viewBuilder.build();
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Content type %s not supported", contentType.name()));
+    }
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/NessieContentGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/NessieContentGenerator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.projectnessie.client.http.HttpClientException;
+import org.projectnessie.error.BaseNessieClientServerException;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.HelpCommand;
+
+@Command(
+    name = "nessie-content-generator",
+    mixinStandardHelpOptions = true,
+    versionProvider = NessieVersionProvider.class,
+    subcommands = {GenerateContent.class, HelpCommand.class})
+public class NessieContentGenerator {
+
+  public static void main(String[] arguments) {
+    System.exit(runMain(arguments));
+  }
+
+  @SuppressWarnings("InstantiationOfUtilityClass")
+  @VisibleForTesting
+  public static int runMain(String[] arguments) {
+    return new CommandLine(new NessieContentGenerator())
+        .setExecutionExceptionHandler(
+            (ex, cmd, parseResult) -> {
+              if (ex instanceof BaseNessieClientServerException
+                  || ex instanceof HttpClientException) {
+                // Just print the exception w/o the stack trace for Nessie related exceptions
+                cmd.getErr().println(cmd.getColorScheme().errorText(ex.toString()));
+              } else {
+                // Print the full stack trace in all other cases.
+                cmd.getErr().println(cmd.getColorScheme().richStackTraceString(ex));
+              }
+              return cmd.getExitCodeExceptionMapper() != null
+                  ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
+                  : cmd.getCommandSpec().exitCodeOnExecutionException();
+            })
+        .execute(arguments);
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/NessieVersionProvider.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/NessieVersionProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import java.io.InputStream;
+import java.util.Properties;
+import picocli.CommandLine.IVersionProvider;
+
+public class NessieVersionProvider implements IVersionProvider {
+  @Override
+  public String[] getVersion() throws Exception {
+    try (InputStream input =
+        NessieVersionProvider.class
+            .getResource("version.properties")
+            .openConnection()
+            .getInputStream()) {
+      Properties props = new Properties();
+      props.load(input);
+      return new String[] {props.getProperty("nessie.version")};
+    }
+  }
+}

--- a/tools/content-generator/src/main/resources/org/projectnessie/tools/contentgenerator/cli/version.properties
+++ b/tools/content-generator/src/main/resources/org/projectnessie/tools/contentgenerator/cli/version.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+nessie.version=${nessie.version}

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.http.HttpClientBuilder;
+import org.projectnessie.tools.contentgenerator.cli.NessieContentGenerator;
+
+class ITGenerateContent {
+
+  static final int NESSIE_HTTP_PORT = Integer.getInteger("quarkus.http.test-port");
+
+  static final String NESSIE_API_URI =
+      String.format("http://localhost:%d/api/v1", NESSIE_HTTP_PORT);
+
+  @Test
+  void basicGenerateContentTest() throws Exception {
+    int numCommits = 20;
+
+    assertThat(
+            NessieContentGenerator.runMain(
+                new String[] {
+                  "generate", "-n", Integer.toString(numCommits), "-u", NESSIE_API_URI
+                }))
+        .isEqualTo(0);
+
+    try (NessieApiV1 api =
+        HttpClientBuilder.builder().withUri(NESSIE_API_URI).build(NessieApiV1.class)) {
+      assertThat(
+              api.getCommitLog().refName(api.getConfig().getDefaultBranch()).get().getOperations())
+          .hasSize(numCommits);
+    }
+  }
+}

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -32,5 +32,6 @@
 
   <modules>
     <module>apprunner-maven-plugin</module>
+    <module>content-generator</module>
   </modules>
 </project>


### PR DESCRIPTION
When testing for example UI functionality, it is nice to have some content in Nessie, but we
do not have a tool for this available. This PR adds a rudimentary tool that creates (nonsense)
commits in 1 or more branches. Functionality supported:
* Generate N commits (defaults to 100)
* Commit to N branches (default: just the default branch)
* Generate tags (default probability: 0)
* Generate expected number of commits over a specified time duration - in other words: sleeps
  for "expected duration" divided by "number of commits" (default: no sleep)
* Genarete content for N tables (default: 1 table)
* Generate content for any content type (default: Iceberg-table)

Uses the picocli library.

```
$ java -jar tools/content-generator/target/nessie-content-generator-0.12.2-SNAPSHOT.jar help generate

Usage: nessie-content-generator generate [-hV] [-b=<branchCount>]
       [-d=<runtimeDuration>] [-n=<numCommits>] [-t=<numTables>]
       [-T=<newTagProbability>] [--type=<contentType>] [-u=<uri>]
Generate commits
  -b, --num-branches=<branchCount>
                             Number of branches to use.
  -d, --duration=<runtimeDuration>
                             Runtime duration, equally distributed among the
                               number of commits to create. See java.time.
                               Duration for argument format details.
  -h, --help                 Show this help message and exit.
  -n, --num-commits=<numCommits>
                             Number of commits to create.
  -t, --num-tables=<numTables>
                             Number of table names, each commit chooses a
                               random table (content-key).
  -T, --tag-probability=<newTagProbability>
                             Probability to create a new tag off the last
                               commit.
      --type=<contentType>   Content-types to generate. Defaults to
                               ICEBERG_TABLE. Possible values: ICEBERG_TABLE,
                               DELTA_LAKE_TABLE, VIEW
  -u, --uri=<uri>            Nessie API endpoint URI, defaults to http:
                               //localhost:19120/api/v1.
  -V, --version              Print version information and exit.
```