### PR TITLE
Optionally fetch additional metadata when retrieving a single Branch

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetReferenceBuilder.java
@@ -34,5 +34,14 @@ public interface GetReferenceBuilder {
               message = Validation.REF_NAME_OR_HASH_MESSAGE)
           String refName);
 
+  /**
+   * Will fetch additional metadata about {@link org.projectnessie.model.Branch} instances, such as
+   * number of commits ahead/behind or the common ancestor in relation to the default branch, and
+   * the commit metadata for the HEAD commit.
+   *
+   * @return {@link GetReferenceBuilder}
+   */
+  GetReferenceBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo);
+
   Reference get() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
@@ -20,6 +20,7 @@ import javax.validation.constraints.NotNull;
 import org.projectnessie.api.http.HttpTreeApi;
 import org.projectnessie.api.params.CommitLogParams;
 import org.projectnessie.api.params.EntriesParams;
+import org.projectnessie.api.params.GetReferenceParams;
 import org.projectnessie.api.params.ReferencesParams;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -64,11 +65,13 @@ class HttpTreeClient implements HttpTreeApi {
   }
 
   @Override
-  public Reference getReferenceByName(@NotNull String refName) throws NessieNotFoundException {
+  public Reference getReferenceByName(@NotNull GetReferenceParams params)
+      throws NessieNotFoundException {
     return client
         .newRequest()
         .path("trees/tree/{ref}")
-        .resolveTemplate("ref", refName)
+        .queryParam("fetchAdditionalInfo", Boolean.toString(params.isFetchAdditionalInfo()))
+        .resolveTemplate("ref", params.getRefName())
         .get()
         .readEntity(Reference.class);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetReference.java
@@ -15,14 +15,14 @@
  */
 package org.projectnessie.client.http.v1api;
 
+import org.projectnessie.api.params.GetReferenceParams;
 import org.projectnessie.client.api.GetReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
 final class HttpGetReference extends BaseHttpRequest implements GetReferenceBuilder {
-
-  private String refName;
+  private GetReferenceParams.Builder builder = GetReferenceParams.builder();
 
   HttpGetReference(NessieApiClient client) {
     super(client);
@@ -30,12 +30,18 @@ final class HttpGetReference extends BaseHttpRequest implements GetReferenceBuil
 
   @Override
   public GetReferenceBuilder refName(String refName) {
-    this.refName = refName;
+    builder.refName(refName);
+    return this;
+  }
+
+  @Override
+  public GetReferenceBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
+    builder.fetchAdditionalInfo(fetchAdditionalInfo);
     return this;
   }
 
   @Override
   public Reference get() throws NessieNotFoundException {
-    return client.getTreeApi().getReferenceByName(refName);
+    return client.getTreeApi().getReferenceByName(builder.build());
   }
 }

--- a/model/src/main/java/org/projectnessie/api/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/TreeApi.java
@@ -21,6 +21,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import org.projectnessie.api.params.CommitLogParams;
 import org.projectnessie.api.params.EntriesParams;
+import org.projectnessie.api.params.GetReferenceParams;
 import org.projectnessie.api.params.ReferencesParams;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -43,7 +44,7 @@ public interface TreeApi {
   /**
    * Get all references.
    *
-   * @return
+   * @return A {@link ReferencesResponse} instance containing all references.
    */
   ReferencesResponse getAllReferences(ReferencesParams params);
 
@@ -73,13 +74,7 @@ public interface TreeApi {
       throws NessieNotFoundException, NessieConflictException;
 
   /** Get details of a particular ref, if it exists. */
-  Reference getReferenceByName(
-      @Valid
-          @NotNull
-          @Pattern(
-              regexp = Validation.REF_NAME_OR_HASH_REGEX,
-              message = Validation.REF_NAME_OR_HASH_MESSAGE)
-          String refName)
+  Reference getReferenceByName(@Valid @NotNull GetReferenceParams params)
       throws NessieNotFoundException;
 
   /**

--- a/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
@@ -37,6 +37,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.projectnessie.api.TreeApi;
 import org.projectnessie.api.params.CommitLogParams;
 import org.projectnessie.api.params.EntriesParams;
+import org.projectnessie.api.params.GetReferenceParams;
 import org.projectnessie.api.params.ReferencesParams;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -155,13 +156,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "403", description = "Not allowed to view the given reference"),
     @APIResponse(responseCode = "404", description = "Ref not found")
   })
-  Reference getReferenceByName(
-      @Parameter(
-              description = "name of ref to fetch",
-              examples = {@ExampleObject(ref = "ref")})
-          @PathParam("ref")
-          String refName)
-      throws NessieNotFoundException;
+  Reference getReferenceByName(@BeanParam GetReferenceParams params) throws NessieNotFoundException;
 
   @Override
   @GET

--- a/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
@@ -17,18 +17,25 @@ package org.projectnessie.api.params;
 
 import java.util.Objects;
 import java.util.StringJoiner;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
-import org.projectnessie.api.http.HttpTreeApi;
+import org.projectnessie.model.Validation;
 
-/**
- * The purpose of this class is to include optional parameters that can be passed to {@link
- * HttpTreeApi#getAllReferences(ReferencesParams)}
- *
- * <p>For easier usage of this class, there is {@link ReferencesParams#builder()}, which allows
- * configuring/setting the different parameters.
- */
-public class ReferencesParams extends AbstractParams {
+public class GetReferenceParams {
+
+  @Parameter(
+      description = "name of ref to fetch",
+      examples = {@ExampleObject(ref = "ref")})
+  @PathParam("ref")
+  @NotNull
+  @Pattern(
+      regexp = Validation.REF_NAME_OR_HASH_REGEX,
+      message = Validation.REF_NAME_OR_HASH_MESSAGE)
+  private String refName;
 
   @Parameter(
       description =
@@ -42,36 +49,31 @@ public class ReferencesParams extends AbstractParams {
   @QueryParam("fetchAdditionalInfo")
   private boolean fetchAdditionalInfo;
 
-  public ReferencesParams() {}
+  public GetReferenceParams() {}
 
-  private ReferencesParams(Integer maxRecords, String pageToken, boolean fetchAdditionalInfo) {
-    super(maxRecords, pageToken);
+  private GetReferenceParams(String refName, boolean fetchAdditionalInfo) {
+    this.refName = refName;
     this.fetchAdditionalInfo = fetchAdditionalInfo;
   }
 
-  private ReferencesParams(Builder builder) {
-    this(builder.maxRecords, builder.pageToken, builder.fetchAdditionalInfo);
+  private GetReferenceParams(Builder builder) {
+    this(builder.refName, builder.fetchAdditionalInfo);
   }
 
   public boolean isFetchAdditionalInfo() {
     return fetchAdditionalInfo;
   }
 
-  public static ReferencesParams.Builder builder() {
-    return new ReferencesParams.Builder();
+  public String getRefName() {
+    return refName;
   }
 
-  public static ReferencesParams empty() {
-    return new ReferencesParams.Builder().build();
+  public static GetReferenceParams.Builder builder() {
+    return new GetReferenceParams.Builder();
   }
 
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", ReferencesParams.class.getSimpleName() + "[", "]")
-        .add("maxRecords=" + maxRecords())
-        .add("pageToken='" + pageToken() + "'")
-        .add("fetchAdditionalInfo=" + fetchAdditionalInfo)
-        .toString();
+  public static GetReferenceParams empty() {
+    return new GetReferenceParams.Builder().build();
   }
 
   @Override
@@ -82,27 +84,32 @@ public class ReferencesParams extends AbstractParams {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    ReferencesParams that = (ReferencesParams) o;
-    return Objects.equals(maxRecords(), that.maxRecords())
-        && Objects.equals(pageToken(), that.pageToken())
-        && Objects.equals(fetchAdditionalInfo, that.fetchAdditionalInfo);
+    GetReferenceParams that = (GetReferenceParams) o;
+    return fetchAdditionalInfo == that.fetchAdditionalInfo && Objects.equals(refName, that.refName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(maxRecords(), pageToken(), fetchAdditionalInfo);
+    return Objects.hash(refName, fetchAdditionalInfo);
   }
 
-  public static class Builder extends AbstractParams.Builder<Builder> {
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", GetReferenceParams.class.getSimpleName() + "[", "]")
+        .add("refName='" + refName + "'")
+        .add("fetchAdditionalInfo=" + fetchAdditionalInfo)
+        .toString();
+  }
+
+  public static class Builder {
+    private String refName;
+    private boolean fetchAdditionalInfo;
 
     private Builder() {}
 
-    private boolean fetchAdditionalInfo = false;
-
-    public ReferencesParams.Builder from(ReferencesParams params) {
-      return maxRecords(params.maxRecords())
-          .pageToken(params.pageToken())
-          .fetchAdditionalInfo(params.fetchAdditionalInfo);
+    public Builder refName(String refName) {
+      this.refName = refName;
+      return this;
     }
 
     public Builder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
@@ -112,9 +119,9 @@ public class ReferencesParams extends AbstractParams {
 
     private void validate() {}
 
-    public ReferencesParams build() {
+    public GetReferenceParams build() {
       validate();
-      return new ReferencesParams(this);
+      return new GetReferenceParams(this);
     }
   }
 }

--- a/model/src/test/java/org/projectnessie/api/params/GetReferenceParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/GetReferenceParamsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.params;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class GetReferenceParamsTest {
+
+  @Test
+  public void testBuilder() {
+    GetReferenceParams params =
+        GetReferenceParams.builder().refName("xx").fetchAdditionalInfo(true).build();
+    assertThat(params.getRefName()).isEqualTo("xx");
+    assertThat(params.isFetchAdditionalInfo()).isTrue();
+  }
+
+  @Test
+  public void testEmpty() {
+    GetReferenceParams params = GetReferenceParams.empty();
+    assertThat(params).isNotNull();
+    assertThat(params.isFetchAdditionalInfo()).isFalse();
+    assertThat(params.getRefName()).isNull();
+  }
+}

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -23,6 +23,7 @@ import org.projectnessie.api.TreeApi;
 import org.projectnessie.api.http.HttpTreeApi;
 import org.projectnessie.api.params.CommitLogParams;
 import org.projectnessie.api.params.EntriesParams;
+import org.projectnessie.api.params.GetReferenceParams;
 import org.projectnessie.api.params.ReferencesParams;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -96,8 +97,8 @@ public class RestTreeResource implements HttpTreeApi {
   }
 
   @Override
-  public Reference getReferenceByName(String refName) throws NessieNotFoundException {
-    return resource().getReferenceByName(refName);
+  public Reference getReferenceByName(GetReferenceParams params) throws NessieNotFoundException {
+    return resource().getReferenceByName(params);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
@@ -23,6 +23,7 @@ import java.security.Principal;
 import javax.annotation.Nullable;
 import org.projectnessie.api.params.CommitLogParams;
 import org.projectnessie.api.params.EntriesParams;
+import org.projectnessie.api.params.GetReferenceParams;
 import org.projectnessie.api.params.ReferencesParams;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -81,8 +82,8 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
   }
 
   @Override
-  public Reference getReferenceByName(String refName) throws NessieNotFoundException {
-    Reference ref = super.getReferenceByName(refName);
+  public Reference getReferenceByName(GetReferenceParams params) throws NessieNotFoundException {
+    Reference ref = super.getReferenceByName(params);
     if (ref instanceof Branch) {
       getAccessChecker().canViewReference(createAccessContext(), BranchName.of(ref.getName()));
     } else if (ref instanceof Tag) {


### PR DESCRIPTION
Additional metadata for Branches can now be fetched on the REST API via
the `fetchAdditionalInfo=true` flag.

The metadata is then returned within a `Branch` instance via the newly introduced
`metadataProperties` map.

The `metadataProperties` map currently has information under the
`numCommitsAhead` / `numCommitsBehind` / `headCommitMeta` /
`commonAncestorHash` keys.