### PR TITLE
Clarify CEL filter javadoc and examples

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Content.java
+++ b/model/src/main/java/org/projectnessie/model/Content.java
@@ -60,6 +60,12 @@ public abstract class Content {
     return UUID.randomUUID().toString();
   }
 
+  /**
+   * Returns the {@link Type} enum constant for this content object.
+   *
+   * <p>The name of the returned enum value should match the JSON type name used for serializing the
+   * content object.
+   */
   @Value.Redacted
   @JsonIgnore
   public abstract Type getType();

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -97,7 +97,7 @@ components:
     expr_by_commit_operations_type:
       value: "operations.exists(op, op.type == 'PUT')"
     expr_by_refType:
-      value: "refType == 'Branch'"
+      value: "refType == 'BRANCH'"
     expr_by_ref_name:
       value: "ref.name == 'my-tag-or-branch'"
     expr_by_ref_commit:


### PR DESCRIPTION
Following up on review comments for #2810

----

I decided not to rename `op.name` as it matches `op.getKey().getName()` and is similar to `op.namespace` in that regard.

Addressing `@JsonIngore` concerns has too much of a ripple effect, but might be doable... leaving it out for now.