### PR TITLE
WIP/EXPERIMENT Add gitflow-incremental-builder

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,6 +37,9 @@ jobs:
   java:
     name: Java/Maven
     runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH_NAME: pull-request-base-ref
+      PR_BRANCH_NAME: pull-request-ref
 
     steps:
     - uses: actions/checkout@v2
@@ -45,11 +48,57 @@ jobs:
     - name: Setup Java, Maven, Gradle
       uses: ./.github/actions/dev-tool-java
 
+    - name: Fetch base branch + PR branch
+      run: |
+        # GITHUB_REF contains refs/pull/1234/merge, which points to a merge-commit, but we want
+        # the head-commit of the PR as refs/pull/1234/head
+        PR_REF=${GITHUB_REF/%merge/head}
+
+        echo ""
+        echo ""
+        echo "=== Fetching ${GITHUB_BASE_REF} and ${PR_REF}"
+        echo ""
+        git fetch --no-tags origin \
+          ${GITHUB_BASE_REF}:${BASE_BRANCH_NAME} \
+          ${PR_REF}:${PR_BRANCH_NAME}
+
+        echo ""
+        echo ""
+        echo "=== HEAD of ${GITHUB_BASE_REF}"
+        echo ""
+        git log -n1 ${BASE_BRANCH_NAME}
+
+        echo ""
+        echo ""
+        echo "=== HEAD of ${PR_REF}"
+        echo ""
+        git log -n1 ${PR_BRANCH_NAME}
+
+        # Just log the merge-base (common ancestor)
+        MERGE_BASE=$(git merge-base ${BASE_BRANCH_NAME} ${PR_BRANCH_NAME})
+
+        echo ""
+        echo ""
+        echo "=== Log of PR branch up to merge-base"
+        echo ""
+        git log ${MERGE_BASE}..${PR_BRANCH_NAME}
+
+        echo ""
+        echo ""
+        echo "=== Diff of PR branch up to merge-base"
+        echo ""
+        git diff --name-only ${MERGE_BASE}..${PR_BRANCH_NAME}
+
     - name: Build with Maven
       env:
         SPARK_LOCAL_IP: localhost
       run: |
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage -Dtest.log.level=WARN
+        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml \
+          -Pcode-coverage \
+          -Dtest.log.level=WARN \
+          -Dgib.disable=false \
+          -Dgib.baseBranch=refs/heads/${PR_BRANCH_NAME} \
+          -Dgib.referenceBranch=refs/heads/${BASE_BRANCH_NAME}
 
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,13 @@
     <surefire.version>3.0.0-M5</surefire.version>
     <testcontainers.version>1.16.3</testcontainers.version>
     <weld.version>3.1.8.Final</weld.version>
+
+    <!-- gitflow-incremental-builder, disabled by default -->
+    <gib.disable>true</gib.disable>
+    <gib.referenceBranch>refs/remotes/origin/main</gib.referenceBranch>
+    <gib.buildAll>true</gib.buildAll>
+    <gib.untracked>false</gib.untracked>
+    <gib.skipTestsForUpstreamModules>true</gib.skipTestsForUpstreamModules>
   </properties>
 
   <dependencyManagement>
@@ -1164,6 +1171,13 @@ limitations under the License.
         <version>${gatling.maven.version}</version>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>com.vackosar.gitflowincrementalbuilder</groupId>
+        <artifactId>gitflow-incremental-builder</artifactId>
+        <version>3.14.5</version>
+      </extension>
+    </extensions>
   </build>
 
   <profiles>


### PR DESCRIPTION
Adds https://github.com/gitflow-incremental-builder/gitflow-incremental-builder to PR builds.

This PR adds gitflow-incremental-builder as a Maven extension to the top-level-pom and is disabled by default.
If enabled, it will figure out the common ancestor ("merge-base" in Git terminology) from the base-reference and "current" reference. It is configured to always _build_ all modules but only run tests on changed modules and its dependants.

pull-request GH workflow is updated to:
* Fetch the base branch and PR branch, so the gitflow-incremental-builder can identify the changes up to the merge-base. (Note: GH provides a "shallow" merge-commit, without any history.)
* Log some potentially useful, Git related information (not necessary for gitflow-incremental-builder to work).
* Run the Maven build with gitflow-incremental-builder enabled and tell it the base-reference and "current" reference names. It will then check for the changed modules.

Some test-PRs:
* [change](https://github.com/snazy/nessie/pull/627) in `tools/content-generator` - only the tests in that module run
* [change](https://github.com/snazy/nessie/pull/628) in `model/` - tests in `:nessie-model` and all dependants run
* [change](https://github.com/snazy/nessie/pull/629) in `versioned/pom.xml` - everything that is in `versioned/` and depends on `versioned/` is tested
* [change](https://github.com/snazy/nessie/pull/630) in top-level `pom.xml` - all tests run

(NOTE: These PRs were run against a "base reference" that had the necessary change for gib in the top-level pom.)