### PR TITLE
Refactor `getNamedRef` to take a plain `String` instead of `NamedRef`

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -131,8 +131,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
       return makeRef(
           getStore()
               .getNamedRef(
-                  toNamedRef(getStore().toRef(params.getRefName())),
-                  getGetNamedRefsParams(params.isFetchAdditionalInfo())));
+                  params.getRefName(), getGetNamedRefsParams(params.isFetchAdditionalInfo())));
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -178,7 +178,7 @@ public interface DatabaseAdapter {
    * @return current HEAD of {@code ref}
    * @throws ReferenceNotFoundException if the named reference {@code ref} does not exist.
    */
-  ReferenceInfo<ByteString> namedRef(NamedRef ref, GetNamedRefsParams params)
+  ReferenceInfo<ByteString> namedRef(String ref, GetNamedRefsParams params)
       throws ReferenceNotFoundException;
 
   /**

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
@@ -72,9 +72,12 @@ public final class DatabaseAdapterUtil {
             "Could not find commit '%s' in reference '%s'.", hash.asString(), ref.getName()));
   }
 
+  public static ReferenceNotFoundException referenceNotFound(String ref) {
+    return new ReferenceNotFoundException(String.format("Named reference '%s' not found", ref));
+  }
+
   public static ReferenceNotFoundException referenceNotFound(NamedRef ref) {
-    return new ReferenceNotFoundException(
-        String.format("Named reference '%s' not found", ref.getName()));
+    return referenceNotFound(ref.getName());
   }
 
   public static ReferenceNotFoundException referenceNotFound(Hash hash) {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -419,11 +419,7 @@ public abstract class AbstractDatabaseAdapterTest {
                     () -> nonExistent.hashOnReference(BranchName.of("main"), Optional.empty()))
                 .isInstanceOf(ReferenceNotFoundException.class),
         () ->
-            assertThatThrownBy(
-                    () ->
-                        nonExistent
-                            .namedRef(BranchName.of("main"), GetNamedRefsParams.DEFAULT)
-                            .getHash())
+            assertThatThrownBy(() -> nonExistent.namedRef("main", GetNamedRefsParams.DEFAULT))
                 .isInstanceOf(ReferenceNotFoundException.class));
   }
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
@@ -164,14 +164,14 @@ public abstract class AbstractGetNamedReferences {
 
     assertAll(
         () ->
-            assertThatThrownBy(() -> databaseAdapter.namedRef(main, null))
+            assertThatThrownBy(() -> databaseAdapter.namedRef(main.getName(), null))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("Parameter for GetNamedRefsParams must not be null"),
         () ->
             assertThatThrownBy(
                     () ->
                         databaseAdapter.namedRef(
-                            parameterValidation,
+                            parameterValidation.getName(),
                             GetNamedRefsParams.builder()
                                 .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
                                 .build()))
@@ -181,7 +181,7 @@ public abstract class AbstractGetNamedReferences {
             assertThatThrownBy(
                     () ->
                         databaseAdapter.namedRef(
-                            parameterValidation,
+                            parameterValidation.getName(),
                             GetNamedRefsParams.builder()
                                 .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
                                 .build()))
@@ -191,7 +191,7 @@ public abstract class AbstractGetNamedReferences {
             assertThatThrownBy(
                     () ->
                         databaseAdapter.namedRef(
-                            parameterValidation,
+                            parameterValidation.getName(),
                             GetNamedRefsParams.builder()
                                 .branchRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
                                 .build()))
@@ -201,7 +201,7 @@ public abstract class AbstractGetNamedReferences {
             assertThatThrownBy(
                     () ->
                         databaseAdapter.namedRef(
-                            parameterValidation,
+                            parameterValidation.getName(),
                             GetNamedRefsParams.builder()
                                 .tagRetrieveOptions(COMPUTE_COMMON_ANCESTOR)
                                 .build()))
@@ -211,7 +211,7 @@ public abstract class AbstractGetNamedReferences {
             assertThatThrownBy(
                     () ->
                         databaseAdapter.namedRef(
-                            parameterValidation,
+                            parameterValidation.getName(),
                             GetNamedRefsParams.builder()
                                 .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
                                 .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
@@ -223,7 +223,7 @@ public abstract class AbstractGetNamedReferences {
             assertThatThrownBy(
                     () ->
                         databaseAdapter.namedRef(
-                            parameterValidation,
+                            parameterValidation.getName(),
                             GetNamedRefsParams.builder()
                                 .branchRetrieveOptions(COMPUTE_AHEAD_BEHIND)
                                 .tagRetrieveOptions(COMPUTE_AHEAD_BEHIND)
@@ -235,36 +235,13 @@ public abstract class AbstractGetNamedReferences {
             assertThatThrownBy(
                     () ->
                         databaseAdapter.namedRef(
-                            parameterValidation,
-                            GetNamedRefsParams.builder()
-                                .branchRetrieveOptions(RetrieveOptions.OMIT)
-                                .tagRetrieveOptions(RetrieveOptions.OMIT)
-                                .build()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                    "Must retrieve branches or tags or both, and match the type of the requested reference."),
-        () ->
-            assertThatThrownBy(
-                    () ->
-                        databaseAdapter.namedRef(
-                            parameterValidation,
-                            GetNamedRefsParams.builder()
-                                .branchRetrieveOptions(RetrieveOptions.OMIT)
-                                .build()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                    "Must retrieve branches or tags or both, and match the type of the requested reference."),
-        () ->
-            assertThatThrownBy(
-                    () ->
-                        databaseAdapter.namedRef(
-                            parameterValidationTag,
+                            parameterValidationTag.getName(),
                             GetNamedRefsParams.builder()
                                 .tagRetrieveOptions(RetrieveOptions.OMIT)
                                 .build()))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ReferenceNotFoundException.class)
                 .hasMessage(
-                    "Must retrieve branches or tags or both, and match the type of the requested reference."));
+                    "Named reference '" + parameterValidationTag.getName() + "' not found"));
   }
 
   @Test
@@ -529,7 +506,8 @@ public abstract class AbstractGetNamedReferences {
     }
 
     for (ReferenceInfo<ByteString> expected : expectedRefs) {
-      assertThat(databaseAdapter.namedRef(expected.getNamedRef(), params)).isEqualTo(expected);
+      assertThat(databaseAdapter.namedRef(expected.getNamedRef().getName(), params))
+          .isEqualTo(expected);
     }
 
     List<NamedRef> failureRefs =
@@ -546,7 +524,7 @@ public abstract class AbstractGetNamedReferences {
             .collect(Collectors.toList());
 
     for (NamedRef ref : failureRefs) {
-      assertThatThrownBy(() -> databaseAdapter.namedRef(ref, params));
+      assertThatThrownBy(() -> databaseAdapter.namedRef(ref.getName(), params));
     }
   }
 

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
@@ -40,6 +40,9 @@ public final class SqlStatements {
       String.format(
           "SELECT hash FROM %s WHERE key_prefix = ? AND ref = ? AND ref_type = ?",
           TABLE_NAMED_REFERENCES);
+  public static final String SELECT_NAMED_REFERENCE_ANY =
+      String.format(
+          "SELECT ref_type, hash FROM %s WHERE key_prefix = ? AND ref = ?", TABLE_NAMED_REFERENCES);
   public static final String CREATE_TABLE_NAMED_REFERENCES =
       String.format(
           "CREATE TABLE %s (\n"

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -127,7 +127,7 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
-  public ReferenceInfo<METADATA> getNamedRef(NamedRef ref, GetNamedRefsParams params)
+  public ReferenceInfo<METADATA> getNamedRef(String ref, GetNamedRefsParams params)
       throws ReferenceNotFoundException {
     return delegate1Ex("getnamedref", () -> delegate.getNamedRef(ref, params));
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -167,12 +167,10 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
-  public ReferenceInfo<METADATA> getNamedRef(NamedRef ref, GetNamedRefsParams params)
+  public ReferenceInfo<METADATA> getNamedRef(String ref, GetNamedRefsParams params)
       throws ReferenceNotFoundException {
     return callWithOneException(
-        "GetNamedRef",
-        b -> b.withTag(TAG_REF, safeRefName(ref)),
-        () -> delegate.getNamedRef(ref, params));
+        "GetNamedRef", b -> b.withTag(TAG_REF, ref), () -> delegate.getNamedRef(ref, params));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -208,7 +208,7 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * @throws NullPointerException if {@code ref} is {@code null}.
    * @throws ReferenceNotFoundException if the reference cannot be found
    */
-  ReferenceInfo<METADATA> getNamedRef(NamedRef ref, GetNamedRefsParams params)
+  ReferenceInfo<METADATA> getNamedRef(String ref, GetNamedRefsParams params)
       throws ReferenceNotFoundException;
 
   /**

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -99,7 +99,7 @@ class TestMetricsVersionStore {
         Stream.of(
             new VersionStoreInvocation<>(
                 "getnamedref",
-                vs -> vs.getNamedRef(BranchName.of("mock-branch"), GetNamedRefsParams.DEFAULT),
+                vs -> vs.getNamedRef("mock-branch", GetNamedRefsParams.DEFAULT),
                 () -> ReferenceInfo.of(Hash.of("cafebabe"), BranchName.of("mock-branch")),
                 refNotFoundThrows),
             new VersionStoreInvocation<>(

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -85,9 +85,7 @@ class TestTracingVersionStore {
                         "GetNamedRef", refNotFoundThrows)
                     .tag("nessie.version-store.ref", "mock-branch")
                     .function(
-                        vs ->
-                            vs.getNamedRef(
-                                BranchName.of("mock-branch"), GetNamedRefsParams.DEFAULT),
+                        vs -> vs.getNamedRef("mock-branch", GetNamedRefsParams.DEFAULT),
                         () -> ReferenceInfo.of(Hash.of("cafebabe"), BranchName.of("mock-branch"))),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "ToRef", refNotFoundThrows)


### PR DESCRIPTION
This eliminates two unnecessary roundtrips:
* removes one call to `VersionStore.toRef()` in `TreeApiImpl.getReferenceByName()`
* Eliminiates the unnecessary DB roundtrip in `PersistVersionStore.toRef()` when
  the reference parameter is not a branch name

This change slightly changes the behavior of `VersionStore.getNamedRef()` as it allows to query a named reference only by its name and return either the matching branch or tag. However, it's still possible to restrict `getNamedRef` to only search for/return a specific type (branch/tag) via the parameter taking the `GetNamedRefsParams`.

Note: if the caller only needs the hash of a reference's HEAD, it's better to use `VersionStore.hashOnReference()` with an empty optional.