### PR TITLE
Do not start Nessie during "verify" whith "skipITs"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,15 @@ on the new feature or improvement.
 
 ## Code changes
 
+### Maven tips
+
+A `./mvnw clean install` runs basically "everything" except release/deployment stuff. This is often
+not necessary. Some tips:
+
+* `./mvnw -Dquickly` Just compiles code, no tests, does not build code under `ui/` and `perftest/`.
+* `./mvnw -DskipTests` Compiles everything, runs no tests.
+* `./mvnw -DskipITs` Compiles everything, runs unit tests, but no integration tests.
+
 ### Development process
 
 The development process doesn't contain many surprises. As most projects on github anyone can contribute by

--- a/clients/deltalake/pom.xml
+++ b/clients/deltalake/pom.xml
@@ -204,7 +204,7 @@
         <artifactId>nessie-apprunner-maven-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>
-          <skip>${skipTests}</skip>
+          <skip>${skipITs}</skip>
           <appArtifactId>org.projectnessie:nessie-quarkus:${project.version}</appArtifactId>
           <systemProperties>
             <!-- disable devservices to stop Quarkus from starting Mongo via testcontainers -->

--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -139,7 +139,7 @@
         <artifactId>nessie-apprunner-maven-plugin</artifactId>
         <version>${client.nessie.version}</version>
         <configuration>
-          <skip>${skipTests}</skip>
+          <skip>${skipITs}</skip>
           <appArtifactId>org.projectnessie:nessie-quarkus:${client.nessie.version}</appArtifactId>
           <systemProperties>
             <!-- disable devservices to stop Quarkus from starting Mongo via testcontainers -->

--- a/perftest/simulations/pom.xml
+++ b/perftest/simulations/pom.xml
@@ -54,7 +54,7 @@
             <phase>pre-integration-test</phase>
             <goals><goal>start</goal></goals>
             <configuration>
-              <skip>${skipTests}</skip>
+              <skip>${skipITs}</skip>
               <name>nessie</name>
               <waitAfterLaunch>1</waitAfterLaunch>
               <workingDir>${project.basedir}</workingDir>
@@ -88,7 +88,7 @@
           </execution>
         </executions>
         <configuration>
-          <skip>${skipTests}</skip>
+          <skip>${skipITs}</skip>
           <jvmArgs>
             <jvmArg>-Dsim.users=10</jvmArg>
           </jvmArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -1437,5 +1437,17 @@ limitations under the License.
         <defaultGoal>clean install</defaultGoal>
       </build>
     </profile>
+    <profile>
+      <id>skipOnSkipTests</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <skipITs>true</skipITs>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/tools/content-generator/pom.xml
+++ b/tools/content-generator/pom.xml
@@ -167,7 +167,7 @@
         <artifactId>nessie-apprunner-maven-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>
-          <skip>${skipTests}</skip>
+          <skip>${skipITs}</skip>
           <appArtifactId>org.projectnessie:nessie-quarkus:${project.version}</appArtifactId>
           <systemProperties>
             <!-- disable devservices to stop Quarkus from starting Mongo via testcontainers -->


### PR DESCRIPTION
Updates the pom.xml files to not even run the app-runner or the nessie Maven plugins with `-DskipITs=true`.

Also update `CONTRIBUTING.md`