### PR TITLE
Optionally fetch metadata properties and attach them to a Branch

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -23,5 +23,20 @@ import org.projectnessie.model.ReferencesResponse;
  * @since {@link NessieApiV1}
  */
 public interface GetAllReferencesBuilder extends PagingBuilder<GetAllReferencesBuilder> {
+
+  /**
+   * Will fetch additional metadata about {@link org.projectnessie.model.Branch} instances, such as
+   * number of commits ahead/behind or the common ancestor in relation to the default branch, and
+   * the commit metadata for the HEAD commit.
+   *
+   * @return {@link GetAllReferencesBuilder}
+   */
+  GetAllReferencesBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo);
+
+  /**
+   * Fetches all references and returns them in a {@link ReferencesResponse} instance.
+   *
+   * @return Fetches all references and returns them in a {@link ReferencesResponse} instance.
+   */
   ReferencesResponse get();
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
@@ -47,6 +47,7 @@ class HttpTreeClient implements HttpTreeApi {
         .path("trees")
         .queryParam("max", params.maxRecords() != null ? params.maxRecords().toString() : null)
         .queryParam("pageToken", params.pageToken())
+        .queryParam("fetchAdditionalInfo", Boolean.toString(params.isFetchAdditionalInfo()))
         .get()
         .readEntity(ReferencesResponse.class);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
@@ -41,6 +41,12 @@ final class HttpGetAllReferences extends BaseHttpRequest implements GetAllRefere
   }
 
   @Override
+  public GetAllReferencesBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
+    params.fetchAdditionalInfo(fetchAdditionalInfo);
+    return this;
+  }
+
+  @Override
   public ReferencesResponse get() {
     return client.getTreeApi().getAllReferences(params.build());
   }

--- a/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
@@ -64,7 +64,10 @@ public interface HttpTreeApi extends TreeApi {
         content =
             @Content(
                 mediaType = MediaType.APPLICATION_JSON,
-                examples = {@ExampleObject(ref = "referencesResponse")},
+                examples = {
+                  @ExampleObject(ref = "referencesResponse"),
+                  @ExampleObject(ref = "referencesResponseWithMetadata")
+                },
                 schema = @Schema(implementation = ReferencesResponse.class))),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
   })

--- a/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
@@ -17,10 +17,13 @@ package org.projectnessie.api.params;
 
 import java.util.Objects;
 import java.util.StringJoiner;
