### PR TITLE
Revert "Bump de.flapdoodle.embed.mongo from 3.1.4 to 3.2.2 (#2840)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <deltalake.version>1.0.0-nessie</deltalake.version>
     <dockerjava.version>3.2.12</dockerjava.version>
     <dynamodb.version>1.12.0</dynamodb.version>
-    <flapdoodle.version>3.2.2</flapdoodle.version>
+    <flapdoodle.version>3.1.4</flapdoodle.version>
     <gatling.maven.version>4.0.1</gatling.maven.version>
     <gatling.version>3.7.2</gatling.version>
     <google-java-format.version>1.13.0</google-java-format.version>

--- a/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/FlapdoodleMongoTestConnectionProviderSource.java
+++ b/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/FlapdoodleMongoTestConnectionProviderSource.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 public class FlapdoodleMongoTestConnectionProviderSource extends MongoTestConnectionProviderSource {
   private static final Pattern LISTEN_ON_PORT_PATTERN =
       Pattern.compile(
-          ".*NETWORK([^\\n]*).*Waiting for connections.*\"port\":([0-9]+).*",
+          ".*NETWORK ([^\\n]*) waiting for connections on port ([0-9]+)\\n.*",
           Pattern.MULTILINE | Pattern.DOTALL);
 
   private final AtomicInteger port = new AtomicInteger();


### PR DESCRIPTION
This reverts commit 5f5097787e6cbd167d5bc53941be1b06c885b902.

That flapdoodle version breaks on various Linux distros. E.g. Ubuntu
for me:
```
Caused by: java.lang.IllegalArgumentException: linux distribution not supported: PRODUCTION:Platform{operatingSystem=Linux, architecture=X86_64, distribution=Ubuntu}
	at de.flapdoodle.embed.mongo.packageresolver.linux.LinuxPackageFinder.lambda$rules$0(LinuxPackageFinder.java:143)
	at de.flapdoodle.embed.mongo.packageresolver.PlatformMatchRules.packageFor(PlatformMatchRules.java:43)
	at de.flapdoodle.embed.mongo.packageresolver.linux.LinuxPackageFinder.packageFor(LinuxPackageFinder.java:48)
	at de.flapdoodle.embed.mongo.packageresolver.PlatformMatchRules.packageFor(PlatformMatchRules.java:43)
	at de.flapdoodle.embed.mongo.packageresolver.PlatformPackageResolver.packageFor(PlatformPackageResolver.java:58)
	at de.flapdoodle.embed.process.store.ArtifactStore.filesToExtract(ArtifactStore.java:93)
	at de.flapdoodle.embed.process.store.ExtractedArtifactStore.extractFileSet(ExtractedArtifactStore.java:82)
	at de.flapdoodle.embed.process.runtime.Starter.prepare(Starter.java:59)
	at de.flapdoodle.embed.process.runtime.Starter.prepare(Starter.java:52)
```