### PR TITLE
Clarify co-existence of DatabaseAdapter instances

### DIFF
--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
@@ -69,7 +69,8 @@ public class NessieJaxRsExtension implements BeforeAllCallback, AfterAllCallback
         PersistVersionStoreExtension.forDatabaseAdapter(
             () -> {
               DatabaseAdapter databaseAdapter = databaseAdapterSupplier.get();
-              databaseAdapter.reinitializeRepo(SERVER_CONFIG.getDefaultBranch());
+              databaseAdapter.eraseRepo();
+              databaseAdapter.initializeRepo(SERVER_CONFIG.getDefaultBranch());
               return databaseAdapter;
             }));
     weld.addExtension(new AccessCheckerExtension());

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusVersionStoreAdvancedConfig.java
@@ -41,13 +41,13 @@ import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
 public interface QuarkusVersionStoreAdvancedConfig
     extends NonTransactionalDatabaseAdapterConfig, TxDatabaseAdapterConfig {
 
-  @WithName("key-prefix")
-  @WithDefault(DEFAULT_KEY_PREFIX)
+  @WithName("repository-id")
+  @WithDefault(DEFAULT_REPOSITORY_ID)
   // Use TrimmedStringConverter for the "key-prefix" property because it can be an empty string,
   // but the default converter will turn empty strings into `null`.
   @WithConverter(TrimmedStringConverter.class)
   @Override
-  String getKeyPrefix();
+  String getRepositoryId();
 
   @WithName("parent-per-commit")
   @WithDefault("" + DEFAULT_PARENTS_PER_COMMIT)

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/profiles/BaseConfigProfile.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/profiles/BaseConfigProfile.java
@@ -26,7 +26,7 @@ public class BaseConfigProfile implements QuarkusTestProfile {
 
   public static final Map<String, String> VERSION_STORE_CONFIG =
       ImmutableMap.<String, String>builder()
-          .put("nessie.version.store.advanced.key-prefix", "nessie-test")
+          .put("nessie.version.store.advanced.repository-id", "nessie-test")
           .put("nessie.version.store.advanced.commit-retries", "42")
           .put("nessie.version.store.advanced.tx.batch-size", "41")
           .build();

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -71,7 +71,7 @@ The following configurations are advanced configurations to configure how Nessie
 
 | Property                                                      | Default values      | Type     | Description                                                         |
 | -----------------------------------------------               | ------------------- | -------- |-------------------------------------------------------------------- |
-| `nessie.version.store.advanced.key-prefix`                     |                     | `String` | Sets prefix for all primary-keys.  |
+| `nessie.version.store.advanced.repository-id`                  |                     | `String` | Sets Nessie repository ID (optional). This ID can be used to distinguish multiple Nessie repositories that reside in the same storage instance.  |
 | `nessie.version.store.advanced.parent-per-commit`              | `20`                | `int`    | Sets the number of parent-commit-hashes stored in Nessie store.  |
 | `nessie.version.store.advanced.key-list-distance`              | `20`                | `int`    | Sets the number "reachable" or "known" keys for each `CommitLogEntry`.   |
 | `nessie.version.store.advanced.max-key-list-size`              | `250_000`           | `int`    | Sets the maximum size of a database object/row. This parameter is respected for `CommitLogEntry` and `KeyList`. This value must not be "on the edge" - means: it must leave enough room for a somewhat large-ish list   |

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/AdjustableDatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/AdjustableDatabaseAdapterConfig.java
@@ -19,7 +19,7 @@ import java.time.Clock;
 
 public interface AdjustableDatabaseAdapterConfig extends DatabaseAdapterConfig {
 
-  AdjustableDatabaseAdapterConfig withKeyPrefix(String keyPrefix);
+  AdjustableDatabaseAdapterConfig withRepositoryId(String repositoryId);
 
   AdjustableDatabaseAdapterConfig withParentsPerCommit(int parentsPerCommit);
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -35,10 +35,14 @@ import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 
 /**
- * Database-Adapter interface that encapsulates all database related logic, ab abstraction between a
+ * Database-Adapter interface that encapsulates all database related logic, an abstraction between a
  * {@link org.projectnessie.versioned.VersionStore} implementation and a variety of different
  * databases that share common core implementations for example for the commit/merge/transplant
  * operations.
+ *
+ * <p>One or more adapter instances may use the same storage (database instance / schema). In this
+ * case adapter instances usually differ by their {@link DatabaseAdapterConfig#getRepositoryId()
+ * repository ID} configuration parameters.
  *
  * <p>Database-adapters treat the actual "Nessie content" and "Nessie commit metadata" as an opaque
  * value ("BLOB") without interpreting the content. Database-adapter must persist serialized values
@@ -57,8 +61,16 @@ public interface DatabaseAdapter {
   /** Ensures that mandatory data is present in the repository, does not change an existing repo. */
   void initializeRepo(String defaultBranchName);
 
-  /** Forces a repository to be re-initialized. */
-  void reinitializeRepo(String defaultBranchName);
+  /**
+   * Forces all repository data managed by this adapter instance to be deleted.
+   *
+   * <p>This includes all data for the configured {@link DatabaseAdapterConfig#getRepositoryId()
+   * repository ID}.
+   *
+   * <p>After erasing a repository {@link #initializeRepo(String)} may be called to reinitialize the
+   * minimal required data structures for the same repository ID.
+   */
+  void eraseRepo();
 
   /** Get the {@link Hash} for "beginning of time". */
   Hash noAncestorHash();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
@@ -27,7 +27,7 @@ import org.immutables.value.Value;
  */
 public interface DatabaseAdapterConfig {
 
-  String DEFAULT_KEY_PREFIX = "";
+  String DEFAULT_REPOSITORY_ID = "";
   int DEFAULT_PARENTS_PER_COMMIT = 20;
   int DEFAULT_KEY_LIST_DISTANCE = 20;
   int DEFAULT_MAX_KEY_LIST_SIZE = 250_000;
@@ -35,12 +35,18 @@ public interface DatabaseAdapterConfig {
   int DEFAULT_COMMIT_RETRIES = Integer.MAX_VALUE;
 
   /**
-   * Prefix for all primary-keys used by a {@link
-   * org.projectnessie.versioned.persist.adapter.DatabaseAdapter} instance.
+   * A free-form string that identifies a particular Nessie storage repository.
+   *
+   * <p>When remote (shared) storage is used, multiple Nessie repositories may co-exist in the same
+   * database (and in the same schema). In that case this configuration parameter can be used to
+   * distinguish those repositories.
+   *
+   * <p>All {@link org.projectnessie.versioned.persist.adapter.DatabaseAdapter} implementations must
+   * respect this parameter.
    */
   @Value.Default
-  default String getKeyPrefix() {
-    return DEFAULT_KEY_PREFIX;
+  default String getRepositoryId() {
+    return DEFAULT_REPOSITORY_ID;
   }
 
   /**

--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -88,7 +88,8 @@ public class CommitBench {
     public void init() throws Exception {
       databaseAdapter = adapterByName();
 
-      databaseAdapter.reinitializeRepo(branch.getName());
+      databaseAdapter.eraseRepo();
+      databaseAdapter.initializeRepo(branch.getName());
 
       versionStore = new PersistVersionStore<>(databaseAdapter, StringStoreWorker.INSTANCE);
 

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -84,7 +84,7 @@ public class DynamoDatabaseAdapter
 
     client = c;
 
-    String keyPrefix = config.getKeyPrefix();
+    String keyPrefix = config.getRepositoryId();
     if (keyPrefix.indexOf(PREFIX_SEPARATOR) >= 0) {
       throw new IllegalArgumentException("Invalid key prefix: " + keyPrefix);
     }
@@ -113,7 +113,7 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  public void reinitializeRepo(String defaultBranchName) {
+  public void eraseRepo() {
     client.client.deleteItem(
         b -> b.tableName(TABLE_GLOBAL_POINTER).key(globalPointerKeyMap).build());
 
@@ -136,8 +136,6 @@ public class DynamoDatabaseAdapter
                                                     .key(
                                                         Collections.singletonMap(
                                                             KEY_NAME, key))))));
-
-    super.initializeRepo(defaultBranchName);
   }
 
   private <T> T loadById(String table, Hash id, Parser<T> parser) {

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -50,7 +50,7 @@ public class InmemoryDatabaseAdapter
       NonTransactionalDatabaseAdapterConfig config, InmemoryStore store) {
     super(config);
 
-    this.keyPrefix = ByteString.copyFromUtf8(config.getKeyPrefix() + ':');
+    this.keyPrefix = ByteString.copyFromUtf8(config.getRepositoryId() + ':');
 
     Objects.requireNonNull(
         store, "Requires a non-null InmemoryStore from InmemoryDatabaseAdapterConfig");
@@ -67,9 +67,8 @@ public class InmemoryDatabaseAdapter
   }
 
   @Override
-  public void reinitializeRepo(String defaultBranchName) {
+  public void eraseRepo() {
     store.reinitializeRepo(keyPrefix);
-    super.initializeRepo(defaultBranchName);
   }
 
   @Override

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -62,8 +62,8 @@ public class RocksDatabaseAdapter
       NonTransactionalDatabaseAdapterConfig config, RocksDbInstance dbInstance) {
     super(config);
 
-    this.keyPrefix = ByteString.copyFromUtf8(config.getKeyPrefix() + ':');
-    this.globalPointerKey = ByteString.copyFromUtf8(config.getKeyPrefix()).toByteArray();
+    this.keyPrefix = ByteString.copyFromUtf8(config.getRepositoryId() + ':');
+    this.globalPointerKey = ByteString.copyFromUtf8(config.getRepositoryId()).toByteArray();
 
     // get the externally configured RocksDbInstance
     Objects.requireNonNull(
@@ -86,13 +86,12 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  public void reinitializeRepo(String defaultBranchName) {
+  public void eraseRepo() {
     try {
       db.delete(dbInstance.getCfGlobalPointer(), globalPointerKey());
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
     }
-    super.initializeRepo(defaultBranchName);
   }
 
   @Override

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -403,9 +403,9 @@ public abstract class AbstractDatabaseAdapterTest {
   }
 
   @Test
-  void nonExistentKeyPrefixTest(
+  void nonExistentRepository(
       @NessieDbAdapter(initializeRepo = false)
-          @NessieDbAdapterConfigItem(name = "key.prefix", value = "non-existent")
+          @NessieDbAdapterConfigItem(name = "repository.id", value = "non-existent")
           DatabaseAdapter nonExistent) {
     assertAll(
         () -> {
@@ -424,10 +424,10 @@ public abstract class AbstractDatabaseAdapterTest {
   }
 
   @Test
-  void keyPrefixBasic(
-      @NessieDbAdapter @NessieDbAdapterConfigItem(name = "key.prefix", value = "foo")
+  void multipleRepositories(
+      @NessieDbAdapter @NessieDbAdapterConfigItem(name = "repository.id", value = "foo")
           DatabaseAdapter foo,
-      @NessieDbAdapter @NessieDbAdapterConfigItem(name = "key.prefix", value = "bar")
+      @NessieDbAdapter @NessieDbAdapterConfigItem(name = "repository.id", value = "bar")
           DatabaseAdapter bar)
       throws Exception {
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
@@ -108,7 +108,8 @@ public class DatabaseAdapterExtension
   }
 
   private static void reinit(DatabaseAdapter adapter) {
-    adapter.reinitializeRepo("main");
+    adapter.eraseRepo();
+    adapter.initializeRepo("main");
   }
 
   @Override

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
@@ -19,112 +19,109 @@ public final class SqlStatements {
 
   public static final String TABLE_NAMED_REFERENCES = "named_refs";
   public static final String DELETE_NAMED_REFERENCE_ALL =
-      String.format("DELETE FROM %s WHERE key_prefix = ?", TABLE_NAMED_REFERENCES);
+      String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_NAMED_REFERENCES);
   public static final String UPDATE_NAMED_REFERENCE =
       String.format(
-          "UPDATE %s SET hash = ? WHERE key_prefix = ? AND ref = ? AND hash = ?",
+          "UPDATE %s SET hash = ? WHERE repo_id = ? AND ref = ? AND hash = ?",
           TABLE_NAMED_REFERENCES);
   public static final String INSERT_NAMED_REFERENCE =
       String.format(
-          "INSERT INTO %s (key_prefix, ref, ref_type, hash) VALUES (?, ?, ?, ?)",
+          "INSERT INTO %s (repo_id, ref, ref_type, hash) VALUES (?, ?, ?, ?)",
           TABLE_NAMED_REFERENCES);
   public static final String DELETE_NAMED_REFERENCE =
       String.format(
-          "DELETE FROM %s WHERE key_prefix = ? AND ref = ? AND hash = ?", TABLE_NAMED_REFERENCES);
+          "DELETE FROM %s WHERE repo_id = ? AND ref = ? AND hash = ?", TABLE_NAMED_REFERENCES);
   public static final String SELECT_NAMED_REFERENCES =
-      String.format(
-          "SELECT ref_type, ref, hash FROM %s WHERE key_prefix = ?", TABLE_NAMED_REFERENCES);
+      String.format("SELECT ref_type, ref, hash FROM %s WHERE repo_id = ?", TABLE_NAMED_REFERENCES);
   public static final String SELECT_NAMED_REFERENCE_NAME =
-      String.format("SELECT hash FROM %s WHERE key_prefix = ? AND ref = ?", TABLE_NAMED_REFERENCES);
+      String.format("SELECT hash FROM %s WHERE repo_id = ? AND ref = ?", TABLE_NAMED_REFERENCES);
   public static final String SELECT_NAMED_REFERENCE =
       String.format(
-          "SELECT hash FROM %s WHERE key_prefix = ? AND ref = ? AND ref_type = ?",
+          "SELECT hash FROM %s WHERE repo_id = ? AND ref = ? AND ref_type = ?",
           TABLE_NAMED_REFERENCES);
   public static final String SELECT_NAMED_REFERENCE_ANY =
       String.format(
-          "SELECT ref_type, hash FROM %s WHERE key_prefix = ? AND ref = ?", TABLE_NAMED_REFERENCES);
+          "SELECT ref_type, hash FROM %s WHERE repo_id = ? AND ref = ?", TABLE_NAMED_REFERENCES);
   public static final String CREATE_TABLE_NAMED_REFERENCES =
       String.format(
           "CREATE TABLE %s (\n"
-              + "  key_prefix {2},\n"
+              + "  repo_id {2},\n"
               + "  ref {4},\n"
               + "  ref_type {5},\n"
               + "  hash {1},\n"
-              + "  PRIMARY KEY (key_prefix, ref)\n"
+              + "  PRIMARY KEY (repo_id, ref)\n"
               + ")",
           TABLE_NAMED_REFERENCES);
 
   public static final String TABLE_GLOBAL_STATE = "global_state";
   public static final String DELETE_GLOBAL_STATE_ALL =
-      String.format("DELETE FROM %s WHERE key_prefix = ?", TABLE_GLOBAL_STATE);
+      String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_GLOBAL_STATE);
   public static final String UPDATE_GLOBAL_STATE_UNCOND =
       String.format(
-          "UPDATE %s SET value = ?, chksum = ?, created_at = ? WHERE key_prefix = ? AND cid = ?",
+          "UPDATE %s SET value = ?, chksum = ?, created_at = ? WHERE repo_id = ? AND cid = ?",
           TABLE_GLOBAL_STATE);
   public static final String UPDATE_GLOBAL_STATE =
       String.format(
-          "UPDATE %s SET value = ?, chksum = ?, created_at = ? WHERE key_prefix = ? AND cid = ? AND chksum = ?",
+          "UPDATE %s SET value = ?, chksum = ?, created_at = ? WHERE repo_id = ? AND cid = ? AND chksum = ?",
           TABLE_GLOBAL_STATE);
   public static final String INSERT_GLOBAL_STATE =
       String.format(
-          "INSERT INTO %s (key_prefix, cid, chksum, value, created_at) VALUES (?, ?, ?, ?, ?)",
+          "INSERT INTO %s (repo_id, cid, chksum, value, created_at) VALUES (?, ?, ?, ?, ?)",
           TABLE_GLOBAL_STATE);
   public static final String SELECT_GLOBAL_STATE_MANY_WITH_LOGS =
       String.format(
-          "SELECT cid, value, created_at FROM %s WHERE key_prefix = ? AND cid IN (%%s)",
+          "SELECT cid, value, created_at FROM %s WHERE repo_id = ? AND cid IN (%%s)",
           TABLE_GLOBAL_STATE);
   public static final String SELECT_GLOBAL_STATE_ALL =
-      String.format("SELECT cid, value FROM %s WHERE key_prefix = ?", TABLE_GLOBAL_STATE);
+      String.format("SELECT cid, value FROM %s WHERE repo_id = ?", TABLE_GLOBAL_STATE);
   public static final String SELECT_GLOBAL_STATE_MANY =
       String.format(
-          "SELECT cid, value FROM %s WHERE key_prefix = ? AND cid IN (%%s)", TABLE_GLOBAL_STATE);
+          "SELECT cid, value FROM %s WHERE repo_id = ? AND cid IN (%%s)", TABLE_GLOBAL_STATE);
   public static final String CREATE_TABLE_GLOBAL_STATE =
       String.format(
           "CREATE TABLE %s (\n"
-              + "  key_prefix {2},\n"
+              + "  repo_id {2},\n"
               + "  cid {6},\n"
               + "  chksum {1},\n"
               + "  value {0},\n"
               + "  created_at {7},\n"
-              + "  PRIMARY KEY (key_prefix, cid)\n"
+              + "  PRIMARY KEY (repo_id, cid)\n"
               + ")",
           TABLE_GLOBAL_STATE);
 
   public static final String TABLE_COMMIT_LOG = "commit_log";
   public static final String DELETE_COMMIT_LOG_ALL =
-      String.format("DELETE FROM %s WHERE key_prefix = ?", TABLE_COMMIT_LOG);
+      String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_COMMIT_LOG);
   public static final String INSERT_COMMIT_LOG =
-      String.format("INSERT INTO %s (key_prefix, hash, value) VALUES (?, ?, ?)", TABLE_COMMIT_LOG);
+      String.format("INSERT INTO %s (repo_id, hash, value) VALUES (?, ?, ?)", TABLE_COMMIT_LOG);
   public static final String SELECT_COMMIT_LOG_MANY =
-      String.format(
-          "SELECT value FROM %s WHERE key_prefix = ? AND hash IN (%%s)", TABLE_COMMIT_LOG);
+      String.format("SELECT value FROM %s WHERE repo_id = ? AND hash IN (%%s)", TABLE_COMMIT_LOG);
   public static final String SELECT_COMMIT_LOG =
-      String.format("SELECT value FROM %s WHERE key_prefix = ? AND hash = ?", TABLE_COMMIT_LOG);
+      String.format("SELECT value FROM %s WHERE repo_id = ? AND hash = ?", TABLE_COMMIT_LOG);
   public static final String CREATE_TABLE_COMMIT_LOG =
       String.format(
           "CREATE TABLE %s (\n"
-              + "  key_prefix {2},\n"
+              + "  repo_id {2},\n"
               + "  hash {1},\n"
               + "  value {0},\n"
-              + "  PRIMARY KEY (key_prefix, hash)\n"
+              + "  PRIMARY KEY (repo_id, hash)\n"
               + ")",
           TABLE_COMMIT_LOG);
 
   public static final String TABLE_KEY_LIST = "key_list";
   public static final String DELETE_KEY_LIST_ALL =
-      String.format("DELETE FROM %s WHERE key_prefix = ?", TABLE_KEY_LIST);
+      String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_KEY_LIST);
   public static final String SELECT_KEY_LIST_MANY =
-      String.format(
-          "SELECT id, value FROM %s WHERE key_prefix = ? AND id IN (%%s)", TABLE_KEY_LIST);
+      String.format("SELECT id, value FROM %s WHERE repo_id = ? AND id IN (%%s)", TABLE_KEY_LIST);
   public static final String INSERT_KEY_LIST =
-      String.format("INSERT INTO %s (key_prefix, id, value) VALUES (?, ?, ?)", TABLE_KEY_LIST);
+      String.format("INSERT INTO %s (repo_id, id, value) VALUES (?, ?, ?)", TABLE_KEY_LIST);
   public static final String CREATE_TABLE_KEY_LIST =
       String.format(
           "CREATE TABLE %s (\n"
-              + "  key_prefix {2},\n"
+              + "  repo_id {2},\n"
               + "  id {1},\n"
               + "  value {0},\n"
-              + "  PRIMARY KEY (key_prefix, id)\n"
+              + "  PRIMARY KEY (repo_id, id)\n"
               + ")",
           TABLE_KEY_LIST);
 


### PR DESCRIPTION
* Rename "key prefix" config properties to "repository ID".
  Even though some adapter use this value as a proper PK prefix,
  conceptually it identifies a Nessie repository within a particular
  storage cluster.

* Convert `DatabaseAdapter.reinitializeRepo()` to `eraseRepo()`
  This is to isolate the "init" logic encapsulated in `initializeRepo()`
  from the "delete data" logic to allow independent execution (whenever
  required).

* Add javadoc about using the same storage backend for multiple repositories.

* Rename RDBMS-based key field from `key_prefix` to `repo`.

* Rename MongoDB ID component from `prefix` to `repo`.