### PR TITLE
Allow CEL-filtering on optional operations in get-commit-log

### DIFF
--- a/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
@@ -53,12 +53,18 @@ public class CommitLogParams extends AbstractParams {
 
   @Parameter(
       description =
-          "A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.\n"
-              + "Usable variables within the expression are 'commit.author' (string) / 'commit.committer' (string) / 'commit.commitTime' (timestamp) / 'commit.hash' (string) / 'commit.message' (string) / 'commit.properties' (map)",
+          "A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.\n\n"
+              + "Usable variables within the expression are:\n\n"
+              + "- 'commit' with fields 'author' (string), 'committer' (string), 'commitTime' (timestamp), 'hash' (string), ',message' (string), 'properties' (map)\n\n"
+              + "- 'operations' (list), each operation has the fields 'type' (string, either 'PUT' or 'DELETE'), 'key' (string, namespace + table name), 'keyElements' (list of strings), 'namespace' (string), 'namespaceElements' (list of strings) and 'name' (string, the \"simple\" table name)\n\n"
+              + "Note that the expression can only test against 'operations', if 'fetchAdditionalInfo' is true.\n\n"
+              + "Hint: when filtering commits, you can determine whether commits are \"missing\" (filtered) by checking whether 'LogEntry.parentCommitHash' is different from the hash of the previous commit in the log response.",
       examples = {
         @ExampleObject(ref = "expr_by_commit_author"),
         @ExampleObject(ref = "expr_by_commit_committer"),
-        @ExampleObject(ref = "expr_by_commitTime")
+        @ExampleObject(ref = "expr_by_commitTime"),
+        @ExampleObject(ref = "expr_by_commit_operations_table_name"),
+        @ExampleObject(ref = "expr_by_commit_operations_type")
       })
   @QueryParam("query_expression")
   private String queryExpression;

--- a/model/src/main/java/org/projectnessie/model/Content.java
+++ b/model/src/main/java/org/projectnessie/model/Content.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -58,6 +59,10 @@ public abstract class Content {
   public String getId() {
     return UUID.randomUUID().toString();
   }
+
+  @Value.Redacted
+  @JsonIgnore
+  public abstract Type getType();
 
   /**
    * Unwrap object if possible, otherwise throw.

--- a/model/src/main/java/org/projectnessie/model/DeltaLakeTable.java
+++ b/model/src/main/java/org/projectnessie/model/DeltaLakeTable.java
@@ -37,4 +37,9 @@ public abstract class DeltaLakeTable extends Content {
 
   @Nullable
   public abstract String getLastCheckpoint();
+
+  @Override
+  public Type getType() {
+    return Type.DELTA_LAKE_TABLE;
+  }
 }

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -71,6 +71,11 @@ public abstract class IcebergTable extends Content {
 
   public abstract int getSortOrderId();
 
+  @Override
+  public Type getType() {
+    return Type.ICEBERG_TABLE;
+  }
+
   public static IcebergTable of(
       String metadataLocation, long snapshotId, int schemaId, int specId, int sortOrderId) {
     return ImmutableIcebergTable.builder()

--- a/model/src/main/java/org/projectnessie/model/SqlView.java
+++ b/model/src/main/java/org/projectnessie/model/SqlView.java
@@ -41,6 +41,11 @@ public abstract class SqlView extends Content {
   @NotNull
   public abstract Dialect getDialect();
 
+  @Override
+  public Type getType() {
+    return Type.VIEW;
+  }
+
   // Schema getSchema();
 
   public static SqlView of(Dialect dialect, String sqlText) {

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -90,6 +90,12 @@ components:
       value: "commit.committer=='nessie_committer'"
     expr_by_commitTime:
       value: "timestamp(commit.commitTime) > timestamp('2021-05-31T08:23:15Z')"
+    expr_by_commit_operations_in_namespace:
+      value: "operations.exists(op, op.key.startsWith('some.name.space.'))"
+    expr_by_commit_operations_table_name:
+      value: "operations.exists(op, op.name == 'BaseTable')"
+    expr_by_commit_operations_type:
+      value: "operations.exists(op, op.type == 'PUT')"
     expr_by_refType:
       value: "refType == 'Branch'"
     expr_by_ref_name:

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -17,13 +17,18 @@ package org.projectnessie.services.cel;
 
 import com.google.api.expr.v1alpha1.Decl;
 import com.google.common.collect.ImmutableList;
-import java.util.Collections;
 import java.util.List;
 import org.projectnessie.cel.checker.Decls;
 import org.projectnessie.cel.tools.ScriptHost;
 import org.projectnessie.cel.types.jackson.JacksonRegistry;
 import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.ImmutableReferenceMetadata;
+import org.projectnessie.model.Namespace;
+import org.projectnessie.model.Operation;
+import org.projectnessie.model.Operation.Delete;
+import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferenceMetadata;
 
@@ -44,6 +49,7 @@ public class CELUtil {
   public static final String VAR_PATH = "path";
   public static final String VAR_ROLE = "role";
   public static final String VAR_OP = "op";
+  public static final String VAR_OPERATIONS = "operations";
 
   public static final List<Decl> REFERENCES_DECLARATIONS =
       ImmutableList.of(
@@ -53,8 +59,11 @@ public class CELUtil {
           Decls.newVar(VAR_REF_TYPE, Decls.String));
 
   public static final List<Decl> COMMIT_LOG_DECLARATIONS =
-      Collections.singletonList(
-          Decls.newVar(VAR_COMMIT, Decls.newObjectType(CommitMeta.class.getName())));
+      ImmutableList.of(
+          Decls.newVar(VAR_COMMIT, Decls.newObjectType(CommitMeta.class.getName())),
+          Decls.newVar(
+              VAR_OPERATIONS,
+              Decls.newListType(Decls.newObjectType(OperationForCel.class.getName()))));
 
   public static final List<Decl> ENTRIES_DECLARATIONS =
       ImmutableList.of(
@@ -69,7 +78,8 @@ public class CELUtil {
           Decls.newVar(VAR_ROLE, Decls.String),
           Decls.newVar(VAR_OP, Decls.String));
 
-  public static final List<Object> COMMIT_LOG_TYPES = Collections.singletonList(CommitMeta.class);
+  public static final List<Object> COMMIT_LOG_TYPES =
+      ImmutableList.of(CommitMeta.class, OperationForCel.class, ContentKey.class, Namespace.class);
 
   public static final List<Object> REFERENCES_TYPES =
       ImmutableList.of(CommitMeta.class, ReferenceMetadata.class, Reference.class);
@@ -77,4 +87,113 @@ public class CELUtil {
   public static final CommitMeta EMPTY_COMMIT_META = CommitMeta.fromMessage("");
   public static final ReferenceMetadata EMPTY_REFERENCE_METADATA =
       ImmutableReferenceMetadata.builder().commitMetaOfHEAD(EMPTY_COMMIT_META).build();
+
+  /**
+   * 'Mirrored' interface wrapping a {@link Operation} for CEL to have convenience fields for CEL
+   * and to avoid missing fields due to {@code @JsonIgnore}.
+   */
+  @SuppressWarnings("unused")
+  public interface OperationForCel {
+    String getType();
+
+    List<String> getKeyElements();
+
+    String getKey();
+
+    String[] getNamespaceElements();
+
+    String getName();
+
+    String getNamespace();
+
+    ContentForCel getContent();
+  }
+
+  /**
+   * 'Mirrored' interface wrapping a {@link Content} for CEL to have convenience fields for CEL and
+   * to avoid missing fields due to {@code @JsonIgnore}.
+   */
+  @SuppressWarnings("unused")
+  public interface ContentForCel {
+    String getType();
+
+    String getId();
+  }
+
+  /**
+   * 'Mirrors' Nessie model objects for CEL.
+   *
+   * @param model Ńessie model object
+   * @return object suitable for CEL expressions
+   */
+  public static Object forCel(Object model) {
+    if (model instanceof Content) {
+      Content c = (Content) model;
+      return new ContentForCel() {
+        @Override
+        public String getType() {
+          return c.getType().name();
+        }
+
+        @Override
+        public String getId() {
+          return c.getId();
+        }
+      };
+    }
+    if (model instanceof Operation) {
+      Operation op = (Operation) model;
+      return new OperationForCel() {
+        @Override
+        public String getType() {
+          if (op instanceof Put) {
+            return "PUT";
+          }
+          if (op instanceof Delete) {
+            return "DELETE";
+          }
+          return "OPERATION";
+        }
+
+        @Override
+        public List<String> getKeyElements() {
+          return op.getKey().getElements();
+        }
+
+        @Override
+        public String getKey() {
+          return op.getKey().toString();
+        }
+
+        @Override
+        public String getNamespace() {
+          return op.getKey().getNamespace().name();
+        }
+
+        @Override
+        public String[] getNamespaceElements() {
+          return op.getKey().getNamespace().getElements();
+        }
+
+        @Override
+        public String getName() {
+          return op.getKey().getName();
+        }
+
+        @Override
+        public ContentForCel getContent() {
+          if (op instanceof Put) {
+            return (ContentForCel) forCel(((Put) op).getContent());
+          }
+          return null;
+        }
+
+        @Override
+        public String toString() {
+          return op.toString();
+        }
+      };
+    }
+    return model;
+  }
 }


### PR DESCRIPTION
Adds `operations` attribute for the CEL to filter the commit log to
allow filtering on e.g. the operation type (PUT/DELETE), the simple
table name, the namespace. Filtering on the operations requires
`fetchAdditionalInfo`.

Fixes #2801
