### PR TITLE
Do not download openapi-tools all the time

### DIFF
--- a/ui/openapitools.json
+++ b/ui/openapitools.json
@@ -2,6 +2,7 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "5.1.1"
+    "version": "5.1.1",
+    "storageDir": "~/.m2/openapi-generator-cli"
   }
 }


### PR DESCRIPTION
Uses a custom storage directory to prevent downloading the openapi-tools for every `./mvnw clean install`

Note: a jar for the exact openapi-tools version to be used lands in that directory.