### PR TITLE
Mark Python VCR cassettes as binary

### DIFF
--- a/python/tests/cassettes/.gitattributes
+++ b/python/tests/cassettes/.gitattributes
@@ -1,0 +1,1 @@
+*.yaml binary linguist-generated


### PR DESCRIPTION
Marking the Python VCR cassettes as binary shall improve readability
of pull requests, as those changes would only show up a a modified
file, but not the whole textual diff, which is massive and usually
useless.