### PR TITLE
Sort JSON in VCR cassettes

### DIFF
--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -180,7 +180,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -191,7 +191,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
       "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
@@ -247,7 +247,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
       "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
@@ -286,8 +286,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
-        "name": "main", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hasMore": false, "references": [{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+        "name": "main", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -312,7 +312,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -323,7 +323,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
       "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -342,7 +342,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
@@ -367,9 +367,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
-        "name": "main", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
-        "name": "dev", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hasMore": false, "references": [{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+        "name": "main", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+        "name": "dev", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
@@ -394,7 +394,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -405,7 +405,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
       "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -450,7 +450,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
@@ -461,7 +461,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
       "name": "dev", "type": "TAG"}'
     headers:
       Accept:
@@ -477,7 +477,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84
   response:
     body:
       string: ''
@@ -500,9 +500,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
-        "name": "main", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
-        "name": "dev", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+      string: '{"hasMore": false, "references": [{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+        "name": "main", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+        "name": "dev", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
         "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,12 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -91,16 +94,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -119,24 +120,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/assign.foo.bar?ref=dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'assign.foo.bar' in reference 'dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''assign.foo.bar'' in reference ''dev''.", "reason": "Not Found",
+        "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '197'
+      - '180'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["assign", "foo", "bar"]}, "content": {"specId": 44, "id": "test_assign",
-      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_assign",
+      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
+      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["assign", "foo", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -154,12 +155,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
+      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -178,17 +180,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
+      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
       "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
@@ -207,14 +210,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=dev
   response:
     body:
-      string: "{\n  \"status\" : 409,\n  \"reason\" : \"Conflict\",\n  \"message\"
-        : \"Named reference 'main' already exists.\",\n  \"errorCode\" : \"REFERENCE_ALREADY_EXISTS\",\n
-        \ \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "REFERENCE_ALREADY_EXISTS", "message": "Named reference
+        ''main'' already exists.", "reason": "Conflict", "serverStackTrace": null,
+        "status": 409}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '174'
+      - '157'
     status:
       code: 409
       message: Conflict
@@ -233,17 +236,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
       "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
@@ -282,16 +286,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "main", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -310,17 +312,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
+      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
       "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -339,12 +342,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
+      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '118'
+      - '107'
     status:
       code: 200
       message: OK
@@ -363,17 +367,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "main", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "dev", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '451'
+      - '381'
     status:
       code: 200
       message: OK
@@ -392,17 +394,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
+      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
       "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -421,14 +424,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=dev
   response:
     body:
-      string: "{\n  \"status\" : 409,\n  \"reason\" : \"Conflict\",\n  \"message\"
-        : \"Named reference 'v1.0' already exists.\",\n  \"errorCode\" : \"REFERENCE_ALREADY_EXISTS\",\n
-        \ \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "REFERENCE_ALREADY_EXISTS", "message": "Named reference
+        ''v1.0'' already exists.", "reason": "Conflict", "serverStackTrace": null,
+        "status": 409}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '174'
+      - '157'
     status:
       code: 409
       message: Conflict
@@ -447,17 +450,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n}"
+      string: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '118'
+      - '107'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455",
+    body: '{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
       "name": "dev", "type": "TAG"}'
     headers:
       Accept:
@@ -473,7 +477,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38
   response:
     body:
       string: ''
@@ -496,17 +500,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" : \"291dd61cb415c8a23d3ea17fca9a55eaf2e7b5d259ec77469de82ffdc496c455\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "main", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "dev", "type": "BRANCH"}, {"hash": "3279eb502c46e0618df9fa9d1ba6cf626a4ebc5e570c3f570aad2b7573ec6b38",
+        "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '451'
+      - '381'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -180,7 +180,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -191,7 +191,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
       "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
@@ -247,7 +247,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
       "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
@@ -286,8 +286,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
-        "name": "main", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hasMore": false, "references": [{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+        "name": "main", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -312,7 +312,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -323,7 +323,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
       "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -342,7 +342,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
@@ -367,9 +367,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
-        "name": "main", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
-        "name": "dev", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hasMore": false, "references": [{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+        "name": "main", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+        "name": "dev", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
@@ -394,7 +394,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -405,7 +405,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
       "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -450,7 +450,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
@@ -461,7 +461,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
       "name": "dev", "type": "TAG"}'
     headers:
       Accept:
@@ -477,7 +477,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc
   response:
     body:
       string: ''
@@ -500,9 +500,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
-        "name": "main", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
-        "name": "dev", "type": "BRANCH"}, {"hash": "0d3a8a07518c7a193f7508d96b3d498d4f5a890fbe099d750040a9a1289f5b84",
+      string: '{"hasMore": false, "references": [{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+        "name": "main", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+        "name": "dev", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
         "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_branch.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_branch.yaml
@@ -14,14 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '193'
+      - '161'
     status:
       code: 200
       message: OK
@@ -40,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -64,12 +64,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -93,12 +94,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -117,16 +119,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -145,12 +145,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -174,12 +175,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -198,17 +200,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  },
-        {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"etl\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '453'
+      - '383'
     status:
       code: 200
       message: OK
@@ -227,17 +227,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  },
-        {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"etl\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '453'
+      - '383'
     status:
       code: 200
       message: OK
@@ -256,17 +254,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  },
-        {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"etl\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '453'
+      - '383'
     status:
       code: 200
       message: OK
@@ -285,12 +281,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"etl\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -331,12 +328,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -377,14 +375,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '193'
+      - '161'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_command_line_interface.yaml
@@ -14,14 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '193'
+      - '161'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '63'
+      - '51'
     status:
       code: 200
       message: OK
@@ -62,12 +63,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -86,12 +88,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -115,13 +118,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev_test_log\",\n  \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_test_log", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '129'
+      - '118'
     status:
       code: 200
       message: OK
@@ -140,16 +143,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev_test_log\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_test_log", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '332'
+      - '281'
     status:
       code: 200
       message: OK
@@ -168,24 +169,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/log.foo.dev?ref=dev_test_log
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'log.foo.dev' in reference 'dev_test_log'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''log.foo.dev'' in reference ''dev_test_log''.", "reason": "Not Found",
+        "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '203'
+      - '186'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie_user1"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["log", "foo", "dev"]}, "content": {"specId": 44, "id": "test_log_dev",
-      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie_user1", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_log_dev",
+      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
+      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["log", "foo", "dev"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -203,13 +204,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev_test_log/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev_test_log\",\n  \"hash\"
-        : \"72a5b98f44c950bb86cd9d1039a431e79b10d3e6afb56a5e00df03a8c463e463\"\n}"
+      string: '{"hash": "58311fef55acfa3f5aca1a34a13bbd366845c2a7973735044bc374a69e7cea28",
+        "name": "dev_test_log", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '129'
+      - '118'
     status:
       code: 200
       message: OK
@@ -228,16 +229,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev_test_log\",\n    \"hash\"
-        : \"72a5b98f44c950bb86cd9d1039a431e79b10d3e6afb56a5e00df03a8c463e463\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "58311fef55acfa3f5aca1a34a13bbd366845c2a7973735044bc374a69e7cea28",
+        "name": "dev_test_log", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '332'
+      - '281'
     status:
       code: 200
       message: OK
@@ -256,24 +255,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/log.foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'log.foo.bar' in reference 'main'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''log.foo.bar'' in reference ''main''.", "reason": "Not Found", "serverStackTrace":
+        null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '195'
+      - '178'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie_user1"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["log", "foo", "bar"]}, "content": {"specId": 44, "id": "test_log",
-      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie_user1", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_log", "metadataLocation":
+      "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "specId": 44,
+      "type": "ICEBERG_TABLE"}, "expectedContent": null, "key": {"elements": ["log",
+      "foo", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -291,12 +290,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
+      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -315,12 +315,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
+      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -339,14 +340,13 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/log.foo.bar?ref=main
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_log\",\n  \"metadataLocation\"
-        : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\" : 43,\n  \"specId\"
-        : 44,\n  \"sortOrderId\" : 45\n}"
+      string: '{"id": "test_log", "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId":
+        42, "sortOrderId": 45, "specId": 44, "type": "ICEBERG_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '163'
+      - '140'
     status:
       code: 200
       message: OK
@@ -365,12 +365,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
+      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -389,16 +390,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
+        "2021-11-17T16:59:42.890299Z", "commitTime": "2021-11-17T16:59:42.890299Z",
+        "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '384'
+      - '326'
     status:
       code: 200
       message: OK
@@ -417,12 +418,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
+      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -438,19 +440,19 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
+        "2021-11-17T16:59:42.890299Z", "commitTime": "2021-11-17T16:59:42.890299Z",
+        "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '384'
+      - '326'
     status:
       code: 200
       message: OK
@@ -469,12 +471,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\"\n}"
+      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -493,22 +496,21 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/entries
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"ICEBERG_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"log\", \"foo\", \"bar\" ]\n    }\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["log", "foo", "bar"]}, "type":
+        "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '160'
+      - '118'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "delete_message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie_user2"}, "operations": [{"key": {"elements": ["log",
-      "foo", "bar"]}, "type": "DELETE"}]}'
+    body: '{"commitMeta": {"author": "nessie_user2", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "delete_message", "properties":
+      null, "signedOffBy": null}, "operations": [{"key": {"elements": ["log", "foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -523,15 +525,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -550,12 +553,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -574,17 +578,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?max=1
   response:
     body:
-      string: "{\n  \"token\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \ \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : true\n}"
+      string: '{"hasMore": true, "operations": [{"author": "nessie_user2", "authorTime":
+        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
+        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
+        "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '447'
+      - '389'
     status:
       code: 200
       message: OK
@@ -603,16 +606,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev_test_log/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"72a5b98f44c950bb86cd9d1039a431e79b10d3e6afb56a5e00df03a8c463e463\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.443550Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.443550Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
+        "2021-11-17T16:59:42.830400Z", "commitTime": "2021-11-17T16:59:42.830400Z",
+        "committer": "", "hash": "58311fef55acfa3f5aca1a34a13bbd366845c2a7973735044bc374a69e7cea28",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '384'
+      - '326'
     status:
       code: 200
       message: OK
@@ -631,12 +634,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -655,20 +659,19 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
+        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
+        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
+        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
+        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '708'
+      - '605'
     status:
       code: 200
       message: OK
@@ -687,12 +690,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -708,19 +712,19 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94&endHash=807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e&endHash=e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
+        "2021-11-17T16:59:42.890299Z", "commitTime": "2021-11-17T16:59:42.890299Z",
+        "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '384'
+      - '326'
     status:
       code: 200
       message: OK
@@ -739,12 +743,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -763,20 +768,19 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
+        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
+        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
+        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
+        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '708'
+      - '605'
     status:
       code: 200
       message: OK
@@ -795,12 +799,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -819,16 +824,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user1%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
+        "2021-11-17T16:59:42.890299Z", "commitTime": "2021-11-17T16:59:42.890299Z",
+        "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '384'
+      - '326'
     status:
       code: 200
       message: OK
@@ -847,12 +852,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -871,16 +877,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user2%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
+        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
+        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '386'
+      - '328'
     status:
       code: 200
       message: OK
@@ -899,12 +905,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -923,20 +930,19 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28commit.author%3D%3D%27nessie_user2%27+%7C%7C+commit.author%3D%3D%27nessie_user1%27%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
+        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
+        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
+        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
+        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '708'
+      - '605'
     status:
       code: 200
       message: OK
@@ -955,12 +961,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -979,20 +986,19 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.committer%3D%3D%27%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
+        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
+        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
+        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
+        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '708'
+      - '605'
     status:
       code: 200
       message: OK
@@ -1011,12 +1017,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -1035,16 +1042,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author+%3D%3D+%27nessie_user2%27+%7C%7C+commit.author+%3D%3D+%27non_existing%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
+        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
+        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '386'
+      - '328'
     status:
       code: 200
       message: OK
@@ -1063,12 +1070,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\"\n}"
+      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -1087,20 +1095,19 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28timestamp%28commit.commitTime%29+%3E+timestamp%28%272001-01-01T00%3A00%3A00%2B00%3A00%27%29+%26%26+timestamp%28commit.commitTime%29+%3C+timestamp%28%272999-12-30T23%3A00%3A00%2B00%3A00%27%29%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"6cddad4ab780c81e09876d88e51cd18833c671cf41e9b7d3e2126bdc20c96d94\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.700638Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.700638Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"807d617005ada6cb8008ce394ea72d1c9ca3d805afaa2ea896b0ff26aa840777\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:56.524663Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:56.524663Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
+        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
+        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
+        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
+        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '708'
+      - '605'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -204,7 +204,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev_test_log/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "58311fef55acfa3f5aca1a34a13bbd366845c2a7973735044bc374a69e7cea28",
+      string: '{"hash": "0b8371b905bf2810da72c105b4ff4f3c005c9fd6abd3c0b36ffca13e90e9505d",
         "name": "dev_test_log", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -230,7 +230,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "58311fef55acfa3f5aca1a34a13bbd366845c2a7973735044bc374a69e7cea28",
+        "name": "main", "type": "BRANCH"}, {"hash": "0b8371b905bf2810da72c105b4ff4f3c005c9fd6abd3c0b36ffca13e90e9505d",
         "name": "dev_test_log", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -290,7 +290,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -315,7 +315,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -365,7 +365,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -391,8 +391,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T16:59:42.890299Z", "commitTime": "2021-11-17T16:59:42.890299Z",
-        "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "2021-11-17T18:59:48.644011Z", "commitTime": "2021-11-17T18:59:48.644011Z",
+        "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -418,7 +418,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -440,12 +440,12 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T16:59:42.890299Z", "commitTime": "2021-11-17T16:59:42.890299Z",
-        "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "2021-11-17T18:59:48.644011Z", "commitTime": "2021-11-17T18:59:48.644011Z",
+        "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -471,7 +471,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -525,10 +525,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -553,7 +553,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -579,10 +579,10 @@ interactions:
   response:
     body:
       string: '{"hasMore": true, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
-        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
+        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
-        "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e"}'
+        "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6"}'
     headers:
       Content-Type:
       - application/json
@@ -607,8 +607,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T16:59:42.830400Z", "commitTime": "2021-11-17T16:59:42.830400Z",
-        "committer": "", "hash": "58311fef55acfa3f5aca1a34a13bbd366845c2a7973735044bc374a69e7cea28",
+        "2021-11-17T18:59:48.580309Z", "commitTime": "2021-11-17T18:59:48.580309Z",
+        "committer": "", "hash": "0b8371b905bf2810da72c105b4ff4f3c005c9fd6abd3c0b36ffca13e90e9505d",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -634,7 +634,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -660,11 +660,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
-        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
+        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
-        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
+        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -690,7 +690,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -712,12 +712,12 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e&endHash=e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a&endHash=d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T16:59:42.890299Z", "commitTime": "2021-11-17T16:59:42.890299Z",
-        "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "2021-11-17T18:59:48.644011Z", "commitTime": "2021-11-17T18:59:48.644011Z",
+        "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -743,7 +743,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -769,11 +769,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
-        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
+        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
-        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
+        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -799,7 +799,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -825,8 +825,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T16:59:42.890299Z", "commitTime": "2021-11-17T16:59:42.890299Z",
-        "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "2021-11-17T18:59:48.644011Z", "commitTime": "2021-11-17T18:59:48.644011Z",
+        "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -852,7 +852,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -878,8 +878,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
-        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
+        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -905,7 +905,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -931,11 +931,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
-        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
+        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
-        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
+        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -961,7 +961,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -987,11 +987,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
-        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
+        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
-        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
+        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -1017,7 +1017,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1043,8 +1043,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
-        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
+        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -1070,7 +1070,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1096,11 +1096,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T16:59:43.035685Z", "commitTime": "2021-11-17T16:59:43.035685Z",
-        "committer": "", "hash": "c942644418461f24ad5f92ef989b3ceba48b469980ff9b1de4d2079c6915d52e",
+        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
+        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T16:59:42.890299Z", "commitTime":
-        "2021-11-17T16:59:42.890299Z", "committer": "", "hash": "e269a65439f8548450a026d175aca4e135af39d1d1c87792ca845b54c241916e",
+        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
+        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -204,7 +204,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev_test_log/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "0b8371b905bf2810da72c105b4ff4f3c005c9fd6abd3c0b36ffca13e90e9505d",
+      string: '{"hash": "560649d2e43eceeeaa4da2444b83da143fa16c1b3ac8358a399675d2dd043795",
         "name": "dev_test_log", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -230,7 +230,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "0b8371b905bf2810da72c105b4ff4f3c005c9fd6abd3c0b36ffca13e90e9505d",
+        "name": "main", "type": "BRANCH"}, {"hash": "560649d2e43eceeeaa4da2444b83da143fa16c1b3ac8358a399675d2dd043795",
         "name": "dev_test_log", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -290,7 +290,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -315,7 +315,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -365,7 +365,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -391,8 +391,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T18:59:48.644011Z", "commitTime": "2021-11-17T18:59:48.644011Z",
-        "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "2021-11-17T19:04:15.495030Z", "commitTime": "2021-11-17T19:04:15.495030Z",
+        "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -418,7 +418,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -440,12 +440,12 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T18:59:48.644011Z", "commitTime": "2021-11-17T18:59:48.644011Z",
-        "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "2021-11-17T19:04:15.495030Z", "commitTime": "2021-11-17T19:04:15.495030Z",
+        "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -471,7 +471,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -525,10 +525,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -553,7 +553,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -579,10 +579,10 @@ interactions:
   response:
     body:
       string: '{"hasMore": true, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
-        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
+        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
-        "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6"}'
+        "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080"}'
     headers:
       Content-Type:
       - application/json
