### PR TITLE
Nessie gc base module to identify expired contents

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
+++ b/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
@@ -19,6 +19,7 @@ import java.util.OptionalInt;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.api.PagingBuilder;
 import org.projectnessie.error.NessieNotFoundException;
@@ -100,12 +101,14 @@ public final class StreamingUtil {
       @Nullable String hashOnRef,
       @Nullable String untilHash,
       @Nullable String filter,
-      OptionalInt maxRecords)
+      OptionalInt maxRecords,
+      boolean fetchAdditionalInfo)
       throws NessieNotFoundException {
+    FetchOption fetchOption = fetchAdditionalInfo ? FetchOption.ALL : FetchOption.MINIMAL;
     return new ResultStreamPaginator<>(
             LogResponse::getLogEntries,
             (reference, pageSize, token) ->
-                builderWithPaging(api.getCommitLog(), pageSize, token)
+                builderWithPaging(api.getCommitLog().fetch(fetchOption), pageSize, token)
                     .refName(reference)
                     .hashOnRef(hashOnRef)
                     .filter(filter)

--- a/gc/gc-base/pom.xml
+++ b/gc/gc-base/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie-gc</artifactId>
+    <version>0.18.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-gc-base</artifactId>
+
+  <name>Nessie - GC - Base Implementation</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-client</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-in-memory</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-in-memory</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-rest-services</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-server-store</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-store</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-jaxrs</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-pool</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/BasicExpiredContentValues.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/BasicExpiredContentValues.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.projectnessie.model.Content;
+
+public final class BasicExpiredContentValues extends ExpiredContentValues {
+
+  private final Set<Content> expiredContents = new HashSet<>();
+  private final Set<Content> liveContents = new HashSet<>();
+
+  @Override
+  protected void addValue(Content content, boolean isExpired) {
+    if (isExpired) {
+      // Move to expired list only if the content is not live from other walked references.
+      if (!liveContents.contains(content)) {
+        expiredContents.add(content);
+      }
+    } else {
+      liveContents.add(content);
+      // If content is found live, remove it from expired set if exists.
+      expiredContents.remove(content);
+    }
+  }
+
+  Set<Content> getExpiredContents() {
+    return expiredContents;
+  }
+
+  public Set<Content> getLiveContents() {
+    return liveContents;
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/ContentValuesCollector.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/ContentValuesCollector.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Reference;
+
+/** Global commit-log scanning state and result. */
+public final class ContentValuesCollector<GC_CONTENT_VALUES extends ExpiredContentValues> {
+
+  private final Supplier<GC_CONTENT_VALUES> newContentValues;
+
+  /** Content per content-id. */
+  final Map<String, GC_CONTENT_VALUES> contentValues = new ConcurrentHashMap<>();
+
+  public ContentValuesCollector(Supplier<GC_CONTENT_VALUES> newContentValues) {
+    this.newContentValues = newContentValues;
+  }
+
+  public GC_CONTENT_VALUES contentValues(String contentId) {
+    return contentValues.computeIfAbsent(contentId, k -> newContentValues.get());
+  }
+
+  public void gotValue(
+      Content content, Reference reference, ContentKey contentKey, boolean isExpired) {
+    contentValues(content.getId()).gotValue(content, reference, contentKey, isExpired);
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/ExpiredContentValues.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/ExpiredContentValues.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Reference;
+
+/**
+ * Contains details about one content object: reference, key, the live values and the expired
+ * values.
+ */
+public abstract class ExpiredContentValues {
+
+  private Reference reference;
+
+  private ContentKey key;
+
+  public ContentKey getKey() {
+    return key;
+  }
+
+  public Reference getReference() {
+    return reference;
+  }
+
+  private void setIfAbsent(Reference reference, ContentKey key) {
+    if (this.reference == null) {
+      this.reference = reference;
+      this.key = key;
+    }
+  }
+
+  void gotValue(Content content, Reference reference, ContentKey key, boolean isExpired) {
+    synchronized (this) {
+      addValue(content, isExpired);
+      setIfAbsent(reference, key);
+    }
+  }
+
+  protected abstract void addValue(Content content, boolean isExpired);
+
+  @Override
+  public String toString() {
+    return "ExpiredContentValues{" + ", Reference=" + reference + ", Key=" + key + '}';
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/GC.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/GC.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import java.time.Instant;
+import java.util.function.Function;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.model.Reference;
+
+public interface GC {
+  static Builder builder() {
+    return new GCBuilder();
+  }
+
+  <GC_CONTENT_VALUES extends ExpiredContentValues> GCResult<GC_CONTENT_VALUES> performGC(
+      ContentValuesCollector<GC_CONTENT_VALUES> contentValuesCollector);
+
+  interface Builder {
+    Builder withApi(NessieApiV1 api);
+
+    /**
+     * Commits that are older than the specified {@code defaultCutOffTimeStamp} will be considered
+     * as eligible for GC.
+     *
+     * <p>This is effectively a shortcut for {@link #withCutOffTimeStampPerReferenceFunc(Function)}.
+     *
+     * @see #withCutOffTimeStampPerReferenceFunc(Function)
+     */
+    Builder withDefaultCutOffTimeStamp(Instant defaultCutOffTimeStamp);
+
+    /**
+     * Adds a function to compute the timestamp after which commits for a named reference are
+     * considered as expired.
+     *
+     * @see #withDefaultCutOffTimeStamp(Instant)
+     */
+    Builder withCutOffTimeStampPerReferenceFunc(
+        Function<Reference, Instant> cutOffTimeStampPerReferenceFunc);
+
+    /** Build the {@link GC} instance. */
+    GC build();
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/GCBuilder.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/GCBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Function;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.model.Reference;
+
+final class GCBuilder implements GC.Builder {
+
+  private NessieApiV1 api;
+  private Instant defaultCutOffTimeStamp;
+  private Function<Reference, Instant> cutOffTimeStampPerRefFunc;
+
+  @Override
+  public GC.Builder withApi(NessieApiV1 api) {
+    this.api = api;
+    return this;
+  }
+
+  @Override
+  public GC.Builder withDefaultCutOffTimeStamp(Instant defaultCutOffTimeStamp) {
+    this.defaultCutOffTimeStamp = defaultCutOffTimeStamp;
+    return this;
+  }
+
+  @Override
+  public GC.Builder withCutOffTimeStampPerReferenceFunc(
+      Function<Reference, Instant> cutOffTimeStampPerReferenceFunc) {
+    this.cutOffTimeStampPerRefFunc = cutOffTimeStampPerReferenceFunc;
+    return this;
+  }
+
+  @Override
+  public GC build() {
+    Instant defaultCutOffTimeStamp =
+        Objects.requireNonNull(
+            this.defaultCutOffTimeStamp, "defaultCutOffTimeStamp must not be null");
+
+    Function<Reference, Instant> cutOffTimestampFunc;
+    if (cutOffTimeStampPerRefFunc == null) {
+      cutOffTimestampFunc = ref -> defaultCutOffTimeStamp;
+    } else {
+      // map the missing reference's cutoff time to defaultCutOffTimeStamp.
+      cutOffTimestampFunc =
+          ref -> {
+            Instant currentVal = cutOffTimeStampPerRefFunc.apply(ref);
+            if (currentVal == null) {
+              return defaultCutOffTimeStamp;
+            } else {
+              return currentVal;
+            }
+          };
+    }
+
+    return new GCImpl(api, cutOffTimestampFunc);
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/GCImpl.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/GCImpl.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.projectnessie.client.StreamingUtil;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.EntriesResponse;
+import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.Operation;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Encapsulates the logic to retrieve all content including their content keys over all commits in
+ * all named-references.
+ */
+final class GCImpl implements GC {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GCImpl.class);
+
+  private final NessieApiV1 api;
+  private final Function<Reference, Instant> cutOffTimestamp;
+
+  GCImpl(NessieApiV1 api, Function<Reference, Instant> cutOffTimestamp) {
+    this.api = api;
+    this.cutOffTimestamp = cutOffTimestamp;
+  }
+
+  @Override
+  public <GC_CONTENT_VALUES extends ExpiredContentValues> GCResult<GC_CONTENT_VALUES> performGC(
+      ContentValuesCollector<GC_CONTENT_VALUES> contentValuesCollector) {
+    // Algorithm for performing the GC to identify the expired contents :
+
+    // Walk through each reference.
+    // For each commit in a reference, collect live table keys or dropped table keys.
+    // For each key, get the content.
+    // If the content's key is in dropped table keys,
+    //     add content to expired set (If the content is not live from previous walks of other
+    // references).
+    // Else if the commit is head commit, add contents to live set.
+    // Else check if the content is expired or not based on cutoff time of this reference.
+    //     Based on that add content to respective sets (live or expired).
+    //
+    // Note: So, If a table is dropped in a reference. Then independent of cutoff time,
+    // all the snapshots for that table in the reference (that are not live in other reference)
+    // will be considered for expiry.
+
+    List<Reference> references = api.getAllReferences().get().getReferences();
+    for (Reference reference : references) {
+      Instant cutOffTimestamp = this.cutOffTimestamp.apply(reference);
+      walkReference(
+          contentValuesCollector,
+          reference,
+          commitMeta ->
+              // If the commit time is older than (think: less than, before) cutoff-time, then
+              // commit is expired.
+              Objects.requireNonNull(commitMeta.getCommitTime()).compareTo(cutOffTimestamp) < 0);
+    }
+    return new GCResult<>(contentValuesCollector.contentValues);
+  }
+
+  private <GC_CONTENT_VALUES extends ExpiredContentValues> void walkReference(
+      ContentValuesCollector<GC_CONTENT_VALUES> contentValuesCollector,
+      Reference reference,
+      Predicate<CommitMeta> expiredCommitPredicate) {
+    try (Stream<LogResponse.LogEntry> commits =
+        StreamingUtil.getCommitLogStream(
+            api, reference.getName(), null, null, null, OptionalInt.empty(), true)) {
+
+      Set<ContentKey> deletedKeys = new HashSet<>();
+      AtomicBoolean commitHead = new AtomicBoolean(true);
+      commits.forEachOrdered(
+          (logEntry) -> {
+            boolean isExpired;
+            if (commitHead.get()) {
+              // If the commit is head commit, then it should be kept live if the table is reachable
+              isExpired = false;
+              commitHead.set(false);
+            } else {
+              // check expiry based on cutoff time
+              isExpired = expiredCommitPredicate.test(logEntry.getCommitMeta());
+            }
+
+            if (logEntry.getOperations() != null) {
+              logEntry
+                  .getOperations()
+                  .forEach(
+                      operation -> {
+                        if (operation instanceof Operation.Delete) {
+                          deletedKeys.add(operation.getKey());
+                        }
+                      });
+            }
+            handleCommit(
+                contentValuesCollector,
+                reference,
+                logEntry.getCommitMeta(),
+                deletedKeys,
+                isExpired);
+          });
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof NessieNotFoundException) {
+        LOGGER.info("Reference {} to retrieve commits no longer exists", reference);
+      } else {
+        throw e;
+      }
+    } catch (NessieNotFoundException e) {
+      LOGGER.info("Reference {} to retrieve commits no longer exists", reference);
+    }
+  }
+
+  private <GC_CONTENT_VALUES extends ExpiredContentValues> void handleCommit(
+      ContentValuesCollector<GC_CONTENT_VALUES> contentValuesCollector,
+      Reference reference,
+      CommitMeta commitMeta,
+      Set<ContentKey> deletedKeys,
+      boolean isExpired) {
+    try {
+      Reference commitReference = referenceWithHash(reference, commitMeta);
+      List<ContentKey> allKeys =
+          api.getEntries().reference(commitReference).get().getEntries().stream()
+              .map(EntriesResponse.Entry::getName)
+              .collect(Collectors.toList());
+      api.getContent()
+          .reference(commitReference)
+          .keys(allKeys)
+          .get()
+          .forEach(
+              (contentKey, content) -> {
+                boolean isContentExpired = isExpired;
+                if (deletedKeys.contains(contentKey)) {
+                  // table is dropped. So, expire all the contents for this ContentKey independent
+                  // of cutOffTimeStamp.
+                  isContentExpired = true;
+                }
+                handleValue(
+                    contentValuesCollector, commitReference, contentKey, content, isContentExpired);
+              });
+    } catch (NessieNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private <GC_CONTENT_VALUES extends ExpiredContentValues> void handleValue(
+      ContentValuesCollector<GC_CONTENT_VALUES> contentValuesCollector,
+      Reference reference,
+      ContentKey contentKey,
+      Content content,
+      boolean isExpired) {
+    LOGGER.info(
+        "{} value content-id {} at commit {} in {} with key {}: {}",
+        isExpired ? "Expired" : "Live",
+        content.getId(),
+        reference.getHash(),
+        reference.getName(),
+        contentKey,
+        content);
+    contentValuesCollector.gotValue(content, reference, contentKey, isExpired);
+  }
+
+  private Reference referenceWithHash(Reference reference, CommitMeta commitMeta) {
+    if (reference instanceof Branch) {
+      reference = Branch.of(reference.getName(), commitMeta.getHash());
+    } else if (reference instanceof Tag) {
+      reference = Tag.of(reference.getName(), commitMeta.getHash());
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Reference %s is neither a branch nor a tag", reference));
+    }
+    return reference;
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/GCResult.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/versioned/persist/gc/GCResult.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import java.util.Map;
+
+public class GCResult<GC_CONTENT_VALUES extends ExpiredContentValues> {
+  private final Map<String, GC_CONTENT_VALUES> contentValues;
+
+  public GCResult(Map<String, GC_CONTENT_VALUES> contentValues) {
+    this.contentValues = contentValues;
+  }
+
+  public Map<String, GC_CONTENT_VALUES> getContentValues() {
+    return contentValues;
+  }
+}

--- a/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/AbstractGCTest.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/AbstractGCTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import static java.util.Arrays.asList;
+
+import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.ImmutableDeltaLakeTable;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
+
+@ExtendWith(DatabaseAdapterExtension.class)
+abstract class AbstractGCTest {
+  @NessieDbAdapter protected static DatabaseAdapter databaseAdapter;
+
+  @ParameterizedTest
+  @MethodSource("datasetsSource")
+  void testDataset(Dataset dataset) {
+    // For every dataset in produceDatasetsSource, perform GC and validate the results.
+    dataset.applyToAdapter(databaseAdapter);
+    performGc(dataset, databaseAdapter);
+  }
+
+  static List<Dataset> datasetsSource() {
+    return produceDatasetsSource(Dataset::new);
+  }
+
+  static final String DEFAULT_BRANCH = "main";
+  static final Instant CUTOFF_TIMESTAMP = Instant.ofEpochSecond(500);
+  // content keys
+  static ContentKey TABLE_ONE = ContentKey.of("table", "one");
+  static ContentKey TABLE_TWO = ContentKey.of("table", "two");
+  static ContentKey TABLE_THREE = ContentKey.of("table", "three");
+  static ContentKey TABLE_FOUR = ContentKey.of("table", "four");
+  // content ids for the table keys
+  static String CID_ONE = "table-one";
+  static String CID_TWO = "table-two";
+  static String CID_THREE = "table-three";
+
+  /**
+   * Common test implementation to verify the expected GC results for a specific data set. This test
+   * is exactly the same for mocked and "real" {@link DatabaseAdapter}s, datasets are exactly the
+   * same, timestamps are exactly the same, hashes however do vary.
+   */
+  protected void performGc(Dataset dataset, DatabaseAdapter databaseAdapter) {
+    // perform GC on the dataset
+    ContentValuesCollector<BasicExpiredContentValues> contentValuesCollector =
+        new ContentValuesCollector<>(BasicExpiredContentValues::new);
+    GC gc =
+        GC.builder()
+            .withApi(new NessieApiMock(databaseAdapter).getApi())
+            .withDefaultCutOffTimeStamp(CUTOFF_TIMESTAMP)
+            .withCutOffTimeStampPerReferenceFunc(dataset.cutOffTimeStampPerRefFunc)
+            .build();
+    GCResult<BasicExpiredContentValues> gcResult = gc.performGC(contentValuesCollector);
+    // compare the expected contents against the actual gc output
+    dataset.verify(gcResult);
+  }
+
+  /** Produces the datasets verified via {@link #performGc(Dataset, DatabaseAdapter)}. */
+  static List<Dataset> produceDatasetsSource(Function<String, Dataset> datasetFactory) {
+    // add each test scenario as one dataset below.
+    return asList(
+        testSingleTableSingleRef(datasetFactory.apply("testSingleTableSingleRef")),
+        testSingleTableMultipleRef(datasetFactory.apply("testSingleTableMultipleRef")),
+        testDropTableSingleRef(datasetFactory.apply("testDropTableSingleRef")),
+        testMultipleTableMultipleRef(datasetFactory.apply("testMultipleTableMultipleRef")),
+        testPerRefCutoffTime(datasetFactory.apply("testPerRefCutoffTime")),
+        testTableRename(datasetFactory.apply("testTableRename")),
+        testMixedContentTypes(datasetFactory.apply("testMixedContentTypes")));
+  }
+
+  // Note: If the content is expected to be expired after the gc (by applying GC algorithm), we are
+  // setting
+  // expectExpired flag as true in putContent() operations. So that, this input content is added for
+  // validation by
+  // comparing with gc output content.
+
+  static Dataset testSingleTableSingleRef(Dataset ds) {
+    return ds
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(10))
+        .putContent(TABLE_ONE, IcebergTable.of("meta1", 42, 42, 42, 42, CID_ONE), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(8))
+        .putContent(TABLE_ONE, IcebergTable.of("meta2", 43, 42, 42, 42, CID_ONE), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP)
+        .putContent(TABLE_ONE, IcebergTable.of("meta3", 44, 42, 42, 42, CID_ONE), false)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(2))
+        .putContent(TABLE_ONE, IcebergTable.of("meta4", 45, 42, 42, 42, CID_ONE), false)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(4))
+        .putContent(TABLE_ONE, IcebergTable.of("meta5", 46, 42, 42, 42, CID_ONE), false)
+        .commit();
+  }
+
+  static Dataset testSingleTableMultipleRef(Dataset ds) {
+    return ds
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(10))
+        .putContent(TABLE_ONE, IcebergTable.of("meta1", 42, 42, 42, 42, CID_ONE), true)
+        .commit()
+        //
+        .switchToBranch("branch-1")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(8))
+        .putContent(TABLE_ONE, IcebergTable.of("meta2", 43, 42, 42, 42, CID_ONE), false)
+        .commit()
+        //
+        .switchToBranch(DEFAULT_BRANCH)
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(6))
+        .putContent(TABLE_ONE, IcebergTable.of("meta3", 44, 42, 42, 42, CID_ONE), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(2))
+        .putContent(TABLE_ONE, IcebergTable.of("meta4", 45, 42, 42, 42, CID_ONE), false)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(4))
+        .putContent(TABLE_ONE, IcebergTable.of("meta5", 46, 42, 42, 42, CID_ONE), false)
+        .commit();
+  }
+
+  static Dataset testDropTableSingleRef(Dataset ds) {
+    return ds
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(10))
+        .putContent(TABLE_ONE, IcebergTable.of("meta1", 42, 42, 42, 42, CID_ONE), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(12))
+        .putContent(TABLE_ONE, IcebergTable.of("meta2", 43, 42, 42, 42, CID_ONE), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(14))
+        .putContent(TABLE_ONE, IcebergTable.of("meta3", 46, 42, 42, 42, CID_ONE), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(16))
+        .deleteContent(TABLE_ONE)
+        .commit();
+  }
+
+  static Dataset testMultipleTableMultipleRef(Dataset ds) {
+    return ds
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(2))
+        .putContent(TABLE_ONE, IcebergTable.of("meta1", 42, 42, 42, 42, CID_ONE), false)
+        .putContent(TABLE_TWO, IcebergTable.of("meta2", 42, 42, 42, 42, CID_TWO), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(1))
+        .deleteContent(TABLE_TWO)
+        .commit()
+        // commit unchanged operation
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(1))
+        .putContent(TABLE_THREE, IcebergTable.of("meta3", 42, 42, 42, 42, CID_THREE), false)
+        .commit()
+        //
+        .switchToBranch("branch-1")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(50))
+        .deleteContent(TABLE_ONE)
+        .commit()
+        //
+        .switchToBranch("branch-2")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(100))
+        .deleteContent(TABLE_THREE)
+        .commit();
+  }
+
+  static Dataset testPerRefCutoffTime(Dataset ds) {
+    return ds
+        //
+        .withCutOffTimeStampPerRefFunc(
+            (ref) -> {
+              ImmutableMap<String, Instant> map =
+                  ImmutableMap.<String, Instant>builder()
+                      .put("branch-1", CUTOFF_TIMESTAMP.plusSeconds(5))
+                      .put("branch-2", CUTOFF_TIMESTAMP.plusSeconds(10))
+                      .build();
+              return map.get(ref.getName());
+            })
+        // Note: Another way to add withCutOffTimeStampPerRefFunc function is as below
+        // .withCutOffTimeStampPerRefFunc(
+        //   ref -> {
+        //     if (ref.getName().equals("branch-1")) {
+        //       return NOT_LIVE.plusSeconds(5);
+        //     } else if ((ref.getName().equals("branch-2"))) {
+        //       return NOT_LIVE.plusSeconds(10);
+        //     } else {
+        //       return null;
+        //     }
+        //   })
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(2))
+        .putContent(TABLE_ONE, IcebergTable.of("meta1", 42, 42, 42, 42, CID_ONE), false)
+        .putContent(TABLE_TWO, IcebergTable.of("meta2", 42, 42, 42, 42, CID_TWO), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(1))
+        .deleteContent(TABLE_TWO)
+        .commit()
+        // commit unchanged operation
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(1))
+        .putContent(TABLE_THREE, IcebergTable.of("meta3", 42, 42, 42, 42, CID_THREE), false)
+        .commit()
+        //
+        .switchToBranch("branch-1")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(3))
+        .putContent(TABLE_THREE, IcebergTable.of("meta4", 43, 42, 42, 42, CID_THREE), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(4))
+        .putContent(TABLE_THREE, IcebergTable.of("meta5", 44, 42, 42, 42, CID_THREE), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(6))
+        .putContent(TABLE_THREE, IcebergTable.of("meta5", 45, 42, 42, 42, CID_THREE), false)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(7))
+        .putContent(TABLE_THREE, IcebergTable.of("meta5", 46, 42, 42, 42, CID_THREE), false)
+        .commit()
+        //
+        .switchToBranch("branch-2")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(3))
+        .putContent(TABLE_TWO, IcebergTable.of("meta4", 43, 42, 42, 42, CID_TWO), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(4))
+        .putContent(TABLE_TWO, IcebergTable.of("meta5", 44, 42, 42, 42, CID_TWO), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(16))
+        .putContent(TABLE_TWO, IcebergTable.of("meta5", 45, 42, 42, 42, CID_TWO), false)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(17))
+        .putContent(TABLE_TWO, IcebergTable.of("meta5", 46, 42, 42, 42, CID_TWO), false)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(50))
+        .deleteContent(TABLE_THREE)
+        .commit();
+  }
+
+  static Dataset testTableRename(Dataset ds) {
+    return ds
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(2))
+        .putContent(TABLE_ONE, IcebergTable.of("meta1", 42, 42, 42, 42, CID_ONE), false)
+        .putContent(TABLE_TWO, IcebergTable.of("meta2", 42, 42, 42, 42, CID_TWO), true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(1))
+        .deleteContent(TABLE_TWO)
+        .commit()
+        // commit unchanged operation
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(1))
+        .putContent(TABLE_THREE, IcebergTable.of("meta3", 42, 42, 42, 42, CID_THREE), false)
+        .commit()
+        //
+        .switchToBranch("branch-1")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(51))
+        .deleteContent(TABLE_ONE)
+        .commit()
+        //
+        .switchToBranch("branch-2")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(52))
+        .deleteContent(TABLE_ONE)
+        .putContent(TABLE_FOUR, IcebergTable.of("meta2_1", 43, 42, 42, 42, CID_TWO), false)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(53))
+        .deleteContent(TABLE_THREE)
+        .commit();
+  }
+
+  static Dataset testMixedContentTypes(Dataset ds) {
+    return ds
+        // commit both iceberg and deltalake content
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(2))
+        .putContent(TABLE_ONE, IcebergTable.of("meta1", 42, 42, 42, 42, CID_ONE), false)
+        .putContent(
+            TABLE_TWO,
+            ImmutableDeltaLakeTable.builder().id(CID_TWO).lastCheckpoint("ch2").build(),
+            true)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.minusSeconds(1))
+        .deleteContent(TABLE_TWO)
+        .commit()
+        // commit unchanged operation
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP)
+        .commit()
+        //
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(1))
+        .putContent(
+            TABLE_THREE,
+            ImmutableDeltaLakeTable.builder().id(CID_THREE).lastCheckpoint("ch3").build(),
+            false)
+        .commit()
+        //
+        .switchToBranch("branch-1")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(50))
+        .deleteContent(TABLE_ONE)
+        .commit()
+        //
+        .switchToBranch("branch-2")
+        .getCommitBuilderWithCutoffTime(CUTOFF_TIMESTAMP.plusSeconds(100))
+        .deleteContent(TABLE_THREE)
+        .commit();
+  }
+}

