### PR TITLE
Allow testing `AccessChecker` via `NessieJaxrsExtension`

### DIFF
--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieAccessChecker.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieAccessChecker.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.jaxrs.ext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for JUnit5 method parameters that receives a {@code Consumer<SecurityContext>} that a
+ * test can use to configure a custom security context.
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface NessieAccessChecker {}

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/PrincipalSecurityContext.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/PrincipalSecurityContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.jaxrs.ext;
+
+import java.security.Principal;
+import javax.ws.rs.core.SecurityContext;
+
+public class PrincipalSecurityContext implements SecurityContext {
+  private final Principal principal;
+
+  private PrincipalSecurityContext(String principalName) {
+    principal = () -> principalName;
+  }
+
+  public static SecurityContext forName(String principalName) {
+    return new PrincipalSecurityContext(principalName);
+  }
+
+  @Override
+  public Principal getUserPrincipal() {
+    return principal;
+  }
+
+  @Override
+  public boolean isUserInRole(String role) {
+    return false;
+  }
+
+  @Override
+  public boolean isSecure() {
+    return false;
+  }
+
+  @Override
+  public String getAuthenticationScheme() {
+    return null;
+  }
+}

--- a/servers/jax-rs/src/main/java/org/projectnessie/services/authz/AccessCheckerExtension.java
+++ b/servers/jax-rs/src/main/java/org/projectnessie/services/authz/AccessCheckerExtension.java
@@ -16,6 +16,7 @@
 package org.projectnessie.services.authz;
 
 import java.security.AccessControlException;
+import java.util.function.Supplier;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
@@ -27,44 +28,92 @@ import org.projectnessie.versioned.NamedRef;
 
 /** This class needs to be in the same package as {@link AccessChecker}. */
 public class AccessCheckerExtension implements Extension {
-  public static final AccessChecker ACCESS_CHECKER =
+  private static final AccessChecker NOOP_ACCESS_CHECKER = new DefaultAccessChecker();
+
+  private volatile Supplier<AccessChecker> accessCheckerSupplier;
+
+  private AccessChecker accessCheckerInstance() {
+    Supplier<AccessChecker> supplier = accessCheckerSupplier;
+    AccessChecker instance = supplier != null ? supplier.get() : null;
+    return instance != null ? instance : NOOP_ACCESS_CHECKER;
+  }
+
+  private final AccessChecker delegator =
       new AccessChecker() {
         @Override
-        public void canViewReference(AccessContext context, NamedRef ref) {}
+        public void canViewReference(AccessContext context, NamedRef ref)
+            throws AccessControlException {
+          accessCheckerInstance().canViewReference(context, ref);
+        }
 
         @Override
-        public void canCreateReference(AccessContext context, NamedRef ref) {}
+        public void canCreateReference(AccessContext context, NamedRef ref)
+            throws AccessControlException {
+          accessCheckerInstance().canCreateReference(context, ref);
+        }
 
         @Override
-        public void canAssignRefToHash(AccessContext context, NamedRef ref) {}
+        public void canAssignRefToHash(AccessContext context, NamedRef ref)
+            throws AccessControlException {
+          accessCheckerInstance().canAssignRefToHash(context, ref);
+        }
 
         @Override
-        public void canDeleteReference(AccessContext context, NamedRef ref) {}
+        public void canDeleteReference(AccessContext context, NamedRef ref)
+            throws AccessControlException {
+          accessCheckerInstance().canDeleteReference(context, ref);
+        }
 
         @Override
-        public void canReadEntries(AccessContext context, NamedRef ref) {}
+        public void canReadEntries(AccessContext context, NamedRef ref)
+            throws AccessControlException {
+          accessCheckerInstance().canReadEntries(context, ref);
+        }
 
         @Override
-        public void canListCommitLog(AccessContext context, NamedRef ref) {}
+        public void canListCommitLog(AccessContext context, NamedRef ref)
+            throws AccessControlException {
+          accessCheckerInstance().canListCommitLog(context, ref);
+        }
 
         @Override
-        public void canCommitChangeAgainstReference(AccessContext context, NamedRef ref) {}
+        public void canCommitChangeAgainstReference(AccessContext context, NamedRef ref)
+            throws AccessControlException {
+          accessCheckerInstance().canCommitChangeAgainstReference(context, ref);
+        }
 
         @Override
         public void canReadEntityValue(
-            AccessContext context, NamedRef ref, ContentKey key, String contentId) {}
+            AccessContext context, NamedRef ref, ContentKey key, String contentId)
+            throws AccessControlException {
+          accessCheckerInstance().canReadEntityValue(context, ref, key, contentId);
+        }
 
         @Override
         public void canUpdateEntity(
-            AccessContext context, NamedRef ref, ContentKey key, String contentId) {}
+            AccessContext context, NamedRef ref, ContentKey key, String contentId)
+            throws AccessControlException {
+          accessCheckerInstance().canUpdateEntity(context, ref, key, contentId);
+        }
 
         @Override
         public void canDeleteEntity(
-            AccessContext context, NamedRef ref, ContentKey key, String contentId) {}
+            AccessContext context, NamedRef ref, ContentKey key, String contentId)
+            throws AccessControlException {
+          accessCheckerInstance().canDeleteEntity(context, ref, key, contentId);
+        }
 
         @Override