@@ -607,8 +607,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T18:59:48.580309Z", "commitTime": "2021-11-17T18:59:48.580309Z",
-        "committer": "", "hash": "0b8371b905bf2810da72c105b4ff4f3c005c9fd6abd3c0b36ffca13e90e9505d",
+        "2021-11-17T19:04:15.431339Z", "commitTime": "2021-11-17T19:04:15.431339Z",
+        "committer": "", "hash": "560649d2e43eceeeaa4da2444b83da143fa16c1b3ac8358a399675d2dd043795",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -634,7 +634,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -660,11 +660,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
-        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
+        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
-        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
+        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -690,7 +690,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -712,12 +712,12 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a&endHash=d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76&endHash=e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T18:59:48.644011Z", "commitTime": "2021-11-17T18:59:48.644011Z",
-        "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "2021-11-17T19:04:15.495030Z", "commitTime": "2021-11-17T19:04:15.495030Z",
+        "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -743,7 +743,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -769,11 +769,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
-        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
+        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
-        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
+        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -799,7 +799,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -825,8 +825,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T18:59:48.644011Z", "commitTime": "2021-11-17T18:59:48.644011Z",
-        "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "2021-11-17T19:04:15.495030Z", "commitTime": "2021-11-17T19:04:15.495030Z",
+        "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -852,7 +852,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -878,8 +878,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
-        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
+        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -905,7 +905,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -931,11 +931,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
-        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
+        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
-        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
+        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -961,7 +961,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -987,11 +987,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
-        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
+        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
-        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
+        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -1017,7 +1017,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1043,8 +1043,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
-        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
+        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -1070,7 +1070,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1096,11 +1096,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T18:59:48.783660Z", "commitTime": "2021-11-17T18:59:48.783660Z",
-        "committer": "", "hash": "6f0f7dc5a04489eeaa7af2e1f99fc63bbf8c2f731727932d071c6fb81123b10a",
+        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
+        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T18:59:48.644011Z", "commitTime":
-        "2021-11-17T18:59:48.644011Z", "committer": "", "hash": "d3d516fd1d84445efc8fc69e899734f78fef8465cd3cfbafbd11aad5603635c6",
+        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
+        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
+      string: '{"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
+        "name": "main", "type": "BRANCH"}, {"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -231,7 +231,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
+      string: '{"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -242,7 +242,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
+    body: '{"fromHash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
       "fromRefName": "dev"}'
     headers:
       Accept:
@@ -281,8 +281,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
-        "name": "main", "type": "BRANCH"}, {"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
+      string: '{"hasMore": false, "references": [{"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
+        "name": "main", "type": "BRANCH"}, {"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+      string: '{"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+        "name": "main", "type": "BRANCH"}, {"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -231,7 +231,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+      string: '{"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -242,7 +242,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+    body: '{"fromHash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
       "fromRefName": "dev"}'
     headers:
       Accept:
@@ -281,8 +281,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
-        "name": "main", "type": "BRANCH"}, {"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+      string: '{"hasMore": false, "references": [{"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
+        "name": "main", "type": "BRANCH"}, {"hash": "12cdbfbfb11aabd9d01ba9020c0509abe2fbebc469d991331fcaadda55409302",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,12 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -91,16 +94,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -119,24 +120,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/merge.foo.bar?ref=dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'merge.foo.bar' in reference 'dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''merge.foo.bar'' in reference ''dev''.", "reason": "Not Found", "serverStackTrace":
+        null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '196'
+      - '179'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["merge", "foo", "bar"]}, "content": {"specId": 44, "id": "test_merge",
-      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_merge",
+      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
+      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["merge", "foo", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -154,12 +155,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n}"
+      string: '{"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -178,16 +180,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -206,12 +206,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -230,17 +231,18 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n}"
+      string: '{"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512",
+    body: '{"fromHash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
       "fromRefName": "dev"}'
     headers:
       Accept:
@@ -279,16 +281,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"1d26ea747944ead371eeeabc5229af13bcfe6069611cc894116c06c9c2125512\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+        "name": "main", "type": "BRANCH"}, {"hash": "4b889def56e51d5ddb0947598c466da67e516175e08bf642d4655fb3719a4424",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_remote.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_remote.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,14 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '193'
+      - '161'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -14,14 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '193'
+      - '161'
     status:
       code: 200
       message: OK
@@ -40,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -69,12 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-tag", "type": "TAG"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -93,16 +94,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"TAG\",\n    \"name\" : \"dev-tag\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-tag", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '324'
+      - '273'
     status:
       code: 200
       message: OK
@@ -121,12 +120,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -150,12 +150,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -174,17 +175,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"TAG\",\n    \"name\" : \"dev-tag\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"etl-tag\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '455'
+      - '385'
     status:
       code: 200
       message: OK
@@ -203,17 +202,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"TAG\",\n    \"name\" : \"dev-tag\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"etl-tag\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '455'
+      - '385'
     status:
       code: 200
       message: OK
