### PR TITLE
Optionally fetch metadata for Tags

### DIFF
--- a/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
@@ -45,6 +45,7 @@ public class GetReferenceParams {
               + "- numCommitsBehind (number of commits behind the default branch)\n\n"
               + "- commitMetaOfHEAD (the commit metadata of the HEAD commit)\n\n"
               + "- commonAncestorHash (the hash of the common ancestor in relation to the default branch).\n\n"
+              + "A returned Tag instance will only contain the 'commitMetaOfHEAD' field.\n\n"
               + "Note that computing & fetching additional metadata might be computationally expensive on the server-side, so this flag should be used with care.")
   @QueryParam("fetchAdditionalInfo")
   private boolean fetchAdditionalInfo;

--- a/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
@@ -33,11 +33,12 @@ public class ReferencesParams extends AbstractParams {
   @Parameter(
       description =
           "If set to true, will fetch additional metadata for references.\n\n"
-              + "A returned Branch instance will then have the following information:\n\n"
+              + "A returned Branch instance will have the following information:\n\n"
               + "- numCommitsAhead (number of commits ahead of the default branch)\n\n"
               + "- numCommitsBehind (number of commits behind the default branch)\n\n"
               + "- commitMetaOfHEAD (the commit metadata of the HEAD commit)\n\n"
               + "- commonAncestorHash (the hash of the common ancestor in relation to the default branch).\n\n"
+              + "A returned Tag instance will only contain the 'commitMetaOfHEAD' field.\n\n"
               + "Note that computing & fetching additional metadata might be computationally expensive on the server-side, so this flag should be used with care.")
   @QueryParam("fetchAdditionalInfo")
   private boolean fetchAdditionalInfo;

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -233,6 +233,32 @@ components:
           - type: TAG
             hash: "a682bfdcd5d357b5c964ef07e2eef61fabba42cb8effa8d62357df45a6cc0371"
             name: "testTag1"
+            metadata:
+              numCommitsAhead: null
+              numCommitsBehind: null
+              commonAncestorHash: null
+              commitMetaOfHEAD:
+                hash: "a682bfdcd5d357b5c964ef07e2eef61fabba42cb8effa8d62357df45a6cc0371"
+                committer: ""
+                author: "nessie-author"
+                signedOffBy: null
+                message: "update table Y"
+                commitTime: "2021-11-23T08:01:14.834397Z"
+                authorTime: "2021-11-23T08:01:14.831371Z"
+                properties: {}
           - type: TAG
             hash: "da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5"
             name: "testTag2"
+            metadata:
+              numCommitsAhead: null
+              numCommitsBehind: null
+              commonAncestorHash: null
+              commitMetaOfHEAD:
+                hash: "da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5"
+                committer: ""
+                author: "nessie-author"
+                signedOffBy: null
+                message: "update table X"
+                commitTime: "2021-11-26T08:01:13.834397Z"
+                authorTime: "2021-11-26T08:01:13.831371Z"
+                properties: {}

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -522,6 +522,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
       return ImmutableTag.builder()
           .name(ref.getName())
           .hash(refWithHash.getHash().asString())
+          .metadata(extractReferenceMetadata(refWithHash))
           .build();
     } else if (ref instanceof BranchName) {
       return ImmutableBranch.builder()


### PR DESCRIPTION
Additional metadata for Tags can be fetched on the REST API via
the `fetchAdditionalInfo=true` flag.

The metadata is then returned within a `Tag` instance and contains information about the HEAD commit.

Depends on #2748