### PR TITLE
Reflog support for txn db backend

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.api;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.Pattern;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.RefLogResponse;
+import org.projectnessie.model.Validation;
+
+/**
+ * Request builder for "get reflog".
+ *
+ * @since {@link NessieApiV1}
+ */
+public interface GetRefLogBuilder extends PagingBuilder<GetRefLogBuilder> {
+
+  /**
+   * Hash of the reflog (inclusive) to start from (in chronological sense), the 'far' end of the
+   * reflog.
+   */
+  GetRefLogBuilder untilHash(
+      @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+          String untilHash);
+
+  /**
+   * Hash of the reflog (inclusive) to end at (in chronological sense), the 'near' end of the
+   * reflog.
+   */
+  GetRefLogBuilder fromHash(
+      @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+          String fromHash);
+
+  RefLogResponse get() throws NessieNotFoundException;
+}

--- a/clients/client/src/main/java/org/projectnessie/client/api/NessieApiV1.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/NessieApiV1.java
@@ -20,6 +20,7 @@ import org.projectnessie.model.Branch;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.NessieConfiguration;
+import org.projectnessie.model.RefLogResponse;
 
 /** Interface for the Nessie V1 API implementation. */
 public interface NessieApiV1 extends NessieApi {
@@ -102,4 +103,24 @@ public interface NessieApiV1 extends NessieApi {
 
   /** Retrieve a diff between two references. */
   GetDiffBuilder getDiff();
+
+  /**
+   * Retrieve the reflog from the HEAD of the RefLog resource, potentially truncated by the backend.
+   *
+   * <p>Retrieves up to {@code maxRecords} refLog-entries starting at the HEAD of the RefLog
+   * resource. The backend <em>may</em> respect the given {@code max} records hint, but return less
+   * or more entries. Backends may also cap the returned entries at a hard-coded limit, the default
+   * REST server implementation has such a hard-coded limit.
+   *
+   * <p>Invoking {@code getRefLog()} does <em>not</em> guarantee to return all reflog entries,
+   * because the result can be truncated by the backend.
+   *
+   * <p>To implement paging, check {@link RefLogResponse#isHasMore() RefLogResponse.isHasMore()}
+   * and, if {@code true}, pass the value of {@link RefLogResponse#getToken()
+   * RefLogResponse.getToken()} in the next invocation of {@code getRefLog()} as the {@code
+   * pageToken} parameter.
+   *
+   * <p>See {@code org.projectnessie.client.StreamingUtil} in {@code nessie-client}.
+   */
+  GetRefLogBuilder getRefLog();
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpRefLogClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpRefLogClient.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http;
+
+import javax.validation.constraints.NotNull;
+import org.projectnessie.api.http.HttpRefLogApi;
+import org.projectnessie.api.params.RefLogParams;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.RefLogResponse;
+
+class HttpRefLogClient implements HttpRefLogApi {
+
+  private final HttpClient client;
+
+  public HttpRefLogClient(HttpClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public RefLogResponse getRefLog(@NotNull RefLogParams params) throws NessieNotFoundException {
+    HttpRequest builder = client.newRequest().path("reflogs");
+    return builder
+        .queryParam(
+            "maxRecords", params.maxRecords() != null ? params.maxRecords().toString() : null)
+        .queryParam("pageToken", params.pageToken())
+        .queryParam("startHash", params.startHash())
+        .queryParam("endHash", params.endHash())
+        .get()
+        .readEntity(RefLogResponse.class);
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/http/NessieApiClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/NessieApiClient.java
@@ -19,6 +19,7 @@ import java.io.Closeable;
 import org.projectnessie.api.http.HttpConfigApi;
 import org.projectnessie.api.http.HttpContentApi;
 import org.projectnessie.api.http.HttpDiffApi;
+import org.projectnessie.api.http.HttpRefLogApi;
 import org.projectnessie.api.http.HttpTreeApi;
 
 public class NessieApiClient implements Closeable {
@@ -26,13 +27,19 @@ public class NessieApiClient implements Closeable {
   private final HttpTreeApi tree;
   private final HttpContentApi content;
   private final HttpDiffApi diff;
+  private final HttpRefLogApi refLog;
 
   public NessieApiClient(
-      HttpConfigApi config, HttpTreeApi tree, HttpContentApi content, HttpDiffApi diff) {
+      HttpConfigApi config,
+      HttpTreeApi tree,
+      HttpContentApi content,
+      HttpDiffApi diff,
+      HttpRefLogApi refLog) {
     this.config = config;
     this.tree = tree;
     this.content = content;
     this.diff = diff;
+    this.refLog = refLog;
   }
 
   public HttpTreeApi getTreeApi() {
@@ -49,6 +56,10 @@ public class NessieApiClient implements Closeable {
 
   public HttpDiffApi getDiffApi() {
     return diff;
+  }
+
+  public HttpRefLogApi getRefLogApi() {
+    return refLog;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import org.projectnessie.api.http.HttpConfigApi;
 import org.projectnessie.api.http.HttpContentApi;
 import org.projectnessie.api.http.HttpDiffApi;
+import org.projectnessie.api.http.HttpRefLogApi;
 import org.projectnessie.api.http.HttpTreeApi;
 import org.projectnessie.client.rest.NessieHttpResponseFilter;
 import org.projectnessie.error.NessieConflictException;
@@ -87,7 +88,8 @@ public class NessieHttpClient extends NessieApiClient {
         wrap(HttpConfigApi.class, new HttpConfigClient(client)),
         wrap(HttpTreeApi.class, new HttpTreeClient(client)),
         wrap(HttpContentApi.class, new HttpContentClient(client)),
-        wrap(HttpDiffApi.class, new HttpDiffClient(client)));
+        wrap(HttpDiffApi.class, new HttpDiffClient(client)),
+        wrap(HttpRefLogApi.class, new HttpRefLogClient(client)));
     this.client = client;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
@@ -26,6 +26,7 @@ import org.projectnessie.client.api.GetCommitLogBuilder;
 import org.projectnessie.client.api.GetContentBuilder;
 import org.projectnessie.client.api.GetDiffBuilder;
 import org.projectnessie.client.api.GetEntriesBuilder;
+import org.projectnessie.client.api.GetRefLogBuilder;
 import org.projectnessie.client.api.GetReferenceBuilder;
 import org.projectnessie.client.api.MergeReferenceBuilder;
 import org.projectnessie.client.api.NessieApiV1;
@@ -126,5 +127,10 @@ public final class HttpApiV1 implements NessieApiV1 {
   @Override
   public GetDiffBuilder getDiff() {
     return new HttpGetDiff(client);
+  }
+
+  @Override
+  public GetRefLogBuilder getRefLog() {
+    return new HttpGetRefLog(client);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v1api;
+
+import org.projectnessie.api.params.RefLogParams;
+import org.projectnessie.client.api.GetRefLogBuilder;
+import org.projectnessie.client.http.NessieApiClient;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.RefLogResponse;
+
+final class HttpGetRefLog extends BaseHttpRequest implements GetRefLogBuilder {
+
+  private final RefLogParams.Builder params = RefLogParams.builder();
+
+  HttpGetRefLog(NessieApiClient client) {
+    super(client);
+  }
+
+  @Override
+  public GetRefLogBuilder untilHash(String untilHash) {
+    params.startHash(untilHash);
+    return this;
+  }
+
+  @Override
+  public GetRefLogBuilder fromHash(String fromHash) {
+    params.endHash(fromHash);
+    return this;
+  }
+
+  @Override
+  public GetRefLogBuilder maxRecords(int maxRecords) {
+    params.maxRecords(maxRecords);
+    return this;
+  }
+
+  @Override
+  public GetRefLogBuilder pageToken(String pageToken) {
+    params.pageToken(pageToken);
+    return this;
+  }
+
+  @Override
+  public RefLogResponse get() throws NessieNotFoundException {
+    return client.getRefLogApi().getRefLog(params.build());
+  }
+}

--- a/model/src/main/java/org/projectnessie/api/RefLogApi.java
+++ b/model/src/main/java/org/projectnessie/api/RefLogApi.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.projectnessie.api.params.RefLogParams;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.RefLogResponse;
+
+public interface RefLogApi {
+
+  // Note: When substantial changes in Nessie API (this and related interfaces) are made
+  // the API version number reported by NessieConfiguration.getMaxSupportedApiVersion()
+  // should be increased as well.
+
+  /**
+   * Retrieve the reflog, potentially truncated by the backend.
+   *
+   * <p>Retrieves up to {@code maxRecords} refLog-entries starting at the HEAD of current-reflog.
+   * The backend <em>may</em> respect the given {@code max} records hint, but return less or more
+   * entries. Backends may also cap the returned entries at a hard-coded limit, the default REST
+   * server implementation has such a hard-coded limit.
+   *
+   * <p>Invoking {@code getRefLog()} does <em>not</em> guarantee to return all refLog entries
+   * because the result can be truncated by the backend.
+   *
+   * <p>To implement paging, check {@link RefLogResponse#isHasMore() RefLogResponse.isHasMore()}
+   * and, if {@code true}, pass the value of {@link RefLogResponse#getToken()
+   * RefLogResponse.getToken()} in the next invocation of {@code getRefLog()} as the {@code
+   * pageToken} parameter.
+   *
+   * <p>See {@code org.projectnessie.client.StreamingUtil} in {@code nessie-client}.
+   *
+   * @return {@link RefLogResponse}
+   */
+  RefLogResponse getRefLog(@Valid @NotNull RefLogParams params) throws NessieNotFoundException;
+}

--- a/model/src/main/java/org/projectnessie/api/http/HttpRefLogApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpRefLogApi.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.http;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.projectnessie.api.RefLogApi;
+import org.projectnessie.api.params.RefLogParams;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.RefLogResponse;
+
+@Consumes(value = MediaType.APPLICATION_JSON)
+@Path("reflogs")
+public interface HttpRefLogApi extends RefLogApi {
+
+  @Override
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Get reflog entries",
+      description =
+          "Retrieve the reflog entries from a specified endHash or from the current HEAD if the endHash is null, "
+              + "potentially truncated by the backend.\n"
+              + "\n"
+              + "Retrieves up to 'maxRecords' refLog-entries starting at the endHash or HEAD."
+              + "The backend may respect the given 'max' records hint, but return less or more entries. "
+              + "Backends may also cap the returned entries at a hard-coded limit, the default "
+              + "REST server implementation has such a hard-coded limit.\n"
+              + "\n"
+              + "To implement paging, check 'hasMore' in the response and, if 'true', pass the value "
+              + "returned as 'token' in the next invocation as the 'pageToken' parameter.\n"
+              + "\n"
+              + "The content and meaning of the returned 'token' is \"private\" to the implementation,"
+              + "treat is as an opaque value.\n"
+              + "\n"
+              + "It is wrong to assume that invoking this method with a very high 'maxRecords' value "
+              + "will return all reflog entries.\n"
+              + "\n")
+  @APIResponses({
+    @APIResponse(
+        responseCode = "200",
+        description = "Returned reflog entries.",
+        content = {
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              schema = @Schema(implementation = RefLogResponse.class))
+        }),
+    @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
+    @APIResponse(responseCode = "400", description = "Unknown Error"),
+    @APIResponse(responseCode = "404", description = "Reflog id doesn't exists")
+  })
+  RefLogResponse getRefLog(@BeanParam RefLogParams params) throws NessieNotFoundException;
+}

--- a/model/src/main/java/org/projectnessie/api/params/AbstractParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/AbstractParams.java
@@ -29,7 +29,7 @@ public abstract class AbstractParams {
   @Parameter(
       description =
           "paging continuation token, as returned in the previous value of the field 'token' in "
-              + "the corresponding 'EntriesResponse' or 'LogResponse' or 'ReferencesResponse'.")
+              + "the corresponding 'EntriesResponse' or 'LogResponse' or 'ReferencesResponse' or 'RefLogResponse'.")
   @QueryParam("pageToken")
   @Nullable
   private String pageToken;

--- a/model/src/main/java/org/projectnessie/api/params/RefLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/RefLogParams.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.params;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+import javax.annotation.Nullable;
+import javax.validation.constraints.Pattern;
+import javax.ws.rs.QueryParam;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.projectnessie.model.Validation;
+
+/**
+ * The purpose of this class is to include optional parameters that can be passed to {@code
+ * HttpRefLogApi#getRefLog(RefLogParams)}.
+ *
+ * <p>For easier usage of this class, there is {@link RefLogParams#builder()}, which allows
+ * configuring/setting the different parameters.
+ */
+public class RefLogParams extends AbstractParams {
+
+  @Nullable
+  @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+  @Parameter(
+      description =
+          "Hash of the reflog (inclusive) to start from (in chronological sense), the 'far' end of the reflog, "
+              + "returned "
+              + "'late' in the result.")
+  @QueryParam("startHash")
+  private String startHash;
+
+  @Nullable
+  @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+  @Parameter(
+      description =
+          "Hash of the reflog (inclusive) to end at (in chronological sense), the 'near' end of the reflog, returned "
+              + "'early' "
+              + "in the result.")
+  @QueryParam("endHash")
+  private String endHash;
+
+  public RefLogParams() {}
+
+  private RefLogParams(String startHash, String endHash, Integer maxRecords, String pageToken) {
+    super(maxRecords, pageToken);
+    this.startHash = startHash;
+    this.endHash = endHash;
+  }
+
+  private RefLogParams(Builder builder) {
+    this(builder.startHash, builder.endHash, builder.maxRecords, builder.pageToken);
+  }
+
+  @Nullable
+  public String startHash() {
+    return startHash;
+  }
+
+  @Nullable
+  public String endHash() {
+    return endHash;
+  }
+
+  public static RefLogParams.Builder builder() {
+    return new RefLogParams.Builder();
+  }
+
+  public static RefLogParams empty() {
+    return new RefLogParams.Builder().build();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", RefLogParams.class.getSimpleName() + "[", "]")
+        .add("startHash='" + startHash + "'")
+        .add("endHash='" + endHash + "'")
+        .add("maxRecords=" + maxRecords())
+        .add("pageToken='" + pageToken() + "'")
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RefLogParams that = (RefLogParams) o;
+    return Objects.equals(startHash, that.startHash)
+        && Objects.equals(endHash, that.endHash)
+        && Objects.equals(maxRecords(), that.maxRecords())
+        && Objects.equals(pageToken(), that.pageToken());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(startHash, endHash, maxRecords(), pageToken());
+  }
+
+  public static class Builder extends AbstractParams.Builder<Builder> {
+
+    private String startHash;
+    private String endHash;
+
+    private Builder() {}
+
+    public Builder startHash(String startHash) {
+      this.startHash = startHash;
+      return this;
+    }
+
+    public Builder endHash(String endHash) {
+      this.endHash = endHash;
+      return this;
+    }
+
+    public Builder from(RefLogParams params) {
+      return startHash(params.startHash)
+          .endHash(params.endHash)
+          .maxRecords(params.maxRecords())
+          .pageToken(params.pageToken());
+    }
+
+    public RefLogParams build() {
+      return new RefLogParams(this);
+    }
+  }
+}

--- a/model/src/main/java/org/projectnessie/error/ErrorCode.java
+++ b/model/src/main/java/org/projectnessie/error/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
   REFERENCE_ALREADY_EXISTS(NessieReferenceAlreadyExistsException::new),
   CONTENT_NOT_FOUND(NessieContentNotFoundException::new),
   REFERENCE_CONFLICT(NessieReferenceConflictException::new),
+  REFLOG_NOT_FOUND(NessieRefLogNotFoundException::new),
   ;
 
   private final Function<NessieError, ? extends BaseNessieClientServerException> exceptionBuilder;

--- a/model/src/main/java/org/projectnessie/error/NessieRefLogNotFoundException.java
+++ b/model/src/main/java/org/projectnessie/error/NessieRefLogNotFoundException.java
@@ -13,18 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.dynamodb;
+package org.projectnessie.error;
 
-final class Tables {
+/** This exception is thrown when a requested reflog is not present in the store. */
+public class NessieRefLogNotFoundException extends NessieNotFoundException {
 
-  static final String TABLE_GLOBAL_POINTER = "global_pointer";
-  static final String TABLE_GLOBAL_LOG = "global_log";
-  static final String TABLE_COMMIT_LOG = "commit_log";
-  static final String TABLE_KEY_LISTS = "key_lists";
-  static final String TABLE_REF_LOG = "ref_log";
+  public NessieRefLogNotFoundException(String message) {
+    super(message);
+  }
 
-  static final String KEY_NAME = "key";
-  static final String VALUE_NAME = "val";
+  public NessieRefLogNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
 
-  private Tables() {}
+  public NessieRefLogNotFoundException(NessieError error) {
+    super(error);
+  }
+
+  @Override
+  public ErrorCode getErrorCode() {
+    return ErrorCode.REFLOG_NOT_FOUND;
+  }
 }

--- a/model/src/main/java/org/projectnessie/model/RefLogResponse.java
+++ b/model/src/main/java/org/projectnessie/model/RefLogResponse.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Schema(type = SchemaType.OBJECT, title = "RefLogResponse")
+@JsonSerialize(as = ImmutableRefLogResponse.class)
+@JsonDeserialize(as = ImmutableRefLogResponse.class)
+public interface RefLogResponse extends PaginatedResponse {
+
+  @NotNull
+  List<RefLogResponseEntry> getLogEntries();
+
+  @Value.Immutable
+  @Schema(type = SchemaType.OBJECT, title = "RefLogResponseEntry")
+  @JsonSerialize(as = ImmutableRefLogResponseEntry.class)
+  @JsonDeserialize(as = ImmutableRefLogResponseEntry.class)
+  interface RefLogResponseEntry {
+    static ImmutableRefLogResponseEntry.Builder builder() {
+      return ImmutableRefLogResponseEntry.builder();
+    }
+
+    /** Reflog id of the current entry. */
+    @NotNull
+    String getRefLogId();
+
+    /** Reference on which current operation is executed. */
+    @NotNull
+    String getRefName();
+
+    /** Reference type can be 'Branch' or 'Tag'. */
+    @NotNull
+    String getRefType();
+
+    /** Output commit hash of the operation. */
+    @NotNull
+    String getCommitHash();
+
+    /** Parent reflog id of the current entry. */
+    @NotNull
+    String getParentRefLogId();
+
+    /** Time in microseconds since epoch. */
+    @NotNull
+    long getOperationTime();
+
+    /** Operation String mapped to ENUM in {@code RefLogEntry.Operation} of 'persist.proto' file. */
+    @NotNull
+    String getOperation();
+
+    /**
+     * Single hash in case of MERGE. One or more hashes in case of TRANSPLANT. Empty list for other
+     * operations.
+     */
+    @NotNull
+    List<String> getSourceHashes();
+  }
+}

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
@@ -39,6 +39,7 @@ import org.projectnessie.services.rest.NessieJaxRsJsonParseExceptionMapper;
 import org.projectnessie.services.rest.RestConfigResource;
 import org.projectnessie.services.rest.RestContentResource;
 import org.projectnessie.services.rest.RestDiffResource;
+import org.projectnessie.services.rest.RestRefLogResource;
 import org.projectnessie.services.rest.RestTreeResource;
 import org.projectnessie.services.rest.ValidationExceptionMapper;
 import org.projectnessie.versioned.PersistVersionStoreExtension;
@@ -86,6 +87,7 @@ public class NessieJaxRsExtension implements BeforeAllCallback, AfterAllCallback
             config.register(RestTreeResource.class);
             config.register(RestContentResource.class);
             config.register(RestDiffResource.class);
+            config.register(RestRefLogResource.class);
             config.register(ConfigApiImpl.class);
             config.register(ContentKeyParamConverterProvider.class);
             config.register(InstantParamConverterProvider.class);

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyRestH2.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyRestH2.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.jaxrs;
 
+import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 import org.projectnessie.versioned.persist.tx.h2.H2DatabaseAdapterFactory;
@@ -22,4 +23,10 @@ import org.projectnessie.versioned.persist.tx.h2.H2TestConnectionProviderSource;
 
 @NessieDbAdapterName(H2DatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(H2TestConnectionProviderSource.class)
-class TestJerseyRestH2 extends AbstractTestJerseyRest {}
+class TestJerseyRestH2 extends AbstractTestJerseyRest {
+
+  @Override
+  public void testReflog() throws BaseNessieClientServerException {
+    // TODO: enable once txn db implementation is done.
+  }
+}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyRestH2.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyRestH2.java
@@ -15,7 +15,6 @@
  */
 package org.projectnessie.jaxrs;
 
-import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 import org.projectnessie.versioned.persist.tx.h2.H2DatabaseAdapterFactory;
@@ -23,10 +22,4 @@ import org.projectnessie.versioned.persist.tx.h2.H2TestConnectionProviderSource;
 
 @NessieDbAdapterName(H2DatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(H2TestConnectionProviderSource.class)
-class TestJerseyRestH2 extends AbstractTestJerseyRest {
-
-  @Override
-  public void testReflog() throws BaseNessieClientServerException {
-    // TODO: enable once txn db implementation is done.
-  }
-}
+class TestJerseyRestH2 extends AbstractTestJerseyRest {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyResteasyH2.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyResteasyH2.java
@@ -22,10 +22,4 @@ import org.projectnessie.versioned.persist.tx.h2.H2TestConnectionProviderSource;
 
 @NessieDbAdapterName(H2DatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(H2TestConnectionProviderSource.class)
-class TestJerseyResteasyH2 extends AbstractTestJerseyResteasy {
-
-  @Override
-  public void testGetRefLog() {
-    // TODO: enable when Txn store is supported for reflog
-  }
-}
+class TestJerseyResteasyH2 extends AbstractTestJerseyResteasy {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyResteasyH2.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyResteasyH2.java
@@ -22,4 +22,10 @@ import org.projectnessie.versioned.persist.tx.h2.H2TestConnectionProviderSource;
 
 @NessieDbAdapterName(H2DatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(H2TestConnectionProviderSource.class)
-class TestJerseyResteasyH2 extends AbstractTestJerseyResteasy {}
+class TestJerseyResteasyH2 extends AbstractTestJerseyResteasy {
+
+  @Override
+  public void testGetRefLog() {
+    // TODO: enable when Txn store is supported for reflog
+  }
+}

--- a/servers/jax-rs/src/main/java/org/projectnessie/services/authz/AccessCheckerExtension.java
+++ b/servers/jax-rs/src/main/java/org/projectnessie/services/authz/AccessCheckerExtension.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.services.authz;
 
+import java.security.AccessControlException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
@@ -60,6 +61,9 @@ public class AccessCheckerExtension implements Extension {
         @Override
         public void canDeleteEntity(
             AccessContext context, NamedRef ref, ContentKey key, String contentId) {}
+
+        @Override
+        public void canViewRefLog(AccessContext context) throws AccessControlException {}
       };
 
   @SuppressWarnings("unused")

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/authz/CelAccessChecker.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/authz/CelAccessChecker.java
@@ -47,7 +47,8 @@ public class CelAccessChecker implements AccessChecker {
     COMMIT_CHANGE_AGAINST_REFERENCE,
     READ_ENTITY_VALUE,
     UPDATE_ENTITY,
-    DELETE_ENTITY;
+    DELETE_ENTITY,
+    VIEW_REFLOG;
   }
 
   @Inject
@@ -121,6 +122,22 @@ public class CelAccessChecker implements AccessChecker {
       throws AccessControlException {
     canViewReference(context, ref);
     canPerformOpOnPath(context, ref, key, AuthorizationRuleType.DELETE_ENTITY);
+  }
+
+  @Override
+  public void canViewRefLog(AccessContext context) throws AccessControlException {
+    if (!config.enabled()) {
+      return;
+    }
+    String roleName = getRoleName(context);
+    ImmutableMap<String, Object> arguments =
+        ImmutableMap.of("role", roleName, "op", AuthorizationRuleType.VIEW_REFLOG.name());
+
+    Supplier<String> errorMsgSupplier =
+        () ->
+            String.format(
+                "'%s' is not allowed for role '%s' ", AuthorizationRuleType.VIEW_REFLOG, roleName);
+    canPerformOp(arguments, errorMsgSupplier);
   }
 
   private String getRoleName(AccessContext context) {

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusVersionStoreAdvancedConfig.java
@@ -88,4 +88,9 @@ public interface QuarkusVersionStoreAdvancedConfig
   @WithDefault("" + DEFAULT_BATCH_SIZE)
   @Override
   int getBatchSize();
+
+  @WithName("parent-per-reflog-entry")
+  @WithDefault("" + DEFAULT_PARENTS_PER_REFLOG_ENTRY)
+  @Override
+  int getParentsPerRefLogEntry();
 }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -40,6 +40,7 @@ import org.projectnessie.model.ImmutableOperations;
 import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Operation.Delete;
 import org.projectnessie.model.Operation.Put;
+import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.model.Reference;
 import org.projectnessie.server.authz.NessieAuthorizationTestProfile;
 
@@ -92,6 +93,8 @@ class TestAuthorizationRules extends BaseClientAuthTest {
 
     branch = shouldFail ? branchWithInvalidHash : retrieveBranch(branchName, role, shouldFail);
     deleteBranch(branch, role, shouldFail);
+
+    getRefLog(role, !role.equals("admin_user"));
   }
 
   @Test
@@ -260,6 +263,17 @@ class TestAuthorizationRules extends BaseClientAuthTest {
     } else {
       List<LogEntry> commits = api().getCommitLog().refName(branchName).get().getLogEntries();
       assertThat(commits).isNotEmpty();
+    }
+  }
+
+  private void getRefLog(String role, boolean shouldFail) throws NessieNotFoundException {
+    if (shouldFail) {
+      assertThatThrownBy(() -> api().getRefLog().get().getLogEntries())
+          .isInstanceOf(NessieForbiddenException.class)
+          .hasMessageContaining(String.format("'VIEW_REFLOG' is not allowed for role '%s'", role));
+    } else {
+      List<RefLogResponse.RefLogResponseEntry> entries = api().getRefLog().get().getLogEntries();
+      assertThat(entries).isNotEmpty();
     }
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
@@ -71,6 +71,9 @@ public class NessieAuthorizationTestProfile extends AuthenticationEnabledProfile
           .put(
               "nessie.server.authorization.rules.allow_commits_without_entity_changes",
               "op=='COMMIT_CHANGE_AGAINST_REFERENCE' && role=='test_user2' && ref.startsWith('allowedBranch')")
+          .put(
+              "nessie.server.authorization.rules.allow_listing_reflog",
+              "op=='VIEW_REFLOG' && role=='admin_user'")
           .build();
 
   @Override

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogResource.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.rest;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+import org.projectnessie.api.RefLogApi;
+import org.projectnessie.api.http.HttpRefLogApi;
+import org.projectnessie.api.params.RefLogParams;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.Content.Type;
+import org.projectnessie.model.RefLogResponse;
+import org.projectnessie.services.authz.AccessChecker;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.services.impl.RefLogApiImplWithAuthorization;
+import org.projectnessie.versioned.VersionStore;
+
+/** REST endpoint for the reflog-API. */
+@RequestScoped
+public class RestRefLogResource implements HttpRefLogApi {
+
+  private final ServerConfig config;
+  private final VersionStore<Content, CommitMeta, Type> store;
+  private final AccessChecker accessChecker;
+
+  @Context SecurityContext securityContext;
+
+  // Mandated by CDI 2.0
+  public RestRefLogResource() {
+    this(null, null, null);
+  }
+
+  @Inject
+  public RestRefLogResource(
+      ServerConfig config,
+      VersionStore<Content, CommitMeta, Type> store,
+      AccessChecker accessChecker) {
+    this.config = config;
+    this.store = store;
+    this.accessChecker = accessChecker;
+  }
+
+  private RefLogApi resource() {
+    return new RefLogApiImplWithAuthorization(
+        config,
+        store,
+        accessChecker,
+        securityContext == null ? null : securityContext.getUserPrincipal());
+  }
+
+  @Override
+  public RefLogResponse getRefLog(RefLogParams params) throws NessieNotFoundException {
+    return resource().getRefLog(params);
+  }
+}

--- a/servers/services/src/main/java/org/projectnessie/services/authz/AccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/AccessChecker.java
@@ -139,4 +139,12 @@ public interface AccessChecker {
    */
   void canDeleteEntity(AccessContext context, NamedRef ref, ContentKey key, String contentId)
       throws AccessControlException;
+
+  /**
+   * Checks whether the given role/principal is allowed to view the reflog entries.
+   *
+   * @param context The context carrying the principal information.
+   * @throws AccessControlException When the permission to view the reflog entries is not granted.
+   */
+  void canViewRefLog(AccessContext context) throws AccessControlException;
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.impl;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.projectnessie.api.RefLogApi;
+import org.projectnessie.api.params.RefLogParams;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.error.NessieRefLogNotFoundException;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.Content.Type;
+import org.projectnessie.model.ImmutableRefLogResponse;
+import org.projectnessie.model.ImmutableRefLogResponseEntry;
+import org.projectnessie.model.RefLogResponse;
+import org.projectnessie.services.authz.AccessChecker;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.RefLog;
+import org.projectnessie.versioned.RefLogNotFoundException;
+import org.projectnessie.versioned.VersionStore;
+
+public class RefLogApiImpl extends BaseApiImpl implements RefLogApi {
+
+  private static final int MAX_REF_LOG_ENTRIES = 250;
+
+  public RefLogApiImpl(
+      ServerConfig config,
+      VersionStore<Content, CommitMeta, Type> store,
+      AccessChecker accessChecker,
+      Principal principal) {
+    super(config, store, accessChecker, principal);
+  }
+
+  @Override
+  public RefLogResponse getRefLog(RefLogParams params) throws NessieNotFoundException {
+    int max =
+        Math.min(
+            params.maxRecords() != null ? params.maxRecords() : MAX_REF_LOG_ENTRIES,
+            MAX_REF_LOG_ENTRIES);
+
+    Hash endHash = null;
+    if (params.endHash() != null) {
+      endHash = Hash.of(Objects.requireNonNull(params.endHash()));
+    }
+    Hash endRef = null == params.pageToken() ? endHash : Hash.of(params.pageToken());
+
+    try (Stream<RefLog> entries = getStore().getRefLog(endRef)) {
+      Stream<RefLogResponse.RefLogResponseEntry> logEntries =
+          entries.map(
+              entry -> {
+                ImmutableRefLogResponseEntry.Builder logEntry =
+                    RefLogResponse.RefLogResponseEntry.builder();
+                logEntry
+                    .refLogId(entry.getRefLogId().asString())
+                    .refName(entry.getRefName())
+                    .refType(entry.getRefType())
+                    .commitHash(entry.getCommitHash().asString())
+                    .operation(entry.getOperation())
+                    .operationTime(entry.getOperationTime())
+                    .parentRefLogId(entry.getParents().get(0).asString());
+                entry.getSourceHashes().forEach(hash -> logEntry.addSourceHashes(hash.asString()));
+                return logEntry.build();
+              });
+
+      logEntries =
+          StreamSupport.stream(
+              StreamUtil.takeUntilIncl(
+                  logEntries.spliterator(),
+                  x -> Objects.equals(x.getRefLogId(), params.startHash())),
+              false);
+
+      List<RefLogResponse.RefLogResponseEntry> items =
+          logEntries.limit(max + 1).collect(Collectors.toList());
+
+      if (items.size() == max + 1) {
+        return ImmutableRefLogResponse.builder()
+            .addAllLogEntries(items.subList(0, max))
+            .isHasMore(true)
+            .token(items.get(max).getRefLogId())
+            .build();
+      }
+      return ImmutableRefLogResponse.builder().addAllLogEntries(items).build();
+    } catch (RefLogNotFoundException e) {
+      throw new NessieRefLogNotFoundException(e.getMessage(), e);
+    }
+  }
+}

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImplWithAuthorization.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.impl;
+
+import java.security.Principal;
+import org.projectnessie.api.params.RefLogParams;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.Content.Type;
+import org.projectnessie.model.RefLogResponse;
+import org.projectnessie.services.authz.AccessChecker;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.versioned.VersionStore;
+
+/** Does authorization check (if enabled) on the {@link RefLogApiImpl}. */
+public class RefLogApiImplWithAuthorization extends RefLogApiImpl {
+
+  public RefLogApiImplWithAuthorization(
+      ServerConfig config,
+      VersionStore<Content, CommitMeta, Type> store,
+      AccessChecker accessChecker,
+      Principal principal) {
+    super(config, store, accessChecker, principal);
+  }
+
+  @Override
+  public RefLogResponse getRefLog(RefLogParams params) throws NessieNotFoundException {
+    getAccessChecker().canViewRefLog(createAccessContext());
+    return super.getRefLog(params);
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/AdjustableDatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/AdjustableDatabaseAdapterConfig.java
@@ -32,4 +32,6 @@ public interface AdjustableDatabaseAdapterConfig extends DatabaseAdapterConfig {
   AdjustableDatabaseAdapterConfig withCommitRetries(int commitRetries);
 
   AdjustableDatabaseAdapterConfig withClock(Clock clock);
+
+  AdjustableDatabaseAdapterConfig withParentsPerRefLogEntry(int parentsPerEntry);
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -306,7 +306,7 @@ public interface DatabaseAdapter {
    * Retrieve the refLog starting at the refLog referenced by {@code offset}.
    *
    * @return stream of {@link RefLog}s
-   * @param offset
+   * @param offset initial reflog id to read from
    */
   Stream<RefLog> refLog(Hash offset) throws RefLogNotFoundException;
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -30,6 +30,8 @@ import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.RefLog;
+import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
@@ -299,4 +301,12 @@ public interface DatabaseAdapter {
    */
   Optional<ContentIdAndBytes> globalContent(
       ContentId contentId, ToIntFunction<ByteString> contentTypeExtractor);
+
+  /**
+   * Retrieve the refLog starting at the refLog referenced by {@code offset}.
+   *
+   * @return stream of {@link RefLog}s
+   * @param offset
+   */
+  Stream<RefLog> refLog(Hash offset) throws RefLogNotFoundException;
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.adapter;
 
 import java.time.Clock;
 import org.immutables.value.Value;
+import org.projectnessie.versioned.RefLog;
 
 /**
  * Base database-adapter configuration type.
@@ -33,6 +34,7 @@ public interface DatabaseAdapterConfig {
   int DEFAULT_MAX_KEY_LIST_SIZE = 250_000;
   int DEFAULT_COMMIT_TIMEOUT = 500;
   int DEFAULT_COMMIT_RETRIES = Integer.MAX_VALUE;
+  int DEFAULT_PARENTS_PER_REFLOG_ENTRY = 20;
 
   /**
    * A free-form string that identifies a particular Nessie storage repository.
@@ -126,5 +128,14 @@ public interface DatabaseAdapterConfig {
   @Value.Default
   default Clock getClock() {
     return Clock.systemUTC();
+  }
+
+  /**
+   * The number of Ancestor (reflogId, commitHash) stored in {@link RefLog#getParents()}. Defaults
+   * to {@value #DEFAULT_PARENTS_PER_REFLOG_ENTRY}.
+   */
+  @Value.Default
+  default int getParentsPerRefLogEntry() {
+    return DEFAULT_PARENTS_PER_REFLOG_ENTRY;
   }
 }

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseClient.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseClient.java
@@ -20,6 +20,7 @@ import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_COMMIT_L
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_GLOBAL_LOG;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_GLOBAL_POINTER;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_KEY_LISTS;
+import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_REF_LOG;
 
 import java.net.URI;
 import java.util.List;
@@ -86,7 +87,12 @@ public class DynamoDatabaseClient implements DatabaseConnectionProvider<DynamoCl
           "Must provide a Dynamo-client-configuration of type DefaultDynamoClientConfig or ProvidedDynamoClientConfig.");
     }
 
-    Stream.of(TABLE_GLOBAL_POINTER, TABLE_GLOBAL_LOG, TABLE_COMMIT_LOG, TABLE_KEY_LISTS)
+    Stream.of(
+            TABLE_GLOBAL_POINTER,
+            TABLE_GLOBAL_LOG,
+            TABLE_COMMIT_LOG,
+            TABLE_KEY_LISTS,
+            TABLE_REF_LOG)
         .forEach(this::createIfMissing);
   }
 

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.RefLog;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
@@ -38,6 +39,7 @@ import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter
 import org.projectnessie.versioned.persist.nontx.NonTransactionalOperationContext;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
 import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
 
 public class InmemoryDatabaseAdapter
@@ -125,10 +127,12 @@ public class InmemoryDatabaseAdapter
       NonTransactionalOperationContext ctx,
       Hash globalId,
       Set<Hash> branchCommits,
-      Set<Hash> newKeyLists) {
+      Set<Hash> newKeyLists,
+      Hash refLogId) {
     store.globalStateLog.remove(dbKey(globalId));
     branchCommits.forEach(h -> store.commitLog.remove(dbKey(h)));
     newKeyLists.forEach(h -> store.keyLists.remove(dbKey(h)));
+    store.refLog.remove(dbKey(refLogId));
   }
 
   @Override
@@ -200,5 +204,32 @@ public class InmemoryDatabaseAdapter
   @Override
   protected int entitySize(KeyWithType entry) {
     return toProto(entry).getSerializedSize();
+  }
+
+  @Override
+  protected void writeRefLog(NonTransactionalOperationContext ctx, RefLogEntry entry)
+      throws ReferenceConflictException {
+    if (store.refLog.putIfAbsent(dbKey(entry.getRefLogId()), entry.toByteString()) != null) {
+      throw new ReferenceConflictException(" RefLog Hash collision detected");
+    }
+  }
+
+  @Override
+  protected RefLog fetchFromRefLog(NonTransactionalOperationContext ctx, Hash refLogId) {
+    if (refLogId == null) {
+      // set the current head as refLogId
+      refLogId = Hash.of(fetchGlobalPointer(ctx).getRefLogId());
+    }
+    return ProtoSerialization.protoToRefLog(store.refLog.get(dbKey(refLogId)));
+  }
+
+  @Override
+  protected List<RefLog> fetchPageFromRefLog(
+      NonTransactionalOperationContext ctx, List<Hash> hashes) {
+    return hashes.stream()
+        .map(this::dbKey)
+        .map(store.refLog::get)
+        .map(ProtoSerialization::protoToRefLog)
+        .collect(Collectors.toList());
   }
 }

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
@@ -30,6 +30,7 @@ public class InmemoryStore implements DatabaseConnectionProvider<InmemoryConfig>
   final ConcurrentMap<ByteString, ByteString> globalStateLog = new ConcurrentHashMap<>();
   final ConcurrentMap<ByteString, ByteString> commitLog = new ConcurrentHashMap<>();
   final ConcurrentMap<ByteString, ByteString> keyLists = new ConcurrentHashMap<>();
+  final ConcurrentMap<ByteString, ByteString> refLog = new ConcurrentHashMap<>();
 
   public InmemoryStore() {}
 
@@ -43,7 +44,7 @@ public class InmemoryStore implements DatabaseConnectionProvider<InmemoryConfig>
   public void close() {}
 
   void reinitializeRepo(ByteString keyPrefix) {
-    Stream.of(globalStatePointer, globalStateLog, commitLog, keyLists)
+    Stream.of(globalStatePointer, globalStateLog, commitLog, keyLists, refLog)
         .forEach(map -> map.keySet().removeIf(bytes -> bytes.startsWith(keyPrefix)));
   }
 }

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseClient.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseClient.java
@@ -31,6 +31,7 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
   private static final String GLOBAL_LOG = "global_log";
   private static final String COMMIT_LOG = "commit_log";
   private static final String KEY_LIST = "key_list";
+  private static final String REF_LOG = "ref_log";
 
   private MongoClientConfig config;
   private MongoClient managedClient;
@@ -38,6 +39,7 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
   private MongoCollection<Document> globalLog;
   private MongoCollection<Document> commitLog;
   private MongoCollection<Document> keyLists;
+  private MongoCollection<Document> refLog;
 
   @Override
   public void configure(MongoClientConfig config) {
@@ -77,6 +79,7 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
     globalLog = database.getCollection(GLOBAL_LOG);
     commitLog = database.getCollection(COMMIT_LOG);
     keyLists = database.getCollection(KEY_LIST);
+    refLog = database.getCollection(REF_LOG);
   }
 
   public MongoCollection<Document> getGlobalPointers() {
@@ -93,5 +96,9 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
 
   public MongoCollection<Document> getKeyLists() {
     return keyLists;
+  }
+
+  public MongoCollection<Document> getRefLog() {
+    return refLog;
   }
 }

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -53,6 +53,8 @@ import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.RefLog;
+import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
@@ -74,6 +76,7 @@ import org.projectnessie.versioned.persist.adapter.spi.TryLoopState;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.ContentIdWithBytes;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer.Type;
 import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
@@ -208,8 +211,20 @@ public abstract class NonTransactionalDatabaseAdapter<
                 writeGlobalCommit(
                     ctx, timeInMicros, Hash.of(pointer.getGlobalId()), Collections.emptyList());
 
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    ctx,
+                    toBranch.getName(),
+                    RefLogEntry.RefType.Branch,
+                    Hash.of(pointer.getRefLogId()),
+                    toHead,
+                    RefLogEntry.Operation.MERGE,
+                    timeInMicros,
+                    Collections.singletonList(from));
+
             // Return hash of last commit (toHead) added to 'targetBranch' (via the casOpLoop)
-            return updateNamedRef(toBranch, pointer, toHead, newGlobalHead);
+            return updateGlobalStatePointer(
+                toBranch, pointer, toHead, newGlobalHead, newRefLogId.asBytes());
           },
           () -> mergeConflictMessage("Retry-failure", from, toBranch, expectedHead));
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
@@ -252,8 +267,20 @@ public abstract class NonTransactionalDatabaseAdapter<
                 writeGlobalCommit(
                     ctx, timeInMicros, Hash.of(pointer.getGlobalId()), Collections.emptyList());
 
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    ctx,
+                    targetBranch.getName(),
+                    RefLogEntry.RefType.Branch,
+                    Hash.of(pointer.getRefLogId()),
+                    targetHead,
+                    RefLogEntry.Operation.TRANSPLANT,
+                    timeInMicros,
+                    sequenceToTransplant);
+
             // Return hash of last commit (targetHead) added to 'targetBranch' (via the casOpLoop)
-            return updateNamedRef(targetBranch, pointer, targetHead, newGlobalHead);
+            return updateGlobalStatePointer(
+                targetBranch, pointer, targetHead, newGlobalHead, newRefLogId.asBytes());
           },
           () ->
               transplantConflictMessage(
@@ -290,11 +317,23 @@ public abstract class NonTransactionalDatabaseAdapter<
                         .map(e -> ContentIdAndBytes.of(e.getKey(), (byte) 0, e.getValue()))
                         .collect(Collectors.toList()));
 
-            return updateNamedRef(
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    ctx,
+                    commitAttempt.getCommitToBranch().getName(),
+                    RefLogEntry.RefType.Branch,
+                    Hash.of(pointer.getRefLogId()),
+                    newBranchCommit.getHash(),
+                    RefLogEntry.Operation.COMMIT,
+                    timeInMicros,
+                    Collections.emptyList());
+
+            return updateGlobalStatePointer(
                 commitAttempt.getCommitToBranch(),
                 pointer,
                 newBranchCommit.getHash(),
-                newGlobalHead);
+                newGlobalHead,
+                newRefLogId.asBytes());
           },
           () ->
               commitConflictMessage(
@@ -332,7 +371,21 @@ public abstract class NonTransactionalDatabaseAdapter<
             // Need a new empty global-log entry to be able to CAS
             Hash newGlobalHead = noopGlobalLogEntry(ctx, pointer);
 
-            return updateNamedRef(ref, pointer, hash, newGlobalHead);
+            RefLogEntry.RefType refType =
+                ref instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    ctx,
+                    ref.getName(),
+                    refType,
+                    Hash.of(pointer.getRefLogId()),
+                    hash,
+                    RefLogEntry.Operation.CREATE_REFERENCE,
+                    commitTimeInMicros(),
+                    Collections.emptyList());
+
+            return updateGlobalStatePointer(
+                ref, pointer, hash, newGlobalHead, newRefLogId.asBytes());
           },
           () -> createConflictMessage("Retry-Failure", ref, target));
     } catch (ReferenceAlreadyExistsException | ReferenceNotFoundException | RuntimeException e) {
@@ -350,13 +403,28 @@ public abstract class NonTransactionalDatabaseAdapter<
           reference,
           CasOpVariant.DELETE_REF,
           (ctx, pointer, branchCommits, newKeyLists) -> {
-            verifyExpectedHash(branchHead(pointer, reference), reference, expectedHead);
+            Hash branchHead = branchHead(pointer, reference);
+            verifyExpectedHash(branchHead, reference, expectedHead);
             Hash newGlobalHead = noopGlobalLogEntry(ctx, pointer);
+
+            RefLogEntry.RefType refType =
+                reference instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    ctx,
+                    reference.getName(),
+                    refType,
+                    Hash.of(pointer.getRefLogId()),
+                    branchHead,
+                    RefLogEntry.Operation.DELETE_REFERENCE,
+                    commitTimeInMicros(),
+                    Collections.emptyList());
 
             GlobalStatePointer.Builder newPointer =
                 GlobalStatePointer.newBuilder().setGlobalId(newGlobalHead.asBytes());
             newPointer.putAllNamedReferences(pointer.getNamedReferencesMap());
             newPointer.removeNamedReferences(reference.getName());
+            newPointer.setRefLogId(newRefLogId.asBytes());
             return newPointer.build();
           },
           () -> deleteConflictMessage("Retry-Failure", reference, expectedHead));
@@ -381,7 +449,21 @@ public abstract class NonTransactionalDatabaseAdapter<
 
             Hash newGlobalHead = noopGlobalLogEntry(ctx, pointer);
 
-            return updateNamedRef(assignee, pointer, assignTo, newGlobalHead);
+            RefLogEntry.RefType refType =
+                assignee instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    ctx,
+                    assignee.getName(),
+                    refType,
+                    Hash.of(pointer.getRefLogId()),
+                    assignTo,
+                    RefLogEntry.Operation.ASSIGN_REFERENCE,
+                    commitTimeInMicros(),
+                    Collections.emptyList());
+
+            return updateGlobalStatePointer(
+                assignee, pointer, assignTo, newGlobalHead, newRefLogId.asBytes());
           },
           () -> assignConflictMessage("Retry-Failure", assignee, expectedHead, assignTo));
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
@@ -402,9 +484,21 @@ public abstract class NonTransactionalDatabaseAdapter<
     NonTransactionalOperationContext ctx = NON_TRANSACTIONAL_OPERATION_CONTEXT;
     if (fetchGlobalPointer(ctx) == null) {
       Hash globalHead;
+      Hash newRefLogId;
       try {
         long timeInMicros = commitTimeInMicros();
         globalHead = writeGlobalCommit(ctx, timeInMicros, NO_ANCESTOR, Collections.emptyList());
+
+        newRefLogId =
+            writeRefLogEntry(
+                ctx,
+                defaultBranchName,
+                RefLogEntry.RefType.Branch,
+                NO_ANCESTOR,
+                NO_ANCESTOR,
+                RefLogEntry.Operation.CREATE_REFERENCE,
+                commitTimeInMicros(),
+                Collections.emptyList());
       } catch (ReferenceConflictException e) {
         throw new RuntimeException(e);
       }
@@ -419,6 +513,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                       .setType(RefPointer.Type.Branch)
                       .setHash(NO_ANCESTOR.asBytes())
                       .build())
+              .setRefLogId(newRefLogId.asBytes())
               .build());
     }
   }
