### PR TITLE
Update merged+transplanted commits with "now" as commit-timestamp

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -864,6 +864,15 @@ public abstract class AbstractTestRest {
             .commit();
     assertThat(committed2.getHash()).isNotNull();
 
+    int commitsToTransplant = 2;
+
+    LogResponse logBranch =
+        api.getCommitLog()
+            .refName(branch.getName())
+            .untilHash(branch.getHash())
+            .maxRecords(commitsToTransplant)
+            .get();
+
     api.commitMultipleOperations()
         .branchName(base.getName())
         .hash(base.getHash())
@@ -882,6 +891,18 @@ public abstract class AbstractTestRest {
             log.getLogEntries().stream().map(LogEntry::getCommitMeta).map(CommitMeta::getMessage))
         .containsExactly(
             "test-transplant-branch2", "test-transplant-branch1", "test-transplant-main");
+
+    // Verify that the commit-timestamp was updated
+    LogResponse logOfTransplanted =
+        api.getCommitLog().refName(base.getName()).maxRecords(commitsToTransplant).get();
+    assertThat(
+            logOfTransplanted.getLogEntries().stream()
+                .map(LogEntry::getCommitMeta)
+                .map(CommitMeta::getCommitTime))
+        .isNotEqualTo(
+            logBranch.getLogEntries().stream()
+                .map(LogEntry::getCommitMeta)
+                .map(CommitMeta::getCommitTime));
 
     assertThat(
             api.getEntries().refName(base.getName()).get().getEntries().stream()
@@ -915,6 +936,15 @@ public abstract class AbstractTestRest {
             .commit();
     assertThat(committed2.getHash()).isNotNull();
 
+    int commitsToMerge = 2;
+
+    LogResponse logBranch =
+        api.getCommitLog()
+            .refName(branch.getName())
+            .untilHash(branch.getHash())
+            .maxRecords(commitsToMerge)
+            .get();
+
     api.commitMultipleOperations()
         .branchName(base.getName())
         .hash(base.getHash())
@@ -928,6 +958,18 @@ public abstract class AbstractTestRest {
     assertThat(
             log.getLogEntries().stream().map(LogEntry::getCommitMeta).map(CommitMeta::getMessage))
         .containsExactly("test-merge-branch2", "test-merge-branch1", "test-merge-main");
+
+    // Verify that the commit-timestamp was updated
+    LogResponse logOfMerged =
+        api.getCommitLog().refName(base.getName()).maxRecords(commitsToMerge).get();
+    assertThat(
+            logOfMerged.getLogEntries().stream()
+                .map(LogEntry::getCommitMeta)
+                .map(CommitMeta::getCommitTime))
+        .isNotEqualTo(
+            logBranch.getLogEntries().stream()
+                .map(LogEntry::getCommitMeta)
+                .map(CommitMeta::getCommitTime));
 
     assertThat(
             api.getEntries().refName(base.getName()).get().getEntries().stream()

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.BranchName;
@@ -145,6 +146,7 @@ public interface DatabaseAdapter {
    *     defaults to the named reference's HEAD.
    * @param expectedHead if present, {@code target}'s current HEAD must be equal to this value
    * @param sequenceToTransplant commits in {@code source} to cherry-pick onto {@code targetBranch}
+   * @param updateCommitMetadata function to rewrite the commit-metadata for copied commits
    * @return the hash of the last cherry-picked commit, in other words the new HEAD of the target
    *     branch
    * @throws ReferenceNotFoundException if either the named reference in {@code commitOnReference}
@@ -154,7 +156,10 @@ public interface DatabaseAdapter {
    *     expected hEAD
    */
   Hash transplant(
-      BranchName targetBranch, Optional<Hash> expectedHead, List<Hash> sequenceToTransplant)
+      BranchName targetBranch,
+      Optional<Hash> expectedHead,
+      List<Hash> sequenceToTransplant,
+      Function<ByteString, ByteString> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
@@ -167,6 +172,7 @@ public interface DatabaseAdapter {
    * @param from commit-hash to start reading commits from.
    * @param toBranch target branch to commit to
    * @param expectedHead if present, {@code toBranch}'s current HEAD must be equal to this value
+   * @param updateCommitMetadata function to rewrite the commit-metadata for copied commits
    * @return the hash of the last cherry-picked commit, in other words the new HEAD of the target
    *     branch
    * @throws ReferenceNotFoundException if either the named reference in {@code toBranch} or the
@@ -175,7 +181,11 @@ public interface DatabaseAdapter {
    *     branch due to a conflicting change or if the expected hash of {@code toBranch} is not its
    *     expected hEAD
    */
-  Hash merge(Hash from, BranchName toBranch, Optional<Hash> expectedHead)
+  Hash merge(
+      Hash from,
+      BranchName toBranch,
+      Optional<Hash> expectedHead,
+      Function<ByteString, ByteString> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
@@ -167,7 +168,11 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   @Override
-  public Hash merge(Hash from, BranchName toBranch, Optional<Hash> expectedHead)
+  public Hash merge(
+      Hash from,
+      BranchName toBranch,
+      Optional<Hash> expectedHead,
+      Function<ByteString, ByteString> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException {
     // The spec for 'VersionStore.merge' mentions "(...) until we arrive at a common ancestor",
     // but old implementations allowed a merge even if the "merge-from" and "merge-to" have no
@@ -196,7 +201,8 @@ public abstract class NonTransactionalDatabaseAdapter<
                     expectedHead,
                     toHead,
                     branchCommits,
-                    newKeyLists);
+                    newKeyLists,
+                    updateCommitMetadata);
 
             Hash newGlobalHead =
                 writeGlobalCommit(
@@ -216,7 +222,10 @@ public abstract class NonTransactionalDatabaseAdapter<
   @SuppressWarnings("RedundantThrows")
   @Override
   public Hash transplant(
-      BranchName targetBranch, Optional<Hash> expectedHead, List<Hash> sequenceToTransplant)
+      BranchName targetBranch,
+      Optional<Hash> expectedHead,
+      List<Hash> sequenceToTransplant,
+      Function<ByteString, ByteString> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException {
     try {
       return casOpLoop(
@@ -236,7 +245,8 @@ public abstract class NonTransactionalDatabaseAdapter<
                     targetHead,
                     sequenceToTransplant,
                     branchCommits,
-                    newKeyLists);
+                    newKeyLists,
+                    updateCommitMetadata);
 
             Hash newGlobalHead =
                 writeGlobalCommit(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractVersionStoreTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.Stream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -532,7 +533,8 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
                     s.transplant(
                         BranchName.of("this-one-should-not-exist"),
                         Optional.empty(),
-                        singletonList(s.hashOnReference(BranchName.of("main"), Optional.empty())))),
+                        singletonList(s.hashOnReference(BranchName.of("main"), Optional.empty())),
+                        Function.identity())),
         new ReferenceNotFoundFunction("transplant/hash/empty")
             .msg(
                 "Could not find commit '12341234123412341234123412341234123412341234' in reference 'main'.")
@@ -541,7 +543,8 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
                     s.transplant(
                         BranchName.of("main"),
                         Optional.of(Hash.of("12341234123412341234123412341234123412341234")),
-                        singletonList(Hash.of("12341234123412341234123412341234123412341234")))),
+                        singletonList(Hash.of("12341234123412341234123412341234123412341234")),
+                        Function.identity())),
         new ReferenceNotFoundFunction("transplant/empty/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
             .function(
@@ -549,7 +552,8 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
                     s.transplant(
                         BranchName.of("main"),
                         Optional.empty(),
-                        singletonList(Hash.of("12341234123412341234123412341234123412341234")))),
+                        singletonList(Hash.of("12341234123412341234123412341234123412341234")),
+                        Function.identity())),
         // merge()
         new ReferenceNotFoundFunction("merge/hash/empty")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
@@ -558,7 +562,8 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
                     s.merge(
                         Hash.of("12341234123412341234123412341234123412341234"),
                         BranchName.of("main"),
-                        Optional.empty())),
+                        Optional.empty(),
+                        Function.identity())),
         new ReferenceNotFoundFunction("merge/empty/hash")
             .msg(
                 "Could not find commit '12341234123412341234123412341234123412341234' in reference 'main'.")
@@ -567,7 +572,8 @@ public abstract class AbstractVersionStoreTest extends AbstractITVersionStore {
                     s.merge(
                         s.noAncestorHash(),
                         BranchName.of("main"),
-                        Optional.of(Hash.of("12341234123412341234123412341234123412341234")))));
+                        Optional.of(Hash.of("12341234123412341234123412341234123412341234")),
+                        Function.identity())));
   }
 
   @ParameterizedTest

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -210,7 +210,11 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  public Hash merge(Hash from, BranchName toBranch, Optional<Hash> expectedHead)
+  public Hash merge(
+      Hash from,
+      BranchName toBranch,
+      Optional<Hash> expectedHead,
+      Function<ByteString, ByteString> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException {
     // The spec for 'VersionStore.merge' mentions "(...) until we arrive at a common ancestor",
     // but old implementations allowed a merge even if the "merge-from" and "merge-to" have no
@@ -237,7 +241,8 @@ public abstract class TxDatabaseAdapter
                     expectedHead,
                     currentHead,
                     h -> {},
-                    h -> {});
+                    h -> {},
+                    updateCommitMetadata);
             return tryMoveNamedReference(conn, toBranch, currentHead, toHead);
           },
           () -> mergeConflictMessage("Conflict", from, toBranch, expectedHead),