@@ -232,17 +229,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"TAG\",\n    \"name\" : \"dev-tag\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  },
-        {\n    \"type\" : \"TAG\",\n    \"name\" : \"etl-tag\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '455'
+      - '385'
     status:
       code: 200
       message: OK
@@ -261,12 +256,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"etl-tag\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -307,12 +303,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"dev-tag\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-tag", "type": "TAG"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -353,14 +350,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '193'
+      - '161'
     status:
       code: 200
       message: OK
@@ -379,12 +375,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -403,12 +400,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -432,12 +430,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '118'
+      - '107'
     status:
       code: 200
       message: OK
@@ -456,16 +455,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" :
-        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '321'
+      - '270'
     status:
       code: 200
       message: OK
@@ -484,16 +481,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"TAG\",\n    \"name\" : \"v1.0\",\n    \"hash\" :
-        \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '321'
+      - '270'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "c55dc0e20f9d1c594bc4cee66cc4e5fb2ba1681a95577bb35d546f5c95d3907e",
+      string: '{"hash": "d86e076ba6d7fc4ef80467bf5a5e6ff7bc2a945dc55435607d638bfa764dc06f",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "c55dc0e20f9d1c594bc4cee66cc4e5fb2ba1681a95577bb35d546f5c95d3907e",
+        "name": "main", "type": "BRANCH"}, {"hash": "d86e076ba6d7fc4ef80467bf5a5e6ff7bc2a945dc55435607d638bfa764dc06f",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=c55dc0e20f9d1c594bc4cee66cc4e5fb2ba1681a95577bb35d546f5c95d3907e
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=d86e076ba6d7fc4ef80467bf5a5e6ff7bc2a945dc55435607d638bfa764dc06f
   response:
     body:
-      string: '{"hash": "faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86",
+      string: '{"hash": "41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86",
+        "name": "main", "type": "BRANCH"}, {"hash": "41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -324,10 +324,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0
   response:
     body:
-      string: '{"hash": "9abeed195aeb5c561950b267901e04b0dded8048dc1d0b213daa0bf8ffbc7e99",
+      string: '{"hash": "a0b2165afa5274232a9fa554e9f5360f53a8acb9cea0d44a848a59757fb7f91f",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -353,7 +353,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "9abeed195aeb5c561950b267901e04b0dded8048dc1d0b213daa0bf8ffbc7e99",
+        "name": "main", "type": "BRANCH"}, {"hash": "a0b2165afa5274232a9fa554e9f5360f53a8acb9cea0d44a848a59757fb7f91f",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -379,14 +379,14 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T16:59:44.879905Z", "commitTime": "2021-11-17T16:59:44.879905Z",
-        "committer": "", "hash": "9abeed195aeb5c561950b267901e04b0dded8048dc1d0b213daa0bf8ffbc7e99",
+        "2021-11-17T18:59:50.513723Z", "commitTime": "2021-11-17T18:59:50.513723Z",
+        "committer": "", "hash": "a0b2165afa5274232a9fa554e9f5360f53a8acb9cea0d44a848a59757fb7f91f",
         "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T16:59:44.836506Z", "commitTime":
-        "2021-11-17T16:59:44.836506Z", "committer": "", "hash": "faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86",
+        "nessie test", "authorTime": "2021-11-17T18:59:50.472548Z", "commitTime":
+        "2021-11-17T18:59:50.472548Z", "committer": "", "hash": "41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0",
         "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T16:59:44.789117Z", "commitTime":
-        "2021-11-17T16:59:44.789117Z", "committer": "", "hash": "c55dc0e20f9d1c594bc4cee66cc4e5fb2ba1681a95577bb35d546f5c95d3907e",
+        "nessie test", "authorTime": "2021-11-17T18:59:50.433798Z", "commitTime":
+        "2021-11-17T18:59:50.433798Z", "committer": "", "hash": "d86e076ba6d7fc4ef80467bf5a5e6ff7bc2a945dc55435607d638bfa764dc06f",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -423,8 +423,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromRefName": "dev", "hashesToTransplant": ["faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86",
-      "9abeed195aeb5c561950b267901e04b0dded8048dc1d0b213daa0bf8ffbc7e99"]}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0",
+      "a0b2165afa5274232a9fa554e9f5360f53a8acb9cea0d44a848a59757fb7f91f"]}'
     headers:
       Accept:
       - '*/*'
@@ -462,7 +462,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "ff58c464084316d02ed3d3911a449958b846007f21fa5d74f8d3a82774823489",
+      string: '{"hash": "8c26644f399c7265438c535794c911c9160db40b34e20d67d1a4e2f0edaf715a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -488,11 +488,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T16:59:44.879905Z", "commitTime": "2021-11-17T16:59:44.879905Z",
-        "committer": "", "hash": "ff58c464084316d02ed3d3911a449958b846007f21fa5d74f8d3a82774823489",
+        "2021-11-17T18:59:50.513723Z", "commitTime": "2021-11-17T18:59:50.513723Z",
+        "committer": "", "hash": "8c26644f399c7265438c535794c911c9160db40b34e20d67d1a4e2f0edaf715a",
         "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T16:59:44.836506Z", "commitTime":
-        "2021-11-17T16:59:44.836506Z", "committer": "", "hash": "7a5d2f983e40a51ff7120442784ce161ccbf98ffb07e7fc82981c94636c095a3",
+        "nessie test", "authorTime": "2021-11-17T18:59:50.472548Z", "commitTime":
+        "2021-11-17T18:59:50.472548Z", "committer": "", "hash": "c7e58f6dfb986c7b11468ee253b1365514ded0bf6f103382f7f2cea9b1d67cd8",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "d86e076ba6d7fc4ef80467bf5a5e6ff7bc2a945dc55435607d638bfa764dc06f",
+      string: '{"hash": "58e66cab98730b2a41d905a2f698e1e5390d79a24492144ea2437dd1bae809b6",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "d86e076ba6d7fc4ef80467bf5a5e6ff7bc2a945dc55435607d638bfa764dc06f",
+        "name": "main", "type": "BRANCH"}, {"hash": "58e66cab98730b2a41d905a2f698e1e5390d79a24492144ea2437dd1bae809b6",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=d86e076ba6d7fc4ef80467bf5a5e6ff7bc2a945dc55435607d638bfa764dc06f
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=58e66cab98730b2a41d905a2f698e1e5390d79a24492144ea2437dd1bae809b6
   response:
     body:
-      string: '{"hash": "41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0",
+      string: '{"hash": "f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0",
+        "name": "main", "type": "BRANCH"}, {"hash": "f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -324,10 +324,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc
   response:
     body:
-      string: '{"hash": "a0b2165afa5274232a9fa554e9f5360f53a8acb9cea0d44a848a59757fb7f91f",
+      string: '{"hash": "f39003e5b714aacdc3b51e69da60e469acff78fc29a4173b17878e7041e5c51b",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -353,7 +353,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "a0b2165afa5274232a9fa554e9f5360f53a8acb9cea0d44a848a59757fb7f91f",
+        "name": "main", "type": "BRANCH"}, {"hash": "f39003e5b714aacdc3b51e69da60e469acff78fc29a4173b17878e7041e5c51b",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -379,14 +379,14 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T18:59:50.513723Z", "commitTime": "2021-11-17T18:59:50.513723Z",
-        "committer": "", "hash": "a0b2165afa5274232a9fa554e9f5360f53a8acb9cea0d44a848a59757fb7f91f",
+        "2021-11-17T19:04:17.365700Z", "commitTime": "2021-11-17T19:04:17.365700Z",
+        "committer": "", "hash": "f39003e5b714aacdc3b51e69da60e469acff78fc29a4173b17878e7041e5c51b",
         "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T18:59:50.472548Z", "commitTime":
-        "2021-11-17T18:59:50.472548Z", "committer": "", "hash": "41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0",
+        "nessie test", "authorTime": "2021-11-17T19:04:17.324291Z", "commitTime":
+        "2021-11-17T19:04:17.324291Z", "committer": "", "hash": "f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc",
         "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T18:59:50.433798Z", "commitTime":
-        "2021-11-17T18:59:50.433798Z", "committer": "", "hash": "d86e076ba6d7fc4ef80467bf5a5e6ff7bc2a945dc55435607d638bfa764dc06f",
+        "nessie test", "authorTime": "2021-11-17T19:04:17.286464Z", "commitTime":
+        "2021-11-17T19:04:17.286464Z", "committer": "", "hash": "58e66cab98730b2a41d905a2f698e1e5390d79a24492144ea2437dd1bae809b6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -423,8 +423,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromRefName": "dev", "hashesToTransplant": ["41f29fe281cb624bae76d120f008676fb750811ed953c6fec421a7cf553d05d0",
-      "a0b2165afa5274232a9fa554e9f5360f53a8acb9cea0d44a848a59757fb7f91f"]}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc",
+      "f39003e5b714aacdc3b51e69da60e469acff78fc29a4173b17878e7041e5c51b"]}'
     headers:
       Accept:
       - '*/*'
@@ -462,7 +462,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "8c26644f399c7265438c535794c911c9160db40b34e20d67d1a4e2f0edaf715a",
+      string: '{"hash": "3070e3405a1180c6c7a2d57bec15c226f121eeb476d9c8fe784aca1c4f580875",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -488,11 +488,11 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T18:59:50.513723Z", "commitTime": "2021-11-17T18:59:50.513723Z",
-        "committer": "", "hash": "8c26644f399c7265438c535794c911c9160db40b34e20d67d1a4e2f0edaf715a",
+        "2021-11-17T19:04:17.365700Z", "commitTime": "2021-11-17T19:04:17.365700Z",
+        "committer": "", "hash": "3070e3405a1180c6c7a2d57bec15c226f121eeb476d9c8fe784aca1c4f580875",
         "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T18:59:50.472548Z", "commitTime":
