### PR TITLE
Fix scm url shown in maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
   <scm>
     <connection>scm:git:https://github.com/projectnessie/nessie</connection>
     <developerConnection>scm:git:https://github.com/projectnessie/nessie</developerConnection>
-    <url>https://github.com/projectnessie/nessie/tree/${project.scm.tag}</url>
+    <url>https://github.com/projectnessie/nessie</url>
     <tag>main</tag>
   </scm>
   <issueManagement>


### PR DESCRIPTION
When looking at https://search.maven.org/artifact/org.projectnessie/nessie the SCM URL is wrong