### PR TITLE
Add CEL-filter to get-all-references

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
+++ b/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
@@ -44,12 +44,15 @@ public final class StreamingUtil {
    * @return stream of {@link Reference} objects
    */
   public static Stream<Reference> getAllReferencesStream(
-      @NotNull NessieApiV1 api, OptionalInt maxRecords) throws NessieNotFoundException {
+      @NotNull NessieApiV1 api, OptionalInt maxRecords, @Nullable String queryExpression)
+      throws NessieNotFoundException {
 
     return new ResultStreamPaginator<>(
             ReferencesResponse::getReferences,
             (r, pageSize, token) ->
-                builderWithPaging(api.getAllReferences(), pageSize, token).get())
+                builderWithPaging(
+                        api.getAllReferences().queryExpression(queryExpression), pageSize, token)
+                    .get())
         .generateStream(null, maxRecords);
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -22,7 +22,8 @@ import org.projectnessie.model.ReferencesResponse;
  *
  * @since {@link NessieApiV1}
  */
-public interface GetAllReferencesBuilder extends PagingBuilder<GetAllReferencesBuilder> {
+public interface GetAllReferencesBuilder
+    extends QueryBuilder<GetAllReferencesBuilder>, PagingBuilder<GetAllReferencesBuilder> {
 
   /**
    * Will fetch additional metadata about {@link org.projectnessie.model.Branch} / {@link

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
@@ -49,6 +49,7 @@ class HttpTreeClient implements HttpTreeApi {
         .queryParam("max", params.maxRecords() != null ? params.maxRecords().toString() : null)
         .queryParam("pageToken", params.pageToken())
         .queryParam("fetchAdditionalInfo", Boolean.toString(params.isFetchAdditionalInfo()))
+        .queryParam("query_expression", params.queryExpression())
         .get()
         .readEntity(ReferencesResponse.class);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
@@ -47,6 +47,12 @@ final class HttpGetAllReferences extends BaseHttpRequest implements GetAllRefere
   }
 
   @Override
+  public GetAllReferencesBuilder queryExpression(String queryExpression) {
+    params.expression(queryExpression);
+    return this;
+  }
+
+  @Override
   public ReferencesResponse get() {
     return client.getTreeApi().getAllReferences(params.build());
   }

--- a/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
@@ -17,7 +17,9 @@ package org.projectnessie.api.params;
 
 import java.util.Objects;
 import java.util.StringJoiner;
+import javax.annotation.Nullable;
 import javax.ws.rs.QueryParam;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.projectnessie.api.http.HttpTreeApi;
 
@@ -44,19 +46,47 @@ public class ReferencesParams extends AbstractParams {
   @QueryParam("fetchAdditionalInfo")
   private boolean fetchAdditionalInfo;
 
+  @Parameter(
+      description =
+          "A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.\n"
+              + "Usable variables within the expression are:\n\n"
+              + "- ref (Reference) describes the reference, with fields name (String), hash (String), metadata (ReferenceMetadata)\n\n"
+              + "- metadata (ReferenceMetadata) shortcut to ref.metadata, never null, but possibly empty\n\n"
+              + "- commit (CommitMeta) - shortcut to ref.metadata.commitMetaOfHEAD, never null, but possibly empty\n\n"
+              + "- refType (String) - the reference type, either BRANCH or TAG\n\n"
+              + "Note that the expression can only test attributes metadata and commit, if 'fetchAdditionalInfo' is true.",
+      examples = {
+        @ExampleObject(ref = "expr_by_refType"),
+        @ExampleObject(ref = "expr_by_ref_name"),
+        @ExampleObject(ref = "expr_by_ref_commit")
+      })
+  @QueryParam("query_expression")
+  @Nullable
+  private String queryExpression;
+
   public ReferencesParams() {}
 
-  private ReferencesParams(Integer maxRecords, String pageToken, boolean fetchAdditionalInfo) {
+  private ReferencesParams(
+      Integer maxRecords, String pageToken, boolean fetchAdditionalInfo, String queryExpression) {
     super(maxRecords, pageToken);
     this.fetchAdditionalInfo = fetchAdditionalInfo;
+    this.queryExpression = queryExpression;
   }
 
   private ReferencesParams(Builder builder) {
-    this(builder.maxRecords, builder.pageToken, builder.fetchAdditionalInfo);
+    this(
+        builder.maxRecords,
+        builder.pageToken,
+        builder.fetchAdditionalInfo,
+        builder.queryExpression);
   }
 
   public boolean isFetchAdditionalInfo() {
     return fetchAdditionalInfo;
+  }
+
+  public String queryExpression() {
+    return queryExpression;
   }
 
   public static ReferencesParams.Builder builder() {
@@ -73,6 +103,7 @@ public class ReferencesParams extends AbstractParams {
         .add("maxRecords=" + maxRecords())
         .add("pageToken='" + pageToken() + "'")
         .add("fetchAdditionalInfo=" + fetchAdditionalInfo)
+        .add("queryExpression=" + queryExpression)
         .toString();
   }
 
@@ -87,28 +118,36 @@ public class ReferencesParams extends AbstractParams {
     ReferencesParams that = (ReferencesParams) o;
     return Objects.equals(maxRecords(), that.maxRecords())
         && Objects.equals(pageToken(), that.pageToken())
-        && Objects.equals(fetchAdditionalInfo, that.fetchAdditionalInfo);
+        && Objects.equals(fetchAdditionalInfo, that.fetchAdditionalInfo)
+        && Objects.equals(queryExpression, that.queryExpression);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(maxRecords(), pageToken(), fetchAdditionalInfo);
+    return Objects.hash(maxRecords(), pageToken(), fetchAdditionalInfo, queryExpression);
   }
 
   public static class Builder extends AbstractParams.Builder<Builder> {
 
     private Builder() {}
 
-    private boolean fetchAdditionalInfo = false;
+    private boolean fetchAdditionalInfo;
+    private String queryExpression;
 
     public ReferencesParams.Builder from(ReferencesParams params) {
       return maxRecords(params.maxRecords())
           .pageToken(params.pageToken())
-          .fetchAdditionalInfo(params.fetchAdditionalInfo);
+          .fetchAdditionalInfo(params.fetchAdditionalInfo)
+          .expression(params.queryExpression);
     }
 
     public Builder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
       this.fetchAdditionalInfo = fetchAdditionalInfo;
+      return this;
+    }
+
+    public Builder expression(String queryExpression) {
+      this.queryExpression = queryExpression;
       return this;
     }
 

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -79,5 +79,5 @@ public interface Reference extends Base {
    */
   @JsonInclude(Include.NON_NULL)
   @Nullable
-  ReferenceMetadata metadata();
+  ReferenceMetadata getMetadata();
 }

--- a/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
+++ b/model/src/main/java/org/projectnessie/model/ReferenceMetadata.java
@@ -40,17 +40,17 @@ import org.immutables.value.Value;
 public interface ReferenceMetadata {
 
   @Nullable
-  Integer numCommitsAhead();
+  Integer getNumCommitsAhead();
 
   @Nullable
-  Integer numCommitsBehind();
+  Integer getNumCommitsBehind();
 
   @Nullable
-  CommitMeta commitMetaOfHEAD();
+  CommitMeta getCommitMetaOfHEAD();
 
   @Nullable
-  String commonAncestorHash();
+  String getCommonAncestorHash();
 
   @Nullable
-  Long numTotalCommits();
+  Long getNumTotalCommits();
 }

--- a/model/src/main/java/org/projectnessie/model/SqlView.java
+++ b/model/src/main/java/org/projectnessie/model/SqlView.java
@@ -43,4 +43,7 @@ public abstract class SqlView extends Content {
 
   // Schema getSchema();
 
+  public static SqlView of(Dialect dialect, String sqlText) {
+    return ImmutableSqlView.builder().dialect(dialect).sqlText(sqlText).build();
+  }
 }

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -90,6 +90,12 @@ components:
       value: "commit.committer=='nessie_committer'"
     expr_by_commitTime:
       value: "timestamp(commit.commitTime) > timestamp('2021-05-31T08:23:15Z')"
+    expr_by_refType:
+      value: "refType == 'Branch'"
+    expr_by_ref_name:
+      value: "ref.name == 'my-tag-or-branch'"
+    expr_by_ref_commit:
+      value: "commit.message == 'invent awesome things'"
 
     commitMessage:
       value: "Example Commit Message"

--- a/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
@@ -27,11 +27,13 @@ public class ReferencesParamsTest {
         ReferencesParams.builder()
             .maxRecords(23)
             .pageToken("abc")
+            .expression("some_expression")
             .fetchAdditionalInfo(true)
             .build();
     assertThat(params.maxRecords()).isEqualTo(23);
     assertThat(params.pageToken()).isEqualTo("abc");
     assertThat(params.isFetchAdditionalInfo()).isTrue();
+    assertThat(params.queryExpression()).isEqualTo("some_expression");
   }
 
   @Test
@@ -39,6 +41,7 @@ public class ReferencesParamsTest {
     ReferencesParams params = ReferencesParams.empty();
     assertThat(params).isNotNull();
     assertThat(params.isFetchAdditionalInfo()).isFalse();
+    assertThat(params.queryExpression()).isNull();
     assertThat(params.pageToken()).isNull();
     assertThat(params.maxRecords()).isNull();
   }

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -17,13 +17,15 @@ package org.projectnessie.services.cel;
 
 import com.google.api.expr.v1alpha1.Decl;
 import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.projectnessie.cel.checker.Decls;
 import org.projectnessie.cel.tools.ScriptHost;
 import org.projectnessie.cel.types.jackson.JacksonRegistry;
 import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ImmutableReferenceMetadata;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.ReferenceMetadata;
 
 /** A utility class for CEL declarations and other things. */
 public class CELUtil {
@@ -32,22 +34,47 @@ public class CELUtil {
   public static final ScriptHost SCRIPT_HOST =
       ScriptHost.newBuilder().registry(JacksonRegistry.newRegistry()).build();
 
+  public static final String VAR_REF = "ref";
+  public static final String VAR_REF_TYPE = "refType";
+  public static final String VAR_REF_META = "refMeta";
+  public static final String VAR_COMMIT = "commit";
+  public static final String VAR_ENTRY = "entry";
+  public static final String VAR_NAMESPACE = "namespace";
+  public static final String VAR_CONTENT_TYPE = "contentType";
+  public static final String VAR_PATH = "path";
+  public static final String VAR_ROLE = "role";
+  public static final String VAR_OP = "op";
+
+  public static final List<Decl> REFERENCES_DECLARATIONS =
+      ImmutableList.of(
+          Decls.newVar(VAR_COMMIT, Decls.newObjectType(CommitMeta.class.getName())),
+          Decls.newVar(VAR_REF, Decls.newObjectType(Reference.class.getName())),
+          Decls.newVar(VAR_REF_META, Decls.newObjectType(ReferenceMetadata.class.getName())),
+          Decls.newVar(VAR_REF_TYPE, Decls.String));
+
   public static final List<Decl> COMMIT_LOG_DECLARATIONS =
       Collections.singletonList(
-          Decls.newVar("commit", Decls.newObjectType(CommitMeta.class.getName())));
+          Decls.newVar(VAR_COMMIT, Decls.newObjectType(CommitMeta.class.getName())));
 
   public static final List<Decl> ENTRIES_DECLARATIONS =
-      Arrays.asList(
-          Decls.newVar("entry", Decls.newMapType(Decls.String, Decls.String)),
-          Decls.newVar("namespace", Decls.String),
-          Decls.newVar("contentType", Decls.String));
+      ImmutableList.of(
+          Decls.newVar(VAR_ENTRY, Decls.newMapType(Decls.String, Decls.String)),
+          Decls.newVar(VAR_NAMESPACE, Decls.String),
+          Decls.newVar(VAR_CONTENT_TYPE, Decls.String));
 
   public static final List<Decl> AUTHORIZATION_RULE_DECLARATIONS =
       ImmutableList.of(
-          Decls.newVar("ref", Decls.String),
-          Decls.newVar("path", Decls.String),
-          Decls.newVar("role", Decls.String),
-          Decls.newVar("op", Decls.String));
+          Decls.newVar(VAR_REF, Decls.String),
+          Decls.newVar(VAR_PATH, Decls.String),
+          Decls.newVar(VAR_ROLE, Decls.String),
+          Decls.newVar(VAR_OP, Decls.String));
 
   public static final List<Object> COMMIT_LOG_TYPES = Collections.singletonList(CommitMeta.class);
+
+  public static final List<Object> REFERENCES_TYPES =
+      ImmutableList.of(CommitMeta.class, ReferenceMetadata.class, Reference.class);
+
+  public static final CommitMeta EMPTY_COMMIT_META = CommitMeta.fromMessage("");
+  public static final ReferenceMetadata EMPTY_REFERENCE_METADATA =
+      ImmutableReferenceMetadata.builder().commitMetaOfHEAD(EMPTY_COMMIT_META).build();
 }


### PR DESCRIPTION
Adds new optional REST API query-parameter `query_expression` for a CEL
script to evaluate against the `Branch` or `Tag` to return.

CEL script invocations have access to these variables:

* `commit` HEAD commit of the reference. Never `null`, but only
  meaningful if the HEAD is not "beginning of time" and
  `fetchAdditionalInfo==true`.
* `ref` of type `Reference` (so `Branch` or `Tag`)
* `refMeta` of type `ReferenceMetadata`. This variable is never `null`,
  but contents depend on reference type and rules for
  `fetchAdditionalInfo`.
* `refType` a string either `Branch` or `Tag`

Also renames a few methods to "proper get...()"ers to make those
properties work.

Fixes #2800