### PR TITLE
Support nested tests in NessieJaxRsExtension

### DIFF
--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieUri.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieUri.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.jaxrs.ext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for JUnit5 method parameters that need a URI to the Nessie server managed by {@link
+ * NessieJaxRsExtension}.
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface NessieUri {}

--- a/servers/jax-rs-testextension/src/test/java/org/projectnessie/jaxrs/ext/TestNessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/test/java/org/projectnessie/jaxrs/ext/TestNessieJaxRsExtension.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.jaxrs.ext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.http.HttpClientBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
+import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
+
+@ExtendWith(DatabaseAdapterExtension.class)
+@NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
+class TestNessieJaxRsExtension {
+
+  @NessieDbAdapter static DatabaseAdapter databaseAdapter;
+
+  @RegisterExtension
+  static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
+
+  private static NessieApiV1 api;
+
+  @BeforeAll
+  static void setupClient(@NessieUri URI uri) {
+    assertThat(databaseAdapter).isNotNull();
+    api = HttpClientBuilder.builder().withUri(uri).build(NessieApiV1.class);
+  }
+
+  private void checkServer() throws NessieNotFoundException {
+    assertThat(api.getDefaultBranch().getName()).isEqualTo("main");
+  }
+
+  @Test
+  void topLevel() throws NessieNotFoundException {
+    checkServer();
+  }
+
+  @Nested
+  class Nested1 {
+    @Test
+    void nestedTest() throws NessieNotFoundException {
+      checkServer();
+    }
+
+    @Nested
+    class NestedTwice {
+      @Test
+      void nestedTest() throws NessieNotFoundException {
+        checkServer();
+      }
+    }
+  }
+
+  @Nested
+  class Nested2 {
+    @Test
+    void nestedTest() throws NessieNotFoundException {
+      checkServer();
+    }
+  }
+}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyRest.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyRest.java
@@ -15,10 +15,13 @@
  */
 package org.projectnessie.jaxrs;
 
+import java.net.URI;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
+import org.projectnessie.jaxrs.ext.NessieUri;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
@@ -32,9 +35,16 @@ abstract class AbstractTestJerseyRest extends AbstractTestRest {
   static org.projectnessie.jaxrs.ext.NessieJaxRsExtension server =
       new NessieJaxRsExtension(() -> databaseAdapter);
 
+  private static URI nessieUri;
+
+  @BeforeAll
+  static void setNessieUri(@NessieUri URI uri) {
+    nessieUri = uri;
+  }
+
   @Override
   @BeforeEach
   public void setUp() {
-    init(server.getURI());
+    init(nessieUri);
   }
 }

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyResteasy.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyResteasy.java
@@ -18,10 +18,12 @@ package org.projectnessie.jaxrs;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
+import java.net.URI;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
+import org.projectnessie.jaxrs.ext.NessieUri;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
@@ -35,9 +37,9 @@ abstract class AbstractTestJerseyResteasy extends AbstractResteasyTest {
   static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
 
   @BeforeAll
-  static void setup() {
-    RestAssured.baseURI = server.getURI().toString();
-    RestAssured.port = server.getURI().getPort();
+  static void setup(@NessieUri URI uri) {
+    RestAssured.baseURI = uri.toString();
+    RestAssured.port = uri.getPort();
     RestAssured.requestSpecification =
         new RequestSpecBuilder()
             .setContentType(ContentType.JSON)


### PR DESCRIPTION
* Use JUnit5 contexts for storing extension state

* Reuse Weld/Jersey objects from the parent context
  in nested test contexts

* Migrate the old getURI() method to an injection
  pattern based on the new @NessieUri annotation.

Fixes #3072