### PR TITLE
Simplify and fix GH workflow cache usage for pip + maven

### DIFF
--- a/.github/actions/dev-tool-python/action.yml
+++ b/.github/actions/dev-tool-python/action.yml
@@ -10,12 +10,8 @@ runs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ inputs.python-version }}
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: 'pip'
+        cache-dependency-path: '**/requirements*.txt'
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -17,20 +17,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.8'
+          cache: 'pip'
+          cache-dependency-path: 'site/requirements.txt'
       - name: Upgrade pip
         run: |
           # install pip=>20.1 to use "pip cache dir"
           python3 -m pip install --upgrade pip
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('site/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: python3 -m pip install -r ./site/requirements.txt
       - name: Generate Static Site


### PR DESCRIPTION
The change in `.github/actions/dev-tool-python/action.yml`, used by
`pull-request.yml`, now includes all requirements*.txt files, so a change
in a PR to for example `rquirements_dev.txt` no longer results in not
reusing an older cache version, that does not have an updated dependency.

See https://github.com/actions/setup-python#caching-packages-dependencies