### PR TITLE
Cleanup HttpClient

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -65,6 +65,15 @@ public final class NessieConfigConstants {
    * false}.
    */
   public static final String CONF_NESSIE_TRACING = "nessie.tracing";
+  /**
+   * Config property name ("{@value #CONF_READ_TIMEOUT}") for the network transport read-timeout.
+   */
+  public static final String CONF_READ_TIMEOUT = "nessie.transport.read-timeout";
+  /**
+   * Config property name ("{@value #CONF_CONNECT_TIMEOUT}") for the network transport connect
+   * timeout.
+   */
+  public static final String CONF_CONNECT_TIMEOUT = "nessie.transport.connect-timeout";
 
   private NessieConfigConstants() {
     // empty

--- a/clients/client/src/main/java/org/projectnessie/client/auth/AwsAuthenticationProvider.java
+++ b/clients/client/src/main/java/org/projectnessie/client/auth/AwsAuthenticationProvider.java
@@ -99,8 +99,8 @@ public class AwsAuthenticationProvider implements NessieAuthenticationProvider {
     }
 
     @Override
-    public void applyToHttpClient(HttpClient client) {
-      client.register(new AwsHttpAuthenticationFilter(region, awsCredentialsProvider));
+    public void applyToHttpClient(HttpClient.Builder client) {
+      client.addRequestFilter(new AwsHttpAuthenticationFilter(region, awsCredentialsProvider));
     }
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/auth/BasicAuthenticationProvider.java
+++ b/clients/client/src/main/java/org/projectnessie/client/auth/BasicAuthenticationProvider.java
@@ -23,7 +23,6 @@ import java.util.Base64;
 import java.util.function.Function;
 import org.projectnessie.client.http.HttpAuthentication;
 import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.client.http.RequestFilter;
 
 /**
  * HTTP BASIC authentication provider.
@@ -76,8 +75,8 @@ public class BasicAuthenticationProvider implements NessieAuthenticationProvider
     }
 
     @Override
-    public void applyToHttpClient(HttpClient client) {
-      client.register((RequestFilter) ctx -> ctx.putHeader("Authorization", authHeaderValue));
+    public void applyToHttpClient(HttpClient.Builder client) {
+      client.addRequestFilter(ctx -> ctx.putHeader("Authorization", authHeaderValue));
     }
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/auth/BearerAuthenticationProvider.java
+++ b/clients/client/src/main/java/org/projectnessie/client/auth/BearerAuthenticationProvider.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import org.projectnessie.client.http.HttpAuthentication;
 import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.client.http.RequestFilter;
 
 public class BearerAuthenticationProvider implements NessieAuthenticationProvider {
 
@@ -52,8 +51,8 @@ public class BearerAuthenticationProvider implements NessieAuthenticationProvide
     }
 
     @Override
-    public void applyToHttpClient(HttpClient client) {
-      client.register((RequestFilter) ctx -> ctx.putHeader("Authorization", authHeaderValue));
+    public void applyToHttpClient(HttpClient.Builder client) {
+      client.addRequestFilter(ctx -> ctx.putHeader("Authorization", authHeaderValue));
     }
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpAuthentication.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpAuthentication.java
@@ -28,5 +28,5 @@ public interface HttpAuthentication extends NessieAuthentication {
    *
    * @param client client to configure
    */
-  void applyToHttpClient(HttpClient client);
+  void applyToHttpClient(HttpClient.Builder client);
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
@@ -15,7 +15,6 @@
  */
 package org.projectnessie.client.http;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
@@ -52,10 +51,6 @@ public class HttpResponse {
   }
 
   public <V> V readEntity(Class<V> clazz) {
-    return readEntity(mapper.readerFor(clazz));
-  }
-
-  public <V> V readEntity(TypeReference<V> clazz) {
     return readEntity(mapper.readerFor(clazz));
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpRuntimeConfig.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpRuntimeConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import javax.net.ssl.SSLContext;
+
+/** Package-private HTTP configuration holder. */
+final class HttpRuntimeConfig {
+  private final URI baseUri;
+  private final ObjectMapper mapper;
+  private final int readTimeoutMillis;
+  private final int connectionTimeoutMillis;
+  private final SSLContext sslContext;
+  private final List<RequestFilter> requestFilters;
+  private final List<ResponseFilter> responseFilters;
+
+  HttpRuntimeConfig(
+      URI baseUri,
+      ObjectMapper mapper,
+      int readTimeoutMillis,
+      int connectionTimeoutMillis,
+      SSLContext sslContext,
+      List<RequestFilter> requestFilters,
+      List<ResponseFilter> responseFilters) {
+    this.baseUri = Objects.requireNonNull(baseUri);
+    if (!"http".equals(baseUri.getScheme()) && !"https".equals(baseUri.getScheme())) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot start http client. %s must be a valid http or https address", baseUri));
+    }
+    this.mapper = mapper;
+    this.readTimeoutMillis = readTimeoutMillis;
+    this.connectionTimeoutMillis = connectionTimeoutMillis;
+    this.sslContext = sslContext;
+    this.requestFilters = requestFilters;
+    this.responseFilters = responseFilters;
+  }
+
+  URI getBaseUri() {
+    return baseUri;
+  }
+
+  ObjectMapper getMapper() {
+    return mapper;
+  }
+
+  int getReadTimeoutMillis() {
+    return readTimeoutMillis;
+  }
+
+  int getConnectionTimeoutMillis() {
+    return connectionTimeoutMillis;
+  }
+
+  SSLContext getSslContext() {
+    return sslContext;
+  }
+
+  List<RequestFilter> getRequestFilters() {
+    return requestFilters;
+  }
+
+  List<ResponseFilter> getResponseFilters() {
+    return responseFilters;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpUtils.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpUtils.java
@@ -18,6 +18,15 @@ package org.projectnessie.client.http;
 import java.util.Objects;
 
 public final class HttpUtils {
+
+  public static final String GZIP = "gzip";
+  public static final String DEFLATE = "deflate";
+  public static final String ACCEPT_ENCODING = GZIP + ";q=1.0, " + DEFLATE + ";q=0.9";
+  public static final String HEADER_ACCEPT = "Accept";
+  public static final String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
+  public static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
+  public static final String HEADER_CONTENT_TYPE = "Content-Type";
+
   private HttpUtils() {}
 
   /**

--- a/clients/client/src/main/java/org/projectnessie/client/http/ResponseContextImpl.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/ResponseContextImpl.java
@@ -27,15 +27,18 @@ class ResponseContextImpl implements ResponseContext {
     this.connection = connection;
   }
 
+  @Override
   public Status getResponseCode() throws IOException {
     return Status.fromCode(connection.getResponseCode());
   }
 
+  @Override
   public InputStream getInputStream() throws IOException {
     return connection.getInputStream();
   }
 
-  public InputStream getErrorStream() {
+  @Override
+  public InputStream getErrorStream() throws IOException {
     return connection.getErrorStream();
   }
 }

--- a/clients/client/src/test/java/org/projectnessie/client/auth/TestAwsAuthProvider.java
+++ b/clients/client/src/test/java/org/projectnessie/client/auth/TestAwsAuthProvider.java
@@ -164,7 +164,7 @@ class TestAwsAuthProvider {
     // Intercept the call to HttpClient.register(RequestFilter) and extract the RequestFilter for
     // our test
     RequestFilter[] authFilter = new RequestFilter[1];
-    HttpClient client = Mockito.mock(HttpClient.class);
+    HttpClient.Builder client = Mockito.mock(HttpClient.Builder.class);
     Mockito.doAnswer(
             invocationOnMock -> {
               Object[] args = invocationOnMock.getArguments();
@@ -179,7 +179,7 @@ class TestAwsAuthProvider {
               return null;
             })
         .when(client)
-        .register((RequestFilter) Mockito.any());
+        .addRequestFilter(Mockito.any());
     httpAuthentication.applyToHttpClient(client);
 
     // Check that the registered RequestFilter works as expected (sets the right HTTP headers)

--- a/clients/client/src/test/java/org/projectnessie/client/auth/TestBasicAuthProvider.java
+++ b/clients/client/src/test/java/org/projectnessie/client/auth/TestBasicAuthProvider.java
@@ -106,7 +106,7 @@ class TestBasicAuthProvider {
     // Intercept the call to HttpClient.register(RequestFilter) and extract the RequestFilter for
     // our test
     RequestFilter[] authFilter = new RequestFilter[1];
-    HttpClient client = Mockito.mock(HttpClient.class);
+    HttpClient.Builder client = Mockito.mock(HttpClient.Builder.class);
     Mockito.doAnswer(
             invocationOnMock -> {
               Object[] args = invocationOnMock.getArguments();
@@ -116,7 +116,7 @@ class TestBasicAuthProvider {
               return null;
             })
         .when(client)
-        .register((RequestFilter) Mockito.any());
+        .addRequestFilter(Mockito.any());
     httpAuthentication.applyToHttpClient(client);
 
     // Check that the registered RequestFilter works as expected (sets the right HTTP header)

--- a/clients/client/src/test/java/org/projectnessie/client/auth/TestBearerAuthenticationProvider.java
+++ b/clients/client/src/test/java/org/projectnessie/client/auth/TestBearerAuthenticationProvider.java
@@ -74,7 +74,7 @@ class TestBearerAuthenticationProvider {
     // Intercept the call to HttpClient.register(RequestFilter) and extract the RequestFilter for
     // our test
     RequestFilter[] authFilter = new RequestFilter[1];
-    HttpClient client = Mockito.mock(HttpClient.class);
+    HttpClient.Builder client = Mockito.mock(HttpClient.Builder.class);
     Mockito.doAnswer(
             invocationOnMock -> {
               Object[] args = invocationOnMock.getArguments();
@@ -84,7 +84,7 @@ class TestBearerAuthenticationProvider {
               return null;
             })
         .when(client)
-        .register((RequestFilter) Mockito.any());
+        .addRequestFilter(Mockito.any());
     httpAuthentication.applyToHttpClient(client);
 
     // Check that the registered RequestFilter works as expected (sets the right HTTP header)

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -127,15 +127,15 @@ public abstract class AbstractTestRest {
         new ObjectMapper()
             .enable(SerializationFeature.INDENT_OUTPUT)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-    HttpClient httpClient = HttpClient.builder().setBaseUri(uri).setObjectMapper(mapper).build();
-    httpClient.register(new NessieHttpResponseFilter(mapper));
+    HttpClient.Builder httpClient = HttpClient.builder().setBaseUri(uri).setObjectMapper(mapper);
+    httpClient.addResponseFilter(new NessieHttpResponseFilter(mapper));
 
     init(api, httpClient);
   }
 
-  protected void init(NessieApiV1 api, @Nullable HttpClient httpClient) {
+  protected void init(NessieApiV1 api, @Nullable HttpClient.Builder httpClient) {
     this.api = api;
-    this.httpClient = httpClient;
+    this.httpClient = httpClient != null ? httpClient.build() : null;
   }
 
   @BeforeEach

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -55,8 +55,12 @@ class TestNessieError {
         new ObjectMapper()
             .enable(SerializationFeature.INDENT_OUTPUT)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-    client = HttpClient.builder().setBaseUri(URI.create(baseURI)).setObjectMapper(mapper).build();
-    client.register(new NessieHttpResponseFilter(mapper));
+    client =
+        HttpClient.builder()
+            .setBaseUri(URI.create(baseURI))
+            .setObjectMapper(mapper)
+            .addResponseFilter(new NessieHttpResponseFilter(mapper))
+            .build();
   }
 
   @Test


### PR DESCRIPTION
* Introduce a `HttpRuntimeConfig` holding the runtime configuration in `HttpClient` passed into every `HttpRequest`
* Move request and response filters into `HttpRuntimeConfig` and configure those filters via the `HttpClient.Builder`
* Add missing configuration options for read + connect timeout
* Wire up missing SSLContext option
* Prepare for the HTTP-compression PR