### PR TITLE
Make sure we always pass arguments for path/ref variables in CelAccessChecker

### DIFF
--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/authz/CelAccessChecker.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/authz/CelAccessChecker.java
@@ -131,7 +131,15 @@ public class CelAccessChecker implements AccessChecker {
     }
     String roleName = getRoleName(context);
     ImmutableMap<String, Object> arguments =
-        ImmutableMap.of("role", roleName, "op", AuthorizationRuleType.VIEW_REFLOG.name());
+        ImmutableMap.of(
+            "role",
+            roleName,
+            "op",
+            AuthorizationRuleType.VIEW_REFLOG.name(),
+            "path",
+            "",
+            "ref",
+            "");
 
     Supplier<String> errorMsgSupplier =
         () ->
@@ -151,7 +159,7 @@ public class CelAccessChecker implements AccessChecker {
     }
     String roleName = getRoleName(context);
     ImmutableMap<String, Object> arguments =
-        ImmutableMap.of("ref", ref.getName(), "role", roleName, "op", type.name());
+        ImmutableMap.of("ref", ref.getName(), "role", roleName, "op", type.name(), "path", "");
 
     Supplier<String> errorMsgSupplier =
         () ->


### PR DESCRIPTION
Given that the `CelAccessChecker` always evaluates all CEL rules in
`compiledRules.getRules().entrySet().stream().anyMatch(..)` we need to
make sure that we always provide arguments for the `path` and `ref`
variables.

Given that the rule execution is non-deterministic (due to the
`entrySet()`), CEL rule execution can fail with something like this:

```
Failed to execute authorization rule with id 'op in ['VIEW_REFERENCE', 'UPDATE_ENTITY'] && role=='test_user' && path.startsWith('allowed.') && ref.startsWith('allowedBranch')' and expression 'org.projectnessie.cel.tools.Script@4b6028c7' due to: undeclared reference to 'id: 10, attributes: [id: 10, names: [org.projectnessie.model.path, org.projectnessie.path, org.path, path]]' (in container '')
```

The above exception happened while checking whether viewing a reference
was allowed when calling `getAllReferences()` (thus we need to make sure
here that `path` is set)