### PR TITLE
Save commit hash before assign operation in reflog

### DIFF
--- a/model/src/main/java/org/projectnessie/model/RefLogResponse.java
+++ b/model/src/main/java/org/projectnessie/model/RefLogResponse.java
@@ -70,8 +70,8 @@ public interface RefLogResponse extends PaginatedResponse {
     String getOperation();
 
     /**
-     * Single hash in case of MERGE. One or more hashes in case of TRANSPLANT. Empty list for other
-     * operations.
+     * Single hash in case of MERGE or ASSIGN. One or more hashes in case of TRANSPLANT. Empty list
+     * for other operations.
      */
     @NotNull
     List<String> getSourceHashes();

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -2468,5 +2468,14 @@ public abstract class AbstractTestRest {
         .isInstanceOf(NessieRefLogNotFoundException.class)
         .hasMessageContaining(
             "RefLog entry for 'f1234d75178d892a133a410355a5a990cf75d2f33eba25d575943d4df632f3a4' does not exist");
+    // verify source hashes for assign reference
+    assertThat(refLogResponse.getLogEntries().get(4).getSourceHashes())
+        .isEqualTo(Collections.singletonList(createdBranch1.getHash()));
+    // verify source hashes for merge
+    assertThat(refLogResponse.getLogEntries().get(3).getSourceHashes())
+        .isEqualTo(Collections.singletonList(branch0.getHash()));
+    // verify source hashes for transplant
+    assertThat(refLogResponse.getLogEntries().get(2).getSourceHashes())
+        .isEqualTo(Collections.singletonList(branch0.getHash()));
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/RefLog.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/RefLog.java
@@ -45,8 +45,8 @@ public interface RefLog {
   String getOperation();
 
   /**
-   * Single hash in case of MERGE. One or more hashes in case of TRANSPLANT. Empty list for other
-   * operations.
+   * Single hash in case of MERGE or ASSIGN. One or more hashes in case of TRANSPLANT. Empty list
+   * for other operations.
    */
   List<Hash> getSourceHashes();
 }

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -443,7 +443,8 @@ public abstract class NonTransactionalDatabaseAdapter<
           assignee,
           CasOpVariant.REF_UPDATE,
           (ctx, pointer, branchCommits, newKeyLists) -> {
-            verifyExpectedHash(branchHead(pointer, assignee), assignee, expectedHead);
+            Hash beforeAssign = branchHead(pointer, assignee);
+            verifyExpectedHash(beforeAssign, assignee, expectedHead);
 
             validateHashExists(ctx, assignTo);
 
@@ -460,7 +461,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                     assignTo,
                     RefLogEntry.Operation.ASSIGN_REFERENCE,
                     commitTimeInMicros(),
-                    Collections.emptyList());
+                    Collections.singletonList(beforeAssign));
 
             return updateGlobalStatePointer(
                 assignee, pointer, assignTo, newGlobalHead, newRefLogId.asBytes());

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -455,16 +455,16 @@ public abstract class TxDatabaseAdapter
       opLoop(
           assignee,
           true,
-          (conn, pointer) -> {
-            pointer = fetchNamedRefHead(conn, assignee);
+          (conn, assigneeHead) -> {
+            assigneeHead = fetchNamedRefHead(conn, assignee);
 
-            verifyExpectedHash(pointer, assignee, expectedHead);
+            verifyExpectedHash(assigneeHead, assignee, expectedHead);
 
             if (!NO_ANCESTOR.equals(assignTo) && fetchFromCommitLog(conn, assignTo) == null) {
               throw referenceNotFound(assignTo);
             }
 
-            Hash resultHash = tryMoveNamedReference(conn, assignee, pointer, assignTo);
+            Hash resultHash = tryMoveNamedReference(conn, assignee, assigneeHead, assignTo);
 
             commitRefLog(
                 conn,
@@ -472,7 +472,7 @@ public abstract class TxDatabaseAdapter
                 assignTo,
                 assignee,
                 AdapterTypes.RefLogEntry.Operation.ASSIGN_REFERENCE,
-                Collections.emptyList());
+                Collections.singletonList(assigneeHead));
 
             return resultHash;
           },

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/RefLogDetails.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/RefLogDetails.java
@@ -44,8 +44,8 @@ public interface RefLogDetails {
   String getOperation();
 
   /**
-   * Single hash in case of MERGE. One or more hashes in case of TRANSPLANT. Empty list for other
-   * operations.
+   * Single hash in case of MERGE or ASSIGN. One or more hashes in case of TRANSPLANT. Empty list
+   * for other operations.
    */
   List<Hash> getSourceHashes();
 }


### PR DESCRIPTION
New gc algorithm requires drop reference and assign reference reflog entry to fetch dead contents from the backend store. Delete reference already having commit hash info. So, storing commit hash before assign in the reflog source hashes field to use it for GC algorithm.