### PR TITLE
Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state

### DIFF
--- a/model/src/main/java/org/projectnessie/api/ContentApi.java
+++ b/model/src/main/java/org/projectnessie/api/ContentApi.java
@@ -39,7 +39,8 @@ public interface ContentApi {
    *
    * <p>If the table-metadata is tracked globally (Iceberg), Nessie returns a {@link Content}
    * object, that contains the most up-to-date part for the globally tracked part (Iceberg:
-   * table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-ID).
+   * table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-ID,
+   * schema-ID, partition-spec-ID, default-sort-order-ID).
    *
    * @param key the {@link ContentKey}s to retrieve
    * @param ref named-reference to retrieve the content for
@@ -64,7 +65,8 @@ public interface ContentApi {
    *
    * <p>If the table-metadata is tracked globally (Iceberg), Nessie returns a {@link Content}
    * object, that contains the most up-to-date part for the globally tracked part (Iceberg:
-   * table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-ID).
+   * table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-ID,
+   * schema-ID, partition-spec-ID, default-sort-order-ID).
    *
    * @param ref named-reference to retrieve the content for
    * @param hashOnRef hash on {@code ref} to retrieve the content for, translates to {@code HEAD},

--- a/model/src/main/java/org/projectnessie/api/ContentApi.java
+++ b/model/src/main/java/org/projectnessie/api/ContentApi.java
@@ -65,8 +65,8 @@ public interface ContentApi {
    *
    * <p>If the table-metadata is tracked globally (Iceberg), Nessie returns a {@link Content}
    * object, that contains the most up-to-date part for the globally tracked part (Iceberg:
-   * table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-ID,
-   * schema-ID, partition-spec-ID, default-sort-order-ID).
+   * table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-id,
+   * schema-id, partition-spec-id, default-sort-order-id).
    *
    * @param ref named-reference to retrieve the content for
    * @param hashOnRef hash on {@code ref} to retrieve the content for, translates to {@code HEAD},

--- a/model/src/main/java/org/projectnessie/api/http/HttpContentApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpContentApi.java
@@ -54,8 +54,8 @@ public interface HttpContentApi extends ContentApi {
               + "If the table-metadata is tracked globally (Iceberg), "
               + "Nessie returns a 'Content' object, that contains the most up-to-date part for "
               + "the globally tracked part (Iceberg: table-metadata) plus the "
-              + "per-Nessie-reference/hash specific part (Iceberg: snapshot-ID, "
-              + "schema-ID, partition-spec-ID, default-sort-order-ID).")
+              + "per-Nessie-reference/hash specific part (Iceberg: snapshot-id, "
+              + "schema-id, partition-spec-id, default-sort-order-id).")
   @APIResponses({
     @APIResponse(
         responseCode = "200",

--- a/model/src/main/java/org/projectnessie/api/http/HttpContentApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpContentApi.java
@@ -54,7 +54,8 @@ public interface HttpContentApi extends ContentApi {
               + "If the table-metadata is tracked globally (Iceberg), "
               + "Nessie returns a 'Content' object, that contains the most up-to-date part for "
               + "the globally tracked part (Iceberg: table-metadata) plus the "
-              + "per-Nessie-reference/hash specific part (Iceberg: snapshot-ID).")
+              + "per-Nessie-reference/hash specific part (Iceberg: snapshot-ID, "
+              + "schema-ID, partition-spec-ID, default-sort-order-ID).")
   @APIResponses({
     @APIResponse(
         responseCode = "200",
@@ -103,7 +104,8 @@ public interface HttpContentApi extends ContentApi {
               + "If the table-metadata is tracked globally (Iceberg), "
               + "Nessie returns a 'Content' object, that contains the most up-to-date part for "
               + "the globally tracked part (Iceberg: table-metadata) plus the "
-              + "per-Nessie-reference/hash specific part (Iceberg: snapshot-ID).")
+              + "per-Nessie-reference/hash specific part (Iceberg: snapshot-ID,"
+              + "schema-ID, partition-spec-ID, default-sort-order-ID).")
   @APIResponses({
     @APIResponse(
         responseCode = "200",

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -28,14 +28,8 @@ import org.immutables.value.Value;
  * Represents the state of an Iceberg table in Nessie. An Iceberg table is globally identified via
  * its {@link Content#getId() unique ID}.
  *
- * <p>The Iceberg-table-state consists of the location to the table-metadata and the state of the ID
- * generators using the serialized version of Iceberg's {@code TableIdGenerators} object.
- *
- * <p>The table-metadata-location is managed on each Nessie reference, which means that all versions
- * of the same table have distinct table-metadata across all named-references (branches and tags).
- *
- * <p>The information needed to generate IDs for an Iceberg table that need to be globally unique,
- * for example the last-column-ID, is managed globally within Nessie.
+ * <p>The Iceberg-table-state consists of the location to the table-metadata and the state of
+ * relevant IDs using a serialized version of those.
  *
  * <p>When adding a new table (aka content-object identified by a content-id), use a {@link
  * org.projectnessie.model.Operation.Put} without an expected-value. In all other cases (updating an
@@ -69,20 +63,38 @@ public abstract class IcebergTable extends Content {
   @NotBlank
   public abstract String getMetadataLocation();
 
-  /** Opaque representation of Iceberg's {@code TableIdGenerators}. */
-  public abstract String getIdGenerators();
+  public abstract long getSnapshotId();
 
-  public static IcebergTable of(String metadataLocation, String idGenerators) {
+  public abstract int getSchemaId();
+
+  public abstract int getSpecId();
+
+  public abstract int getSortOrderId();
+
+  public static IcebergTable of(
+      String metadataLocation, long snapshotId, int schemaId, int specId, int sortOrderId) {
     return ImmutableIcebergTable.builder()
         .metadataLocation(metadataLocation)
-        .idGenerators(idGenerators)
+        .snapshotId(snapshotId)
+        .schemaId(schemaId)
+        .specId(specId)
+        .sortOrderId(sortOrderId)
         .build();
   }
 
-  public static IcebergTable of(String metadataLocation, String idGenerators, String contentId) {
+  public static IcebergTable of(
+      String metadataLocation,
+      long snapshotId,
+      int schemaId,
+      int specId,
+      int sortOrderId,
+      String contentId) {
     return ImmutableIcebergTable.builder()
         .metadataLocation(metadataLocation)
-        .idGenerators(idGenerators)
+        .snapshotId(snapshotId)
+        .schemaId(schemaId)
+        .specId(specId)
+        .sortOrderId(sortOrderId)
         .id(contentId)
         .build();
   }

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
@@ -55,7 +55,14 @@ class CommitToBranchSimulation extends Simulation {
           val contentId = tableName
 
           val tableMeta = IcebergTable
-            .of(s"path_on_disk_${tableName}_$commitNum", "x", contentId)
+            .of(
+              s"path_on_disk_${tableName}_$commitNum",
+              42,
+              43,
+              44,
+              45,
+              contentId
+            )
 
           // TODO the expectedContent is wrong!! commitNum is for the session, but we need the actual global state!!
           val op =
@@ -65,7 +72,10 @@ class CommitToBranchSimulation extends Simulation {
                 tableMeta,
                 IcebergTable.of(
                   s"path_on_disk_${tableName}_${commitNum - 1}",
-                  "x",
+                  42,
+                  43,
+                  44,
+                  45,
                   contentId
                 )
               )

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -47,7 +47,10 @@ class IcebergTable(Content):
     """Dataclass for Nessie Content."""
 
     metadata_location: str = desert.ib(fields.Str(data_key="metadataLocation"))
-    id_generators: str = desert.ib(fields.Str(data_key="idGenerators"))
+    snapshot_id: int = desert.ib(fields.Int(data_key="snapshotId"))
+    schema_id: int = desert.ib(fields.Int(data_key="schemaId"))
+    spec_id: int = desert.ib(fields.Int(data_key="specId"))
+    sort_order_id: int = desert.ib(fields.Int(data_key="sortOrderId"))
 
     @staticmethod
     def requires_expected_state() -> bool:
@@ -56,7 +59,11 @@ class IcebergTable(Content):
 
     def pretty_print(self: "IcebergTable") -> str:
         """Print out for cli."""
-        return "Iceberg table:\n\tmetadata-location:{}\n\tid-generators:{}".format(self.metadata_location, self.id_generators)
+        return (
+            f"Iceberg table:\n\tmetadata-location:{self.metadata_location}\n\tsnapshot-id:{self.snapshot_id}"
+            f"\n\tschema-id:{self.schema_id}"
+            f"\n\tpartition-spec-id:{self.spec_id}\n\tdefault-sort-order-id:{self.sort_order_id}"
+        )
 
 
 IcebergTableSchema = desert.schema_class(IcebergTable)

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -60,9 +60,9 @@ class IcebergTable(Content):
     def pretty_print(self: "IcebergTable") -> str:
         """Print out for cli."""
         return (
-            f"Iceberg table:\n\tmetadata-location:{self.metadata_location}\n\tsnapshot-id:{self.snapshot_id}"
-            f"\n\tschema-id:{self.schema_id}"
-            f"\n\tpartition-spec-id:{self.spec_id}\n\tdefault-sort-order-id:{self.sort_order_id}"
+            f"Iceberg table:\n\tmetadata-location: {self.metadata_location}\n\tsnapshot-id: {self.snapshot_id}"
+            f"\n\tschema-id: {self.schema_id}"
+            f"\n\tpartition-spec-id: {self.spec_id}\n\tdefault-sort-order-id: {self.sort_order_id}"
         )
 
 

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -131,12 +131,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["assign", "foo", "bar"]}, "content":
-      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_assign", "snapshotId":
-      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
-      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie test",
-      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
-      message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["assign", "foo", "bar"]}, "content": {"specId": 44, "id": "test_assign",
+      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -154,7 +154,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -178,7 +178,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -188,8 +188,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
-      "type": "BRANCH"}'
+    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+      "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -243,8 +243,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
-      "type": "BRANCH"}'
+    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -283,9 +283,9 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n  }
+        : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -310,7 +310,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -320,8 +320,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
-      "type": "TAG"}'
+    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -339,7 +339,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -364,10 +364,10 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
+        : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n  },
+        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -392,7 +392,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -402,8 +402,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
-      "type": "TAG"}'
+    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -447,7 +447,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -457,8 +457,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
-      "type": "TAG"}'
+    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+      "name": "dev", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -473,7 +473,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455
   response:
     body:
       string: ''
@@ -497,10 +497,10 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
+        : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n  },
+        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -131,11 +131,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["assign", "foo", "bar"]}, "content": {"idGenerators": "xyz", "metadataLocation":
-      "/a/b/c", "id": "test_assign", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["assign", "foo", "bar"]}, "content":
+      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_assign", "snapshotId":
+      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
+      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie test",
+      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
+      message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -144,7 +145,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '399'
+      - '443'
       Content-Type:
       - application/json
       User-Agent:
@@ -153,7 +154,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -177,7 +178,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -187,7 +188,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": "9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95",
+    body: '{"name": "main", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
       "type": "BRANCH"}'
     headers:
       Accept:
@@ -242,7 +243,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95",
+    body: '{"name": "dev", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
       "type": "BRANCH"}'
     headers:
       Accept:
@@ -282,9 +283,9 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n  }
+        : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -309,7 +310,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -319,7 +320,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95",
+    body: '{"name": "v1.0", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
       "type": "TAG"}'
     headers:
       Accept:
@@ -338,7 +339,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -363,10 +364,10 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n
+        : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n  },
+        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -391,7 +392,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -401,7 +402,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95",
+    body: '{"name": "v1.0", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
       "type": "TAG"}'
     headers:
       Accept:
