### PR TITLE
Unify TreeApi.deleteX() + TreeApi.assignX()

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.http;
 
+import java.util.Locale;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.api.http.HttpTreeApi;
@@ -80,47 +81,32 @@ class HttpTreeClient implements HttpTreeApi {
   }
 
   @Override
-  public void assignTag(
-      @NotNull String tagName, @NotNull String expectedHash, @NotNull Reference assignTo)
+  public void assignReference(
+      @NotNull Reference.ReferenceType referenceType,
+      @NotNull String referenceName,
+      @NotNull String expectedHash,
+      @Valid @NotNull Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
     client
         .newRequest()
-        .path("trees/tag/{tagName}")
-        .resolveTemplate("tagName", tagName)
+        .path("trees/{referenceType}/{referenceName}")
+        .resolveTemplate("referenceType", referenceType.name().toLowerCase(Locale.ROOT))
+        .resolveTemplate("referenceName", referenceName)
         .queryParam("expectedHash", expectedHash)
         .put(assignTo);
   }
 
   @Override
-  public void deleteTag(@NotNull String tagName, @NotNull String expectedHash)
+  public void deleteReference(
+      @NotNull Reference.ReferenceType referenceType,
+      @NotNull String referenceName,
+      @NotNull String expectedHash)
       throws NessieConflictException, NessieNotFoundException {
     client
         .newRequest()
-        .path("trees/tag/{tagName}")
-        .resolveTemplate("tagName", tagName)
-        .queryParam("expectedHash", expectedHash)
-        .delete();
-  }
-
-  @Override
-  public void assignBranch(
-      @NotNull String branchName, @NotNull String expectedHash, @NotNull Reference assignTo)
-      throws NessieNotFoundException, NessieConflictException {
-    client
-        .newRequest()
-        .path("trees/branch/{branchName}")
-        .resolveTemplate("branchName", branchName)
-        .queryParam("expectedHash", expectedHash)
-        .put(assignTo);
-  }
-
-  @Override
-  public void deleteBranch(@NotNull String branchName, @NotNull String expectedHash)
-      throws NessieConflictException, NessieNotFoundException {
-    client
-        .newRequest()
-        .path("trees/branch/{branchName}")
-        .resolveTemplate("branchName", branchName)
+        .path("trees/{referenceType}/{referenceName}")
+        .resolveTemplate("referenceType", referenceType.name().toLowerCase(Locale.ROOT))
+        .resolveTemplate("referenceName", referenceName)
         .queryParam("expectedHash", expectedHash)
         .delete();
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
@@ -37,6 +37,6 @@ final class HttpAssignBranch extends BaseHttpOnBranchRequest<AssignBranchBuilder
 
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
-    client.getTreeApi().assignBranch(branchName, hash, assignTo);
+    client.getTreeApi().assignReference(Reference.ReferenceType.BRANCH, branchName, hash, assignTo);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
@@ -38,6 +38,6 @@ final class HttpAssignTag extends BaseHttpOnTagRequest<AssignTagBuilder>
 
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
-    client.getTreeApi().assignTag(tagName, hash, assignTo);
+    client.getTreeApi().assignReference(Reference.ReferenceType.TAG, tagName, hash, assignTo);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteBranch.java
@@ -19,6 +19,7 @@ import org.projectnessie.client.api.DeleteBranchBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
 
 final class HttpDeleteBranch extends BaseHttpOnBranchRequest<DeleteBranchBuilder>
     implements DeleteBranchBuilder {
@@ -28,6 +29,6 @@ final class HttpDeleteBranch extends BaseHttpOnBranchRequest<DeleteBranchBuilder
 
   @Override
   public void delete() throws NessieConflictException, NessieNotFoundException {
-    client.getTreeApi().deleteBranch(branchName, hash);
+    client.getTreeApi().deleteReference(Reference.ReferenceType.BRANCH, branchName, hash);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteTag.java
@@ -19,6 +19,7 @@ import org.projectnessie.client.api.DeleteTagBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
 
 final class HttpDeleteTag extends BaseHttpOnTagRequest<DeleteTagBuilder>
     implements DeleteTagBuilder {
@@ -29,6 +30,6 @@ final class HttpDeleteTag extends BaseHttpOnTagRequest<DeleteTagBuilder>
 
   @Override
   public void delete() throws NessieConflictException, NessieNotFoundException {
-    client.getTreeApi().deleteTag(tagName, hash);
+    client.getTreeApi().deleteReference(Reference.ReferenceType.TAG, tagName, hash);
   }
 }

--- a/model/src/main/java/org/projectnessie/api/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/TreeApi.java
@@ -128,44 +128,25 @@ public interface TreeApi {
       @Valid @NotNull CommitLogParams params)
       throws NessieNotFoundException;
 
-  /** Update a tag. */
-  void assignTag(
+  /** Update a reference's HEAD to point to a different commit. */
+  void assignReference(
+      @Valid @NotNull Reference.ReferenceType referenceType,
       @Valid
           @NotNull
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-          String tagName,
+          String referenceName,
       @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String oldHash,
       @Valid @NotNull Reference assignTo)
       throws NessieNotFoundException, NessieConflictException;
 
-  /** Delete a tag. */
-  void deleteTag(
+  /** Delete a named reference. */
+  void deleteReference(
+      @Valid @NotNull Reference.ReferenceType referenceType,
       @Valid
           @NotNull
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-          String tagName,
-      @Valid @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
-          String hash)
-      throws NessieConflictException, NessieNotFoundException;
-
-  /** Update a branch. */
-  void assignBranch(
-      @Valid
-          @NotNull
-          @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-          String branchName,
-      @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
-          String oldHash,
-      @Valid @NotNull Reference assignTo)
-      throws NessieNotFoundException, NessieConflictException;
-
-  /** Delete a branch. */
-  void deleteBranch(
-      @Valid
-          @NotNull
-          @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-          String branchName,
+          String referenceName,
       @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String hash)
       throws NessieConflictException, NessieNotFoundException;

--- a/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
@@ -272,98 +272,40 @@ public interface HttpTreeApi extends TreeApi {
 
   @Override
   @PUT
-  @Path("tag/{tagName}")
+  @Path("{referenceType}/{referenceName}")
   @Operation(
-      summary = "Set a tag to a specific hash via a named-reference.",
+      summary = "Set a named reference to a specific hash via a named-reference.",
       description =
-          "This operation takes the name of the tag to reassign and the hash and the name of a "
+          "This operation takes the name of the named reference to reassign and the hash and the name of a "
               + "named-reference via which the caller has access to that hash.")
   @APIResponses({
     @APIResponse(responseCode = "204", description = "Assigned successfully"),
     @APIResponse(responseCode = "400", description = "Invalid input, ref/hash name not valid"),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
-    @APIResponse(responseCode = "403", description = "Not allowed to view or assign tag"),
-    @APIResponse(responseCode = "404", description = "One or more references don't exist"),
-    @APIResponse(responseCode = "412", description = "Update conflict")
-  })
-  void assignTag(
-      @Parameter(
-              description = "Tag name to reassign",
-              examples = {@ExampleObject(ref = "ref")})
-          @PathParam("tagName")
-          String tagName,
-      @Parameter(
-              description = "Expected previous hash of tag",
-              examples = {@ExampleObject(ref = "hash")})
-          @QueryParam("expectedHash")
-          String oldHash,
-      @RequestBody(
-              description =
-                  "Reference hash to which 'tagName' shall be assigned to. This must be either a "
-                      + "'Branch' or 'Tag' via which the hash is visible to the caller.",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON,
-                      examples = {@ExampleObject(ref = "refObj"), @ExampleObject(ref = "tagObj")}))
-          Reference assignTo)
-      throws NessieNotFoundException, NessieConflictException;
-
-  @Override
-  @DELETE
-  @Path("tag/{tagName}")
-  @Operation(summary = "Delete a tag")
-  @APIResponses({
-    @APIResponse(responseCode = "204", description = "Deleted successfully."),
-    @APIResponse(responseCode = "400", description = "Invalid input, ref/hash name not valid"),
-    @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
-    @APIResponse(responseCode = "403", description = "Not allowed to view or delete tag"),
-    @APIResponse(responseCode = "404", description = "Ref doesn't exists"),
-    @APIResponse(responseCode = "409", description = "update conflict"),
-  })
-  void deleteTag(
-      @Parameter(
-              description = "Tag to delete",
-              examples = {@ExampleObject(ref = "ref")})
-          @PathParam("tagName")
-          String tagName,
-      @Parameter(
-              description = "Expected hash of tag",
-              examples = {@ExampleObject(ref = "hash")})
-          @QueryParam("expectedHash")
-          String hash)
-      throws NessieConflictException, NessieNotFoundException;
-
-  @Override
-  @PUT
-  @Path("branch/{branchName}")
-  @Operation(
-      summary = "Set a branch to a specific hash via a named-reference.",
-      description =
-          "This operation takes the name of the branch to reassign and the hash and the name of a "
-              + "named-reference via which the caller has access to that hash.")
-  @APIResponses({
-    @APIResponse(responseCode = "204", description = "Assigned successfully"),
-    @APIResponse(responseCode = "400", description = "Invalid input, ref/hash name not valid"),
-    @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
-    @APIResponse(responseCode = "403", description = "Not allowed to view or assign branch"),
+    @APIResponse(responseCode = "403", description = "Not allowed to view or assign reference"),
     @APIResponse(responseCode = "404", description = "One or more references don't exist"),
     @APIResponse(responseCode = "409", description = "Update conflict")
   })
-  void assignBranch(
+  void assignReference(
       @Parameter(
-              description = "Tag name to reassign",
+              description = "Reference type to reassign",
+              examples = {@ExampleObject(ref = "referenceType")})
+          @PathParam("referenceType")
+          Reference.ReferenceType referenceType,
+      @Parameter(
+              description = "Reference name to reassign",
               examples = {@ExampleObject(ref = "ref")})
-          @PathParam("branchName")
-          String branchName,
+          @PathParam("referenceName")
+          String referenceName,
       @Parameter(
-              description = "Expected previous hash of tag",
+              description = "Expected previous hash of reference",
               examples = {@ExampleObject(ref = "hash")})
           @QueryParam("expectedHash")
           String oldHash,
       @RequestBody(
               description =
-                  "Reference hash to which 'branchName' shall be assigned to. This must be either a "
-                      + "'Branch' or 'Tag' via which the hash is visible to the caller.",
+                  "Reference hash to which 'referenceName' shall be assigned to. This must be either a "
+                      + "'Transaction', 'Branch' or 'Tag' via which the hash is visible to the caller.",
               content =
                   @Content(
                       mediaType = MediaType.APPLICATION_JSON,
@@ -373,22 +315,27 @@ public interface HttpTreeApi extends TreeApi {
 
   @Override
   @DELETE
-  @Path("branch/{branchName}")
-  @Operation(summary = "Delete a branch endpoint")
+  @Path("{referenceType}/{referenceName}")
+  @Operation(summary = "Delete a reference endpoint")
   @APIResponses({
     @APIResponse(responseCode = "204", description = "Deleted successfully."),
     @APIResponse(responseCode = "400", description = "Invalid input, ref/hash name not valid"),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
-    @APIResponse(responseCode = "403", description = "Not allowed to view or delete branch"),
+    @APIResponse(responseCode = "403", description = "Not allowed to view or delete reference"),
     @APIResponse(responseCode = "404", description = "Ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "update conflict"),
   })
-  void deleteBranch(
+  void deleteReference(
       @Parameter(
-              description = "Branch to delete",
+              description = "Reference type to delete",
+              examples = {@ExampleObject(ref = "referenceType")})
+          @PathParam("referenceType")
+          Reference.ReferenceType referenceType,
+      @Parameter(
+              description = "Reference name to delete",
               examples = {@ExampleObject(ref = "ref")})
-          @PathParam("branchName")
-          String branchName,
+          @PathParam("referenceName")
+          String referenceName,
       @Parameter(
               description = "Expected hash of tag",
               examples = {@ExampleObject(ref = "hash")})

--- a/model/src/main/java/org/projectnessie/model/Branch.java
+++ b/model/src/main/java/org/projectnessie/model/Branch.java
@@ -40,6 +40,11 @@ public interface Branch extends Reference {
     validateReferenceName(getName());
   }
 
+  @Override
+  default ReferenceType getType() {
+    return ReferenceType.BRANCH;
+  }
+
   static ImmutableBranch.Builder builder() {
     return ImmutableBranch.builder();
   }

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -17,6 +17,7 @@ package org.projectnessie.model;
 
 import static org.projectnessie.model.Validation.validateHash;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -80,4 +81,15 @@ public interface Reference extends Base {
   @JsonInclude(Include.NON_NULL)
   @Nullable
   ReferenceMetadata getMetadata();
+
+  @JsonIgnore
+  @Value.Redacted
+  ReferenceType getType();
+
+  /** The reference type as an enum. */
+  @Schema(enumeration = {"branch", "tag"}) // Required to have lower-case values in OpenAPI
+  enum ReferenceType {
+    BRANCH,
+    TAG
+  }
 }

--- a/model/src/main/java/org/projectnessie/model/Tag.java
+++ b/model/src/main/java/org/projectnessie/model/Tag.java
@@ -40,6 +40,11 @@ public interface Tag extends Reference {
     validateReferenceName(getName());
   }
 
+  @Override
+  default ReferenceType getType() {
+    return ReferenceType.TAG;
+  }
+
   static ImmutableTag.Builder builder() {
     return ImmutableTag.builder();
   }

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -39,6 +39,9 @@ components:
     ref:
       value: "main"
 
+    referenceType:
+      value: "branch"
+
     hash:
       value: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
 

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
@@ -45,6 +45,7 @@ import org.projectnessie.services.rest.InstantParamConverterProvider;
 import org.projectnessie.services.rest.NessieExceptionMapper;
 import org.projectnessie.services.rest.NessieJaxRsJsonMappingExceptionMapper;
 import org.projectnessie.services.rest.NessieJaxRsJsonParseExceptionMapper;
+import org.projectnessie.services.rest.ReferenceTypeParamConverterProvider;
 import org.projectnessie.services.rest.RestConfigResource;
 import org.projectnessie.services.rest.RestContentResource;
 import org.projectnessie.services.rest.RestDiffResource;
@@ -176,6 +177,7 @@ public class NessieJaxRsExtension
               config.register(RestRefLogResource.class);
               config.register(ConfigApiImpl.class);
               config.register(ContentKeyParamConverterProvider.class);
+              config.register(ReferenceTypeParamConverterProvider.class);
               config.register(InstantParamConverterProvider.class);
               config.register(ValidationExceptionMapper.class, 10);
               config.register(NessieExceptionMapper.class);

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -1493,32 +1493,31 @@ public abstract class AbstractTestRest {
                             .commit())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".branchName: " + REF_NAME_MESSAGE)
+                .hasMessageContaining(REF_NAME_MESSAGE)
                 .hasMessageContaining(opsCountMsg),
         () ->
             assertThatThrownBy(
                     () -> api.deleteBranch().branchName(invalidBranchName).hash(validHash).delete())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("deleteBranch.branchName: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> api.getCommitLog().refName(invalidBranchName).untilHash(validHash).get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("getCommitLog.ref: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> api.getEntries().refName(invalidBranchName).hashOnRef(validHash).get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("getEntries.refName: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(() -> api.getReference().refName(invalidBranchName).get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(
-                    "getReferenceByName.params.refName: " + REF_NAME_OR_HASH_MESSAGE),
+                .hasMessageContaining(REF_NAME_OR_HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->
@@ -1529,7 +1528,7 @@ public abstract class AbstractTestRest {
                             .assign())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("assignTag.tagName: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () -> {
           if (null != httpClient) {
             assertThatThrownBy(
@@ -1542,8 +1541,8 @@ public abstract class AbstractTestRest {
                             .post(null))
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("mergeRefIntoBranch.branchName: " + REF_NAME_MESSAGE)
-                .hasMessageContaining("mergeRefIntoBranch.merge: must not be null");
+                .hasMessageContaining(REF_NAME_MESSAGE)
+                .hasMessageContaining(".merge: must not be null");
           }
         },
         () ->
@@ -1556,13 +1555,13 @@ public abstract class AbstractTestRest {
                             .merge())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("mergeRefIntoBranch.branchName: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> api.deleteTag().tagName(invalidBranchName).hash(validHash).delete())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("deleteTag.tagName: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->
@@ -1575,8 +1574,7 @@ public abstract class AbstractTestRest {
                             .transplant())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(
-                    "transplantCommitsIntoBranch.branchName: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->
@@ -1587,7 +1585,7 @@ public abstract class AbstractTestRest {
                             .get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".ref: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->
@@ -1598,13 +1596,13 @@ public abstract class AbstractTestRest {
                             .get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".ref: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> api.getDiff().fromRefName(invalidBranchName).toRefName("main").get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".fromRef: " + REF_NAME_MESSAGE));
+                .hasMessageContaining(REF_NAME_MESSAGE));
   }
 
   @ParameterizedTest
@@ -1643,7 +1641,7 @@ public abstract class AbstractTestRest {
                     () -> api.deleteBranch().branchName(validBranchName).hash(invalidHash).delete())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("deleteBranch.hash: " + HASH_MESSAGE),
+                .hasMessageContaining(".hash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->
@@ -1654,7 +1652,7 @@ public abstract class AbstractTestRest {
                             .assign())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("assignTag.oldHash: " + HASH_MESSAGE),
+                .hasMessageContaining(".oldHash: " + HASH_MESSAGE),
         () -> {
           if (null != httpClient) {
             assertThatThrownBy(
@@ -1668,7 +1666,7 @@ public abstract class AbstractTestRest {
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
                 .hasMessageContaining("mergeRefIntoBranch.merge: must not be null")
-                .hasMessageContaining("mergeRefIntoBranch.hash: " + HASH_MESSAGE);
+                .hasMessageContaining(".hash: " + HASH_MESSAGE);
           }
         },
         () ->
@@ -1681,13 +1679,13 @@ public abstract class AbstractTestRest {
                             .merge())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("mergeRefIntoBranch.hash: " + HASH_MESSAGE),
+                .hasMessageContaining(".hash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> api.deleteTag().tagName(validBranchName).hash(invalidHash).delete())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("deleteTag.hash: " + HASH_MESSAGE),
+                .hasMessageContaining(".hash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->
@@ -1700,14 +1698,14 @@ public abstract class AbstractTestRest {
                             .transplant())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("transplantCommitsIntoBranch.hash: " + HASH_MESSAGE),
+                .hasMessageContaining(".hash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(() -> api.getContent().refName(invalidHash).get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
                 .hasMessageContaining(
                     ".request.requestedKeys: size must be between 1 and 2147483647")
-                .hasMessageContaining(".ref: " + REF_NAME_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> api.getContent().refName(validBranchName).hashOnRef(invalidHash).get())
@@ -1732,19 +1730,19 @@ public abstract class AbstractTestRest {
                     () -> api.getCommitLog().refName(validBranchName).untilHash(invalidHash).get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("getCommitLog.params.startHash: " + HASH_MESSAGE),
+                .hasMessageContaining(".params.startHash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> api.getCommitLog().refName(validBranchName).hashOnRef(invalidHash).get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("getCommitLog.params.endHash: " + HASH_MESSAGE),
+                .hasMessageContaining(".params.endHash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> api.getEntries().refName(validBranchName).hashOnRef(invalidHash).get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining("getEntries.params.hashOnRef: " + HASH_MESSAGE));
+                .hasMessageContaining(".params.hashOnRef: " + HASH_MESSAGE));
   }
 
   @ParameterizedTest
@@ -1795,7 +1793,8 @@ public abstract class AbstractTestRest {
                                     .queryParam("expectedHash", validHash)
                                     .put(null)))
                 .isInstanceOf(NessieBadRequestException.class)
-                .hasMessage("Bad Request (HTTP/400): assignTag.assignTo: must not be null"),
+                .hasMessageStartingWith("Bad Request (HTTP/400):")
+                .hasMessageContaining(".assignTo: must not be null"),
         () ->
             assertThatThrownBy(
                     () ->
@@ -1854,22 +1853,22 @@ public abstract class AbstractTestRest {
     assertThatThrownBy(() -> api.getCommitLog().refName(invalidRef).get())
         .isInstanceOf(NessieBadRequestException.class)
         .hasMessageContaining("Bad Request (HTTP/400):")
-        .hasMessageContaining("getCommitLog.ref: " + REF_NAME_MESSAGE);
+        .hasMessageContaining(REF_NAME_MESSAGE);
 
     assertThatThrownBy(() -> api.getEntries().refName(invalidRef).get())
         .isInstanceOf(NessieBadRequestException.class)
         .hasMessageContaining("Bad Request (HTTP/400):")
-        .hasMessageContaining("getEntries.refName: " + REF_NAME_MESSAGE);
+        .hasMessageContaining(REF_NAME_MESSAGE);
 
     assertThatThrownBy(() -> api.getContent().key(key).refName(invalidRef).get())
         .isInstanceOf(NessieBadRequestException.class)
         .hasMessageContaining("Bad Request (HTTP/400):")
-        .hasMessageContaining(".ref: " + REF_NAME_MESSAGE);
+        .hasMessageContaining(REF_NAME_MESSAGE);
 
     assertThatThrownBy(() -> api.getContent().refName(invalidRef).key(key).get())
         .isInstanceOf(NessieBadRequestException.class)
         .hasMessageContaining("Bad Request (HTTP/400):")
-        .hasMessageContaining(".ref: " + REF_NAME_MESSAGE);
+        .hasMessageContaining(REF_NAME_MESSAGE);
   }
 
   @Test

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/ReferenceTypeParamConverterProvider.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/ReferenceTypeParamConverterProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.rest;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Locale;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Reference.ReferenceType;
+
+/**
+ * Provider for {@link ReferenceTypeParamConverter}, to convert between lower-case representations
+ * of {@link Reference.ReferenceType} in REST paths and upper-case in the Java enum..
+ */
+@Provider
+public class ReferenceTypeParamConverterProvider implements ParamConverterProvider {
+
+  private static final ReferenceTypeParamConverter REFERENCE_TYPE_PARAM_CONVERTER =
+      new ReferenceTypeParamConverter();
+
+  @Override
+  public <T> ParamConverter<T> getConverter(
+      Class<T> rawType, Type genericType, Annotation[] annotations) {
+    if (rawType == Reference.ReferenceType.class) {
+      @SuppressWarnings("unchecked")
+      ParamConverter<T> r = (ParamConverter<T>) REFERENCE_TYPE_PARAM_CONVERTER;
+      return r;
+    }
+    return null;
+  }
+
+  static final class ReferenceTypeParamConverter implements ParamConverter<ReferenceType> {
+
+    @Override
+    public ReferenceType fromString(String value) {
+      return ReferenceType.valueOf(value.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public String toString(ReferenceType value) {
+      return value.name().toLowerCase(Locale.ROOT);
+    }
+  }
+}

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -114,27 +114,20 @@ public class RestTreeResource implements HttpTreeApi {
   }
 
   @Override
-  public void assignTag(String tagName, String oldHash, Reference assignTo)
+  public void assignReference(
+      Reference.ReferenceType referenceType,
+      String referenceName,
+      String oldHash,
+      Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
-    resource().assignTag(tagName, oldHash, assignTo);
+    resource().assignReference(referenceType, referenceName, oldHash, assignTo);
   }
 
   @Override
-  public void deleteTag(String tagName, String hash)
+  public void deleteReference(
+      Reference.ReferenceType referenceType, String referenceName, String hash)
       throws NessieConflictException, NessieNotFoundException {
-    resource().deleteTag(tagName, hash);
-  }
-
-  @Override
-  public void assignBranch(String branchName, String oldHash, Reference assignTo)
-      throws NessieNotFoundException, NessieConflictException {
-    resource().assignBranch(branchName, oldHash, assignTo);
-  }
-
-  @Override
-  public void deleteBranch(String branchName, String hash)
-      throws NessieConflictException, NessieNotFoundException {
-    resource().deleteBranch(branchName, hash);
+    resource().deleteReference(referenceType, referenceName, hash);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefUtil.java
@@ -38,6 +38,19 @@ public final class RefUtil {
     throw new IllegalArgumentException(String.format("Unsupported reference '%s'", reference));
   }
 
+  public static NamedRef toNamedRef(Reference.ReferenceType referenceType, String referenceName) {
+    Objects.requireNonNull(referenceType, "referenceType must not be null");
+    switch (referenceType) {
+      case BRANCH:
+        return BranchName.of(referenceName);
+      case TAG:
+        return TagName.of(referenceName);
+      default:
+        throw new IllegalArgumentException(
+            String.format("Invalid reference type '%s'", referenceType));
+    }
+  }
+
   public static Reference toReference(NamedRef namedRef, Hash hash) {
     Objects.requireNonNull(namedRef, "namedRef must not be null");
     return toReference(namedRef, hash != null ? hash.asString() : null);

--- a/servers/services/src/test/java/org/projectnessie/services/impl/RefUtilTest.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/RefUtilTest.java
@@ -67,10 +67,30 @@ class RefUtilTest {
                       public ReferenceMetadata getMetadata() {
                         return null;
                       }
+
+                      @Override
+                      public ReferenceType getType() {
+                        return null;
+                      }
                     }))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith(
             "Unsupported reference 'org.projectnessie.services.impl.RefUtilTest");
+  }
+
+  @Test
+  void toNamedRefTyped() {
+    assertThat(RefUtil.toNamedRef(Reference.ReferenceType.BRANCH, REF_NAME))
+        .isEqualTo(BranchName.of(REF_NAME));
+    assertThat(RefUtil.toNamedRef(Reference.ReferenceType.TAG, REF_NAME))
+        .isEqualTo(TagName.of(REF_NAME));
+  }
+
+  @Test
+  void toNamedRefTypedErrors() {
+    assertThatThrownBy(() -> RefUtil.toNamedRef(null, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("referenceType must not be null");
   }
 
   @Test


### PR DESCRIPTION
Refactors the deleteBranch + deleteTag methods to deleteReference
and assignBranch + assignTag to assignReference.

The strings `tag` + `branch` in the REST paths become path
parameters based on an enum.

This is a non-breaking change for the REST API.

This eliminates duplicate code.