-        "2021-11-17T18:59:50.472548Z", "committer": "", "hash": "c7e58f6dfb986c7b11468ee253b1365514ded0bf6f103382f7f2cea9b1d67cd8",
+        "nessie test", "authorTime": "2021-11-17T19:04:17.324291Z", "commitTime":
+        "2021-11-17T19:04:17.324291Z", "committer": "", "hash": "4c735cb88b20d6b22374f5278d3997987d795825c4b5c08a1f23c848ede194d6",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,12 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -91,16 +94,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -119,24 +120,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/transplant.foo.bar?ref=dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'transplant.foo.bar' in reference 'dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''transplant.foo.bar'' in reference ''dev''.", "reason": "Not Found",
+        "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '201'
+      - '184'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["transplant", "foo", "bar"]}, "content": {"specId": 44, "id":
-      "test_transplant_1", "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_transplant_1",
+      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
+      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["transplant", "foo", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -154,12 +155,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"951f5e148490c1d885fc1bac6f093206349fd5acfb56efeff64a48014e0366de\"\n}"
+      string: '{"hash": "c55dc0e20f9d1c594bc4cee66cc4e5fb2ba1681a95577bb35d546f5c95d3907e",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -178,16 +180,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"951f5e148490c1d885fc1bac6f093206349fd5acfb56efeff64a48014e0366de\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "c55dc0e20f9d1c594bc4cee66cc4e5fb2ba1681a95577bb35d546f5c95d3907e",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -206,24 +206,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/bar.bar?ref=dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'bar.bar' in reference 'dev'.\",\n  \"errorCode\"
-        : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''bar.bar'' in reference ''dev''.", "reason": "Not Found", "serverStackTrace":
+        null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '190'
+      - '173'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["bar", "bar"]}, "content": {"specId": 44, "id": "test_transplant_2",
-      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_transplant_2",
+      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
+      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["bar", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -238,15 +238,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=951f5e148490c1d885fc1bac6f093206349fd5acfb56efeff64a48014e0366de
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=c55dc0e20f9d1c594bc4cee66cc4e5fb2ba1681a95577bb35d546f5c95d3907e
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7\"\n}"
+      string: '{"hash": "faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -265,16 +266,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -293,24 +292,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/foo.baz?ref=dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'foo.baz' in reference 'dev'.\",\n  \"errorCode\"
-        : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''foo.baz'' in reference ''dev''.", "reason": "Not Found", "serverStackTrace":
+        null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '190'
+      - '173'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["foo", "baz"]}, "content": {"specId": 44, "id": "test_transplant_3",
-      "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "metadataLocation": "/a/b/c",
-      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_transplant_3",
+      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
+      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["foo", "baz"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -325,15 +324,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8\"\n}"
+      string: '{"hash": "9abeed195aeb5c561950b267901e04b0dded8048dc1d0b213daa0bf8ffbc7e99",
+        "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '120'
+      - '109'
     status:
       code: 200
       message: OK
@@ -352,16 +352,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"dev\",\n    \"hash\"
-        : \"0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "9abeed195aeb5c561950b267901e04b0dded8048dc1d0b213daa0bf8ffbc7e99",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '323'
+      - '272'
     status:
       code: 200
       message: OK
@@ -380,24 +378,22 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.714414Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:58.714414Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.669717Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:58.669717Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"951f5e148490c1d885fc1bac6f093206349fd5acfb56efeff64a48014e0366de\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.624028Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:58.624028Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
+        "2021-11-17T16:59:44.879905Z", "commitTime": "2021-11-17T16:59:44.879905Z",
+        "committer": "", "hash": "9abeed195aeb5c561950b267901e04b0dded8048dc1d0b213daa0bf8ffbc7e99",
+        "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
+        "nessie test", "authorTime": "2021-11-17T16:59:44.836506Z", "commitTime":
+        "2021-11-17T16:59:44.836506Z", "committer": "", "hash": "faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86",
+        "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
+        "nessie test", "authorTime": "2021-11-17T16:59:44.789117Z", "commitTime":
+        "2021-11-17T16:59:44.789117Z", "committer": "", "hash": "c55dc0e20f9d1c594bc4cee66cc4e5fb2ba1681a95577bb35d546f5c95d3907e",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '1025'
+      - '877'
     status:
       code: 200
       message: OK
@@ -416,18 +412,19 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"fromRefName": "dev", "hashesToTransplant": ["88d3434b922c52584d795f00c26a496b20e9b2674ef4ddb6be68b7d2ab8ec0e7",
-      "0bbfa4ad27bb1ef19a8823e74dd648ff632bc7ba8437f4bb5bbf0f4c6a28f2b8"]}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["faddef49de2a35cbe91ce99079b4f342bdbb39d72620d8d0f7f8a633e64a6a86",
+      "9abeed195aeb5c561950b267901e04b0dded8048dc1d0b213daa0bf8ffbc7e99"]}'
     headers:
       Accept:
       - '*/*'
@@ -465,12 +462,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"f642677fb7dd347eb6d3956c7506a6f49aad73c47858c367802223d080221d33\"\n}"
+      string: '{"hash": "ff58c464084316d02ed3d3911a449958b846007f21fa5d74f8d3a82774823489",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -489,20 +487,19 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"f642677fb7dd347eb6d3956c7506a6f49aad73c47858c367802223d080221d33\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.714414Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:58.714414Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"ff162b9aa1d98f5acc9db590f94da568c06ef258f24c02827c6560a8e056ad5e\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:53:58.669717Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:53:58.669717Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
+        "2021-11-17T16:59:44.879905Z", "commitTime": "2021-11-17T16:59:44.879905Z",
+        "committer": "", "hash": "ff58c464084316d02ed3d3911a449958b846007f21fa5d74f8d3a82774823489",
+        "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
+        "nessie test", "authorTime": "2021-11-17T16:59:44.836506Z", "commitTime":
+        "2021-11-17T16:59:44.836506Z", "committer": "", "hash": "7a5d2f983e40a51ff7120442784ce161ccbf98ffb07e7fc82981c94636c095a3",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '704'
+      - '601'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "7f8770997a0f1bb59ebab198f6ba724d072e9cb44840fc473cad90749328d1e3",
+      string: '{"hash": "2373f91a10898dd81b2e1b87db837202bbfabd7802d86fd81a751dc5716c8e51",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -206,7 +206,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "7f8770997a0f1bb59ebab198f6ba724d072e9cb44840fc473cad90749328d1e3",
+        "name": "main", "type": "BRANCH"}, {"hash": "2373f91a10898dd81b2e1b87db837202bbfabd7802d86fd81a751dc5716c8e51",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -235,10 +235,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=7f8770997a0f1bb59ebab198f6ba724d072e9cb44840fc473cad90749328d1e3
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=2373f91a10898dd81b2e1b87db837202bbfabd7802d86fd81a751dc5716c8e51
   response:
     body:
-      string: '{"hash": "e69fc56763faa12b9b90e12292b9fdcfaa5fb2f9a342c296bea44ca0e43c034d",
+      string: '{"hash": "fad32414207f3091ccfbc030448a8b6832ef221d230cb6eb04c770b74d82bf3d",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "2373f91a10898dd81b2e1b87db837202bbfabd7802d86fd81a751dc5716c8e51",
+      string: '{"hash": "f814e1e92b6921d6b3ac56d468ec562e97133557e439726e6fee5ed2fa39e1f1",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -206,7 +206,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2373f91a10898dd81b2e1b87db837202bbfabd7802d86fd81a751dc5716c8e51",
+        "name": "main", "type": "BRANCH"}, {"hash": "f814e1e92b6921d6b3ac56d468ec562e97133557e439726e6fee5ed2fa39e1f1",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -235,10 +235,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=2373f91a10898dd81b2e1b87db837202bbfabd7802d86fd81a751dc5716c8e51
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=f814e1e92b6921d6b3ac56d468ec562e97133557e439726e6fee5ed2fa39e1f1
   response:
     body:
-      string: '{"hash": "fad32414207f3091ccfbc030448a8b6832ef221d230cb6eb04c770b74d82bf3d",
+      string: '{"hash": "cd4bbbd6f5bb422c05ae02afe30150ad26a791de4248c7a3204afef9b36fc1a2",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,13 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_delete_dev\",\n
-        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '143'
+      - '132'
     status:
       code: 200
       message: OK
@@ -92,16 +94,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_delete_dev\",\n
-        \   \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_commit_delete_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '346'
+      - '295'
     status:
       code: 200
       message: OK
@@ -120,24 +120,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_commit_delete_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.iceberg.foo' in reference 'contents_commit_delete_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.iceberg.foo'' in reference ''contents_commit_delete_dev''.",
+        "reason": "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '225'
+      - '208'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
-      "test_contents_delete", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42,
-      "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_contents_delete",
+      "metadataLocation": "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "specId": 42, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -155,13 +155,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_delete_dev\",\n
-        \ \"hash\" : \"44eef1796a019b990caba6d5cadb9aa933ca4b883b9eac15971edd5069d862bc\"\n}"
+      string: '{"hash": "7f8770997a0f1bb59ebab198f6ba724d072e9cb44840fc473cad90749328d1e3",
+        "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '143'
+      - '132'
     status:
       code: 200
       message: OK
@@ -180,14 +180,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_commit_delete_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"ICEBERG_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"iceberg\", \"foo\"
-        ]\n    }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "iceberg", "foo"]},
+        "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '171'
+      - '129'
     status:
       code: 200
       message: OK