@@ -446,7 +447,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -456,7 +457,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95",
+    body: '{"name": "dev", "hash": "5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca",
       "type": "TAG"}'
     headers:
       Accept:
@@ -472,7 +473,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca
   response:
     body:
       string: ''
@@ -496,10 +497,10 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"9f983acf8888862652e98bb2528fc835afe1a119ad2f193e5158720438679e95\"\n
+        : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n  },
+        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"5f0627e27678c6eb5e4313d1261a55d744b102fa7e6d0f1bf0132a20b7b9f5ca\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_branch.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_branch.yaml
@@ -74,8 +74,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -155,8 +155,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "etl", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -180,11 +180,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie_user1", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["log", "foo", "dev"]}, "content": {"idGenerators": "xyz", "metadataLocation":
-      "/a/b/c", "id": "test_log_dev", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["log", "foo", "dev"]}, "content":
+      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_log_dev", "snapshotId":
+      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
+      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie_user1",
+      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
+      message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -193,7 +194,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '398'
+      - '442'
       Content-Type:
       - application/json
       User-Agent:
@@ -203,7 +204,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev_test_log\",\n  \"hash\"
-        : \"9a0c04da3ea2962f3d56ed1b4b8cfb15d40d090516a4ef8c1c024ac9a355d2da\"\n}"
+        : \"b3a38c9da93d8ea21b030dc02ba7393b3ef921be71fadeaf285c05984d07ae0e\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -230,7 +231,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev_test_log\",\n    \"hash\"
-        : \"9a0c04da3ea2962f3d56ed1b4b8cfb15d40d090516a4ef8c1c024ac9a355d2da\"\n  }
+        : \"b3a38c9da93d8ea21b030dc02ba7393b3ef921be71fadeaf285c05984d07ae0e\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -267,11 +268,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie_user1", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["log", "foo", "bar"]}, "content": {"idGenerators": "xyz", "metadataLocation":
-      "/a/b/c", "id": "test_log", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["log", "foo", "bar"]}, "content":
+      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_log", "snapshotId":
+      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
+      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie_user1",
+      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
+      message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -280,7 +282,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '394'
+      - '438'
       Content-Type:
       - application/json
       User-Agent:
@@ -289,7 +291,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -313,7 +315,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -338,12 +340,13 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_log\",\n  \"metadataLocation\"
-        : \"/a/b/c\",\n  \"idGenerators\" : \"xyz\"\n}"
+        : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\" : 43,\n  \"specId\"
+        : 44,\n  \"sortOrderId\" : 45\n}"
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '110'
+      - '163'
     status:
       code: 200
       message: OK
@@ -362,7 +365,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -386,10 +389,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -414,7 +417,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -435,13 +438,13 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -466,7 +469,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -502,10 +505,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie_user2", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "delete_message",
-      "signedOffBy": null}, "operations": [{"key": {"elements": ["log", "foo", "bar"]},
-      "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["log", "foo", "bar"]}, "type": "DELETE"}],
+      "commitMeta": {"hash": null, "author": "nessie_user2", "signedOffBy": null,
+      "committer": null, "commitTime": null, "message": "delete_message", "properties":
+      null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -520,10 +523,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -547,7 +550,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -571,11 +574,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?max=1
   response:
     body:
-      string: "{\n  \"token\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
-        \ \"operations\" : [ {\n    \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\",\n
+      string: "{\n  \"token\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+        \ \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.685649Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.685649Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : true\n}"
     headers:
       Content-Type:
@@ -600,10 +603,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev_test_log/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"9a0c04da3ea2962f3d56ed1b4b8cfb15d40d090516a4ef8c1c024ac9a355d2da\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"b3a38c9da93d8ea21b030dc02ba7393b3ef921be71fadeaf285c05984d07ae0e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.426175Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.426175Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.673672Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.673672Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -628,7 +631,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -652,14 +655,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.685649Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.685649Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -684,7 +687,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -705,13 +708,13 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1&endHash=d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7&endHash=6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -736,7 +739,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -760,14 +763,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.685649Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.685649Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -792,7 +795,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -816,10 +819,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user1%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -844,7 +847,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -868,10 +871,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user2%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.685649Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.685649Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -896,7 +899,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -920,14 +923,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28commit.author%3D%3D%27nessie_user2%27+%7C%7C+commit.author%3D%3D%27nessie_user1%27%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.685649Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.685649Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -952,7 +955,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -976,14 +979,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.committer%3D%3D%27%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.685649Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.685649Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -1008,7 +1011,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -1032,10 +1035,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author+%3D%3D+%27nessie_user2%27+%7C%7C+commit.author+%3D%3D+%27non_existing%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.685649Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.685649Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -1060,7 +1063,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -1084,14 +1087,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28timestamp%28commit.commitTime%29+%3E+timestamp%28%272001-01-01T00%3A00%3A00%2B00%3A00%27%29+%26%26+timestamp%28commit.commitTime%29+%3C+timestamp%28%272999-12-30T23%3A00%3A00%2B00%3A00%27%29%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"08d4b67cabbc709cbad9e9f5618a3196e5ace53088b1322a8c7181afc56126a1\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.685649Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.685649Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"d7f2439ccdcb233ce58085b4a3c4c81dc88a370d42caa524838b36417e3fed2d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:46.508832Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:46.508832Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -96,8 +96,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev_test_log", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev_test_log", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -180,12 +180,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["log", "foo", "dev"]}, "content":
-      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_log_dev", "snapshotId":
-      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
-      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie_user1",
-      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
-      message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie_user1"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["log", "foo", "dev"]}, "content": {"specId": 44, "id": "test_log_dev",
+      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -204,7 +204,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev_test_log\",\n  \"hash\"
-        : \"b3a38c9da93d8ea21b030dc02ba7393b3ef921be71fadeaf285c05984d07ae0e\"\n}"
+        : \"72a5b98f44c950bb86cd9d1039a431e79b10d3e6afb56a5e00df03a8c463e463\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -231,7 +231,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev_test_log\",\n    \"hash\"
-        : \"b3a38c9da93d8ea21b030dc02ba7393b3ef921be71fadeaf285c05984d07ae0e\"\n  }
+        : \"72a5b98f44c950bb86cd9d1039a431e79b10d3e6afb56a5e00df03a8c463e463\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -268,12 +268,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["log", "foo", "bar"]}, "content":
-      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_log", "snapshotId":
-      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
-      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie_user1",
-      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
-      message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie_user1"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["log", "foo", "bar"]}, "content": {"specId": 44, "id": "test_log",
+      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -291,7 +291,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -315,7 +315,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -365,7 +365,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -389,10 +389,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -417,7 +417,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -438,13 +438,13 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -469,7 +469,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -505,10 +505,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["log", "foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"hash": null, "author": "nessie_user2", "signedOffBy": null,
-      "committer": null, "commitTime": null, "message": "delete_message", "properties":
-      null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "delete_message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie_user2"}, "operations": [{"key": {"elements": ["log",
+      "foo", "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -523,10 +523,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -550,7 +550,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -574,11 +574,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?max=1
   response:
     body:
-      string: "{\n  \"token\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
-        \ \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
+      string: "{\n  \"token\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
+        \ \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : true\n}"
     headers:
       Content-Type:
@@ -603,10 +603,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev_test_log/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"b3a38c9da93d8ea21b030dc02ba7393b3ef921be71fadeaf285c05984d07ae0e\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"72a5b98f44c950bb86cd9d1039a431e79b10d3e6afb56a5e00df03a8c463e463\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.673672Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.673672Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.443550Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.443550Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -631,7 +631,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -655,14 +655,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -687,7 +687,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -708,13 +708,13 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7&endHash=6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94&endHash=807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -739,7 +739,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -763,14 +763,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -795,7 +795,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -819,10 +819,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user1%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -847,7 +847,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -871,10 +871,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user2%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -899,7 +899,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -923,14 +923,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28commit.author%3D%3D%27nessie_user2%27+%7C%7C+commit.author%3D%3D%27nessie_user1%27%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -955,7 +955,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -979,14 +979,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.committer%3D%3D%27%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -1011,7 +1011,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -1035,10 +1035,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author+%3D%3D+%27nessie_user2%27+%7C%7C+commit.author+%3D%3D+%27non_existing%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -1063,7 +1063,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -1087,14 +1087,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28timestamp%28commit.commitTime%29+%3E+timestamp%28%272001-01-01T00%3A00%3A00%2B00%3A00%27%29+%26%26+timestamp%28commit.commitTime%29+%3C+timestamp%28%272999-12-30T23%3A00%3A00%2B00%3A00%27%29%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"ebee451199fe78825ae36768d24fd38ce807ace73ef9578d7773d905bb92eab7\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.911863Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.911863Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"6511cc49074099e2a93fc78164f3f6cb213af98323c436ed9f0f32fcd3d9d51d\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:13.764962Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:13.764962Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -131,11 +131,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["merge", "foo", "bar"]}, "content": {"idGenerators": "xyz", "metadataLocation":
-      "/a/b/c", "id": "test_merge", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["merge", "foo", "bar"]}, "content":
+      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_merge", "snapshotId":
+      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
+      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie test",
+      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
+      message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -144,7 +145,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '397'
+      - '441'
       Content-Type:
       - application/json
       User-Agent:
@@ -153,7 +154,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"120fd20c68e136107564c20a87182b49cf256eddede9d4af336e7d3de06f23f9\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -180,7 +181,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"120fd20c68e136107564c20a87182b49cf256eddede9d4af336e7d3de06f23f9\"\n  }
+        : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -229,7 +230,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"120fd20c68e136107564c20a87182b49cf256eddede9d4af336e7d3de06f23f9\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -239,7 +240,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromRefName": "dev", "fromHash": "120fd20c68e136107564c20a87182b49cf256eddede9d4af336e7d3de06f23f9"}'
+    body: '{"fromHash": "3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557",
+      "fromRefName": "dev"}'
     headers:
       Accept:
       - '*/*'
@@ -278,9 +280,9 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"120fd20c68e136107564c20a87182b49cf256eddede9d4af336e7d3de06f23f9\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"120fd20c68e136107564c20a87182b49cf256eddede9d4af336e7d3de06f23f9\"\n  }
+        : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -131,12 +131,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["merge", "foo", "bar"]}, "content":
-      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_merge", "snapshotId":
-      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
-      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie test",
-      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
-      message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["merge", "foo", "bar"]}, "content": {"specId": 44, "id": "test_merge",
+      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -154,7 +154,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -181,7 +181,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n  }
+        : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -230,7 +230,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -240,7 +240,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557",
+    body: '{"fromHash": "1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512",
       "fromRefName": "dev"}'
     headers:
       Accept:
@@ -280,9 +280,9 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"3621ecc9448ed18f400aea4cf556b0bd07527bedad24c47bc231f1e19af5b557\"\n  }
+        : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -50,8 +50,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev-tag", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "TAG"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev-tag", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -131,8 +131,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "etl-tag", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "TAG"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "etl-tag", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -413,8 +413,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "v1.0", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "TAG"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -131,12 +131,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["transplant", "foo", "bar"]}, "content": {"idGenerators": "xyz",
-      "metadataLocation": "/a/b/c", "id": "test_transplant_1", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["transplant", "foo", "bar"]}, "content":
+      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_transplant_1", "snapshotId":
+      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
+      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie test",
+      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
+      message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -145,7 +145,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '409'
+      - '453'
       Content-Type:
       - application/json
       User-Agent:
@@ -154,7 +154,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"361fcc55fa0489aa62c931d1e3a83f85703142eef392b020420bdcb881353a87\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"a11da436fc167bc2c1696892e7f4ad7174b773a1459eb711e80f59d81419e406\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -181,7 +181,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"361fcc55fa0489aa62c931d1e3a83f85703142eef392b020420bdcb881353a87\"\n  }
+        : \"a11da436fc167bc2c1696892e7f4ad7174b773a1459eb711e80f59d81419e406\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -218,11 +218,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["bar", "bar"]}, "content": {"idGenerators": "xyz", "metadataLocation":
-      "/a/b/c", "id": "test_transplant_2", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["bar", "bar"]}, "content": {"metadataLocation":
+      "/a/b/c", "specId": 44, "id": "test_transplant_2", "snapshotId": 42, "sortOrderId":
+      45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent": null, "type":
+      "PUT"}], "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy":
+      null, "committer": null, "commitTime": null, "message": "test message", "properties":
+      null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -231,16 +232,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '395'
+      - '439'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=361fcc55fa0489aa62c931d1e3a83f85703142eef392b020420bdcb881353a87
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=a11da436fc167bc2c1696892e7f4ad7174b773a1459eb711e80f59d81419e406
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"60689f38c5e1dcfbc03223926a49b5d79f3798cd60a7b4d3701e2ae5257c266d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -267,7 +268,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"60689f38c5e1dcfbc03223926a49b5d79f3798cd60a7b4d3701e2ae5257c266d\"\n  }
+        : \"8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -304,11 +305,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["foo", "baz"]}, "content": {"idGenerators": "xyz", "metadataLocation":
-      "/a/b/c", "id": "test_transplant_3", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["foo", "baz"]}, "content": {"metadataLocation":
+      "/a/b/c", "specId": 44, "id": "test_transplant_3", "snapshotId": 42, "sortOrderId":
+      45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent": null, "type":
+      "PUT"}], "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy":
+      null, "committer": null, "commitTime": null, "message": "test message", "properties":
+      null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -317,16 +319,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '395'
+      - '439'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=60689f38c5e1dcfbc03223926a49b5d79f3798cd60a7b4d3701e2ae5257c266d
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"c33ffb75a555d105bcad6b3219825a41e887676d54f4be1a2390c3974df3ed82\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -353,7 +355,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"c33ffb75a555d105bcad6b3219825a41e887676d54f4be1a2390c3974df3ed82\"\n  }
+        : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -378,18 +380,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"c33ffb75a555d105bcad6b3219825a41e887676d54f4be1a2390c3974df3ed82\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:48.622931Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:48.622931Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"60689f38c5e1dcfbc03223926a49b5d79f3798cd60a7b4d3701e2ae5257c266d\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.831148Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:15.831148Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:48.571268Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:48.571268Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"361fcc55fa0489aa62c931d1e3a83f85703142eef392b020420bdcb881353a87\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.791785Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:15.791785Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"a11da436fc167bc2c1696892e7f4ad7174b773a1459eb711e80f59d81419e406\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:48.533002Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:48.533002Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.742494Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:15.742494Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -424,8 +426,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hashesToTransplant": ["60689f38c5e1dcfbc03223926a49b5d79f3798cd60a7b4d3701e2ae5257c266d",
-      "c33ffb75a555d105bcad6b3219825a41e887676d54f4be1a2390c3974df3ed82"], "fromRefName":
+    body: '{"hashesToTransplant": ["8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11",
+      "11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e"], "fromRefName":
       "dev"}'
     headers:
       Accept:
@@ -464,7 +466,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d575bf1f9967fe77bb12dde178a91c7395f273de0892a39f19a43af0a62e656d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -488,14 +490,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d575bf1f9967fe77bb12dde178a91c7395f273de0892a39f19a43af0a62e656d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:48.622931Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:48.622931Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"90034ae2ef5dfb16c129fe0257ca73e35d7ce5021fbf2295f889164beb2a08d8\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.831148Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:15.831148Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"d468acde984c40256790cde3c874db2482523a52467f7533d7ad05a4472e98f7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:48.571268Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:48.571268Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.791785Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:15.791785Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -131,12 +131,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["transplant", "foo", "bar"]}, "content":
-      {"metadataLocation": "/a/b/c", "specId": 44, "id": "test_transplant_1", "snapshotId":
-      42, "sortOrderId": 45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent":
-      null, "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie test",
-      "signedOffBy": null, "committer": null, "commitTime": null, "message": "test
-      message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["transplant", "foo", "bar"]}, "content": {"specId": 44, "id":
+      "test_transplant_1", "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation":
+      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -154,7 +154,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"a11da436fc167bc2c1696892e7f4ad7174b773a1459eb711e80f59d81419e406\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"951f5e148490c1d885fc1bac6f093206349fd5acfb56efeff64a48014e0366de\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -181,7 +181,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"a11da436fc167bc2c1696892e7f4ad7174b773a1459eb711e80f59d81419e406\"\n  }
+        : \"951f5e148490c1d885fc1bac6f093206349fd5acfb56efeff64a48014e0366de\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -218,12 +218,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["bar", "bar"]}, "content": {"metadataLocation":
-      "/a/b/c", "specId": 44, "id": "test_transplant_2", "snapshotId": 42, "sortOrderId":
-      45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent": null, "type":
-      "PUT"}], "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy":
-      null, "committer": null, "commitTime": null, "message": "test message", "properties":
-      null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["bar", "bar"]}, "content": {"specId": 44, "id": "test_transplant_2",
+      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=a11da436fc167bc2c1696892e7f4ad7174b773a1459eb711e80f59d81419e406
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=951f5e148490c1d885fc1bac6f093206349fd5acfb56efeff64a48014e0366de
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -268,7 +268,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11\"\n  }
+        : \"88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -305,12 +305,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["foo", "baz"]}, "content": {"metadataLocation":
-      "/a/b/c", "specId": 44, "id": "test_transplant_3", "snapshotId": 42, "sortOrderId":
-      45, "schemaId": 43, "type": "ICEBERG_TABLE"}, "expectedContent": null, "type":
-      "PUT"}], "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy":
-      null, "committer": null, "commitTime": null, "message": "test message", "properties":
-      null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["foo", "baz"]}, "content": {"specId": 44, "id": "test_transplant_3",
+      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -325,10 +325,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -355,7 +355,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\"\n  }
+        : \"0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -380,18 +380,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.831148Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:15.831148Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.714414Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:58.714414Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.791785Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:15.791785Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"a11da436fc167bc2c1696892e7f4ad7174b773a1459eb711e80f59d81419e406\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.669717Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:58.669717Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"951f5e148490c1d885fc1bac6f093206349fd5acfb56efeff64a48014e0366de\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.742494Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:15.742494Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.624028Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:58.624028Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -426,9 +426,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hashesToTransplant": ["8e23bdee54cf6a90c912a982e9b477b2d99c49340e75370f75026d4a16441a11",
-      "11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e"], "fromRefName":
-      "dev"}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7",
+      "0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8"]}'
     headers:
       Accept:
       - '*/*'
@@ -466,7 +465,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"f642677fb7dd347eb6d3956c7506a6f49aad73c47858c367802223d080221d33\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -490,14 +489,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"f642677fb7dd347eb6d3956c7506a6f49aad73c47858c367802223d080221d33\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.831148Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:15.831148Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"d468acde984c40256790cde3c874db2482523a52467f7533d7ad05a4472e98f7\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.714414Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:58.714414Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"ff162b9aa1d98f5acc9db590f94da568c06ef258f24c02827c6560a8e056ad5e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:15.791785Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:15.791785Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.669717Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:53:58.669717Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_auth/test_bearer_auth.yaml
+++ b/python/tests/cassettes/test_nessie_cli_auth/test_bearer_auth.yaml
@@ -15,9 +15,9 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"f642677fb7dd347eb6d3956c7506a6f49aad73c47858c367802223d080221d33\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\"\n  }
+        : \"0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -42,7 +42,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"f642677fb7dd347eb6d3956c7506a6f49aad73c47858c367802223d080221d33\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -65,7 +65,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=f642677fb7dd347eb6d3956c7506a6f49aad73c47858c367802223d080221d33
   response:
     body:
       string: ''
@@ -88,7 +88,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8
   response:
     body:
       string: ''
@@ -144,8 +144,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/cassettes/test_nessie_cli_auth/test_bearer_auth.yaml
+++ b/python/tests/cassettes/test_nessie_cli_auth/test_bearer_auth.yaml
@@ -15,9 +15,9 @@ interactions:
   response:
     body:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"d575bf1f9967fe77bb12dde178a91c7395f273de0892a39f19a43af0a62e656d\"\n
+        \   \"name\" : \"main\",\n    \"hash\" : \"e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"c33ffb75a555d105bcad6b3219825a41e887676d54f4be1a2390c3974df3ed82\"\n  }
+        : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\"\n  }
         ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -42,7 +42,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d575bf1f9967fe77bb12dde178a91c7395f273de0892a39f19a43af0a62e656d\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -65,7 +65,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=d575bf1f9967fe77bb12dde178a91c7395f273de0892a39f19a43af0a62e656d
+    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=e11868270fa15eac481634bfe6ca9eb7f6c9737c94cc9062098dbbfd98c54b9d
   response:
     body:
       string: ''
