### PR TITLE
Filter named references and keys

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -34,6 +34,13 @@ public interface GetAllReferencesBuilder extends PagingBuilder<GetAllReferencesB
   GetAllReferencesBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo);
 
   /**
+   * Only return references with a name that matches the given filter.
+   *
+   * @param filter reference name filter.
+   */
+  GetAllReferencesBuilder filter(String filter);
+
+  /**
    * Fetches all references and returns them in a {@link ReferencesResponse} instance.
    *
    * @return Fetches all references and returns them in a {@link ReferencesResponse} instance.

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -30,5 +30,12 @@ public interface GetEntriesBuilder
 
   GetEntriesBuilder namespaceDepth(Integer namespaceDepth);
 
+  /**
+   * Only return entries with keys that match the given filter.
+   *
+   * @param filter key filter.
+   */
+  GetEntriesBuilder filter(String filter);
+
   EntriesResponse get() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
@@ -49,6 +49,7 @@ class HttpTreeClient implements HttpTreeApi {
         .queryParam("max", params.maxRecords() != null ? params.maxRecords().toString() : null)
         .queryParam("pageToken", params.pageToken())
         .queryParam("fetchAdditionalInfo", Boolean.toString(params.isFetchAdditionalInfo()))
+        .queryParam("filter", params.filter())
         .get()
         .readEntity(ReferencesResponse.class);
   }
@@ -184,6 +185,7 @@ class HttpTreeClient implements HttpTreeApi {
         .queryParam(
             "namespaceDepth",
             params.namespaceDepth() == null ? null : String.valueOf(params.namespaceDepth()))
+        .queryParam("filter", params.filter())
         .get()
         .readEntity(EntriesResponse.class);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
@@ -47,6 +47,12 @@ final class HttpGetAllReferences extends BaseHttpRequest implements GetAllRefere
   }
 
   @Override
+  public GetAllReferencesBuilder filter(String filter) {
+    params.filter(filter);
+    return this;
+  }
+
+  @Override
   public ReferencesResponse get() {
     return client.getTreeApi().getAllReferences(params.build());
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
@@ -55,6 +55,12 @@ final class HttpGetEntries extends BaseHttpOnReferenceRequest<GetEntriesBuilder>
   }
 
   @Override