@@ -206,24 +205,22 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_delete_dev\",\n
-        \   \"hash\" : \"44eef1796a019b990caba6d5cadb9aa933ca4b883b9eac15971edd5069d862bc\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "7f8770997a0f1bb59ebab198f6ba724d072e9cb44840fc473cad90749328d1e3",
+        "name": "contents_commit_delete_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '346'
+      - '295'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "delete test table", "commitTime": null, "properties": null, "committer":
-      null, "author": null}, "operations": [{"key": {"elements": ["this", "is", "iceberg",
-      "foo"]}, "type": "DELETE"}]}'
+    body: '{"commitMeta": {"author": null, "authorTime": null, "commitTime": null,
+      "committer": null, "hash": null, "message": "delete test table", "properties":
+      null, "signedOffBy": null}, "operations": [{"key": {"elements": ["this", "is",
+      "iceberg", "foo"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -238,16 +235,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=44eef1796a019b990caba6d5cadb9aa933ca4b883b9eac15971edd5069d862bc
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=7f8770997a0f1bb59ebab198f6ba724d072e9cb44840fc473cad90749328d1e3
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_delete_dev\",\n
-        \ \"hash\" : \"731fa342fce6079ab3155b7a932f2a75c250dabc4fd43480564ac2bd1d655112\"\n}"
+      string: '{"hash": "e69fc56763faa12b9b90e12292b9fdcfaa5fb2f9a342c296bea44ca0e43c034d",
+        "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '143'
+      - '132'
     status:
       code: 200
       message: OK
@@ -266,12 +263,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_commit_delete_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '60'
+      - '48'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "66a911602b737bc748953c76639429157426c7e20726c89f4cf176fabd758ef6",
+      string: '{"hash": "bf9b1e56870a9e4281d87f4bd8a85ad3246a645b9c1d02f08f5e3d1df56978a7",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -182,7 +182,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "66a911602b737bc748953c76639429157426c7e20726c89f4cf176fabd758ef6",
+        "name": "main", "type": "BRANCH"}, {"hash": "bf9b1e56870a9e4281d87f4bd8a85ad3246a645b9c1d02f08f5e3d1df56978a7",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -239,10 +239,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=66a911602b737bc748953c76639429157426c7e20726c89f4cf176fabd758ef6
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=bf9b1e56870a9e4281d87f4bd8a85ad3246a645b9c1d02f08f5e3d1df56978a7
   response:
     body:
-      string: '{"hash": "01743f03e7f1e2b8119333ff11a9ea38dcbd94badc7ff50ef83bcfe16d3c2f15",
+      string: '{"hash": "68375c8ff013ae6f5cb843bfa5d8b6957ad505407f3826c2b470f6b75000e16a",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,13 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '156'
+      - '145'
     status:
       code: 200
       message: OK
@@ -92,16 +94,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \   \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '359'
+      - '308'
     status:
       code: 200
       message: OK
@@ -120,25 +121,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/commit.expected.contents?ref=contents_commit_with_no__expected_state
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'commit.expected.contents' in reference
-        'contents_commit_with_no__expected_state'.\",\n  \"errorCode\" : \"CONTENT_NOT_FOUND\",\n
-        \ \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''commit.expected.contents'' in reference ''contents_commit_with_no__expected_state''.",
+        "reason": "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '243'
+      - '226'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "commit 1", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["commit", "expected", "contents"]}, "content": {"checkpointLocationHistory":
-      ["def"], "metadataLocationHistory": ["asd111"], "lastCheckpoint": "x", "id":
-      "test_commit_no_expected_state", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "commit 1", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"checkpointLocationHistory":
+      ["def"], "id": "test_commit_no_expected_state", "lastCheckpoint": "x", "metadataLocationHistory":
+      ["asd111"], "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "key": {"elements":
+      ["commit", "expected", "contents"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -156,13 +156,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \ \"hash\" : \"dcdc812a8756a0da0f1ccc2829bc357f2a4309872ae46fad8621010535d2e2c2\"\n}"
+      string: '{"hash": "66a911602b737bc748953c76639429157426c7e20726c89f4cf176fabd758ef6",
+        "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '156'
+      - '145'
     status:
       code: 200
       message: OK
@@ -181,16 +181,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \   \"hash\" : \"dcdc812a8756a0da0f1ccc2829bc357f2a4309872ae46fad8621010535d2e2c2\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "66a911602b737bc748953c76639429157426c7e20726c89f4cf176fabd758ef6",
+        "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '359'
+      - '308'
     status:
       code: 200
       message: OK
@@ -209,24 +208,23 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/commit.expected.contents?ref=contents_commit_with_no__expected_state
   response:
     body:
-      string: "{\n  \"type\" : \"DELTA_LAKE_TABLE\",\n  \"id\" : \"test_commit_no_expected_state\",\n
-        \ \"metadataLocationHistory\" : [ \"asd111\" ],\n  \"checkpointLocationHistory\"
-        : [ \"def\" ],\n  \"lastCheckpoint\" : \"x\"\n}"
+      string: '{"checkpointLocationHistory": ["def"], "id": "test_commit_no_expected_state",
+        "lastCheckpoint": "x", "metadataLocationHistory": ["asd111"], "type": "DELTA_LAKE_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '188'
+      - '167'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "commit 2", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["commit", "expected", "contents"]}, "content": {"checkpointLocationHistory":
-      ["def"], "metadataLocationHistory": ["asd222"], "lastCheckpoint": "x", "id":
-      "test_commit_no_expected_state", "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "commit 2", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"checkpointLocationHistory":
+      ["def"], "id": "test_commit_no_expected_state", "lastCheckpoint": "x", "metadataLocationHistory":
+      ["asd222"], "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "key": {"elements":
+      ["commit", "expected", "contents"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -241,16 +239,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=dcdc812a8756a0da0f1ccc2829bc357f2a4309872ae46fad8621010535d2e2c2
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=66a911602b737bc748953c76639429157426c7e20726c89f4cf176fabd758ef6
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_no__expected_state\",\n
-        \ \"hash\" : \"f2818b2ffb7c3e865eb7dcbbc7c1e43dbc97cba8bd1ad7671b9e9f5c4f7c2f0b\"\n}"
+      string: '{"hash": "01743f03e7f1e2b8119333ff11a9ea38dcbd94badc7ff50ef83bcfe16d3c2f15",
+        "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '156'
+      - '145'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "bf9b1e56870a9e4281d87f4bd8a85ad3246a645b9c1d02f08f5e3d1df56978a7",
+      string: '{"hash": "cd12f3af0a51e6d905c96d0106778e111f263a9d2de39cadfded6eec9996b654",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -182,7 +182,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "bf9b1e56870a9e4281d87f4bd8a85ad3246a645b9c1d02f08f5e3d1df56978a7",
+        "name": "main", "type": "BRANCH"}, {"hash": "cd12f3af0a51e6d905c96d0106778e111f263a9d2de39cadfded6eec9996b654",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -239,10 +239,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=bf9b1e56870a9e4281d87f4bd8a85ad3246a645b9c1d02f08f5e3d1df56978a7
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=cd12f3af0a51e6d905c96d0106778e111f263a9d2de39cadfded6eec9996b654
   response:
     body:
-      string: '{"hash": "68375c8ff013ae6f5cb843bfa5d8b6957ad505407f3826c2b470f6b75000e16a",
+      string: '{"hash": "89623127333753ebaf9b41ff58762ab0d4c77dbb387e4ab0fea187978d370345",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,13 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '152'
+      - '141'
     status:
       code: 200
       message: OK
@@ -92,16 +94,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \   \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '355'
+      - '304'
     status:
       code: 200
       message: OK
@@ -120,24 +121,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=content_commit_with_edited_data_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.iceberg.foo' in reference 'content_commit_with_edited_data_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.iceberg.foo'' in reference ''content_commit_with_edited_data_dev''.",
+        "reason": "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '234'
+      - '217'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
-      "test_content_commit_with_edited_data", "schemaId": 42, "snapshotId": 42, "sortOrderId":
-      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_content_commit_with_edited_data",
+      "metadataLocation": "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "specId": 42, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -155,13 +156,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \ \"hash\" : \"d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1\"\n}"
+      string: '{"hash": "2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687",
+        "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '152'
+      - '141'
     status:
       code: 200
       message: OK
@@ -180,14 +181,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/content_commit_with_edited_data_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"ICEBERG_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"iceberg\", \"foo\"
-        ]\n    }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "iceberg", "foo"]},
+        "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '171'
+      - '129'
     status:
       code: 200
       message: OK
@@ -206,16 +206,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \   \"hash\" : \"d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687",
+        "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '355'
+      - '304'
     status:
       code: 200
       message: OK
@@ -234,14 +233,14 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=content_commit_with_edited_data_dev
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_content_commit_with_edited_data\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
-        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
+      string: '{"id": "test_content_commit_with_edited_data", "metadataLocation":
+        "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42, "specId": 42,
+        "type": "ICEBERG_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '191'
+      - '168'
     status:
       code: 200
       message: OK
@@ -260,16 +259,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/content_commit_with_edited_data_dev/log
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"operations\" : [ {\n    \"hash\" : \"d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-11-11T14:54:00.346928Z\",\n
-        \   \"authorTime\" : \"2021-11-11T14:54:00.346928Z\",\n    \"properties\"
-        : { }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
+        "2021-11-17T16:59:46.736988Z", "commitTime": "2021-11-17T16:59:46.736988Z",
+        "committer": "", "hash": "2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687",
+        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '383'
+      - '325'
     status:
       code: 200
       message: OK
@@ -288,16 +287,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \   \"hash\" : \"d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687",
+        "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '355'
+      - '304'
     status:
       code: 200
       message: OK
@@ -316,27 +314,26 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=content_commit_with_edited_data_dev
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_content_commit_with_edited_data\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
-        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
+      string: '{"id": "test_content_commit_with_edited_data", "metadataLocation":
+        "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42, "specId": 42,
+        "type": "ICEBERG_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '191'
+      - '168'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": {"specId":
-      42, "id": "test_content_commit_with_edited_data", "schemaId": 42, "snapshotId":
-      42, "sortOrderId": 42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"},
-      "key": {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId":
-      42, "id": "test_content_commit_with_edited_data", "schemaId": 42, "snapshotId":
-      42, "sortOrderId": 42, "metadataLocation": "/d/e/f", "type": "ICEBERG_TABLE"},
-      "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_content_commit_with_edited_data",
+      "metadataLocation": "/d/e/f", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "specId": 42, "type": "ICEBERG_TABLE"}, "expectedContent": {"id": "test_content_commit_with_edited_data",
+      "metadataLocation": "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "specId": 42, "type": "ICEBERG_TABLE"}, "key": {"elements": ["this", "is",
+      "iceberg", "foo"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -351,16 +348,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=d3d536ff8d0aa48697216120d8a641b47b588b5d0b94edf9c65eb0e11e1eb5d1
+    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"content_commit_with_edited_data_dev\",\n
-        \ \"hash\" : \"ff6835d1693a896f4d772eda76f692decb04d84d48d46586dbf5ec2d1bb80437\"\n}"
+      string: '{"hash": "a50eea22f82cc86bcf37ac29c5315e1636da7b760ef09a61cdba169a8725c341",
+        "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '152'
+      - '141'
     status:
       code: 200
       message: OK
@@ -379,14 +376,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/content_commit_with_edited_data_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"ICEBERG_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"iceberg\", \"foo\"
-        ]\n    }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "iceberg", "foo"]},
+        "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '171'
+      - '129'
     status:
       code: 200
       message: OK
@@ -405,14 +401,14 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=content_commit_with_edited_data_dev
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_content_commit_with_edited_data\",\n
-        \ \"metadataLocation\" : \"/d/e/f\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
-        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
+      string: '{"id": "test_content_commit_with_edited_data", "metadataLocation":
+        "/d/e/f", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42, "specId": 42,
+        "type": "ICEBERG_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '191'
+      - '168'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad",
+      string: '{"hash": "c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -207,7 +207,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad",
+        "name": "main", "type": "BRANCH"}, {"hash": "c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -260,8 +260,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T18:59:52.072073Z", "commitTime": "2021-11-17T18:59:52.072073Z",
-        "committer": "", "hash": "88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad",
+        "2021-11-17T19:04:18.672511Z", "commitTime": "2021-11-17T19:04:18.672511Z",
+        "committer": "", "hash": "c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -288,7 +288,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad",
+        "name": "main", "type": "BRANCH"}, {"hash": "c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad
+    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c
   response:
     body:
-      string: '{"hash": "1642478ea0adda1c443f7452b2e8ed3b8f4fa77e0a4c8530efd4c5403c4ee9c1",
+      string: '{"hash": "72251d96f792b92809840b335037049222749c18885a2e563bf36ad0e83c3b92",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687",
+      string: '{"hash": "88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -207,7 +207,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687",
+        "name": "main", "type": "BRANCH"}, {"hash": "88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -260,8 +260,8 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T16:59:46.736988Z", "commitTime": "2021-11-17T16:59:46.736988Z",
-        "committer": "", "hash": "2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687",
+        "2021-11-17T18:59:52.072073Z", "commitTime": "2021-11-17T18:59:52.072073Z",
+        "committer": "", "hash": "88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad",
         "message": "test message", "properties": {}, "signedOffBy": null}], "token":
         null}'
     headers:
@@ -288,7 +288,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687",
+        "name": "main", "type": "BRANCH"}, {"hash": "88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=2d71e686fe920c9a3d875034d937ddeb8a3fc509aa13262cdf119ecbd40b6687
+    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=88bcd605787b3fc6c8852882380a75457ccd4a9f29a7deb5afa37ee45ae73fad
   response:
     body:
-      string: '{"hash": "a50eea22f82cc86bcf37ac29c5315e1636da7b760ef09a61cdba169a8725c341",
+      string: '{"hash": "1642478ea0adda1c443f7452b2e8ed3b8f4fa77e0a4c8530efd4c5403c4ee9c1",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,13 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '162'
+      - '151'
     status:
       code: 200
       message: OK
@@ -92,16 +94,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \   \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}],
+        "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '365'
+      - '314'
     status:
       code: 200
       message: OK
@@ -120,25 +121,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_commit_with_empty_content_delete_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.iceberg.foo' in reference 'contents_commit_with_empty_content_delete_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.iceberg.foo'' in reference ''contents_commit_with_empty_content_delete_dev''.",
+        "reason": "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '244'
+      - '227'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
-      "test_contents_with_empty_content_delete", "schemaId": 42, "snapshotId": 42,
-      "sortOrderId": 42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type":
-      "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_contents_with_empty_content_delete",
+      "metadataLocation": "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "specId": 42, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -156,13 +156,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \ \"hash\" : \"e761fff6b3ddcdc272a9c8b1cb9d86ca485643a7e3cc3bab05f146ebcc4ac37c\"\n}"
+      string: '{"hash": "4ba20743fb65c2078418b44bb3219f9adef7547d37a8494cf0afede10f3649d7",
+        "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '162'
+      - '151'
     status:
       code: 200
       message: OK
@@ -181,14 +181,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_commit_with_empty_content_delete_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"ICEBERG_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"iceberg\", \"foo\"
-        ]\n    }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "iceberg", "foo"]},
+        "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '171'
+      - '129'
     status:
       code: 200
       message: OK