@@ -486,8 +581,12 @@ public abstract class NonTransactionalDatabaseAdapter<
   // Non-Transactional DatabaseAdapter subclass API (protected)
   // /////////////////////////////////////////////////////////////////////////////////////////////
 
-  protected GlobalStatePointer updateNamedRef(
-      NamedRef target, GlobalStatePointer pointer, Hash toHead, Hash newGlobalHead) {
+  protected GlobalStatePointer updateGlobalStatePointer(
+      NamedRef target,
+      GlobalStatePointer pointer,
+      Hash toHead,
+      Hash newGlobalHead,
+      ByteString newRefLogId) {
     GlobalStatePointer.Builder newPointer =
         GlobalStatePointer.newBuilder().setGlobalId(newGlobalHead.asBytes());
 
@@ -496,6 +595,8 @@ public abstract class NonTransactionalDatabaseAdapter<
     newPointer.putNamedReferences(
         target.getName(),
         RefPointer.newBuilder().setType(protoTypeForRef(target)).setHash(toHead.asBytes()).build());
+
+    newPointer.setRefLogId(newRefLogId);
 
     return newPointer.build();
   }
@@ -659,7 +760,11 @@ public abstract class NonTransactionalDatabaseAdapter<
             individualCommits.add(branchHead);
           }
           cleanUpCommitCas(
-              ctx, Hash.of(newPointer.getGlobalId()), individualCommits, individualKeyLists);
+              ctx,
+              Hash.of(newPointer.getGlobalId()),
+              individualCommits,
+              individualKeyLists,
+              Hash.of(newPointer.getRefLogId()));
         }
 
         tryState.retry();
