### PR TITLE
Track total number of commits

### DIFF
--- a/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
@@ -45,7 +45,9 @@ public class GetReferenceParams {
               + "- numCommitsBehind (number of commits behind the default branch)\n\n"
               + "- commitMetaOfHEAD (the commit metadata of the HEAD commit)\n\n"
               + "- commonAncestorHash (the hash of the common ancestor in relation to the default branch).\n\n"
-              + "A returned Tag instance will only contain the 'commitMetaOfHEAD' field.\n\n"
+              + "- commonAncestorHash (the hash of the common ancestor in relation to the default branch).\n\n"
+              + "- numTotalCommits (the total number of commits in this reference).\n\n"
+              + "A returned Tag instance will only contain the 'commitMetaOfHEAD' and 'numTotalCommits' fields.\n\n"
               + "Note that computing & fetching additional metadata might be computationally expensive on the server-side, so this flag should be used with care.")
   @QueryParam("fetchAdditionalInfo")
   private boolean fetchAdditionalInfo;

--- a/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
@@ -38,7 +38,8 @@ public class ReferencesParams extends AbstractParams {
               + "- numCommitsBehind (number of commits behind the default branch)\n\n"
               + "- commitMetaOfHEAD (the commit metadata of the HEAD commit)\n\n"
               + "- commonAncestorHash (the hash of the common ancestor in relation to the default branch).\n\n"
-              + "A returned Tag instance will only contain the 'commitMetaOfHEAD' field.\n\n"
+              + "- numTotalCommits (the total number of commits in this reference).\n\n"
+              + "A returned Tag instance will only contain the 'commitMetaOfHEAD' and 'numTotalCommits' fields.\n\n"
               + "Note that computing & fetching additional metadata might be computationally expensive on the server-side, so this flag should be used with care.")
   @QueryParam("fetchAdditionalInfo")
   private boolean fetchAdditionalInfo;

--- a/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
+++ b/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
@@ -31,7 +31,8 @@ import org.immutables.value.Value;
             + "- numCommitsAhead (number of commits ahead of the default branch)\n\n"
             + "- numCommitsBehind (number of commits behind the default branch)\n\n"
             + "- commitMetaOfHEAD (the commit metadata of the HEAD commit)\n\n"
-            + "- commonAncestorHash (the hash of the common ancestor in relation to the default branch).\n\n")
+            + "- commonAncestorHash (the hash of the common ancestor in relation to the default branch).\n\n"
+            + "- numTotalCommits (the total number of commits in this reference).\n\n")
 @Value.Immutable
 @JsonSerialize(as = ImmutableReferenceMetadata.class)
 @JsonDeserialize(as = ImmutableReferenceMetadata.class)

--- a/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
+++ b/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
@@ -49,4 +49,7 @@ public interface ReferenceMetadata {
 
   @Nullable
   String commonAncestorHash();
+
+  @Nullable
+  Long numTotalCommits();
 }

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -214,6 +214,7 @@ components:
               numCommitsAhead: 1
               numCommitsBehind: 2
               commonAncestorHash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+              numTotalCommits: 42
               commitMetaOfHEAD:
                 hash: "da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5"
                 committer: ""
@@ -237,6 +238,7 @@ components:
               numCommitsAhead: null
               numCommitsBehind: null
               commonAncestorHash: null
+              numTotalCommits: 42
               commitMetaOfHEAD:
                 hash: "a682bfdcd5d357b5c964ef07e2eef61fabba42cb8effa8d62357df45a6cc0371"
                 committer: ""
@@ -253,6 +255,7 @@ components:
               numCommitsAhead: null
               numCommitsBehind: null
               commonAncestorHash: null
+              numTotalCommits: 42
               commitMetaOfHEAD:
                 hash: "da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5"
                 committer: ""

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -1906,6 +1906,7 @@ public abstract class AbstractTestRest {
     assertThat(referenceMetadata.numCommitsBehind()).isNull();
     assertThat(referenceMetadata.commitMetaOfHEAD()).isEqualTo(commitMeta);
     assertThat(referenceMetadata.commonAncestorHash()).isNull();
+    assertThat(referenceMetadata.numTotalCommits()).isEqualTo(10);
   }
 
   protected void unwrap(Executable exec) throws Throwable {

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -1828,11 +1828,14 @@ public abstract class AbstractTestRest {
                 .filter(r -> r.getName().startsWith(branchPrefix))
                 .map(r -> (Branch) r))
         .hasSize(numBranches)
-        .allSatisfy(branch -> verifyMetadataProperties(commitsPerBranch, 0, branch, main.get()));
+        .allSatisfy(
+            branch ->
+                verifyMetadataProperties(
+                    commitsPerBranch, 0, branch, main.get(), commitsPerBranch));
 
     assertThat(references.stream().filter(r -> r.getName().startsWith(tagPrefix)).map(r -> (Tag) r))
         .hasSize(numBranches)
-        .allSatisfy(tag -> verifyMetadataProperties(tag));
+        .allSatisfy(this::verifyMetadataProperties);
   }
 
   @Test
