### PR TITLE
Filter support for reflog and streamUtil implementation

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -26,7 +26,8 @@ import org.projectnessie.model.Validation;
  *
  * @since {@link NessieApiV1}
  */
-public interface GetRefLogBuilder extends PagingBuilder<GetRefLogBuilder> {
+public interface GetRefLogBuilder
+    extends PagingBuilder<GetRefLogBuilder>, QueryBuilder<GetRefLogBuilder> {
 
   /**
    * Hash of the reflog (inclusive) to start from (in chronological sense), the 'far' end of the

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpRefLogClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpRefLogClient.java
@@ -38,6 +38,7 @@ class HttpRefLogClient implements HttpRefLogApi {
         .queryParam("pageToken", params.pageToken())
         .queryParam("startHash", params.startHash())
         .queryParam("endHash", params.endHash())
+        .queryParam("filter", params.filter())
         .get()
         .readEntity(RefLogResponse.class);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
@@ -42,6 +42,12 @@ final class HttpGetRefLog extends BaseHttpRequest implements GetRefLogBuilder {
   }
 
   @Override
+  public GetRefLogBuilder filter(String filter) {
+    params.filter(filter);
+    return this;
+  }
+
+  @Override
   public GetRefLogBuilder maxRecords(int maxRecords) {
     params.maxRecords(maxRecords);
     return this;

--- a/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
@@ -51,6 +51,7 @@ public class CommitLogParams extends AbstractParams {
   @QueryParam("endHash")
   private String endHash;
 
+  @Nullable
   @Parameter(
       description =
           "A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.\n\n"

--- a/model/src/main/java/org/projectnessie/api/params/RefLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/RefLogParams.java
@@ -52,16 +52,31 @@ public class RefLogParams extends AbstractParams {
   @QueryParam("endHash")
   private String endHash;
 
+  @Nullable
+  @Parameter(
+      description =
+          "A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.\n\n"
+              + "Usable variables within the expression are:\n\n"
+              + "- 'reflog' with fields 'refLogId' (string), 'refName' (string), 'commitHash' (string), 'parentRefLogId' "
+              + "(string), ',operation' (string), 'operationTime' (long)\n\n"
+              + "Hint: when filtering entries, you can determine whether entries are \"missing\" (filtered) by "
+              + "checking whether 'ReflogResponseEntry.parentRefLogId' is different from the hash of the previous "
+              + "reflog in the log response.")
+  @QueryParam("filter")
+  private String filter;
+
   public RefLogParams() {}
 
-  private RefLogParams(String startHash, String endHash, Integer maxRecords, String pageToken) {
+  private RefLogParams(
+      String startHash, String endHash, Integer maxRecords, String pageToken, String filter) {
     super(maxRecords, pageToken);
     this.startHash = startHash;
     this.endHash = endHash;
+    this.filter = filter;
   }
 
   private RefLogParams(Builder builder) {
-    this(builder.startHash, builder.endHash, builder.maxRecords, builder.pageToken);
+    this(builder.startHash, builder.endHash, builder.maxRecords, builder.pageToken, builder.filter);
   }
 
   @Nullable
@@ -72,6 +87,11 @@ public class RefLogParams extends AbstractParams {
   @Nullable
   public String endHash() {
     return endHash;
+  }
+
+  @Nullable
+  public String filter() {
+    return filter;
   }
 
   public static RefLogParams.Builder builder() {
@@ -87,6 +107,7 @@ public class RefLogParams extends AbstractParams {
     return new StringJoiner(", ", RefLogParams.class.getSimpleName() + "[", "]")
         .add("startHash='" + startHash + "'")
         .add("endHash='" + endHash + "'")
+        .add("filter='" + filter + "'")
         .add("maxRecords=" + maxRecords())
         .add("pageToken='" + pageToken() + "'")
         .toString();
@@ -103,19 +124,21 @@ public class RefLogParams extends AbstractParams {
     RefLogParams that = (RefLogParams) o;
     return Objects.equals(startHash, that.startHash)
         && Objects.equals(endHash, that.endHash)
+        && Objects.equals(filter, that.filter)
         && Objects.equals(maxRecords(), that.maxRecords())
         && Objects.equals(pageToken(), that.pageToken());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startHash, endHash, maxRecords(), pageToken());
+    return Objects.hash(startHash, endHash, filter, maxRecords(), pageToken());
   }
 
   public static class Builder extends AbstractParams.Builder<Builder> {
 
     private String startHash;
     private String endHash;
+    private String filter;
 
     private Builder() {}
 
@@ -129,9 +152,15 @@ public class RefLogParams extends AbstractParams {
       return this;
     }
 
+    public Builder filter(String filter) {
+      this.filter = filter;
+      return this;
+    }
+
     public Builder from(RefLogParams params) {
       return startHash(params.startHash)
           .endHash(params.endHash)
+          .filter(params.filter)
           .maxRecords(params.maxRecords())
           .pageToken(params.pageToken());
     }

--- a/model/src/test/java/org/projectnessie/api/params/RefLogParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/RefLogParamsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.params;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+public class RefLogParamsTest {
+
+  @Test
+  public void testBuilder() {
+    Integer maxRecords = 23;
+    String startHash = "1234567890123456";
+    String endHash = "00000";
+    String pageToken = "aabbcc";
+    String filter = "some_expression";
+
+    Supplier<RefLogParams> generator =
+        () ->
+            RefLogParams.builder()
+                .filter(filter)
+                .maxRecords(maxRecords)
+                .pageToken(pageToken)
+                .startHash(startHash)
+                .endHash(endHash)
+                .build();
+
+    verify(maxRecords, startHash, endHash, pageToken, filter, generator);
+  }
+
+  @Test
+  public void testEmpty() {
+    verify(null, null, null, null, null, RefLogParams::empty);
+  }
+
+  private void verify(
+      Integer maxRecords,
+      String startHash,
+      String endHash,
+      String pageToken,
+      String filter,
+      Supplier<RefLogParams> generator) {
+    assertThat(generator.get())
+        .isEqualTo(generator.get())
+        .extracting(
+            RefLogParams::pageToken,
+            RefLogParams::maxRecords,
+            RefLogParams::filter,
+            RefLogParams::startHash,
+            RefLogParams::endHash,
+            RefLogParams::hashCode)
+        .containsExactly(
+            pageToken, maxRecords, filter, startHash, endHash, generator.get().hashCode());
+  }
+}

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -29,6 +29,7 @@ import org.projectnessie.model.Namespace;
 import org.projectnessie.model.Operation;
 import org.projectnessie.model.Operation.Delete;
 import org.projectnessie.model.Operation.Put;
+import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferenceMetadata;
 
@@ -50,6 +51,7 @@ public class CELUtil {
   public static final String VAR_ROLE = "role";
   public static final String VAR_OP = "op";
   public static final String VAR_OPERATIONS = "operations";
+  public static final String VAR_REFLOG = "reflog";
 
   public static final List<Decl> REFERENCES_DECLARATIONS =
       ImmutableList.of(
@@ -81,12 +83,20 @@ public class CELUtil {
   public static final List<Object> COMMIT_LOG_TYPES =
       ImmutableList.of(CommitMeta.class, OperationForCel.class, ContentKey.class, Namespace.class);
 
+  public static final List<Object> REFLOG_TYPES =
+      ImmutableList.of(RefLogResponse.RefLogResponseEntry.class);
+
   public static final List<Object> REFERENCES_TYPES =
       ImmutableList.of(CommitMeta.class, ReferenceMetadata.class, Reference.class);
 
   public static final CommitMeta EMPTY_COMMIT_META = CommitMeta.fromMessage("");
   public static final ReferenceMetadata EMPTY_REFERENCE_METADATA =
       ImmutableReferenceMetadata.builder().commitMetaOfHEAD(EMPTY_COMMIT_META).build();
+
+  public static final List<Decl> REFLOG_DECLARATIONS =
+      ImmutableList.of(
+          Decls.newVar(
+              VAR_REFLOG, Decls.newObjectType(RefLogResponse.RefLogResponseEntry.class.getName())));
 
   /**
    * 'Mirrored' interface wrapping a {@link Operation} for CEL to have convenience fields for CEL


### PR DESCRIPTION
For new GC algorithm, need to filter just DELETE_REFERENCE and ASSIGN_REFERENCE reflog entries from the backend store. Having CEL filter can help in reducing the data in HTTP response by providing the filtered results.