### PR TITLE
Add Reference#metadata field to OpenAPI Schema / Fix OpenAPI Schema title for ReferenceMetadata

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -43,7 +43,8 @@ import org.immutables.value.Value;
     // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
     properties = {
       @SchemaProperty(name = "name", pattern = Validation.REF_NAME_REGEX),
-      @SchemaProperty(name = "hash", pattern = Validation.HASH_REGEX)
+      @SchemaProperty(name = "hash", pattern = Validation.HASH_REGEX),
+      @SchemaProperty(name = "metadata", nullable = true)
     })
 @JsonSubTypes({@Type(Branch.class), @Type(Tag.class)})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")

--- a/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
+++ b/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 
 @Schema(
     type = SchemaType.OBJECT,
-    title = "Additional metadata for a 'Reference'.",
+    title = "ReferenceMetadata",
     description =
         "Only returned by the server when explicitly requested by the client and contains the following information:\n\n"
             + "- numCommitsAhead (number of commits ahead of the default branch)\n\n"


### PR DESCRIPTION
With the previous title the ReferenceMetadata object wouldn't be shown
in the `Schemas` section in the Swagger UI.