### PR TITLE
Exclude the `META-INF/openapi.yaml` template file

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -115,6 +115,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>META-INF/openapi.yaml</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
`nessie-model.jar` includes both the "template" `META-INF/openapi.yaml` and the actual `META-INF/openapi/openapi.yaml`, which is confusing.

This change excludes the template file from the generated jar.