### PR TITLE
Revert "Bump dependency-check-maven from 6.5.1 to 6.5.2 (#2986)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -780,7 +780,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>6.5.2</version>
+          <version>6.5.1</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This reverts commit c76957f1944ca662d1af5e22b9af7f50d57dbf5c.