### PR TITLE
Enhance commit log

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
+++ b/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
@@ -26,6 +26,7 @@ import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.EntriesResponse.Entry;
 import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferencesResponse;
 
@@ -92,7 +93,7 @@ public final class StreamingUtil {
    * @param ref a named reference (branch or tag name) or a commit-hash
    * @return stream of {@link CommitMeta} objects
    */
-  public static Stream<CommitMeta> getCommitLogStream(
+  public static Stream<LogEntry> getCommitLogStream(
       @NotNull NessieApiV1 api,
       @NotNull String ref,
       @Nullable String hashOnRef,
@@ -101,7 +102,7 @@ public final class StreamingUtil {
       OptionalInt maxRecords)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
-            LogResponse::getOperations,
+            LogResponse::getLogEntries,
             (reference, pageSize, token) ->
                 builderWithPaging(api.getCommitLog(), pageSize, token)
                     .refName(reference)

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
@@ -30,6 +30,14 @@ public interface GetCommitLogBuilder
     extends QueryBuilder<GetCommitLogBuilder>,
         PagingBuilder<GetCommitLogBuilder>,
         OnReferenceBuilder<GetCommitLogBuilder> {
+
+  /**
+   * Will fetch additional metadata about each commit like operations in a commit and parent hash.
+   *
+   * @return {@link GetAllReferencesBuilder}
+   */
+  GetCommitLogBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo);
+
   GetCommitLogBuilder untilHash(
       @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String untilHash);

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
@@ -138,6 +138,7 @@ class HttpTreeClient implements HttpTreeApi {
         .queryParam("query_expression", params.queryExpression())
         .queryParam("startHash", params.startHash())
         .queryParam("endHash", params.endHash())
+        .queryParam("fetchAdditionalInfo", params.isFetchAdditionalInfo() ? "true" : null)
         .get()
         .readEntity(LogResponse.class);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetCommitLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetCommitLog.java
@@ -31,6 +31,12 @@ final class HttpGetCommitLog extends BaseHttpOnReferenceRequest<GetCommitLogBuil
   }
 
   @Override
+  public GetCommitLogBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
+    params.fetchAdditionalInfo(fetchAdditionalInfo);
+    return this;
+  }
+
+  @Override
   public GetCommitLogBuilder untilHash(String untilHash) {
     params.startHash(untilHash);
     return this;

--- a/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
@@ -247,7 +247,10 @@ public interface HttpTreeApi extends TreeApi {
         content = {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
-              examples = {@ExampleObject(ref = "logResponse")},
+              examples = {
+                @ExampleObject(ref = "logResponseAdditionalInfo"),
+                @ExampleObject(ref = "logResponseSimple")
+              },
               schema = @Schema(implementation = LogResponse.class))
         }),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),

--- a/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
@@ -63,6 +63,16 @@ public class CommitLogParams extends AbstractParams {
   @QueryParam("query_expression")
   private String queryExpression;
 
+  @Parameter(
+      description =
+          "If set to true, will fetch additional metadata, parent commit hash and operations in a commit, for each commit.")
+  @QueryParam("fetchAdditionalInfo")
+  private boolean fetchAdditionalInfo;
+
+  public boolean isFetchAdditionalInfo() {
+    return fetchAdditionalInfo;
+  }
+
   public CommitLogParams() {}
 
   private CommitLogParams(
@@ -70,11 +80,13 @@ public class CommitLogParams extends AbstractParams {
       String endHash,
       Integer maxRecords,
       String pageToken,
-      String queryExpression) {
+      String queryExpression,
+      boolean fetchAdditionalInfo) {
     super(maxRecords, pageToken);
     this.startHash = startHash;
     this.endHash = endHash;
     this.queryExpression = queryExpression;
+    this.fetchAdditionalInfo = fetchAdditionalInfo;
   }
 
   private CommitLogParams(Builder builder) {
@@ -83,7 +95,8 @@ public class CommitLogParams extends AbstractParams {
         builder.endHash,
         builder.maxRecords,
         builder.pageToken,
-        builder.queryExpression);
+        builder.queryExpression,
+        builder.fetchAdditionalInfo);
   }
 
   @Nullable
@@ -116,6 +129,7 @@ public class CommitLogParams extends AbstractParams {
         .add("maxRecords=" + maxRecords())
         .add("pageToken='" + pageToken() + "'")
         .add("queryExpression='" + queryExpression + "'")
+        .add("fetchAdditionalInfo='" + fetchAdditionalInfo + "'")
         .toString();
   }
 
@@ -132,12 +146,14 @@ public class CommitLogParams extends AbstractParams {
         && Objects.equals(endHash, that.endHash)
         && Objects.equals(maxRecords(), that.maxRecords())
         && Objects.equals(pageToken(), that.pageToken())
-        && Objects.equals(queryExpression, that.queryExpression);
+        && Objects.equals(queryExpression, that.queryExpression)
+        && Objects.equals(fetchAdditionalInfo, that.fetchAdditionalInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startHash, endHash, maxRecords(), pageToken(), queryExpression);
+    return Objects.hash(
+        startHash, endHash, maxRecords(), pageToken(), queryExpression, fetchAdditionalInfo);
   }
 
   public static class Builder extends AbstractParams.Builder<Builder> {
@@ -145,6 +161,7 @@ public class CommitLogParams extends AbstractParams {
     private String startHash;
     private String endHash;
     private String queryExpression;
+    private boolean fetchAdditionalInfo;
 
     private Builder() {}
 
@@ -163,12 +180,18 @@ public class CommitLogParams extends AbstractParams {
       return this;
     }
 
+    public Builder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
+      this.fetchAdditionalInfo = fetchAdditionalInfo;
+      return this;
+    }
+
     public Builder from(CommitLogParams params) {
       return startHash(params.startHash)
           .endHash(params.endHash)
           .maxRecords(params.maxRecords())
           .pageToken(params.pageToken())
-          .expression(params.queryExpression);
+          .expression(params.queryExpression)
+          .fetchAdditionalInfo(params.fetchAdditionalInfo);
     }
 
     private void validate() {}

--- a/model/src/main/java/org/projectnessie/model/LogResponse.java
+++ b/model/src/main/java/org/projectnessie/model/LogResponse.java
@@ -18,6 +18,7 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -30,5 +31,24 @@ import org.immutables.value.Value;
 public interface LogResponse extends PaginatedResponse {
 
   @NotNull
-  List<CommitMeta> getOperations();
+  List<LogEntry> getLogEntries();
+
+  @Value.Immutable
+  @Schema(type = SchemaType.OBJECT, title = "LogEntry")
+  @JsonSerialize(as = ImmutableLogEntry.class)
+  @JsonDeserialize(as = ImmutableLogEntry.class)
+  interface LogEntry {
+    static ImmutableLogEntry.Builder builder() {
+      return ImmutableLogEntry.builder();
+    }
+
+    @NotNull
+    CommitMeta getCommitMeta();
+
+    @Nullable
+    String getParentCommitHash();
+
+    @Nullable
+    List<Operation> getOperations();
+  }
 }

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -159,21 +159,54 @@ components:
               uuid: "b874b5d5-f926-4eed-9be7-b2380d9810c0"
               metadataLocation: "/path/to/metadata/"
 
-    logResponse:
+    logResponseAdditionalInfo:
       value:
         token: "xxx"
-        operations:
-          - author: "authorName <authorName@example.com>"
-            authorTime: "2021-04-07T14:42:25.534748Z"
-            commitTime: "2021-04-07T14:42:25.534748Z"
-            committer: "committerName <committerName@example.com>"
-            hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
-            message: "Example Commit Message"
-            properties:
-              additionalProp1: "xxx"
-              additionalProp2: "yyy"
-              additionalProp3: "zzz"
-            signedOffBy: "signedOffByName <signedOffBy@example.com>"
+        logEntries:
+          - commitMeta:
+              author: "authorName <authorName@example.com>"
+              authorTime: "2021-04-07T14:42:25.534748Z"
+              commitTime: "2021-04-07T14:42:25.534748Z"
+              committer: "committerName <committerName@example.com>"
+              hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+              message: "Example Commit Message"
+              properties:
+                additionalProp1: "xxx"
+                additionalProp2: "yyy"
+                additionalProp3: "zzz"
+              signedOffBy: "signedOffByName <signedOffBy@example.com>"
+            parentCommitHash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+            operations:
+              - type: DELETE
+                key:
+                  elements:
+                    - deleted
+                    - table
+              - type: PUT
+                key:
+                  elements:
+                    - example
+                    - key
+                content:
+                  type: ICEBERG_TABLE
+                  uuid: "b874b5d5-f926-4eed-9be7-b2380d9810c0"
+                  metadataLocation: "/path/to/metadata/"
+    logResponseSimple:
+      value:
+        token: "xxx"
+        logEntries:
+          - commitMeta:
+              author: "authorName <authorName@example.com>"
+              authorTime: "2021-04-07T14:42:25.534748Z"
+              commitTime: "2021-04-07T14:42:25.534748Z"
+              committer: "committerName <committerName@example.com>"
+              hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+              message: "Example Commit Message"
+              properties:
+                additionalProp1: "xxx"
+                additionalProp2: "yyy"
+                additionalProp3: "zzz"
+              signedOffBy: "signedOffByName <signedOffBy@example.com>"
 
     referencesResponse:
       value:

--- a/model/src/test/java/org/projectnessie/api/params/CommitLogParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/CommitLogParamsTest.java
@@ -17,6 +17,7 @@ package org.projectnessie.api.params;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 public class CommitLogParamsTest {
@@ -28,30 +29,53 @@ public class CommitLogParamsTest {
     String endHash = "00000";
     String pageToken = "aabbcc";
     String queryExpression = "some_expression";
-    CommitLogParams params =
-        CommitLogParams.builder()
-            .expression(queryExpression)
-            .maxRecords(maxRecords)
-            .pageToken(pageToken)
-            .startHash(startHash)
-            .endHash(endHash)
-            .build();
+    boolean fetchAdditionalInfo = true;
 
-    assertThat(params.pageToken()).isEqualTo(pageToken);
-    assertThat(params.maxRecords()).isEqualTo(maxRecords);
-    assertThat(params.queryExpression()).isEqualTo(queryExpression);
-    assertThat(params.startHash()).isEqualTo(startHash);
-    assertThat(params.endHash()).isEqualTo(endHash);
+    Supplier<CommitLogParams> generator =
+        () ->
+            CommitLogParams.builder()
+                .expression(queryExpression)
+                .maxRecords(maxRecords)
+                .pageToken(pageToken)
+                .startHash(startHash)
+                .endHash(endHash)
+                .fetchAdditionalInfo(fetchAdditionalInfo)
+                .build();
+
+    verify(
+        maxRecords, startHash, endHash, pageToken, queryExpression, fetchAdditionalInfo, generator);
   }
 
   @Test
   public void testEmpty() {
-    CommitLogParams params = CommitLogParams.empty();
-    assertThat(params).isNotNull();
-    assertThat(params.maxRecords()).isNull();
-    assertThat(params.pageToken()).isNull();
-    assertThat(params.queryExpression()).isNull();
-    assertThat(params.startHash()).isNull();
-    assertThat(params.endHash()).isNull();
+    verify(null, null, null, null, null, false, CommitLogParams::empty);
+  }
+
+  private void verify(
+      Integer maxRecords,
+      String startHash,
+      String endHash,
+      String pageToken,
+      String queryExpression,
+      boolean fetchAdditionalInfo,
+      Supplier<CommitLogParams> generator) {
+    assertThat(generator.get())
+        .isEqualTo(generator.get())
+        .extracting(
+            CommitLogParams::pageToken,
+            CommitLogParams::maxRecords,
+            CommitLogParams::queryExpression,
+            CommitLogParams::startHash,
+            CommitLogParams::endHash,
+            CommitLogParams::isFetchAdditionalInfo,
+            CommitLogParams::hashCode)
+        .containsExactly(
+            pageToken,
+            maxRecords,
+            queryExpression,
+            startHash,
+            endHash,
+            fetchAdditionalInfo,
+            generator.get().hashCode());
   }
 }

--- a/python/pynessie/client/_endpoints.py
+++ b/python/pynessie/client/_endpoints.py
@@ -201,6 +201,7 @@ def list_logs(
     hash_on_ref: Optional[str] = None,
     ssl_verify: bool = True,
     max_records: Optional[int] = None,
+    fetch_additional_info: bool = False,
     **filtering_args: Any
 ) -> dict:
     """Fetch a list of all logs from a known starting reference.
@@ -219,6 +220,8 @@ def list_logs(
         params["hashOnRef"] = hash_on_ref
     if max_records:
         params["max"] = max_records
+    if fetch_additional_info:
+        params["fetchAdditionalInfo"] = "true"
     return cast(dict, _get(base_url + "/trees/tree/{}/log".format(ref), auth, ssl_verify=ssl_verify, params=filtering_args))
 
 

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -180,7 +180,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -191,7 +191,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+    body: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
       "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
@@ -247,7 +247,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+    body: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
       "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
@@ -286,8 +286,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
-        "name": "main", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hasMore": false, "references": [{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
+        "name": "main", "type": "BRANCH"}, {"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -312,7 +312,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -323,7 +323,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+    body: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
       "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -342,7 +342,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
@@ -367,9 +367,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
-        "name": "main", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
-        "name": "dev", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hasMore": false, "references": [{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
+        "name": "main", "type": "BRANCH"}, {"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
+        "name": "dev", "type": "BRANCH"}, {"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:
@@ -394,7 +394,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -405,7 +405,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+    body: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
       "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -450,7 +450,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
@@ -461,7 +461,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+    body: '{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
       "name": "dev", "type": "TAG"}'
     headers:
       Accept:
@@ -477,7 +477,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6
   response:
     body:
       string: ''
@@ -500,9 +500,9 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
-        "name": "main", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
-        "name": "dev", "type": "BRANCH"}, {"hash": "a75579edea485857ecaa0fc1dbf2ad9813221d1aa9794ce53e5a487bbc9047bc",
+      string: '{"hasMore": false, "references": [{"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
+        "name": "main", "type": "BRANCH"}, {"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
+        "name": "dev", "type": "BRANCH"}, {"hash": "de968893f7d7c30a89059c9ccc4751dfb2d0c61caf1a0fcef70b749c8320eae6",
         "name": "v1.0", "type": "TAG"}], "token": null}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -39,7 +39,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [], "token": null}'
+      string: '{"hasMore": false, "logEntries": [], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -204,7 +204,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev_test_log/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "560649d2e43eceeeaa4da2444b83da143fa16c1b3ac8358a399675d2dd043795",
+      string: '{"hash": "a77da0eeb3821d0a205e91244b28cabc70b4a9e5c7a0dac86ec767982d74d01f",
         "name": "dev_test_log", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -230,7 +230,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "560649d2e43eceeeaa4da2444b83da143fa16c1b3ac8358a399675d2dd043795",
+        "name": "main", "type": "BRANCH"}, {"hash": "a77da0eeb3821d0a205e91244b28cabc70b4a9e5c7a0dac86ec767982d74d01f",
         "name": "dev_test_log", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -268,7 +268,7 @@ interactions:
       message: Not Found
 - request:
     body: '{"commitMeta": {"author": "nessie_user1", "authorTime": null, "commitTime":
-      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "committer": null, "hash": null, "message": "commit to main", "properties":
       null, "signedOffBy": null}, "operations": [{"content": {"id": "test_log", "metadataLocation":
       "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId": 45, "specId": 44,
       "type": "ICEBERG_TABLE"}, "expectedContent": null, "key": {"elements": ["log",
@@ -281,7 +281,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '438'
+      - '440'
       Content-Type:
       - application/json
       User-Agent:
@@ -290,7 +290,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
+      string: '{"hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -315,7 +315,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
+      string: '{"hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -365,7 +365,64 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
+      string: '{"hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "name": "main", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '110'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?fetchAdditionalInfo=true
+  response:
+    body:
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        [{"content": {"id": "test_log", "metadataLocation": "/a/b/c", "schemaId":
+        43, "snapshotId": 42, "sortOrderId": 45, "specId": 44, "type": "ICEBERG_TABLE"},
+        "expectedContent": null, "key": {"elements": ["log", "foo", "bar"]}, "type":
+        "PUT"}], "parentCommitHash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"}],
+        "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '687'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree
+  response:
+    body:
+      string: '{"hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -390,16 +447,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T19:04:15.495030Z", "commitTime": "2021-11-17T19:04:15.495030Z",
-        "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '326'
+      - '390'
     status:
       code: 200
       message: OK
@@ -418,7 +475,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
+      string: '{"hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -440,19 +497,19 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080
+    uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T19:04:15.495030Z", "commitTime": "2021-11-17T19:04:15.495030Z",
-        "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '326'
+      - '390'
     status:
       code: 200
       message: OK
@@ -471,7 +528,60 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
+      string: '{"hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "name": "main", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '110'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a
+  response:
+    body:
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '390'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree
+  response:
+    body:
+      string: '{"hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -525,10 +635,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -553,7 +663,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -578,16 +688,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?max=1
   response:
     body:
-      string: '{"hasMore": true, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
-        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
-        "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
-        "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080"}'
+      string: '{"hasMore": true, "logEntries": [{"commitMeta": {"author": "nessie_user2",
+        "authorTime": "2021-11-27T09:52:03.340389Z", "commitTime": "2021-11-27T09:52:03.340389Z",
+        "committer": "", "hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '389'
+      - '451'
     status:
       code: 200
       message: OK
@@ -606,16 +716,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev_test_log/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T19:04:15.431339Z", "commitTime": "2021-11-17T19:04:15.431339Z",
-        "committer": "", "hash": "560649d2e43eceeeaa4da2444b83da143fa16c1b3ac8358a399675d2dd043795",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.026765Z", "commitTime": "2021-11-27T09:52:03.026765Z",
+        "committer": "", "hash": "a77da0eeb3821d0a205e91244b28cabc70b4a9e5c7a0dac86ec767982d74d01f",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '326'
+      - '388'
     status:
       code: 200
       message: OK
@@ -634,7 +744,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -659,19 +769,20 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
-        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
-        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
-        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
+        "authorTime": "2021-11-27T09:52:03.340389Z", "commitTime": "2021-11-27T09:52:03.340389Z",
+        "committer": "", "hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '605'
+      - '731'
     status:
       code: 200
       message: OK
@@ -690,7 +801,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -712,19 +823,19 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76&endHash=e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a&endHash=48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T19:04:15.495030Z", "commitTime": "2021-11-17T19:04:15.495030Z",
-        "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '326'
+      - '390'
     status:
       code: 200
       message: OK
@@ -743,7 +854,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -768,19 +879,20 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
-        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
-        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
-        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
+        "authorTime": "2021-11-27T09:52:03.340389Z", "commitTime": "2021-11-27T09:52:03.340389Z",
+        "committer": "", "hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '605'
+      - '731'
     status:
       code: 200
       message: OK
@@ -799,7 +911,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -824,16 +936,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user1%27
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user1", "authorTime":
-        "2021-11-17T19:04:15.495030Z", "commitTime": "2021-11-17T19:04:15.495030Z",
-        "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '326'
+      - '390'
     status:
       code: 200
       message: OK
@@ -852,7 +964,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -877,16 +989,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author%3D%3D%27nessie_user2%27
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
-        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
-        "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
+        "authorTime": "2021-11-27T09:52:03.340389Z", "commitTime": "2021-11-27T09:52:03.340389Z",
+        "committer": "", "hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '328'
+      - '390'
     status:
       code: 200
       message: OK
@@ -905,7 +1017,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -930,19 +1042,20 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28commit.author%3D%3D%27nessie_user2%27+%7C%7C+commit.author%3D%3D%27nessie_user1%27%29
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
-        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
-        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
-        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
+        "authorTime": "2021-11-27T09:52:03.340389Z", "commitTime": "2021-11-27T09:52:03.340389Z",
+        "committer": "", "hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '605'
+      - '731'
     status:
       code: 200
       message: OK
@@ -961,7 +1074,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -986,19 +1099,20 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.committer%3D%3D%27%27
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
-        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
-        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
-        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
+        "authorTime": "2021-11-27T09:52:03.340389Z", "commitTime": "2021-11-27T09:52:03.340389Z",
+        "committer": "", "hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '605'
+      - '731'
     status:
       code: 200
       message: OK
@@ -1017,7 +1131,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1042,16 +1156,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=commit.author+%3D%3D+%27nessie_user2%27+%7C%7C+commit.author+%3D%3D+%27non_existing%27
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
-        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
-        "message": "delete_message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
+        "authorTime": "2021-11-27T09:52:03.340389Z", "commitTime": "2021-11-27T09:52:03.340389Z",
+        "committer": "", "hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '328'
+      - '390'
     status:
       code: 200
       message: OK
@@ -1070,7 +1184,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
+      string: '{"hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1095,19 +1209,20 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?query_expression=%28timestamp%28commit.commitTime%29+%3E+timestamp%28%272001-01-01T00%3A00%3A00%2B00%3A00%27%29+%26%26+timestamp%28commit.commitTime%29+%3C+timestamp%28%272999-12-30T23%3A00%3A00%2B00%3A00%27%29%29
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie_user2", "authorTime":
-        "2021-11-17T19:04:15.636684Z", "commitTime": "2021-11-17T19:04:15.636684Z",
-        "committer": "", "hash": "f4d147b355365c5b5cfb57f360c422688922e93bfde5f668ddc36f1b7af3ab76",
-        "message": "delete_message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie_user1", "authorTime": "2021-11-17T19:04:15.495030Z", "commitTime":
-        "2021-11-17T19:04:15.495030Z", "committer": "", "hash": "e978e7d63f35941cf6504d55fd918b4957a58fae51900e2890310d700481d080",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
+        "authorTime": "2021-11-27T09:52:03.340389Z", "commitTime": "2021-11-27T09:52:03.340389Z",
+        "committer": "", "hash": "ca5936d8addce7e06aa0c2e2d76d1e75773414073b2458228242166be9d4489a",
+        "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2021-11-27T09:52:03.118392Z", "commitTime": "2021-11-27T09:52:03.118392Z",
+        "committer": "", "hash": "48403b4755ce1051bd66461acaa1aa7733b435f6d0c42d94ea06b765c5848a7a",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '605'
+      - '731'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
+      string: '{"hash": "e76d7e66713417f9145aeb78d500e1aefc7017b2fd7113f989294b32965a55ea",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
+        "name": "main", "type": "BRANCH"}, {"hash": "e76d7e66713417f9145aeb78d500e1aefc7017b2fd7113f989294b32965a55ea",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -231,7 +231,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
+      string: '{"hash": "e76d7e66713417f9145aeb78d500e1aefc7017b2fd7113f989294b32965a55ea",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -242,7 +242,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromHash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
+    body: '{"fromHash": "e76d7e66713417f9145aeb78d500e1aefc7017b2fd7113f989294b32965a55ea",
       "fromRefName": "dev"}'
     headers:
       Accept:
@@ -281,8 +281,8 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
-        "name": "main", "type": "BRANCH"}, {"hash": "780c1096452c0da30b4a8db387a88871e44e3d51a065cd0441050155ae1859e4",
+      string: '{"hasMore": false, "references": [{"hash": "e76d7e66713417f9145aeb78d500e1aefc7017b2fd7113f989294b32965a55ea",
+        "name": "main", "type": "BRANCH"}, {"hash": "e76d7e66713417f9145aeb78d500e1aefc7017b2fd7113f989294b32965a55ea",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "58e66cab98730b2a41d905a2f698e1e5390d79a24492144ea2437dd1bae809b6",
+      string: '{"hash": "c0d9d2da80e0e4ff51a59bc8684fd7e94ca79db7f111baf7f8b7cce49d97e0c2",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "58e66cab98730b2a41d905a2f698e1e5390d79a24492144ea2437dd1bae809b6",
+        "name": "main", "type": "BRANCH"}, {"hash": "c0d9d2da80e0e4ff51a59bc8684fd7e94ca79db7f111baf7f8b7cce49d97e0c2",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=58e66cab98730b2a41d905a2f698e1e5390d79a24492144ea2437dd1bae809b6
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=c0d9d2da80e0e4ff51a59bc8684fd7e94ca79db7f111baf7f8b7cce49d97e0c2
   response:
     body:
-      string: '{"hash": "f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc",
+      string: '{"hash": "97960cb544a65532b42ed27ec0827eca6d59a9f2b637cab679c882e30897f3cd",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc",
+        "name": "main", "type": "BRANCH"}, {"hash": "97960cb544a65532b42ed27ec0827eca6d59a9f2b637cab679c882e30897f3cd",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -324,10 +324,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=97960cb544a65532b42ed27ec0827eca6d59a9f2b637cab679c882e30897f3cd
   response:
     body:
-      string: '{"hash": "f39003e5b714aacdc3b51e69da60e469acff78fc29a4173b17878e7041e5c51b",
+      string: '{"hash": "30b46660c53bbfea67891562a15eabdfc7c74c37e222f788a8e9c6dc07a7fd73",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -353,7 +353,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "f39003e5b714aacdc3b51e69da60e469acff78fc29a4173b17878e7041e5c51b",
+        "name": "main", "type": "BRANCH"}, {"hash": "30b46660c53bbfea67891562a15eabdfc7c74c37e222f788a8e9c6dc07a7fd73",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -378,22 +378,24 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T19:04:17.365700Z", "commitTime": "2021-11-17T19:04:17.365700Z",
-        "committer": "", "hash": "f39003e5b714aacdc3b51e69da60e469acff78fc29a4173b17878e7041e5c51b",
-        "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T19:04:17.324291Z", "commitTime":
-        "2021-11-17T19:04:17.324291Z", "committer": "", "hash": "f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc",
-        "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T19:04:17.286464Z", "commitTime":
-        "2021-11-17T19:04:17.286464Z", "committer": "", "hash": "58e66cab98730b2a41d905a2f698e1e5390d79a24492144ea2437dd1bae809b6",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie
+        test", "authorTime": "2021-11-27T09:52:05.163747Z", "commitTime": "2021-11-27T09:52:05.163747Z",
+        "committer": "", "hash": "30b46660c53bbfea67891562a15eabdfc7c74c37e222f788a8e9c6dc07a7fd73",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie test",
+        "authorTime": "2021-11-27T09:52:05.098707Z", "commitTime": "2021-11-27T09:52:05.098707Z",
+        "committer": "", "hash": "97960cb544a65532b42ed27ec0827eca6d59a9f2b637cab679c882e30897f3cd",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie test",
+        "authorTime": "2021-11-27T09:52:05.059746Z", "commitTime": "2021-11-27T09:52:05.059746Z",
+        "committer": "", "hash": "c0d9d2da80e0e4ff51a59bc8684fd7e94ca79db7f111baf7f8b7cce49d97e0c2",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '877'
+      - '1063'
     status:
       code: 200
       message: OK
@@ -423,8 +425,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromRefName": "dev", "hashesToTransplant": ["f0aa0e8d17ce834d68c6628cf6a824e3172a0c9a68a85fc8cfa77612db3605cc",
-      "f39003e5b714aacdc3b51e69da60e469acff78fc29a4173b17878e7041e5c51b"]}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["97960cb544a65532b42ed27ec0827eca6d59a9f2b637cab679c882e30897f3cd",
+      "30b46660c53bbfea67891562a15eabdfc7c74c37e222f788a8e9c6dc07a7fd73"]}'
     headers:
       Accept:
       - '*/*'
@@ -462,7 +464,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "3070e3405a1180c6c7a2d57bec15c226f121eeb476d9c8fe784aca1c4f580875",
+      string: '{"hash": "d0c9c530b16bbcf8dfa24389feed898c9cf80699d2374bd0239c87a37ff55403",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -487,19 +489,20 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T19:04:17.365700Z", "commitTime": "2021-11-17T19:04:17.365700Z",
-        "committer": "", "hash": "3070e3405a1180c6c7a2d57bec15c226f121eeb476d9c8fe784aca1c4f580875",
-        "message": "test message", "properties": {}, "signedOffBy": null}, {"author":
-        "nessie test", "authorTime": "2021-11-17T19:04:17.324291Z", "commitTime":
-        "2021-11-17T19:04:17.324291Z", "committer": "", "hash": "4c735cb88b20d6b22374f5278d3997987d795825c4b5c08a1f23c848ede194d6",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie
+        test", "authorTime": "2021-11-27T09:52:05.163747Z", "commitTime": "2021-11-27T09:52:05.163747Z",
+        "committer": "", "hash": "d0c9c530b16bbcf8dfa24389feed898c9cf80699d2374bd0239c87a37ff55403",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie test",
+        "authorTime": "2021-11-27T09:52:05.098707Z", "commitTime": "2021-11-27T09:52:05.098707Z",
+        "committer": "", "hash": "93203af9a65dc2ba8670e2416314398206997ecfdf0e28c82f3f3bc2aab94979",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '601'
+      - '725'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_delete.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "f814e1e92b6921d6b3ac56d468ec562e97133557e439726e6fee5ed2fa39e1f1",
+      string: '{"hash": "66dc01a40d8bcb5cd9310905e2bdc2f09e757283953c28abee454199a17a5fca",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -206,7 +206,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "f814e1e92b6921d6b3ac56d468ec562e97133557e439726e6fee5ed2fa39e1f1",
+        "name": "main", "type": "BRANCH"}, {"hash": "66dc01a40d8bcb5cd9310905e2bdc2f09e757283953c28abee454199a17a5fca",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -235,10 +235,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=f814e1e92b6921d6b3ac56d468ec562e97133557e439726e6fee5ed2fa39e1f1
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_delete_dev/commit?expectedHash=66dc01a40d8bcb5cd9310905e2bdc2f09e757283953c28abee454199a17a5fca
   response:
     body:
-      string: '{"hash": "cd4bbbd6f5bb422c05ae02afe30150ad26a791de4248c7a3204afef9b36fc1a2",
+      string: '{"hash": "5285ad6444b088a58ce9c0358311784445af6ce86963198aa5df65f67fc4a187",
         "name": "contents_commit_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_no_expected_state.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "cd12f3af0a51e6d905c96d0106778e111f263a9d2de39cadfded6eec9996b654",
+      string: '{"hash": "43f421e50ae2583055405d9447f6eaec372b0ad19571a3dfb1d33ceb3333ee6d",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -182,7 +182,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "cd12f3af0a51e6d905c96d0106778e111f263a9d2de39cadfded6eec9996b654",
+        "name": "main", "type": "BRANCH"}, {"hash": "43f421e50ae2583055405d9447f6eaec372b0ad19571a3dfb1d33ceb3333ee6d",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -239,10 +239,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=cd12f3af0a51e6d905c96d0106778e111f263a9d2de39cadfded6eec9996b654
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_no__expected_state/commit?expectedHash=43f421e50ae2583055405d9447f6eaec372b0ad19571a3dfb1d33ceb3333ee6d
   response:
     body:
-      string: '{"hash": "89623127333753ebaf9b41ff58762ab0d4c77dbb387e4ab0fea187978d370345",
+      string: '{"hash": "02ddde87c82ceb7118794d47c6ed2498d10df04b2f4990b54ef2e04c317ba3a7",
         "name": "contents_commit_with_no__expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_edited_data.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c",
+      string: '{"hash": "51bf6c54e7f302b20b659adbd32fb9e59a030475b5cf283702079a0f8221796f",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -207,7 +207,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c",
+        "name": "main", "type": "BRANCH"}, {"hash": "51bf6c54e7f302b20b659adbd32fb9e59a030475b5cf283702079a0f8221796f",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -259,16 +259,16 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/content_commit_with_edited_data_dev/log
   response:
     body:
-      string: '{"hasMore": false, "operations": [{"author": "nessie test", "authorTime":
-        "2021-11-17T19:04:18.672511Z", "commitTime": "2021-11-17T19:04:18.672511Z",
-        "committer": "", "hash": "c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c",
-        "message": "test message", "properties": {}, "signedOffBy": null}], "token":
-        null}'
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie
+        test", "authorTime": "2021-11-27T09:52:06.612842Z", "commitTime": "2021-11-27T09:52:06.612842Z",
+        "committer": "", "hash": "51bf6c54e7f302b20b659adbd32fb9e59a030475b5cf283702079a0f8221796f",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '325'
+      - '387'
     status:
       code: 200
       message: OK
@@ -288,7 +288,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c",
+        "name": "main", "type": "BRANCH"}, {"hash": "51bf6c54e7f302b20b659adbd32fb9e59a030475b5cf283702079a0f8221796f",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}], "token":
         null}'
     headers:
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=c24799676bb1013677707777629d97beeffe56440cd8c00541f6cb466bea321c
+    uri: http://localhost:19120/api/v1/trees/branch/content_commit_with_edited_data_dev/commit?expectedHash=51bf6c54e7f302b20b659adbd32fb9e59a030475b5cf283702079a0f8221796f
   response:
     body:
-      string: '{"hash": "72251d96f792b92809840b335037049222749c18885a2e563bf36ad0e83c3b92",
+      string: '{"hash": "304b5e68609da14d042c73acf1d56d47b1968cb803a89f5478f6bc763c3fae7e",
         "name": "content_commit_with_edited_data_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_empty_content_delete.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "4ec97c0a869256ad611f5aa41bc1a3c46c86d28918cdc9c16decde730b7dea47",
+      string: '{"hash": "099191b78a1bf47ea4beeffe1d82ec4e07cfb1b64699367492d00e4a36fe0320",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -207,7 +207,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "4ec97c0a869256ad611f5aa41bc1a3c46c86d28918cdc9c16decde730b7dea47",
+        "name": "main", "type": "BRANCH"}, {"hash": "099191b78a1bf47ea4beeffe1d82ec4e07cfb1b64699367492d00e4a36fe0320",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}],
         "token": null}'
     headers:
@@ -263,10 +263,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=4ec97c0a869256ad611f5aa41bc1a3c46c86d28918cdc9c16decde730b7dea47
+    uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_empty_content_delete_dev/commit?expectedHash=099191b78a1bf47ea4beeffe1d82ec4e07cfb1b64699367492d00e4a36fe0320
   response:
     body:
-      string: '{"hash": "4348af730e504fda0225c572123eb6d6bfe5c83b7832cdd0d4f4d1bd32546be5",
+      string: '{"hash": "f62b91777075095c6b1f06ad30410953f60aeb2ea345a074a43927a6c8c426f2",
         "name": "contents_commit_with_empty_content_delete_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_commit_with_expected_state.yaml
@@ -156,7 +156,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_commit_with_expected_state/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "05e13d6c8fb630b14f3749ac6f75288096ebd96ea647c32a9c60cadbc0dd91a3",
+      string: '{"hash": "e72f433b5781ce1a533eab7225b4a7a1aee105d822df254b20353c6a6fa7ae47",
         "name": "contents_commit_with_expected_state", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -182,7 +182,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "05e13d6c8fb630b14f3749ac6f75288096ebd96ea647c32a9c60cadbc0dd91a3",
+        "name": "main", "type": "BRANCH"}, {"hash": "e72f433b5781ce1a533eab7225b4a7a1aee105d822df254b20353c6a6fa7ae47",
         "name": "contents_commit_with_expected_state", "type": "BRANCH"}], "token":
         null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "6586a987f5eccd0dc6979219e9c4161cfdfe804027e1d6da01f7d717788f2dde",
+      string: '{"hash": "169d0c7652a2965969843c0cdde8cb34d4c6535d6da02d2518bac072a440da89",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "6586a987f5eccd0dc6979219e9c4161cfdfe804027e1d6da01f7d717788f2dde",
+        "name": "main", "type": "BRANCH"}, {"hash": "169d0c7652a2965969843c0cdde8cb34d4c6535d6da02d2518bac072a440da89",
         "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=6586a987f5eccd0dc6979219e9c4161cfdfe804027e1d6da01f7d717788f2dde
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=169d0c7652a2965969843c0cdde8cb34d4c6535d6da02d2518bac072a440da89
   response:
     body:
-      string: '{"hash": "4c8d20f65efde54b2890c053b88173616962b075b07b70742d647023a7ea4ca1",
+      string: '{"hash": "ce300dbcda861589824e725c164dbdaab2ffb46ca618f4b8950d41561a0d6711",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "4c8d20f65efde54b2890c053b88173616962b075b07b70742d647023a7ea4ca1",
+        "name": "main", "type": "BRANCH"}, {"hash": "ce300dbcda861589824e725c164dbdaab2ffb46ca618f4b8950d41561a0d6711",
         "name": "contents_list_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -323,10 +323,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=4c8d20f65efde54b2890c053b88173616962b075b07b70742d647023a7ea4ca1
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=ce300dbcda861589824e725c164dbdaab2ffb46ca618f4b8950d41561a0d6711
   response:
     body:
-      string: '{"hash": "2d693c9921383e364b1ae1bb8b9e63ad03bada6073f34f427d3446b4eb0d61ba",
+      string: '{"hash": "858f610a05c8aaea55db9fef4960c7399f25ce910b5f66bf4666771040df708b",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "6dd7836bd5351cc08104042e53219073e623f75e904d248612b7f4b64a591725",
+      string: '{"hash": "412c729af2e3ec462a3f02a3efe92a108cf5865310e047aa51ad2bca286600a1",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -181,7 +181,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "6dd7836bd5351cc08104042e53219073e623f75e904d248612b7f4b64a591725",
+        "name": "main", "type": "BRANCH"}, {"hash": "412c729af2e3ec462a3f02a3efe92a108cf5865310e047aa51ad2bca286600a1",
         "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -238,10 +238,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=6dd7836bd5351cc08104042e53219073e623f75e904d248612b7f4b64a591725
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=412c729af2e3ec462a3f02a3efe92a108cf5865310e047aa51ad2bca286600a1
   response:
     body:
-      string: '{"hash": "e39bfc535da4921c7df5544daff5a60aee048adc06e6c01915cab48a72e891ad",
+      string: '{"hash": "b3b2b12e6fd5be797df9a2e3060f8f800da57c53531a017bbfde3c7481ca5cf0",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -267,7 +267,7 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "e39bfc535da4921c7df5544daff5a60aee048adc06e6c01915cab48a72e891ad",
+        "name": "main", "type": "BRANCH"}, {"hash": "b3b2b12e6fd5be797df9a2e3060f8f800da57c53531a017bbfde3c7481ca5cf0",
         "name": "contents_view_dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -323,10 +323,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=e39bfc535da4921c7df5544daff5a60aee048adc06e6c01915cab48a72e891ad
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=b3b2b12e6fd5be797df9a2e3060f8f800da57c53531a017bbfde3c7481ca5cf0
   response:
     body:
-      string: '{"hash": "efb623fbd451452240a2daf3f7dcb0408ba999f18248f7ad9ee470c1233d20c4",
+      string: '{"hash": "d70593ed0351b918113b707c9053dc0bafe3a8e4d4b014bca6d0f494b0566438",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractResteasyTest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractResteasyTest.java
@@ -211,7 +211,7 @@ public abstract class AbstractResteasyTest {
 
     LogResponse log =
         rest().get("trees/tree/test/log").then().statusCode(200).extract().as(LogResponse.class);
-    Assertions.assertEquals(3, log.getOperations().size());
+    Assertions.assertEquals(3, log.getLogEntries().size());
 
     Branch b1 = rest().get("trees/tree/test").as(Branch.class);
     rest()
@@ -334,10 +334,10 @@ public abstract class AbstractResteasyTest {
             .statusCode(200)
             .extract()
             .as(LogResponse.class);
-    assertThat(log.getOperations()).hasSize(numCommits);
+    assertThat(log.getLogEntries()).hasSize(numCommits);
     Instant firstCommitTime =
-        log.getOperations().get(log.getOperations().size() - 1).getCommitTime();
-    Instant lastCommitTime = log.getOperations().get(0).getCommitTime();
+        log.getLogEntries().get(log.getLogEntries().size() - 1).getCommitMeta().getCommitTime();
+    Instant lastCommitTime = log.getLogEntries().get(0).getCommitMeta().getCommitTime();
     assertThat(firstCommitTime).isNotNull();
     assertThat(lastCommitTime).isNotNull();
 
@@ -350,8 +350,8 @@ public abstract class AbstractResteasyTest {
             .statusCode(200)
             .extract()
             .as(LogResponse.class);
-    assertThat(log.getOperations()).hasSize(1);
-    assertThat(log.getOperations().get(0).getAuthor()).isEqualTo(author);
+    assertThat(log.getLogEntries()).hasSize(1);
+    assertThat(log.getLogEntries().get(0).getCommitMeta().getAuthor()).isEqualTo(author);
 
     log =
         rest()
@@ -363,9 +363,10 @@ public abstract class AbstractResteasyTest {
             .statusCode(200)
             .extract()
             .as(LogResponse.class);
-    assertThat(log.getOperations()).hasSize(numCommits - 1);
-    log.getOperations()
-        .forEach(commit -> assertThat(commit.getCommitTime()).isAfter(firstCommitTime));
+    assertThat(log.getLogEntries()).hasSize(numCommits - 1);
+    log.getLogEntries()
+        .forEach(
+            commit -> assertThat(commit.getCommitMeta().getCommitTime()).isAfter(firstCommitTime));
 
     log =
         rest()
@@ -377,9 +378,10 @@ public abstract class AbstractResteasyTest {
             .statusCode(200)
             .extract()
             .as(LogResponse.class);
-    assertThat(log.getOperations()).hasSize(numCommits - 1);
-    log.getOperations()
-        .forEach(commit -> assertThat(commit.getCommitTime()).isBefore(lastCommitTime));
+    assertThat(log.getLogEntries()).hasSize(numCommits - 1);
+    log.getLogEntries()
+        .forEach(
+            commit -> assertThat(commit.getCommitMeta().getCommitTime()).isBefore(lastCommitTime));
 
     log =
         rest()
@@ -393,8 +395,8 @@ public abstract class AbstractResteasyTest {
             .statusCode(200)
             .extract()
             .as(LogResponse.class);
-    assertThat(log.getOperations()).hasSize(1);
-    assertThat(log.getOperations().get(0).getCommitTime())
+    assertThat(log.getLogEntries()).hasSize(1);
+    assertThat(log.getLogEntries().get(0).getCommitMeta().getCommitTime())
         .isBefore(lastCommitTime)
         .isAfter(firstCommitTime);
   }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -37,6 +37,7 @@ import org.projectnessie.model.EntriesResponse.Entry;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableDelete;
 import org.projectnessie.model.ImmutableOperations;
+import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Operation.Delete;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Reference;
@@ -252,12 +253,12 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   private void getCommitLog(String branchName, String role, boolean shouldFail)
       throws NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> api().getCommitLog().refName(branchName).get().getOperations())
+      assertThatThrownBy(() -> api().getCommitLog().refName(branchName).get().getLogEntries())
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(
               String.format("'LIST_COMMIT_LOG' is not allowed for role '%s' on reference", role));
     } else {
-      List<CommitMeta> commits = api().getCommitLog().refName(branchName).get().getOperations();
+      List<LogEntry> commits = api().getCommitLog().refName(branchName).get().getLogEntries();
       assertThat(commits).isNotEmpty();
     }
   }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -53,12 +53,13 @@ import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.ImmutableBranch;
+import org.projectnessie.model.ImmutableLogEntry;
 import org.projectnessie.model.ImmutableLogResponse;
 import org.projectnessie.model.ImmutableReferenceMetadata;
-import org.projectnessie.model.ImmutableReferenceMetadata.Builder;
 import org.projectnessie.model.ImmutableReferencesResponse;
 import org.projectnessie.model.ImmutableTag;
 import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Merge;
 import org.projectnessie.model.Operation;
 import org.projectnessie.model.Operations;
@@ -70,6 +71,7 @@ import org.projectnessie.model.Transplant;
 import org.projectnessie.services.authz.AccessChecker;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.Delete;
 import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.GetNamedRefsParams.RetrieveOptions;
@@ -218,25 +220,56 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
                 namedRef, null == params.pageToken() ? params.endHash() : params.pageToken())
             .getHash();
 
-    try (Stream<WithHash<CommitMeta>> commits = getStore().getCommits(endRef)) {
-      Stream<CommitMeta> s =
+    try (Stream<Commit<CommitMeta, Content>> commits =
+        getStore().getCommits(endRef, params.isFetchAdditionalInfo())) {
+      Stream<LogEntry> logEntries =
+          commits.map(
+              commit -> {
+                CommitMeta commitMetaWithHash =
+                    addHashToCommitMeta(commit.getHash(), commit.getCommitMeta());
+                ImmutableLogEntry.Builder logEntry = LogEntry.builder();
+                logEntry.commitMeta(commitMetaWithHash);
+                if (params.isFetchAdditionalInfo()) {
+                  if (commit.getParentHash() != null) {
+                    logEntry.parentCommitHash(commit.getParentHash().asString());
+                  }
+                  commit
+                      .getOperations()
+                      .forEach(
+                          op -> {
+                            ContentKey key = ContentKey.of(op.getKey().getElements());
+                            if (op instanceof Put) {
+                              Content content = ((Put<Content>) op).getValue();
+                              logEntry.addOperations(Operation.Put.of(key, content));
+                            }
+                            if (op instanceof Delete) {
+                              logEntry.addOperations(Operation.Delete.of(key));
+                            }
+                          });
+                }
+                return logEntry.build();
+              });
+
+      logEntries =
           StreamSupport.stream(
               StreamUtil.takeUntilIncl(
-                  commits
-                      .map(cwh -> addHashToCommitMeta(cwh.getHash(), cwh.getValue()))
-                      .spliterator(),
-                  x -> x.getHash().equals(params.startHash())),
+                  logEntries.spliterator(),
+                  x -> x.getCommitMeta().getHash().equals(params.startHash())),
               false);
-      List<CommitMeta> items =
-          filterCommitLog(s, params.queryExpression()).limit(max + 1).collect(Collectors.toList());
+
+      List<LogEntry> items =
+          filterCommitLog(logEntries, params.queryExpression())
+              .limit(max + 1)
+              .collect(Collectors.toList());
+
       if (items.size() == max + 1) {
         return ImmutableLogResponse.builder()
-            .addAllOperations(items.subList(0, max))
+            .addAllLogEntries(items.subList(0, max))
             .isHasMore(true)
-            .token(items.get(max).getHash())
+            .token(items.get(max).getCommitMeta().getHash())
             .build();
       }
-      return ImmutableLogResponse.builder().addAllOperations(items).build();
+      return ImmutableLogResponse.builder().addAllLogEntries(items).build();
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     }
@@ -249,13 +282,13 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
   /**
    * Applies different filters to the {@link Stream} of commits based on the query expression.
    *
-   * @param commits The commit log that different filters will be applied to
+   * @param logEntries The commit log that different filters will be applied to
    * @param queryExpression The query expression to filter by
    * @return A potentially filtered {@link Stream} of commits based on the query expression
    */
-  private Stream<CommitMeta> filterCommitLog(Stream<CommitMeta> commits, String queryExpression) {
+  private Stream<LogEntry> filterCommitLog(Stream<LogEntry> logEntries, String queryExpression) {
     if (Strings.isNullOrEmpty(queryExpression)) {
-      return commits;
+      return logEntries;
     }
 
     final Script script;
@@ -270,10 +303,11 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
     } catch (ScriptException e) {
       throw new IllegalArgumentException(e);
     }
-    return commits.filter(
-        commit -> {
+    return logEntries.filter(
+        logEntry -> {
           try {
-            return script.execute(Boolean.class, ImmutableMap.of("commit", commit));
+            return script.execute(
+                Boolean.class, ImmutableMap.of("commit", logEntry.getCommitMeta()));
           } catch (ScriptException e) {
             throw new RuntimeException(e);
           }
@@ -536,7 +570,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
 
   @Nullable
   private static ReferenceMetadata extractReferenceMetadata(ReferenceInfo<CommitMeta> refWithHash) {
-    Builder builder = ImmutableReferenceMetadata.builder();
+    ImmutableReferenceMetadata.Builder builder = ImmutableReferenceMetadata.builder();
     boolean found = false;
     if (null != refWithHash.getAheadBehind()) {
       found = true;

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -182,6 +182,11 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
     return content instanceof IcebergTable;
   }
 
+  @Override
+  public boolean requiresGlobalState(Type type) {
+    return type == Type.ICEBERG_TABLE;
+  }
+
   private static ObjectTypes.Content parse(ByteString onReferenceValue) {
     try {
       return ObjectTypes.Content.parseFrom(onReferenceValue);

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
@@ -58,7 +58,7 @@ class ITGenerateContent {
                   }))
           .isEqualTo(0);
 
-      assertThat(api.getCommitLog().refName(testCaseBranch).get().getOperations())
+      assertThat(api.getCommitLog().refName(testCaseBranch).get().getLogEntries())
           .hasSize(numCommits);
     }
   }

--- a/ui/src/Explore/CommitDetails.test.tsx
+++ b/ui/src/Explore/CommitDetails.test.tsx
@@ -22,20 +22,22 @@ import CommitDetails from "./CommitDetails";
 it("Commit details renders", async () => {
   const now = new Date();
   now.setDate(now.getDate() - 1);
-  const commitMeta = {
-    hash: "deadbeef",
-    author: "bob",
-    commitTime: now,
-    authorTime: now,
-    committer: "sally",
-    message: "commitMessage",
-    properties: { a: "b", c: "d" },
+  const logEntry = {
+    commitMeta: {
+      hash: "deadbeef",
+      author: "bob",
+      commitTime: now,
+      authorTime: now,
+      committer: "sally",
+      message: "commitMessage",
+      properties: { a: "b", c: "d" },
+    },
   };
 
   const { getByText, asFragment } = render(
     <React.StrictMode>
       <BrowserRouter>
-        <CommitDetails currentRef={"main"} commitDetails={commitMeta} />
+        <CommitDetails currentRef={"main"} commitDetails={logEntry} />
       </BrowserRouter>
     </React.StrictMode>
   );

--- a/ui/src/Explore/CommitDetails.tsx
+++ b/ui/src/Explore/CommitDetails.tsx
@@ -17,12 +17,12 @@
 import { Card } from "react-bootstrap";
 import moment from "moment";
 import React, { Fragment } from "react";
-import { CommitMeta } from "../utils";
+import { LogEntry } from "../utils";
 import "./CommitDetails.css";
 import { EmptyMessageView } from "./Components";
 
 const CommitDetails = (props: {
-  commitDetails: CommitMeta | undefined;
+  commitDetails: LogEntry | undefined;
   currentRef: string;
 }): React.ReactElement => {
   const { commitDetails, currentRef } = props;
@@ -38,7 +38,7 @@ const CommitDetails = (props: {
       hash,
       committer,
       commitTime,
-    } = commitDetails;
+    } = commitDetails.commitMeta;
     const additionalProperties =
       properties &&
       Object.keys(properties)

--- a/ui/src/Explore/CommitHeader.test.tsx
+++ b/ui/src/Explore/CommitHeader.test.tsx
@@ -24,17 +24,19 @@ import nock from "nock";
 it("CommitHeader renders", async () => {
   const now = new Date();
   now.setDate(now.getDate() - 1);
-  const commitMeta = {
-    hash: "deadbeef",
-    author: "bob",
-    commitTime: now,
-    committer: "sally",
-    message: "commitMessage",
-    properties: { a: "b", c: "d" },
+  const logEntry = {
+    commitMeta: {
+      hash: "deadbeef",
+      author: "bob",
+      commitTime: now,
+      committer: "sally",
+      message: "commitMessage",
+      properties: { a: "b", c: "d" },
+    },
   };
   const scope = nock("http://localhost/api/v1")
     .get("/trees/tree/main/log")
-    .reply(200, { token: "foo", operations: [commitMeta] });
+    .reply(200, { token: "foo", logEntries: [logEntry] });
 
   const { getByText, asFragment } = render(
     <React.StrictMode>

--- a/ui/src/Explore/CommitLog.test.tsx
+++ b/ui/src/Explore/CommitLog.test.tsx
@@ -25,17 +25,19 @@ import { createMemoryHistory } from "history";
 it("Commit log renders", async () => {
   const now = new Date();
   now.setDate(now.getDate() - 1);
-  const commitMeta = {
-    hash: "deadbeef",
-    author: "bob",
-    commitTime: now,
-    committer: "sally",
-    message: "commitMessage",
-    properties: { a: "b", c: "d" },
+  const logEntry = {
+    commitMeta: {
+      hash: "deadbeef",
+      author: "bob",
+      commitTime: now,
+      committer: "sally",
+      message: "commitMessage",
+      properties: { a: "b", c: "d" },
+    },
   };
   const scope1 = nock("http://localhost/api/v1")
     .get("/trees/tree/main/log?max=10")
-    .reply(200, { token: "foo", operations: [commitMeta] });
+    .reply(200, { token: "foo", logEntries: [logEntry] });
 
   const { getByText, asFragment } = render(
     <React.StrictMode>

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -267,4 +267,14 @@ public interface DatabaseAdapter {
    */
   Stream<ContentIdAndBytes> globalContent(
       Set<ContentId> keys, ToIntFunction<ByteString> contentTypeExtractor);
+
+  /**
+   * Retrieves the global content for the given contents-id.
+   *
+   * @param contentId contents-id to retrieve the global content for
+   * @param contentTypeExtractor function to extract the content-type
+   * @return global content, if present or an empty optional, never {@code null}.
+   */
+  Optional<ContentIdAndBytes> globalContent(
+      ContentId contentId, ToIntFunction<ByteString> contentTypeExtractor);
 }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.Delete;
 import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
@@ -207,7 +208,7 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
     }
 
     // Verify that all commits are there and that the order of the commits is correct
-    List<String> committedValues = commitsList(branch, s -> s.map(WithHash::getValue));
+    List<String> committedValues = commitsList(branch, s -> s.map(Commit::getCommitMeta), false);
     Collections.reverse(expectedValues);
     assertEquals(expectedValues, committedValues);
   }
@@ -420,13 +421,14 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
         // getCommits()
         new ReferenceNotFoundFunction("getCommits/branch")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.getCommits(BranchName.of("this-one-should-not-exist"))),
+            .function(s -> s.getCommits(BranchName.of("this-one-should-not-exist"), false)),
         new ReferenceNotFoundFunction("getCommits/tag")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.getCommits(TagName.of("this-one-should-not-exist"))),
+            .function(s -> s.getCommits(TagName.of("this-one-should-not-exist"), false)),
         new ReferenceNotFoundFunction("getCommits/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
-            .function(s -> s.getCommits(Hash.of("12341234123412341234123412341234123412341234"))),
+            .function(
+                s -> s.getCommits(Hash.of("12341234123412341234123412341234123412341234"), false)),
         // getValue()
         new ReferenceNotFoundFunction("getValue/branch")
             .msg("Named reference 'this-one-should-not-exist' not found")
@@ -586,7 +588,7 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
           ReferenceConflictException {
     BranchName main = BranchName.of("main");
     WithHash<Ref> mainRef = store.toRef(main.getName());
-    assertThat(store().getCommits(main)).isEmpty();
+    assertThat(store().getCommits(main, false)).isEmpty();
     try (Stream<ReferenceInfo<String>> refs = store().getNamedRefs(GetNamedRefsParams.DEFAULT)) {
       assertThat(refs).extracting(r -> r.getNamedRef().getName()).containsExactly(main.getName());
     }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Commit.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Commit.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface Commit<METADATA, VALUE> {
+  static <METADATA, VALUE> ImmutableCommit.Builder<METADATA, VALUE> builder() {
+    return ImmutableCommit.builder();
+  }
+
+  Hash getHash();
+
+  METADATA getCommitMeta();
+
+  @Nullable
+  Hash getParentHash();
+
+  @Nullable
+  List<Operation<VALUE>> getOperations();
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -139,8 +139,9 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
-  public Stream<WithHash<METADATA>> getCommits(Ref ref) throws ReferenceNotFoundException {
-    return delegateStream1Ex("getcommits", () -> delegate.getCommits(ref));
+  public Stream<Commit<METADATA, VALUE>> getCommits(Ref ref, boolean fetchAdditionalInfo)
+      throws ReferenceNotFoundException {
+    return delegateStream1Ex("getcommits", () -> delegate.getCommits(ref, fetchAdditionalInfo));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
@@ -39,6 +39,8 @@ public interface StoreWorker<CONTENT, COMMIT_METADATA, CONTENT_TYPE extends Enum
 
   boolean requiresGlobalState(CONTENT content);
 
+  boolean requiresGlobalState(CONTENT_TYPE contentType);
+
   CONTENT_TYPE getType(Byte payload);
 
   default CONTENT_TYPE getType(CONTENT content) {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -180,9 +180,12 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
-  public Stream<WithHash<METADATA>> getCommits(Ref ref) throws ReferenceNotFoundException {
+  public Stream<Commit<METADATA, VALUE>> getCommits(Ref ref, boolean fetchAdditionalInfo)
+      throws ReferenceNotFoundException {
     return callStreamWithOneException(
-        "GetCommits", b -> b.withTag(TAG_REF, safeToString(ref)), () -> delegate.getCommits(ref));
+        "GetCommits",
+        b -> b.withTag(TAG_REF, safeToString(ref)),
+        () -> delegate.getCommits(ref, fetchAdditionalInfo));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -227,10 +227,12 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * Get a stream of all ancestor commits to a provided ref.
    *
    * @param ref the stream to get commits for.
+   * @param fetchAdditionalInfo include additional information like operations and parent hash
    * @return A stream of commits.
    * @throws ReferenceNotFoundException if {@code ref} is not present in the store
    */
-  Stream<WithHash<METADATA>> getCommits(Ref ref) throws ReferenceNotFoundException;
+  Stream<Commit<METADATA, VALUE>> getCommits(Ref ref, boolean fetchAdditionalInfo)
+      throws ReferenceNotFoundException;
 
   /**
    * Get a stream of all available keys for the given ref.

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -143,11 +143,11 @@ class TestMetricsVersionStore {
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(
                 "getcommits",
-                vs -> vs.getCommits(BranchName.of("mock-branch")),
+                vs -> vs.getCommits(BranchName.of("mock-branch"), false),
                 () ->
                     Stream.of(
-                        WithHash.of(Hash.of("cafebabe"), "log#1"),
-                        WithHash.of(Hash.of("deadbeef"), "log#2")),
+                        Commit.builder().hash(Hash.of("cafebabe")).commitMeta("log#1").build(),
+                        Commit.builder().hash(Hash.of("deadbeef")).commitMeta("log#2").build()),
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "getkeys",

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -161,11 +161,17 @@ class TestTracingVersionStore {
                         "GetCommits", refNotFoundThrows)
                     .tag("nessie.version-store.ref", "BranchName{name=mock-branch}")
                     .function(
-                        vs -> vs.getCommits(BranchName.of("mock-branch")),
+                        vs -> vs.getCommits(BranchName.of("mock-branch"), false),
                         () ->
                             Stream.of(
-                                WithHash.of(Hash.of("cafebabe"), "log#1"),
-                                WithHash.of(Hash.of("deadbeef"), "log#2"))),
+                                Commit.builder()
+                                    .hash(Hash.of("cafebabe"))
+                                    .commitMeta("log#1")
+                                    .build(),
+                                Commit.builder()
+                                    .hash(Hash.of("deadbeef"))
+                                    .commitMeta("log#2")
+                                    .build())),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "GetKeys", refNotFoundThrows)
                     .tag("nessie.version-store.ref", "Hash cafe4242")

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/StringStoreWorker.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/StringStoreWorker.java
@@ -106,6 +106,11 @@ public final class StringStoreWorker implements StoreWorker<String, String, Test
   }
 
   @Override
+  public boolean requiresGlobalState(TestEnum testEnum) {
+    return true;
+  }
+
+  @Override
   public Serializer<String> getMetadataSerializer() {
     return METADATA;
   }


### PR DESCRIPTION
Allows to optionally return additional information from the commit log.

The `LogResponse` type has been changed to contain a list of `LogEntry` elements, which contain a `CommitMeta` and, if requested, also the operations (`Put` or `Delete`) of each commit.

The Python CLI behaves as it currently does. The `nessie log` command got a new flag to retrieve and show the additional information.

* Adds new parameter `fetchAdditionalInfo` to commit-log REST endpoint.
* Changes return type of commit-log REST endpoint, returns a list of `LogEntry`
  that contains the `CommitMeta` plus the optionally fetched list of operations.
* Adds a `--extended` flag to Nessie CLI's `log` command to include the additional
  information. Behaves exactly as before without the `--extended` flag.