@@ -88,7 +88,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"c33ffb75a555d105bcad6b3219825a41e887676d54f4be1a2390c3974df3ed82\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=c33ffb75a555d105bcad6b3219825a41e887676d54f4be1a2390c3974df3ed82
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=11abd950c5e0088ab2a3bb30c9a511ca37225344c3790bfd6c81a5c60210324e
   response:
     body:
       string: ''

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "contents_commit_delete_dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_contents_delete",
-      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
-      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
-      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
-      "test message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
+      "test_contents_delete", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42,
+      "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_delete_dev\",\n
-        \ \"hash\" : \"58b5634c3eebe333fec73a31df4b31676c79530b30211ef0f0cd93a6d8fe7d12\"\n}"
+        \ \"hash\" : \"44eef1796a019b990caba6d5cadb9aa933ca4b883b9eac15971edd5069d862bc\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -209,7 +209,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_delete_dev\",\n
-        \   \"hash\" : \"58b5634c3eebe333fec73a31df4b31676c79530b30211ef0f0cd93a6d8fe7d12\"\n
+        \   \"hash\" : \"44eef1796a019b990caba6d5cadb9aa933ca4b883b9eac15971edd5069d862bc\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -220,10 +220,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "type": "DELETE"}], "commitMeta": {"hash": null, "author": null, "signedOffBy":
-      null, "committer": null, "commitTime": null, "message": "delete test table",
-      "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "delete test table", "commitTime": null, "properties": null, "committer":
+      null, "author": null}, "operations": [{"key": {"elements": ["this", "is", "iceberg",
+      "foo"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -238,11 +238,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=58b5634c3eebe333fec73a31df4b31676c79530b30211ef0f0cd93a6d8fe7d12
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=44eef1796a019b990caba6d5cadb9aa933ca4b883b9eac15971edd5069d862bc
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_delete_dev\",\n
-        \ \"hash\" : \"f798272414c83d3f1a52411a3792977ec4e12303ce8c5b44301873e13566d70e\"\n}"
+        \ \"hash\" : \"731fa342fce6079ab3155b7a932f2a75c250dabc4fd43480564ac2bd1d655112\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"idGenerators":
-      "xyz", "metadataLocation": "/a/b/c", "id": "test_contents_delete", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_contents_delete",
+      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
+      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
+      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
+      "test message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -146,7 +146,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '416'
+      - '460'
       Content-Type:
       - application/json
       User-Agent:
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_delete_dev\",\n
-        \ \"hash\" : \"4be9dfed84e1d6d39125e16f7501130e376cdfce6ea4a1b594657aae74cf0ce6\"\n}"
+        \ \"hash\" : \"58b5634c3eebe333fec73a31df4b31676c79530b30211ef0f0cd93a6d8fe7d12\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -209,7 +209,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_delete_dev\",\n
-        \   \"hash\" : \"4be9dfed84e1d6d39125e16f7501130e376cdfce6ea4a1b594657aae74cf0ce6\"\n
+        \   \"hash\" : \"58b5634c3eebe333fec73a31df4b31676c79530b30211ef0f0cd93a6d8fe7d12\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -220,10 +220,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": null, "authorTime": null,
-      "hash": null, "properties": null, "committer": null, "message": "delete test
-      table", "signedOffBy": null}, "operations": [{"key": {"elements": ["this", "is",
-      "iceberg", "foo"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "type": "DELETE"}], "commitMeta": {"hash": null, "author": null, "signedOffBy":
+      null, "committer": null, "commitTime": null, "message": "delete test table",
+      "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -238,11 +238,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=4be9dfed84e1d6d39125e16f7501130e376cdfce6ea4a1b594657aae74cf0ce6
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=58b5634c3eebe333fec73a31df4b31676c79530b30211ef0f0cd93a6d8fe7d12
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_delete_dev\",\n
-        \ \"hash\" : \"3e6f18cc20f7feb8994cabbcb88969d4357f4fa2399a962b4176b378775a5476\"\n}"
+        \ \"hash\" : \"f798272414c83d3f1a52411a3792977ec4e12303ce8c5b44301873e13566d70e\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "contents_commit_with_no__expected_state", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -133,13 +133,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["commit", "expected", "contents"]},
-      "content": {"lastCheckpoint": "x", "metadataLocationHistory": ["asd111"], "id":
-      "test_commit_no_expected_state", "checkpointLocationHistory": ["def"], "type":
-      "DELTA_LAKE_TABLE"}, "expectedContent": null, "type": "PUT"}], "commitMeta":
-      {"hash": null, "author": "nessie test", "signedOffBy": null, "committer": null,
-      "commitTime": null, "message": "commit 1", "properties": null, "authorTime":
-      null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "commit 1", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["commit", "expected", "contents"]}, "content": {"checkpointLocationHistory":
+      ["def"], "metadataLocationHistory": ["asd111"], "lastCheckpoint": "x", "id":
+      "test_commit_no_expected_state", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -158,7 +157,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \ \"hash\" : \"e7cc1f02793565557163864ab67aeae5febcef732eba79f601d9079e438082bd\"\n}"
+        \ \"hash\" : \"dcdc812a8756a0da0f1ccc2829bc357f2a4309872ae46fad8621010535d2e2c2\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -185,7 +184,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \   \"hash\" : \"e7cc1f02793565557163864ab67aeae5febcef732eba79f601d9079e438082bd\"\n
+        \   \"hash\" : \"dcdc812a8756a0da0f1ccc2829bc357f2a4309872ae46fad8621010535d2e2c2\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -222,13 +221,12 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["commit", "expected", "contents"]},
-      "content": {"lastCheckpoint": "x", "metadataLocationHistory": ["asd222"], "id":
-      "test_commit_no_expected_state", "checkpointLocationHistory": ["def"], "type":
-      "DELTA_LAKE_TABLE"}, "expectedContent": null, "type": "PUT"}], "commitMeta":
-      {"hash": null, "author": "nessie test", "signedOffBy": null, "committer": null,
-      "commitTime": null, "message": "commit 2", "properties": null, "authorTime":
-      null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "commit 2", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["commit", "expected", "contents"]}, "content": {"checkpointLocationHistory":
+      ["def"], "metadataLocationHistory": ["asd222"], "lastCheckpoint": "x", "id":
+      "test_commit_no_expected_state", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -243,11 +241,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=e7cc1f02793565557163864ab67aeae5febcef732eba79f601d9079e438082bd
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=dcdc812a8756a0da0f1ccc2829bc357f2a4309872ae46fad8621010535d2e2c2
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \ \"hash\" : \"d930df1b43561a6ef6d0ea9cc0835fba0f21a5d616558a30d1c65b53297efc44\"\n}"
+        \ \"hash\" : \"f2818b2ffb7c3e865eb7dcbbc7c1e43dbc97cba8bd1ad7671b9e9f5c4f7c2f0b\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
@@ -133,12 +133,13 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "commit
-      1", "signedOffBy": null}, "operations": [{"expectedContent": null, "key": {"elements":
-      ["commit", "expected", "contents"]}, "content": {"lastCheckpoint": "x", "metadataLocationHistory":
-      ["asd111"], "checkpointLocationHistory": ["def"], "id": "test_commit_no_expected_state",
-      "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["commit", "expected", "contents"]},
+      "content": {"lastCheckpoint": "x", "metadataLocationHistory": ["asd111"], "id":
+      "test_commit_no_expected_state", "checkpointLocationHistory": ["def"], "type":
+      "DELTA_LAKE_TABLE"}, "expectedContent": null, "type": "PUT"}], "commitMeta":
+      {"hash": null, "author": "nessie test", "signedOffBy": null, "committer": null,
+      "commitTime": null, "message": "commit 1", "properties": null, "authorTime":
+      null}}'
     headers:
       Accept:
       - '*/*'
@@ -157,7 +158,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \ \"hash\" : \"48eca33b72dacdef25fb482b6c27974230ff5a85b71e2c73e99bc4320b4fe272\"\n}"
+        \ \"hash\" : \"e7cc1f02793565557163864ab67aeae5febcef732eba79f601d9079e438082bd\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -184,7 +185,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \   \"hash\" : \"48eca33b72dacdef25fb482b6c27974230ff5a85b71e2c73e99bc4320b4fe272\"\n
+        \   \"hash\" : \"e7cc1f02793565557163864ab67aeae5febcef732eba79f601d9079e438082bd\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -221,12 +222,13 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "commit
-      2", "signedOffBy": null}, "operations": [{"expectedContent": null, "key": {"elements":
-      ["commit", "expected", "contents"]}, "content": {"lastCheckpoint": "x", "metadataLocationHistory":
-      ["asd222"], "checkpointLocationHistory": ["def"], "id": "test_commit_no_expected_state",
-      "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["commit", "expected", "contents"]},
+      "content": {"lastCheckpoint": "x", "metadataLocationHistory": ["asd222"], "id":
+      "test_commit_no_expected_state", "checkpointLocationHistory": ["def"], "type":
+      "DELTA_LAKE_TABLE"}, "expectedContent": null, "type": "PUT"}], "commitMeta":
+      {"hash": null, "author": "nessie test", "signedOffBy": null, "committer": null,
+      "commitTime": null, "message": "commit 2", "properties": null, "authorTime":
+      null}}'
     headers:
       Accept:
       - '*/*'
@@ -241,11 +243,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=48eca33b72dacdef25fb482b6c27974230ff5a85b71e2c73e99bc4320b4fe272
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=e7cc1f02793565557163864ab67aeae5febcef732eba79f601d9079e438082bd
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \ \"hash\" : \"812e03c026c66b7d4fc79a716b519a526ddb7b28d5da02ceda23345fc27ef530\"\n}"
+        \ \"hash\" : \"d930df1b43561a6ef6d0ea9cc0835fba0f21a5d616558a30d1c65b53297efc44\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "content_commit_with_edited_data_dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_content_commit_with_edited_data",
-      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
-      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
-      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
-      "test message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
+      "test_content_commit_with_edited_data", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \ \"hash\" : \"54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f\"\n}"
+        \ \"hash\" : \"d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -209,7 +209,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \   \"hash\" : \"54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f\"\n
+        \   \"hash\" : \"d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -260,10 +260,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/content_commit_with_edited_data_dev/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:17.573168Z\",\n
-        \   \"authorTime\" : \"2021-11-10T13:43:17.573168Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:54:00.346928Z\",\n
+        \   \"authorTime\" : \"2021-11-11T14:54:00.346928Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -291,7 +291,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \   \"hash\" : \"54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f\"\n
+        \   \"hash\" : \"d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -328,14 +328,15 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "content": {"metadataLocation": "/d/e/f", "specId": 42, "id": "test_content_commit_with_edited_data",
-      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
-      "expectedContent": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_content_commit_with_edited_data",
-      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
-      "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy":
-      null, "committer": null, "commitTime": null, "message": "test message", "properties":
-      null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": {"specId":
+      42, "id": "test_content_commit_with_edited_data", "schemaId": 42, "snapshotId":
+      42, "sortOrderId": 42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"},
+      "key": {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId":
+      42, "id": "test_content_commit_with_edited_data", "schemaId": 42, "snapshotId":
+      42, "sortOrderId": 42, "metadataLocation": "/d/e/f", "type": "ICEBERG_TABLE"},
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -350,11 +351,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f
+    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \ \"hash\" : \"57f447891f2ae60dd0ac3cd2eed312383b980cb4b2b211e43f13a4c719f1c8e4\"\n}"
+        \ \"hash\" : \"ff6835d1693a896f4d772eda76f692decb04d84d48d46586dbf5ec2d1bb80437\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"idGenerators":
-      "xyz", "metadataLocation": "/a/b/c", "id": "test_content_commit_with_edited_data",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_content_commit_with_edited_data",
+      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
+      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
+      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
+      "test message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -146,7 +146,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '432'
+      - '476'
       Content-Type:
       - application/json
       User-Agent:
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \ \"hash\" : \"d38c0ad992019cacf156c38f5e4a4c3bf482c774a5a69c61436d1ffe78fb08fe\"\n}"
+        \ \"hash\" : \"54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -209,7 +209,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \   \"hash\" : \"d38c0ad992019cacf156c38f5e4a4c3bf482c774a5a69c61436d1ffe78fb08fe\"\n
+        \   \"hash\" : \"54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -235,12 +235,13 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_content_commit_with_edited_data\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"idGenerators\" : \"xyz\"\n}"
+        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
+        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '138'
+      - '191'
     status:
       code: 200
       message: OK
@@ -259,10 +260,10 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/content_commit_with_edited_data_dev/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d38c0ad992019cacf156c38f5e4a4c3bf482c774a5a69c61436d1ffe78fb08fe\",\n
+      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-08T16:11:50.323345Z\",\n
-        \   \"authorTime\" : \"2021-11-08T16:11:50.323345Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-10T13:43:17.573168Z\",\n
+        \   \"authorTime\" : \"2021-11-10T13:43:17.573168Z\",\n    \"properties\"
         : { }\n  } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -290,7 +291,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \   \"hash\" : \"d38c0ad992019cacf156c38f5e4a4c3bf482c774a5a69c61436d1ffe78fb08fe\"\n
