### PR TITLE
Python: Add CLI command to show a diff between two references

### DIFF
--- a/python/docs/branch.rst
+++ b/python/docs/branch.rst
@@ -42,6 +42,10 @@
                              of the given source-reference.
      -c, --condition TEXT    Expected hash. Only perform the action if the branch
                              currently points to the hash specified by this option.
+     -x, --extended          Retrieve additional metadata for a branch, such as
+                             number of commits ahead/behind, info about the HEAD
+                             commit, number of total commits, or the common
+                             ancestor hash.
      --help                  Show this message and exit.
    
    

--- a/python/docs/diff.rst
+++ b/python/docs/diff.rst
@@ -1,0 +1,17 @@
+.. code-block:: bash
+
+   Usage: nessie diff [OPTIONS] FROM_REF TO_REF
+   
+     Show diff between two given references.
+   
+     from_ref/to_ref: name of branch or tag to use to show the diff
+   
+     Examples:
+   
+         nessie diff from_ref to_ref -> show diff between 'from_ref' and 'to_ref'
+   
+   Options:
+     --help  Show this message and exit.
+   
+   
+

--- a/python/docs/log.rst
+++ b/python/docs/log.rst
@@ -62,6 +62,12 @@
                                      commit.committer=='nessie_committer'
                                      timestamp(commit.commitTime) >
                                      timestamp('2021-06-21T10:39:17.977922Z')
+     -x, --extended                  Retrieve all available information for the
+                                     commit entries. This option will also return
+                                     the operations for each commit and the parent
+                                     hash. The schema of the JSON output will then
+                                     produce a list of LogEntrySchema, otherwise a
+                                     list of CommitMetaSchema.
      --help                          Show this message and exit.
    
    

--- a/python/docs/main.rst
+++ b/python/docs/main.rst
@@ -19,6 +19,7 @@
      cherry-pick  Cherry-pick HASHES onto another branch.
      config       Set and view config.
      content      View, list content, and commit changes.
+     diff         Show diff between two given references.
      log          Show commit log.
      merge        Merge FROM_REF into another branch.
      remote       Set and view remote endpoint.

--- a/python/docs/tag.rst
+++ b/python/docs/tag.rst
@@ -43,6 +43,9 @@
                              the given source-reference.
      -c, --condition TEXT    Expected hash. Only perform the action if the tag
                              currently points to the hash specified by this option.
+     -x, --extended          Retrieve additional metadata for a tag, such as number
+                             of commits ahead/behind, info about the HEAD commit,
+                             number of total commits, or the common ancestor hash.
      --help                  Show this message and exit.
    
    

--- a/python/pynessie/cli.py
+++ b/python/pynessie/cli.py
@@ -28,6 +28,7 @@ from .commands import branch_
 from .commands import cherry_pick
 from .commands import config
 from .commands import content
+from .commands import diff
 from .commands import log
 from .commands import merge
 from .commands import remote
@@ -75,6 +76,7 @@ cli.add_command(tag)
 cli.add_command(merge)
 cli.add_command(cherry_pick)
 cli.add_command(content)
+cli.add_command(diff)
 
 
 if __name__ == "__main__":