@@ -251,7 +256,11 @@ public abstract class TxDatabaseAdapter
 
   @SuppressWarnings("RedundantThrows")
   @Override
-  public Hash transplant(BranchName targetBranch, Optional<Hash> expectedHead, List<Hash> commits)
+  public Hash transplant(
+      BranchName targetBranch,
+      Optional<Hash> expectedHead,
+      List<Hash> commits,
+      Function<ByteString, ByteString> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException {
     try {
       return opLoop(
@@ -269,7 +278,8 @@ public abstract class TxDatabaseAdapter
                     currentHead,
                     commits,
                     h -> {},
-                    h -> {});
+                    h -> {},
+                    updateCommitMetadata);
 
             return tryMoveNamedReference(conn, targetBranch, currentHead, targetHead);
           },

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
@@ -92,17 +93,27 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
 
   @Override
   public void transplant(
-      BranchName targetBranch, Optional<Hash> referenceHash, List<Hash> sequenceToTransplant)
+      BranchName targetBranch,
+      Optional<Hash> referenceHash,
+      List<Hash> sequenceToTransplant,
+      Function<METADATA, METADATA> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(
-        "transplant", () -> delegate.transplant(targetBranch, referenceHash, sequenceToTransplant));
+        "transplant",
+        () ->
+            delegate.transplant(
+                targetBranch, referenceHash, sequenceToTransplant, updateCommitMetadata));
   }
 
   @Override
