### PR TITLE
Reading with detached commit-IDs

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Branch.java
+++ b/model/src/main/java/org/projectnessie/model/Branch.java
@@ -20,6 +20,7 @@ import static org.projectnessie.model.Validation.validateReferenceName;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -31,6 +32,10 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableBranch.class)
 @JsonTypeName("BRANCH")
 public interface Branch extends Reference {
+
+  @Override
+  @Nullable
+  String getHash();
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateReferenceName(String)}.

--- a/model/src/main/java/org/projectnessie/model/Detached.java
+++ b/model/src/main/java/org/projectnessie/model/Detached.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import static org.projectnessie.model.Validation.validateHash;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.NotEmpty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+
+/**
+ * API representation of a detached Nessie commit, a commit without a named reference. The reserved
+ * reference name {@value #REF_NAME} is used to indicate "datached" commit IDs. This object is akin
+ * to a Ref in Git terminology.
+ */
+@Value.Immutable
+@Schema(type = SchemaType.OBJECT, title = "Detached commit hash")
+@JsonSerialize(as = ImmutableDetached.class)
+@JsonDeserialize(as = ImmutableDetached.class)
+@JsonTypeName("DETACHED")
+public interface Detached extends Reference {
+
+  String REF_NAME = "DETACHED";
+
+  @Override
+  @Value.Redacted
+  @JsonIgnore
+  default String getName() {
+    return REF_NAME;
+  }
+
+  @Override
+  @NotEmpty
+  String getHash();
+
+  /** Validation rule using {@link Validation#validateReferenceName(String)}. */
+  @Value.Check
+  default void checkHash() {
+    validateHash(getHash());
+  }
+
+  @Override
+  default ReferenceType getType() {
+    throw new UnsupportedOperationException("Illegal use of detached reference");
+  }
+
+  static ImmutableDetached.Builder builder() {
+    return ImmutableDetached.builder();
+  }
+
+  static Detached of(String hash) {
+    return builder().hash(hash).build();
+  }
+}

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -35,10 +35,11 @@ import org.immutables.value.Value;
 @Schema(
     type = SchemaType.OBJECT,
     title = "Reference",
-    oneOf = {Branch.class, Tag.class},
+    oneOf = {Branch.class, Tag.class, Detached.class},
     discriminatorMapping = {
       @DiscriminatorMapping(value = "TAG", schema = Tag.class),
       @DiscriminatorMapping(value = "BRANCH", schema = Branch.class),
+      @DiscriminatorMapping(value = "DETACHED", schema = Detached.class)
     },
     discriminatorProperty = "type",
     // Smallrye does neither support JsonFormat nor javax.validation.constraints.Pattern :(
@@ -47,7 +48,7 @@ import org.immutables.value.Value;
       @SchemaProperty(name = "hash", pattern = Validation.HASH_REGEX),
       @SchemaProperty(name = "metadata", nullable = true)
     })
