### PR TITLE
Allow reference-deletion w/o expected-hash

### DIFF
--- a/model/src/main/java/org/projectnessie/api/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/TreeApi.java
@@ -166,7 +166,7 @@ public interface TreeApi {
           @NotNull
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String branchName,
-      @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+      @Valid @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String hash)
       throws NessieConflictException, NessieNotFoundException;
 

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -184,6 +184,32 @@ public abstract class AbstractTestRest {
   }
 
   @Test
+  public void deleteReferences() throws NessieNotFoundException, NessieConflictException {
+    String mainHash = api.getReference().refName("main").get().getHash();
+
+    String tagName1 = "createReferences_tag1";
+    String tagName2 = "createReferences_tag2";
+    String branchName1 = "createReferences_branch1";
+    String branchName2 = "createReferences_branch2";
+
+    api.createReference().sourceRefName("main").reference(Tag.of(tagName1, mainHash)).create();
+    api.createReference().sourceRefName("main").reference(Tag.of(tagName2, mainHash)).create();
+    api.createReference()
+        .sourceRefName("main")
+        .reference(Branch.of(branchName1, mainHash))
+        .create();
+    api.createReference()
+        .sourceRefName("main")
+        .reference(Branch.of(branchName2, mainHash))
+        .create();
+
+    api.deleteTag().tagName(tagName1).delete();
+    api.deleteTag().tagName(tagName2).hash(mainHash).delete();
+    api.deleteBranch().branchName(branchName1).delete();
+    api.deleteBranch().branchName(branchName2).hash(mainHash).delete();
+  }
+
+  @Test
   public void createReferences() throws NessieNotFoundException {
     String mainHash = api.getReference().refName("main").get().getHash();
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -610,7 +610,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
   protected void deleteReference(NamedRef ref, String hash)
       throws NessieConflictException, NessieNotFoundException {
     try {
-      getStore().delete(ref, toHash(hash, true));
+      getStore().delete(ref, toHash(hash, false));
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     } catch (ReferenceConflictException e) {


### PR DESCRIPTION
Update delete-branch + delete-tag endpoints to make the expected-hash parameter optional.