### PR TITLE
Only allow reference-names for get-reference REST endpoint

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetReferenceBuilder.java
@@ -29,10 +29,7 @@ import org.projectnessie.model.Validation;
  */
 public interface GetReferenceBuilder {
   GetReferenceBuilder refName(
-      @NotNull
-          @Pattern(
-              regexp = Validation.REF_NAME_OR_HASH_REGEX,
-              message = Validation.REF_NAME_OR_HASH_MESSAGE)
+      @NotNull @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String refName);
 
   /**

--- a/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
@@ -33,9 +33,7 @@ public class GetReferenceParams {
       examples = {@ExampleObject(ref = "ref")})
   @PathParam("ref")
   @NotNull
-  @Pattern(
-      regexp = Validation.REF_NAME_OR_HASH_REGEX,
-      message = Validation.REF_NAME_OR_HASH_MESSAGE)
+  @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
   private String refName;
 
   @Parameter(

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestInvalidWithHttp.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestInvalidWithHttp.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.projectnessie.model.Validation.HASH_MESSAGE;
 import static org.projectnessie.model.Validation.REF_NAME_MESSAGE;
-import static org.projectnessie.model.Validation.REF_NAME_OR_HASH_MESSAGE;
 
 import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.function.Executable;
@@ -106,7 +105,7 @@ public abstract class AbstractRestInvalidWithHttp extends AbstractRestInvalidRef
             assertThatThrownBy(() -> getApi().getReference().refName(invalidBranchName).get())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(REF_NAME_OR_HASH_MESSAGE),
+                .hasMessageContaining(REF_NAME_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->


### PR DESCRIPTION
The REST endpoint implements "get reference by name", allowing a commit-ID does not make much sense.