-  public void merge(Hash fromHash, BranchName toBranch, Optional<Hash> expectedHash)
+  public void merge(
+      Hash fromHash,
+      BranchName toBranch,
+      Optional<Hash> expectedHash,
+      Function<METADATA, METADATA> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(
-        "merge", () -> delegate.merge(fromHash, toBranch, expectedHash));
+        "merge", () -> delegate.merge(fromHash, toBranch, expectedHash, updateCommitMetadata));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
@@ -110,7 +111,10 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
 
   @Override
   public void transplant(
-      BranchName targetBranch, Optional<Hash> referenceHash, List<Hash> sequenceToTransplant)
+      BranchName targetBranch,
+      Optional<Hash> referenceHash,
+      List<Hash> sequenceToTransplant,
+      Function<METADATA, METADATA> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
         "Transplant",
@@ -118,11 +122,17 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
             b.withTag(TAG_TARGET_BRANCH, safeRefName(targetBranch))
                 .withTag(TAG_HASH, safeToString(referenceHash))
                 .withTag(TAG_TRANSPLANTS, safeSize(sequenceToTransplant)),
-        () -> delegate.transplant(targetBranch, referenceHash, sequenceToTransplant));
+        () ->
+            delegate.transplant(
+                targetBranch, referenceHash, sequenceToTransplant, updateCommitMetadata));
   }
 
   @Override