@@ -674,6 +779,14 @@ public abstract class NonTransactionalDatabaseAdapter<
    */
   protected abstract void writeGlobalCommit(
       NonTransactionalOperationContext ctx, GlobalStateLogEntry entry)
+      throws ReferenceConflictException;
+
+  /**
+   * Write a new refLog-entry with a best-effort approach to prevent hash-collisions but without any
+   * other consistency checks/guarantees. Some implementations however can enforce strict
+   * consistency checks/guarantees.
+   */
+  protected abstract void writeRefLog(NonTransactionalOperationContext ctx, RefLogEntry entry)
       throws ReferenceConflictException;
 
   /**
@@ -732,7 +845,8 @@ public abstract class NonTransactionalDatabaseAdapter<
       NonTransactionalOperationContext ctx,
       Hash globalId,
       Set<Hash> branchCommits,
-      Set<Hash> newKeyLists);
+      Set<Hash> newKeyLists,
+      Hash refLogId);
 
   /**
    * Writes a global-state-log-entry without any operations, just to move the global-pointer
@@ -853,4 +967,71 @@ public abstract class NonTransactionalDatabaseAdapter<
 
   protected abstract List<GlobalStateLogEntry> fetchPageFromGlobalLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes);
+
+  protected Hash writeRefLogEntry(
+      NonTransactionalOperationContext ctx,
+      String refName,
+      RefLogEntry.RefType refType,
+      Hash parentRefLogId,
+      Hash commitHash,
+      RefLogEntry.Operation operation,
+      long timeInMicros,
+      List<Hash> sourceHashes)
+      throws ReferenceConflictException {
+
+    Hash currentRefLogId = randomHash();
+    RefLog parentEntry = fetchFromRefLog(ctx, parentRefLogId);
+    RefLogEntry refLogEntry =
+        buildRefLogEntry(
+            refName,
+            refType,
+            parentRefLogId,
+            commitHash,
+            operation,
+            timeInMicros,
+            sourceHashes,
+            currentRefLogId,
+            parentEntry);
+
+    writeRefLog(ctx, refLogEntry);
+
+    return currentRefLogId;
+  }
+
+  private RefLogEntry buildRefLogEntry(
+      String refName,
+      RefLogEntry.RefType refType,
+      Hash parentRefLogId,
+      Hash commitHash,
+      RefLogEntry.Operation operation,
+      long timeInMicros,
+      List<Hash> sourceHashes,
+      Hash currentRefLogId,
+      RefLog parentEntry) {
+    Stream<Hash> newParents = Stream.of(parentRefLogId);
+
+    if (parentEntry != null) {
+      newParents =
+          Stream.concat(
+              newParents,
+              parentEntry.getParents().stream().limit(config.getParentsPerRefLogEntry() - 1));
+    }
+
+    RefLogEntry.Builder entry =
+        RefLogEntry.newBuilder()
+            .setRefLogId(currentRefLogId.asBytes())
+            .setRefName(ByteString.copyFromUtf8(refName))
+            .setRefType(refType)
+            .setCommitHash(commitHash.asBytes())
+            .setOperationTime(timeInMicros)
+            .setOperation(operation);
+    sourceHashes.forEach(hash -> entry.addSourceHashes(hash.asBytes()));
+    newParents.forEach(p -> entry.addParents(p.asBytes()));
+    return entry.build();
+  }
+
+  @Override
+  public Stream<RefLog> refLog(Hash offset) throws RefLogNotFoundException {
+    return readRefLogStream(NON_TRANSACTIONAL_OPERATION_CONTEXT, offset);
+  }
 }

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDbInstance.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDbInstance.java
@@ -50,14 +50,16 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
   public static final String CF_GLOBAL_LOG = "global_log";
   public static final String CF_COMMIT_LOG = "commit_log";
   public static final String CF_KEY_LIST = "key_list";
+  public static final String CF_REF_LOG = "ref_log";
 
   public static final List<String> CF_ALL =
-      Arrays.asList(CF_GLOBAL_POINTER, CF_GLOBAL_LOG, CF_COMMIT_LOG, CF_KEY_LIST);
+      Arrays.asList(CF_GLOBAL_POINTER, CF_GLOBAL_LOG, CF_COMMIT_LOG, CF_KEY_LIST, CF_REF_LOG);
 
   private ColumnFamilyHandle cfGlobalPointer;
   private ColumnFamilyHandle cfGlobalLog;
   private ColumnFamilyHandle cfCommitLog;
   private ColumnFamilyHandle cfKeyList;
+  private ColumnFamilyHandle cfRefLog;
 
   private final ReadWriteLock lock = new StampedLock().asReadWriteLock();
 
@@ -122,6 +124,7 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
         cfGlobalLog = columnFamilyHandleMap.get(CF_GLOBAL_LOG);
         cfCommitLog = columnFamilyHandleMap.get(CF_COMMIT_LOG);
         cfKeyList = columnFamilyHandleMap.get(CF_KEY_LIST);
+        cfRefLog = columnFamilyHandleMap.get(CF_REF_LOG);
       } catch (RocksDBException e) {
         throw new RuntimeException("RocksDB failed to start", e);
       }
@@ -150,5 +153,9 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
 
   public TransactionDB getDb() {
     return db;
+  }
+
+  public ColumnFamilyHandle getCfRefLog() {
+    return cfRefLog;
   }
 }

--- a/versioned/persist/serialize/src/main/proto/persist.proto
+++ b/versioned/persist/serialize/src/main/proto/persist.proto
@@ -77,10 +77,34 @@ message GlobalStateLogEntry {
   repeated ContentIdWithBytes puts = 4;
 }
 
+message RefLogEntry {
+  bytes ref_log_id = 1;
+  bytes ref_name = 2;
+  enum RefType {
+    Branch = 0;
+    Tag = 1;
+  }
+  RefType ref_type = 3;
+  bytes commit_hash = 4;
+  repeated bytes parents = 5;
+  int64 operation_time = 6;
+  enum Operation {
+    CREATE_REFERENCE = 0;
+    COMMIT = 1;
+    DELETE_REFERENCE = 2;
+    ASSIGN_REFERENCE = 3;
+    MERGE = 4;
+    TRANSPLANT = 5;
+  }
+  Operation operation = 7;
+  repeated bytes source_hashes = 8;
+}
+
 // Used by non-transactional database-adapters
 message GlobalStatePointer {
   bytes global_id = 1;
   map<string, RefPointer> named_references = 2;
+  bytes ref_log_id = 3;
 }
 
 // Used by non-transactional database-adapters

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -40,6 +40,8 @@ import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.Operation;
 import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.Ref;
+import org.projectnessie.versioned.RefLog;
+import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
@@ -344,5 +346,10 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
       return (Hash) ref;
     }
     throw new IllegalArgumentException(String.format("Unsupported reference '%s'", ref));
+  }
+
+  @Override
+  public Stream<RefLog> getRefLog(Hash refLogId) throws RefLogNotFoundException {
+    return databaseAdapter.refLog(refLogId);
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
@@ -125,5 +125,45 @@ public final class SqlStatements {
               + ")",
           TABLE_KEY_LIST);
 
+  public static final String TABLE_REF_LOG = "ref_log";
+  public static final String TABLE_REF_LOG_HEAD = "ref_log_head";
+  public static final String INSERT_REF_LOG =
+      String.format("INSERT INTO %s (repo_id, hash, value) VALUES (?, ?, ?)", TABLE_REF_LOG);
+  public static final String DELETE_REF_LOG_ALL =
+      String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_REF_LOG);
+  public static final String SELECT_REF_LOG =
+      String.format("SELECT value FROM %s WHERE repo_id = ? AND hash = ?", TABLE_REF_LOG);
+  public static final String SELECT_REF_LOG_MANY =
+      String.format("SELECT value FROM %s WHERE repo_id = ? AND hash IN (%%s)", TABLE_REF_LOG);
+  public static final String CREATE_TABLE_REF_LOG =
+      // here 'hash' is ref_log_id, 'value' is proto serialized RefLogEntry
+      String.format(
+          "CREATE TABLE %s (\n"
+              + "  repo_id {2},\n"
+              + "  hash {1},\n"
+              + "  value {0},\n"
+              + "  PRIMARY KEY (repo_id, hash)\n"
+              + ")",
+          TABLE_REF_LOG);
+
+  public static final String UPDATE_REF_LOG_HEAD =
+      String.format("UPDATE %s SET id = ? WHERE repo_id = ? AND id = ?", TABLE_REF_LOG_HEAD);
+  public static final String INSERT_REF_LOG_HEAD =
+      String.format(
+          "INSERT INTO %s (repo_id, id, random_key) VALUES (?, ?, ?)", TABLE_REF_LOG_HEAD);
+  public static final String DELETE_REF_LOG_HEAD_ALL =
+      String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_REF_LOG_HEAD);
+  public static final String SELECT_REF_LOG_HEAD =
+      String.format("SELECT id FROM %s WHERE repo_id = ?", TABLE_REF_LOG_HEAD);
+  public static final String CREATE_TABLE_REF_LOG_HEAD =
+      String.format(
+          "CREATE TABLE %s (\n"
+              + "  repo_id {2},\n"
+              + "  id {1},\n"
+              + "  random_key {1},\n"
+              + "  PRIMARY KEY (repo_id, random_key)\n"
+              + ")",
+          TABLE_REF_LOG_HEAD);
+
   private SqlStatements() {}
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -59,6 +59,7 @@ import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.RefLog;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
@@ -589,6 +590,12 @@ public abstract class TxDatabaseAdapter
   @Override
   protected int entitySize(KeyWithType entry) {
     return toProto(entry).getSerializedSize();
+  }
+
+  @Override
+  public Stream<RefLog> refLog(Hash offset) {
+    // TODO:
+    return null;
   }
 
   protected Connection borrowConnection() {
@@ -1224,6 +1231,18 @@ public abstract class TxDatabaseAdapter
       }
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  protected RefLog fetchFromRefLog(Connection ctx, Hash refLogId) {
+    // TODO:
+    return null;
+  }
+
+  @Override
+  protected List<RefLog> fetchPageFromRefLog(Connection ctx, List<Hash> hashes) {
+    // TODO:
+    return null;
   }
 
   /**

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -21,6 +21,7 @@ import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUti
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.deleteConflictMessage;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.mergeConflictMessage;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.newHasher;
+import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.randomHash;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.referenceAlreadyExists;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.referenceNotFound;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.transplantConflictMessage;
@@ -28,6 +29,7 @@ import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUti
 import static org.projectnessie.versioned.persist.adapter.spi.TryLoopState.newTryLoopState;
 import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToCommitLogEntry;
 import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToKeyList;
+import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToRefLog;
 import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.toProto;
 
 import com.google.common.base.Preconditions;
@@ -60,6 +62,7 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.RefLog;
+import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
@@ -79,6 +82,7 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.spi.TryLoopState;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes;
 
 /**
  * Transactional/relational {@link AbstractDatabaseAdapter} implementation using JDBC primitives.
@@ -244,7 +248,20 @@ public abstract class TxDatabaseAdapter
                     h -> {},
                     h -> {},
                     updateCommitMetadata);
-            return tryMoveNamedReference(conn, toBranch, currentHead, toHead);
+            Hash resultHash = tryMoveNamedReference(conn, toBranch, currentHead, toHead);
+            Hash parentId = getRefLogHead(conn);
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    conn,
+                    toBranch.getName(),
+                    AdapterTypes.RefLogEntry.RefType.Branch,
+                    parentId,
+                    toHead,
+                    AdapterTypes.RefLogEntry.Operation.MERGE,
+                    timeInMicros,
+                    Collections.singletonList(from));
+            updateRefLogHead(newRefLogId, parentId, conn);
+            return resultHash;
           },
           () -> mergeConflictMessage("Conflict", from, toBranch, expectedHead),
           () -> mergeConflictMessage("Retry-failure", from, toBranch, expectedHead));
@@ -282,6 +299,20 @@ public abstract class TxDatabaseAdapter
                     h -> {},
                     updateCommitMetadata);
 
+            Hash parentId = getRefLogHead(conn);
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    conn,
+                    targetBranch.getName(),
+                    AdapterTypes.RefLogEntry.RefType.Branch,
+                    parentId,
+                    targetHead,
+                    AdapterTypes.RefLogEntry.Operation.TRANSPLANT,
+                    timeInMicros,
+                    commits);
+
+            updateRefLogHead(newRefLogId, parentId, conn);
+
             return tryMoveNamedReference(conn, targetBranch, currentHead, targetHead);
           },
           () -> transplantConflictMessage("Conflict", targetBranch, expectedHead, commits),
@@ -309,8 +340,25 @@ public abstract class TxDatabaseAdapter
 
             upsertGlobalStates(commitAttempt, conn, newBranchCommit.getCreatedTime());
 
-            return tryMoveNamedReference(
-                conn, commitAttempt.getCommitToBranch(), branchHead, newBranchCommit.getHash());
+            Hash resultHash =
+                tryMoveNamedReference(
+                    conn, commitAttempt.getCommitToBranch(), branchHead, newBranchCommit.getHash());
+
+            Hash parentId = getRefLogHead(conn);
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    conn,
+                    commitAttempt.getCommitToBranch().getName(),
+                    AdapterTypes.RefLogEntry.RefType.Branch,
+                    parentId,
+                    newBranchCommit.getHash(),
+                    AdapterTypes.RefLogEntry.Operation.COMMIT,
+                    timeInMicros,
+                    Collections.emptyList());
+
+            updateRefLogHead(newRefLogId, parentId, conn);
+
+            return resultHash;
           },
           () ->
               commitConflictMessage(
@@ -351,6 +399,24 @@ public abstract class TxDatabaseAdapter
 
             insertNewReference(conn, ref, hash);
 
+            AdapterTypes.RefLogEntry.RefType refType =
+                ref instanceof TagName
+                    ? AdapterTypes.RefLogEntry.RefType.Tag
+                    : AdapterTypes.RefLogEntry.RefType.Branch;
+            Hash parentId = getRefLogHead(conn);
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    conn,
+                    ref.getName(),
+                    refType,
+                    parentId,
+                    hash,
+                    AdapterTypes.RefLogEntry.Operation.CREATE_REFERENCE,
+                    commitTimeInMicros(),
+                    Collections.emptyList());
+
+            updateRefLogHead(newRefLogId, parentId, conn);
+
             return hash;
           },
           () -> createConflictMessage("Conflict", ref, target),
@@ -371,6 +437,24 @@ public abstract class TxDatabaseAdapter
           false,
           (conn, pointer) -> {
             verifyExpectedHash(pointer, reference, expectedHead);
+
+            AdapterTypes.RefLogEntry.RefType refType =
+                reference instanceof TagName
+                    ? AdapterTypes.RefLogEntry.RefType.Tag
+                    : AdapterTypes.RefLogEntry.RefType.Branch;
+            Hash parentId = getRefLogHead(conn);
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    conn,
+                    reference.getName(),
+                    refType,
+                    parentId,
+                    fetchNamedRefHead(conn, reference),
+                    AdapterTypes.RefLogEntry.Operation.DELETE_REFERENCE,
+                    commitTimeInMicros(),
+                    Collections.emptyList());
+
+            updateRefLogHead(newRefLogId, parentId, conn);
 
             try (PreparedStatement ps =
                 conn.prepareStatement(SqlStatements.DELETE_NAMED_REFERENCE)) {
@@ -408,6 +492,24 @@ public abstract class TxDatabaseAdapter
               throw referenceNotFound(assignTo);
             }
 
+            AdapterTypes.RefLogEntry.RefType refType =
+                assignee instanceof TagName
+                    ? AdapterTypes.RefLogEntry.RefType.Tag
+                    : AdapterTypes.RefLogEntry.RefType.Branch;
+            Hash parentId = getRefLogHead(conn);
+            Hash newRefLogId =
+                writeRefLogEntry(
+                    conn,
+                    assignee.getName(),
+                    refType,
+                    parentId,
+                    assignTo,
+                    AdapterTypes.RefLogEntry.Operation.ASSIGN_REFERENCE,
+                    commitTimeInMicros(),
+                    Collections.emptyList());
+
+            updateRefLogHead(newRefLogId, parentId, conn);
+
             return tryMoveNamedReference(conn, assignee, pointer, assignTo);
           },
           () -> assignConflictMessage("Conflict", assignee, expectedHead, assignTo),
@@ -437,6 +539,19 @@ public abstract class TxDatabaseAdapter
       if (!checkNamedRefExistence(conn, BranchName.of(defaultBranchName))) {
         insertNewReference(conn, BranchName.of(defaultBranchName), NO_ANCESTOR);
 
+        Hash newRefLogId =
+            writeRefLogEntry(
+                conn,
+                defaultBranchName,
+                AdapterTypes.RefLogEntry.RefType.Branch,
+                NO_ANCESTOR,
+                NO_ANCESTOR,
+                AdapterTypes.RefLogEntry.Operation.CREATE_REFERENCE,
+                commitTimeInMicros(),
+                Collections.emptyList());
+
+        insertRefLogHead(newRefLogId, conn);
+
         txCommit(conn);
       }
     } catch (Exception e) {
@@ -463,6 +578,14 @@ public abstract class TxDatabaseAdapter
         ps.executeUpdate();
       }
       try (PreparedStatement ps = conn.prepareStatement(SqlStatements.DELETE_KEY_LIST_ALL)) {
+        ps.setString(1, config.getRepositoryId());
+        ps.executeUpdate();
+      }
+      try (PreparedStatement ps = conn.prepareStatement(SqlStatements.DELETE_REF_LOG_ALL)) {
+        ps.setString(1, config.getRepositoryId());
+        ps.executeUpdate();
+      }
+      try (PreparedStatement ps = conn.prepareStatement(SqlStatements.DELETE_REF_LOG_HEAD_ALL)) {
         ps.setString(1, config.getRepositoryId());
         ps.executeUpdate();
       }
@@ -593,9 +716,18 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  public Stream<RefLog> refLog(Hash offset) {
-    // TODO:
-    return null;
+  public Stream<RefLog> refLog(Hash offset) throws RefLogNotFoundException {
+    Connection conn = borrowConnection();
+    boolean failed = true;
+    try {
+      Stream<RefLog> intLog = readRefLogStream(conn, offset);
+      failed = false;
+      return intLog.onClose(() -> releaseConnection(conn));
+    } finally {
+      if (failed) {
+        releaseConnection(conn);
+      }
+    }
   }
 
   protected Connection borrowConnection() {
@@ -1233,18 +1365,6 @@ public abstract class TxDatabaseAdapter
     }
   }
 
-  @Override
-  protected RefLog fetchFromRefLog(Connection ctx, Hash refLogId) {
-    // TODO:
-    return null;
-  }
-
-  @Override
-  protected List<RefLog> fetchPageFromRefLog(Connection ctx, List<Hash> hashes) {
-    // TODO:
-    return null;
-  }
-
   /**
    * Provides a map of table name to create-table-DDL. The DDL statements are processed by {@link
    * java.text.MessageFormat} to inject the parameters returned by {@link
@@ -1275,6 +1395,12 @@ public abstract class TxDatabaseAdapter
         .put(
             SqlStatements.TABLE_KEY_LIST,
             Collections.singletonList(SqlStatements.CREATE_TABLE_KEY_LIST))
+        .put(
+            SqlStatements.TABLE_REF_LOG,
+            Collections.singletonList(SqlStatements.CREATE_TABLE_REF_LOG))
+        .put(
+            SqlStatements.TABLE_REF_LOG_HEAD,
+            Collections.singletonList(SqlStatements.CREATE_TABLE_REF_LOG_HEAD))
         .build();
   }
 
@@ -1322,5 +1448,169 @@ public abstract class TxDatabaseAdapter
   /** Whether this implementation shall use bates for DDL operations to create tables. */
   protected boolean batchDDL() {
     return false;
+  }
+
+  protected Hash writeRefLogEntry(
+      Connection connection,
+      String refName,
+      AdapterTypes.RefLogEntry.RefType refType,
+      Hash parentRefLogId,
+      Hash commitHash,
+      AdapterTypes.RefLogEntry.Operation operation,
+      long timeInMicros,
+      List<Hash> sourceHashes)
+      throws ReferenceConflictException {
+
+    Hash currentRefLogId = randomHash();
+    RefLog parentEntry = fetchFromRefLog(connection, parentRefLogId);
+    AdapterTypes.RefLogEntry refLogEntry =
+        buildRefLogEntry(
+            refName,
+            refType,
+            parentRefLogId,
+            commitHash,
+            operation,
+            timeInMicros,
+            sourceHashes,
+            currentRefLogId,
+            parentEntry);
+
+    writeRefLog(connection, refLogEntry);
+
+    return currentRefLogId;
+  }
+
+  protected void writeRefLog(Connection connection, AdapterTypes.RefLogEntry entry)
+      throws ReferenceConflictException {
+    try (PreparedStatement ps = connection.prepareStatement(SqlStatements.INSERT_REF_LOG)) {
+      ps.setString(1, config.getRepositoryId());
+      ps.setString(2, Hash.of(entry.getRefLogId()).asString());
+      ps.setBytes(3, entry.toByteArray());
+      ps.executeUpdate();
+    } catch (SQLException e) {
+      if (isRetryTransaction(e)) {
+        throw new RetryTransactionException();
+      }
+      throwIfReferenceConflictException(
+          e, () -> String.format("Hash collision for '%s' in ref-log", entry.getRefLogId()));
+      throw new RuntimeException(e);
+    }
+  }
+
+  private AdapterTypes.RefLogEntry buildRefLogEntry(
+      String refName,
+      AdapterTypes.RefLogEntry.RefType refType,
+      Hash parentRefLogId,
+      Hash commitHash,
+      AdapterTypes.RefLogEntry.Operation operation,
+      long timeInMicros,
+      List<Hash> sourceHashes,
+      Hash currentRefLogId,
+      RefLog parentEntry) {
+    Stream<Hash> newParents = Stream.of(parentRefLogId);
+
+    if (parentEntry != null) {
+      newParents =
+          Stream.concat(
+              newParents,
+              parentEntry.getParents().stream().limit(config.getParentsPerRefLogEntry() - 1));
+    }
+
+    AdapterTypes.RefLogEntry.Builder entry =
+        AdapterTypes.RefLogEntry.newBuilder()
+            .setRefLogId(currentRefLogId.asBytes())
+            .setRefName(ByteString.copyFromUtf8(refName))
+            .setRefType(refType)
+            .setCommitHash(commitHash.asBytes())
+            .setOperationTime(timeInMicros)
+            .setOperation(operation);
+    sourceHashes.forEach(hash -> entry.addSourceHashes(hash.asBytes()));
+    newParents.forEach(p -> entry.addParents(p.asBytes()));
+    return entry.build();
+  }
+
+  protected void updateRefLogHead(Hash newRefLogId, Hash parentRefLogId, Connection conn)
+      throws SQLException {
+    PreparedStatement psUpdate = conn.prepareStatement(SqlStatements.UPDATE_REF_LOG_HEAD);
+    psUpdate.setString(1, newRefLogId.asString());
+    psUpdate.setString(2, config.getRepositoryId());
+    psUpdate.setString(3, parentRefLogId.asString());
+    if (psUpdate.executeUpdate() != 1) {
+      // No need to continue, just throw a legit constraint-violation that will be
+      // converted to a "proper ReferenceConflictException" later up in the stack.
+      throw newIntegrityConstraintViolationException();
+    }
+  }
+
+  protected void insertRefLogHead(Hash newRefLogId, Connection conn) throws SQLException {
+    PreparedStatement selectStatement = conn.prepareStatement(SqlStatements.SELECT_REF_LOG_HEAD);
+    selectStatement.setString(1, config.getRepositoryId());
+    // insert if the table is empty
+    if (!selectStatement.executeQuery().next()) {
+      PreparedStatement psUpdate = conn.prepareStatement(SqlStatements.INSERT_REF_LOG_HEAD);
+      psUpdate.setString(1, config.getRepositoryId());
+      psUpdate.setString(2, newRefLogId.asString());
+      psUpdate.setString(3, randomHash().asString());
+      if (psUpdate.executeUpdate() != 1) {
+        // No need to continue, just throw a legit constraint-violation that will be
+        // converted to a "proper ReferenceConflictException" later up in the stack.
+        throw newIntegrityConstraintViolationException();
+      }
+    }
+  }
+
+  protected Hash getRefLogHead(Connection conn) throws SQLException {
+    PreparedStatement psSelect = conn.prepareStatement(SqlStatements.SELECT_REF_LOG_HEAD);
+    psSelect.setString(1, config.getRepositoryId());
+    ResultSet resultSet = psSelect.executeQuery();
+    if (resultSet.next()) {
+      return Hash.of(resultSet.getString(1));
+    }
+    return null;
+  }
+
+  @Override
+  protected RefLog fetchFromRefLog(Connection connection, Hash refLogId) {
+    if (refLogId == null) {
+      // set the current head as refLogId
+      try {
+        refLogId = getRefLogHead(connection);
+      } catch (SQLException e) {
+        e.printStackTrace();
+        // TODO:
+      }
+    }
+    try (PreparedStatement ps = connection.prepareStatement(SqlStatements.SELECT_REF_LOG)) {
+      ps.setString(1, config.getRepositoryId());
+      ps.setString(2, refLogId.asString());
+      try (ResultSet rs = ps.executeQuery()) {
+        return rs.next() ? protoToRefLog(rs.getBytes(1)) : null;
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected List<RefLog> fetchPageFromRefLog(Connection connection, List<Hash> hashes) {
+    String sql = sqlForManyPlaceholders(SqlStatements.SELECT_REF_LOG_MANY, hashes.size());
+
+    try (PreparedStatement ps = connection.prepareStatement(sql)) {
+      ps.setString(1, config.getRepositoryId());
+      for (int i = 0; i < hashes.size(); i++) {
+        ps.setString(2 + i, hashes.get(i).asString());
+      }
+
+      Map<Hash, RefLog> result = new HashMap<>(hashes.size() * 2);
+      try (ResultSet rs = ps.executeQuery()) {
+        while (rs.next()) {
+          RefLog entry = protoToRefLog(rs.getBytes(1));
+          result.put(Objects.requireNonNull(entry).getRefLogId(), entry);
+        }
+      }
+      return hashes.stream().map(result::get).collect(Collectors.toList());
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/RefLog.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/RefLog.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import java.util.List;
+import org.immutables.value.Value;
+
+/** Represents a reflog-entry stored in the database. */
+@Value.Immutable
+public interface RefLog {
+
+  /** Reflog id of the current entry. */
+  Hash getRefLogId();
+
+  /** Reference on which current operation is executed. */
+  String getRefName();
+
+  /** Reference type can be 'Branch' or 'Tag'. */
+  String getRefType();
+
+  /** Output commit hash of the operation. */
+  Hash getCommitHash();
+
+  /** Parent reflog id of the current entry. */
+  List<Hash> getParents();
+
+  /** Time in microseconds since epoch. */
+  long getOperationTime();
+
+  /** Operation String mapped to ENUM in {@code RefLogEntry.Operation} of 'persist.proto' file. */
+  String getOperation();
+
+  /**
+   * Single hash in case of MERGE. One or more hashes in case of TRANSPLANT. Empty list for other
+   * operations.
+   */
+  List<Hash> getSourceHashes();
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/RefLogNotFoundException.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/RefLogNotFoundException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nonnull;
+
+/** Exception thrown when a reflog is not present in the store. */
+public class RefLogNotFoundException extends VersionStoreException {
+  private static final long serialVersionUID = -4782304450647510330L;
+
+  public RefLogNotFoundException(String message) {
+    super(message);
+  }
+
+  public RefLogNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Create a {@code RefLogNotFoundException} instance based on the provided reference.
+   *
+   * @param refLogId the refLogId string not found in the store
+   * @return a {@code RefLogNotFoundException} instance
+   * @throws NullPointerException if {@code refLogId} is {@code null}.
+   */
+  @Nonnull
+  public static RefLogNotFoundException forRefLogId(@Nonnull String refLogId) {
+    requireNonNull(refLogId);
+    return new RefLogNotFoundException(format("RefLog entry for '%s' does not exist", refLogId));
+  }
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -229,6 +229,11 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
         () -> delegate.getDiffs(from, to));
   }
 
+  @Override
+  public Stream<RefLog> getRefLog(Hash refLogId) throws RefLogNotFoundException {
+    return delegate.getRefLog(refLogId);
+  }
+
   private Span createSpan(String name, Consumer<SpanBuilder> spanBuilder) {
     Tracer tracer = GlobalTracer.get();
     String spanName = makeSpanName(name);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -281,4 +281,12 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * @return A stream of values that are different.
    */
   Stream<Diff<VALUE>> getDiffs(Ref from, Ref to) throws ReferenceNotFoundException;
+
+  /**
+   * Get a stream of all reflog entries from the initial refLogId.
+   *
+   * @param refLogId initial reflog id to be used
+   * @return A stream of reflog entries.
+   */
+  Stream<RefLog> getRefLog(Hash refLogId) throws RefLogNotFoundException;
 }


### PR DESCRIPTION
This PR depends on #2950 

please only refer the new commit in this PR.

Changes:
Added two txn tables in the backend. One to store the reflog and one to keep the relog head (it will always have one row)
Enabled the txn reflog testcases.