### PR TITLE
Remove `VersionStore.toRef()`

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
@@ -26,9 +26,10 @@ import org.projectnessie.model.Content;
 import org.projectnessie.services.authz.AccessChecker;
 import org.projectnessie.services.authz.ServerAccessContext;
 import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
-import org.projectnessie.versioned.Ref;
+import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.WithHash;
@@ -57,13 +58,8 @@ abstract class BaseApiImpl {
     }
     WithHash<NamedRef> namedRefWithHash;
     try {
-      WithHash<Ref> refWithHash = getStore().toRef(namedRef);
-      Ref ref = refWithHash.getValue();
-      if (!(ref instanceof NamedRef)) {
-        throw new ReferenceNotFoundException(
-            String.format("Named reference '%s' not found", namedRef));
-      }
-      namedRefWithHash = WithHash.of(refWithHash.getHash(), (NamedRef) ref);
+      ReferenceInfo<CommitMeta> ref = getStore().getNamedRef(namedRef, GetNamedRefsParams.DEFAULT);
+      namedRefWithHash = WithHash.of(ref.getHash(), ref.getNamedRef());
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     }

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -50,7 +50,6 @@ import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.Unchanged;
 import org.projectnessie.versioned.VersionStore;
-import org.projectnessie.versioned.WithHash;
 import org.projectnessie.versioned.WithType;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
@@ -84,12 +83,6 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
   @Override
   public Hash noAncestorHash() {
     return databaseAdapter.noAncestorHash();
-  }
-
-  @Override
-  public WithHash<Ref> toRef(@Nonnull String refOfUnknownType) throws ReferenceNotFoundException {
-    ReferenceInfo<METADATA> refInfo = getNamedRef(refOfUnknownType, GetNamedRefsParams.DEFAULT);
-    return WithHash.of(refInfo.getHash(), refInfo.getNamedRef());
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -76,11 +76,6 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
   }
 
   @Override
-  public WithHash<Ref> toRef(@Nonnull String refOfUnknownType) throws ReferenceNotFoundException {
-    return delegate1Ex("toref", () -> delegate.toRef(refOfUnknownType));
-  }
-
-  @Override
   public Hash commit(
       @Nonnull BranchName branch,
       @Nonnull Optional<Hash> referenceHash,

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceNotFoundException.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceNotFoundException.java
@@ -15,11 +15,6 @@
  */
 package org.projectnessie.versioned;
 
-import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
-
-import javax.annotation.Nonnull;
-
 /** Exception thrown when a reference is not present in the store. */
 public class ReferenceNotFoundException extends VersionStoreException {
   private static final long serialVersionUID = -4231207387427624751L;
@@ -30,43 +25,5 @@ public class ReferenceNotFoundException extends VersionStoreException {
 
   public ReferenceNotFoundException(String message, Throwable cause) {
     super(message, cause);
-  }
-
-  /**
-   * Create a {@code ReferenceNotFoundException} instance with an accurate message based on the
-   * provided reference.
-   *
-   * @param ref the reference not found in the store
-   * @return a {@code ReferenceNotFoundException} instance
-   * @throws NullPointerException if {@code ref} is {@code null}.
-   */
-  @Nonnull
-  public static ReferenceNotFoundException forReference(@Nonnull Ref ref) {
-    requireNonNull(ref);
-
-    final String message;
-    if (ref instanceof BranchName) {
-      message = format("Branch '%s' does not exist", ((BranchName) ref).getName());
-    } else if (ref instanceof TagName) {
-      message = format("Tag '%s' does not exist", ((TagName) ref).getName());
-    } else if (ref instanceof Hash) {
-      message = format("Hash '%s' does not exist", ((Hash) ref).asString());
-    } else {
-      return forReference(ref.toString());
-    }
-    return new ReferenceNotFoundException(message);
-  }
-
-  /**
-   * Create a {@code ReferenceNotFoundException} instance based on the provided reference.
-   *
-   * @param ref the reference string not found in the store
-   * @return a {@code ReferenceNotFoundException} instance
-   * @throws NullPointerException if {@code ref} is {@code null}.
-   */
-  @Nonnull
-  public static ReferenceNotFoundException forReference(@Nonnull String ref) {
-    requireNonNull(ref);
-    return new ReferenceNotFoundException(format("Ref '%s' does not exist", ref));
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -88,12 +88,6 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
   }
 
   @Override
-  public WithHash<Ref> toRef(@Nonnull String refOfUnknownType) throws ReferenceNotFoundException {
-    return callWithOneException(
-        "ToRef", b -> b.withTag(TAG_REF, refOfUnknownType), () -> delegate.toRef(refOfUnknownType));
-  }
-
-  @Override
   public Hash commit(
       @Nonnull BranchName branch,
       @Nonnull Optional<Hash> referenceHash,

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -64,20 +64,6 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
   Hash noAncestorHash();
 
   /**
-   * Determine what kind of ref a string is and convert it into the appropriate type (along with the
-   * current associated hash).
-   *
-   * <p>If a branch or tag has the same name as the string form of a valid hash, the branch or tag
-   * name are returned.
-   *
-   * @param refOfUnknownType A string that may be a branch, tag or hash.
-   * @return The concrete ref type with its hash.
-   * @throws ReferenceNotFoundException If the string doesn't map to a valid ref.
-   * @throws NullPointerException if {@code refOfUnknownType} is {@code null}.
-   */
-  WithHash<Ref> toRef(@Nonnull String refOfUnknownType) throws ReferenceNotFoundException;
-
-  /**
    * Create a new commit and add to a branch.
    *
    * <p>If {@code referenceHash} is not empty, for each key referenced by one of the operations, the

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -104,11 +104,6 @@ class TestMetricsVersionStore {
                 () -> ReferenceInfo.of(Hash.of("cafebabe"), BranchName.of("mock-branch")),
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
-                "toref",
-                vs -> vs.toRef("mock-branch"),
-                () -> WithHash.of(Hash.of("deadbeefcafebabe"), BranchName.of("mock-branch")),
-                refNotFoundThrows),
-            new VersionStoreInvocation<>(
                 "commit",
                 vs ->
                     vs.commit(

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -89,13 +89,6 @@ class TestTracingVersionStore {
                         vs -> vs.getNamedRef("mock-branch", GetNamedRefsParams.DEFAULT),
                         () -> ReferenceInfo.of(Hash.of("cafebabe"), BranchName.of("mock-branch"))),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
-                        "ToRef", refNotFoundThrows)
-                    .tag("nessie.version-store.ref", "mock-branch")
-                    .function(
-                        vs -> vs.toRef("mock-branch"),
-                        () ->
-                            WithHash.of(Hash.of("deadbeefcafebabe"), BranchName.of("mock-branch"))),
-                new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Commit", refNotFoundAndRefConflictThrows)
                     .tag("nessie.version-store.branch", "mock-branch")
                     .tag("nessie.version-store.num-ops", 0)


### PR DESCRIPTION
`VersionStore.toRef()` was already only used from tests and was superseded with `getNamedRef()` a while ago.