-  public void merge(Hash fromHash, BranchName toBranch, Optional<Hash> expectedHash)
+  public void merge(
+      Hash fromHash,
+      BranchName toBranch,
+      Optional<Hash> expectedHash,
+      Function<METADATA, METADATA> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
         "Merge",
@@ -130,7 +140,7 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
             b.withTag(TAG_FROM_HASH, safeToString(fromHash))
                 .withTag(TAG_TO_BRANCH, safeRefName(toBranch))
                 .withTag(TAG_EXPECTED_HASH, safeToString(expectedHash)),
-        () -> delegate.merge(fromHash, toBranch, expectedHash));
+        () -> delegate.merge(fromHash, toBranch, expectedHash, updateCommitMetadata));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
@@ -111,13 +112,17 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * @param referenceHash The hash to use as a reference for conflict detection. If not present, do
    *     not perform conflict detection
    * @param sequenceToTransplant The sequence of hashes to transplant.
+   * @param updateCommitMetadata
    * @throws ReferenceConflictException if {@code referenceHash} values do not match the stored
    *     values for {@code branch}
    * @throws ReferenceNotFoundException if {@code branch} or if any of the hashes from {@code
    *     sequenceToTransplant} is not present in the store.
    */
   void transplant(
-      BranchName targetBranch, Optional<Hash> referenceHash, List<Hash> sequenceToTransplant)
+      BranchName targetBranch,
+      Optional<Hash> referenceHash,
+      List<Hash> sequenceToTransplant,
+      Function<METADATA, METADATA> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
@@ -138,12 +143,17 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * @param fromHash The hash we are using to get additional commits
    * @param toBranch The branch that we are merging into
    * @param expectedHash The current head of the branch to validate before updating (optional).
+   * @param updateCommitMetadata
    * @throws ReferenceConflictException if {@code expectedBranchHash} doesn't match the stored hash
    *     for {@code toBranch}
    * @throws ReferenceNotFoundException if {@code toBranch} or {@code fromHash} is not present in
    *     the store.
    */
-  void merge(Hash fromHash, BranchName toBranch, Optional<Hash> expectedHash)
+  void merge(
+      Hash fromHash,
+      BranchName toBranch,
+      Optional<Hash> expectedHash,
+      Function<METADATA, METADATA> updateCommitMetadata)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
@@ -121,11 +122,19 @@ class TestMetricsVersionStore {
                 "transplant",
                 vs ->
                     vs.transplant(
-                        BranchName.of("mock-branch"), Optional.empty(), Collections.emptyList()),
+                        BranchName.of("mock-branch"),
+                        Optional.empty(),
+                        Collections.emptyList(),
+                        Function.identity()),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(
                 "merge",
-                vs -> vs.merge(Hash.of("42424242"), BranchName.of("mock-branch"), Optional.empty()),
+                vs ->
+                    vs.merge(
+                        Hash.of("42424242"),
+                        BranchName.of("mock-branch"),
+                        Optional.empty(),
+                        Function.identity()),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(
                 "assign",

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -117,7 +118,8 @@ class TestTracingVersionStore {
                             vs.transplant(
                                 BranchName.of("mock-branch"),
                                 Optional.empty(),
-                                Collections.emptyList())),
+                                Collections.emptyList(),
+                                Function.identity())),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Merge", refNotFoundAndRefConflictThrows)
                     .tag("nessie.version-store.to-branch", "mock-branch")