--- a/python/pynessie/client/_endpoints.py
+++ b/python/pynessie/client/_endpoints.py
@@ -206,7 +206,7 @@ def list_logs(
     ssl_verify: bool = True,
     max_records: Optional[int] = None,
     fetch_additional_info: bool = False,
-    **filtering_args: Any
+    **filtering_args: Any,
 ) -> dict:
     """Fetch a list of all logs from a known starting reference.
 
@@ -340,3 +340,16 @@ def commit(
     url = "/trees/branch/{}/commit".format(branch)
     params = {"expectedHash": expected_hash}
     return cast(dict, _post(base_url + url, auth, json=operations, ssl_verify=ssl_verify, params=params))
+
+
+def get_diff(base_url: str, auth: Optional[AuthBase], from_ref: str, to_ref: str, ssl_verify: bool = True) -> dict:
+    """Fetch the diff for two given references.
+
+    :param base_url: base Nessie url
+    :param auth: Authentication settings
+    :param from_ref: the starting ref for the diff
+    :param to_ref:  the ending ref for the diff
+    :param ssl_verify: ignore ssl errors if False
+    :return: json dict of a Diff
+    """
+    return cast(dict, _get(f"{base_url}/diffs/{from_ref}...{to_ref}", auth, ssl_verify=ssl_verify))

--- a/python/pynessie/client/nessie_client.py
+++ b/python/pynessie/client/nessie_client.py
@@ -33,6 +33,7 @@ from ._endpoints import delete_branch
 from ._endpoints import delete_tag
 from ._endpoints import get_content
 from ._endpoints import get_default_branch
+from ._endpoints import get_diff
 from ._endpoints import get_reference
 from ._endpoints import list_logs
 from ._endpoints import list_tables
@@ -43,6 +44,8 @@ from ..model import CommitMeta
 from ..model import Content
 from ..model import ContentKey
 from ..model import ContentSchema
+from ..model import DiffResponse
+from ..model import DiffResponseSchema
 from ..model import Entries
 from ..model import EntriesSchema
 from ..model import LogEntry
@@ -274,3 +277,14 @@ class NessieClient:
     def get_base_url(self: "NessieClient") -> str:
         """Return Nessie server configured base URL."""
         return self._base_url
+
+    def get_diff(
+        self: "NessieClient",
+        from_ref: str,
+        to_ref: str,
+    ) -> DiffResponse:
+        """Retrieve the diff between from_ref and to_ref.
+
+        from_ref / to_ref can be any ref.
+        """
+        return DiffResponseSchema().load(get_diff(self._base_url, self._auth, from_ref, to_ref, self._ssl_verify))

--- a/python/pynessie/commands/__init__.py
+++ b/python/pynessie/commands/__init__.py
@@ -21,9 +21,10 @@ from .branch import branch_
 from .cherry_pick import cherry_pick
 from .config import config
 from .content import content
+from .diff import diff
 from .log import log
 from .merge import merge
 from .remote import remote
 from .tag import tag
 
-__all__ = ["remote", "tag", "branch_", "cherry_pick", "config", "log", "merge", "content"]
+__all__ = ["remote", "tag", "branch_", "cherry_pick", "config", "log", "merge", "content", "diff"]

--- a/python/pynessie/commands/diff.py
+++ b/python/pynessie/commands/diff.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""diff CLI command."""
+
+
+import click
+
+from ..cli_common_context import ContextObject
+from ..decorators import error_handler, pass_client
+from ..model import DiffResponseSchema
+
+
+@click.command("diff")
+@click.argument("from_ref", nargs=1, required=True)
+@click.argument("to_ref", nargs=1, required=True)
+@pass_client
+@error_handler
+def diff(ctx: ContextObject, from_ref: str, to_ref: str) -> None:  # noqa: C901
+    """Show diff between two given references.
+
+    from_ref/to_ref: name of branch or tag to use to show the diff
+
+    Examples:
+
+        nessie diff from_ref to_ref -> show diff between 'from_ref' and 'to_ref'
+
+    """
+    diff_response = ctx.nessie.get_diff(from_ref=from_ref, to_ref=to_ref)
+    if ctx.json:
+        click.echo(DiffResponseSchema().dumps(diff_response))
+    else:
+        click.echo_via_pager(x.pretty_print() + "\n" for index, x in enumerate(diff_response.diffs))

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -418,3 +418,35 @@ class MultiContents:
 
 
 MultiContentSchema = desert.schema_class(MultiContents)