+        \   \"hash\" : \"54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -316,23 +317,25 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_content_commit_with_edited_data\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"idGenerators\" : \"xyz\"\n}"
+        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
+        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '138'
+      - '191'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": {"idGenerators":
-      "xyz", "metadataLocation": "/a/b/c", "id": "test_content_commit_with_edited_data",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "content": {"idGenerators": "xyz", "metadataLocation": "/d/e/f", "id": "test_content_commit_with_edited_data",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "content": {"metadataLocation": "/d/e/f", "specId": 42, "id": "test_content_commit_with_edited_data",
+      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
+      "expectedContent": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_content_commit_with_edited_data",
+      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
+      "type": "PUT"}], "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy":
+      null, "committer": null, "commitTime": null, "message": "test message", "properties":
+      null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -341,17 +344,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '552'
+      - '640'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=d38c0ad992019cacf156c38f5e4a4c3bf482c774a5a69c61436d1ffe78fb08fe
+    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=54c35c40b9c35bada360ed1398be5a11fd7e4a959b73ca5ca07780d40bd1fc3f
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \ \"hash\" : \"10a13c8acf3777d7cf35353507b004da7313ff0616f5825368375dfbe3e0ab6a\"\n}"
+        \ \"hash\" : \"57f447891f2ae60dd0ac3cd2eed312383b980cb4b2b211e43f13a4c719f1c8e4\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -402,12 +405,13 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_content_commit_with_edited_data\",\n
-        \ \"metadataLocation\" : \"/d/e/f\",\n  \"idGenerators\" : \"xyz\"\n}"
+        \ \"metadataLocation\" : \"/d/e/f\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
+        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '138'
+      - '191'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "contents_commit_with_empty_content_delete_dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -132,12 +132,13 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_contents_with_empty_content_delete",
-      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
-      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
-      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
-      "test message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
+      "test_contents_with_empty_content_delete", "schemaId": 42, "snapshotId": 42,
+      "sortOrderId": 42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type":
+      "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -156,7 +157,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \ \"hash\" : \"e589f9b67f01e777e86fa97043adbe28b9835a7d152bc97143200aeb8fcf12bd\"\n}"
+        \ \"hash\" : \"e761fff6b3ddcdc272a9c8b1cb9d86ca485643a7e3cc3bab05f146ebcc4ac37c\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -209,7 +210,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \   \"hash\" : \"e589f9b67f01e777e86fa97043adbe28b9835a7d152bc97143200aeb8fcf12bd\"\n
+        \   \"hash\" : \"e761fff6b3ddcdc272a9c8b1cb9d86ca485643a7e3cc3bab05f146ebcc4ac37c\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -246,10 +247,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "type": "DELETE"}], "commitMeta": {"hash": null, "author": null, "signedOffBy":
-      null, "committer": null, "commitTime": null, "message": "delete table", "properties":
-      null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "delete table", "commitTime": null, "properties": null, "committer":
+      null, "author": null}, "operations": [{"key": {"elements": ["this", "is", "iceberg",
+      "foo"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -264,11 +265,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=e589f9b67f01e777e86fa97043adbe28b9835a7d152bc97143200aeb8fcf12bd
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=e761fff6b3ddcdc272a9c8b1cb9d86ca485643a7e3cc3bab05f146ebcc4ac37c
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \ \"hash\" : \"f013c5e4b3f0f38cadd723af11e47c51052c0118bded0c641829be647bae3b4a\"\n}"
+        \ \"hash\" : \"b7bbb351e52a9ac30f9d252573c4b7be364e63bd6958c0986c45e2613640ec4a\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"idGenerators":
-      "xyz", "metadataLocation": "/a/b/c", "id": "test_contents_with_empty_content_delete",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_contents_with_empty_content_delete",
+      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
+      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
+      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
+      "test message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -146,7 +146,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '435'
+      - '479'
       Content-Type:
       - application/json
       User-Agent:
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \ \"hash\" : \"dedb1c862008e6a486e64e86da2163f386b6f2a43692c4ca06ef4a6ebd1d0fab\"\n}"
+        \ \"hash\" : \"e589f9b67f01e777e86fa97043adbe28b9835a7d152bc97143200aeb8fcf12bd\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -209,7 +209,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \   \"hash\" : \"dedb1c862008e6a486e64e86da2163f386b6f2a43692c4ca06ef4a6ebd1d0fab\"\n
+        \   \"hash\" : \"e589f9b67f01e777e86fa97043adbe28b9835a7d152bc97143200aeb8fcf12bd\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -235,20 +235,21 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_contents_with_empty_content_delete\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"idGenerators\" : \"xyz\"\n}"
+        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
+        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '141'
+      - '194'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": null, "authorTime": null,
-      "hash": null, "properties": null, "committer": null, "message": "delete table",
-      "signedOffBy": null}, "operations": [{"key": {"elements": ["this", "is", "iceberg",
-      "foo"]}, "type": "DELETE"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "type": "DELETE"}], "commitMeta": {"hash": null, "author": null, "signedOffBy":
+      null, "committer": null, "commitTime": null, "message": "delete table", "properties":
+      null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -263,11 +264,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=dedb1c862008e6a486e64e86da2163f386b6f2a43692c4ca06ef4a6ebd1d0fab
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=e589f9b67f01e777e86fa97043adbe28b9835a7d152bc97143200aeb8fcf12bd
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \ \"hash\" : \"5e113967dad18e5d905c85e3f9e90f31c5a3bea37308bded237cc68a2cfbef72\"\n}"
+        \ \"hash\" : \"f013c5e4b3f0f38cadd723af11e47c51052c0118bded0c641829be647bae3b4a\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "contents_commit_with_expected_state", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "contents_commit_with_expected_state", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -133,12 +133,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["commit", "expected", "contents"]},
-      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_expected_contents",
-      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
-      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
-      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
-      "commit 1", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "commit 1", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["commit", "expected", "contents"]}, "content": {"specId": 42,
+      "id": "test_expected_contents", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -157,7 +157,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_expected_state\",\n
-        \ \"hash\" : \"d779dbf39d1894d9b1d4925cca8cf088fa7f0f3d4fe58f0b10baa3c3a18d7431\"\n}"
+        \ \"hash\" : \"ee02e3b3495818c9b151e2684242cbc8ffd84d116d1731db8a87e3d817e78795\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -184,7 +184,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_expected_state\",\n
-        \   \"hash\" : \"d779dbf39d1894d9b1d4925cca8cf088fa7f0f3d4fe58f0b10baa3c3a18d7431\"\n
+        \   \"hash\" : \"ee02e3b3495818c9b151e2684242cbc8ffd84d116d1731db8a87e3d817e78795\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
@@ -133,12 +133,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "commit
-      1", "signedOffBy": null}, "operations": [{"expectedContent": null, "key": {"elements":
-      ["commit", "expected", "contents"]}, "content": {"idGenerators": "xyz", "metadataLocation":
-      "/a/b/c", "id": "test_expected_contents", "type": "ICEBERG_TABLE"}, "type":
-      "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["commit", "expected", "contents"]},
+      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_expected_contents",
+      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
+      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
+      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
+      "commit 1", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -147,7 +147,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '416'
+      - '460'
       Content-Type:
       - application/json
       User-Agent:
@@ -157,7 +157,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_expected_state\",\n
-        \ \"hash\" : \"d878236e630948097c6db2c2f303a0d40558d3397bb66a83b1164d082aadcd1f\"\n}"
+        \ \"hash\" : \"d779dbf39d1894d9b1d4925cca8cf088fa7f0f3d4fe58f0b10baa3c3a18d7431\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -184,7 +184,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_expected_state\",\n
-        \   \"hash\" : \"d878236e630948097c6db2c2f303a0d40558d3397bb66a83b1164d082aadcd1f\"\n
+        \   \"hash\" : \"d779dbf39d1894d9b1d4925cca8cf088fa7f0f3d4fe58f0b10baa3c3a18d7431\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -210,12 +210,13 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_expected_contents\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"idGenerators\" : \"xyz\"\n}"
+        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
+        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '124'
+      - '177'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "contents_list_dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_contents_list",
-      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
-      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
-      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
-      "test message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
+      "test_contents_list", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42, "metadataLocation":
+      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"3dcbd662556e1a204e81ff1580b5350fa8c0d85d9bb9b1557bb0feb0f4033773\"\n}"
+        \ \"hash\" : \"61860b04f3a0a3819fa7c23c39bfa4e6ecb2a3c94ef876bb560fdc0f92cec1ad\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -183,7 +183,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_list_dev\",\n
-        \   \"hash\" : \"3dcbd662556e1a204e81ff1580b5350fa8c0d85d9bb9b1557bb0feb0f4033773\"\n
+        \   \"hash\" : \"61860b04f3a0a3819fa7c23c39bfa4e6ecb2a3c94ef876bb560fdc0f92cec1ad\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -220,12 +220,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "delta", "bar"]}, "content":
-      {"lastCheckpoint": "x", "metadataLocationHistory": ["asd"], "id": "uuid2", "checkpointLocationHistory":
-      ["def"], "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "type": "PUT"}],
-      "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy": null, "committer":
-      null, "commitTime": null, "message": "test message", "properties": null, "authorTime":
-      null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "delta", "bar"]}, "content": {"checkpointLocationHistory":
+      ["def"], "metadataLocationHistory": ["asd"], "lastCheckpoint": "x", "id": "uuid2",
+      "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -240,11 +240,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=3dcbd662556e1a204e81ff1580b5350fa8c0d85d9bb9b1557bb0feb0f4033773
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=61860b04f3a0a3819fa7c23c39bfa4e6ecb2a3c94ef876bb560fdc0f92cec1ad
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"91564336cf8cbacaa731533b9469b6eb50fd88d1f4a2cb58f15832d612bf541e\"\n}"
+        \ \"hash\" : \"244dd123b6e1490a6bbcf9cb73d23cedaf4823c5958003c0e90926eaf74a30af\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -271,7 +271,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_list_dev\",\n
-        \   \"hash\" : \"91564336cf8cbacaa731533b9469b6eb50fd88d1f4a2cb58f15832d612bf541e\"\n
+        \   \"hash\" : \"244dd123b6e1490a6bbcf9cb73d23cedaf4823c5958003c0e90926eaf74a30af\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -308,11 +308,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"key": {"elements": ["this", "is", "sql", "baz"]}, "content":
-      {"sqlText": "SELECT * FROM foo", "id": "uuid3", "dialect": "SPARK", "type":
-      "VIEW"}, "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null,
-      "author": "nessie test", "signedOffBy": null, "committer": null, "commitTime":
-      null, "message": "test message", "properties": null, "authorTime": null}}'
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "sql", "baz"]}, "content": {"dialect": "SPARK",
+      "sqlText": "SELECT * FROM foo", "id": "uuid3", "type": "VIEW"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -327,11 +327,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=91564336cf8cbacaa731533b9469b6eb50fd88d1f4a2cb58f15832d612bf541e
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=244dd123b6e1490a6bbcf9cb73d23cedaf4823c5958003c0e90926eaf74a30af
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"0fba21d37f68745e575aaec9dceb04192f6c5f21a09884b7615f283decd83849\"\n}"
+        \ \"hash\" : \"389469c5c3ae0c57f320c22921545e7172fecf56fc438a02c7118427e958be69\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"idGenerators":
-      "xyz", "metadataLocation": "/a/b/c", "id": "test_contents_list", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_contents_list",
+      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
+      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
+      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
+      "test message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -146,7 +146,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '414'
+      - '458'
       Content-Type:
       - application/json
       User-Agent:
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"637b0b26d08125bcacbca1ef7f9bdbe0c0bb5879c0204f4ff1e5edcc798c032e\"\n}"
+        \ \"hash\" : \"3dcbd662556e1a204e81ff1580b5350fa8c0d85d9bb9b1557bb0feb0f4033773\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -183,7 +183,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_list_dev\",\n
-        \   \"hash\" : \"637b0b26d08125bcacbca1ef7f9bdbe0c0bb5879c0204f4ff1e5edcc798c032e\"\n
+        \   \"hash\" : \"3dcbd662556e1a204e81ff1580b5350fa8c0d85d9bb9b1557bb0feb0f4033773\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -220,12 +220,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "delta", "bar"]}, "content": {"lastCheckpoint":
-      "x", "metadataLocationHistory": ["asd"], "checkpointLocationHistory": ["def"],
-      "id": "uuid2", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "delta", "bar"]}, "content":
+      {"lastCheckpoint": "x", "metadataLocationHistory": ["asd"], "id": "uuid2", "checkpointLocationHistory":
+      ["def"], "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "type": "PUT"}],
+      "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy": null, "committer":
+      null, "commitTime": null, "message": "test message", "properties": null, "authorTime":
+      null}}'
     headers:
       Accept:
       - '*/*'
