### PR TITLE
Generate python docs for nested commands

### DIFF
--- a/python/CONTRIBUTING.rst
+++ b/python/CONTRIBUTING.rst
@@ -77,10 +77,8 @@ Ready to contribute? Here's how to set up `nessie` for local development.
    Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+   tests, including testing other Python versions with tox and all docs have been generated::
 
-    $ flake8 pynessie tests
-    $ python setup.py test or pytest
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.

--- a/python/docs/branch.rst
+++ b/python/docs/branch.rst
@@ -1,48 +1,48 @@
 .. code-block:: bash
 
-	Usage: cli branch [OPTIONS] [BRANCH] [BASE_REF]
-	
-	  Branch operations.
-	
-	  BRANCH name of branch to list or create/assign
-	
-	  BASE_REF name of branch or tag from which to create/assign the new BRANCH
-	
-	  Examples:
-	
-	      nessie branch -> list all branches
-	
-	      nessie branch -l -> list all branches
-	
-	      nessie branch -l main -> list only main
-	
-	      nessie branch -d main -> delete main
-	
-	      nessie branch new_branch -> create new branch named 'new_branch' at
-	      current HEAD of the default branch
-	
-	      nessie branch new_branch main -> create new branch named 'new_branch' at
-	      head of reference named 'main'
-	
-	      nessie branch -o 12345678abcdef new_branch main -> create a branch named
-	      'new_branch' at hash 12345678abcdef on reference named 'main'
-	
-	      nessie branch -f existing_branch main -> assign branch named
-	      'existing_branch' to head of reference named 'main'
-	
-	      nessie branch -o 12345678abcdef -f existing_branch main -> assign branch
-	      named 'existing_branch' to hash 12345678abcdef on reference named 'main'
-	
-	Options:
-	  -l, --list              list branches
-	  -d, --delete            delete a branch
-	  -f, --force             force branch assignment
-	  -o, --hash-on-ref TEXT  Hash on source-reference for 'create' and 'assign'
-	                          operations, if the branch shall not point to the HEAD
-	                          of the given source-reference.
-	  -c, --condition TEXT    Expected hash. Only perform the action if the branch
-	                          currently points to the hash specified by this option.
-	  --help                  Show this message and exit.
-	
-	
+   Usage: nessie branch [OPTIONS] [BRANCH] [BASE_REF]
+   
+     Branch operations.
+   
+     BRANCH name of branch to list or create/assign
+   
+     BASE_REF name of branch or tag from which to create/assign the new BRANCH
+   
+     Examples:
+   
+         nessie branch -> list all branches
+   
+         nessie branch -l -> list all branches
+   
+         nessie branch -l main -> list only main
+   
+         nessie branch -d main -> delete main
+   
+         nessie branch new_branch -> create new branch named 'new_branch' at
+         current HEAD of the default branch
+   
+         nessie branch new_branch main -> create new branch named 'new_branch' at
+         head of reference named 'main'
+   
+         nessie branch -o 12345678abcdef new_branch main -> create a branch named
+         'new_branch' at hash 12345678abcdef on reference named 'main'
+   
+         nessie branch -f existing_branch main -> assign branch named
+         'existing_branch' to head of reference named 'main'
+   
+         nessie branch -o 12345678abcdef -f existing_branch main -> assign branch
+         named 'existing_branch' to hash 12345678abcdef on reference named 'main'
+   
+   Options:
+     -l, --list              list branches
+     -d, --delete            delete a branch
+     -f, --force             force branch assignment
+     -o, --hash-on-ref TEXT  Hash on source-reference for 'create' and 'assign'
+                             operations, if the branch shall not point to the HEAD
+                             of the given source-reference.
+     -c, --condition TEXT    Expected hash. Only perform the action if the branch
+                             currently points to the hash specified by this option.
+     --help                  Show this message and exit.
+   
+   
 

--- a/python/docs/cherry-pick.rst
+++ b/python/docs/cherry-pick.rst
@@ -1,32 +1,32 @@
 .. code-block:: bash
 
