### PR TITLE
Let dependabot catch indirect dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,14 +150,17 @@
     <awssdk.version>2.17.100</awssdk.version>
     <bouncycastle.version>1.66</bouncycastle.version>
     <cel.version>0.2.2</cel.version>
+    <checkstyle.version>9.2</checkstyle.version>
     <!-- to fix circular dependencies with NessieClient, certain projects need to use the same Nessie version as Iceberg/Delta has -->
     <client.nessie.version>0.9.2</client.nessie.version>
     <deltalake.version>1.0.0-nessie</deltalake.version>
     <dockerjava.version>3.2.12</dockerjava.version>
     <dynamodb.version>1.12.0</dynamodb.version>
+    <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <flapdoodle.version>3.1.4</flapdoodle.version>
     <gatling.maven.version>4.0.1</gatling.maven.version>
     <gatling.version>3.7.2</gatling.version>
+    <google-error-prone.version>2.10.0</google-error-prone.version>
     <google-java-format.version>1.13.0</google-java-format.version>
     <guava.version>31.0.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
@@ -521,6 +524,16 @@
         <artifactId>google-java-format</artifactId>
         <version>${google-java-format.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_core</artifactId>
+        <version>${google-error-prone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>jp.skypencil.errorprone.slf4j</groupId>
+        <artifactId>errorprone-slf4j</artifactId>
+        <version>${errorprone-slf4j.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -559,7 +572,7 @@
               <path>
                 <groupId>org.immutables</groupId>
                 <artifactId>value</artifactId>
-                <version>2.8.2</version>
+                <version>${immutables.version}</version>
               </path>
             </annotationProcessorPaths>
             <compilerArgs>
@@ -644,7 +657,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>9.2</version>
+              <version>${checkstyle.version}</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -1189,12 +1202,12 @@ limitations under the License.
                 <path>
                   <groupId>com.google.errorprone</groupId>
                   <artifactId>error_prone_core</artifactId>
-                  <version>2.9.0</version>
+                  <version>${google-error-prone.version}</version>
                 </path>
                 <path>
                   <groupId>jp.skypencil.errorprone.slf4j</groupId>
                   <artifactId>errorprone-slf4j</artifactId>
-                  <version>0.1.4</version>
+                  <version>${errorprone-slf4j.version}</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>


### PR DESCRIPTION
dependabot doesn't properly catch artifacts used by annotation processors.

This change adds properties for the remaining dependencies and also adds those to dependencyManagement.