### PR TITLE
Use 'get' prefix for DiffResponse/DiffEntry properties

### DIFF
--- a/model/src/main/java/org/projectnessie/model/DiffResponse.java
+++ b/model/src/main/java/org/projectnessie/model/DiffResponse.java
@@ -29,18 +29,18 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableDiffResponse.class)
 public interface DiffResponse {
 
-  List<DiffEntry> diffs();
+  List<DiffEntry> getDiffs();
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableDiffEntry.class)
   @JsonDeserialize(as = ImmutableDiffEntry.class)
   interface DiffEntry {
-    ContentKey key();
+    ContentKey getKey();
 
     @Nullable
-    Content from();
+    Content getFrom();
 
     @Nullable
-    Content to();
+    Content getTo();
   }
 }

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractResteasyTest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractResteasyTest.java
@@ -459,10 +459,10 @@ public abstract class AbstractResteasyTest {
             .as(DiffResponse.class);
 
     assertThat(diffResponse).isNotNull();
-    assertThat(diffResponse.diffs()).hasSize(1);
-    DiffEntry diff = diffResponse.diffs().get(0);
-    assertThat(diff.key()).isEqualTo(contentKey);
-    assertThat(diff.from()).isEqualTo(fromTable);
-    assertThat(diff.to()).isEqualTo(toTable);
+    assertThat(diffResponse.getDiffs()).hasSize(1);
+    DiffEntry diff = diffResponse.getDiffs().get(0);
+    assertThat(diff.getKey()).isEqualTo(contentKey);
+    assertThat(diff.getFrom()).isEqualTo(fromTable);
+    assertThat(diff.getTo()).isEqualTo(toTable);
   }
 }

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -2161,32 +2161,40 @@ public abstract class AbstractTestRest {
 
     // we only committed to toRef, the "from" diff should be null
     assertThat(
-            api.getDiff().fromRefName(fromRef.getName()).toRefName(toRef.getName()).get().diffs())
+            api.getDiff()
+                .fromRefName(fromRef.getName())
+                .toRefName(toRef.getName())
+                .get()
+                .getDiffs())
         .hasSize(commitsPerBranch)
         .allSatisfy(
             diff -> {
-              assertThat(diff.key()).isNotNull();
-              assertThat(diff.from()).isNull();
-              assertThat(diff.to()).isNotNull();
+              assertThat(diff.getKey()).isNotNull();
+              assertThat(diff.getFrom()).isNull();
+              assertThat(diff.getTo()).isNotNull();
             });
 
     // after committing to fromRef, "from/to" diffs should both have data
     createCommits(fromRef, 1, commitsPerBranch, fromRef.getHash());
 
     assertThat(
-            api.getDiff().fromRefName(fromRef.getName()).toRefName(toRef.getName()).get().diffs())
+            api.getDiff()
+                .fromRefName(fromRef.getName())
+                .toRefName(toRef.getName())
+                .get()
+                .getDiffs())
         .hasSize(commitsPerBranch)
         .allSatisfy(
             diff -> {
-              assertThat(diff.key()).isNotNull();
-              assertThat(diff.from()).isNotNull();
-              assertThat(diff.to()).isNotNull();
+              assertThat(diff.getKey()).isNotNull();
+              assertThat(diff.getFrom()).isNotNull();
+              assertThat(diff.getTo()).isNotNull();
 
               // we only have a diff on the ID
-              assertThat(diff.from().getId()).isNotEqualTo(diff.to().getId());
-              Optional<IcebergTable> fromTable = diff.from().unwrap(IcebergTable.class);
+              assertThat(diff.getFrom().getId()).isNotEqualTo(diff.getTo().getId());
+              Optional<IcebergTable> fromTable = diff.getFrom().unwrap(IcebergTable.class);
               assertThat(fromTable).isPresent();
-              Optional<IcebergTable> toTable = diff.to().unwrap(IcebergTable.class);
+              Optional<IcebergTable> toTable = diff.getTo().unwrap(IcebergTable.class);
               assertThat(toTable).isPresent();
 
               assertThat(fromTable.get().getMetadataLocation())
@@ -2216,13 +2224,17 @@ public abstract class AbstractTestRest {
 
     // now that we deleted all tables on toRef, the diff for "to" should be null
     assertThat(
-            api.getDiff().fromRefName(fromRef.getName()).toRefName(toRef.getName()).get().diffs())
+            api.getDiff()
+                .fromRefName(fromRef.getName())
+                .toRefName(toRef.getName())
+                .get()
+                .getDiffs())
         .hasSize(commitsPerBranch)
         .allSatisfy(
             diff -> {
-              assertThat(diff.key()).isNotNull();
-              assertThat(diff.from()).isNotNull();
-              assertThat(diff.to()).isNull();
+              assertThat(diff.getKey()).isNotNull();
+              assertThat(diff.getFrom()).isNotNull();
+              assertThat(diff.getTo()).isNull();
             });
   }
 


### PR DESCRIPTION
Properties need to be prefixed with `get` so that they properly show up
as properties in the OpenAPI spec. For example,
https://app.swaggerhub.com/apis/projectnessie/nessie/0.16.0#/ shows that
it's not the case without this fix.