### PR TITLE
Fix Python CI

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -30,7 +30,7 @@ deps =
     -r{toxinidir}/requirements_lint.txt
 commands =
     flake8 pynessie tests tools
-    safety check --ignore=41002
+    safety check --ignore=41002 --ignore=43313
     mypy --ignore-missing-imports -p pynessie
 
 [testenv:pylint]


### PR DESCRIPTION
"safety" started to report
```
  +============================+===========+==========================+==========+
  | package                    | installed | affected                 | ID       |
  +============================+===========+==========================+==========+
  | pytest-runner              | 5.3.1     | >0                       | 43313    |
  +==============================================================================+
```
but there's no newer version for pytest-runner. This change just ignores this one.

https://pypi.org/project/pytest-runner/ reports that it depends on deprecated
features and breaks pip security.