### PR TITLE
More flexible `GetNamedRefsParams` to distinguish tags + branches

### DIFF
--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -122,8 +122,7 @@ public abstract class NonTransactionalDatabaseAdapter<
       throws ReferenceNotFoundException {
     Preconditions.checkNotNull(params, "Parameter for GetNamedRefsParams must not be null");
     Preconditions.checkArgument(
-        (params.isRetrieveTags() && ref instanceof TagName)
-            || (params.isRetrieveBranches() && ref instanceof BranchName),
+        namedRefsRetrieveOptionsForReference(params, ref).isRetrieve(),
         "Must retrieve branches or tags or both, and match the type of the requested reference.");
 
     GlobalStatePointer pointer = fetchGlobalPointer(NON_TRANSACTIONAL_OPERATION_CONTEXT);
@@ -147,8 +146,7 @@ public abstract class NonTransactionalDatabaseAdapter<
       throws ReferenceNotFoundException {
     Preconditions.checkNotNull(params, "Parameter for GetNamedRefsParams must not be null.");
     Preconditions.checkArgument(
-        params.isRetrieveTags() || params.isRetrieveBranches(),
-        "Must retrieve branches or tags or both.");
+        namedRefsAnyRetrieves(params), "Must retrieve branches or tags or both.");
 
     GlobalStatePointer pointer = fetchGlobalPointer(NON_TRANSACTIONAL_OPERATION_CONTEXT);
     if (pointer == null) {
@@ -751,7 +749,7 @@ public abstract class NonTransactionalDatabaseAdapter<
    */
   private Hash namedRefsDefaultBranchHead(GetNamedRefsParams params, GlobalStatePointer pointer)
       throws ReferenceNotFoundException {
-    if (params.isComputeAheadBehind() || params.isComputeCommonAncestor()) {
+    if (namedRefsRequiresBaseReference(params)) {
       Preconditions.checkNotNull(params.getBaseReference(), "Base reference name missing.");
       return branchHead(pointer, params.getBaseReference());
     }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.GetNamedRefsParams.RetrieveOptions;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ImmutableReferenceInfo;
 import org.projectnessie.versioned.Key;
@@ -48,6 +49,13 @@ public abstract class AbstractGetNamedReferences {
   private static final Key SOME_KEY = Key.of("a", "b", "c");
   private static final String SOME_CONTENT_ID = "abc";
   private final DatabaseAdapter databaseAdapter;
+
+  static RetrieveOptions COMPUTE_AHEAD_BEHIND =
+      RetrieveOptions.builder().isComputeAheadBehind(true).build();
+  static RetrieveOptions COMPUTE_COMMON_ANCESTOR =
+      RetrieveOptions.builder().isComputeAheadBehind(true).build();
+  static RetrieveOptions COMPUTE_ALL =
+      RetrieveOptions.builder().isComputeAheadBehind(true).isComputeCommonAncestor(true).build();
 
   protected AbstractGetNamedReferences(DatabaseAdapter databaseAdapter) {
     this.databaseAdapter = databaseAdapter;
@@ -76,14 +84,9 @@ public abstract class AbstractGetNamedReferences {
             assertThatThrownBy(
                     () ->
                         databaseAdapter.namedRefs(
-                            GetNamedRefsParams.builder().isComputeAheadBehind(true).build()))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage("Base reference name missing."),
-        () ->
-            assertThatThrownBy(
-                    () ->
-                        databaseAdapter.namedRefs(
-                            GetNamedRefsParams.builder().isComputeCommonAncestor(true).build()))
+                            GetNamedRefsParams.builder()
+                                .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                                .build()))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("Base reference name missing."),
         () ->
@@ -91,7 +94,35 @@ public abstract class AbstractGetNamedReferences {
                     () ->
                         databaseAdapter.namedRefs(
                             GetNamedRefsParams.builder()
-                                .isComputeAheadBehind(true)
+                                .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                                .build()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Base reference name missing."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRefs(
+                            GetNamedRefsParams.builder()
+                                .branchRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
+                                .build()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Base reference name missing."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRefs(
+                            GetNamedRefsParams.builder()
+                                .tagRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
+                                .build()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Base reference name missing."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRefs(
+                            GetNamedRefsParams.builder()
+                                .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                                .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
                                 .baseReference(BranchName.of("no-no-no"))
                                 .build()))
                 .isInstanceOf(ReferenceNotFoundException.class)
@@ -101,7 +132,8 @@ public abstract class AbstractGetNamedReferences {
                     () ->
                         databaseAdapter.namedRefs(
                             GetNamedRefsParams.builder()
-                                .isComputeAheadBehind(true)
+                                .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                                .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
                                 .baseReference(TagName.of("blah-no"))
                                 .build()))
                 .isInstanceOf(ReferenceNotFoundException.class)
@@ -111,8 +143,8 @@ public abstract class AbstractGetNamedReferences {
                     () ->
                         databaseAdapter.namedRefs(
                             GetNamedRefsParams.builder()
-                                .isRetrieveBranches(false)
-                                .isRetrieveTags(false)
+                                .branchRetrieveOptions(RetrieveOptions.OMIT)
+                                .tagRetrieveOptions(RetrieveOptions.OMIT)
                                 .build()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Must retrieve branches or tags or both."));
@@ -142,15 +174,9 @@ public abstract class AbstractGetNamedReferences {
                     () ->
                         databaseAdapter.namedRef(
                             parameterValidation,
-                            GetNamedRefsParams.builder().isComputeAheadBehind(true).build()))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage("Base reference name missing."),
-        () ->
-            assertThatThrownBy(
-                    () ->
-                        databaseAdapter.namedRef(
-                            parameterValidation,
-                            GetNamedRefsParams.builder().isComputeCommonAncestor(true).build()))
+                            GetNamedRefsParams.builder()
+                                .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                                .build()))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("Base reference name missing."),
         () ->
@@ -159,7 +185,38 @@ public abstract class AbstractGetNamedReferences {
                         databaseAdapter.namedRef(
                             parameterValidation,
                             GetNamedRefsParams.builder()
-                                .isComputeAheadBehind(true)
+                                .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                                .build()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Base reference name missing."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRef(
+                            parameterValidation,
+                            GetNamedRefsParams.builder()
+                                .branchRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
+                                .build()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Base reference name missing."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRef(
+                            parameterValidation,
+                            GetNamedRefsParams.builder()
+                                .tagRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
+                                .build()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Base reference name missing."),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        databaseAdapter.namedRef(
+                            parameterValidation,
+                            GetNamedRefsParams.builder()
+                                .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                                .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
                                 .baseReference(BranchName.of("no-no-no"))
                                 .build()))
                 .isInstanceOf(ReferenceNotFoundException.class)
@@ -170,7 +227,8 @@ public abstract class AbstractGetNamedReferences {
                         databaseAdapter.namedRef(
                             parameterValidation,
                             GetNamedRefsParams.builder()
-                                .isComputeAheadBehind(true)
+                                .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                                .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
                                 .baseReference(TagName.of("blah-no"))
                                 .build()))
                 .isInstanceOf(ReferenceNotFoundException.class)
@@ -181,8 +239,8 @@ public abstract class AbstractGetNamedReferences {
                         databaseAdapter.namedRef(
                             parameterValidation,
                             GetNamedRefsParams.builder()
-                                .isRetrieveBranches(false)
-                                .isRetrieveTags(false)
+                                .branchRetrieveOptions(RetrieveOptions.OMIT)
+                                .tagRetrieveOptions(RetrieveOptions.OMIT)
                                 .build()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
@@ -192,7 +250,9 @@ public abstract class AbstractGetNamedReferences {
                     () ->
                         databaseAdapter.namedRef(
                             parameterValidation,
-                            GetNamedRefsParams.builder().isRetrieveBranches(false).build()))
+                            GetNamedRefsParams.builder()
+                                .branchRetrieveOptions(RetrieveOptions.OMIT)
+                                .build()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
                     "Must retrieve branches or tags or both, and match the type of the requested reference."),
@@ -201,7 +261,9 @@ public abstract class AbstractGetNamedReferences {
                     () ->
                         databaseAdapter.namedRef(
                             parameterValidationTag,
-                            GetNamedRefsParams.builder().isRetrieveTags(false).build()))
+                            GetNamedRefsParams.builder()
+                                .tagRetrieveOptions(RetrieveOptions.OMIT)
+                                .build()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
                     "Must retrieve branches or tags or both, and match the type of the requested reference."));
@@ -362,35 +424,97 @@ public abstract class AbstractGetNamedReferences {
         () -> verifyReferences(GetNamedRefsParams.builder().build(), references),
         () ->
             verifyReferences(
-                GetNamedRefsParams.builder().isRetrieveCommitMetaForHead(true).build(), references),
+                GetNamedRefsParams.builder()
+                    .branchRetrieveOptions(RetrieveOptions.COMMIT_META)
+                    .tagRetrieveOptions(RetrieveOptions.COMMIT_META)
+                    .build(),
+                references),
         () ->
             verifyReferences(
                 GetNamedRefsParams.builder()
-                    .baseReference(BranchName.of(MAIN_BRANCH))
-                    .isComputeCommonAncestor(true)
+                    .branchRetrieveOptions(RetrieveOptions.COMMIT_META)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .tagRetrieveOptions(RetrieveOptions.COMMIT_META)
                     .build(),
                 references),
         () ->
             verifyReferences(
                 GetNamedRefsParams.builder()
                     .baseReference(BranchName.of(MAIN_BRANCH))
-                    .isComputeAheadBehind(true)
+                    .branchRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
+                    .tagRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
                     .build(),
                 references),
         () ->
             verifyReferences(
                 GetNamedRefsParams.builder()
                     .baseReference(BranchName.of(MAIN_BRANCH))
-                    .isComputeAheadBehind(true)
-                    .isComputeCommonAncestor(true)
+                    .branchRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
                     .build(),
                 references),
         () ->
             verifyReferences(
-                GetNamedRefsParams.builder().isRetrieveBranches(false).build(), references),
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .tagRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
+                    .build(),
+                references),
         () ->
             verifyReferences(
-                GetNamedRefsParams.builder().isRetrieveTags(false).build(), references));
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                    .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .branchRetrieveOptions(COMPUTE_ALL)
+                    .tagRetrieveOptions(COMPUTE_ALL)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .tagRetrieveOptions(COMPUTE_ALL)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder()
+                    .baseReference(BranchName.of(MAIN_BRANCH))
+                    .branchRetrieveOptions(COMPUTE_ALL)
+                    .build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder().branchRetrieveOptions(RetrieveOptions.OMIT).build(),
+                references),
+        () ->
+            verifyReferences(
+                GetNamedRefsParams.builder().tagRetrieveOptions(RetrieveOptions.OMIT).build(),
+                references));
   }
 
   private void verifyReferences(GetNamedRefsParams params, ExpectedNamedReference... references)