@@ -207,16 +206,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \   \"hash\" : \"e761fff6b3ddcdc272a9c8b1cb9d86ca485643a7e3cc3bab05f146ebcc4ac37c\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "4ba20743fb65c2078418b44bb3219f9adef7547d37a8494cf0afede10f3649d7",
+        "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}],
+        "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '365'
+      - '314'
     status:
       code: 200
       message: OK
@@ -235,21 +233,21 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_commit_with_empty_content_delete_dev
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_contents_with_empty_content_delete\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
-        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
+      string: '{"id": "test_contents_with_empty_content_delete", "metadataLocation":
+        "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42, "specId": 42,
+        "type": "ICEBERG_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '194'
+      - '171'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "delete table", "commitTime": null, "properties": null, "committer":
-      null, "author": null}, "operations": [{"key": {"elements": ["this", "is", "iceberg",
+    body: '{"commitMeta": {"author": null, "authorTime": null, "commitTime": null,
+      "committer": null, "hash": null, "message": "delete table", "properties": null,
+      "signedOffBy": null}, "operations": [{"key": {"elements": ["this", "is", "iceberg",
       "foo"]}, "type": "DELETE"}]}'
     headers:
       Accept:
@@ -265,16 +263,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=e761fff6b3ddcdc272a9c8b1cb9d86ca485643a7e3cc3bab05f146ebcc4ac37c
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=4ba20743fb65c2078418b44bb3219f9adef7547d37a8494cf0afede10f3649d7
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_empty_content_delete_dev\",\n
-        \ \"hash\" : \"b7bbb351e52a9ac30f9d252573c4b7be364e63bd6958c0986c45e2613640ec4a\"\n}"
+      string: '{"hash": "61fcbf1ba7fc6ab000f43a351ef57a389b0662e398b24d8fe3f4935101430a20",
+        "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '162'
+      - '151'
     status:
       code: 200
       message: OK
@@ -293,12 +291,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_commit_with_empty_content_delete_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '60'
+      - '48'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "13df9052c8e4d1aa771d5e2fbb44668c4d24fbacb12a10172f4aa1e62ed9e1a9",
+      string: '{"hash": "4ec97c0a869256ad611f5aa41bc1a3c46c86d28918cdc9c16decde730b7dea47",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -207,7 +207,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "13df9052c8e4d1aa771d5e2fbb44668c4d24fbacb12a10172f4aa1e62ed9e1a9",
+        "name": "main", "type": "BRANCH"}, {"hash": "4ec97c0a869256ad611f5aa41bc1a3c46c86d28918cdc9c16decde730b7dea47",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}],
         "token": null}'
     headers:
@@ -263,10 +263,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=13df9052c8e4d1aa771d5e2fbb44668c4d24fbacb12a10172f4aa1e62ed9e1a9
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=4ec97c0a869256ad611f5aa41bc1a3c46c86d28918cdc9c16decde730b7dea47
   response:
     body:
-      string: '{"hash": "3d450b9c1fdd6b4425e7de96503c191992e346d941cc4e6955e9ccbc705adb37",
+      string: '{"hash": "4348af730e504fda0225c572123eb6d6bfe5c83b7832cdd0d4f4d1bd32546be5",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "4ba20743fb65c2078418b44bb3219f9adef7547d37a8494cf0afede10f3649d7",
+      string: '{"hash": "13df9052c8e4d1aa771d5e2fbb44668c4d24fbacb12a10172f4aa1e62ed9e1a9",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -207,7 +207,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "4ba20743fb65c2078418b44bb3219f9adef7547d37a8494cf0afede10f3649d7",
+        "name": "main", "type": "BRANCH"}, {"hash": "13df9052c8e4d1aa771d5e2fbb44668c4d24fbacb12a10172f4aa1e62ed9e1a9",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}],
         "token": null}'
     headers:
@@ -263,10 +263,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=4ba20743fb65c2078418b44bb3219f9adef7547d37a8494cf0afede10f3649d7
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=13df9052c8e4d1aa771d5e2fbb44668c4d24fbacb12a10172f4aa1e62ed9e1a9
   response:
     body:
-      string: '{"hash": "61fcbf1ba7fc6ab000f43a351ef57a389b0662e398b24d8fe3f4935101430a20",
+      string: '{"hash": "3d450b9c1fdd6b4425e7de96503c191992e346d941cc4e6955e9ccbc705adb37",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_expected_state/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "9621bb01ef3ee103aa293ea9eabee4feff8da881c58399dcf218c70290b451e1",
+      string: '{"hash": "05e13d6c8fb630b14f3749ac6f75288096ebd96ea647c32a9c60cadbc0dd91a3",
         "name": "contents_commit_with_expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -182,7 +182,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "9621bb01ef3ee103aa293ea9eabee4feff8da881c58399dcf218c70290b451e1",
+        "name": "main", "type": "BRANCH"}, {"hash": "05e13d6c8fb630b14f3749ac6f75288096ebd96ea647c32a9c60cadbc0dd91a3",
         "name": "contents_commit_with_expected_state", "type": "BRANCH"}], "token":
         null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_expected_state/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "054790e73675052ba83bd24fd4c446c57006fc25ed0f53c183bb19d25a122f5e",
+      string: '{"hash": "9621bb01ef3ee103aa293ea9eabee4feff8da881c58399dcf218c70290b451e1",
         "name": "contents_commit_with_expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -182,7 +182,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "054790e73675052ba83bd24fd4c446c57006fc25ed0f53c183bb19d25a122f5e",
+        "name": "main", "type": "BRANCH"}, {"hash": "9621bb01ef3ee103aa293ea9eabee4feff8da881c58399dcf218c70290b451e1",
         "name": "contents_commit_with_expected_state", "type": "BRANCH"}], "token":
         null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,13 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_expected_state\",\n
-        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_commit_with_expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '152'
+      - '141'
     status:
       code: 200
       message: OK
@@ -92,16 +94,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_expected_state\",\n
-        \   \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_commit_with_expected_state", "type": "BRANCH"}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '355'
+      - '304'
     status:
       code: 200
       message: OK
@@ -120,25 +121,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/commit.expected.contents?ref=contents_commit_with_expected_state
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'commit.expected.contents' in reference
-        'contents_commit_with_expected_state'.\",\n  \"errorCode\" : \"CONTENT_NOT_FOUND\",\n
-        \ \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''commit.expected.contents'' in reference ''contents_commit_with_expected_state''.",
+        "reason": "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '239'
+      - '222'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "commit 1", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["commit", "expected", "contents"]}, "content": {"specId": 42,
-      "id": "test_expected_contents", "schemaId": 42, "snapshotId": 42, "sortOrderId":
-      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "commit 1", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_expected_contents",
+      "metadataLocation": "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "specId": 42, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["commit", "expected", "contents"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -156,13 +156,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_expected_state/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_commit_with_expected_state\",\n
-        \ \"hash\" : \"ee02e3b3495818c9b151e2684242cbc8ffd84d116d1731db8a87e3d817e78795\"\n}"
+      string: '{"hash": "054790e73675052ba83bd24fd4c446c57006fc25ed0f53c183bb19d25a122f5e",
+        "name": "contents_commit_with_expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '152'
+      - '141'
     status:
       code: 200
       message: OK
@@ -181,16 +181,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_commit_with_expected_state\",\n
-        \   \"hash\" : \"ee02e3b3495818c9b151e2684242cbc8ffd84d116d1731db8a87e3d817e78795\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "054790e73675052ba83bd24fd4c446c57006fc25ed0f53c183bb19d25a122f5e",
+        "name": "contents_commit_with_expected_state", "type": "BRANCH"}], "token":
+        null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '355'
+      - '304'
     status:
       code: 200
       message: OK
@@ -209,14 +208,13 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/commit.expected.contents?ref=contents_commit_with_expected_state
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_expected_contents\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
-        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
+      string: '{"id": "test_expected_contents", "metadataLocation": "/a/b/c", "schemaId":
+        42, "snapshotId": 42, "sortOrderId": 42, "specId": 42, "type": "ICEBERG_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '177'
+      - '154'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "dbe5367da31ae34bfabf4ece49c36bac05229f352f14575309e7e8dce99b41c1",
+      string: '{"hash": "fdb4d30b6448bfedf68baab18f16050f6c12b9ae291be0c3eefd82f5c99f9cbf",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "dbe5367da31ae34bfabf4ece49c36bac05229f352f14575309e7e8dce99b41c1",
+        "name": "main", "type": "BRANCH"}, {"hash": "fdb4d30b6448bfedf68baab18f16050f6c12b9ae291be0c3eefd82f5c99f9cbf",
         "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=dbe5367da31ae34bfabf4ece49c36bac05229f352f14575309e7e8dce99b41c1
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=fdb4d30b6448bfedf68baab18f16050f6c12b9ae291be0c3eefd82f5c99f9cbf
   response:
     body:
-      string: '{"hash": "1d93cfc9400a116da87def238544ea27b1a89fd21fac542e3630bac150c7eb07",
+      string: '{"hash": "c0eb9e9b77bbfda17ab18ea6e5cbbff9f36525d12cc11db1e98dcd78817b6180",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "1d93cfc9400a116da87def238544ea27b1a89fd21fac542e3630bac150c7eb07",
+        "name": "main", "type": "BRANCH"}, {"hash": "c0eb9e9b77bbfda17ab18ea6e5cbbff9f36525d12cc11db1e98dcd78817b6180",
         "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -323,10 +323,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=1d93cfc9400a116da87def238544ea27b1a89fd21fac542e3630bac150c7eb07
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=c0eb9e9b77bbfda17ab18ea6e5cbbff9f36525d12cc11db1e98dcd78817b6180
   response:
     body:
-      string: '{"hash": "023acee691defa609cb3aec257fb40e409838bdf6c49c07fadd517ea84d9df48",
+      string: '{"hash": "310ab1bd2fc8e9c591f9c453b8cc3c2c67a9ba906314b7b539f35b5833ec21cc",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,13 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '134'
+      - '123'
     status:
       code: 200
       message: OK
@@ -92,16 +94,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_list_dev\",\n
-        \   \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '337'
+      - '286'
     status:
       code: 200
       message: OK
@@ -120,24 +120,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_list_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.iceberg.foo' in reference 'contents_list_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.iceberg.foo'' in reference ''contents_list_dev''.", "reason":
+        "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '216'
+      - '199'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
-      "test_contents_list", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42, "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_contents_list",
+      "metadataLocation": "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "specId": 42, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -155,13 +155,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"61860b04f3a0a3819fa7c23c39bfa4e6ecb2a3c94ef876bb560fdc0f92cec1ad\"\n}"
+      string: '{"hash": "dbe5367da31ae34bfabf4ece49c36bac05229f352f14575309e7e8dce99b41c1",
+        "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '134'
+      - '123'
     status:
       code: 200
       message: OK
@@ -180,16 +180,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_list_dev\",\n
-        \   \"hash\" : \"61860b04f3a0a3819fa7c23c39bfa4e6ecb2a3c94ef876bb560fdc0f92cec1ad\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "dbe5367da31ae34bfabf4ece49c36bac05229f352f14575309e7e8dce99b41c1",
+        "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '337'
+      - '286'
     status:
       code: 200
       message: OK
@@ -208,24 +206,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_list_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.delta.bar' in reference 'contents_list_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.delta.bar'' in reference ''contents_list_dev''.", "reason":
+        "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '214'
+      - '197'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "delta", "bar"]}, "content": {"checkpointLocationHistory":
-      ["def"], "metadataLocationHistory": ["asd"], "lastCheckpoint": "x", "id": "uuid2",
-      "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"checkpointLocationHistory":
+      ["def"], "id": "uuid2", "lastCheckpoint": "x", "metadataLocationHistory": ["asd"],
+      "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "key": {"elements": ["this",
+      "is", "delta", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -240,16 +238,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=61860b04f3a0a3819fa7c23c39bfa4e6ecb2a3c94ef876bb560fdc0f92cec1ad
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=dbe5367da31ae34bfabf4ece49c36bac05229f352f14575309e7e8dce99b41c1
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"244dd123b6e1490a6bbcf9cb73d23cedaf4823c5958003c0e90926eaf74a30af\"\n}"
+      string: '{"hash": "1d93cfc9400a116da87def238544ea27b1a89fd21fac542e3630bac150c7eb07",
+        "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '134'
+      - '123'
     status:
       code: 200
       message: OK
@@ -268,16 +266,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_list_dev\",\n
-        \   \"hash\" : \"244dd123b6e1490a6bbcf9cb73d23cedaf4823c5958003c0e90926eaf74a30af\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "1d93cfc9400a116da87def238544ea27b1a89fd21fac542e3630bac150c7eb07",
+        "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '337'
+      - '286'
     status:
       code: 200
       message: OK
@@ -296,23 +292,23 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.sql.baz?ref=contents_list_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.sql.baz' in reference 'contents_list_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.sql.baz'' in reference ''contents_list_dev''.", "reason":
+        "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '212'
+      - '195'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "sql", "baz"]}, "content": {"dialect": "SPARK",
-      "sqlText": "SELECT * FROM foo", "id": "uuid3", "type": "VIEW"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"dialect": "SPARK",
+      "id": "uuid3", "sqlText": "SELECT * FROM foo", "type": "VIEW"}, "expectedContent":
+      null, "key": {"elements": ["this", "is", "sql", "baz"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -327,16 +323,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=244dd123b6e1490a6bbcf9cb73d23cedaf4823c5958003c0e90926eaf74a30af
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=1d93cfc9400a116da87def238544ea27b1a89fd21fac542e3630bac150c7eb07
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_list_dev\",\n
-        \ \"hash\" : \"389469c5c3ae0c57f320c22921545e7172fecf56fc438a02c7118427e958be69\"\n}"
+      string: '{"hash": "023acee691defa609cb3aec257fb40e409838bdf6c49c07fadd517ea84d9df48",
+        "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '134'
+      - '123'
     status:
       code: 200
       message: OK
@@ -355,14 +351,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"ICEBERG_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"iceberg\", \"foo\"
-        ]\n    }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "iceberg", "foo"]},
+        "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '171'
+      - '129'
     status:
       code: 200
       message: OK