-	Usage: cli cherry-pick [OPTIONS] [HASHES]...
-	
-	  Cherry-pick HASHES onto another branch.
-	
-	  HASHES commit hashes to be cherry-picked from the source reference.
-	
-	  Examples:
-	
-	      nessie cherry-pick -c 12345678abcdef -s dev 21345678abcdef 31245678abcdef
-	      -> cherry pick 2 commits with commit hash '21345678abcdef'
-	      '31245678abcdef' from dev branch to default branch with default branch's
-	      expected hash '12345678abcdef'
-	
-	      nessie cherry-pick -b main -c 12345678abcdef -s dev 21345678abcdef
-	      31245678abcdef -> cherry pick 2 commits with commit hash '21345678abcdef'
-	      '31245678abcdef' from dev branch to a branch named main with main branch's
-	      expected hash '12345678abcdef'
-	
-	Options:
-	  -b, --branch TEXT      branch to cherry-pick onto. If not supplied the default
-	                         branch from config is used
-	  -f, --force            force branch assignment
-	  -c, --condition TEXT   Expected hash. Only perform the action if the branch
-	                         currently points to the hash specified by this option.
-	  -s, --source-ref TEXT  Name of the reference used to read the hashes from.
-	                         [required]
-	  --help                 Show this message and exit.
-	
-	
+   Usage: nessie cherry-pick [OPTIONS] [HASHES]...
+   
+     Cherry-pick HASHES onto another branch.
+   
+     HASHES commit hashes to be cherry-picked from the source reference.
+   
+     Examples:
+   
+         nessie cherry-pick -c 12345678abcdef -s dev 21345678abcdef 31245678abcdef
+         -> cherry pick 2 commits with commit hash '21345678abcdef'
+         '31245678abcdef' from dev branch to default branch with default branch's
+         expected hash '12345678abcdef'
+   
+         nessie cherry-pick -b main -c 12345678abcdef -s dev 21345678abcdef
+         31245678abcdef -> cherry pick 2 commits with commit hash '21345678abcdef'
+         '31245678abcdef' from dev branch to a branch named main with main branch's
+         expected hash '12345678abcdef'
+   
+   Options:
+     -b, --branch TEXT      branch to cherry-pick onto. If not supplied the default
+                            branch from config is used
+     -f, --force            force branch assignment
+     -c, --condition TEXT   Expected hash. Only perform the action if the branch
+                            currently points to the hash specified by this option.
+     -s, --source-ref TEXT  Name of the reference used to read the hashes from.
+                            [required]
+     --help                 Show this message and exit.
+   
+   
 

--- a/python/docs/cli.rst
+++ b/python/docs/cli.rst
@@ -1,5 +1,5 @@
 
-UI Commands
+CLI Commands
 ===========
 
 Available Commands
@@ -57,9 +57,9 @@ Perform a cherry-pick operation. This takes the list of commits ``HASHES`` and a
 
 .. include:: cherry-pick.rst
 
-Contents Command
+Content Command
 ----------------
 
-View and list contents.
+View, list content, and commit changes.
 
-.. include:: contents.rst
+.. include:: content.rst

--- a/python/docs/config.rst
+++ b/python/docs/config.rst
@@ -1,17 +1,17 @@
 .. code-block:: bash
 
-	Usage: cli config [OPTIONS] [KEY]
-	
-	  Set and view config.
-	
-	Options:
-	  --get TEXT    get config parameter
-	  --add TEXT    set config parameter
-	  -l, --list    list config parameters
-	  --unset TEXT  unset config parameter
-	  --type TEXT   type to interpret config value to set or get. Allowed options:
-	                bool, int
-	  -h, --help    Show this message and exit.
-	
-	
+   Usage: nessie config [OPTIONS] [KEY]
+   
+     Set and view config.
+   
+   Options:
+     --get TEXT    get config parameter
+     --add TEXT    set config parameter
+     -l, --list    list config parameters
+     --unset TEXT  unset config parameter
+     --type TEXT   type to interpret config value to set or get. Allowed options:
+                   bool, int
+     -h, --help    Show this message and exit.
+   
+   
 

--- a/python/docs/content.rst
+++ b/python/docs/content.rst
@@ -1,16 +1,33 @@
 .. code-block:: bash
 
-	Usage: cli content [OPTIONS] COMMAND [ARGS]...
-	
-	  View, list content, and commit changes.
-	
-	Options:
-	  --help  Show this message and exit.
-	
-	Commands:
-	  commit  Commit content.
-	  list    List content.
-	  view    View content.
-	
-	
+   Usage: nessie content [OPTIONS] COMMAND [ARGS]...
+   
+     View, list content, and commit changes.
+   
+   Options:
+     --help  Show this message and exit.
+   
+   Commands:
+     commit  Commit content.
+     list    List content.
+     view    View content.
+   
+   
+
+It contains the following sub-commands:
+
+Content List Command
+~~~~~~~~~
+
+.. include:: content_list.rst
+
+Content View Command
+~~~~~~~~~
+
+.. include:: content_view.rst
+
+Content Commit Command
+~~~~~~~~~
+
+.. include:: content_commit.rst
 