-@JsonSubTypes({@Type(Branch.class), @Type(Tag.class)})
+@JsonSubTypes({@Type(Branch.class), @Type(Tag.class), @Type(Detached.class)})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface Reference extends Base {
   /** Human-readable reference name. */
@@ -56,7 +57,6 @@ public interface Reference extends Base {
   String getName();
 
   /** backend system id. Usually the 32-byte hash of the commit this reference points to. */
-  @Nullable
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
   String getHash();
 

--- a/model/src/main/java/org/projectnessie/model/Tag.java
+++ b/model/src/main/java/org/projectnessie/model/Tag.java
@@ -20,6 +20,7 @@ import static org.projectnessie.model.Validation.validateReferenceName;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -31,6 +32,10 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTag.class)
 @JsonTypeName("TAG")
 public interface Tag extends Reference {
+
+  @Override
+  @Nullable
+  String getHash();
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateReferenceName(String)}.

--- a/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/model/src/main/java/org/projectnessie/model/Validation.java
@@ -18,6 +18,7 @@ package org.projectnessie.model;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -48,9 +49,9 @@ public final class Validation {
   public static final String REF_NAME_OR_HASH_MESSAGE =
       "Reference must be either a reference name or hash, " + REF_RULE + " or " + HASH_RULE;
   public static final String FORBIDDEN_REF_NAME_MESSAGE =
-      "Reference name mut not be HEAD, BARE or a potential commit ID representation.";
+      "Reference name mut not be HEAD, DETACHED or a potential commit ID representation.";
   public static final Set<String> FORBIDDEN_REF_NAMES =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("HEAD", "BARE")));
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("HEAD", "DETACHED")));
 
   private Validation() {
     // empty
@@ -131,14 +132,15 @@ public final class Validation {
   }
 
   /**
-   * Checks whether {@code ref} represents a forbidden reference name ({@code HEAD} or {@code BARE})
-   * or could represent a commit-ID.
+   * Checks whether {@code ref} represents a forbidden reference name ({@code HEAD} or {@code
+   * DETACHED}) or could represent a commit-ID.
    *
    * @param ref reference name to check
    * @return {@code true}, if forbidden
    */
   public static boolean isForbiddenReferenceName(String ref) {
-    return FORBIDDEN_REF_NAMES.contains(ref) || HASH_PATTERN.matcher(ref).matches();
+    return FORBIDDEN_REF_NAMES.contains(ref.toUpperCase(Locale.ROOT))
+        || HASH_PATTERN.matcher(ref).matches();
   }
 
   /**

--- a/model/src/test/java/org/projectnessie/model/TestValidation.java
+++ b/model/src/test/java/org/projectnessie/model/TestValidation.java
@@ -84,7 +84,7 @@ class TestValidation {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"BARE", "HEAD"})
+  @ValueSource(strings = {"DETACHED", "HEAD", "detached", "head", "dEtAcHeD", "hEaD"})
   // Note: hashes validated in validHashes()
   void forbiddenReferenceNames(String refName) {
     assertThat(isForbiddenReferenceName(refName)).isTrue();

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestReferences.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestReferences.java
@@ -75,7 +75,7 @@ public abstract class AbstractRestReferences extends AbstractRestMisc {
   @ValueSource(
       strings = {
         "HEAD",
-        "BARE",
+        "DETACHED",
         "cafebabedeadbeef",
         "a234567890123456",
         "CAFEBABEDEADBEEF",

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractRestAccessCheckDetached.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractRestAccessCheckDetached.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.jaxrs;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.security.AccessControlException;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.rest.NessieForbiddenException;
+import org.projectnessie.jaxrs.ext.NessieAccessChecker;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Detached;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Operation.Put;
+import org.projectnessie.model.Tag;
+import org.projectnessie.services.authz.AccessChecker;
+import org.projectnessie.services.authz.AccessContext;
+import org.projectnessie.services.authz.DefaultAccessChecker;
+import org.projectnessie.versioned.DetachedRef;
+import org.projectnessie.versioned.NamedRef;
+
+/** See {@link AbstractTestRest} for details about and reason for the inheritance model. */
+public abstract class AbstractRestAccessCheckDetached extends AbstractTestRest {
+
+  private static final String VIEW_MSG = "Must not view detached references";
+  private static final String COMMITS_MSG = "Must not list from detached references";
+  private static final String READ_MSG = "Must not read from detached references";
+  private static final String ENTITIES_MSG = "Must not get entities from detached references";
+
+  @Test
+  public void detachedRefAccessChecks(
+      @NessieAccessChecker Consumer<AccessChecker> accessCheckerConsumer) throws Exception {
+    accessCheckerConsumer.accept(
+        new DefaultAccessChecker() {
+          @Override
+          public void canViewReference(AccessContext context, NamedRef ref)
+              throws AccessControlException {
+            if (ref instanceof DetachedRef) {
+              throw new AccessControlException(VIEW_MSG);
+            }
+            assertThat(ref.getName()).isNotEqualTo(DetachedRef.REF_NAME);
+          }
+
+          @Override
+          public void canListCommitLog(AccessContext context, NamedRef ref)
+              throws AccessControlException {
+            if (ref instanceof DetachedRef) {
+              throw new AccessControlException(COMMITS_MSG);
+            }
+            assertThat(ref.getName()).isNotEqualTo(DetachedRef.REF_NAME);
+          }
+
+          @Override
+          public void canReadEntityValue(
+              AccessContext context, NamedRef ref, ContentKey key, String contentId)
+              throws AccessControlException {
+            if (ref instanceof DetachedRef) {
+              throw new AccessControlException(ENTITIES_MSG);
+            }
+            assertThat(ref.getName()).isNotEqualTo(DetachedRef.REF_NAME);
+          }
+
+          @Override
+          public void canReadEntries(AccessContext context, NamedRef ref)
+              throws AccessControlException {
+            if (ref instanceof DetachedRef) {
+              throw new AccessControlException(READ_MSG);
+            }
+            assertThat(ref.getName()).isNotEqualTo(DetachedRef.REF_NAME);
+          }
+        });
+
+    Branch main = createBranch("committerAndAuthor");
+    Branch merge = createBranch("committerAndAuthorMerge");
+    Branch transplant = createBranch("committerAndAuthorTransplant");
+
+    IcebergTable meta1 = IcebergTable.of("meep", 42, 42, 42, 42);
+    ContentKey key = ContentKey.of("meep");
+    Branch mainCommit =
+        getApi()
+            .commitMultipleOperations()
+            .branchName(main.getName())
+            .hash(main.getHash())
+            .commitMeta(CommitMeta.builder().message("no security context").build())
+            .operation(Put.of(key, meta1))
+            .commit();
+
+    Branch detachedAsBranch = Branch.of(Detached.REF_NAME, mainCommit.getHash());
+    Tag detachedAsTag = Tag.of(Detached.REF_NAME, mainCommit.getHash());
+    Detached detached = Detached.of(mainCommit.getHash());
+
+    assertThat(Stream.of(detached, detachedAsBranch, detachedAsTag))
+        .allSatisfy(
+            ref ->
+                assertAll(
+                    () ->
+                        assertThatThrownBy(() -> getApi().getCommitLog().reference(ref).get())
+                            .describedAs("ref='%s', getCommitLog", ref)
+                            .isInstanceOf(NessieForbiddenException.class)
+                            .hasMessageContaining(COMMITS_MSG),
+                    () ->
+                        assertThatThrownBy(
+                                () ->
+                                    getApi()
+                                        .mergeRefIntoBranch()
+                                        .fromRef(ref)
+                                        .branch(merge)
+                                        .merge())
+                            .describedAs("ref='%s', mergeRefIntoBranch", ref)
+                            .isInstanceOf(NessieForbiddenException.class)
+                            .hasMessageContaining(VIEW_MSG),
+                    () ->
+                        assertThatThrownBy(
+                                () ->
+                                    getApi()
+                                        .transplantCommitsIntoBranch()
+                                        .fromRefName(ref.getName())
+                                        .hashesToTransplant(singletonList(ref.getHash()))
+                                        .branch(transplant)
+                                        .transplant())
+                            .describedAs("ref='%s', transplantCommitsIntoBranch", ref)
+                            .isInstanceOf(NessieForbiddenException.class)
+                            .hasMessageContaining(VIEW_MSG),
+                    () ->
+                        assertThatThrownBy(() -> getApi().getEntries().reference(ref).get())
+                            .describedAs("ref='%s', getEntries", ref)
+                            .isInstanceOf(NessieForbiddenException.class)
+                            .hasMessageContaining(READ_MSG),
+                    () ->
+                        assertThatThrownBy(
+                                () -> getApi().getContent().reference(ref).key(key).get())
+                            .describedAs("ref='%s', getContent", ref)
+                            .isInstanceOf(NessieForbiddenException.class)
+                            .hasMessageContaining(ENTITIES_MSG),
+                    () ->
+                        assertThatThrownBy(() -> getApi().getDiff().fromRef(ref).toRef(main).get())
+                            .describedAs("ref='%s', getDiff1", ref)
+                            .isInstanceOf(NessieForbiddenException.class)
+                            .hasMessageContaining(VIEW_MSG),
+                    () ->
+                        assertThatThrownBy(() -> getApi().getDiff().fromRef(main).toRef(ref).get())
+                            .describedAs("ref='%s', getDiff2", ref)
+                            .isInstanceOf(NessieForbiddenException.class)
+                            .hasMessageContaining(VIEW_MSG)));
+  }
+}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractRestSecurityContext.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractRestSecurityContext.java
@@ -32,7 +32,7 @@ import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Operation.Put;
 
 /** See {@link AbstractTestRest} for details about and reason for the inheritance model. */
-public abstract class AbstractRestSecurityContext extends AbstractTestRest {
+public abstract class AbstractRestSecurityContext extends AbstractRestAccessCheckDetached {
   @Test
   public void committerAndAuthor(
       @NessieSecurityContext Consumer<SecurityContext> securityContextConsumer) throws Exception {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
@@ -16,6 +16,7 @@
 package org.projectnessie.services.impl;
 
 import java.security.Principal;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -26,6 +27,7 @@ import org.projectnessie.model.Content;
 import org.projectnessie.services.authz.AccessChecker;
 import org.projectnessie.services.authz.ServerAccessContext;
 import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.versioned.DetachedRef;
 import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
@@ -56,6 +58,13 @@ abstract class BaseApiImpl {
     if (null == namedRef) {
       namedRef = config.getDefaultBranch();
     }
+
+    if (DetachedRef.REF_NAME.equals(namedRef)) {
+      Objects.requireNonNull(
+          hashOnRef, String.format("hashOnRef must not be null for '%s'", DetachedRef.REF_NAME));
+      return WithHash.of(Hash.of(hashOnRef), DetachedRef.INSTANCE);
+    }
+
     WithHash<NamedRef> namedRefWithHash;
     try {
       ReferenceInfo<CommitMeta> ref = getStore().getNamedRef(namedRef, GetNamedRefsParams.DEFAULT);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefUtil.java
@@ -17,9 +17,11 @@ package org.projectnessie.services.impl;
 
 import java.util.Objects;
 import org.projectnessie.model.Branch;
+import org.projectnessie.model.Detached;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.DetachedRef;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.TagName;
@@ -34,6 +36,9 @@ public final class RefUtil {
     }
     if (reference instanceof Tag) {
       return TagName.of(reference.getName());
+    }
+    if (reference instanceof Detached) {
+      return DetachedRef.INSTANCE;
     }
     throw new IllegalArgumentException(String.format("Unsupported reference '%s'", reference));
   }
@@ -63,6 +68,10 @@ public final class RefUtil {
     }
     if (namedRef instanceof TagName) {
       return Tag.of(namedRef.getName(), hash);
+    }
+    if (namedRef instanceof DetachedRef) {
+      return Detached.of(
+          Objects.requireNonNull(hash, "hash must not be null for detached references"));
     }
     throw new IllegalArgumentException(String.format("Unsupported named reference '%s'", namedRef));
   }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -66,6 +66,7 @@ import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Detached;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.ImmutableBranch;
 import org.projectnessie.model.ImmutableLogEntry;
@@ -553,6 +554,9 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
 
   private Hash toHash(String referenceName, String hashOnReference)
       throws ReferenceNotFoundException {
+    if (Detached.REF_NAME.equals(referenceName)) {
+      return Hash.of(hashOnReference);
+    }
     if (hashOnReference == null) {
       return getStore().getNamedRef(referenceName, GetNamedRefsParams.DEFAULT).getHash();
     }

--- a/servers/services/src/test/java/org/projectnessie/services/impl/RefUtilTest.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/RefUtilTest.java
@@ -22,10 +22,12 @@ import static org.projectnessie.services.impl.RefUtil.toReference;
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.model.Branch;
+import org.projectnessie.model.Detached;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferenceMetadata;
 import org.projectnessie.model.Tag;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.DetachedRef;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.TagName;
@@ -40,6 +42,8 @@ class RefUtilTest {
     assertThat(RefUtil.toNamedRef(Branch.of(REF_NAME, HASH_VALUE)))
         .isEqualTo(BranchName.of(REF_NAME));
     assertThat(RefUtil.toNamedRef(Tag.of(REF_NAME, HASH_VALUE))).isEqualTo(TagName.of(REF_NAME));
+    assertThat(RefUtil.toNamedRef(Detached.of(HASH_VALUE))).isSameAs(DetachedRef.INSTANCE);
+
     assertThat(RefUtil.toNamedRef(Branch.of(REF_NAME, null))).isEqualTo(BranchName.of(REF_NAME));
     assertThat(RefUtil.toNamedRef(Tag.of(REF_NAME, null))).isEqualTo(TagName.of(REF_NAME));
   }
@@ -99,6 +103,8 @@ class RefUtilTest {
         .isEqualTo(Branch.of(REF_NAME, HASH_VALUE));
     assertThat(RefUtil.toReference(TagName.of(REF_NAME), HASH_VALUE))
         .isEqualTo(Tag.of(REF_NAME, HASH_VALUE));
+    assertThat(RefUtil.toReference(DetachedRef.INSTANCE, HASH_VALUE))
+        .isEqualTo(Detached.of(HASH_VALUE));
     assertThat(RefUtil.toReference(BranchName.of(REF_NAME), (String) null))
         .isEqualTo(Branch.of(REF_NAME, null));
     assertThat(RefUtil.toReference(TagName.of(REF_NAME), (String) null))
@@ -111,6 +117,8 @@ class RefUtilTest {
         .isEqualTo(Branch.of(REF_NAME, HASH_VALUE));
     assertThat(RefUtil.toReference(TagName.of(REF_NAME), Hash.of(HASH_VALUE)))
         .isEqualTo(Tag.of(REF_NAME, HASH_VALUE));
+    assertThat(RefUtil.toReference(DetachedRef.INSTANCE, Hash.of(HASH_VALUE)))
+        .isEqualTo(Detached.of(HASH_VALUE));
     assertThat(RefUtil.toReference(BranchName.of(REF_NAME), (Hash) null))
         .isEqualTo(Branch.of(REF_NAME, null));
     assertThat(RefUtil.toReference(TagName.of(REF_NAME), (Hash) null))
@@ -143,6 +151,9 @@ class RefUtilTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith(
             "Unsupported named reference 'org.projectnessie.services.impl.RefUtilTest");
+    assertThatThrownBy(() -> toReference(DetachedRef.INSTANCE, (String) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("hash must not be null for detached references");
   }
 
   @Test
@@ -171,5 +182,8 @@ class RefUtilTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith(
             "Unsupported named reference 'org.projectnessie.services.impl.RefUtilTest");
+    assertThatThrownBy(() -> toReference(DetachedRef.INSTANCE, (Hash) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("hash must not be null for detached references");
   }
 }

--- a/ui/src/Explore/Explore.tsx
+++ b/ui/src/Explore/Explore.tsx
@@ -49,6 +49,8 @@ const loadBranchesAndTags = (): Promise<Reference[] | void> => {
 const refName = (a: Reference): string => {
   const t = a.type;
   switch (t) {
+    case "DETACHED":
+      return a.hash;
     case "BRANCH":
       return a.name;
     case "TAG":

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/DetachedRef.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/DetachedRef.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import javax.annotation.Nonnull;
+import org.immutables.value.Value;
+
+/** A named reference representing a branch. */
+@Value.Immutable
+public interface DetachedRef extends NamedRef {
+
+  String REF_NAME = "DETACHED";
+
+  DetachedRef INSTANCE = ImmutableDetachedRef.builder().build();
+
+  @Nonnull
+  @Override
+  @Value.Redacted
+  default String getName() {
+    return REF_NAME;
+  }
+}


### PR DESCRIPTION
(Re)introduces reading from "detached" commit IDs, i.e. only specify the commit-id/hash instead of the reference name or reference name plus hash. This PR does not update or break the public API.

To allow reading with "detached" commit IDs via the existing REST APIs, this change uses a special reference name `DETACHED`.