+import javax.ws.rs.QueryParam;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.projectnessie.api.http.HttpTreeApi;
 
 /**
- * The purpose of this class is to include optional parameters that can be passed to {@code
- * HttpTreeApi#getEntries(String, EntriesParams)}.
+ * The purpose of this class is to include optional parameters that can be passed to {@link
+ * HttpTreeApi#getAllReferences(ReferencesParams)}
  *
  * <p>For easier usage of this class, there is {@link ReferencesParams#builder()}, which allows
  * configuring/setting the different parameters.
@@ -29,12 +32,29 @@ public class ReferencesParams extends AbstractParams {
 
   public ReferencesParams() {}
 
-  private ReferencesParams(Integer maxRecords, String pageToken) {
+  @Parameter(
+      description =
+          "If set to true, will fetch additional metadata for branches, such as number of commits ahead/behind or the common ancestor in relation to the default branch, and the commit metadata for the HEAD commit.\n\n"
+              + "A returned Branch instance will then have a map of 'metadataProperties' with the following keys:\n\n"
+              + "- numCommitsAhead (number of commits ahead of the default branch)\n\n"
+              + "- numCommitsBehind (number of commits behind the default branch)\n\n"
+              + "- headCommitMeta (the commit metadata of the HEAD commit)\n\n"
+              + "- commonAncestorHash (the hash of the common ancestor in relation to the default branch).\n\n"
+              + "Note that computing & fetching additional metadata might be computationally expensive on the server-side, so this flag should be used with care.")
+  @QueryParam("fetchAdditionalInfo")
+  private boolean fetchAdditionalInfo;
+
+  public boolean isFetchAdditionalInfo() {
+    return fetchAdditionalInfo;
+  }
+
+  private ReferencesParams(Integer maxRecords, String pageToken, boolean fetchAdditionalInfo) {
     super(maxRecords, pageToken);
+    this.fetchAdditionalInfo = fetchAdditionalInfo;
   }
 
   private ReferencesParams(Builder builder) {
-    this(builder.maxRecords, builder.pageToken);
+    this(builder.maxRecords, builder.pageToken, builder.fetchAdditionalInfo);
   }
 
   public static ReferencesParams.Builder builder() {
@@ -50,6 +70,7 @@ public class ReferencesParams extends AbstractParams {
     return new StringJoiner(", ", ReferencesParams.class.getSimpleName() + "[", "]")
         .add("maxRecords=" + maxRecords())
         .add("pageToken='" + pageToken() + "'")
+        .add("fetchAdditionalInfo=" + fetchAdditionalInfo)
         .toString();
   }
 
@@ -63,20 +84,30 @@ public class ReferencesParams extends AbstractParams {
     }
     ReferencesParams that = (ReferencesParams) o;
     return Objects.equals(maxRecords(), that.maxRecords())
-        && Objects.equals(pageToken(), that.pageToken());
+        && Objects.equals(pageToken(), that.pageToken())
+        && Objects.equals(fetchAdditionalInfo, that.fetchAdditionalInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(maxRecords(), pageToken());
+    return Objects.hash(maxRecords(), pageToken(), fetchAdditionalInfo);
   }
 
   public static class Builder extends AbstractParams.Builder<Builder> {
 
     private Builder() {}
 
+    private boolean fetchAdditionalInfo = false;
+
     public ReferencesParams.Builder from(ReferencesParams params) {
-      return maxRecords(params.maxRecords()).pageToken(params.pageToken());
+      return maxRecords(params.maxRecords())
+          .pageToken(params.pageToken())
+          .fetchAdditionalInfo(params.fetchAdditionalInfo);
+    }
+
+    public Builder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
+      this.fetchAdditionalInfo = fetchAdditionalInfo;
+      return this;
     }
 
     private void validate() {}

--- a/model/src/main/java/org/projectnessie/model/Branch.java
+++ b/model/src/main/java/org/projectnessie/model/Branch.java
@@ -17,9 +17,13 @@ package org.projectnessie.model;
 
 import static org.projectnessie.model.Validation.validateReferenceName;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Collections;
+import java.util.Map;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -31,6 +35,10 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableBranch.class)
 @JsonTypeName("BRANCH")
 public interface Branch extends Reference {
+  String NUM_COMMITS_AHEAD = "numCommitsAhead";
+  String NUM_COMMITS_BEHIND = "numCommitsBehind";
+  String HEAD_COMMIT_META = "headCommitMeta";
+  String COMMON_ANCESTOR_HASH = "commonAncestorHash";
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateReferenceName(String)}.
@@ -46,5 +54,27 @@ public interface Branch extends Reference {
 
   static Branch of(String name, String hash) {
     return builder().name(name).hash(hash).build();
+  }
+
+  /**
+   * Returns a map of metadata properties that describe this branch. Note that these properties
+   * <b>can be added</b> by the server when a {@link Branch} instance is returned. A returned {@link
+   * Branch} instance can then have the following keys:
+   *
+   * <ul>
+   *   <li>{@value Branch#NUM_COMMITS_AHEAD}: number of commits ahead of the default branch
+   *   <li>{@value Branch#NUM_COMMITS_BEHIND}: number of commits behind the default branch
+   *   <li>{@value Branch#HEAD_COMMIT_META}: the commit metadata of the HEAD commit
+   *   <li>{@value Branch#COMMON_ANCESTOR_HASH}: the hash of the common ancestor in relation to the
+   *       default branch.
+   * </ul>
+   *
+   * @return A map of metadata properties that describe this branch. Note that these properties
+   *     <b>can be added</b> by the server when a {@link Branch} instance is returned.
+   */
+  @Value.Default
+  @JsonInclude(Include.NON_EMPTY)
+  default Map<String, Object> metadataProperties() {
+    return Collections.emptyMap();
   }
 }

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -189,3 +189,50 @@ components:
           - type: BRANCH
             hash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
             name: "main"