--- a/python/docs/content_commit.rst
+++ b/python/docs/content_commit.rst
@@ -1,0 +1,43 @@
+.. code-block:: bash
+
+   Usage: nessie content commit [OPTIONS] KEY...
+   
+     Commit content.
+   
+         KEY is the content key that is associated with a specific content to
+         commit. This accepts as well multiple keys with space in between.
+   
+     Examples:
+   
+         nessie content commit -m "my awesome commit message" -r dev -c 122345abcd
+         my_table -> Commit to branch 'dev' on expected hash '122345abcd' (head of
+         the branch) the content from the interactive editor with the commit
+         message "my awesome commit message" for content "my_table".
+   
+         nessie content commit -i -r dev -c 122345abcd my_table -> Commit to branch
+         'dev' on expected hash '122345abcd' (head of the branch) the content from
+         STDIN with the commit message from the interactive editor for content
+         "my_table".
+   
+         nessie content commit -m "my awesome commit message" -R -r dev -c
+         122345abcd my_table_1 my_table_2 -> Delete contents "my_table_1" and
+         "my_table_2" from branch 'dev' on expected hash '122345abcd' and commit to
+         branch 'dev" with the commit message "my awesome commit message".
+   
+   Options:
+     -r, --ref TEXT             Branch to commit content to. If not supplied the
+                                default branch from config is used.
+     -i, --stdin                Read content for --set from STDIN (separated by
+                                Ctrl-D)
+     -s, --expect-same-content  Send the same content both as the new and expected
+                                (old contents) parameters for the edit operations
+     -c, --condition TEXT       Expected hash. Only perform the action if the
+                                branch currently points to the hash specified by
+                                this option.  [required]
+     -R, --remove-key           Delete a content.
+     -m, --message TEXT         Commit message.
+     --author TEXT              The author to use for the commit
+     --help                     Show this message and exit.
+   
+   
+

--- a/python/docs/content_list.rst
+++ b/python/docs/content_list.rst
@@ -1,0 +1,39 @@
+.. code-block:: bash
+
+   Usage: nessie content list [OPTIONS]
+   
+     List content.
+   
+     Examples:
+   
+         nessie content list -r dev -> List all contents in 'dev' branch.
+   
+         nessie content list -r dev -t DELTA_LAKE_TABLE ->  List all contents in
+         'dev' branch with type `DELTA_LAKE_TABLE`.
+   
+         nessie content list -r dev --query
+         "entry.namespace.startsWith('some.name.space')" -> List all contents in
+         'dev' branch that start with 'some.name.space'
+   
+   Options:
+     -r, --ref TEXT                  Branch to list from. If not supplied the
+                                     default branch from config is used
+     -t, --type TEXT                 entity types to filter on, if no entity types
+                                     are passed then all types are returned
+     --query, --query-expression TEXT
+                                     Allows advanced filtering using the Common
+                                     Expression Language (CEL). An intro to CEL can
+                                     be found at https://github.com/google/cel-
+                                     spec/blob/master/doc/intro.md. Some examples
+                                     with usable variables 'entry.namespace'
+                                     (string) & 'entry.contentType' (string) are:
+                                     entry.namespace.startsWith('a.b.c')
+                                     entry.contentType in
+                                     ['ICEBERG_TABLE','DELTA_LAKE_TABLE']
+                                     entry.namespace.startsWith('some.name.space')
+                                     && entry.contentType in
+                                     ['ICEBERG_TABLE','DELTA_LAKE_TABLE']
+     --help                          Show this message and exit.
+   
+   
+

--- a/python/docs/content_view.rst
+++ b/python/docs/content_view.rst
@@ -1,0 +1,21 @@
+.. code-block:: bash
+
+   Usage: nessie content view [OPTIONS] KEY...
+   
+     View content.
+   
+         KEY is the content key that is associated with a specific content to view.
+         This accepts as well multiple keys with space in between.
+   
+     Examples:
+   
+         nessie content view -r dev my_table -> View content details for content
+         "my_table" in 'dev' branch.
+   
+   Options:
+     -r, --ref TEXT  Branch to list from. If not supplied the default branch from
+                     config is used.
+     --help          Show this message and exit.
+   
+   
+

--- a/python/docs/log.rst
+++ b/python/docs/log.rst
@@ -1,68 +1,68 @@
 .. code-block:: bash
 