@@ -240,11 +240,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=637b0b26d08125bcacbca1ef7f9bdbe0c0bb5879c0204f4ff1e5edcc798c032e
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=3dcbd662556e1a204e81ff1580b5350fa8c0d85d9bb9b1557bb0feb0f4033773
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"79b7d1477fe125600e32750eea90aedff7d412ab75428590e3d4bbe927673480\"\n}"
+        \ \"hash\" : \"91564336cf8cbacaa731533b9469b6eb50fd88d1f4a2cb58f15832d612bf541e\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -271,7 +271,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_list_dev\",\n
-        \   \"hash\" : \"79b7d1477fe125600e32750eea90aedff7d412ab75428590e3d4bbe927673480\"\n
+        \   \"hash\" : \"91564336cf8cbacaa731533b9469b6eb50fd88d1f4a2cb58f15832d612bf541e\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -308,11 +308,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"commitTime": null, "author": "nessie test", "authorTime":
-      null, "hash": null, "properties": null, "committer": null, "message": "test
-      message", "signedOffBy": null}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "sql", "baz"]}, "content": {"dialect": "SPARK",
-      "sqlText": "SELECT * FROM foo", "id": "uuid3", "type": "VIEW"}, "type": "PUT"}]}'
+    body: '{"operations": [{"key": {"elements": ["this", "is", "sql", "baz"]}, "content":
+      {"sqlText": "SELECT * FROM foo", "id": "uuid3", "dialect": "SPARK", "type":
+      "VIEW"}, "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null,
+      "author": "nessie test", "signedOffBy": null, "committer": null, "commitTime":
+      null, "message": "test message", "properties": null, "authorTime": null}}'
     headers:
       Accept:
       - '*/*'
@@ -327,11 +327,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=79b7d1477fe125600e32750eea90aedff7d412ab75428590e3d4bbe927673480
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=91564336cf8cbacaa731533b9469b6eb50fd88d1f4a2cb58f15832d612bf541e
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"7d4e3a686a38aa14b804e56a00d13b6858e3c9ba805fe5cd8e1849772628ff82\"\n}"
+        \ \"hash\" : \"0fba21d37f68745e575aaec9dceb04192f6c5f21a09884b7615f283decd83849\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "contents_view_dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -132,21 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-<<<<<<< HEAD
-    body: '{"commitMeta": {"author": "nessie test", "signedOffBy": null, "properties":
-      null, "message": "test message", "committer": null, "hash": null, "commitTime":
-      null, "authorTime": null}, "operations": [{"key": {"elements": ["this", "is",
-      "iceberg", "foo"]}, "expectedContent": null, "content": {"idGenerators": "xyz",
-      "metadataLocation": "/a/b/c", "id": "test_contents_view", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
-=======
-    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
-      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_contents_view",
-      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
-      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
-      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
-      "test message", "properties": null, "authorTime": null}}'
->>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
+      "test_contents_view", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42, "metadataLocation":
+      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -165,11 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-<<<<<<< HEAD
-        \ \"hash\" : \"68f5ecfaf5bdc76d417b60cb8531613ebef2c07cbd8e9499f7a21655f57b89ce\"\n}"
-=======
-        \ \"hash\" : \"ac3fbc79e1534ad5ea294166b4f022b3647d4cf67863bc39c564c23044a0e22e\"\n}"
->>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
+        \ \"hash\" : \"de1e5eb78d57239f4b348b6c648ea63dfedd8e30f303862af0b61275ba5e1b49\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -196,11 +183,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_view_dev\",\n
-<<<<<<< HEAD
-        \   \"hash\" : \"68f5ecfaf5bdc76d417b60cb8531613ebef2c07cbd8e9499f7a21655f57b89ce\"\n
-=======
-        \   \"hash\" : \"ac3fbc79e1534ad5ea294166b4f022b3647d4cf67863bc39c564c23044a0e22e\"\n
->>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
+        \   \"hash\" : \"de1e5eb78d57239f4b348b6c648ea63dfedd8e30f303862af0b61275ba5e1b49\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -237,21 +220,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-<<<<<<< HEAD
-    body: '{"commitMeta": {"author": "nessie test", "signedOffBy": null, "properties":
-      null, "message": "test message", "committer": null, "hash": null, "commitTime":
-      null, "authorTime": null}, "operations": [{"key": {"elements": ["this", "is",
-      "delta", "bar"]}, "expectedContent": null, "content": {"metadataLocationHistory":
-      ["asd"], "checkpointLocationHistory": ["def"], "lastCheckpoint": "x", "id":
-      "uuid2", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
-=======
-    body: '{"operations": [{"key": {"elements": ["this", "is", "delta", "bar"]}, "content":
-      {"lastCheckpoint": "x", "metadataLocationHistory": ["asd"], "id": "uuid2", "checkpointLocationHistory":
-      ["def"], "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "type": "PUT"}],
-      "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy": null, "committer":
-      null, "commitTime": null, "message": "test message", "properties": null, "authorTime":
-      null}}'
->>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "delta", "bar"]}, "content": {"checkpointLocationHistory":
+      ["def"], "metadataLocationHistory": ["asd"], "lastCheckpoint": "x", "id": "uuid2",
+      "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -266,19 +240,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-<<<<<<< HEAD
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=68f5ecfaf5bdc76d417b60cb8531613ebef2c07cbd8e9499f7a21655f57b89ce
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=de1e5eb78d57239f4b348b6c648ea63dfedd8e30f303862af0b61275ba5e1b49
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-        \ \"hash\" : \"f0d992864be441e83687256b39bc1f996cfbf81ea6b42c1e107f8c68f2310555\"\n}"
-=======
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=ac3fbc79e1534ad5ea294166b4f022b3647d4cf67863bc39c564c23044a0e22e
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-        \ \"hash\" : \"fed054616bd822155dc2d320bdd48967335d7c2b0bf113cca80a779617cf27f8\"\n}"
->>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
+        \ \"hash\" : \"47a9003ec38a8de1907b6a9c518867ad478ccaba36244f24acb9fbe35d01d989\"\n}"
     headers:
       Content-Type:
       - application/json
@@ -305,11 +271,7 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_view_dev\",\n
-<<<<<<< HEAD
-        \   \"hash\" : \"f0d992864be441e83687256b39bc1f996cfbf81ea6b42c1e107f8c68f2310555\"\n
-=======
-        \   \"hash\" : \"fed054616bd822155dc2d320bdd48967335d7c2b0bf113cca80a779617cf27f8\"\n
->>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
+        \   \"hash\" : \"47a9003ec38a8de1907b6a9c518867ad478ccaba36244f24acb9fbe35d01d989\"\n
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -346,19 +308,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-<<<<<<< HEAD
-    body: '{"commitMeta": {"author": "nessie test", "signedOffBy": null, "properties":
-      null, "message": "test message", "committer": null, "hash": null, "commitTime":
-      null, "authorTime": null}, "operations": [{"key": {"elements": ["this", "is",
-      "sql.baz"]}, "expectedContent": null, "content": {"sqlText": "SELECT * FROM
-      foo", "dialect": "SPARK", "id": "uuid3", "type": "VIEW"}, "type": "PUT"}]}'
-=======
-    body: '{"operations": [{"key": {"elements": ["this", "is", "sql", "baz"]}, "content":
-      {"sqlText": "SELECT * FROM foo", "id": "uuid3", "dialect": "SPARK", "type":
-      "VIEW"}, "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null,
-      "author": "nessie test", "signedOffBy": null, "committer": null, "commitTime":
-      null, "message": "test message", "properties": null, "authorTime": null}}'
->>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
+    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
+      "message": "test message", "commitTime": null, "properties": null, "committer":
+      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
+      {"elements": ["this", "is", "sql.baz"]}, "content": {"dialect": "SPARK", "sqlText":
+      "SELECT * FROM foo", "id": "uuid3", "type": "VIEW"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -373,19 +327,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-<<<<<<< HEAD
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=f0d992864be441e83687256b39bc1f996cfbf81ea6b42c1e107f8c68f2310555
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=47a9003ec38a8de1907b6a9c518867ad478ccaba36244f24acb9fbe35d01d989
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-        \ \"hash\" : \"18af029596bcaf748ca002cae0fae5ec312bdf85ebe1a3f14089a35ab8707024\"\n}"
-=======
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=fed054616bd822155dc2d320bdd48967335d7c2b0bf113cca80a779617cf27f8
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-        \ \"hash\" : \"8f6ccb5052814fbffe8c2f4e7711707827fe481ff27eefc9518ef3ca189d4366\"\n}"
->>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
+        \ \"hash\" : \"87da44ba71b55a9aa2ce3666df8387e2abd99909238035aaebf646e38a39e4d9\"\n}"
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
@@ -132,12 +132,21 @@ interactions:
       code: 404
       message: Not Found
 - request:
+<<<<<<< HEAD
     body: '{"commitMeta": {"author": "nessie test", "signedOffBy": null, "properties":
       null, "message": "test message", "committer": null, "hash": null, "commitTime":
       null, "authorTime": null}, "operations": [{"key": {"elements": ["this", "is",
       "iceberg", "foo"]}, "expectedContent": null, "content": {"idGenerators": "xyz",
       "metadataLocation": "/a/b/c", "id": "test_contents_view", "type": "ICEBERG_TABLE"},
       "type": "PUT"}]}'
+=======
+    body: '{"operations": [{"key": {"elements": ["this", "is", "iceberg", "foo"]},
+      "content": {"metadataLocation": "/a/b/c", "specId": 42, "id": "test_contents_view",
+      "snapshotId": 42, "sortOrderId": 42, "schemaId": 42, "type": "ICEBERG_TABLE"},
+      "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null, "author":
+      "nessie test", "signedOffBy": null, "committer": null, "commitTime": null, "message":
+      "test message", "properties": null, "authorTime": null}}'
+>>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
     headers:
       Accept:
       - '*/*'
@@ -146,7 +155,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '414'
+      - '458'
       Content-Type:
       - application/json
       User-Agent:
@@ -156,7 +165,11 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
+<<<<<<< HEAD
         \ \"hash\" : \"68f5ecfaf5bdc76d417b60cb8531613ebef2c07cbd8e9499f7a21655f57b89ce\"\n}"
+=======
+        \ \"hash\" : \"ac3fbc79e1534ad5ea294166b4f022b3647d4cf67863bc39c564c23044a0e22e\"\n}"
+>>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
     headers:
       Content-Type:
       - application/json
@@ -183,7 +196,11 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_view_dev\",\n
+<<<<<<< HEAD
         \   \"hash\" : \"68f5ecfaf5bdc76d417b60cb8531613ebef2c07cbd8e9499f7a21655f57b89ce\"\n
+=======
+        \   \"hash\" : \"ac3fbc79e1534ad5ea294166b4f022b3647d4cf67863bc39c564c23044a0e22e\"\n
+>>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -220,12 +237,21 @@ interactions:
       code: 404
       message: Not Found
 - request:
+<<<<<<< HEAD
     body: '{"commitMeta": {"author": "nessie test", "signedOffBy": null, "properties":
       null, "message": "test message", "committer": null, "hash": null, "commitTime":
       null, "authorTime": null}, "operations": [{"key": {"elements": ["this", "is",
       "delta", "bar"]}, "expectedContent": null, "content": {"metadataLocationHistory":
       ["asd"], "checkpointLocationHistory": ["def"], "lastCheckpoint": "x", "id":
       "uuid2", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
+=======
+    body: '{"operations": [{"key": {"elements": ["this", "is", "delta", "bar"]}, "content":
+      {"lastCheckpoint": "x", "metadataLocationHistory": ["asd"], "id": "uuid2", "checkpointLocationHistory":
+      ["def"], "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "type": "PUT"}],
+      "commitMeta": {"hash": null, "author": "nessie test", "signedOffBy": null, "committer":
+      null, "commitTime": null, "message": "test message", "properties": null, "authorTime":
+      null}}'
+>>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
     headers:
       Accept:
       - '*/*'
@@ -240,11 +266,19 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
+<<<<<<< HEAD
     uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=68f5ecfaf5bdc76d417b60cb8531613ebef2c07cbd8e9499f7a21655f57b89ce
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
         \ \"hash\" : \"f0d992864be441e83687256b39bc1f996cfbf81ea6b42c1e107f8c68f2310555\"\n}"
+=======
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=ac3fbc79e1534ad5ea294166b4f022b3647d4cf67863bc39c564c23044a0e22e
+  response:
+    body:
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
+        \ \"hash\" : \"fed054616bd822155dc2d320bdd48967335d7c2b0bf113cca80a779617cf27f8\"\n}"
+>>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
     headers:
       Content-Type:
       - application/json
@@ -271,7 +305,11 @@ interactions:
       string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
         \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
         \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_view_dev\",\n
+<<<<<<< HEAD
         \   \"hash\" : \"f0d992864be441e83687256b39bc1f996cfbf81ea6b42c1e107f8c68f2310555\"\n
+=======
+        \   \"hash\" : \"fed054616bd822155dc2d320bdd48967335d7c2b0bf113cca80a779617cf27f8\"\n
+>>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
         \ } ],\n  \"hasMore\" : false\n}"
     headers:
       Content-Type:
@@ -308,11 +346,19 @@ interactions:
       code: 404
       message: Not Found
 - request:
+<<<<<<< HEAD
     body: '{"commitMeta": {"author": "nessie test", "signedOffBy": null, "properties":
       null, "message": "test message", "committer": null, "hash": null, "commitTime":
       null, "authorTime": null}, "operations": [{"key": {"elements": ["this", "is",
       "sql.baz"]}, "expectedContent": null, "content": {"sqlText": "SELECT * FROM
       foo", "dialect": "SPARK", "id": "uuid3", "type": "VIEW"}, "type": "PUT"}]}'
+=======
+    body: '{"operations": [{"key": {"elements": ["this", "is", "sql", "baz"]}, "content":
+      {"sqlText": "SELECT * FROM foo", "id": "uuid3", "dialect": "SPARK", "type":
+      "VIEW"}, "expectedContent": null, "type": "PUT"}], "commitMeta": {"hash": null,
+      "author": "nessie test", "signedOffBy": null, "committer": null, "commitTime":
+      null, "message": "test message", "properties": null, "authorTime": null}}'
+>>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
     headers:
       Accept:
       - '*/*'
@@ -327,11 +373,19 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
+<<<<<<< HEAD
     uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=f0d992864be441e83687256b39bc1f996cfbf81ea6b42c1e107f8c68f2310555
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
         \ \"hash\" : \"18af029596bcaf748ca002cae0fae5ec312bdf85ebe1a3f14089a35ab8707024\"\n}"
+=======
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=fed054616bd822155dc2d320bdd48967335d7c2b0bf113cca80a779617cf27f8
+  response:
+    body:
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
+        \ \"hash\" : \"8f6ccb5052814fbffe8c2f4e7711707827fe481ff27eefc9518ef3ca189d4366\"\n}"
+>>>>>>> 745542d7d (Move table-metadata-pointer back to global state, use snapshot,schema,spec,sort-order ids as on-ref state)
     headers:
       Content-Type:
       - application/json
@@ -356,12 +410,13 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_contents_view\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"idGenerators\" : \"xyz\"\n}"
+        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
+        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '173'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -26,7 +26,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "main", "hash": null, "type": "BRANCH"}'
+    body: '{"hash": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -56,8 +56,8 @@ interactions:
       code: 409
       message: Conflict
 - request:
-    body: '{"name": "test", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "type": "BRANCH"}'
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "name": "test", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -77,7 +77,7 @@ def test_remote() -> None:
 
 
 def _new_table(table_id: str) -> IcebergTable:
-    return IcebergTable(table_id, "/a/b/c", "xyz")
+    return IcebergTable(table_id, "/a/b/c", 42, 43, 44, 45)
 
 
 @pytest.mark.vcr

--- a/python/tests/test_nessie_cli_content.py
+++ b/python/tests/test_nessie_cli_content.py
@@ -231,8 +231,10 @@ def test_content_commit_no_expected_state() -> None:
     make_commit("commit.expected.contents", table2, branch, message="commit 2")
 
 
-def _create_iceberg_table(table_id: str, metadata_location: str = "/a/b/c", id_generators: str = "xyz") -> IcebergTable:
-    return IcebergTable(table_id, metadata_location, id_generators)
+def _create_iceberg_table(
+    table_id: str, metadata_location: str = "/a/b/c", snapshot_id: int = 42, schema_id: int = 42, spec_id: int = 42, sort_order_id: int = 42
+) -> IcebergTable:
+    return IcebergTable(table_id, metadata_location, snapshot_id, schema_id, spec_id, sort_order_id)
 
 
 def _create_delta_lake_table(

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractResteasyTest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractResteasyTest.java
@@ -85,7 +85,7 @@ public abstract class AbstractResteasyTest {
         newReference,
         rest().get("trees/tree/test").then().statusCode(200).extract().as(Branch.class));
 
-    IcebergTable table = IcebergTable.of("/the/directory/over/there", "x");
+    IcebergTable table = IcebergTable.of("/the/directory/over/there", 42, 42, 42, 42);
 
     Branch commitResponse =
         rest()
@@ -111,13 +111,13 @@ public abstract class AbstractResteasyTest {
       updates[i] =
           ImmutablePut.builder()
               .key(ContentKey.of("item", Integer.toString(i)))
-              .content(IcebergTable.of("/the/directory/over/there/" + i, "x"))
+              .content(IcebergTable.of("/the/directory/over/there/" + i, 42, 42, 42, 42))
               .build();
     }
     updates[10] =
         ImmutablePut.builder()
             .key(ContentKey.of("xxx", "test"))
-            .content(IcebergTable.of("/the/directory/over/there/has/been/moved", "x"))
+            .content(IcebergTable.of("/the/directory/over/there/has/been/moved", 42, 42, 42, 42))
             .build();
 
     Reference branch = rest().get("trees/tree/test").as(Reference.class);
@@ -143,7 +143,9 @@ public abstract class AbstractResteasyTest {
     Assertions.assertEquals(updates[10].getContent(), res.body().as(Content.class));
 
     IcebergTable currentTable = table;
-    table = IcebergTable.of("/the/directory/over/there/has/been/moved/again", "x", table.getId());
+    table =
+        IcebergTable.of(
+            "/the/directory/over/there/has/been/moved/again", 42, 42, 42, 42, table.getId());
 
     Branch b2 = rest().get("trees/tree/test").as(Branch.class);
     rest()
@@ -246,10 +248,11 @@ public abstract class AbstractResteasyTest {
                 (expectedMetadataUrl != null)
                     ? Put.of(
                         ContentKey.of(contentKey),
-                        IcebergTable.of(metadataUrl, "x", contentId),
-                        IcebergTable.of(expectedMetadataUrl, "x", contentId))
+                        IcebergTable.of(metadataUrl, 42, 42, 42, 42, contentId),
+                        IcebergTable.of(expectedMetadataUrl, 42, 42, 42, 42, contentId))
                     : Put.of(
-                        ContentKey.of(contentKey), IcebergTable.of(metadataUrl, "x", contentId)))
+                        ContentKey.of(contentKey),
+                        IcebergTable.of(metadataUrl, 42, 42, 42, 42, contentId)))
             .commitMeta(CommitMeta.builder().author(author).message("").build())
             .build();
     return rest()