@@ -381,14 +376,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?query_expression=entry.contentType+in+%5B%27DELTA_LAKE_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"DELTA_LAKE_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"delta\", \"bar\"
-        ]\n    }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "delta", "bar"]},
+        "type": "DELTA_LAKE_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '172'
+      - '130'
     status:
       code: 200
       message: OK
@@ -407,14 +401,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?query_expression=entry.contentType+%3D%3D+%27ICEBERG_TABLE%27
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"ICEBERG_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"iceberg\", \"foo\"
-        ]\n    }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "iceberg", "foo"]},
+        "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '171'
+      - '129'
     status:
       code: 200
       message: OK
@@ -433,16 +426,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?query_expression=entry.contentType+in+%5B%27ICEBERG_TABLE%27%2C+%27DELTA_LAKE_TABLE%27%5D
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"DELTA_LAKE_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"delta\", \"bar\"
-        ]\n    }\n  }, {\n    \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\"
-        : [ \"this\", \"is\", \"iceberg\", \"foo\" ]\n    }\n  } ],\n  \"hasMore\"
-        : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "delta", "bar"]},
+        "type": "DELTA_LAKE_TABLE"}, {"name": {"elements": ["this", "is", "iceberg",
+        "foo"]}, "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '284'
+      - '213'
     status:
       code: 200
       message: OK
@@ -461,14 +452,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?query_expression=entry.namespace.startsWith%28%27this.is.del%27%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"DELTA_LAKE_TABLE\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"delta\", \"bar\"
-        ]\n    }\n  } ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "delta", "bar"]},
+        "type": "DELTA_LAKE_TABLE"}], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '172'
+      - '130'
     status:
       code: 200
       message: OK