-	Usage: cli log [OPTIONS] [REF]
-	
-	  Show commit log.
-	
-	  REF name of branch or tag to use to show the commit logs
-	
-	  Examples:
-	
-	      nessie log -> show commit logs using the configured default branch
-	
-	      nessie log dev -> show commit logs for 'dev' branch
-	
-	      nessie log -n 5 dev -> show commit logs for 'dev' branch limited by 5
-	      commits
-	
-	      nessie log --revision-range 12345678abcdef..12345678efghj dev -> show
-	      commit logs in range of hash '12345678abcdef' and '12345678efghj' in 'dev'
-	      branch
-	
-	      nessie log --author nessie.user dev -> show commit logs for user
-	      'nessie.user' in 'dev' branch
-	
-	      nessie log --query "commit.author == 'nessie_user2' || commit.author ==
-	      'non_existing'" dev -> show commit logs using query in 'dev' branch
-	
-	      nessie log --after "2019-01-01T00:00:00+00:00" --before
-	      "2021-01-01T00:00:00+00:00" dev -> show commit logs between
-	      "2019-01-01T00:00:00+00:00" and "2021-01-01T00:00:00+00:00" in 'dev'
-	      branch
-	
-	Options:
-	  -n, --number INTEGER            number of log entries to return
-	  --since, --after TEXT           Only include commits newer than specific date,
-	                                  such as '2001-01-01T00:00:00+00:00'
-	  --until, --before TEXT          Only include commits older than specific date,
-	                                  such as '2999-12-30T23:00:00+00:00'
-	  --author TEXT                   Limit commits to a specific author (this is
-	                                  the original committer). Supports specifying
-	                                  multiple authors to filter by.
-	  --committer TEXT                Limit commits to a specific committer (this is
-	                                  the logged in user/account who performed the
-	                                  commit). Supports specifying multiple
-	                                  committers to filter by.
-	  -r, --revision-range TEXT       Hash to start viewing log from. If of the form
-	                                  '<start_hash>'..'<end_hash>' only show log for
-	                                  given range on the particular ref that was
-	                                  provided, the '<end_hash>' is inclusive and
-	                                  '<start_hash>' is exclusive.
-	  --query, --query-expression TEXT
-	                                  Allows advanced filtering using the Common
-	                                  Expression Language (CEL). An intro to CEL can
-	                                  be found at https://github.com/google/cel-
-	                                  spec/blob/master/doc/intro.md. Some examples
-	                                  with usable variables 'commit.author' (string)
-	                                  / 'commit.committer' (string) /
-	                                  'commit.commitTime' (timestamp) /
-	                                  'commit.hash' (string) / 'commit.message'
-	                                  (string) / 'commit.properties' (map) are:
-	                                  commit.author=='nessie_author'
-	                                  commit.committer=='nessie_committer'
-	                                  timestamp(commit.commitTime) >
-	                                  timestamp('2021-06-21T10:39:17.977922Z')
-	  --help                          Show this message and exit.
-	
-	
+   Usage: nessie log [OPTIONS] [REF]
+   
+     Show commit log.
+   
+     REF name of branch or tag to use to show the commit logs
+   
+     Examples:
+   
+         nessie log -> show commit logs using the configured default branch
+   
+         nessie log dev -> show commit logs for 'dev' branch
+   
+         nessie log -n 5 dev -> show commit logs for 'dev' branch limited by 5
+         commits
+   
+         nessie log --revision-range 12345678abcdef..12345678efghj dev -> show
+         commit logs in range of hash '12345678abcdef' and '12345678efghj' in 'dev'
+         branch
+   
+         nessie log --author nessie.user dev -> show commit logs for user
+         'nessie.user' in 'dev' branch
+   
+         nessie log --query "commit.author == 'nessie_user2' || commit.author ==
+         'non_existing'" dev -> show commit logs using query in 'dev' branch
+   
+         nessie log --after "2019-01-01T00:00:00+00:00" --before
+         "2021-01-01T00:00:00+00:00" dev -> show commit logs between
+         "2019-01-01T00:00:00+00:00" and "2021-01-01T00:00:00+00:00" in 'dev'
+         branch
+   
+   Options:
+     -n, --number INTEGER            number of log entries to return
+     --since, --after TEXT           Only include commits newer than specific date,
+                                     such as '2001-01-01T00:00:00+00:00'
+     --until, --before TEXT          Only include commits older than specific date,
+                                     such as '2999-12-30T23:00:00+00:00'
+     --author TEXT                   Limit commits to a specific author (this is
+                                     the original committer). Supports specifying
+                                     multiple authors to filter by.
+     --committer TEXT                Limit commits to a specific committer (this is
+                                     the logged in user/account who performed the
+                                     commit). Supports specifying multiple
+                                     committers to filter by.
+     -r, --revision-range TEXT       Hash to start viewing log from. If of the form
+                                     '<start_hash>'..'<end_hash>' only show log for
+                                     given range on the particular ref that was
+                                     provided, the '<end_hash>' is inclusive and
+                                     '<start_hash>' is exclusive.
+     --query, --query-expression TEXT
+                                     Allows advanced filtering using the Common
+                                     Expression Language (CEL). An intro to CEL can
+                                     be found at https://github.com/google/cel-
+                                     spec/blob/master/doc/intro.md. Some examples
+                                     with usable variables 'commit.author' (string)
+                                     / 'commit.committer' (string) /
+                                     'commit.commitTime' (timestamp) /
+                                     'commit.hash' (string) / 'commit.message'
+                                     (string) / 'commit.properties' (map) are:
+                                     commit.author=='nessie_author'
+                                     commit.committer=='nessie_committer'
+                                     timestamp(commit.commitTime) >
+                                     timestamp('2021-06-21T10:39:17.977922Z')
+     --help                          Show this message and exit.
+   
+   
 