+    referencesResponseWithMetadata:
+      value:
+        token: null
+        hasMore: false
+        references:
+          - type: BRANCH
+            hash: "84c57a20c5e956af4af40f3cc34ecc8a9028b9586da135c79011b1867aa3191d"
+            name: "main"
+            metadataProperties:
+              headCommitMeta:
+                hash: "84c57a20c5e956af4af40f3cc34ecc8a9028b9586da135c79011b1867aa3191d"
+                committer: ""
+                author: "nessie-author"
+                signedOffBy: null
+                message: "update table"
+                commitTime: "2021-11-26T08:01:13.855974Z"
+                authorTime: "2021-11-26T08:01:13.852826Z"
+                properties: {}
+          - type: BRANCH
+            hash: "da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5"
+            name: "dev"
+            metadataProperties:
+              numCommitsAhead: 1
+              numCommitsBehind: 2
+              commonAncestorHash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+              headCommitMeta:
+                hash: "da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5"
+                committer: ""
+                author: "nessie-author"
+                signedOffBy: null
+                message: "update table X"
+                commitTime: "2021-11-26T08:01:13.834397Z"
+                authorTime: "2021-11-26T08:01:13.831371Z"
+                properties: {}
+          - type: BRANCH
+            hash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+            name: "dev2"
+            metadataProperties:
+              numCommitsAhead: 0
+              numCommitsBehind: 2
+              commonAncestorHash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+          - type: TAG
+            hash: "a682bfdcd5d357b5c964ef07e2eef61fabba42cb8effa8d62357df45a6cc0371"
+            name: "testTag1"
+          - type: TAG
+            hash: "da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5"
+            name: "testTag2"

--- a/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.params;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ReferencesParamsTest {
+
+  @Test
+  public void testBuilder() {
+    ReferencesParams params =
+        ReferencesParams.builder()
+            .maxRecords(23)
+            .pageToken("abc")
+            .fetchAdditionalInfo(true)
+            .build();
+    assertThat(params.maxRecords()).isEqualTo(23);
+    assertThat(params.pageToken()).isEqualTo("abc");
+    assertThat(params.isFetchAdditionalInfo()).isTrue();
+  }
+
+  @Test
+  public void testEmpty() {
+    ReferencesParams params = ReferencesParams.empty();
+    assertThat(params).isNotNull();
+    assertThat(params.isFetchAdditionalInfo()).isFalse();
+    assertThat(params.pageToken()).isNull();
+    assertThat(params.maxRecords()).isNull();
+  }
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Hash.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Hash.java
@@ -116,7 +116,7 @@ public final class Hash implements Ref {
   }
 
   @Override
-  public final String toString() {
+  public String toString() {
     return "Hash " + asString();
   }
 }


### PR DESCRIPTION
Additional metadata for Branches can now be fetched on the REST API via
the `fetchMetadata=true` flag.

The metadata is then returned within a `Branch` instance via the newly introduced
`metadataProperties` map.

The `metadataProperties` map currently has information under the
`numCommitsAhead` / `numCommitsBehind` / `headCommitMeta` /
`commonAncestorHash` keys.

Note that these changes currently do not affect the Python client in any way, since the Python client doesn't pass the `fetchAdditionalInfo=true` flag. This also means that we don't need to change the schema in the Python's client model classes due to https://github.com/projectnessie/nessie/pull/2734/files#diff-f943e12034e6350b04e3fba9735a5996106b2e88afe9302638244fe2ba77ea76R76.