### PR TITLE
Use `hashOnReference()` instead of `getNamedRef().getHash()`

### DIFF
--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -40,7 +40,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.Operation;
@@ -194,7 +193,7 @@ public class CommitBench {
           "initial commit meta " + Thread.currentThread().getId(),
           initialOperations(bp, keys, contentIds));
 
-      Hash hash = bp.versionStore.getNamedRef(bp.branch, GetNamedRefsParams.DEFAULT).getHash();
+      Hash hash = bp.versionStore.hashOnReference(bp.branch, Optional.empty());
 
       bp.versionStore.create(branch, Optional.of(hash));
     }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceConflictException;
@@ -307,7 +306,7 @@ public abstract class AbstractCommitScenarios {
     for (int commitNum = 0; commitNum < 3; commitNum++) {
       Map<Key, ContentAndState<ByteString>> values =
           databaseAdapter.values(
-              databaseAdapter.namedRef(branch, GetNamedRefsParams.DEFAULT).getHash(),
+              databaseAdapter.hashOnReference(branch, Optional.empty()),
               keys,
               KeyFilterPredicate.ALLOW_ALL);
       commit =

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceConflictException;
@@ -167,9 +166,7 @@ public abstract class AbstractConcurrency {
                   List<ByteString> currentStates =
                       databaseAdapter
                           .values(
-                              databaseAdapter
-                                  .namedRef(branch, GetNamedRefsParams.DEFAULT)
-                                  .getHash(),
+                              databaseAdapter.hashOnReference(branch, Optional.empty()),
                               keys,
                               KeyFilterPredicate.ALLOW_ALL)
                           .values()
@@ -222,8 +219,7 @@ public abstract class AbstractConcurrency {
       for (Entry<BranchName, Set<Key>> branchKeys : keysPerBranch.entrySet()) {
         BranchName branch = branchKeys.getKey();
         databaseAdapter.create(
-            branch,
-            databaseAdapter.namedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT).getHash());
+            branch, databaseAdapter.hashOnReference(BranchName.of("main"), Optional.empty()));
         ImmutableCommitAttempt.Builder commitAttempt =
             ImmutableCommitAttempt.builder()
                 .commitToBranch(branchKeys.getKey())
@@ -255,7 +251,7 @@ public abstract class AbstractConcurrency {
 
       for (Entry<BranchName, Set<Key>> branchKeys : keysPerBranch.entrySet()) {
         BranchName branch = branchKeys.getKey();
-        Hash hash = databaseAdapter.namedRef(branch, GetNamedRefsParams.DEFAULT).getHash();
+        Hash hash = databaseAdapter.hashOnReference(branch, Optional.empty());
         Map<Key, ByteString> onRef = onRefStates.get(branch);
         ArrayList<Key> keys = new ArrayList<>(branchKeys.getValue());
         Map<Key, ContentAndState<ByteString>> values =

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
@@ -69,8 +69,7 @@ public abstract class AbstractGetNamedReferences {
 
     Hash hash = databaseAdapter.noAncestorHash();
 
-    assertThat(databaseAdapter.namedRef(main, GetNamedRefsParams.DEFAULT).getHash())
-        .isEqualTo(hash);
+    assertThat(databaseAdapter.hashOnReference(main, Optional.empty())).isEqualTo(hash);
 
     databaseAdapter.create(parameterValidation, hash);
     databaseAdapter.create(parameterValidationTag, hash);
@@ -158,8 +157,7 @@ public abstract class AbstractGetNamedReferences {
 
     Hash hash = databaseAdapter.noAncestorHash();
 
-    assertThat(databaseAdapter.namedRef(main, GetNamedRefsParams.DEFAULT).getHash())
-        .isEqualTo(hash);
+    assertThat(databaseAdapter.hashOnReference(main, Optional.empty())).isEqualTo(hash);
 
     databaseAdapter.create(parameterValidation, hash);
     databaseAdapter.create(parameterValidationTag, hash);
@@ -283,8 +281,7 @@ public abstract class AbstractGetNamedReferences {
     Hash mainHash = hash;
     Hash branchHash = hash;
 
-    assertThat(databaseAdapter.namedRef(main, GetNamedRefsParams.DEFAULT).getHash())
-        .isEqualTo(hash);
+    assertThat(databaseAdapter.hashOnReference(main, Optional.empty())).isEqualTo(hash);
 
     // Have 'main' + a branch + a tag
     //  all point to the "no ancestor" hash (aka "beginning of time")

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGlobalStates.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGlobalStates.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceConflictException;
@@ -176,9 +175,8 @@ public abstract class AbstractGlobalStates {
                             () ->
                                 databaseAdapter.create(
                                     b,
-                                    databaseAdapter
-                                        .namedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT)
-                                        .getHash()))));
+                                    databaseAdapter.hashOnReference(
+                                        BranchName.of("main"), Optional.empty())))));
     Map<ContentId, ByteString> currentStates = new HashMap<>();
     Set<Key> keys =
         IntStream.range(0, param.tables)
@@ -261,7 +259,7 @@ public abstract class AbstractGlobalStates {
   void commitCheckGlobalStateMismatches() throws Exception {
     BranchName branch = BranchName.of("main");
 
-    Hash branchInitial = databaseAdapter.namedRef(branch, GetNamedRefsParams.DEFAULT).getHash();
+    Hash branchInitial = databaseAdapter.hashOnReference(branch, Optional.empty());
 
     databaseAdapter.commit(
         ImmutableCommitAttempt.builder()

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceNotFoundException;
@@ -63,8 +62,7 @@ public abstract class AbstractManyCommits {
   void manyCommits(int numCommits) throws Exception {
     BranchName branch = BranchName.of("manyCommits-" + numCommits);
     databaseAdapter.create(
-        branch,
-        databaseAdapter.namedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT).getHash());
+        branch, databaseAdapter.hashOnReference(BranchName.of("main"), Optional.empty()));
 
     Hash[] commits = new Hash[numCommits];
 
@@ -103,8 +101,7 @@ public abstract class AbstractManyCommits {
     }
 
     try (Stream<CommitLogEntry> log =
-        databaseAdapter.commitLog(
-            databaseAdapter.namedRef(branch, GetNamedRefsParams.DEFAULT).getHash())) {
+        databaseAdapter.commitLog(databaseAdapter.hashOnReference(branch, Optional.empty()))) {
       assertThat(log.count()).isEqualTo(numCommits);
     }
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -21,6 +21,7 @@ import com.google.protobuf.ByteString;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -29,7 +30,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.persist.adapter.ContentId;
@@ -118,7 +118,7 @@ public abstract class AbstractManyKeys {
       databaseAdapter.commit(commit.build());
     }
 
-    Hash mainHead = databaseAdapter.namedRef(main, GetNamedRefsParams.DEFAULT).getHash();
+    Hash mainHead = databaseAdapter.hashOnReference(main, Optional.empty());
     try (Stream<KeyWithType> keys = databaseAdapter.keys(mainHead, KeyFilterPredicate.ALLOW_ALL)) {
       List<Key> fetchedKeys = keys.map(KeyWithType::getKey).collect(Collectors.toList());
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
@@ -193,7 +193,7 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
           commitHash = store().commit(branch, Optional.of(hashKnownByUser), msg, ops);
         } catch (ReferenceConflictException inconsistentValueException) {
           if (param.allowInconsistentValueException) {
-            hashKnownByUser = store().getNamedRef(branch, GetNamedRefsParams.DEFAULT).getHash();
+            hashKnownByUser = store().hashOnReference(branch, Optional.empty());
             commitHash = store().commit(branch, Optional.of(hashKnownByUser), msg, ops);
           } else {
             throw inconsistentValueException;
@@ -530,9 +530,7 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
                     s.transplant(
                         BranchName.of("this-one-should-not-exist"),
                         Optional.empty(),
-                        singletonList(
-                            s.getNamedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT)
-                                .getHash()))),
+                        singletonList(s.hashOnReference(BranchName.of("main"), Optional.empty())))),
         new ReferenceNotFoundFunction("transplant/hash/empty")
             .msg(
                 "Could not find commit '12341234123412341234123412341234123412341234' in reference 'main'.")

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/CommitBuilder.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/CommitBuilder.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Delete;
-import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.Operation;
@@ -170,10 +169,10 @@ public class CommitBuilder<ValueT, MetadataT, EnumT extends Enum<EnumT>> {
       throws ReferenceNotFoundException, ReferenceConflictException {
     Optional<Hash> reference =
         fromLatest
-            ? Optional.of(store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash())
+            ? Optional.of(store.hashOnReference(branchName, Optional.empty()))
             : referenceHash;
     Hash commitHash = store.commit(branchName, reference, metadata, operations);
-    Hash storeHash = store.getNamedRef(branchName, GetNamedRefsParams.DEFAULT).getHash();
+    Hash storeHash = store.hashOnReference(branchName, Optional.empty());
     Assertions.assertEquals(storeHash, commitHash);
     return commitHash;
   }


### PR DESCRIPTION
Rather boring change to use `hashOnReference(...)` instead of `getNamedRef(...).getHash()`