--- a/python/docs/main.rst
+++ b/python/docs/main.rst
@@ -1,28 +1,28 @@
 .. code-block:: bash
 
-	Usage: cli [OPTIONS] COMMAND [ARGS]...
-	
-	  Nessie cli tool.
-	
-	  Interact with Nessie branches and tables via the command line
-	
-	Options:
-	  --json             write output in json format.
-	  -v, --verbose      Verbose output.
-	  --endpoint TEXT    Optional endpoint, if different from config file.
-	  --auth-token TEXT  Optional bearer auth token, if different from config file.
-	  --version
-	  --help             Show this message and exit.
-	
-	Commands:
-	  branch       Branch operations.
-	  cherry-pick  Cherry-pick HASHES onto another branch.
-	  config       Set and view config.
-	  content      View, list content, and commit changes.
-	  log          Show commit log.
-	  merge        Merge FROM_REF into another branch.
-	  remote       Set and view remote endpoint.
-	  tag          Tag operations.
-	
-	
+   Usage: nessie [OPTIONS] COMMAND [ARGS]...
+   
+     Nessie cli tool.
+   
+     Interact with Nessie branches and tables via the command line
+   
+   Options:
+     --json             write output in json format.
+     -v, --verbose      Verbose output.
+     --endpoint TEXT    Optional endpoint, if different from config file.
+     --auth-token TEXT  Optional bearer auth token, if different from config file.
+     --version
+     --help             Show this message and exit.
+   
+   Commands:
+     branch       Branch operations.
+     cherry-pick  Cherry-pick HASHES onto another branch.
+     config       Set and view config.
+     content      View, list content, and commit changes.
+     log          Show commit log.
+     merge        Merge FROM_REF into another branch.
+     remote       Set and view remote endpoint.
+     tag          Tag operations.
+   
+   
 

--- a/python/docs/merge.rst
+++ b/python/docs/merge.rst
@@ -1,33 +1,33 @@
 .. code-block:: bash
 
-	Usage: cli merge [OPTIONS] [FROM_REF]
-	
-	  Merge FROM_REF into another branch.
-	
-	  FROM_REF can be a hash or branch.
-	
-	  Examples:
-	
-	      nessie merge -c 12345678abcdef dev -> merge dev to default branch with
-	      default branch's expected hash '12345678abcdef'
-	
-	      nessie merge -b main -c 12345678abcdef dev -> merge dev to a branch named
-	      main with main branch's expected hash '12345678abcdef'
-	
-	      nessie merge -b main -o 56781234abcdef -c 12345678abcdef dev -> merge dev
-	      at hash-on-ref '56781234abcdef' to main branch with main branch's expected
-	      hash '12345678abcdef'
-	
-	      nessie merge -f -b main dev -> forcefully merge dev to a branch named main
-	
-	Options:
-	  -b, --branch TEXT       branch to merge onto. If not supplied the default
-	                          branch from config is used
-	  -f, --force             force branch assignment
-	  -c, --condition TEXT    Expected hash. Only perform the action if the branch
-	                          currently points to the hash specified by this option.
-	  -o, --hash-on-ref TEXT  Hash on merge-from-reference
-	  --help                  Show this message and exit.
-	
-	
+   Usage: nessie merge [OPTIONS] [FROM_REF]
+   
+     Merge FROM_REF into another branch.
+   
+     FROM_REF can be a hash or branch.
+   
+     Examples:
+   
+         nessie merge -c 12345678abcdef dev -> merge dev to default branch with
+         default branch's expected hash '12345678abcdef'
+   
+         nessie merge -b main -c 12345678abcdef dev -> merge dev to a branch named
+         main with main branch's expected hash '12345678abcdef'
+   
+         nessie merge -b main -o 56781234abcdef -c 12345678abcdef dev -> merge dev
+         at hash-on-ref '56781234abcdef' to main branch with main branch's expected
+         hash '12345678abcdef'
+   
+         nessie merge -f -b main dev -> forcefully merge dev to a branch named main
+   
+   Options:
+     -b, --branch TEXT       branch to merge onto. If not supplied the default
+                             branch from config is used
+     -f, --force             force branch assignment
+     -c, --condition TEXT    Expected hash. Only perform the action if the branch
+                             currently points to the hash specified by this option.
+     -o, --hash-on-ref TEXT  Hash on merge-from-reference
+     --help                  Show this message and exit.
+   
+   
 

