### PR TITLE
Check that the target ref can be read when authorization is enabled

### DIFF
--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
@@ -74,6 +74,12 @@ public class NessieAuthorizationTestProfile extends AuthenticationEnabledProfile
           .put(
               "nessie.server.authorization.rules.allow_listing_reflog",
               "op=='VIEW_REFLOG' && role=='admin_user'")
+          .put(
+              "nessie.server.authorization.rules.allow_creation_user1",
+              "op=='CREATE_REFERENCE' && role=='user1' && ref.matches('.*')")
+          .put(
+              "nessie.server.authorization.rules.allow_view_merge_delete_user1",
+              "op in ['VIEW_REFERENCE', 'ASSIGN_REFERENCE_TO_HASH', 'COMMIT_CHANGE_AGAINST_REFERENCE', 'DELETE_REFERENCE'] && role=='user1' && (ref.startsWith('allowedBranch') || ref == 'main')")
           .build();
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -123,7 +123,7 @@ public class CELUtil {
   /**
    * 'Mirrors' Nessie model objects for CEL.
    *
-   * @param model Ńessie model object
+   * @param model Nessie model object
    * @return object suitable for CEL expressions
    */
   public static Object forCel(Object model) {


### PR DESCRIPTION
 In this case the target ref is the one
* we assign a reference to
* merge a branch into
* transplant commits into


fixes #3058