### PR TITLE
Enhance `DatabaseAdapter.namedRefs()`

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -25,13 +25,14 @@ import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Diff;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
-import org.projectnessie.versioned.WithHash;
 
 /**
  * Database-Adapter interface that encapsulates all database related logic, ab abstraction between a
@@ -180,9 +181,12 @@ public interface DatabaseAdapter {
   /**
    * Get all named references including their current HEAD.
    *
-   * @return stream with all named references including their current HEAD.
+   * @param params options that control which information shall be returned in each {@link
+   *     ReferenceInfo}, see {@link ReferenceInfo} for details.
+   * @return stream with all named references.
    */
-  Stream<WithHash<NamedRef>> namedRefs();
+  Stream<ReferenceInfo<ByteString>> namedRefs(GetNamedRefsParams params)
+      throws ReferenceNotFoundException;
 
   /**
    * Create a new named reference.

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.google.protobuf.ByteString;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.ImmutableReferenceInfo;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.ReferenceInfo;
+import org.projectnessie.versioned.ReferenceInfo.CommitsAheadBehind;
+import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.TagName;
+import org.projectnessie.versioned.persist.adapter.ContentId;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+
+public abstract class AbstractGetNamedReferences {
+
+  public static final String MAIN_BRANCH = "main";
+  private static final Key SOME_KEY = Key.of("a", "b", "c");
+  private static final String SOME_CONTENT_ID = "abc";
+  private final DatabaseAdapter databaseAdapter;
+
+  protected AbstractGetNamedReferences(DatabaseAdapter databaseAdapter) {
+    this.databaseAdapter = databaseAdapter;
+  }
+
+  @Test
+  public void parameterValidation() throws Exception {
+    BranchName main = BranchName.of(MAIN_BRANCH);
+    BranchName parameterValidation = BranchName.of("parameterValidation");
+    TagName parameterValidationTag = TagName.of("parameterValidationTag");
+
+    Hash hash = databaseAdapter.noAncestorHash();
+
+    assertThat(databaseAdapter.toHash(main)).isEqualTo(hash);
+
+    databaseAdapter.create(parameterValidation, hash);
+    databaseAdapter.create(parameterValidationTag, hash);
+
+    assertAll(
+        () ->
+            assertThatThrownBy(() -> databaseAdapter.namedRefs(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Parameter for GetNamedRefsParams must not be null."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRefs(
+                            GetNamedRefsParams.builder().isComputeAheadBehind(true).build()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Base reference name missing."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRefs(
+                            GetNamedRefsParams.builder().isComputeCommonAncestor(true).build()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Base reference name missing."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRefs(
+                            GetNamedRefsParams.builder()
+                                .isComputeAheadBehind(true)
+                                .baseReference(BranchName.of("no-no-no"))
+                                .build()))
+                .isInstanceOf(ReferenceNotFoundException.class)
+                .hasMessage("Named reference 'no-no-no' not found"),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRefs(
+                            GetNamedRefsParams.builder()
+                                .isComputeAheadBehind(true)
+                                .baseReference(TagName.of("blah-no"))
+                                .build()))
+                .isInstanceOf(ReferenceNotFoundException.class)
+                .hasMessage("Named reference 'blah-no' not found"),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRefs(
+                            GetNamedRefsParams.builder()
+                                .isRetrieveBranches(false)
+                                .isRetrieveTags(false)
+                                .build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Must retrieve branches or tags or both."));
+  }
+
+  @Test
+  public void fromNoAncestor() throws Exception {
+    BranchName main = BranchName.of(MAIN_BRANCH);
+    BranchName branch = BranchName.of("fromNoAncestorBranch");
+    BranchName branch2 = BranchName.of("fromNoAncestorBranch2");
+    BranchName branch3 = BranchName.of("fromNoAncestorBranch3");
+    TagName tag = TagName.of("fromNoAncestorTag");
+    TagName tag2 = TagName.of("fromNoAncestorTag2");
+    TagName tag3 = TagName.of("fromNoAncestorTag3");
+
+    Hash hash = databaseAdapter.noAncestorHash();
+    Hash mainHash = hash;
+    Hash branchHash = hash;
+
+    assertThat(databaseAdapter.toHash(main)).isEqualTo(hash);
+
+    // Have 'main' + a branch + a tag
+    //  all point to the "no ancestor" hash (aka "beginning of time")
+
+    databaseAdapter.create(branch, hash);
+    databaseAdapter.create(tag, hash);
+
+    verifyReferences(
+        new ExpectedNamedReference(main, mainHash, 0, 0, hash, null),
+        new ExpectedNamedReference(branch, branchHash, 0, 0, hash, null),
+        new ExpectedNamedReference(tag, hash, 0, 0, hash, null));
+
+    // Add 100 commits to 'main'
+
+    for (int i = 0; i < 100; i++) {
+      mainHash = dummyCommit(main, mainHash, i + 1);
+    }
+
+    // Expect a commit-metadata for 'main', branch+tag are then 100 commits behind.
+
+    verifyReferences(
+        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(branch, branchHash, 0, 100, hash, null),
+        new ExpectedNamedReference(tag, hash, 0, 100, hash, null));
+
+    // Add 42 commits to branch
+
+    for (int i = 0; i < 42; i++) {
+      branchHash = dummyCommit(branch, branchHash, i + 1);
+    }
+
+    // same expectations as above, but branch is now also 42 commits ahead
+
+    verifyReferences(
+        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(branch, branchHash, 42, 100, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, hash, 0, 100, hash, null));
+
+    // create a branch2 + tag2 from 'main'
+
+    Hash main100 = mainHash;
+    Hash branch2Hash = databaseAdapter.create(branch2, main100);
+    Hash tag2Hash = databaseAdapter.create(tag2, main100);
+
+    // same expectations as above, but include branch2 + tag2
+    // - common ancestor of branch2 + tag2 is the 100th commit on 'main'
+
+    verifyReferences(
+        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(branch, branchHash, 42, 100, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, hash, 0, 100, hash, null),
+        new ExpectedNamedReference(branch2, branch2Hash, 0, 0, main100, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(tag2, tag2Hash, 0, 0, main100, commitMetaFor(main, 100)));
+
+    // add 900 commits to 'main'
+
+    for (int i = 100; i < 1000; i++) {
+      mainHash = dummyCommit(main, mainHash, i + 1);
+    }
+
+    // similar to the above, but:
+    // - branch + tag are now 100+900 = 1000 commits behind
+
+    verifyReferences(
+        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
+        new ExpectedNamedReference(branch, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, hash, 0, 1000, hash, null),
+        new ExpectedNamedReference(branch2, branch2Hash, 0, 900, main100, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(tag2, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)));
+
+    // add 42 commits to branch2
+
+    for (int i = 0; i < 42; i++) {
+      branch2Hash = dummyCommit(branch2, branch2Hash, i + 1);
+    }
+
+    // similar to the above, but:
+    // - branch2 is now also 42 commits ahead
+
+    verifyReferences(
+        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
+        new ExpectedNamedReference(branch, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, hash, 0, 1000, hash, null),
+        new ExpectedNamedReference(
+            branch2, branch2Hash, 42, 900, main100, commitMetaFor(branch2, 42)),
+        new ExpectedNamedReference(tag2, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)));
+
+    // Create branch2+tag3 at branch2
+
+    Hash branch2plus42 = branch2Hash;
+    Hash branch3Hash = databaseAdapter.create(branch3, branch2plus42);
+    Hash tag3Hash = databaseAdapter.create(tag3, branch2plus42);
+
+    // Add 42 commits to branch3
+
+    for (int i = 0; i < 42; i++) {
+      branch3Hash = dummyCommit(branch3, branch3Hash, i + 1);
+    }
+
+    // similar to the above, but:
+    // - tag3 is 42 commits ahead
+    // - branch3 is 84 commits ahead
+
+    verifyReferences(
+        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
+        new ExpectedNamedReference(branch, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, hash, 0, 1000, hash, null),
+        new ExpectedNamedReference(
+            branch2, branch2Hash, 42, 900, main100, commitMetaFor(branch2, 42)),
+        new ExpectedNamedReference(tag2, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(
+            branch3, branch3Hash, 84, 900, main100, commitMetaFor(branch3, 42)),
+        new ExpectedNamedReference(tag3, tag3Hash, 42, 900, main100, commitMetaFor(branch2, 42)));
+  }
+
+  private ByteString commitMetaFor(NamedRef ref, int num) {
+    return ByteString.copyFromUtf8("dummy commit " + ref.getName() + " " + num);
+  }
+
+  private Hash dummyCommit(BranchName branch, Hash expectedHash, int num) throws Exception {
+    return databaseAdapter.commit(
+        ImmutableCommitAttempt.builder()
+            .commitMetaSerialized(commitMetaFor(branch, num))
+            .commitToBranch(branch)
+            .expectedHead(Optional.of(expectedHash))
+            .addPuts(
+                KeyWithBytes.of(
+                    SOME_KEY,
+                    ContentId.of(SOME_CONTENT_ID),
+                    (byte) 42,
+                    ByteString.copyFromUtf8("dummy content")))
+            .build());
+  }
+
+  private void verifyReferences(ExpectedNamedReference... references) {
+    assertAll(
+        () -> verifyReferences(GetNamedRefsParams.builder().build(), references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder().isRetrieveCommitMetaForHead(true).build(), references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .isComputeCommonAncestor(true)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .isComputeAheadBehind(true)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .isComputeAheadBehind(true)
+                    .isComputeCommonAncestor(true)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder().isRetrieveBranches(false).build(), references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder().isRetrieveTags(false).build(), references));
+  }
+
+  private void verifyReferences(GetNamedRefsParams params, ExpectedNamedReference... references)
+      throws ReferenceNotFoundException {
+    List<ReferenceInfo<ByteString>> expected =
+        Arrays.stream(references)
+            .map(expectedRef -> expectedRef.expected(params))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+
+    try (Stream<ReferenceInfo<ByteString>> refs = databaseAdapter.namedRefs(params)) {
+      assertThat(refs)
+          .describedAs("GetNamedRefsParams=%s - references=%s", params, references)
+          .containsExactlyInAnyOrderElementsOf(expected);
+    }
+  }
+
+  static class ExpectedNamedReference {
+    final NamedRef ref;
+    final Hash hash;
+    final CommitsAheadBehind aheadBehind;
+    final Hash commonAncestor;
+    final ByteString commitMeta;
+
+    ExpectedNamedReference(
+        NamedRef ref,
+        Hash hash,
+        int ahead,
+        int behind,
+        Hash commonAncestor,
+        ByteString commitMeta) {
+      this.ref = ref;
+      this.hash = hash;
+      this.aheadBehind = CommitsAheadBehind.of(ahead, behind);
+      this.commonAncestor = commonAncestor;
+      this.commitMeta = commitMeta;
+    }
+
+    ReferenceInfo<ByteString> expected(GetNamedRefsParams params) {
+      if (!params.isRetrieveTags() && (ref instanceof TagName)) {
+        return null;
+      }
+      if (!params.isRetrieveBranches() && (ref instanceof BranchName)) {
+        return null;
+      }
+      ImmutableReferenceInfo.Builder<ByteString> builder =
+          ReferenceInfo.<ByteString>builder().namedRef(ref).hash(hash);
+      if (!ref.equals(params.getBaseReference())) {
+        if (params.isComputeAheadBehind()) {
+          builder.aheadBehind(aheadBehind);
+        }
+        if (params.isComputeCommonAncestor()) {
+          builder.commonAncestor(commonAncestor);
+        }
+      }
+      if (params.isRetrieveCommitMetaForHead()) {
+        builder.headCommitMeta(commitMeta);
+      }
+      return builder.build();
+    }
+
+    @Override
+    public String toString() {
+      return "ExpectedNamedReference{"
+          + "ref="
+          + ref
+          + ", hash="
+          + hash
+          + ", aheadBehind="
+          + aheadBehind
+          + ", commonAncestor="
+          + commonAncestor
+          + '}';
+    }
+  }
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.IntFunction;
+import java.util.stream.Stream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Delete;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.Operation;
@@ -46,6 +48,7 @@ import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.Ref;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.StringStoreWorker;
 import org.projectnessie.versioned.TagName;
@@ -584,9 +587,9 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
     BranchName main = BranchName.of("main");
     WithHash<Ref> mainRef = store.toRef(main.getName());
     assertThat(store().getCommits(main)).isEmpty();
-    assertThat(store.getNamedRefs())
-        .extracting(r -> r.getValue().getName())
-        .containsExactly(main.getName());
+    try (Stream<ReferenceInfo<String>> refs = store().getNamedRefs(GetNamedRefsParams.DEFAULT)) {
+      assertThat(refs).extracting(r -> r.getNamedRef().getName()).containsExactly(main.getName());
+    }
 
     BranchName testBranch = BranchName.of("testBranch");
     Hash testBranchHash = store.create(testBranch, Optional.empty());

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/GetNamedRefsParams.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/GetNamedRefsParams.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * Parameters that control the values that shall be returned via for each {@link ReferenceInfo} via
+ * functionality to retrieve the named references.
+ */
+@Value.Immutable
+public interface GetNamedRefsParams {
+
+  GetNamedRefsParams DEFAULT = builder().build();
+
+  static ImmutableGetNamedRefsParams.Builder builder() {
+    return ImmutableGetNamedRefsParams.builder();
+  }
+
+  /**
+   * Named reference to use as the base for the computation of {@link
+   * ReferenceInfo#getAheadBehind()}. If this parameter is not {@code null}, the branch must exist.
+   *
+   * @return name of the base reference. Can be {@code null}, if not needed.
+   */
+  @Nullable
+  NamedRef getBaseReference();
+
+  /**
+   * Whether to compute {@link ReferenceInfo#getAheadBehind()}, requires a non-{@code null} {@link
+   * #getBaseReference()}, defaults to {@code false}.
+   */
+  @Value.Default
+  default boolean isComputeAheadBehind() {
+    return false;
+  }
+
+  /** Whether to identify the common ancestor on the default branch. */
+  @Value.Default
+  default boolean isComputeCommonAncestor() {
+    return false;
+  }
+
+  /**
+   * Whether to retrieve the commit-meta information of each reference's HEAD commit in {@link
+   * ReferenceInfo#getHeadCommitMeta()}, defaults to {@code false}.
+   */
+  @Value.Default
+  default boolean isRetrieveCommitMetaForHead() {
+    return false;
+  }
+
+  /** Whether to retrieve branches, defaults to {@code true}. */
+  @Value.Default
+  default boolean isRetrieveBranches() {
+    return true;
+  }
+
+  /** Whether to retrieve tags, defaults to {@code true}. */
+  @Value.Default
+  default boolean isRetrieveTags() {
+    return true;
+  }
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -133,8 +133,9 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
-  public Stream<WithHash<NamedRef>> getNamedRefs() {
-    return delegateStream("getnamedrefs", delegate::getNamedRefs);
+  public Stream<ReferenceInfo<METADATA>> getNamedRefs(GetNamedRefsParams params)
+      throws ReferenceNotFoundException {
+    return delegateStream1Ex("getnamedrefs", () -> delegate.getNamedRefs(params));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceInfo.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ReferenceInfo<METADATA> {
+  NamedRef getNamedRef();
+
+  Hash getHash();
+
+  @Nullable
+  Hash getCommonAncestor();
+
+  ReferenceInfo<METADATA> withCommonAncestor(@Nullable Hash value);
+
+  @Nullable
+  CommitsAheadBehind getAheadBehind();
+
+  ReferenceInfo<METADATA> withAheadBehind(@Nullable CommitsAheadBehind value);
+
+  @Nullable
+  METADATA getHeadCommitMeta();
+
+  ReferenceInfo<METADATA> withHeadCommitMeta(@Nullable METADATA value);
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  default <UPDATED_METADATA> ReferenceInfo<UPDATED_METADATA> withUpdatedCommitMeta(
+      UPDATED_METADATA commitMeta) {
+    ReferenceInfo updated = this;
+    return updated.withHeadCommitMeta(commitMeta);
+  }
+
+  static <METADATA> ImmutableReferenceInfo.Builder<METADATA> builder() {
+    return ImmutableReferenceInfo.builder();
+  }
+
+  static <METADATA> ReferenceInfo<METADATA> of(Hash hash, NamedRef namedRef) {
+    return ReferenceInfo.<METADATA>builder().namedRef(namedRef).hash(hash).build();
+  }
+
+  @Value.Immutable
+  interface CommitsAheadBehind {
+
+    int getBehind();
+
+    int getAhead();
+
+    static CommitsAheadBehind of(int ahead, int behind) {
+      return ImmutableCommitsAheadBehind.builder().ahead(ahead).behind(behind).build();
+    }
+  }
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -174,8 +174,9 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
-  public Stream<WithHash<NamedRef>> getNamedRefs() {
-    return callStream("GetNamedRefs", b -> {}, delegate::getNamedRefs);
+  public Stream<ReferenceInfo<METADATA>> getNamedRefs(GetNamedRefsParams params)
+      throws ReferenceNotFoundException {
+    return callStreamWithOneException("GetNamedRefs", b -> {}, () -> delegate.getNamedRefs(params));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -213,9 +213,12 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    *
    * <p><em>IMPORTANT NOTE:</em> The returned {@link Stream} <em>must be closed</em>!
    *
+   * @param params options that control which information shall be returned in each {@link
+   *     ReferenceInfo}, see {@link ReferenceInfo} for details.
    * @return All refs and their associated hashes.
    */
-  Stream<WithHash<NamedRef>> getNamedRefs();
+  Stream<ReferenceInfo<METADATA>> getNamedRefs(GetNamedRefsParams params)
+      throws ReferenceNotFoundException;
 
   /**
    * Get a stream of all ancestor commits to a provided ref.

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -156,7 +156,8 @@ class TestMetricsVersionStore {
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "getnamedrefs",
-                VersionStore::getNamedRefs,
+                stringStringDummyEnumVersionStore ->
+                    stringStringDummyEnumVersionStore.getNamedRefs(GetNamedRefsParams.DEFAULT),
                 () ->
                     Stream.of(
                         WithHash.of(Hash.of("cafebabe"), BranchName.of("foo")),

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -174,7 +174,9 @@ class TestTracingVersionStore {
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "GetNamedRefs", runtimeThrows)
                     .function(
-                        VersionStore::getNamedRefs,
+                        stringStringDummyEnumVersionStore ->
+                            stringStringDummyEnumVersionStore.getNamedRefs(
+                                GetNamedRefsParams.DEFAULT),
                         () ->
                             Stream.of(
                                 WithHash.of(Hash.of("cafebabe"), BranchName.of("foo")),


### PR DESCRIPTION
Goal of this PR is to optionally expose more information about named references. The caller decides which kind of information shall be retrieved. The default behavior is unchanged and only returns a collection of reference names + type + HEAD hash.

`DatabaseAdapter.namedRefs()` gets a new argument `NamedReferencesParams`, that allows to request:
* exclusion of tags in the result
* exclusion of branches in the result
* retrieving the commit-meta of the named reference's HEAD
* retrieving the common-ancestor of the named reference and the default branch
* retrieving the number of commits behind + ahead relative to the common-ancestor

The type describing each named reference in the result of `DatabaseAdapter.namedRefs()` has been changed to `NamedReference<METADATA>` and allows returning the selected information.

The new types `NamedReference` and  `NamedReferencesParams` are defined in `:nessie-versioned-spi` and are not meant to be exposed via the REST API. Updating the REST API is work for a separate PR.