--- a/python/docs/remote.rst
+++ b/python/docs/remote.rst
@@ -1,16 +1,33 @@
 .. code-block:: bash
 
-	Usage: cli remote [OPTIONS] COMMAND [ARGS]...
-	
-	  Set and view remote endpoint.
-	
-	Options:
-	  --help  Show this message and exit.
-	
-	Commands:
-	  add       Set current remote.
-	  set-head  Set current default branch.
-	  show      Show current remote.
-	
-	
+   Usage: nessie remote [OPTIONS] COMMAND [ARGS]...
+   
+     Set and view remote endpoint.
+   
+   Options:
+     --help  Show this message and exit.
+   
+   Commands:
+     add       Set current remote.
+     set-head  Set current default branch.
+     show      Show current remote.
+   
+   
+
+It contains the following sub-commands:
+
+Remote Show Command
+~~~~~~~~~
+
+.. include:: remote_show.rst
+
+Remote Add Command
+~~~~~~~~~
+
+.. include:: remote_add.rst
+
+Remote Set-head Command
+~~~~~~~~~
+
+.. include:: remote_set-head.rst
 

--- a/python/docs/remote_add.rst
+++ b/python/docs/remote_add.rst
@@ -1,0 +1,11 @@
+.. code-block:: bash
+
+   Usage: nessie remote add [OPTIONS] ENDPOINT
+   
+     Set current remote.
+   
+   Options:
+     --help  Show this message and exit.
+   
+   
+

--- a/python/docs/remote_set-head.rst
+++ b/python/docs/remote_set-head.rst
@@ -1,0 +1,12 @@
+.. code-block:: bash
+
+   Usage: nessie remote set-head [OPTIONS] HEAD
+   
+     Set current default branch. If -d is passed it will remove the default branch.
+   
+   Options:
+     -d, --delete  delete the default branch
+     --help        Show this message and exit.
+   
+   
+

--- a/python/docs/remote_show.rst
+++ b/python/docs/remote_show.rst
@@ -1,0 +1,11 @@
+.. code-block:: bash
+
+   Usage: nessie remote show [OPTIONS]
+   
+     Show current remote.
+   
+   Options:
+     --help  Show this message and exit.
+   
+   
+

--- a/python/docs/tag.rst
+++ b/python/docs/tag.rst
@@ -1,49 +1,49 @@
 .. code-block:: bash
 