@@ -399,7 +402,7 @@ public abstract class AbstractResteasyTest {
   @Test
   public void testGetContent() {
     Branch branch = makeBranch("content-test");
-    IcebergTable table = IcebergTable.of("content-table1", "x");
+    IcebergTable table = IcebergTable.of("content-table1", 42, 42, 42, 42);
 
     commit(table.getId(), branch, "key1", table.getMetadataLocation());
 

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -242,7 +242,7 @@ public abstract class AbstractTestRest {
     String root = "ref_name_" + refNamePart.replaceAll("[^a-z]", "");
     Branch main = createBranch(root);
 
-    IcebergTable meta = IcebergTable.of("meep", "x");
+    IcebergTable meta = IcebergTable.of("meep", 42, 42, 42, 42);
     main =
         api.commitMultipleOperations()
             .branchName(main.getName())
@@ -319,7 +319,7 @@ public abstract class AbstractTestRest {
 
     // Need to have at least one op, otherwise all following operations (assignTag/Branch, merge,
     // delete) will fail
-    meta = IcebergTable.of("foo", "x");
+    meta = IcebergTable.of("foo", 42, 42, 42, 42);
     api.commitMultipleOperations()
         .branchName(branchName)
         .hash(branchHash)
@@ -574,7 +574,7 @@ public abstract class AbstractTestRest {
     for (int j = 0; j < numAuthors; j++) {
       String author = "author-" + j;
       for (int i = 0; i < commitsPerAuthor; i++) {
-        IcebergTable meta = IcebergTable.of("some-file-" + i, "x");
+        IcebergTable meta = IcebergTable.of("some-file-" + i, 42, 42, 42, 42);
         String nextHash =
             api.commitMultipleOperations()
                 .branchName(branch.getName())
@@ -638,7 +638,7 @@ public abstract class AbstractTestRest {
     for (int i = 0; i < commits; i++) {
       String msg = "message-for-" + i;
       allMessages.add(msg);
-      IcebergTable tableMeta = IcebergTable.of("some-file-" + i, "x");
+      IcebergTable tableMeta = IcebergTable.of("some-file-" + i, 42, 42, 42, 42);
       String nextHash =
           api.commitMultipleOperations()
               .branchName(branch.getName())
@@ -675,8 +675,8 @@ public abstract class AbstractTestRest {
     Branch base = createBranch("transplant-base");
     Branch branch = createBranch("transplant-branch");
 
-    IcebergTable table1 = IcebergTable.of("transplant-table1", "x");
-    IcebergTable table2 = IcebergTable.of("transplant-table2", "y");
+    IcebergTable table1 = IcebergTable.of("transplant-table1", 42, 42, 42, 42);
+    IcebergTable table2 = IcebergTable.of("transplant-table2", 43, 43, 43, 43);
 
     Branch committed1 =
         api.commitMultipleOperations()
@@ -725,8 +725,8 @@ public abstract class AbstractTestRest {
     Branch base = createBranch("merge-base");
     Branch branch = createBranch("merge-branch");
 
-    IcebergTable table1 = IcebergTable.of("merge-table1", "x");
-    IcebergTable table2 = IcebergTable.of("merge-table2", "y");
+    IcebergTable table1 = IcebergTable.of("merge-table1", 42, 42, 42, 42);
+    IcebergTable table2 = IcebergTable.of("merge-table2", 43, 43, 43, 43);
 
     Branch committed1 =
         api.commitMultipleOperations()
@@ -812,8 +812,8 @@ public abstract class AbstractTestRest {
     Branch branch = createBranch("foo");
     ContentKey a = ContentKey.of("a");
     ContentKey b = ContentKey.of("b");
-    IcebergTable ta = IcebergTable.of("path1", "x");
-    IcebergTable tb = IcebergTable.of("path2", "x");
+    IcebergTable ta = IcebergTable.of("path1", 42, 42, 42, 42);
+    IcebergTable tb = IcebergTable.of("path2", 42, 42, 42, 42);
     api.commitMultipleOperations()
         .branch(branch)
         .operation(Put.of(a, ta))
@@ -873,7 +873,7 @@ public abstract class AbstractTestRest {
     return Stream.of(
         new ContentAndOperationType(
             Type.ICEBERG_TABLE,
-            Put.of(ContentKey.of("iceberg"), IcebergTable.of("/iceberg/table", "x"))),
+            Put.of(ContentKey.of("iceberg"), IcebergTable.of("/iceberg/table", 42, 42, 42, 42))),
         new ContentAndOperationType(
             Type.VIEW,
             Put.of(
@@ -981,7 +981,7 @@ public abstract class AbstractTestRest {
     Branch branch = createBranch("filterTypes");
     ContentKey a = ContentKey.of("a");
     ContentKey b = ContentKey.of("b");
-    IcebergTable tam = IcebergTable.of("path1", "x");
+    IcebergTable tam = IcebergTable.of("path1", 42, 42, 42, 42);
     SqlView tb =
         ImmutableSqlView.builder().sqlText("select * from table").dialect(Dialect.DREMIO).build();
     api.commitMultipleOperations()
@@ -1040,22 +1040,22 @@ public abstract class AbstractTestRest {
     ContentKey fourth = ContentKey.of("a", "fourthTable");
     api.commitMultipleOperations()
         .branch(branch)
-        .operation(Put.of(first, IcebergTable.of("path1", "x")))
+        .operation(Put.of(first, IcebergTable.of("path1", 42, 42, 42, 42)))
         .commitMeta(CommitMeta.fromMessage("commit 1"))
         .commit();
     api.commitMultipleOperations()
         .branch(branch)
-        .operation(Put.of(second, IcebergTable.of("path2", "x")))
+        .operation(Put.of(second, IcebergTable.of("path2", 42, 42, 42, 42)))
         .commitMeta(CommitMeta.fromMessage("commit 2"))
         .commit();
     api.commitMultipleOperations()
         .branch(branch)
-        .operation(Put.of(third, IcebergTable.of("path3", "x")))
+        .operation(Put.of(third, IcebergTable.of("path3", 42, 42, 42, 42)))
         .commitMeta(CommitMeta.fromMessage("commit 3"))
         .commit();
     api.commitMultipleOperations()
         .branch(branch)
-        .operation(Put.of(fourth, IcebergTable.of("path4", "x")))
+        .operation(Put.of(fourth, IcebergTable.of("path4", 42, 42, 42, 42)))
         .commitMeta(CommitMeta.fromMessage("commit 4"))
         .commit();
 
@@ -1117,7 +1117,7 @@ public abstract class AbstractTestRest {
     for (int i = 0; i < 5; i++) {
       api.commitMultipleOperations()
           .branch(branch)
-          .operation(Put.of(keys.get(i), IcebergTable.of("path" + i, "x")))
+          .operation(Put.of(keys.get(i), IcebergTable.of("path" + i, 42, 42, 42, 42)))
           .commitMeta(CommitMeta.fromMessage("commit " + i))
           .commit();
     }
@@ -1230,7 +1230,7 @@ public abstract class AbstractTestRest {
     Branch branch = createBranch("specialchar");
     // ContentKey k = ContentKey.of("/%国","国.国");
     ContentKey k = ContentKey.of("a.b", "c.txt");
-    IcebergTable ta = IcebergTable.of("path1", "x");
+    IcebergTable ta = IcebergTable.of("path1", 42, 42, 42, 42);
     api.commitMultipleOperations()
         .branch(branch)
         .operation(Put.of(k, ta))

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
@@ -74,7 +74,7 @@ class AbstractTestBasicOperations {
         () ->
             api.commitMultipleOperations()
                 .branch(branch)
-                .operation(Put.of(key, IcebergTable.of("foo", "x", "cid-foo")))
+                .operation(Put.of(key, IcebergTable.of("foo", 42, 42, 42, 42, "cid-foo")))
                 .commitMeta(CommitMeta.fromMessage("empty message"))
                 .commit());
 
@@ -109,7 +109,7 @@ class AbstractTestBasicOperations {
           // have conflicts.
           api.commitMultipleOperations()
               .branch(b)
-              .operation(Put.of(key, IcebergTable.of("bar", "x", "cid-bar")))
+              .operation(Put.of(key, IcebergTable.of("bar", 42, 42, 42, 42, "cid-bar")))
               .commitMeta(CommitMeta.fromMessage(""))
               .commit();
         });

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -76,7 +76,7 @@ class TestAuthorizationRules extends BaseClientAuthTest {
     listAllReferences(branchName, shouldFail);
 
     String cid = "cid-foo-" + UUID.randomUUID();
-    addContent(branch, Put.of(key, IcebergTable.of("foo", "x", cid)), role, shouldFail);
+    addContent(branch, Put.of(key, IcebergTable.of("foo", 42, 42, 42, 42, cid)), role, shouldFail);
 
     if (!shouldFail) {
       // These requests cannot succeed, because "disallowedBranchForTestUser" could not be created
@@ -112,7 +112,7 @@ class TestAuthorizationRules extends BaseClientAuthTest {
                     .commitMultipleOperations()
                     .branch(branch)
                     .commitMeta(CommitMeta.fromMessage("add stuff"))
-                    .operation(Put.of(key, IcebergTable.of("foo", "x", "cid-foo")))
+                    .operation(Put.of(key, IcebergTable.of("foo", 42, 42, 42, 42, "cid-foo")))
                     .commit())
         .isInstanceOf(NessieForbiddenException.class)
         .hasMessageContaining(

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNativeNessieError.java
@@ -50,7 +50,7 @@ public class ITNativeNessieError {
   @Test
   void testNullParamViolation() {
     ContentKey k = ContentKey.of("a");
-    IcebergTable t = IcebergTable.of("path1", "x");
+    IcebergTable t = IcebergTable.of("path1", 42, 42, 42, 42);
     assertEquals(
         "Bad Request (HTTP/400): commitMultipleOperations.hash: must not be null",
         assertThrows(

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -29,6 +29,7 @@ import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.ImmutableDeltaLakeTable;
 import org.projectnessie.model.ImmutableDeltaLakeTable.Builder;
+import org.projectnessie.model.ImmutableIcebergTable;
 import org.projectnessie.model.ImmutableSqlView;
 import org.projectnessie.model.SqlView;
 import org.projectnessie.model.SqlView.Dialect;
@@ -121,13 +122,14 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
         if (!global.hasIcebergMetadataPointer()) {
           throw noIcebergMetadataPointer();
         }
-        return IcebergTable.of(
-            global.getIcebergMetadataPointer().getMetadataLocation(),
-            content.getIcebergRefState().getSnapshotId(),
-            content.getIcebergRefState().getSchemaId(),
-            content.getIcebergRefState().getSpecId(),
-            content.getIcebergRefState().getSortOrderId(),
-            content.getId());
+        return ImmutableIcebergTable.builder()
+            .metadataLocation(global.getIcebergMetadataPointer().getMetadataLocation())
+            .snapshotId(content.getIcebergRefState().getSnapshotId())
+            .schemaId(content.getIcebergRefState().getSchemaId())
+            .specId(content.getIcebergRefState().getSpecId())
+            .sortOrderId(content.getIcebergRefState().getSortOrderId())
+            .id(content.getId())
+            .build();
 
       case SQL_VIEW:
         ObjectTypes.SqlView view = content.getSqlView();

--- a/servers/store/src/main/proto/table.proto
+++ b/servers/store/src/main/proto/table.proto
@@ -23,7 +23,7 @@ option java_generate_equals_and_hash = true;
 message Content {
   oneof object_type {
     IcebergMetadataPointer iceberg_metadata_pointer = 1;
-    IcebergGlobal iceberg_global = 2;
+    IcebergRefState iceberg_ref_state = 2;
     SqlView sql_view = 3;
     DeltaLakeTable delta_lake_table = 4;
   }
@@ -34,8 +34,11 @@ message IcebergMetadataPointer {
   string metadata_location = 1;
 }
 
-message IcebergGlobal {
-  string id_generators = 1;
+message IcebergRefState {
+  int64 snapshot_id = 1;
+  int32 schema_id = 2;
+  int32 spec_id = 3;
+  int32 sort_order_id = 4;
 }
 
 message SqlView {

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -35,8 +35,8 @@ import org.projectnessie.model.ImmutableDeltaLakeTable;
 import org.projectnessie.model.ImmutableSqlView;
 import org.projectnessie.model.SqlView;
 import org.projectnessie.store.ObjectTypes;
-import org.projectnessie.store.ObjectTypes.IcebergGlobal;
 import org.projectnessie.store.ObjectTypes.IcebergMetadataPointer;
+import org.projectnessie.store.ObjectTypes.IcebergRefState;
 
 class TestStoreWorker {
   private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -69,18 +69,23 @@ class TestStoreWorker {
   @Test
   void testSerdeIceberg() {
     String path = "foo/bar";
-    IcebergTable table = IcebergTable.of(path, "xyz", ID);
+    IcebergTable table = IcebergTable.of(path, 42, 43, 44, 45, ID);
 
     ObjectTypes.Content protoTableGlobal =
         ObjectTypes.Content.newBuilder()
             .setId(ID)
-            .setIcebergGlobal(IcebergGlobal.newBuilder().setIdGenerators("xyz"))
+            .setIcebergMetadataPointer(
+                IcebergMetadataPointer.newBuilder().setMetadataLocation(path))
             .build();
     ObjectTypes.Content protoOnRef =
         ObjectTypes.Content.newBuilder()
             .setId(ID)
-            .setIcebergMetadataPointer(
-                IcebergMetadataPointer.newBuilder().setMetadataLocation(path))
+            .setIcebergRefState(
+                IcebergRefState.newBuilder()
+                    .setSnapshotId(42)
+                    .setSchemaId(43)
+                    .setSpecId(44)
+                    .setSortOrderId(45))
             .build();
 
     ByteString tableGlobalBytes = worker.toStoreGlobalState(table);

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
@@ -233,7 +233,10 @@ public class GenerateContent extends AbstractCommand {
       case ICEBERG_TABLE:
         ImmutableIcebergTable.Builder icebergBuilder =
             ImmutableIcebergTable.builder()
-                .idGenerators("ids " + random.nextLong())
+                .snapshotId(random.nextLong())
+                .schemaId(random.nextInt())
+                .specId(random.nextInt())
+                .sortOrderId(random.nextInt())
                 .metadataLocation("metadata " + random.nextLong());
         if (currentContents != null) {
           icebergBuilder.id(currentContents.getId());

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
@@ -23,7 +23,10 @@ import org.immutables.value.Value.Immutable;
 @Immutable
 public interface ContentAndState<CONTENT> {
 
-  /** Per-named-reference state for a content key. For example, Iceberg's snapshot-ID. */
+  /**
+   * Per-named-reference state for a content key. For example, Iceberg's snapshot-ID, schema-ID,
+   * partition-spec-ID, default-sort-order-ID.
+   */
   @Nonnull
   CONTENT getRefState();
 


### PR DESCRIPTION
This change basically reverts #2313. It moves the Iceberg table-metadata-pointer back to Nessie's global state and snapshot ID plus other relevant IDs (schema-ID, partition-spec-ID, sort-order-ID) to Nessie's on-reference state.

A working version of the Iceberg changes is in this branch: https://github.com/snazy/iceberg/tree/back-to-single-table-metadata