-        public void canViewRefLog(AccessContext context) throws AccessControlException {}
+        public void canViewRefLog(AccessContext context) throws AccessControlException {
+          accessCheckerInstance().canViewRefLog(context);
+        }
       };
+
+  public AccessCheckerExtension setAccessCheckerSupplier(
+      Supplier<AccessChecker> accessCheckerSupplier) {
+    this.accessCheckerSupplier = accessCheckerSupplier;
+    return this;
+  }
 
   @SuppressWarnings("unused")
   public void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager bm) {
@@ -72,6 +121,6 @@ public class AccessCheckerExtension implements Extension {
         .addType(AccessChecker.class)
         .addQualifier(Default.Literal.INSTANCE)
         .scope(ApplicationScoped.class)
-        .produceWith(i -> ACCESS_CHECKER);
+        .produceWith(i -> delegator);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/DefaultAccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/DefaultAccessChecker.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.authz;
+
+import java.security.AccessControlException;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.versioned.NamedRef;
+
+public class DefaultAccessChecker implements AccessChecker {
+
+  @Override
+  public void canViewReference(AccessContext context, NamedRef ref) throws AccessControlException {}
+
+  @Override
+  public void canCreateReference(AccessContext context, NamedRef ref)
+      throws AccessControlException {}
+
+  @Override
+  public void canAssignRefToHash(AccessContext context, NamedRef ref)
+      throws AccessControlException {}
+
+  @Override
+  public void canDeleteReference(AccessContext context, NamedRef ref)
+      throws AccessControlException {}
+
+  @Override
+  public void canReadEntries(AccessContext context, NamedRef ref) throws AccessControlException {}
+
+  @Override
+  public void canListCommitLog(AccessContext context, NamedRef ref) throws AccessControlException {}
+
+  @Override
+  public void canCommitChangeAgainstReference(AccessContext context, NamedRef ref)
+      throws AccessControlException {}
+
+  @Override
+  public void canReadEntityValue(
+      AccessContext context, NamedRef ref, ContentKey key, String contentId)
+      throws AccessControlException {}
+
+  @Override
+  public void canUpdateEntity(AccessContext context, NamedRef ref, ContentKey key, String contentId)
+      throws AccessControlException {}
+
+  @Override
+  public void canDeleteEntity(AccessContext context, NamedRef ref, ContentKey key, String contentId)
+      throws AccessControlException {}
+
+  @Override
+  public void canViewRefLog(AccessContext context) throws AccessControlException {}
+}


### PR DESCRIPTION
This allows upcoming PR(s) to run tests in nessie-jaxrs-tests via Jersey that supply mocked/custom `AccessContext` implementations. Also adds a convenience `DefaultAccessContext` implementation.