+
+
+@attr.dataclass
+class DiffEntry:
+    """Dataclass for a Diff."""
+
+    content_key: ContentKey = desert.ib(fields.Nested(ContentKeySchema, data_key="key"))
+    from_content: Content = desert.ib(fields.Nested(ContentSchema, default=None, data_key="from", allow_none=True))
+    to_content: Content = desert.ib(fields.Nested(ContentSchema, default=None, data_key="to", allow_none=True))
+
+    def pretty_print(self: "DiffEntry") -> str:
+        """Print out for cli."""
+        # pylint: disable=E1101
+        from_output = f"{self.from_content.pretty_print()}" if self.from_content else ""
+        to_output = f"{self.to_content.pretty_print()}" if self.to_content else ""
+        return (
+            f"ContentKey: {self.content_key.to_path_string()}\nFROM:\n\t{from_output}\nTO:\n{to_output}"
+            f"\n----------------------------------------"
+        )
+
+
+DiffEntrySchema = desert.schema_class(DiffEntry)
+
+
+@attr.dataclass
+class DiffResponse:
+    """Dataclass for a DiffResponse."""
+
+    diffs: List[DiffEntry] = desert.ib(fields.List(fields.Nested(DiffEntrySchema(), data_key="diffs")))
+
+
+DiffResponseSchema = desert.schema_class(DiffResponse)

--- a/python/tests/cassettes/test_nessie_cli/test_diff.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_diff.yaml
@@ -1,0 +1,218 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/diffs/main...main
+  response:
+    body:
+      string: '{"diffs": []}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '13'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '110'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/main
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '110'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "metadata": null, "name": "dev_test_diff", "type": "BRANCH"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_test_diff", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '119'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_test_diff", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '282'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/contents/diff.foo.dev?ref=dev_test_diff
+  response:
+    body:
+      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
+        for key ''diff.foo.dev'' in reference ''dev_test_diff''.", "reason": "Not
+        Found", "serverStackTrace": null, "status": 404}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '188'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"commitMeta": {"author": "nessie_user1", "authorTime": null, "commitTime":
+      null, "committer": null, "hash": null, "message": "test message", "properties":
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "dev_test_diff",
+      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
+      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
+      {"elements": ["diff", "foo", "dev"]}, "type": "PUT"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '444'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/branch/dev_test_diff/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+  response:
+    body:
+      string: '{"hash": "b3edc5f95a6b1fe6312fbce9791086e9edc43df37a04b758d4d36ef9d575b26f",
+        "name": "dev_test_diff", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '119'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: http://localhost:19120/api/v1/diffs/main...dev_test_diff
+  response:
+    body:
+      string: '{"diffs": [{"from": null, "key": {"elements": ["diff", "foo", "dev"]},
+        "to": {"id": "dev_test_diff", "metadataLocation": "/a/b/c", "schemaId": 43,
+        "snapshotId": 42, "sortOrderId": 45, "specId": 44, "type": "ICEBERG_TABLE"}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '225'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
This adds the `nessie diff <from> <to>` command in order to show a diff
between the two given references. Below is an example with a diff
output.

`$ nessie diff main some-tag`

```
ContentKey: create-contents-2021-12-03-09-48-05.contents.0
FROM:
        Iceberg table:
        metadata-location: metadata 5112074875886197399
        snapshot-id: 1187121107708844201
        schema-id: 1780143928
        partition-spec-id: 1539871200
        default-sort-order-id: -1074107305
TO:
Iceberg table:
        metadata-location: metadata 5112074875886197399
        snapshot-id: -705475403760755661
        schema-id: 793115611
        partition-spec-id: 1354059563
        default-sort-order-id: -430174857
----------------------------------------
ContentKey: create-contents-2021-12-03-10-08-20.contents.0
FROM:
        SqlView:
        Dialect: SPARK
        Sql: SELECT blah FROM meh;
TO:

----------------------------------------
ContentKey: create-contents-2021-12-03-10-07-32.contents.0
FROM:
        DeltaLake table:
        Last Checkpoint: Another checkpoint -6275691305927605975
        Delta History: metadata location history 8459483870524679488
                Another metadata location -7686374625771270702
        Checkpoint History:
TO:

----------------------------------------