-	Usage: cli tag [OPTIONS] [TAG_NAME] [BASE_REF]
-	
-	  Tag operations.
-	
-	  TAG_NAME name of branch to list or create/assign
-	
-	  BASE_REF name of branch or tag whose HEAD reference is to be used for the new
-	  tag
-	
-	  Examples:
-	
-	      nessie tag -> list all tags
-	
-	      nessie tag -l -> list all tags
-	
-	      nessie tag -l v1.0 -> list only tag "v1.0"
-	
-	      nessie tag -d v1.0 -> delete tag "v1.0"
-	
-	      nessie tag new_tag -> create new tag named 'new_tag' at current HEAD of
-	      the default branch
-	
-	      nessie tag new_tag main -> create new tag named 'new_tag' at head of
-	      reference named 'main' (branch or tag)
-	
-	      nessie tag -o 12345678abcdef new_tag test -> create new tag named
-	      'new_tag' at hash 12345678abcdef on reference named 'test'
-	
-	      nessie tag -f existing_tag main -> assign tag named 'existing_tag' to head
-	      of reference named 'main'
-	
-	      nessie tag -o 12345678abcdef -f existing_tag main -> assign tag named
-	      'existing_tag' to hash 12345678abcdef on reference named 'main'
-	
-	Options:
-	  -l, --list              list branches
-	  -d, --delete            delete a branches
-	  -f, --force             force branch assignment
-	  -o, --hash-on-ref TEXT  Hash on source-reference for 'create' and 'assign'
-	                          operations, if the tag shall not point to the HEAD of
-	                          the given source-reference.
-	  -c, --condition TEXT    Expected hash. Only perform the action if the tag
-	                          currently points to the hash specified by this option.
-	  --help                  Show this message and exit.
-	
-	
+   Usage: nessie tag [OPTIONS] [TAG_NAME] [BASE_REF]
+   
+     Tag operations.
+   
+     TAG_NAME name of branch to list or create/assign
+   
+     BASE_REF name of branch or tag whose HEAD reference is to be used for the new
+     tag
+   
+     Examples:
+   
+         nessie tag -> list all tags
+   
+         nessie tag -l -> list all tags
+   
+         nessie tag -l v1.0 -> list only tag "v1.0"
+   
+         nessie tag -d v1.0 -> delete tag "v1.0"
+   
+         nessie tag new_tag -> create new tag named 'new_tag' at current HEAD of
+         the default branch
+   
+         nessie tag new_tag main -> create new tag named 'new_tag' at head of
+         reference named 'main' (branch or tag)
+   
+         nessie tag -o 12345678abcdef new_tag test -> create new tag named
+         'new_tag' at hash 12345678abcdef on reference named 'test'
+   
+         nessie tag -f existing_tag main -> assign tag named 'existing_tag' to head
+         of reference named 'main'
+   
+         nessie tag -o 12345678abcdef -f existing_tag main -> assign tag named
+         'existing_tag' to hash 12345678abcdef on reference named 'main'
+   
+   Options:
+     -l, --list              list branches
+     -d, --delete            delete a branches
+     -f, --force             force branch assignment
+     -o, --hash-on-ref TEXT  Hash on source-reference for 'create' and 'assign'
+                             operations, if the tag shall not point to the HEAD of
+                             the given source-reference.
+     -c, --condition TEXT    Expected hash. Only perform the action if the tag
+                             currently points to the hash specified by this option.
+     --help                  Show this message and exit.
+   
+   
 

--- a/python/pynessie/cli.py
+++ b/python/pynessie/cli.py
@@ -42,7 +42,7 @@ def _print_version(ctx: Any, param: Any, value: Any) -> None:
     ctx.exit()
 
 
-@click.group()
+@click.group("nessie")
 @click.option("--json", is_flag=True, help="write output in json format.")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output.")
 @click.option("--endpoint", help="Optional endpoint, if different from config file.")

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -17,8 +17,6 @@
 #
 """Tests for `pynessie` package."""
 import itertools
-import os
-from pathlib import Path
 
 import confuse
 import pytest
@@ -37,8 +35,8 @@ from .conftest import execute_cli_command, make_commit
 @pytest.mark.vcr
 def test_command_line_interface() -> None:
     """Test the CLI."""
-    assert "Usage: cli" in execute_cli_command([])
-    assert "Usage: cli" in execute_cli_command(["--help"])
+    assert "Usage: nessie" in execute_cli_command([])
+    assert "Usage: nessie" in execute_cli_command(["--help"])
     assert __version__ in execute_cli_command(["--version"])
     references = ReferenceSchema().loads(execute_cli_command(["--json", "branch", "-l"]), many=True)
     assert len(references) == 1
@@ -48,7 +46,7 @@ def test_command_line_interface() -> None:
 
 def test_config_options() -> None:
     """Ensure config cli option is consistent."""
-    assert "Usage: cli" in execute_cli_command(["config"])
+    assert "Usage: nessie" in execute_cli_command(["config"])
     vars_to_add = ["--add x", "--get x", "--list", "--unset x"]
     for i in itertools.permutations(vars_to_add, 2):
         assert "Error: Illegal usage: " in execute_cli_command(["config"] + [*i[0].split(" "), *i[1].split(" ")], ret_val=2)
@@ -241,18 +239,3 @@ def test_transplant() -> None:
 
     logs = simplejson.loads(execute_cli_command(["--json", "log"]))
     assert len(logs) == 2  # two commits were transplanted into an empty `main`
