### PR TITLE
Ensure stable order of references in GlobalStatePointer

### DIFF
--- a/versioned/persist/serialize/src/main/proto/persist.proto
+++ b/versioned/persist/serialize/src/main/proto/persist.proto
@@ -103,8 +103,14 @@ message RefLogEntry {
 // Used by non-transactional database-adapters
 message GlobalStatePointer {
   bytes global_id = 1;
-  map<string, RefPointer> named_references = 2;
+  // most recently updated named reference appears first
+  repeated NamedReference named_references = 2;
   bytes ref_log_id = 3;
+}
+
+message NamedReference {
+  string name = 1;
+  RefPointer ref = 2;
 }
 
 // Used by non-transactional database-adapters

--- a/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/serialize/TestSerialization.java
+++ b/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/serialize/TestSerialization.java
@@ -46,6 +46,7 @@ import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.NamedReference;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
 
@@ -364,9 +365,13 @@ class TestSerialization {
   static GlobalStatePointer createGlobalState() {
     GlobalStatePointer.Builder state = GlobalStatePointer.newBuilder().setGlobalId(randomBytes(32));
     for (int i = 0; i < 50; i++) {
-      state.putNamedReferences(
-          randomString(32),
-          RefPointer.newBuilder().setType(RefPointer.Type.Branch).setHash(randomBytes(32)).build());
+      state.addNamedReferences(
+          NamedReference.newBuilder()
+              .setName(randomString(32))
+              .setRef(
+                  RefPointer.newBuilder()
+                      .setType(RefPointer.Type.Branch)
+                      .setHash(randomBytes(32))));
     }
     return state.build();
   }


### PR DESCRIPTION
As pointed out in the review of #3028, Java's `Map` does not ensure a stable order of elements.
This was definitely a problem in that PR.

Nessie's `GlobalStatePointer` also uses a `Map` for the named references. Although the
design of the code ensures that the order of elements in `GlobalStatePointer.namedReferences`
is stable, it feels safer to refactor that property to a list.

The "order" of the list is: most recently updated named references appear at the beginning of
that list. This change brings more advantages beside the "defined order or elements":
* Most recently updated references appear before "stale" references.
* Allows to "spill out" stale references to a separate table, if that becomes necessary, i.e.
  when there are too many references, the GSP becomes big and databases suffer from that size.
* (Probably neglectible:) a bit less (de)serialization effort as the map on top of the protobuf
  list is gone.

Note: in protobuf it is safe to "refactor" a `map<K, V>` to `repeated ELEM` where `ELEM ::= message { K key = 1; V value = 2 }` (which is how maps were "defined" before protobuf 3.