+  public GetEntriesBuilder filter(String filter) {
+    params.filter(filter);
+    return this;
+  }
+
+  @Override
   public EntriesResponse get() throws NessieNotFoundException {
     params.hashOnRef(hashOnRef);
     return client.getTreeApi().getEntries(refName, params.build());

--- a/model/src/main/java/org/projectnessie/api/params/EntriesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/EntriesParams.java
@@ -60,6 +60,12 @@ public class EntriesParams extends AbstractParams {
   @QueryParam("query_expression")
   private String queryExpression;
 
+  @Parameter(
+      description =
+          "If present, only return keys that match the given filter, applied before the queryExpression.")
+  @QueryParam("filter")
+  private String filter;
+
   public EntriesParams() {}
 
   private EntriesParams(
@@ -67,11 +73,13 @@ public class EntriesParams extends AbstractParams {
       Integer maxRecords,
       String pageToken,
       Integer namespaceDepth,
-      String queryExpression) {
+      String queryExpression,
+      String filter) {
     super(maxRecords, pageToken);
     this.hashOnRef = hashOnRef;
     this.namespaceDepth = namespaceDepth;
     this.queryExpression = queryExpression;
+    this.filter = filter;
   }
 
   private EntriesParams(Builder builder) {
@@ -80,7 +88,8 @@ public class EntriesParams extends AbstractParams {
         builder.maxRecords,
         builder.pageToken,
         builder.namespaceDepth,
-        builder.queryExpression);
+        builder.queryExpression,
+        builder.filter);
   }
 
   public static EntriesParams.Builder builder() {
@@ -104,6 +113,11 @@ public class EntriesParams extends AbstractParams {
     return namespaceDepth;
   }
 
+  @Nullable
+  public String filter() {
+    return filter;
+  }
+
   @Override
   public String toString() {
     return new StringJoiner(", ", EntriesParams.class.getSimpleName() + "[", "]")
@@ -112,6 +126,7 @@ public class EntriesParams extends AbstractParams {
         .add("pageToken='" + pageToken() + "'")
         .add("queryExpression='" + queryExpression + "'")
         .add("namespaceDepth='" + namespaceDepth + "'")
+        .add("filter=" + filter)
         .toString();
   }
 
@@ -128,12 +143,14 @@ public class EntriesParams extends AbstractParams {
         && Objects.equals(maxRecords(), that.maxRecords())
         && Objects.equals(pageToken(), that.pageToken())
         && Objects.equals(namespaceDepth, that.namespaceDepth)
-        && Objects.equals(queryExpression, that.queryExpression);
+        && Objects.equals(queryExpression, that.queryExpression)
+        && Objects.equals(filter, that.filter);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(hashOnRef, maxRecords(), pageToken(), namespaceDepth, queryExpression);
+    return Objects.hash(
+        hashOnRef, maxRecords(), pageToken(), namespaceDepth, queryExpression, filter);
   }
 
   public static class Builder extends AbstractParams.Builder<Builder> {
@@ -141,15 +158,16 @@ public class EntriesParams extends AbstractParams {
     private String hashOnRef;
     private String queryExpression;
     private Integer namespaceDepth;
+    private String filter;
 
     private Builder() {}
 
-    public EntriesParams.Builder hashOnRef(String hashOnRef) {
+    public Builder hashOnRef(String hashOnRef) {
       this.hashOnRef = hashOnRef;
       return this;
     }
 
-    public EntriesParams.Builder expression(String queryExpression) {
+    public Builder expression(String queryExpression) {
       this.queryExpression = queryExpression;
       return this;
     }
@@ -159,12 +177,18 @@ public class EntriesParams extends AbstractParams {
       return this;
     }
 
+    public Builder filter(String filter) {
+      this.filter = filter;
+      return this;
+    }
+
     public EntriesParams.Builder from(EntriesParams params) {
       return hashOnRef(params.hashOnRef)
           .maxRecords(params.maxRecords())
           .pageToken(params.pageToken())
           .namespaceDepth(params.namespaceDepth)
-          .expression(params.queryExpression);
+          .expression(params.queryExpression)
+          .filter(params.filter);
     }
 
     private void validate() {}

--- a/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
@@ -17,6 +17,7 @@ package org.projectnessie.api.params;
 
 import java.util.Objects;
 import java.util.StringJoiner;
+import javax.annotation.Nullable;
 import javax.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.projectnessie.api.http.HttpTreeApi;
@@ -44,19 +45,30 @@ public class ReferencesParams extends AbstractParams {
   @QueryParam("fetchAdditionalInfo")
   private boolean fetchAdditionalInfo;
 
+  @Parameter(description = "If present, only return references that match the given filter.")
+  @QueryParam("filter")
+  private String filter;
+
   public ReferencesParams() {}
 
-  private ReferencesParams(Integer maxRecords, String pageToken, boolean fetchAdditionalInfo) {
+  private ReferencesParams(
+      Integer maxRecords, String pageToken, boolean fetchAdditionalInfo, String filter) {
     super(maxRecords, pageToken);
     this.fetchAdditionalInfo = fetchAdditionalInfo;
+    this.filter = filter;
   }
 
   private ReferencesParams(Builder builder) {
-    this(builder.maxRecords, builder.pageToken, builder.fetchAdditionalInfo);
+    this(builder.maxRecords, builder.pageToken, builder.fetchAdditionalInfo, builder.filter);
   }
 
   public boolean isFetchAdditionalInfo() {
     return fetchAdditionalInfo;
+  }
+
+  @Nullable
+  public String filter() {
+    return filter;
   }
 
   public static ReferencesParams.Builder builder() {
@@ -73,6 +85,7 @@ public class ReferencesParams extends AbstractParams {
         .add("maxRecords=" + maxRecords())
         .add("pageToken='" + pageToken() + "'")
         .add("fetchAdditionalInfo=" + fetchAdditionalInfo)
+        .add("filter=" + filter)
         .toString();
   }
 
@@ -87,12 +100,13 @@ public class ReferencesParams extends AbstractParams {
     ReferencesParams that = (ReferencesParams) o;
     return Objects.equals(maxRecords(), that.maxRecords())
         && Objects.equals(pageToken(), that.pageToken())
-        && Objects.equals(fetchAdditionalInfo, that.fetchAdditionalInfo);
+        && Objects.equals(fetchAdditionalInfo, that.fetchAdditionalInfo)
+        && Objects.equals(filter, that.filter);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(maxRecords(), pageToken(), fetchAdditionalInfo);
+    return Objects.hash(maxRecords(), pageToken(), fetchAdditionalInfo, filter);
   }
 
   public static class Builder extends AbstractParams.Builder<Builder> {
@@ -100,15 +114,22 @@ public class ReferencesParams extends AbstractParams {
     private Builder() {}
 
     private boolean fetchAdditionalInfo = false;
+    private String filter;
 
     public ReferencesParams.Builder from(ReferencesParams params) {
       return maxRecords(params.maxRecords())
           .pageToken(params.pageToken())
-          .fetchAdditionalInfo(params.fetchAdditionalInfo);
+          .fetchAdditionalInfo(params.fetchAdditionalInfo)
+          .filter(params.filter);
     }
 
     public Builder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
       this.fetchAdditionalInfo = fetchAdditionalInfo;
+      return this;
+    }
+
+    public Builder filter(String filter) {
+      this.filter = filter;
       return this;
     }
 

--- a/model/src/test/java/org/projectnessie/api/params/EntriesParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/EntriesParamsTest.java
@@ -28,6 +28,7 @@ public class EntriesParamsTest {
     String hash = "1234567890123456";
     String pageToken = "aabbcc";
     String queryExpression = "some_expression";
+    String filter = "some_filter";
     EntriesParams params =
         EntriesParams.builder()
             .maxRecords(maxRecords)
@@ -35,12 +36,14 @@ public class EntriesParamsTest {
             .expression(queryExpression)
             .hashOnRef(hash)
             .namespaceDepth(namespaceDepth)
+            .filter(filter)
             .build();
 
     assertThat(params.pageToken()).isEqualTo(pageToken);
     assertThat(params.maxRecords()).isEqualTo(maxRecords);
     assertThat(params.namespaceDepth()).isEqualTo(namespaceDepth);
     assertThat(params.queryExpression()).isEqualTo(queryExpression);
+    assertThat(params.filter()).isEqualTo(filter);
     assertThat(params.hashOnRef()).isEqualTo(hash);
   }
 
@@ -52,6 +55,7 @@ public class EntriesParamsTest {
     assertThat(params.pageToken()).isNull();
     assertThat(params.queryExpression()).isNull();
     assertThat(params.namespaceDepth()).isNull();
+    assertThat(params.filter()).isNull();
     assertThat(params.hashOnRef()).isNull();
   }
 }

--- a/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
@@ -27,10 +27,12 @@ public class ReferencesParamsTest {
         ReferencesParams.builder()
             .maxRecords(23)
             .pageToken("abc")
+            .filter("filter")
             .fetchAdditionalInfo(true)
             .build();
     assertThat(params.maxRecords()).isEqualTo(23);
     assertThat(params.pageToken()).isEqualTo("abc");
+    assertThat(params.filter()).isEqualTo("filter");
     assertThat(params.isFetchAdditionalInfo()).isTrue();
   }
 
@@ -40,6 +42,7 @@ public class ReferencesParamsTest {
     assertThat(params).isNotNull();
     assertThat(params.isFetchAdditionalInfo()).isFalse();
     assertThat(params.pageToken()).isNull();
+    assertThat(params.filter()).isNull();
     assertThat(params.maxRecords()).isNull();
   }
 }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ErrorTestService.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ErrorTestService.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.server.error;
 
+import static org.mockito.ArgumentMatchers.any;
+
 import java.util.stream.Stream;
 import javax.enterprise.context.RequestScoped;
 import javax.validation.ConstraintDeclarationException;
@@ -138,11 +140,11 @@ public class ErrorTestService {
     }
 
     DatabaseAdapter databaseAdapter = Mockito.mock(DatabaseAdapter.class);
-    Mockito.when(databaseAdapter.namedRefs(Mockito.any())).thenThrow(ex);
+    Mockito.when(databaseAdapter.namedRefs(any(), any())).thenThrow(ex);
 
     PersistVersionStore<String, String, StringStoreWorker.TestEnum> tvs =
         new PersistVersionStore<>(databaseAdapter, StringStoreWorker.INSTANCE);
-    try (Stream<ReferenceInfo<String>> refs = tvs.getNamedRefs(GetNamedRefsParams.DEFAULT)) {
+    try (Stream<ReferenceInfo<String>> refs = tvs.getNamedRefs(GetNamedRefsParams.DEFAULT, null)) {
       refs.forEach(ref -> {});
     }
     return "we should not get here";

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.BranchName;
@@ -186,9 +187,11 @@ public interface DatabaseAdapter {
    *
    * @param params options that control which information shall be returned in each {@link
    *     ReferenceInfo}, see {@link ReferenceInfo} for details.
+   * @param referenceFilter optional filter predicate to include/exclude references from the result
    * @return stream with all named references.
    */
-  Stream<ReferenceInfo<ByteString>> namedRefs(GetNamedRefsParams params)
+  Stream<ReferenceInfo<ByteString>> namedRefs(
+      GetNamedRefsParams params, Predicate<NamedRef> referenceFilter)
       throws ReferenceNotFoundException;
 
   /**

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
@@ -135,7 +136,8 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   @Override
-  public Stream<ReferenceInfo<ByteString>> namedRefs(GetNamedRefsParams params)
+  public Stream<ReferenceInfo<ByteString>> namedRefs(
+      GetNamedRefsParams params, Predicate<NamedRef> referenceFilter)
       throws ReferenceNotFoundException {
     Preconditions.checkNotNull(params, "Parameter for GetNamedRefsParams must not be null.");
     Preconditions.checkArgument(
@@ -155,6 +157,10 @@ public abstract class NonTransactionalDatabaseAdapter<
                     ReferenceInfo.of(
                         Hash.of(r.getValue().getHash()),
                         toNamedRef(r.getValue().getType(), r.getKey())));
+
+    if (referenceFilter != null) {
+      refs = refs.filter(r -> referenceFilter.test(r.getNamedRef()));
+    }
 
     return namedRefsFilterAndEnhance(
         NON_TRANSACTIONAL_OPERATION_CONTEXT, params, defaultBranchHead, refs);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -109,7 +109,7 @@ public abstract class AbstractDatabaseAdapterTest {
     BranchName branch = BranchName.of("main");
 
     try (Stream<ReferenceInfo<ByteString>> refs =
-        databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT)) {
+        databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT, null)) {
       assertThat(refs.map(ReferenceInfo::getNamedRef)).containsExactlyInAnyOrder(branch);
     }
 
@@ -123,7 +123,7 @@ public abstract class AbstractDatabaseAdapterTest {
     assertThat(createHash).isEqualTo(mainHash);
 
     try (Stream<ReferenceInfo<ByteString>> refs =
-        databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT)) {
+        databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT, null)) {
       assertThat(refs.map(ReferenceInfo::getNamedRef)).containsExactlyInAnyOrder(branch, create);
     }
 
@@ -157,7 +157,7 @@ public abstract class AbstractDatabaseAdapterTest {
         .isInstanceOf(ReferenceNotFoundException.class);
 
     try (Stream<ReferenceInfo<ByteString>> refs =
-        databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT)) {
+        databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT, null)) {
       assertThat(refs.map(ReferenceInfo::getNamedRef)).containsExactlyInAnyOrder(branch);
     }
   }
@@ -410,7 +410,7 @@ public abstract class AbstractDatabaseAdapterTest {
     assertAll(
         () -> {
           try (Stream<ReferenceInfo<ByteString>> r =
-              nonExistent.namedRefs(GetNamedRefsParams.DEFAULT)) {
+              nonExistent.namedRefs(GetNamedRefsParams.DEFAULT, null)) {
             assertThat(r).isEmpty();
           }
         },
@@ -464,12 +464,12 @@ public abstract class AbstractDatabaseAdapterTest {
     assertThat(barMain).isNotEqualTo(fooMain).isEqualTo(barBranch);
 
     // Verify that key-prefix "foo" only sees "its" main-branch and foo-branch
-    try (Stream<ReferenceInfo<ByteString>> refs = foo.namedRefs(GetNamedRefsParams.DEFAULT)) {
+    try (Stream<ReferenceInfo<ByteString>> refs = foo.namedRefs(GetNamedRefsParams.DEFAULT, null)) {
       assertThat(refs)
           .containsExactlyInAnyOrder(
               ReferenceInfo.of(fooMain, main), ReferenceInfo.of(fooBranch, fooBranchName));
     }
-    try (Stream<ReferenceInfo<ByteString>> refs = bar.namedRefs(GetNamedRefsParams.DEFAULT)) {
+    try (Stream<ReferenceInfo<ByteString>> refs = bar.namedRefs(GetNamedRefsParams.DEFAULT, null)) {
       assertThat(refs)
           .containsExactlyInAnyOrder(
               ReferenceInfo.of(barMain, main), ReferenceInfo.of(barBranch, barBranchName));

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
@@ -465,13 +465,14 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
         // getKeys()
         new ReferenceNotFoundFunction("getKeys/branch")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.getKeys(BranchName.of("this-one-should-not-exist"))),
+            .function(s -> s.getKeys(BranchName.of("this-one-should-not-exist"), null)),
         new ReferenceNotFoundFunction("getKeys/tag")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.getKeys(TagName.of("this-one-should-not-exist"))),
+            .function(s -> s.getKeys(TagName.of("this-one-should-not-exist"), null)),
         new ReferenceNotFoundFunction("getKeys/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
-            .function(s -> s.getKeys(Hash.of("12341234123412341234123412341234123412341234"))),
+            .function(
+                s -> s.getKeys(Hash.of("12341234123412341234123412341234123412341234"), null)),
         // assign()
         new ReferenceNotFoundFunction("assign/branch/ok")
             .msg("Named reference 'this-one-should-not-exist' not found")
@@ -589,7 +590,8 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
     BranchName main = BranchName.of("main");
     WithHash<Ref> mainRef = store.toRef(main.getName());
     assertThat(store().getCommits(main, false)).isEmpty();
-    try (Stream<ReferenceInfo<String>> refs = store().getNamedRefs(GetNamedRefsParams.DEFAULT)) {
+    try (Stream<ReferenceInfo<String>> refs =
+        store().getNamedRefs(GetNamedRefsParams.DEFAULT, null)) {
       assertThat(refs).extracting(r -> r.getNamedRef().getName()).containsExactly(main.getName());
     }
 

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -49,6 +49,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
@@ -167,7 +168,8 @@ public abstract class TxDatabaseAdapter
     }
   }
 
-  public Stream<ReferenceInfo<ByteString>> namedRefs(GetNamedRefsParams params)
+  public Stream<ReferenceInfo<ByteString>> namedRefs(
+      GetNamedRefsParams params, Predicate<NamedRef> referenceFilter)
       throws ReferenceNotFoundException {
     Preconditions.checkNotNull(params, "Parameter for GetNamedRefsParams must not be null.");
     Preconditions.checkArgument(
@@ -180,6 +182,10 @@ public abstract class TxDatabaseAdapter
       Hash defaultBranchHead = namedRefsDefaultBranchHead(conn, params);
 
       Stream<ReferenceInfo<ByteString>> refs = fetchNamedRefs(conn);
+
+      if (referenceFilter != null) {
+        refs = refs.filter(ri -> referenceFilter.test(ri.getNamedRef()));
+      }
 
       refs = namedRefsFilterAndEnhance(conn, params, defaultBranchHead, refs);
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
@@ -133,9 +134,10 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
-  public Stream<ReferenceInfo<METADATA>> getNamedRefs(GetNamedRefsParams params)
+  public Stream<ReferenceInfo<METADATA>> getNamedRefs(
+      GetNamedRefsParams params, Predicate<NamedRef> namedRefFilter)
       throws ReferenceNotFoundException {
-    return delegateStream1Ex("getnamedrefs", () -> delegate.getNamedRefs(params));
+    return delegateStream1Ex("getnamedrefs", () -> delegate.getNamedRefs(params, namedRefFilter));
   }
 
   @Override
@@ -145,8 +147,9 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
-  public Stream<WithType<Key, VALUE_TYPE>> getKeys(Ref ref) throws ReferenceNotFoundException {
-    return delegateStream1Ex("getkeys", () -> delegate.getKeys(ref));
+  public Stream<WithType<Key, VALUE_TYPE>> getKeys(Ref ref, Predicate<Key> keyFilter)
+      throws ReferenceNotFoundException {
+    return delegateStream1Ex("getkeys", () -> delegate.getKeys(ref, keyFilter));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
@@ -174,9 +175,11 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
-  public Stream<ReferenceInfo<METADATA>> getNamedRefs(GetNamedRefsParams params)
+  public Stream<ReferenceInfo<METADATA>> getNamedRefs(
+      GetNamedRefsParams params, Predicate<NamedRef> namedRefFilter)
       throws ReferenceNotFoundException {
-    return callStreamWithOneException("GetNamedRefs", b -> {}, () -> delegate.getNamedRefs(params));
+    return callStreamWithOneException(
+        "GetNamedRefs", b -> {}, () -> delegate.getNamedRefs(params, namedRefFilter));
   }
 
   @Override
@@ -189,9 +192,12 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
-  public Stream<WithType<Key, VALUE_TYPE>> getKeys(Ref ref) throws ReferenceNotFoundException {
+  public Stream<WithType<Key, VALUE_TYPE>> getKeys(Ref ref, Predicate<Key> keyFilter)
+      throws ReferenceNotFoundException {
     return callStreamWithOneException(
-        "GetKeys", b -> b.withTag(TAG_REF, safeToString(ref)), () -> delegate.getKeys(ref));
+        "GetKeys",
+        b -> b.withTag(TAG_REF, safeToString(ref)),
+        () -> delegate.getKeys(ref, keyFilter));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
@@ -218,9 +219,11 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    *
    * @param params options that control which information shall be returned in each {@link
    *     ReferenceInfo}, see {@link ReferenceInfo} for details.
+   * @param namedRefFilter optional filter predicate to include/exclude references from the result
    * @return All refs and their associated hashes.
    */
-  Stream<ReferenceInfo<METADATA>> getNamedRefs(GetNamedRefsParams params)
+  Stream<ReferenceInfo<METADATA>> getNamedRefs(
+      GetNamedRefsParams params, Predicate<NamedRef> namedRefFilter)
       throws ReferenceNotFoundException;
 
   /**
@@ -238,10 +241,12 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * Get a stream of all available keys for the given ref.
    *
    * @param ref The ref to get keys for.
+   * @param keyFilter optional filter predicate to include/exclude keys from the result
    * @return The stream of keys available for this ref.
    * @throws ReferenceNotFoundException if {@code ref} is not present in the store
    */
-  Stream<WithType<Key, VALUE_TYPE>> getKeys(Ref ref) throws ReferenceNotFoundException;
+  Stream<WithType<Key, VALUE_TYPE>> getKeys(Ref ref, Predicate<Key> keyFilter)
+      throws ReferenceNotFoundException;
 
   /**
    * Get the value for a provided ref.

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -151,13 +151,14 @@ class TestMetricsVersionStore {
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "getkeys",
-                vs -> vs.getKeys(Hash.of("cafe4242")),
+                vs -> vs.getKeys(Hash.of("cafe4242"), null),
                 () -> Stream.of(Key.of("hello", "world")),
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "getnamedrefs",
                 stringStringDummyEnumVersionStore ->
-                    stringStringDummyEnumVersionStore.getNamedRefs(GetNamedRefsParams.DEFAULT),
+                    stringStringDummyEnumVersionStore.getNamedRefs(
+                        GetNamedRefsParams.DEFAULT, null),
                 () ->
                     Stream.of(
                         WithHash.of(Hash.of("cafebabe"), BranchName.of("foo")),

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -176,14 +176,14 @@ class TestTracingVersionStore {
                         "GetKeys", refNotFoundThrows)
                     .tag("nessie.version-store.ref", "Hash cafe4242")
                     .function(
-                        vs -> vs.getKeys(Hash.of("cafe4242")),
+                        vs -> vs.getKeys(Hash.of("cafe4242"), null),
                         () -> Stream.of(Key.of("hello", "world"))),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "GetNamedRefs", runtimeThrows)
                     .function(
                         stringStringDummyEnumVersionStore ->
                             stringStringDummyEnumVersionStore.getNamedRefs(
-                                GetNamedRefsParams.DEFAULT),
+                                GetNamedRefsParams.DEFAULT, null),
                         () ->
                             Stream.of(
                                 WithHash.of(Hash.of("cafebabe"), BranchName.of("foo")),

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractITVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractITVersionStore.java
@@ -153,7 +153,7 @@ public abstract class AbstractITVersionStore {
 
     List<ReferenceInfo<String>> namedRefs;
     try (Stream<ReferenceInfo<String>> str =
-        store().getNamedRefs(GetNamedRefsParams.DEFAULT).filter(this::filterMainBranch)) {
+        store().getNamedRefs(GetNamedRefsParams.DEFAULT, null).filter(this::filterMainBranch)) {
       namedRefs = str.collect(Collectors.toList());
     }
     assertThat(namedRefs)
@@ -177,7 +177,7 @@ public abstract class AbstractITVersionStore {
     assertThrows(
         ReferenceNotFoundException.class, () -> store().hashOnReference(branch, Optional.empty()));
     try (Stream<ReferenceInfo<String>> str =
-        store().getNamedRefs(GetNamedRefsParams.DEFAULT).filter(this::filterMainBranch)) {
+        store().getNamedRefs(GetNamedRefsParams.DEFAULT, null).filter(this::filterMainBranch)) {
       assertThat(str).hasSize(2); // bar + baz
     }
     assertThrows(ReferenceNotFoundException.class, () -> store().delete(branch, Optional.of(hash)));
@@ -277,7 +277,7 @@ public abstract class AbstractITVersionStore {
 
     List<ReferenceInfo<String>> namedRefs;
     try (Stream<ReferenceInfo<String>> str =
-        store().getNamedRefs(GetNamedRefsParams.DEFAULT).filter(this::filterMainBranch)) {
+        store().getNamedRefs(GetNamedRefsParams.DEFAULT, null).filter(this::filterMainBranch)) {
       namedRefs = str.collect(Collectors.toList());
     }
     assertThat(namedRefs)
@@ -296,7 +296,7 @@ public abstract class AbstractITVersionStore {
     assertThrows(
         ReferenceNotFoundException.class, () -> store().hashOnReference(tag, Optional.empty()));
     try (Stream<ReferenceInfo<String>> str =
-        store().getNamedRefs(GetNamedRefsParams.DEFAULT).filter(this::filterMainBranch)) {
+        store().getNamedRefs(GetNamedRefsParams.DEFAULT, null).filter(this::filterMainBranch)) {
       assertThat(str).hasSize(2); // foo + another-tag
     }
     assertThrows(
@@ -338,7 +338,7 @@ public abstract class AbstractITVersionStore {
     assertThrows(
         ReferenceNotFoundException.class, () -> store().hashOnReference(branch, Optional.empty()));
     try (Stream<ReferenceInfo<String>> str =
-        store().getNamedRefs(GetNamedRefsParams.DEFAULT).filter(this::filterMainBranch)) {
+        store().getNamedRefs(GetNamedRefsParams.DEFAULT, null).filter(this::filterMainBranch)) {
       assertThat(str).isEmpty();
     }
     assertThrows(
@@ -383,15 +383,15 @@ public abstract class AbstractITVersionStore {
             commit(secondCommit, "Second Commit"),
             commit(initialCommit, "Initial Commit"));
 
-    try (Stream<Key> keys = store().getKeys(branch).map(WithType::getValue)) {
+    try (Stream<Key> keys = store().getKeys(branch, null).map(WithType::getValue)) {
       assertThat(keys).containsExactlyInAnyOrder(Key.of("t1"), Key.of("t2"), Key.of("t4"));
     }
 
-    try (Stream<Key> keys = store().getKeys(secondCommit).map(WithType::getValue)) {
+    try (Stream<Key> keys = store().getKeys(secondCommit, null).map(WithType::getValue)) {
       assertThat(keys).containsExactlyInAnyOrder(Key.of("t1"), Key.of("t4"));
     }
 
-    try (Stream<Key> keys = store().getKeys(initialCommit).map(WithType::getValue)) {
+    try (Stream<Key> keys = store().getKeys(initialCommit, null).map(WithType::getValue)) {
       assertThat(keys).containsExactlyInAnyOrder(Key.of("t1"), Key.of("t2"), Key.of("t3"));
     }
 
@@ -478,7 +478,7 @@ public abstract class AbstractITVersionStore {
             commit(t1Commit, "T1 Commit"),
             commit(initialCommit, "Initial Commit"));
 
-    try (Stream<Key> keys = store().getKeys(branch).map(WithType::getValue)) {
+    try (Stream<Key> keys = store().getKeys(branch, null).map(WithType::getValue)) {
       assertThat(keys).containsExactlyInAnyOrder(Key.of("t1"), Key.of("t2"), Key.of("t3"));
     }
 


### PR DESCRIPTION
Adds an optional `filter` parameter to the REST endpoints to get all
named references and get entries for a reference.

Filtering implementation is implemented in a very simple way, it just
uses `String.contains()` on the name of the reference / the string
representation of a `Key`.