### PR TITLE
Register CEL value wrappers for reflection inside Quarkus

### DIFF
--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/relect/ModelReflections.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/relect/ModelReflections.java
@@ -17,6 +17,7 @@ package org.projectnessie.server.relect;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.projectnessie.error.NessieError;
+import org.projectnessie.services.cel.CELUtil;
 
 /**
  * This class tracks classes explicitly registered for "reflection" during Quarkus Server native
@@ -24,5 +25,6 @@ import org.projectnessie.error.NessieError;
  *
  * <p>In particular, this list is about Nessie model classes.
  */
-@RegisterForReflection(targets = NessieError.class)
+@RegisterForReflection(
+    targets = {NessieError.class, CELUtil.OperationForCel.class, CELUtil.ContentForCel.class})
 public abstract class ModelReflections {}


### PR DESCRIPTION
This is to fix Native test failures from #2810

----

```
[INFO] Running org.projectnessie.server.ITNativeRestApiInMemory
2021-12-02 17:38:27,693 WARN  [io.mic.cor.ins.int.OnlyOnceLoggingDenyMeterFilter] (vert.x-eventloop-thread-0) Reached the maximum number (100) of URI tags for 'http.server.requests'. Are you using path parameters?
Error:  Tests run: 64, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 3.161 s <<< FAILURE! - in org.projectnessie.server.ITNativeRestApiInMemory
Dec 02, 2021 5:38:30 PM io.quarkus.test.oidc.server.OidcWiremockTestResource stop
Error:  org.projectnessie.server.ITNativeRestApiInMemory.filterCommitLogOperations  Time elapsed: 0.012 s  <<< ERROR!
INFO: Keycloak was shut down
org.projectnessie.client.rest.NessieBadRequestException: 
Bad Request (HTTP/400): org.projectnessie.cel.tools.ScriptCreateException: check failed: ERROR: <input>:1:25: undefined field 'type'
 | operations.exists(op, op.type == 'PUT')
 | ........................^
```