@@ -128,7 +130,8 @@ class TestTracingVersionStore {
                             vs.merge(
                                 Hash.of("42424242"),
                                 BranchName.of("mock-branch"),
-                                Optional.empty())),
+                                Optional.empty(),
+                                Function.identity())),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Assign", refNotFoundAndRefConflictThrows)
                     .tag("nessie.version-store.ref", "BranchName{name=mock-branch}")

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractITVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractITVersionStore.java
@@ -828,7 +828,8 @@ public abstract class AbstractITVersionStore {
           .transplant(
               newBranch,
               Optional.of(initialHash),
-              Arrays.asList(firstCommit, secondCommit, thirdCommit));
+              Arrays.asList(firstCommit, secondCommit, thirdCommit),
+              Function.identity());
       assertThat(
               store()
                   .getValues(
@@ -851,7 +852,8 @@ public abstract class AbstractITVersionStore {
           .transplant(
               newBranch,
               Optional.of(initialHash),
-              Arrays.asList(firstCommit, secondCommit, thirdCommit));
+              Arrays.asList(firstCommit, secondCommit, thirdCommit),
+              Function.identity());
       assertThat(
               store()
                   .getValues(
@@ -879,7 +881,8 @@ public abstract class AbstractITVersionStore {
                   .transplant(
                       newBranch,
                       Optional.of(initialHash),
-                      Arrays.asList(firstCommit, secondCommit, thirdCommit)));
+                      Arrays.asList(firstCommit, secondCommit, thirdCommit),
+                      Function.identity()));
     }
 
     @Test
@@ -893,7 +896,8 @@ public abstract class AbstractITVersionStore {
           .transplant(
               newBranch,
               Optional.of(initialHash),
-              Arrays.asList(firstCommit, secondCommit, thirdCommit));
+              Arrays.asList(firstCommit, secondCommit, thirdCommit),
+              Function.identity());
       assertThat(
               store()
                   .getValues(
@@ -916,7 +920,8 @@ public abstract class AbstractITVersionStore {
                   .transplant(
                       newBranch,
                       Optional.of(initialHash),
-                      Arrays.asList(firstCommit, secondCommit, thirdCommit)));
+                      Arrays.asList(firstCommit, secondCommit, thirdCommit),
+                      Function.identity()));
     }
 
     @Test
@@ -930,7 +935,8 @@ public abstract class AbstractITVersionStore {
                   .transplant(
                       newBranch,
                       Optional.of(initialHash),
-                      Collections.singletonList(Hash.of("1234567890abcdef"))));
+                      Collections.singletonList(Hash.of("1234567890abcdef")),
+                      Function.identity()));
     }
 
     @Test
@@ -942,7 +948,10 @@ public abstract class AbstractITVersionStore {
 
       store()
           .transplant(
-              newBranch, Optional.empty(), Arrays.asList(firstCommit, secondCommit, thirdCommit));
+              newBranch,
+              Optional.empty(),
+              Arrays.asList(firstCommit, secondCommit, thirdCommit),
+              Function.identity());
       assertThat(
               store()
                   .getValues(
@@ -969,7 +978,8 @@ public abstract class AbstractITVersionStore {
                   .transplant(
                       newBranch,
                       Optional.empty(),
-                      Arrays.asList(secondCommit, firstCommit, thirdCommit)));
+                      Arrays.asList(secondCommit, firstCommit, thirdCommit),
+                      Function.identity()));
     }
 
     @Test
@@ -993,7 +1003,8 @@ public abstract class AbstractITVersionStore {
                   .transplant(
                       newBranch,
                       Optional.of(unrelatedCommit),
-                      Arrays.asList(firstCommit, secondCommit, thirdCommit)));
+                      Arrays.asList(firstCommit, secondCommit, thirdCommit),
+                      Function.identity()));
     }
 
     @Test