@@ -1861,7 +1864,8 @@ public abstract class AbstractTestRest {
     // fetching additional metadata for a single branch
     ref = api.getReference().refName(branchName).fetchAdditionalInfo(true).get();
     assertThat(ref).isNotNull().isInstanceOf(Branch.class);
-    verifyMetadataProperties(numCommits, 0, (Branch) ref, api.getReference().refName("main").get());
+    verifyMetadataProperties(
+        numCommits, 0, (Branch) ref, api.getReference().refName("main").get(), numCommits);
 
     // fetching additional metadata for a single tag
     ref = api.getReference().refName(tagName).fetchAdditionalInfo(true).get();
@@ -1870,7 +1874,11 @@ public abstract class AbstractTestRest {
   }
 
   private void verifyMetadataProperties(
-      int expectedCommitsAhead, int expectedCommitsBehind, Branch branch, Reference reference)
+      int expectedCommitsAhead,
+      int expectedCommitsBehind,
+      Branch branch,
+      Reference reference,
+      long expectedCommits)
       throws NessieNotFoundException {
     List<CommitMeta> commits =
         api.getCommitLog().refName(branch.getName()).maxRecords(1).get().getOperations();
@@ -1883,6 +1891,7 @@ public abstract class AbstractTestRest {
     assertThat(referenceMetadata.numCommitsBehind()).isEqualTo(expectedCommitsBehind);
     assertThat(referenceMetadata.commitMetaOfHEAD()).isEqualTo(commitMeta);
     assertThat(referenceMetadata.commonAncestorHash()).isEqualTo(reference.getHash());
+    assertThat(referenceMetadata.numTotalCommits()).isEqualTo(expectedCommits);
   }
 
   private void verifyMetadataProperties(Tag tag) throws NessieNotFoundException {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -548,6 +548,10 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
       builder.commitMetaOfHEAD(
           addHashToCommitMeta(refWithHash.getHash(), refWithHash.getHeadCommitMeta()));
     }
+    if (0L != refWithHash.getCommitSeq()) {
+      found = true;
+      builder.numTotalCommits(refWithHash.getCommitSeq());
+    }
     if (null != refWithHash.getCommonAncestor()) {
       found = true;
       builder.commonAncestorHash(refWithHash.getCommonAncestor().asString());

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
@@ -30,6 +30,12 @@ public interface CommitLogEntry {
 
   Hash getHash();
 
+  /**
+   * Monotonically increasing counter representing the number of commits since the "beginning of
+   * time.
+   */
+  long getCommitSeq();
+
   /** Zero, one or more parent-entry hashes of this commit, nearest parent first. */
   List<Hash> getParents();
 
@@ -70,6 +76,7 @@ public interface CommitLogEntry {
   static CommitLogEntry of(
       long createdTime,
       Hash hash,
+      long commitSeq,
       List<Hash> parents,
       ByteString metadata,
       List<KeyWithBytes> puts,
@@ -80,6 +87,7 @@ public interface CommitLogEntry {
     return ImmutableCommitLogEntry.builder()
         .createdTime(createdTime)
         .hash(hash)
+        .commitSeq(commitSeq)
         .parents(parents)
         .metadata(metadata)
         .puts(puts)

--- a/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/serialize/ProtoSerialization.java
+++ b/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/serialize/ProtoSerialization.java
@@ -35,6 +35,7 @@ public class ProtoSerialization {
         AdapterTypes.CommitLogEntry.newBuilder()
             .setCreatedTime(entry.getCreatedTime())
             .setHash(entry.getHash().asBytes())
+            .setCommitSeq(entry.getCommitSeq())
             .setMetadata(entry.getMetadata())
             .setKeyListDistance(entry.getKeyListDistance());
 
@@ -81,6 +82,7 @@ public class ProtoSerialization {
         ImmutableCommitLogEntry.builder()
             .createdTime(proto.getCreatedTime())
             .hash(Hash.of(proto.getHash()))
+            .commitSeq(proto.getCommitSeq())
             .metadata(proto.getMetadata())
             .keyListDistance(proto.getKeyListDistance());
 

--- a/versioned/persist/serialize/src/main/proto/persist.proto
+++ b/versioned/persist/serialize/src/main/proto/persist.proto
@@ -30,6 +30,7 @@ message CommitLogEntry {
   int32 key_list_distance = 7;
   repeated KeyWithType key_list = 8;
   repeated bytes key_list_ids = 9;
+  int64 commitSeq = 10;
 }
 
 message Key {

--- a/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/serialize/TestSerialization.java
+++ b/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/serialize/TestSerialization.java
@@ -310,6 +310,10 @@ class TestSerialization {
     return Key.of("some" + r.nextInt(10000), "other" + r.nextInt(10000));
   }
 
+  public static long randomLong() {
+    return ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+  }
+
   public static Hash randomHash() {
     return Hash.of(randomBytes(16));
   }
@@ -359,6 +363,7 @@ class TestSerialization {
     return CommitLogEntry.of(
         System.nanoTime() / 1000L,
         randomHash(),
+        randomLong(),
         Arrays.asList(
             randomHash(),
             randomHash(),

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
@@ -267,9 +267,9 @@ public abstract class AbstractGetNamedReferences {
     databaseAdapter.create(tag, hash);
 
     verifyReferences(
-        new ExpectedNamedReference(main, mainHash, 0, 0, hash, null),
-        new ExpectedNamedReference(branch, branchHash, 0, 0, hash, null),
-        new ExpectedNamedReference(tag, hash, 0, 0, hash, null));
+        new ExpectedNamedReference(main, 0L, mainHash, 0, 0, hash, null),
+        new ExpectedNamedReference(branch, 0L, branchHash, 0, 0, hash, null),
+        new ExpectedNamedReference(tag, 0L, hash, 0, 0, hash, null));
 
     // Add 100 commits to 'main'
 
@@ -280,9 +280,9 @@ public abstract class AbstractGetNamedReferences {
     // Expect a commit-metadata for 'main', branch+tag are then 100 commits behind.
 
     verifyReferences(
-        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
-        new ExpectedNamedReference(branch, branchHash, 0, 100, hash, null),
-        new ExpectedNamedReference(tag, hash, 0, 100, hash, null));
+        new ExpectedNamedReference(main, 100, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(branch, 0, branchHash, 0, 100, hash, null),
+        new ExpectedNamedReference(tag, 0, hash, 0, 100, hash, null));
 
     // Add 42 commits to branch
 
@@ -293,9 +293,10 @@ public abstract class AbstractGetNamedReferences {
     // same expectations as above, but branch is now also 42 commits ahead
 
     verifyReferences(
-        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
-        new ExpectedNamedReference(branch, branchHash, 42, 100, hash, commitMetaFor(branch, 42)),
-        new ExpectedNamedReference(tag, hash, 0, 100, hash, null));
+        new ExpectedNamedReference(main, 100, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(
+            branch, 42, branchHash, 42, 100, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, 0, hash, 0, 100, hash, null));
 
     // create a branch2 + tag2 from 'main'
 
@@ -307,11 +308,13 @@ public abstract class AbstractGetNamedReferences {
     // - common ancestor of branch2 + tag2 is the 100th commit on 'main'
 
     verifyReferences(
-        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
-        new ExpectedNamedReference(branch, branchHash, 42, 100, hash, commitMetaFor(branch, 42)),
-        new ExpectedNamedReference(tag, hash, 0, 100, hash, null),
-        new ExpectedNamedReference(branch2, branch2Hash, 0, 0, main100, commitMetaFor(main, 100)),
-        new ExpectedNamedReference(tag2, tag2Hash, 0, 0, main100, commitMetaFor(main, 100)));
+        new ExpectedNamedReference(main, 100, mainHash, 0, 0, hash, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(
+            branch, 42, branchHash, 42, 100, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, 0, hash, 0, 100, hash, null),
+        new ExpectedNamedReference(
+            branch2, 100, branch2Hash, 0, 0, main100, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(tag2, 100, tag2Hash, 0, 0, main100, commitMetaFor(main, 100)));
 
     // add 900 commits to 'main'
 
@@ -323,11 +326,13 @@ public abstract class AbstractGetNamedReferences {
     // - branch + tag are now 100+900 = 1000 commits behind
 
     verifyReferences(
-        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
-        new ExpectedNamedReference(branch, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
-        new ExpectedNamedReference(tag, hash, 0, 1000, hash, null),
-        new ExpectedNamedReference(branch2, branch2Hash, 0, 900, main100, commitMetaFor(main, 100)),
-        new ExpectedNamedReference(tag2, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)));
+        new ExpectedNamedReference(main, 1000, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
+        new ExpectedNamedReference(
+            branch, 42, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, 0, hash, 0, 1000, hash, null),
+        new ExpectedNamedReference(
+            branch2, 100, branch2Hash, 0, 900, main100, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(tag2, 100, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)));
 
     // add 42 commits to branch2
 
@@ -339,12 +344,13 @@ public abstract class AbstractGetNamedReferences {
     // - branch2 is now also 42 commits ahead
 
     verifyReferences(
-        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
-        new ExpectedNamedReference(branch, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
-        new ExpectedNamedReference(tag, hash, 0, 1000, hash, null),
+        new ExpectedNamedReference(main, 1000, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
         new ExpectedNamedReference(
-            branch2, branch2Hash, 42, 900, main100, commitMetaFor(branch2, 42)),
-        new ExpectedNamedReference(tag2, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)));
+            branch, 42, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, 0, hash, 0, 1000, hash, null),
+        new ExpectedNamedReference(
+            branch2, 142, branch2Hash, 42, 900, main100, commitMetaFor(branch2, 42)),
+        new ExpectedNamedReference(tag2, 100, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)));
 
     // Create branch2+tag3 at branch2
 
@@ -363,15 +369,17 @@ public abstract class AbstractGetNamedReferences {
     // - branch3 is 84 commits ahead
 
     verifyReferences(
-        new ExpectedNamedReference(main, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
-        new ExpectedNamedReference(branch, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
-        new ExpectedNamedReference(tag, hash, 0, 1000, hash, null),
+        new ExpectedNamedReference(main, 1000, mainHash, 0, 0, hash, commitMetaFor(main, 1000)),
         new ExpectedNamedReference(
-            branch2, branch2Hash, 42, 900, main100, commitMetaFor(branch2, 42)),
-        new ExpectedNamedReference(tag2, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)),
+            branch, 42, branchHash, 42, 1000, hash, commitMetaFor(branch, 42)),
+        new ExpectedNamedReference(tag, 0, hash, 0, 1000, hash, null),
         new ExpectedNamedReference(
-            branch3, branch3Hash, 84, 900, main100, commitMetaFor(branch3, 42)),
-        new ExpectedNamedReference(tag3, tag3Hash, 42, 900, main100, commitMetaFor(branch2, 42)));
+            branch2, 142, branch2Hash, 42, 900, main100, commitMetaFor(branch2, 42)),
+        new ExpectedNamedReference(tag2, 100, tag2Hash, 0, 900, main100, commitMetaFor(main, 100)),
+        new ExpectedNamedReference(
+            branch3, 184, branch3Hash, 84, 900, main100, commitMetaFor(branch3, 42)),
+        new ExpectedNamedReference(
+            tag3, 142, tag3Hash, 42, 900, main100, commitMetaFor(branch2, 42)));
   }
 
   private ByteString commitMetaFor(NamedRef ref, int num) {
@@ -530,6 +538,7 @@ public abstract class AbstractGetNamedReferences {
 
   static class ExpectedNamedReference {
     final NamedRef ref;
+    final long commitSeq;
     final Hash hash;
     final CommitsAheadBehind aheadBehind;
     final Hash commonAncestor;
@@ -537,12 +546,14 @@ public abstract class AbstractGetNamedReferences {
 
     ExpectedNamedReference(
         NamedRef ref,
+        long commitSeq,
         Hash hash,
         int ahead,
         int behind,
         Hash commonAncestor,
         ByteString commitMeta) {
       this.ref = ref;
+      this.commitSeq = commitSeq;
       this.hash = hash;
       this.aheadBehind = CommitsAheadBehind.of(ahead, behind);
       this.commonAncestor = commonAncestor;
@@ -574,7 +585,7 @@ public abstract class AbstractGetNamedReferences {
         }
       }
       if (opts.isRetrieveCommitMetaForHead()) {
-        builder.headCommitMeta(commitMeta);
+        builder.headCommitMeta(commitMeta).commitSeq(commitSeq);
       }
       return builder.build();
     }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceInfo.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceInfo.java
@@ -24,6 +24,11 @@ public interface ReferenceInfo<METADATA> {
 
   Hash getHash();
 
+  @Value.Default
+  default long getCommitSeq() {
+    return 0L;
+  }
+
   @Nullable
   Hash getCommonAncestor();
 


### PR DESCRIPTION
Allows retrieval of the total number of commits on a reference.

Via REST: in the `ReferenceMetadata`, if `fetchAdditionalInfo` is true.
Via VersionStore/DatabaseAdapter: if `retrieveCommitMetaForHead` is true.

The total number of commits is tracked as a field in every commit. The
first commit since "beginning of time" starts at `1`, following commits
"increment" this number. Since the commit history is immutable, the
number of commits since "beginning of time" is immutable as well.