@@ -451,23 +575,30 @@ public abstract class AbstractGetNamedReferences {
     }
 
     ReferenceInfo<ByteString> expected(GetNamedRefsParams params) {
-      if (!params.isRetrieveTags() && (ref instanceof TagName)) {
+      RetrieveOptions opts;
+      if (ref instanceof TagName) {
+        opts = params.getTagRetrieveOptions();
+      } else if (ref instanceof BranchName) {
+        opts = params.getBranchRetrieveOptions();
+      } else {
+        throw new IllegalArgumentException("" + ref);
+      }
+
+      if (!opts.isRetrieve()) {
         return null;
       }
-      if (!params.isRetrieveBranches() && (ref instanceof BranchName)) {
-        return null;
-      }
+
       ImmutableReferenceInfo.Builder<ByteString> builder =
           ReferenceInfo.<ByteString>builder().namedRef(ref).hash(hash);
       if (!ref.equals(params.getBaseReference())) {
-        if (params.isComputeAheadBehind()) {
+        if (opts.isComputeAheadBehind()) {
           builder.aheadBehind(aheadBehind);
         }
-        if (params.isComputeCommonAncestor()) {
+        if (opts.isComputeCommonAncestor()) {
           builder.commonAncestor(commonAncestor);
         }
       }
-      if (params.isRetrieveCommitMetaForHead()) {
+      if (opts.isRetrieveCommitMetaForHead()) {
         builder.headCommitMeta(commitMeta);
       }
       return builder.build();

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -152,8 +152,7 @@ public abstract class TxDatabaseAdapter
       throws ReferenceNotFoundException {
     Preconditions.checkNotNull(params, "Parameter for GetNamedRefsParams must not be null");
     Preconditions.checkArgument(
-        (params.isRetrieveTags() && ref instanceof TagName)
-            || (params.isRetrieveBranches() && ref instanceof BranchName),
+        namedRefsRetrieveOptionsForReference(params, ref).isRetrieve(),
         "Must retrieve branches or tags or both, and match the type of the requested reference.");
 
     Connection conn = borrowConnection();
@@ -175,8 +174,7 @@ public abstract class TxDatabaseAdapter
       throws ReferenceNotFoundException {
     Preconditions.checkNotNull(params, "Parameter for GetNamedRefsParams must not be null.");
     Preconditions.checkArgument(
-        params.isRetrieveTags() || params.isRetrieveBranches(),
-        "Must retrieve branches or tags or both.");
+        namedRefsAnyRetrieves(params), "Must retrieve branches or tags or both.");
 
     Connection conn = borrowConnection();
     boolean failed = true;
@@ -784,7 +782,7 @@ public abstract class TxDatabaseAdapter
    */
   private Hash namedRefsDefaultBranchHead(Connection conn, GetNamedRefsParams params)
       throws ReferenceNotFoundException {
-    if (params.isComputeAheadBehind() || params.isComputeCommonAncestor()) {
+    if (namedRefsRequiresBaseReference(params)) {
       Preconditions.checkNotNull(params.getBaseReference(), "Base reference name missing.");
       return fetchNamedRefHead(conn, params.getBaseReference());
     }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/GetNamedRefsParams.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/GetNamedRefsParams.java
@@ -33,46 +33,83 @@ public interface GetNamedRefsParams {
 
   /**
    * Named reference to use as the base for the computation of {@link
-   * ReferenceInfo#getAheadBehind()}. If this parameter is not {@code null}, the branch must exist.
+   * ReferenceInfo#getAheadBehind()}. If this parameter is not {@code null}, the given reference
+   * must exist.
    *
    * @return name of the base reference. Can be {@code null}, if not needed.
    */
   @Nullable
   NamedRef getBaseReference();
 
-  /**
-   * Whether to compute {@link ReferenceInfo#getAheadBehind()}, requires a non-{@code null} {@link
-   * #getBaseReference()}, defaults to {@code false}.
-   */
-  @Value.Default
-  default boolean isComputeAheadBehind() {
-    return false;
-  }
-
-  /** Whether to identify the common ancestor on the default branch. */
-  @Value.Default
-  default boolean isComputeCommonAncestor() {
-    return false;
-  }
-
-  /**
-   * Whether to retrieve the commit-meta information of each reference's HEAD commit in {@link
-   * ReferenceInfo#getHeadCommitMeta()}, defaults to {@code false}.
-   */
-  @Value.Default
-  default boolean isRetrieveCommitMetaForHead() {
-    return false;
-  }
-
   /** Whether to retrieve branches, defaults to {@code true}. */
   @Value.Default
-  default boolean isRetrieveBranches() {
-    return true;
+  default RetrieveOptions getBranchRetrieveOptions() {
+    return RetrieveOptions.BARE;
   }
 
   /** Whether to retrieve tags, defaults to {@code true}. */
   @Value.Default
-  default boolean isRetrieveTags() {
-    return true;
+  default RetrieveOptions getTagRetrieveOptions() {
+    return RetrieveOptions.BARE;
+  }
+
+  @Value.Immutable
+  interface RetrieveOptions {
+
+    /** Constant to not retrieve any information (omit tags or branches). */
+    RetrieveOptions OMIT = RetrieveOptions.builder().isRetrieve(false).build();
+
+    /** Constant to retrieve only the HEAD commit hash. */
+    RetrieveOptions BARE = RetrieveOptions.builder().build();
+
+    /** Constant to retrieve the HEAD commit hash plus the commit-meta of the HEAD commit. */
+    RetrieveOptions COMMIT_META =
+        RetrieveOptions.builder().isRetrieveCommitMetaForHead(true).build();
+
+    /**
+     * Constant to retrieve the HEAD commit hash, the commit-meta of the HEAD commit, the
+     * common-ancestor to the base reference and the commits ahead and behind relative to the base
+     * reference.
+     */
+    RetrieveOptions BASE_REFERENCE_RELATED_AND_COMMIT_META =
+        RetrieveOptions.builder()
+            .isComputeAheadBehind(true)
+            .isComputeCommonAncestor(true)
+            .isRetrieveCommitMetaForHead(true)
+            .build();
+
+    static ImmutableRetrieveOptions.Builder builder() {
+      return ImmutableRetrieveOptions.builder();
+    }
+
+    /** Whether to retrieve the reference information at all, defaults to {@code true}. */
+    @Value.Default
+    default boolean isRetrieve() {
+      return true;
+    }
+
+    /**
+     * Whether to compute {@link ReferenceInfo#getAheadBehind()}, requires a non-{@code null} {@link
+     * #getBaseReference()}, defaults to {@code false}.
+     */
+    @Value.Default
+    default boolean isComputeAheadBehind() {
+      return false;
+    }
+
+    /** Whether to identify the common ancestor on the default branch, defaults to {@code false}. */
+    @Value.Default
+    default boolean isComputeCommonAncestor() {
+      return false;
+    }
+
+    /**
+     * Whether to retrieve the commit-meta information of each reference's HEAD commit in {@link
+     * ReferenceInfo#getHeadCommitMeta()}, defaults to {@code false}.
+     */
+    @Value.Default
+    default boolean isRetrieveCommitMetaForHead() {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Allows to retrieve branches and tags with references-type specific
additional information. With this the call site can retrive for
example branches with commits ahead/behind but tags without that
additional information.