@@ -1004,7 +1015,10 @@ public abstract class AbstractITVersionStore {
 
       store()
           .transplant(
-              newBranch, Optional.of(initialHash), Arrays.asList(firstCommit, secondCommit));
+              newBranch,
+              Optional.of(initialHash),
+              Arrays.asList(firstCommit, secondCommit),
+              Function.identity());
       assertThat(
               store().getValues(newBranch, Arrays.asList(Key.of("t1"), Key.of("t4"), Key.of("t5"))))
           .containsExactlyInAnyOrderEntriesOf(
@@ -1057,7 +1071,7 @@ public abstract class AbstractITVersionStore {
       final BranchName newBranch = BranchName.of("bar_1");
       store().create(newBranch, Optional.of(initialHash));
 
-      store().merge(thirdCommit, newBranch, Optional.of(initialHash));
+      store().merge(thirdCommit, newBranch, Optional.of(initialHash), Function.identity());
       assertThat(
               store()
                   .getValues(
@@ -1078,7 +1092,7 @@ public abstract class AbstractITVersionStore {
       store().create(newBranch, Optional.of(initialHash));
       final Hash newCommit = commit("Unrelated commit").put("t5", "v5_1").toBranch(newBranch);
 
-      store().merge(thirdCommit, newBranch, Optional.empty());
+      store().merge(thirdCommit, newBranch, Optional.empty(), Function.identity());
       assertThat(
               store()
                   .getValues(
@@ -1111,11 +1125,21 @@ public abstract class AbstractITVersionStore {
       store()
           .commit(
               etl, Optional.empty(), "commit 1", Collections.singletonList(Put.of(key, "value1")));
-      store().merge(store().hashOnReference(etl, Optional.empty()), review, Optional.empty());
+      store()
+          .merge(
+              store().hashOnReference(etl, Optional.empty()),
+              review,
+              Optional.empty(),
+              Function.identity());
       store()
           .commit(
               etl, Optional.empty(), "commit 2", Collections.singletonList(Put.of(key, "value2")));
-      store().merge(store().hashOnReference(etl, Optional.empty()), review, Optional.empty());
+      store()
+          .merge(
+              store().hashOnReference(etl, Optional.empty()),
+              review,
+              Optional.empty(),
+              Function.identity());
       assertEquals(store().getValue(review, key), "value2");
     }
 
@@ -1126,7 +1150,7 @@ public abstract class AbstractITVersionStore {
 
       final Hash newCommit = commit("Unrelated commit").put("t5", "v5_1").toBranch(newBranch);
 
-      store().merge(thirdCommit, newBranch, Optional.empty());
+      store().merge(thirdCommit, newBranch, Optional.empty(), Function.identity());
       assertThat(
               store()
                   .getValues(
@@ -1178,7 +1202,7 @@ public abstract class AbstractITVersionStore {
                   "commit 4",
                   Collections.singletonList(Put.of(key2, "value4")));
 
-      assertThatThrownBy(() -> store().merge(barHash, foo, Optional.empty()))
+      assertThatThrownBy(() -> store().merge(barHash, foo, Optional.empty(), Function.identity()))
           .isInstanceOf(ReferenceConflictException.class)
           .hasMessageContaining("The following keys have been changed in conflict:")
           .hasMessageContaining(key1.toString())
@@ -1193,7 +1217,8 @@ public abstract class AbstractITVersionStore {
 
       assertThrows(
           ReferenceConflictException.class,
-          () -> store().merge(thirdCommit, newBranch, Optional.of(initialHash)));
+          () ->
+              store().merge(thirdCommit, newBranch, Optional.of(initialHash), Function.identity()));
     }
 
     @Test
@@ -1201,7 +1226,8 @@ public abstract class AbstractITVersionStore {
       final BranchName newBranch = BranchName.of("bar_5");
       assertThrows(
           ReferenceNotFoundException.class,
-          () -> store().merge(thirdCommit, newBranch, Optional.of(initialHash)));
+          () ->
+              store().merge(thirdCommit, newBranch, Optional.of(initialHash), Function.identity()));
     }
 
     @Test
@@ -1210,7 +1236,13 @@ public abstract class AbstractITVersionStore {
       store().create(newBranch, Optional.of(initialHash));
       assertThrows(
           ReferenceNotFoundException.class,
-          () -> store().merge(Hash.of("1234567890abcdef"), newBranch, Optional.of(initialHash)));
+          () ->
+              store()
+                  .merge(
+                      Hash.of("1234567890abcdef"),
+                      newBranch,
+                      Optional.of(initialHash),
+                      Function.identity()));
     }
   }
 


### PR DESCRIPTION
This change also prevents potential data corruption described in #2881.

Fixes #2881