### PR TITLE
Allow enhanced information for a single named reference

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -76,18 +76,6 @@ public interface DatabaseAdapter {
       throws ReferenceNotFoundException;
 
   /**
-   * Resolve the current HEAD of the given named-reference.
-   *
-   * <p>This is actually a convenience for {@link #hashOnReference(NamedRef, Optional)
-   * hashOnReference(ref, Optional.empty()}.
-   *
-   * @param ref named reference to resolve
-   * @return current HEAD of {@code ref}
-   * @throws ReferenceNotFoundException if the named reference {@code ref} does not exist.
-   */
-  Hash toHash(NamedRef ref) throws ReferenceNotFoundException;
-
-  /**
    * Retrieve the reference-local and global state for the given keys for the specified commit.
    *
    * @param commit commit to retrieve the values for.
@@ -177,6 +165,21 @@ public interface DatabaseAdapter {
    */
   Hash merge(Hash from, BranchName toBranch, Optional<Hash> expectedHead)
       throws ReferenceNotFoundException, ReferenceConflictException;
+
+  /**
+   * Resolve the current HEAD of the given named-reference and optionally additional information.
+   *
+   * <p>This is actually a convenience for {@link #hashOnReference(NamedRef, Optional)
+   * hashOnReference(ref, Optional.empty()}.
+   *
+   * @param ref named reference to resolve
+   * @param params options that control which information shall be returned in {@link
+   *     ReferenceInfo}, see {@link GetNamedRefsParams} for details.
+   * @return current HEAD of {@code ref}
+   * @throws ReferenceNotFoundException if the named reference {@code ref} does not exist.
+   */
+  ReferenceInfo<ByteString> namedRef(NamedRef ref, GetNamedRefsParams params)
+      throws ReferenceNotFoundException;
 
   /**
    * Get all named references including their current HEAD.

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -116,11 +116,6 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
   }
 
   @Override
-  public Hash toHash(NamedRef ref) throws ReferenceNotFoundException {
-    return hashOnReference(ref, Optional.empty());
-  }
-
-  @Override
   public Hash noAncestorHash() {
     return NO_ANCESTOR;
   }

--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -40,6 +40,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.Operation;
@@ -193,7 +194,7 @@ public class CommitBench {
           "initial commit meta " + Thread.currentThread().getId(),
           initialOperations(bp, keys, contentIds));
 
-      Hash hash = bp.versionStore.toHash(bp.branch);
+      Hash hash = bp.versionStore.getNamedRef(bp.branch, GetNamedRefsParams.DEFAULT).getHash();
 
       bp.versionStore.create(branch, Optional.of(hash));
     }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceConflictException;
@@ -306,7 +307,9 @@ public abstract class AbstractCommitScenarios {
     for (int commitNum = 0; commitNum < 3; commitNum++) {
       Map<Key, ContentAndState<ByteString>> values =
           databaseAdapter.values(
-              databaseAdapter.toHash(branch), keys, KeyFilterPredicate.ALLOW_ALL);
+              databaseAdapter.namedRef(branch, GetNamedRefsParams.DEFAULT).getHash(),
+              keys,
+              KeyFilterPredicate.ALLOW_ALL);
       commit =
           ImmutableCommitAttempt.builder()
               .commitToBranch(branch)

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceConflictException;
@@ -166,7 +167,11 @@ public abstract class AbstractConcurrency {
                   List<ByteString> currentStates =
                       databaseAdapter
                           .values(
-                              databaseAdapter.toHash(branch), keys, KeyFilterPredicate.ALLOW_ALL)
+                              databaseAdapter
+                                  .namedRef(branch, GetNamedRefsParams.DEFAULT)
+                                  .getHash(),
+                              keys,
+                              KeyFilterPredicate.ALLOW_ALL)
                           .values()
                           .stream()
                           .map(ContentAndState::getGlobalState)
@@ -216,7 +221,9 @@ public abstract class AbstractConcurrency {
 
       for (Entry<BranchName, Set<Key>> branchKeys : keysPerBranch.entrySet()) {
         BranchName branch = branchKeys.getKey();
-        databaseAdapter.create(branch, databaseAdapter.toHash(BranchName.of("main")));
+        databaseAdapter.create(
+            branch,
+            databaseAdapter.namedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT).getHash());
         ImmutableCommitAttempt.Builder commitAttempt =
             ImmutableCommitAttempt.builder()
                 .commitToBranch(branchKeys.getKey())
@@ -248,7 +255,7 @@ public abstract class AbstractConcurrency {
 
       for (Entry<BranchName, Set<Key>> branchKeys : keysPerBranch.entrySet()) {
         BranchName branch = branchKeys.getKey();
-        Hash hash = databaseAdapter.toHash(branch);
+        Hash hash = databaseAdapter.namedRef(branch, GetNamedRefsParams.DEFAULT).getHash();
         Map<Key, ByteString> onRef = onRefStates.get(branch);
         ArrayList<Key> keys = new ArrayList<>(branchKeys.getValue());
         Map<Key, ContentAndState<ByteString>> values =

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGlobalStates.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGlobalStates.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceConflictException;
@@ -174,7 +175,10 @@ public abstract class AbstractGlobalStates {
                         catchingFunction(
                             () ->
                                 databaseAdapter.create(
-                                    b, databaseAdapter.toHash(BranchName.of("main"))))));
+                                    b,
+                                    databaseAdapter
+                                        .namedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT)
+                                        .getHash()))));
     Map<ContentId, ByteString> currentStates = new HashMap<>();
     Set<Key> keys =
         IntStream.range(0, param.tables)
@@ -257,7 +261,7 @@ public abstract class AbstractGlobalStates {
   void commitCheckGlobalStateMismatches() throws Exception {
     BranchName branch = BranchName.of("main");
 
-    Hash branchInitial = databaseAdapter.toHash(branch);
+    Hash branchInitial = databaseAdapter.namedRef(branch, GetNamedRefsParams.DEFAULT).getHash();
 
     databaseAdapter.commit(
         ImmutableCommitAttempt.builder()

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceNotFoundException;
@@ -61,7 +62,9 @@ public abstract class AbstractManyCommits {
   // Note: 1000 commits is quite the max that in-JVM H2 database can handle
   void manyCommits(int numCommits) throws Exception {
     BranchName branch = BranchName.of("manyCommits-" + numCommits);
-    databaseAdapter.create(branch, databaseAdapter.toHash(BranchName.of("main")));
+    databaseAdapter.create(
+        branch,
+        databaseAdapter.namedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT).getHash());
 
     Hash[] commits = new Hash[numCommits];
 
@@ -99,7 +102,9 @@ public abstract class AbstractManyCommits {
       }
     }
 
-    try (Stream<CommitLogEntry> log = databaseAdapter.commitLog(databaseAdapter.toHash(branch))) {
+    try (Stream<CommitLogEntry> log =
+        databaseAdapter.commitLog(
+            databaseAdapter.namedRef(branch, GetNamedRefsParams.DEFAULT).getHash())) {
       assertThat(log.count()).isEqualTo(numCommits);
     }
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.persist.adapter.ContentId;
@@ -117,7 +118,7 @@ public abstract class AbstractManyKeys {
       databaseAdapter.commit(commit.build());
     }
 
-    Hash mainHead = databaseAdapter.toHash(main);
+    Hash mainHead = databaseAdapter.namedRef(main, GetNamedRefsParams.DEFAULT).getHash();
     try (Stream<KeyWithType> keys = databaseAdapter.keys(mainHead, KeyFilterPredicate.ALLOW_ALL)) {
       List<Key> fetchedKeys = keys.map(KeyWithType::getKey).collect(Collectors.toList());
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
@@ -193,7 +193,7 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
           commitHash = store().commit(branch, Optional.of(hashKnownByUser), msg, ops);
         } catch (ReferenceConflictException inconsistentValueException) {
           if (param.allowInconsistentValueException) {
-            hashKnownByUser = store().toHash(branch);
+            hashKnownByUser = store().getNamedRef(branch, GetNamedRefsParams.DEFAULT).getHash();
             commitHash = store().commit(branch, Optional.of(hashKnownByUser), msg, ops);
           } else {
             throw inconsistentValueException;
@@ -530,7 +530,9 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
                     s.transplant(
                         BranchName.of("this-one-should-not-exist"),
                         Optional.empty(),
-                        singletonList(s.toHash(BranchName.of("main"))))),
+                        singletonList(
+                            s.getNamedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT)
+                                .getHash()))),
         new ReferenceNotFoundFunction("transplant/hash/empty")
             .msg(
                 "Could not find commit '12341234123412341234123412341234123412341234' in reference 'main'.")

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -75,12 +75,6 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
-  @Nonnull
-  public Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException {
-    return delegate1Ex("tohash", () -> delegate.toHash(ref));
-  }
-
-  @Override
   public WithHash<Ref> toRef(@Nonnull String refOfUnknownType) throws ReferenceNotFoundException {
     return delegate1Ex("toref", () -> delegate.toRef(refOfUnknownType));
   }
@@ -130,6 +124,12 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(
         "delete", () -> delegate.delete(ref, hash));
+  }
+
+  @Override
+  public ReferenceInfo<METADATA> getNamedRef(NamedRef ref, GetNamedRefsParams params)
+      throws ReferenceNotFoundException {
+    return delegate1Ex("getnamedref", () -> delegate.getNamedRef(ref, params));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -87,13 +87,6 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
-  @Nonnull
-  public Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException {
-    return callWithOneException(
-        "ToHash", b -> b.withTag(TAG_REF, safeRefName(ref)), () -> delegate.toHash(ref));
-  }
-
-  @Override
   public WithHash<Ref> toRef(@Nonnull String refOfUnknownType) throws ReferenceNotFoundException {
     return callWithOneException(
         "ToRef", b -> b.withTag(TAG_REF, refOfUnknownType), () -> delegate.toRef(refOfUnknownType));
@@ -171,6 +164,15 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
         "Delete",
         b -> b.withTag(TAG_REF, safeToString(ref)).withTag(TAG_HASH, safeToString(hash)),
         () -> delegate.delete(ref, hash));
+  }
+
+  @Override
+  public ReferenceInfo<METADATA> getNamedRef(NamedRef ref, GetNamedRefsParams params)
+      throws ReferenceNotFoundException {
+    return callWithOneException(
+        "GetNamedRef",
+        b -> b.withTag(TAG_REF, safeRefName(ref)),
+        () -> delegate.getNamedRef(ref, params));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -195,7 +195,8 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
-   * Provide the current hash for the given NamedRef.
+   * Resolve the given {@link NamedRef} and return information about it, which at least contains the
+   * current HEAD commit hash plus, optionally, additional information.
    *
    * <p>This is a functionally equivalent to {@link #hashOnReference(NamedRef, Optional)
    * hashOnReference(ref, Optional.empty())}.

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -63,20 +63,6 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
   Hash noAncestorHash();
 
   /**
-   * Provide the current hash for the given NamedRef.
-   *
-   * <p>This is a functionally equivalent to {@link #hashOnReference(NamedRef, Optional)
-   * hashOnReference(ref, Optional.empty())}.
-   *
-   * @param ref The Branch or Tag to lookup.
-   * @return The current hash for that ref.
-   * @throws NullPointerException if {@code ref} is {@code null}.
-   * @throws ReferenceNotFoundException if the reference cannot be found
-   */
-  @Nonnull
-  Hash toHash(@Nonnull NamedRef ref) throws ReferenceNotFoundException;
-
-  /**
    * Determine what kind of ref a string is and convert it into the appropriate type (along with the
    * current associated hash).
    *
@@ -207,6 +193,22 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    */
   void delete(NamedRef ref, Optional<Hash> hash)
       throws ReferenceNotFoundException, ReferenceConflictException;
+
+  /**
+   * Provide the current hash for the given NamedRef.
+   *
+   * <p>This is a functionally equivalent to {@link #hashOnReference(NamedRef, Optional)
+   * hashOnReference(ref, Optional.empty())}.
+   *
+   * @param ref The branch or tag to lookup.
+   * @param params options that control which information shall be returned in {@link
+   *     ReferenceInfo}, see {@link GetNamedRefsParams} for details.
+   * @return Requested information about the requested reference.
+   * @throws NullPointerException if {@code ref} is {@code null}.
+   * @throws ReferenceNotFoundException if the reference cannot be found
+   */
+  ReferenceInfo<METADATA> getNamedRef(NamedRef ref, GetNamedRefsParams params)
+      throws ReferenceNotFoundException;
 
   /**
    * List named refs.

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -98,9 +98,9 @@ class TestMetricsVersionStore {
     Stream<VersionStoreInvocation<?>> versionStoreFunctions =
         Stream.of(
             new VersionStoreInvocation<>(
-                "tohash",
-                vs -> vs.toHash(BranchName.of("mock-branch")),
-                () -> Hash.of("cafebabe"),
+                "getnamedref",
+                vs -> vs.getNamedRef(BranchName.of("mock-branch"), GetNamedRefsParams.DEFAULT),
+                () -> ReferenceInfo.of(Hash.of("cafebabe"), BranchName.of("mock-branch")),
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "toref",

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -82,10 +82,13 @@ class TestTracingVersionStore {
         versionStoreFunctions =
             Stream.of(
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
-                        "ToHash", refNotFoundThrows)
+                        "GetNamedRef", refNotFoundThrows)
                     .tag("nessie.version-store.ref", "mock-branch")
                     .function(
-                        vs -> vs.toHash(BranchName.of("mock-branch")), () -> Hash.of("cafebabe")),
+                        vs ->
+                            vs.getNamedRef(
+                                BranchName.of("mock-branch"), GetNamedRefsParams.DEFAULT),
+                        () -> ReferenceInfo.of(Hash.of("cafebabe"), BranchName.of("mock-branch"))),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "ToRef", refNotFoundThrows)
                     .tag("nessie.version-store.ref", "mock-branch")

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/CommitBuilder.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/CommitBuilder.java
@@ -168,12 +168,9 @@ public class CommitBuilder<ValueT, MetadataT, EnumT extends Enum<EnumT>> {
    */
   public Hash toBranch(BranchName branchName)
       throws ReferenceNotFoundException, ReferenceConflictException {
-    Optional<Hash> reference =
-        fromLatest
-            ? Optional.of(store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash())
-            : referenceHash;
-    Hash commitHash = store.commit(branchName, reference, metadata, operations);
     Hash storeHash = store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash();
+    Optional<Hash> reference = fromLatest ? Optional.of(storeHash) : referenceHash;
+    Hash commitHash = store.commit(branchName, reference, metadata, operations);
     Assertions.assertEquals(storeHash, commitHash);
     return commitHash;
   }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/CommitBuilder.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/CommitBuilder.java
@@ -168,9 +168,12 @@ public class CommitBuilder<ValueT, MetadataT, EnumT extends Enum<EnumT>> {
    */
   public Hash toBranch(BranchName branchName)
       throws ReferenceNotFoundException, ReferenceConflictException {
-    Hash storeHash = store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash();
-    Optional<Hash> reference = fromLatest ? Optional.of(storeHash) : referenceHash;
+    Optional<Hash> reference =
+        fromLatest
+            ? Optional.of(store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash())
+            : referenceHash;
     Hash commitHash = store.commit(branchName, reference, metadata, operations);
+    Hash storeHash = store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash();
     Assertions.assertEquals(storeHash, commitHash);
     return commitHash;
   }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/CommitBuilder.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/CommitBuilder.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Delete;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.Operation;
@@ -167,9 +168,12 @@ public class CommitBuilder<ValueT, MetadataT, EnumT extends Enum<EnumT>> {
    */
   public Hash toBranch(BranchName branchName)
       throws ReferenceNotFoundException, ReferenceConflictException {
-    Optional<Hash> reference = fromLatest ? Optional.of(store.toHash(branchName)) : referenceHash;
+    Optional<Hash> reference =
+        fromLatest
+            ? Optional.of(store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash())
+            : referenceHash;
     Hash commitHash = store.commit(branchName, reference, metadata, operations);
-    Hash storeHash = store.toHash(branchName);
+    Hash storeHash = store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash();
     Assertions.assertEquals(storeHash, commitHash);
     return commitHash;
   }


### PR DESCRIPTION
This is a planned follow-up on top of #2726 to inquire additional information for a single named reference:
* retrieving the commit-meta of the named reference's HEAD
* retrieving the common-ancestor of the named reference and the default branch
* retrieving the number of commits behind + ahead relative to the common-ancestor
