### PR TITLE
Skip integration tests by default for PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,11 +45,20 @@ jobs:
     - name: Setup Java, Maven, Gradle
       uses: ./.github/actions/dev-tool-java
 
+    - name: Config
+      run: |
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'pr-with-ITs') }}" == "false" ]]; then
+          echo "Skipping integration tests"
+        fi
+
     - name: Build with Maven
       env:
         SPARK_LOCAL_IP: localhost
       run: |
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage -Dtest.log.level=WARN
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'pr-with-ITs') }}" == "false" ]]; then
+          ITS="-PwithoutITs"
+        fi
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage -Dtest.log.level=WARN ${ITS}
 
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build

--- a/pom.xml
+++ b/pom.xml
@@ -1421,6 +1421,12 @@ limitations under the License.
       </modules>
     </profile>
     <profile>
+      <id>withoutITs</id>
+      <properties>
+        <skipITs>true</skipITs>
+      </properties>
+    </profile>
+    <profile>
       <id>build-quickly</id>
       <activation>
         <property>


### PR DESCRIPTION
Introduces a new Maven profile `withoutITs`.

PRs run without integration tests by default. The new label `pr-with-ITs` enables running ITs.

This improves CI runtime for PRs from ~30 minutes to <20 minutes.