### PR TITLE
Fix NPE for unchanged operation for fetching commit log with additional info

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -236,18 +236,21 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
                   if (commit.getParentHash() != null) {
                     logEntry.parentCommitHash(commit.getParentHash().asString());
                   }
-                  Objects.requireNonNull(commit.getOperations())
-                      .forEach(
-                          op -> {
-                            ContentKey key = ContentKey.of(op.getKey().getElements());
-                            if (op instanceof Put) {
-                              Content content = ((Put<Content>) op).getValue();
-                              logEntry.addOperations(Operation.Put.of(key, content));
-                            }
-                            if (op instanceof Delete) {
-                              logEntry.addOperations(Operation.Delete.of(key));
-                            }
-                          });
+                  if (commit.getOperations() != null) {
+                    commit
+                        .getOperations()
+                        .forEach(
+                            op -> {
+                              ContentKey key = ContentKey.of(op.getKey().getElements());
+                              if (op instanceof Put) {
+                                Content content = ((Put<Content>) op).getValue();
+                                logEntry.addOperations(Operation.Put.of(key, content));
+                              }
+                              if (op instanceof Delete) {
+                                logEntry.addOperations(Operation.Delete.of(key));
+                              }
+                            });
+                  }
                 }
                 return logEntry.build();
               });


### PR DESCRIPTION
Operation will be null for unchanged operation, but the code is expecting non-null object, Hence the NPE.