### PR TITLE
Disable errorprone for generated sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1196,7 +1196,7 @@ limitations under the License.
             <configuration>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne</arg>
+                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-*sources/.*</arg>
               </compilerArgs>
               <annotationProcessorPaths combine.children="append">
                 <path>

--- a/versioned/persist/bench/pom.xml
+++ b/versioned/persist/bench/pom.xml
@@ -122,13 +122,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <compilerArgs combine.children="append">
-            <arg>-XDcompilePolicy=simple</arg>
-            <arg>-Xplugin:ErrorProne</arg>
-          </compilerArgs>
           <annotationProcessorPaths combine.children="append">
             <path>
               <groupId>org.openjdk.jmh</groupId>


### PR DESCRIPTION
Skips running errorprone on generated source file.

Also fixes the maven-compiler-plugin configuration in `:nessie-versioned-persist-bench` to not include errorprone options.