### PR TITLE
Add hashOnRef to DiffApi from + to

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetDiffBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetDiffBuilder.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.api;
 
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.DiffResponse;
+import org.projectnessie.model.Reference;
 
 /**
  * Request builder for retrieving a diff between two references.
@@ -27,7 +28,27 @@ public interface GetDiffBuilder {
 
   GetDiffBuilder fromRefName(String fromRefName);
 
+  GetDiffBuilder fromHashOnRef(String fromHashOnRef);
+
+  default GetDiffBuilder fromRef(Reference fromRef) {
+    GetDiffBuilder r = fromRefName(fromRef.getName());
+    if (fromRef.getHash() != null) {
+      r = r.fromHashOnRef(fromRef.getHash());
+    }
+    return r;
+  }
+
   GetDiffBuilder toRefName(String toRefName);
+
+  GetDiffBuilder toHashOnRef(String toHashOnRef);
+
+  default GetDiffBuilder toRef(Reference toRef) {
+    GetDiffBuilder r = toRefName(toRef.getName());
+    if (toRef.getHash() != null) {
+      r = r.toHashOnRef(toRef.getHash());
+    }
+    return r;
+  }
 
   DiffResponse get() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpDiffClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpDiffClient.java
@@ -33,9 +33,14 @@ class HttpDiffClient implements HttpDiffApi {
   public DiffResponse getDiff(@NotNull DiffParams params) throws NessieNotFoundException {
     return client
         .newRequest()
-        .path("diffs/{fromRef}...{toRef}")
+        .path("diffs/{fromRef}{fromHashOnRef}...{toRef}{toHashOnRef}")
         .resolveTemplate("fromRef", params.getFromRef())
         .resolveTemplate("toRef", params.getToRef())
+        .resolveTemplate(
+            "fromHashOnRef",
+            params.getFromHashOnRef() != null ? "*" + params.getFromHashOnRef() : "")
+        .resolveTemplate(
+            "toHashOnRef", params.getToHashOnRef() != null ? "*" + params.getToHashOnRef() : "")
         .get()
         .readEntity(DiffResponse.class);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetDiff.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetDiff.java
@@ -36,8 +36,20 @@ final class HttpGetDiff extends BaseHttpRequest implements GetDiffBuilder {
   }
 
   @Override
+  public GetDiffBuilder fromHashOnRef(String fromHashOnRef) {
+    builder.fromHashOnRef(fromHashOnRef);
+    return this;
+  }
+
+  @Override
   public GetDiffBuilder toRefName(String toRefName) {
     builder.toRef(toRefName);
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder toHashOnRef(String toHashOnRef) {
+    builder.toHashOnRef(toHashOnRef);
     return this;
   }
 

--- a/model/src/main/java/org/projectnessie/api/http/HttpDiffApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpDiffApi.java
@@ -38,8 +38,20 @@ public interface HttpDiffApi extends DiffApi {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("{fromRef}...{toRef}")
-  @Operation(summary = "Get a diff for two given references")
+  @Path(
+      "{fromRef : [^*]+}{f : [*]?}{fromHashOnRef : ([^.]*)?}...{toRef : [^*]+}{t : [*]?}{toHashOnRef : ([^.]*)?}")
+  @Operation(
+      summary = "Get a diff for two given references",
+      description =
+          "The URL pattern is basically 'from' and 'to' separated by '...' (three dots). "
+              + "'from' and 'to' must start with a reference name, optionally followed by hash on "
+              + "that reference, the hash prefixed with the'*' character.\n"
+              + "\n"
+              + "Examples: \n"
+              + "  diffs/main...myBranch\n"
+              + "  diffs/main...myBranch*1234567890123456\n"
+              + "  diffs/main*1234567890123456...myBranch\n"
+              + "  diffs/main*1234567890123456...myBranch*1234567890123456\n")
   @APIResponses({
     @APIResponse(
         responseCode = "200",

--- a/model/src/main/java/org/projectnessie/api/params/DiffParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/DiffParams.java
@@ -16,6 +16,7 @@
 package org.projectnessie.api.params;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.ws.rs.PathParam;
@@ -25,6 +26,8 @@ import org.projectnessie.model.Validation;
 
 public class DiffParams {
 
+  public static final String HASH_OPTIONAL_REGEX = "(" + Validation.HASH_REGEX + ")?";
+
   @NotNull
   @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
   @Parameter(
@@ -32,6 +35,14 @@ public class DiffParams {
       examples = {@ExampleObject(ref = "ref")})
   @PathParam("fromRef")
   private String fromRef;
+
+  @Nullable
+  @Pattern(regexp = HASH_OPTIONAL_REGEX, message = Validation.HASH_MESSAGE)
+  @Parameter(
+      description = "Optional hash on the 'from' reference to start the diff from",
+      examples = {@ExampleObject(ref = "hash")})
+  @PathParam("fromHashOnRef")
+  private String fromHashOnRef;
 
   @NotNull
   @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
@@ -41,23 +52,54 @@ public class DiffParams {
   @PathParam("toRef")
   private String toRef;
 
+  @Nullable
+  @Pattern(regexp = HASH_OPTIONAL_REGEX, message = Validation.HASH_MESSAGE)
+  @Parameter(
+      description = "Optional hash on the 'to' reference to end the diff at.",
+      examples = {@ExampleObject(ref = "hash")})
+  @PathParam("toHashOnRef")
+  private String toHashOnRef;
+
   public DiffParams() {}
 
-  private DiffParams(String fromRef, String toRef) {
+  private DiffParams(String fromRef, String fromHashOnRef, String toRef, String toHashOnRef) {
     this.fromRef = fromRef;
+    this.fromHashOnRef = fromHashOnRef;
     this.toRef = toRef;
+    this.toHashOnRef = toHashOnRef;
   }
 
   private DiffParams(Builder builder) {
-    this(builder.fromRef, builder.toRef);
+    this(builder.fromRef, builder.fromHashOnRef, builder.toRef, builder.toHashOnRef);
   }
 
   public String getFromRef() {
     return fromRef;
   }
 
+  public String getFromHashOnRef() {
+    return emptyToNull(fromHashOnRef);
+  }
+
   public String getToRef() {
     return toRef;
+  }
+
+  public String getToHashOnRef() {
+    return emptyToNull(toHashOnRef);
+  }
+
+  private static String emptyToNull(String s) {
+    if (s == null || s.isEmpty()) {
+      return null;
+    }
+    if (s.charAt(0) == '*') {
+      if (s.length() == 1) {
+        return null;
+      }
+      return s.substring(1);
+    }
+    return s;
   }
 
   public static DiffParams.Builder builder() {
@@ -73,22 +115,30 @@ public class DiffParams {
       return false;
     }
     DiffParams that = (DiffParams) o;
-    return Objects.equals(fromRef, that.fromRef) && Objects.equals(toRef, that.toRef);
+    return Objects.equals(fromRef, that.fromRef)
+        && Objects.equals(fromHashOnRef, that.fromHashOnRef)
+        && Objects.equals(toRef, that.toRef)
+        && Objects.equals(toHashOnRef, that.toHashOnRef);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(fromRef, toRef);
+    return Objects.hash(fromRef, fromHashOnRef, toRef, toHashOnRef);
   }
 
   public static class Builder {
     private String fromRef;
+    private String fromHashOnRef;
     private String toRef;
+    private String toHashOnRef;
 
     public Builder() {}
 
     public Builder from(DiffParams params) {
-      return fromRef(params.fromRef).toRef(params.toRef);
+      return fromRef(params.fromRef)
+          .fromHashOnRef(params.fromHashOnRef)
+          .toRef(params.toRef)
+          .toHashOnRef(params.toHashOnRef);
     }
 
     public Builder fromRef(String fromRef) {
@@ -96,8 +146,18 @@ public class DiffParams {
       return this;
     }
 
+    public Builder fromHashOnRef(String fromHashOnRef) {
+      this.fromHashOnRef = fromHashOnRef;
+      return this;
+    }
+
     public Builder toRef(String toRef) {
       this.toRef = toRef;
+      return this;
+    }
+
+    public Builder toHashOnRef(String toHashOnRef) {
+      this.toHashOnRef = toHashOnRef;
       return this;
     }
 

--- a/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/model/src/main/java/org/projectnessie/model/Validation.java
@@ -25,11 +25,14 @@ import java.util.regex.Pattern;
 
 /** Collection of validation rules. */
 public final class Validation {
-  public static final String HASH_REGEX = "^[0-9a-fA-F]{8,64}$";
-  public static final String REF_NAME_REGEX =
-      "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9._-])?$";
+
+  public static final String HASH_RAW_REGEX = "[0-9a-fA-F]{8,64}";
+  public static final String HASH_REGEX = "^" + HASH_RAW_REGEX + "$";
+  public static final String REF_NAME_RAW_REGEX =
+      "[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9._-])";
+  public static final String REF_NAME_REGEX = "^" + REF_NAME_RAW_REGEX + "?$";
   public static final String REF_NAME_OR_HASH_REGEX =
-      "^(([0-9a-fA-F]{8,64})|([A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9._-])?))$";
+      "^((" + HASH_RAW_REGEX + ")|(" + REF_NAME_RAW_REGEX + "?))$";
 
   public static final Pattern HASH_PATTERN = Pattern.compile(HASH_REGEX);
   public static final Pattern REF_NAME_PATTERN = Pattern.compile(REF_NAME_REGEX);

--- a/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/model/src/main/java/org/projectnessie/model/Validation.java
@@ -29,10 +29,10 @@ public final class Validation {
   public static final String HASH_RAW_REGEX = "[0-9a-fA-F]{8,64}";
   public static final String HASH_REGEX = "^" + HASH_RAW_REGEX + "$";
   public static final String REF_NAME_RAW_REGEX =
-      "[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9._-])";
-  public static final String REF_NAME_REGEX = "^" + REF_NAME_RAW_REGEX + "?$";
+      "[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?";
+  public static final String REF_NAME_REGEX = "^" + REF_NAME_RAW_REGEX + "$";
   public static final String REF_NAME_OR_HASH_REGEX =
-      "^((" + HASH_RAW_REGEX + ")|(" + REF_NAME_RAW_REGEX + "?))$";
+      "^((" + HASH_RAW_REGEX + ")|(" + REF_NAME_RAW_REGEX + "))$";
 
   public static final Pattern HASH_PATTERN = Pattern.compile(HASH_REGEX);
   public static final Pattern REF_NAME_PATTERN = Pattern.compile(REF_NAME_REGEX);
@@ -40,8 +40,8 @@ public final class Validation {
 
   private static final String HASH_RULE = "consist of the hex representation of 4-32 bytes";
   private static final String REF_RULE =
-      "start with a letter, followed by letters, digits, a ./_- character, "
-          + "not end with a slash, not contain ..";
+      "start with a letter, followed by letters, digits, one of the ./_- characters, "
+          + "not end with a slash or dot, not contain '..'";
 
   public static final String HASH_MESSAGE = "Hash must " + HASH_RULE;
   public static final String REF_NAME_MESSAGE = "Reference name must " + REF_RULE;

--- a/model/src/test/java/org/projectnessie/api/params/DiffParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/DiffParamsTest.java
@@ -24,9 +24,36 @@ public class DiffParamsTest {
 
   @Test
   public void testBuilder() {
-    DiffParams params = DiffParams.builder().fromRef("from").toRef("to").build();
-    assertThat(params.getFromRef()).isEqualTo("from");
-    assertThat(params.getToRef()).isEqualTo("to");
+    DiffParams params =
+        DiffParams.builder()
+            .fromRef("from")
+            .fromHashOnRef("fromHash")
+            .toRef("to")
+            .toHashOnRef("toHash")
+            .build();
+    assertThat(params)
+        .extracting(
+            DiffParams::getFromRef,
+            DiffParams::getFromHashOnRef,
+            DiffParams::getToRef,
+            DiffParams::getToHashOnRef)
+        .containsExactly("from", "fromHash", "to", "toHash");
+    params = DiffParams.builder().fromRef("from").toRef("to").toHashOnRef("toHash").build();
+    assertThat(params)
+        .extracting(
+            DiffParams::getFromRef,
+            DiffParams::getFromHashOnRef,
+            DiffParams::getToRef,
+            DiffParams::getToHashOnRef)
+        .containsExactly("from", null, "to", "toHash");
+    params = DiffParams.builder().fromRef("from").toRef("to").build();
+    assertThat(params)
+        .extracting(
+            DiffParams::getFromRef,
+            DiffParams::getFromHashOnRef,
+            DiffParams::getToRef,
+            DiffParams::getToHashOnRef)
+        .containsExactly("from", null, "to", null);
   }
 
   @Test


### PR DESCRIPTION
Support "hashOnRef" on the `diffs/` endpoint for both "from" and "to".

The change is backwards compatible for older clients (older clients continue to work, newer clients may include the hashOnRef, which is not understood by older servers).

Example paths:
* `diffs/main...myBranch`
* `diffs/main...myBranch*1234567890123456`
* `diffs/main*1234567890123456...myBranch`
* `diffs/main*1234567890123456...myBranch*1234567890123456`

It's using the `*` character to separate the reference name from the hash, because that's one of the few characters that are not HTTP-escaped.