@@ -487,18 +477,15 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?query_expression=entry.namespace.startsWith%28%27this.is%27%29
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ {\n    \"type\" : \"VIEW\",\n
-        \   \"name\" : {\n      \"elements\" : [ \"this\", \"is\", \"sql\", \"baz\"
-        ]\n    }\n  }, {\n    \"type\" : \"DELTA_LAKE_TABLE\",\n    \"name\" : {\n
-        \     \"elements\" : [ \"this\", \"is\", \"delta\", \"bar\" ]\n    }\n  },
-        {\n    \"type\" : \"ICEBERG_TABLE\",\n    \"name\" : {\n      \"elements\"
-        : [ \"this\", \"is\", \"iceberg\", \"foo\" ]\n    }\n  } ],\n  \"hasMore\"
-        : false\n}"
+      string: '{"entries": [{"name": {"elements": ["this", "is", "sql", "baz"]}, "type":
+        "VIEW"}, {"name": {"elements": ["this", "is", "delta", "bar"]}, "type": "DELTA_LAKE_TABLE"},
+        {"name": {"elements": ["this", "is", "iceberg", "foo"]}, "type": "ICEBERG_TABLE"}],
+        "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '383'
+      - '283'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "fdb4d30b6448bfedf68baab18f16050f6c12b9ae291be0c3eefd82f5c99f9cbf",
+      string: '{"hash": "6586a987f5eccd0dc6979219e9c4161cfdfe804027e1d6da01f7d717788f2dde",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "fdb4d30b6448bfedf68baab18f16050f6c12b9ae291be0c3eefd82f5c99f9cbf",
+        "name": "main", "type": "BRANCH"}, {"hash": "6586a987f5eccd0dc6979219e9c4161cfdfe804027e1d6da01f7d717788f2dde",
         "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=fdb4d30b6448bfedf68baab18f16050f6c12b9ae291be0c3eefd82f5c99f9cbf
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=6586a987f5eccd0dc6979219e9c4161cfdfe804027e1d6da01f7d717788f2dde
   response:
     body:
-      string: '{"hash": "c0eb9e9b77bbfda17ab18ea6e5cbbff9f36525d12cc11db1e98dcd78817b6180",
+      string: '{"hash": "4c8d20f65efde54b2890c053b88173616962b075b07b70742d647023a7ea4ca1",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "c0eb9e9b77bbfda17ab18ea6e5cbbff9f36525d12cc11db1e98dcd78817b6180",
+        "name": "main", "type": "BRANCH"}, {"hash": "4c8d20f65efde54b2890c053b88173616962b075b07b70742d647023a7ea4ca1",
         "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -323,10 +323,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=c0eb9e9b77bbfda17ab18ea6e5cbbff9f36525d12cc11db1e98dcd78817b6180
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=4c8d20f65efde54b2890c053b88173616962b075b07b70742d647023a7ea4ca1
   response:
     body:
-      string: '{"hash": "310ab1bd2fc8e9c591f9c453b8cc3c2c67a9ba906314b7b539f35b5833ec21cc",
+      string: '{"hash": "2d693c9921383e364b1ae1bb8b9e63ad03bada6073f34f427d3446b4eb0d61ba",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "f4cf6256de4dafe5e03dc7d33464f39288bbe829f38a42e1a8d7f9c437fdcefa",
+      string: '{"hash": "6dd7836bd5351cc08104042e53219073e623f75e904d248612b7f4b64a591725",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "f4cf6256de4dafe5e03dc7d33464f39288bbe829f38a42e1a8d7f9c437fdcefa",
+        "name": "main", "type": "BRANCH"}, {"hash": "6dd7836bd5351cc08104042e53219073e623f75e904d248612b7f4b64a591725",
         "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=f4cf6256de4dafe5e03dc7d33464f39288bbe829f38a42e1a8d7f9c437fdcefa
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=6dd7836bd5351cc08104042e53219073e623f75e904d248612b7f4b64a591725
   response:
     body:
-      string: '{"hash": "cefebcf08f4be2936b15e0bdf5ac73a1903f3b5d0d997c299a089fe16a3a35d4",
+      string: '{"hash": "e39bfc535da4921c7df5544daff5a60aee048adc06e6c01915cab48a72e891ad",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "cefebcf08f4be2936b15e0bdf5ac73a1903f3b5d0d997c299a089fe16a3a35d4",
+        "name": "main", "type": "BRANCH"}, {"hash": "e39bfc535da4921c7df5544daff5a60aee048adc06e6c01915cab48a72e891ad",
         "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -323,10 +323,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=cefebcf08f4be2936b15e0bdf5ac73a1903f3b5d0d997c299a089fe16a3a35d4
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=e39bfc535da4921c7df5544daff5a60aee048adc06e6c01915cab48a72e891ad
   response:
     body:
-      string: '{"hash": "b4cb5c6299b35a064efc4a32b17b30cce7d13f5674335ef08b7a6fda4bc97b52",
+      string: '{"hash": "efb623fbd451452240a2daf3f7dcb0408ba999f18248f7ad9ee470c1233d20c4",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
@@ -14,12 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -38,12 +39,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -67,13 +69,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-        \ \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '134'
+      - '123'
     status:
       code: 200
       message: OK
@@ -92,16 +94,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_view_dev\",\n
-        \   \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '337'
+      - '286'
     status:
       code: 200
       message: OK
@@ -120,24 +120,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_view_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.iceberg.foo' in reference 'contents_view_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.iceberg.foo'' in reference ''contents_view_dev''.", "reason":
+        "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '216'
+      - '199'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "iceberg", "foo"]}, "content": {"specId": 42, "id":
-      "test_contents_view", "schemaId": 42, "snapshotId": 42, "sortOrderId": 42, "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_contents_view",
+      "metadataLocation": "/a/b/c", "schemaId": 42, "snapshotId": 42, "sortOrderId":
+      42, "specId": 42, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["this", "is", "iceberg", "foo"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -155,13 +155,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-        \ \"hash\" : \"de1e5eb78d57239f4b348b6c648ea63dfedd8e30f303862af0b61275ba5e1b49\"\n}"
+      string: '{"hash": "ee0a1c19768e89563bdb53270791a090633e5647b6ab2cf01ca5f0466046a2cf",
+        "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '134'
+      - '123'
     status:
       code: 200
       message: OK
@@ -180,16 +180,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_view_dev\",\n
-        \   \"hash\" : \"de1e5eb78d57239f4b348b6c648ea63dfedd8e30f303862af0b61275ba5e1b49\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "ee0a1c19768e89563bdb53270791a090633e5647b6ab2cf01ca5f0466046a2cf",
+        "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '337'
+      - '286'
     status:
       code: 200
       message: OK
@@ -208,24 +206,24 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_view_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.delta.bar' in reference 'contents_view_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.delta.bar'' in reference ''contents_view_dev''.", "reason":
+        "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '214'
+      - '197'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "delta", "bar"]}, "content": {"checkpointLocationHistory":
-      ["def"], "metadataLocationHistory": ["asd"], "lastCheckpoint": "x", "id": "uuid2",
-      "type": "DELTA_LAKE_TABLE"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"checkpointLocationHistory":
+      ["def"], "id": "uuid2", "lastCheckpoint": "x", "metadataLocationHistory": ["asd"],
+      "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "key": {"elements": ["this",
+      "is", "delta", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -240,16 +238,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=de1e5eb78d57239f4b348b6c648ea63dfedd8e30f303862af0b61275ba5e1b49
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=ee0a1c19768e89563bdb53270791a090633e5647b6ab2cf01ca5f0466046a2cf
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-        \ \"hash\" : \"47a9003ec38a8de1907b6a9c518867ad478ccaba36244f24acb9fbe35d01d989\"\n}"
+      string: '{"hash": "a97353374c75d3252920e501f394317bbaf25bc2a6398fb3f5197a61f6cae423",
+        "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '134'
+      - '123'
     status:
       code: 200
       message: OK
@@ -268,16 +266,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"contents_view_dev\",\n
-        \   \"hash\" : \"47a9003ec38a8de1907b6a9c518867ad478ccaba36244f24acb9fbe35d01d989\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "a97353374c75d3252920e501f394317bbaf25bc2a6398fb3f5197a61f6cae423",
+        "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '337'
+      - '286'
     status:
       code: 200
       message: OK
@@ -296,23 +292,23 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.sql%00baz?ref=contents_view_dev
   response:
     body:
-      string: "{\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"message\"
-        : \"Could not find content for key 'this.is.sql.baz' in reference 'contents_view_dev'.\",\n
-        \ \"errorCode\" : \"CONTENT_NOT_FOUND\",\n  \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''this.is.sql.baz'' in reference ''contents_view_dev''.", "reason":
+        "Not Found", "serverStackTrace": null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '212'
+      - '195'
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"commitMeta": {"hash": null, "authorTime": null, "signedOffBy": null,
-      "message": "test message", "commitTime": null, "properties": null, "committer":
-      null, "author": "nessie test"}, "operations": [{"expectedContent": null, "key":
-      {"elements": ["this", "is", "sql.baz"]}, "content": {"dialect": "SPARK", "sqlText":
-      "SELECT * FROM foo", "id": "uuid3", "type": "VIEW"}, "type": "PUT"}]}'
+    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"dialect": "SPARK",
+      "id": "uuid3", "sqlText": "SELECT * FROM foo", "type": "VIEW"}, "expectedContent":
+      null, "key": {"elements": ["this", "is", "sql.baz"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -327,16 +323,16 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=47a9003ec38a8de1907b6a9c518867ad478ccaba36244f24acb9fbe35d01d989
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=a97353374c75d3252920e501f394317bbaf25bc2a6398fb3f5197a61f6cae423
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_view_dev\",\n
-        \ \"hash\" : \"87da44ba71b55a9aa2ce3666df8387e2abd99909238035aaebf646e38a39e4d9\"\n}"
+      string: '{"hash": "2d8503c623969cc207495730705ce0f665c8fd668d763db76eab140e03914e49",
+        "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '134'
+      - '123'
     status:
       code: 200
       message: OK
@@ -355,14 +351,13 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_view_dev
   response:
     body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_contents_view\",\n
-        \ \"metadataLocation\" : \"/a/b/c\",\n  \"snapshotId\" : 42,\n  \"schemaId\"
-        : 42,\n  \"specId\" : 42,\n  \"sortOrderId\" : 42\n}"
+      string: '{"id": "test_contents_view", "metadataLocation": "/a/b/c", "schemaId":
+        42, "snapshotId": 42, "sortOrderId": 42, "specId": 42, "type": "ICEBERG_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '173'
+      - '150'
     status:
       code: 200
       message: OK
@@ -381,14 +376,13 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_view_dev
   response:
     body:
-      string: "{\n  \"type\" : \"DELTA_LAKE_TABLE\",\n  \"id\" : \"uuid2\",\n  \"metadataLocationHistory\"
-        : [ \"asd\" ],\n  \"checkpointLocationHistory\" : [ \"def\" ],\n  \"lastCheckpoint\"
-        : \"x\"\n}"
+      string: '{"checkpointLocationHistory": ["def"], "id": "uuid2", "lastCheckpoint":
+        "x", "metadataLocationHistory": ["asd"], "type": "DELTA_LAKE_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '161'
+      - '140'
     status:
       code: 200
       message: OK
@@ -407,13 +401,13 @@ interactions:
     uri: http://localhost:19120/api/v1/contents/this.is.sql%00baz?ref=contents_view_dev
   response:
     body:
-      string: "{\n  \"type\" : \"VIEW\",\n  \"id\" : \"uuid3\",\n  \"sqlText\" : \"SELECT
-        * FROM foo\",\n  \"dialect\" : \"SPARK\"\n}"
+      string: '{"dialect": "SPARK", "id": "uuid3", "sqlText": "SELECT * FROM foo",
+        "type": "VIEW"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '97'
+      - '83'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "ee0a1c19768e89563bdb53270791a090633e5647b6ab2cf01ca5f0466046a2cf",
+      string: '{"hash": "f4cf6256de4dafe5e03dc7d33464f39288bbe829f38a42e1a8d7f9c437fdcefa",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "ee0a1c19768e89563bdb53270791a090633e5647b6ab2cf01ca5f0466046a2cf",
+        "name": "main", "type": "BRANCH"}, {"hash": "f4cf6256de4dafe5e03dc7d33464f39288bbe829f38a42e1a8d7f9c437fdcefa",
         "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=ee0a1c19768e89563bdb53270791a090633e5647b6ab2cf01ca5f0466046a2cf
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=f4cf6256de4dafe5e03dc7d33464f39288bbe829f38a42e1a8d7f9c437fdcefa
   response:
     body:
-      string: '{"hash": "a97353374c75d3252920e501f394317bbaf25bc2a6398fb3f5197a61f6cae423",
+      string: '{"hash": "cefebcf08f4be2936b15e0bdf5ac73a1903f3b5d0d997c299a089fe16a3a35d4",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "a97353374c75d3252920e501f394317bbaf25bc2a6398fb3f5197a61f6cae423",
+        "name": "main", "type": "BRANCH"}, {"hash": "cefebcf08f4be2936b15e0bdf5ac73a1903f3b5d0d997c299a089fe16a3a35d4",
         "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -323,10 +323,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=a97353374c75d3252920e501f394317bbaf25bc2a6398fb3f5197a61f6cae423
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=cefebcf08f4be2936b15e0bdf5ac73a1903f3b5d0d997c299a089fe16a3a35d4
   response:
     body:
-      string: '{"hash": "2d8503c623969cc207495730705ce0f665c8fd668d763db76eab140e03914e49",
+      string: '{"hash": "b4cb5c6299b35a064efc4a32b17b30cce7d13f5674335ef08b7a6fda4bc97b52",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
+++ b/python/tests/cassettes/test_nessie_client/test_client_interface_e2e.yaml
@@ -14,14 +14,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '193'
+      - '161'
     status:
       code: 200
       message: OK
@@ -44,14 +43,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"status\" : 409,\n  \"reason\" : \"Conflict\",\n  \"message\"
-        : \"Named reference 'main' already exists.\",\n  \"errorCode\" : \"REFERENCE_ALREADY_EXISTS\",\n
-        \ \"serverStackTrace\" : null\n}"
+      string: '{"errorCode": "REFERENCE_ALREADY_EXISTS", "message": "Named reference
+        ''main'' already exists.", "reason": "Conflict", "serverStackTrace": null,
+        "status": 409}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '174'
+      - '157'
     status:
       code: 409
       message: Conflict
@@ -75,12 +74,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"test\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "test", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -99,16 +99,14 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ }, {\n    \"type\" : \"BRANCH\",\n    \"name\" : \"test\",\n    \"hash\"
-        : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n  }
-        ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "test", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '324'
+      - '273'
     status:
       code: 200
       message: OK
@@ -127,12 +125,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/test
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"test\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "test", "type": "BRANCH"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '121'
+      - '110'
     status:
       code: 200
       message: OK
@@ -151,12 +150,12 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/test/entries?hashOnRef=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"entries\" : [ ],\n  \"hasMore\" : false\n}"
+      string: '{"entries": [], "hasMore": false, "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '60'
+      - '48'
     status:
       code: 200
       message: OK
@@ -197,14 +196,13 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: "{\n  \"token\" : null,\n  \"references\" : [ {\n    \"type\" : \"BRANCH\",\n
-        \   \"name\" : \"main\",\n    \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n
-        \ } ],\n  \"hasMore\" : false\n}"
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '193'
+      - '161'
     status:
       code: 200
       message: OK

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -164,14 +164,17 @@ def _reformat_body(obj: dict) -> None:
 class _NessieSortingSerializer:
     @staticmethod
     def deserialize(cassette_string: str) -> Any:
+        """Delegates to the default yaml cassette serializer."""
         return yamlserializer.deserialize(cassette_string)
 
     @staticmethod
     def serialize(cassette_dict: dict) -> str:
+        """Reformats JSON payloads in requests and responses.
+
+        This is to avoid spurious changes in cassette yaml files under source control.
+        """
         if "interactions" in cassette_dict:
             for i in cassette_dict["interactions"]:
-                # Reformat JSON payloads in requests and responses to avoid spurious changes
-                # in cassette yaml files under source control.
                 _reformat_body(i["request"])
                 _reformat_body(i["response"])
 
@@ -187,7 +190,7 @@ def pytest_recording_configure(config: Config, vcr: VCR) -> None:
 
 @pytest.fixture(scope="module")
 def vcr_config() -> dict:
-    """VCR config that adds a cus tom before_record_request callback."""
+    """VCR config that adds a custom before_record_request callback."""
     nessie_test_config.cleanup = False
     return {
         "before_record_request": before_record_cb,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -142,22 +142,23 @@ def _sort_json(value: str) -> str:
 def _reformat_body(obj: dict) -> None:
     """Sorts JSON objects embedded in HTTP payload by their keys."""
     body = obj["body"]
-    length = None
-    if isinstance(body, str):
-        sorted_json = _sort_json(body)
-        length = len(sorted_json)
-        obj["body"] = sorted_json
-    elif isinstance(body, dict):
-        sorted_json = _sort_json(body["string"])
-        length = len(sorted_json)
-        body["string"] = sorted_json
+    sorted_json = None
+    if body:
+        if isinstance(body, str):
+            sorted_json = _sort_json(body)
+            obj["body"] = sorted_json
+        elif isinstance(body, dict):
+            sorted_json = _sort_json(body["string"])
+            body["string"] = sorted_json
+        else:
+            raise RuntimeError("Unexpected cassette structure")
 
     # Adjust content length if changed
-    if length:
+    if sorted_json:
         headers = obj["headers"]
         for k in headers:
             if k.lower() == "content-length":  # might have different case in cassettes
-                headers[k] = [str(length)]  # one-element list
+                headers[k] = [str(len(sorted_json))]  # one-element list
                 break
 
 


### PR DESCRIPTION
* Add a custom VCR serializer.
* Re-parse and sort JSON payloads
* Avoid new lines in JSON payloads
* Delegate actual cassette storage to the old serializer.

----

The idea is to reduce spurious cassette changes when tests are re-recorded in the future (cf. #2651).

I did not re-record auth tests expecting them to be removed under #2650 

I did not re-record `test_nessie_cli_error` cassettes because those were hand-written from the start.