### PR TITLE
Allow fetching commit log from hash for dead reference for reflog user

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestInvalidRefs.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestInvalidRefs.java
@@ -118,9 +118,7 @@ public abstract class AbstractRestInvalidRefs extends AbstractRestEntries {
     assertThatThrownBy(
             () -> getApi().getCommitLog().refName(branch.getName()).hashOnRef(invalidHash).get())
         .isInstanceOf(NessieNotFoundException.class)
-        .hasMessageContaining(
-            String.format(
-                "Could not find commit '%s' in reference '%s'.", invalidHash, branch.getName()));
+        .hasMessageContaining(String.format("Commit '%s' not found", invalidHash));
 
     assertThatThrownBy(
             () -> getApi().getEntries().refName(branch.getName()).hashOnRef(invalidHash).get())

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -266,10 +266,14 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
             MAX_COMMIT_LOG_ENTRIES);
 
     // we should only allow named references when no paging is defined
-    Ref endRef =
-        namedRefWithHashOrThrow(
-                namedRef, null == params.pageToken() ? params.endHash() : params.pageToken())
-            .getHash();
+    String hash = null == params.pageToken() ? params.endHash() : params.pageToken();
+    Ref endRef;
+    if (hash == null) {
+      endRef = namedRefWithHashOrThrow(namedRef, null).getHash();
+    } else {
+      // TreeApiImplWithAuthorization already validated by calling namedRefWithHashOrThrow
+      endRef = Hash.of(hash);
+    }
 
     boolean fetchAll = FetchOption.isFetchAll(params.fetchOption());
     try (Stream<Commit<CommitMeta, Content>> commits = getStore().getCommits(endRef, fetchAll)) {


### PR DESCRIPTION
For GC, need to fetch the expired contents (expired because reference is deleted or assigned) from the backend store. 
Currently we only support fetching commit log + contents for the live references. Hence, need a way to fetch from dead references. 

Changes:
When authz is enabled,
    allow fetching commit log from hash for dead reference for reflog user and continue the same restrictions for normal user.
When authz is disabled,
    anyone can fetch commit log from hash for dead reference.

Note: 
When Hash is not provided, cannot fetch commit log from the dead reference irrespective of the access control.    
    