-
-
-@pytest.mark.doc
-def test_all_help_options() -> None:
-    """Write out all help options to std out."""
-    args = ["", "config", "branch", "tag", "remote", "log", "merge", "cherry-pick", "content"]
-
-    for i in args:
-        result = execute_cli_command([x for x in [i] if x] + ["--help"])
-        cwd = os.getcwd()
-        with open(Path(Path(cwd), "docs", "{}.rst".format(i if i else "main")), "w", encoding="UTF-8") as f:
-            f.write(".. code-block:: bash\n\n\t")
-            for line in result.split("\n"):
-                f.write(line + "\n\t")
-            f.write("\n\n")

--- a/python/tools/generate_docs.py
+++ b/python/tools/generate_docs.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Generate pynessie docs script."""
+import os
+from pathlib import Path
+from typing import IO, List, Optional
+
+from click import Group
+from click.testing import CliRunner
+
+from pynessie import cli
+
+PATH_DOCS = "docs"
+
+
+def generate_docs() -> None:
+    """Generate all the commands docs."""
+    print("Generating docs....\n\n")
+    # Write the initial CLI help doc
+    _write_command_doc([])
+    # Go through all the commands items and generate the docs
+    _generate_commands_docs([], cli.cli)
+
+
+def _write_command_doc(command: List[str]) -> None:
+    with _open_doc_file(command) as f:
+        _write_command_output_to_file(f, command + ["--help"])
+
+
+def _open_doc_file(command: List[str]) -> IO:
+    file_name = _get_file_name_from_command(command)
+    cwd = os.getcwd()
+    file_full_path = Path(Path(cwd), PATH_DOCS, file_name)
+    print(f"Writing file: {file_full_path.parent}/{file_full_path.name}")
+    return open(file_full_path, "w", encoding="UTF-8")
+
+
+def _get_file_name_from_command(command: List[str]) -> str:
+    return f"{'_'.join(command) if len(command) > 0 else 'main'}.rst"
+
+
+def _write_command_output_to_file(file_io: IO, command: List[str]) -> None:
+    result = _run_cli(command)
+    space = "   "
+    file_io.write(f".. code-block:: bash\n\n{space}")
+    for line in result.split("\n"):
+        file_io.write(line + f"\n{space}")
+    file_io.write("\n\n")
+
+
+def _run_cli(args: List[str], input_data: Optional[str] = None) -> str:
+    return CliRunner().invoke(cli.cli, args, input=input_data).output
+
+
+def _generate_commands_docs(parent_commands: List[str], command_group: Group) -> None:
+    for name, value in command_group.commands.items():
+        command = parent_commands + [name]
+        if isinstance(value, Group):
+            _write_command_group_doc(command, list(value.commands.keys()))
+            _generate_commands_docs(command, value)
+        else:
+            _write_command_doc(command)
+
+
+def _write_command_group_doc(command: List[str], command_items: List[str]) -> None:
+    with _open_doc_file(command) as f:
+        _write_command_output_to_file(f, command + ["--help"])
+        f.write("It contains the following sub-commands:\n\n")
+        for item in command_items:
+            _write_sub_command_reference_to_file(f, command + [item])
+
+
+def _write_sub_command_reference_to_file(file_io: IO, command: List[str]) -> None:
+    command_title = " ".join([c.capitalize() for c in command])
+
+    file_io.write(f"{command_title} Command\n")
+    file_io.write("~~~~~~~~~\n\n")
+    file_io.write(f".. include:: {_get_file_name_from_command(command)}\n\n")
+
+
+if __name__ == "__main__":
+    generate_docs()  # pragma: no cover

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -15,7 +15,7 @@
 #
 
 [tox]
-envlist = py36, py37, py38, py39, flake8, pylint
+envlist = py36, py37, py38, py39, flake8, pylint, docs
 
 [gh-actions]
 python =
@@ -29,7 +29,7 @@ basepython = python
 deps =
     -r{toxinidir}/requirements_lint.txt
 commands =
-    flake8 pynessie tests
+    flake8 pynessie tests tools
     safety check --ignore=41002
     mypy --ignore-missing-imports -p pynessie
 
@@ -38,7 +38,14 @@ basepython = python
 deps =
     -r{toxinidir}/requirements_lint.txt
 commands =
-    pylint pynessie tests
+    pylint pynessie tests tools
+
+[testenv:docs]
+basepython = python
+deps =
+    -r{toxinidir}/requirements_dev.txt
+commands =
+    python tools/generate_docs.py
 
 [testenv]
 setenv =


### PR DESCRIPTION
Fixes: https://github.com/projectnessie/nessie/issues/2614

As well, refactoring and moving the docs generation script from the tests into its own script under `python/tools/generate_docs.py` that can be triggered through `tox` or `tox -e docs`