--- a/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/CommitBuilder.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/CommitBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import com.google.protobuf.ByteString;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ImmutableCommitMeta;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.persist.adapter.ContentId;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+
+public final class CommitBuilder {
+  final Instant ts;
+  final NamedRef ref;
+  final Dataset dataset;
+  final Map<ContentId, ByteString> globals = new HashMap<>();
+  final List<KeyWithBytes> puts = new ArrayList<>();
+  final List<Key> deletes = new ArrayList<>();
+
+  CommitBuilder(Dataset dataset, NamedRef ref, Instant ts) {
+    this.ts = ts;
+    this.ref = ref;
+    this.dataset = dataset;
+  }
+
+  /**
+   * Adds a "Put operation" for a key/content-id/content-value and whether that value is expected to
+   * be live or non-live after GC. Note: the expectExpired can be passed as true, if this content is
+   * expected to be expired after gc
+   */
+  CommitBuilder putContent(ContentKey key, Content content, boolean expectExpired) {
+    ContentId cid = ContentId.of(content.getId());
+    puts.add(
+        KeyWithBytes.of(
+            Key.of(key.getElements().toArray(new String[0])),
+            cid,
+            (byte) Dataset.STORE_WORKER.getType(content).ordinal(),
+            Dataset.STORE_WORKER.toStoreOnReferenceState(content)));
+    if (Dataset.STORE_WORKER.requiresGlobalState(content)) {
+      globals.put(cid, Dataset.STORE_WORKER.toStoreGlobalState(content));
+    }
+    Map<String, Set<Content>> expect =
+        expectExpired ? dataset.expectedExpired : dataset.expectedLive;
+    expect.computeIfAbsent(content.getId(), x -> new HashSet<>()).add(content);
+    return this;
+  }
+
+  /** Adds a "Delete operation" for a key. */
+  CommitBuilder deleteContent(ContentKey delete) {
+    deletes.add(Key.of(delete.getElements().toArray(new String[0])));
+    return this;
+  }
+
+  /** Build and record this commit. */
+  Dataset commit() {
+    return dataset.recordCommit(
+        adapter -> {
+          ImmutableCommitAttempt.Builder commit =
+              ImmutableCommitAttempt.builder()
+                  .commitMetaSerialized(
+                      Dataset.STORE_WORKER
+                          .getMetadataSerializer()
+                          .toBytes(
+                              ImmutableCommitMeta.builder()
+                                  .commitTime(ts)
+                                  .committer("")
+                                  .authorTime(ts)
+                                  .author("")
+                                  .message("foo message")
+                                  .build()))
+                  .putAllGlobal(globals)
+                  .commitToBranch((BranchName) ref)
+                  .addAllPuts(puts)
+                  .addAllDeletes(deletes);
+          try {
+            adapter.commit(commit.build());
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+  }
+}

--- a/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/Dataset.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/Dataset.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Reference;
+import org.projectnessie.server.store.TableCommitMetaStoreWorker;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.ReferenceAlreadyExistsException;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+
+public class Dataset {
+  NamedRef currentRef;
+  final List<Consumer<DatabaseAdapter>> ops = new ArrayList<>();
+  final Set<NamedRef> knownRefs = new HashSet<>();
+  final String name;
+  final Map<String, Set<Content>> expectedLive = new HashMap<>();
+  final Map<String, Set<Content>> expectedExpired = new HashMap<>();
+  Function<Reference, Instant> cutOffTimeStampPerRefFunc;
+  static final String DEFAULT_BRANCH = "main";
+  static final TableCommitMetaStoreWorker STORE_WORKER = new TableCommitMetaStoreWorker();
+
+  Dataset(String name) {
+    this.name = name;
+    currentRef = BranchName.of(DEFAULT_BRANCH);
+  }
+
+  Dataset withCutOffTimeStampPerRefFunc(Function<Reference, Instant> cutOffTimeStampPerRefFunc) {
+    this.cutOffTimeStampPerRefFunc = cutOffTimeStampPerRefFunc;
+    return this;
+  }
+
+  /**
+   * Switches to the given branch, creates the branch if necessary from the current branch's HEAD.
+   */
+  Dataset switchToBranch(String branchName) {
+    NamedRef ref = BranchName.of(branchName);
+    NamedRef current = this.currentRef;
+    this.currentRef = ref;
+    if (knownRefs.add(ref)) {
+      ops.add(
+          adapter -> {
+            try {
+              adapter.create(
+                  ref, adapter.namedRef(current.getName(), GetNamedRefsParams.DEFAULT).getHash());
+            } catch (ReferenceAlreadyExistsException e) {
+              // Do nothing, just switch the branch
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          });
+    }
+    return this;
+  }
+
+  /**
+   * Starts building a commit with the given timestamp as the system-commit-timestamp recorded in
+   * the commit.
+   */
+  CommitBuilder getCommitBuilderWithCutoffTime(Instant timestamp) {
+    return new CommitBuilder(this, currentRef, timestamp);
+  }
+
+  Dataset recordCommit(Consumer<DatabaseAdapter> commitProducer) {
+    ops.add(commitProducer);
+    return this;
+  }
+
+  public void applyToAdapter(DatabaseAdapter databaseAdapter) {
+    for (Consumer<DatabaseAdapter> op : ops) {
+      op.accept(databaseAdapter);
+    }
+  }
+
+  /**
+   * Verifies that the {@link GCResult} contains the expected content-ids and live/non-live
+   * content-values.
+   */
+  public void verify(GCResult<BasicExpiredContentValues> contentValuesPerType) {
+    assertThat(contentValuesPerType.getContentValues()).isNotNull();
+
+    Set<Map.Entry<String, BasicExpiredContentValues>> entries =
+        contentValuesPerType.getContentValues().entrySet();
+
+    Map<String, Set<Content>> actualLive =
+        entries.stream()
+            .filter(e -> !e.getValue().getLiveContents().isEmpty())
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getLiveContents()));
+    compareContents(actualLive, expectedLive);
+
+    Map<String, Set<Content>> actualExpired =
+        entries.stream()
+            .filter(e -> !e.getValue().getExpiredContents().isEmpty())
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getExpiredContents()));
+    compareContents(actualExpired, expectedExpired);
+  }
+
+  void compareContents(Map<String, Set<Content>> actual, Map<String, Set<Content>> expected) {
+    assertThat(actual.size()).isEqualTo(expected.size());
+    for (String key : expected.keySet()) {
+      List<Content> expectedContents = new ArrayList<>(expected.get(key));
+      expectedContents.sort(new ContentComparator());
+      List<Content> actualContents = new ArrayList<>(actual.get(key));
+      actualContents.sort(new ContentComparator());
+      assertThat(expectedContents.size()).isEqualTo(actualContents.size());
+      for (int i = 0; i < expectedContents.size(); i++) {
+        compareContent(expectedContents.get(i), actualContents.get(i));
+      }
+    }
+  }
+
+  void compareContent(Content actual, Content expected) {
+    if (expected.getType().equals(Content.Type.ICEBERG_TABLE)) {
+      // exclude global state in comparison as it will change as per the commit and won't be same
+      // as original.
+      // compare only snapshot id
+      assertThat(((IcebergTable) expected).getSnapshotId())
+          .isEqualTo(((IcebergTable) actual).getSnapshotId());
+    } else {
+      assertThat(expected).isEqualTo(actual);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  static class ContentComparator implements Comparator<Content> {
+    @Override
+    public int compare(Content c1, Content c2) {
+      if (c1.getType().equals(Content.Type.ICEBERG_TABLE)) {
+        return Long.compare(
+            ((IcebergTable) c1).getSnapshotId(), ((IcebergTable) c2).getSnapshotId());
+      } else {
+        return c1.getId().compareTo(c2.getId());
+      }
+    }
+  }
+}

--- a/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/NessieApiMock.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/NessieApiMock.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import static org.projectnessie.versioned.persist.gc.Dataset.DEFAULT_BRANCH;
+
+import org.projectnessie.api.http.HttpContentApi;
+import org.projectnessie.api.http.HttpTreeApi;
+import org.projectnessie.client.http.NessieApiClient;
+import org.projectnessie.client.http.v1api.HttpApiV1;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.services.authz.AccessCheckerExtension;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.services.rest.RestContentResource;
+import org.projectnessie.services.rest.RestRefLogResource;
+import org.projectnessie.services.rest.RestTreeResource;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.store.PersistVersionStore;
+
+public class NessieApiMock {
+
+  private final ServerConfig serverConfig;
+  private final PersistVersionStore<Content, CommitMeta, Content.Type> versionStore;
+
+  public NessieApiMock(DatabaseAdapter databaseAdapter) {
+    versionStore = new PersistVersionStore<>(databaseAdapter, Dataset.STORE_WORKER);
+    serverConfig = getServerConfig();
+  }
+
+  private ServerConfig getServerConfig() {
+    return new ServerConfig() {
+      @Override
+      public String getDefaultBranch() {
+        return DEFAULT_BRANCH;
+      }
+
+      @Override
+      public boolean sendStacktraceToClient() {
+        return false;
+      }
+    };
+  }
+
+  public HttpApiV1 getApi() {
+    HttpTreeApi treeApi =
+        new RestTreeResource(serverConfig, versionStore, AccessCheckerExtension.ACCESS_CHECKER);
+    HttpContentApi contentApi =
+        new RestContentResource(serverConfig, versionStore, AccessCheckerExtension.ACCESS_CHECKER);
+    RestRefLogResource refLogApi =
+        new RestRefLogResource(serverConfig, versionStore, AccessCheckerExtension.ACCESS_CHECKER);
+    return new HttpApiV1(new NessieApiClient(null, treeApi, contentApi, null, refLogApi));
+  }
+}

--- a/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/TestGCInMemory.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/versioned/persist/gc/TestGCInMemory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.gc;
+
+import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
+import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
+
+@NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
+class TestGCInMemory extends AbstractGCTest {}

--- a/gc/pom.xml
+++ b/gc/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie</artifactId>
+    <version>0.18.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-gc</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Nessie - GC - Parent</name>
+
+  <modules>
+    <module>gc-base</module>
+    <!--    <module>gc-iceberg</module>-->
+  </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
     <module>model</module>
     <module>clients</module>
     <module>versioned</module>
+    <module>gc</module>
     <module>servers</module>
     <module>tools</module>
   </modules>

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -790,7 +790,7 @@ public abstract class AbstractTestRest {
             .collect(Collectors.toList());
     List<CommitMeta> completeLog =
         StreamingUtil.getCommitLogStream(
-                api, branch.getName(), null, null, null, OptionalInt.of(pageSizeHint))
+                api, branch.getName(), null, null, null, OptionalInt.of(pageSizeHint), false)
             .map(LogEntry::getCommitMeta)
             .collect(Collectors.toList());
     assertThat(completeLog.stream().map(CommitMeta::getMessage))
@@ -827,7 +827,7 @@ public abstract class AbstractTestRest {
 
     List<CommitMeta> completeLog =
         StreamingUtil.getCommitLogStream(
-                api, branch.getName(), null, null, null, OptionalInt.of(pageSizeHint))
+                api, branch.getName(), null, null, null, OptionalInt.of(pageSizeHint), false)
             .map(LogEntry::getCommitMeta)
             .collect(Collectors.toList());
     assertEquals(


### PR DESCRIPTION
- Added a gc-base module to identify expired contents.
- Introduced interface to accept default cutoff timestamp and cutoff timestamp per reference.
- Implemented a gc algorithm [commented out the detailed algorithm in `GCImpl::performGC`]
