### PR TITLE
Track Nessie database repo state/version

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -272,6 +272,21 @@ public interface DatabaseAdapter {
   Stream<Difference> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException;
 
+  /** Fetches the current version and descriptive attributes of the repository. */
+  RepoDescription fetchRepositoryDescription();
+
+  /**
+   * Updates the repository description. Takes a function that receives the current repository
+   * description and returns the updated description.
+   *
+   * @param updater updater function, the input argument is never {@code null}, if {@code updater}
+   *     return {@code null}, the update will be aborted
+   * @throws ReferenceConflictException thrown if the repository description could not be updated
+   *     due to other concurrent updates
+   */
+  void updateRepositoryDescription(Function<RepoDescription, RepoDescription> updater)
+      throws ReferenceConflictException;
+
   // NOTE: the following is NOT a "proposed" API, just an idea of how the supporting functions
   // for Nessie-GC need to look like.
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/RepoDescription.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/RepoDescription.java
@@ -13,19 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.dynamodb;
+package org.projectnessie.versioned.persist.adapter;
 
-final class Tables {
+import java.util.Map;
+import org.immutables.value.Value;
 
-  static final String TABLE_REPO_DESC = "repo_desc";
-  static final String TABLE_GLOBAL_POINTER = "global_pointer";
-  static final String TABLE_GLOBAL_LOG = "global_log";
-  static final String TABLE_COMMIT_LOG = "commit_log";
-  static final String TABLE_KEY_LISTS = "key_lists";
-  static final String TABLE_REF_LOG = "ref_log";
+/** Keeps track of the logical state of a Nessie repository. */
+@Value.Immutable
+public interface RepoDescription {
+  RepoDescription DEFAULT = builder().repoVersion(0).build();
 
-  static final String KEY_NAME = "key";
-  static final String VALUE_NAME = "val";
+  /** A logical version number describing the logical data model. */
+  int getRepoVersion();
 
-  private Tables() {}
+  /** Map of properties for a Nessie repository. */
+  Map<String, String> getProperties();
+
+  static ImmutableRepoDescription.Builder builder() {
+    return ImmutableRepoDescription.builder();
+  }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
@@ -141,6 +141,10 @@ public final class DatabaseAdapterUtil {
         assignTo.asString());
   }
 
+  public static String repoDescUpdateConflictMessage(String err) {
+    return String.format("%s during update of the repository description", err);
+  }
+
   /**
    * Verifies that {@code expectedHead}, if present, is equal to {@code referenceCurrentHead}.
    * Throws a {@link ReferenceConflictException} if not.

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseClient.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseClient.java
@@ -21,6 +21,7 @@ import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_GLOBAL_L
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_GLOBAL_POINTER;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_KEY_LISTS;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_REF_LOG;
+import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_REPO_DESC;
 
 import java.net.URI;
 import java.util.List;
@@ -88,6 +89,7 @@ public class DynamoDatabaseClient implements DatabaseConnectionProvider<DynamoCl
     }
 
     Stream.of(
+            TABLE_REPO_DESC,
             TABLE_GLOBAL_POINTER,
             TABLE_GLOBAL_LOG,
             TABLE_COMMIT_LOG,

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
@@ -21,10 +21,13 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
 
 public class InmemoryStore implements DatabaseConnectionProvider<InmemoryConfig> {
 
+  final ConcurrentMap<ByteString, AtomicReference<RepoDescription>> repoDesc =
+      new ConcurrentHashMap<>();
   final ConcurrentMap<ByteString, AtomicReference<GlobalStatePointer>> globalStatePointer =
       new ConcurrentHashMap<>();
   final ConcurrentMap<ByteString, ByteString> globalStateLog = new ConcurrentHashMap<>();
@@ -44,7 +47,7 @@ public class InmemoryStore implements DatabaseConnectionProvider<InmemoryConfig>
   public void close() {}
 
   void reinitializeRepo(ByteString keyPrefix) {
-    Stream.of(globalStatePointer, globalStateLog, commitLog, keyLists, refLog)
+    Stream.of(repoDesc, globalStatePointer, globalStateLog, commitLog, keyLists, refLog)
         .forEach(map -> map.keySet().removeIf(bytes -> bytes.startsWith(keyPrefix)));
   }
 }

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseClient.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseClient.java
@@ -27,6 +27,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
 
 public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClientConfig> {
 
+  private static final String REPO_DESC = "repo_desc";
   private static final String GLOBAL_POINTER = "global_pointer";
   private static final String GLOBAL_LOG = "global_log";
   private static final String COMMIT_LOG = "commit_log";
@@ -35,6 +36,7 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
 
   private MongoClientConfig config;
   private MongoClient managedClient;
+  private MongoCollection<Document> repoDesc;
   private MongoCollection<Document> globalPointers;
   private MongoCollection<Document> globalLog;
   private MongoCollection<Document> commitLog;
@@ -75,11 +77,16 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
     MongoDatabase database =
         mongoClient.getDatabase(
             Objects.requireNonNull(config.getDatabaseName(), "Database name must be set"));
+    repoDesc = database.getCollection(REPO_DESC);
     globalPointers = database.getCollection(GLOBAL_POINTER);
     globalLog = database.getCollection(GLOBAL_LOG);
     commitLog = database.getCollection(COMMIT_LOG);
     keyLists = database.getCollection(KEY_LIST);
     refLog = database.getCollection(REF_LOG);
+  }
+
+  public MongoCollection<Document> getRepoDesc() {
+    return repoDesc;
   }
 
   public MongoCollection<Document> getGlobalPointers() {

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDbInstance.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDbInstance.java
@@ -46,6 +46,7 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
 
   private String dbPath;
 
+  public static final String CF_REPO_PROPS = "repo_props";
   public static final String CF_GLOBAL_POINTER = "global_pointer";
   public static final String CF_GLOBAL_LOG = "global_log";
   public static final String CF_COMMIT_LOG = "commit_log";
@@ -53,8 +54,10 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
   public static final String CF_REF_LOG = "ref_log";
 
   public static final List<String> CF_ALL =
-      Arrays.asList(CF_GLOBAL_POINTER, CF_GLOBAL_LOG, CF_COMMIT_LOG, CF_KEY_LIST, CF_REF_LOG);
+      Arrays.asList(
+          CF_REPO_PROPS, CF_GLOBAL_POINTER, CF_GLOBAL_LOG, CF_COMMIT_LOG, CF_KEY_LIST, CF_REF_LOG);
 
+  private ColumnFamilyHandle cfRepoProps;
   private ColumnFamilyHandle cfGlobalPointer;
   private ColumnFamilyHandle cfGlobalLog;
   private ColumnFamilyHandle cfCommitLog;
@@ -120,6 +123,7 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
           columnFamilyHandleMap.put(cf, columnFamilyHandles.get(i + 1));
         }
 
+        cfRepoProps = columnFamilyHandleMap.get(CF_REPO_PROPS);
         cfGlobalPointer = columnFamilyHandleMap.get(CF_GLOBAL_POINTER);
         cfGlobalLog = columnFamilyHandleMap.get(CF_GLOBAL_LOG);
         cfCommitLog = columnFamilyHandleMap.get(CF_COMMIT_LOG);
@@ -129,6 +133,10 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
         throw new RuntimeException("RocksDB failed to start", e);
       }
     }
+  }
+
+  public ColumnFamilyHandle getCfRepoProps() {
+    return cfRepoProps;
   }
 
   public ColumnFamilyHandle getCfGlobalPointer() {

--- a/versioned/persist/serialize/src/main/proto/persist.proto
+++ b/versioned/persist/serialize/src/main/proto/persist.proto
@@ -122,3 +122,13 @@ message RefPointer {
   Type type = 1;
   bytes hash = 2;
 }
+
+message RepoProps {
+  int32 repo_version = 1;
+  repeated Entry properties = 2;
+}
+
+message Entry {
+  string key = 1;
+  string value = 2;
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -59,6 +59,13 @@ public abstract class AbstractDatabaseAdapterTest {
   @NessieDbAdapter protected static DatabaseAdapter databaseAdapter;
 
   @Nested
+  public class RepoDescription extends AbstractRepoDescription {
+    RepoDescription() {
+      super(databaseAdapter);
+    }
+  }
+
+  @Nested
   public class GlobalStates extends AbstractGlobalStates {
     GlobalStates() {
       super(databaseAdapter);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRepoDescription.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRepoDescription.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.RepoDescription;
+
+/** Verifies handling of repo-description in the database-adapters. */
+public abstract class AbstractRepoDescription {
+
+  private final DatabaseAdapter databaseAdapter;
+
+  protected AbstractRepoDescription(DatabaseAdapter databaseAdapter) {
+    this.databaseAdapter = databaseAdapter;
+  }
+
+  @Test
+  void emptyIsDefault() throws Exception {
+    assertThat(databaseAdapter.fetchRepositoryDescription()).isEqualTo(RepoDescription.DEFAULT);
+    databaseAdapter.updateRepositoryDescription(
+        d -> {
+          assertThat(d).isEqualTo(RepoDescription.DEFAULT);
+          return null;
+        });
+  }
+
+  @Test
+  void updates() throws Exception {
+    RepoDescription update1 =
+        RepoDescription.builder()
+            .repoVersion(42)
+            .putProperties("a", "b")
+            .putProperties("c", "d")
+            .build();
+    RepoDescription update2 =
+        RepoDescription.builder()
+            .repoVersion(666)
+            .putProperties("a", "e")
+            .putProperties("c", "f")
+            .build();
+
+    databaseAdapter.updateRepositoryDescription(
+        d -> {
+          assertThat(d).isEqualTo(RepoDescription.DEFAULT);
+          return update1;
+        });
+    assertThat(databaseAdapter.fetchRepositoryDescription()).isEqualTo(update1);
+
+    databaseAdapter.updateRepositoryDescription(
+        d -> {
+          assertThat(d).isEqualTo(update1);
+          return update2;
+        });
+    assertThat(databaseAdapter.fetchRepositoryDescription()).isEqualTo(update2);
+  }
+}

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
@@ -17,6 +17,26 @@ package org.projectnessie.versioned.persist.tx;
 
 public final class SqlStatements {
 
+  public static final String TABLE_REPO_DESCRIPTION = "repo_desc";
+  public static final String DELETE_REPO_DESCRIPTIONE_ALL =
+      String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_REPO_DESCRIPTION);
+  public static final String UPDATE_REPO_DESCRIPTION =
+      String.format(
+          "UPDATE %s SET repo_desc = ? WHERE repo_id = ? AND repo_desc = ?",
+          TABLE_REPO_DESCRIPTION);
+  public static final String INSERT_REPO_DESCRIPTION =
+      String.format("INSERT INTO %s (repo_id, repo_desc) VALUES (?, ?)", TABLE_REPO_DESCRIPTION);
+  public static final String SELECT_REPO_DESCRIPTION =
+      String.format("SELECT repo_desc FROM %s WHERE repo_id = ?", TABLE_REPO_DESCRIPTION);
+  public static final String CREATE_TABLE_REPO_DESCRIPTION =
+      String.format(
+          "CREATE TABLE %s (\n"
+              + "  repo_id {2},\n"
+              + "  repo_desc {0},\n"
+              + "  PRIMARY KEY (repo_id)\n"
+              + ")",
+          TABLE_REPO_DESCRIPTION);
+
   public static final String TABLE_NAMED_REFERENCES = "named_refs";
   public static final String DELETE_NAMED_REFERENCE_ALL =
       String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_NAMED_REFERENCES);


### PR DESCRIPTION
With the current work on implementing the ref-log it becomes kinda obvious that repository migration on the database level need to be handled.

The idea in this change is to have a description about the repository that provides these attributes:
* `repo_version` an integer version describing the repository, but not the database layout
* `properties` as a generic key-value bag describing the repository configuration

Behavior:
* if no repository-description exists, assume version `0` and an empty properties

Version `0` would be what we have now (including the ref-log).

Fixes #3009