### PR TITLE
Detached commits / pynessie

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/model/src/main/java/org/projectnessie/model/Validation.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 /** Collection of validation rules. */
 public final class Validation {
 
+  // Note: when changing a regex here, also update it in python/
   public static final String HASH_RAW_REGEX = "[0-9a-fA-F]{8,64}";
   public static final String HASH_REGEX = "^" + HASH_RAW_REGEX + "$";
   public static final String REF_NAME_RAW_REGEX =

--- a/python/pynessie/client/_endpoints.py
+++ b/python/pynessie/client/_endpoints.py
@@ -343,17 +343,32 @@ def commit(
     return cast(dict, _post(base_url + url, auth, json=operations, ssl_verify=ssl_verify, params=params))
 
 
-def get_diff(base_url: str, auth: Optional[AuthBase], from_ref: str, to_ref: str, ssl_verify: bool = True) -> dict:
+def get_diff(
+    base_url: str,
+    auth: Optional[AuthBase],
+    from_ref: str,
+    to_ref: str,
+    from_hash_on_ref: Optional[str] = None,
+    to_hash_on_ref: Optional[str] = None,
+    ssl_verify: bool = True,
+) -> dict:
     """Fetch the diff for two given references.
 
     :param base_url: base Nessie url
     :param auth: Authentication settings
     :param from_ref: the starting ref for the diff
     :param to_ref:  the ending ref for the diff
+    :param from_hash_on_ref: optional hash on from reference
+    :param to_hash_on_ref: optional hash on to reference
     :param ssl_verify: ignore ssl errors if False
     :return: json dict of a Diff
     """
-    return cast(dict, _get(f"{base_url}/diffs/{from_ref}...{to_ref}", auth, ssl_verify=ssl_verify))
+    from_hash_on_ref_asterisk = f"*{from_hash_on_ref}" if from_hash_on_ref else ""
+    to_hash_on_ref_asterisk = f"*{to_hash_on_ref}" if to_hash_on_ref else ""
+    return cast(
+        dict,
+        _get(f"{base_url}/diffs/{from_ref}{from_hash_on_ref_asterisk}...{to_ref}{to_hash_on_ref_asterisk}", auth, ssl_verify=ssl_verify),
+    )
 
 
 def list_reflog(

--- a/python/pynessie/commands/branch.py
+++ b/python/pynessie/commands/branch.py
@@ -86,6 +86,9 @@ def branch_(
         nessie branch -o 12345678abcdef new_branch main -> create a branch named 'new_branch' at hash 12345678abcdef
     on reference named 'main'
 
+        nessie branch new_branch main@12345678abcdef -> create a branch named 'new_branch' at hash 12345678abcdef
+    on reference named 'main', alternate syntax for the above
+
         nessie branch -f existing_branch main -> assign branch named 'existing_branch' to head of reference named 'main'
 
         nessie branch -o 12345678abcdef -f existing_branch main -> assign branch named 'existing_branch' to hash 12345678abcdef

--- a/python/pynessie/commands/diff.py
+++ b/python/pynessie/commands/diff.py
@@ -17,12 +17,11 @@
 
 """diff CLI command."""
 
-
 import click
 
 from ..cli_common_context import ContextObject
 from ..decorators import error_handler, pass_client
-from ..model import DiffResponseSchema
+from ..model import DiffResponseSchema, split_into_reference_and_hash
 
 
 @click.command("diff")
@@ -33,14 +32,32 @@ from ..model import DiffResponseSchema
 def diff(ctx: ContextObject, from_ref: str, to_ref: str) -> None:  # noqa: C901
     """Show diff between two given references.
 
-    from_ref/to_ref: name of branch or tag to use to show the diff
+    'from_ref'/'to_ref': name of branch or tag to use to show the diff
+
+    'from_ref' and 'to_ref' can be either:
+
+        The name of a reference (branch or tag), resolving to the HEAD of the
+        named reference.
+
+        The name of a reference (branch or tag) with a commit-id on that named
+        reference.
+
+        A detached commit-id/hash. Example:
 
     Examples:
 
-        nessie diff from_ref to_ref -> show diff between 'from_ref' and 'to_ref'
+        nessie diff from_ref to_ref -> show diff between 'from_ref' and 'to_ref', using the HEADs of both references
+
+        nessie diff main@1234567890abcdef my-branch -> compare main branch at commit-id 1234567890abcdef with the HEAD of my-branch
+
+        nessie diff 1234567890abcdef main -> compare the main branch w/ commit-id 1234567890abcdef
 
     """
-    diff_response = ctx.nessie.get_diff(from_ref=from_ref, to_ref=to_ref)
+    from_ref, from_hash_on_ref = split_into_reference_and_hash(from_ref)
+
+    to_ref, to_hash_on_ref = split_into_reference_and_hash(to_ref)
+
+    diff_response = ctx.nessie.get_diff(from_ref=from_ref, to_ref=to_ref, from_hash_on_ref=from_hash_on_ref, to_hash_on_ref=to_hash_on_ref)
     if ctx.json:
         click.echo(DiffResponseSchema().dumps(diff_response))
     else:

--- a/python/pynessie/commands/tag.py
+++ b/python/pynessie/commands/tag.py
@@ -86,6 +86,9 @@ def tag(
         nessie tag -o 12345678abcdef new_tag test -> create new tag named 'new_tag' at hash 12345678abcdef on
     reference named 'test'
 
+        nessie tag new_tag test@12345678abcdef -> create new tag named 'new_tag' at hash 12345678abcdef on
+    reference named 'test', alternative syntax of the above
+
         nessie tag -f existing_tag main -> assign tag named 'existing_tag' to head of reference named 'main'
 
         nessie tag -o 12345678abcdef -f existing_tag main -> assign tag named 'existing_tag' to hash 12345678abcdef

--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -34,7 +34,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -89,14 +89,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "dev", "type": "BRANCH"}], "token": null}'
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -115,7 +115,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/assign.foo.bar?ref=dev
   response:
@@ -150,12 +150,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+      string: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -175,12 +175,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+      string: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -191,7 +191,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+    body: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
       "metadata": null, "name": "main", "type": "BRANCH"}'
     headers:
       Accept:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=dev
   response:
@@ -231,7 +231,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -247,7 +247,32 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/dev
+  response:
+    body:
+      string: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "dev", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '109'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
       "metadata": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
@@ -261,7 +286,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: PUT
     uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
@@ -281,13 +306,13 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
-        "name": "main", "type": "BRANCH"}, {"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+      string: '{"hasMore": false, "references": [{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "main", "type": "BRANCH"}, {"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
         "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
@@ -307,12 +332,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+      string: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -323,7 +348,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+    body: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
       "metadata": null, "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -337,12 +362,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+      string: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
         "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
@@ -362,15 +387,15 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
-        "name": "main", "type": "BRANCH"}, {"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
-        "name": "dev", "type": "BRANCH"}, {"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
-        "name": "v1.0", "type": "TAG"}], "token": null}'
+      string: '{"hasMore": false, "references": [{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "v1.0", "type": "TAG"}, {"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "main", "type": "BRANCH"}, {"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -389,12 +414,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+      string: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -405,7 +430,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+    body: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
       "metadata": null, "name": "v1.0", "type": "TAG"}'
     headers:
       Accept:
@@ -419,7 +444,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=dev
   response:
@@ -445,12 +470,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
+      string: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
         "name": "v1.0", "type": "TAG"}'
     headers:
       Content-Type:
@@ -461,8 +486,33 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
-      "metadata": null, "name": "dev", "type": "TAG"}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/dev
+  response:
+    body:
+      string: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "dev", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '109'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+      "metadata": null, "name": "dev", "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -471,13 +521,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '124'
+      - '127'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0
   response:
     body:
       string: ''
@@ -495,15 +545,15 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
-        "name": "main", "type": "BRANCH"}, {"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
-        "name": "dev", "type": "BRANCH"}, {"hash": "77772ff9010377f9f4fe7d1bdbcf94b8f761d10542940e205a1b878b01230b9c",
-        "name": "v1.0", "type": "TAG"}], "token": null}'
+      string: '{"hasMore": false, "references": [{"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "v1.0", "type": "TAG"}, {"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "main", "type": "BRANCH"}, {"hash": "f1a2d6b0d7befc6a683a478e80fe34bb1234e19b4c1e37b7c65a1553c2f4e9a0",
+        "name": "dev", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli/test_branch.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_branch.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
@@ -34,7 +34,32 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '161'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -59,7 +84,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -89,7 +114,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -114,14 +139,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "dev", "type": "BRANCH"}], "token": null}'
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -140,7 +165,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -170,7 +195,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -195,20 +220,50 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "etl", "type": "BRANCH"}], "token": null}'
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
       - '383'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "metadata": null, "name": "dev_hash", "type": "BRANCH"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=DETACHED
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_hash", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '114'
     status:
       code: 200
       message: OK
@@ -222,20 +277,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "etl", "type": "BRANCH"}], "token": null}'
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '383'
+      - '499'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "metadata": null, "name": "etl_hash", "type": "BRANCH"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl_hash", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '114'
     status:
       code: 200
       message: OK
@@ -249,20 +335,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "etl", "type": "BRANCH"}], "token": null}'
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '383'
+      - '615'
     status:
       code: 200
       message: OK
@@ -276,20 +364,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "etl", "type": "BRANCH"}], "token": null}'
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '383'
+      - '615'
     status:
       code: 200
       message: OK
@@ -303,7 +393,65 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '615'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '615'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/test.branch.metadata?ref=dev
   response:
@@ -338,12 +486,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "9ead6b7d053b9c5794006be7fbb671dd9ffcb313649b2b25bad9dcff6ae18203",
+      string: '{"hash": "ff17e2c40dec2499e80b9c17f69a0196f0c40045bbdc5ac6bc80ab32fdac65d7",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -363,28 +511,34 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees?fetch=ALL
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "9ead6b7d053b9c5794006be7fbb671dd9ffcb313649b2b25bad9dcff6ae18203",
+      string: '{"hasMore": false, "references": [{"hash": "ff17e2c40dec2499e80b9c17f69a0196f0c40045bbdc5ac6bc80ab32fdac65d7",
         "metadata": {"commitMetaOfHEAD": {"author": "nessie_user1", "authorTime":
-        "2021-12-07T10:04:02.497243Z", "commitTime": "2021-12-07T10:04:02.497243Z",
-        "committer": "", "hash": "9ead6b7d053b9c5794006be7fbb671dd9ffcb313649b2b25bad9dcff6ae18203",
+        "2022-01-31T10:05:35.980062Z", "commitTime": "2022-01-31T10:05:35.980062Z",
+        "committer": "", "hash": "ff17e2c40dec2499e80b9c17f69a0196f0c40045bbdc5ac6bc80ab32fdac65d7",
         "message": "test message", "properties": {}, "signedOffBy": null}, "commonAncestorHash":
         "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d", "numCommitsAhead":
         1, "numCommitsBehind": 0, "numTotalCommits": 1}, "name": "dev", "type": "BRANCH"},
         {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "metadata": {"commitMetaOfHEAD": null, "commonAncestorHash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "numCommitsAhead": 0, "numCommitsBehind": 0, "numTotalCommits": null}, "name":
-        "etl", "type": "BRANCH"}], "token": null}'
+        "etl_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "metadata": {"commitMetaOfHEAD": null, "commonAncestorHash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "numCommitsAhead": 0, "numCommitsBehind": 0, "numTotalCommits": null}, "name":
+        "dev_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "metadata": {"commitMetaOfHEAD": null, "commonAncestorHash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "numCommitsAhead": 0, "numCommitsBehind": 0, "numTotalCommits": null}, "name":
+        "etl", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '1051'
+      - '1683'
     status:
       code: 200
       message: OK
@@ -398,7 +552,36 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "ff17e2c40dec2499e80b9c17f69a0196f0c40045bbdc5ac6bc80ab32fdac65d7",
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_hash", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '615'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/etl
   response:
@@ -425,7 +608,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: DELETE
     uri: http://localhost:19120/api/v1/trees/branch/etl?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
@@ -445,12 +628,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: '{"hash": "9ead6b7d053b9c5794006be7fbb671dd9ffcb313649b2b25bad9dcff6ae18203",
+      string: '{"hash": "ff17e2c40dec2499e80b9c17f69a0196f0c40045bbdc5ac6bc80ab32fdac65d7",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -472,9 +655,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=9ead6b7d053b9c5794006be7fbb671dd9ffcb313649b2b25bad9dcff6ae18203
+    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=ff17e2c40dec2499e80b9c17f69a0196f0c40045bbdc5ac6bc80ab32fdac65d7
   response:
     body:
       string: ''
@@ -492,7 +675,101 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/etl_hash
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl_hash", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '114'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.27.1
+    method: DELETE
+    uri: http://localhost:19120/api/v1/trees/branch/etl_hash?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+  response:
+    body:
+      string: ''
+    headers: {}
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/dev_hash
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev_hash", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '114'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.27.1
+    method: DELETE
+    uri: http://localhost:19120/api/v1/trees/branch/dev_hash?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+  response:
+    body:
+      string: ''
+    headers: {}
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:

--- a/python/tests/cassettes/test_nessie_cli/test_diff.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_diff.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/diffs/main...main
   response:
@@ -33,7 +33,32 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '161'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -58,7 +83,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -88,7 +113,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -113,14 +138,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "dev_test_diff", "type": "BRANCH"}], "token": null}'
+        "name": "dev_test_diff", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -139,7 +164,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/diff.foo.dev?ref=dev_test_diff
   response:
@@ -174,12 +199,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev_test_diff/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "e4aa6de033c499df09d907a2d71d36f99e52db277c07f5a6ded99e132af0bd4c",
+      string: '{"hash": "68d49014deee149e6f2ec7aa953ec5cacf3c404d057247aecba1a1497f839af8",
         "name": "dev_test_diff", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -199,9 +224,113 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "68d49014deee149e6f2ec7aa953ec5cacf3c404d057247aecba1a1497f839af8",
+        "name": "dev_test_diff", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '282'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/diffs/main...dev_test_diff
+  response:
+    body:
+      string: '{"diffs": [{"from": null, "key": {"elements": ["diff", "foo", "dev"]},
+        "to": {"id": "dev_test_diff", "metadataLocation": "/a/b/c", "schemaId": 43,
+        "snapshotId": 42, "sortOrderId": 45, "specId": 44, "type": "ICEBERG_TABLE"}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '225'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/diffs/DETACHED*2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d...DETACHED*68d49014deee149e6f2ec7aa953ec5cacf3c404d057247aecba1a1497f839af8
+  response:
+    body:
+      string: '{"diffs": [{"from": null, "key": {"elements": ["diff", "foo", "dev"]},
+        "to": {"id": "dev_test_diff", "metadataLocation": "/a/b/c", "schemaId": 43,
+        "snapshotId": 42, "sortOrderId": 45, "specId": 44, "type": "ICEBERG_TABLE"}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '225'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/diffs/DETACHED*2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d...DETACHED*68d49014deee149e6f2ec7aa953ec5cacf3c404d057247aecba1a1497f839af8
+  response:
+    body:
+      string: '{"diffs": [{"from": null, "key": {"elements": ["diff", "foo", "dev"]},
+        "to": {"id": "dev_test_diff", "metadataLocation": "/a/b/c", "schemaId": 43,
+        "snapshotId": 42, "sortOrderId": 45, "specId": 44, "type": "ICEBERG_TABLE"}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '225'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/diffs/main*2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d...dev_test_diff*68d49014deee149e6f2ec7aa953ec5cacf3c404d057247aecba1a1497f839af8
   response:
     body:
       string: '{"diffs": [{"from": null, "key": {"elements": ["diff", "foo", "dev"]},

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -9,7 +9,32 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '161'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -34,7 +59,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
@@ -58,7 +83,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -83,7 +108,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -113,7 +138,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -138,14 +163,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "dev_test_log", "type": "BRANCH"}], "token": null}'
+        "name": "dev_test_log", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -164,7 +189,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/log.foo.dev?ref=dev_test_log
   response:
@@ -199,12 +224,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev_test_log/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "2a732b9ca6d092680cf6cb6fd7c4932d251a761be3df2a418d5277a41fee680d",
+      string: '{"hash": "f3bb2fa6a832fade5b992499ed9c5ae2dadc8d9ed7a05c71cadd4421aead2efe",
         "name": "dev_test_log", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -224,14 +249,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2a732b9ca6d092680cf6cb6fd7c4932d251a761be3df2a418d5277a41fee680d",
-        "name": "dev_test_log", "type": "BRANCH"}], "token": null}'
+      string: '{"hasMore": false, "references": [{"hash": "f3bb2fa6a832fade5b992499ed9c5ae2dadc8d9ed7a05c71cadd4421aead2efe",
+        "name": "dev_test_log", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -250,7 +275,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/log.foo.bar?ref=main
   response:
@@ -285,12 +310,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+      string: '{"hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -310,12 +335,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+      string: '{"hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -335,7 +360,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/log.foo.bar?ref=main
   response:
@@ -360,12 +385,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+      string: '{"hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -385,14 +410,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log?fetch=ALL
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         [{"content": {"id": "test_log", "metadataLocation": "/a/b/c", "schemaId":
         43, "snapshotId": 42, "sortOrderId": 45, "specId": 44, "type": "ICEBERG_TABLE"},
@@ -417,12 +442,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+      string: '{"hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -442,14 +467,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -470,12 +495,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/DETACHED/log?endHash=317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe
+  response:
+    body:
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '390'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+      string: '{"hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -495,14 +548,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -523,12 +576,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+      string: '{"hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -548,14 +601,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -576,12 +629,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+      string: '{"hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -601,7 +654,88 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe
+  response:
+    body:
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '390'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe
+  response:
+    body:
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
+        "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '390'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree
+  response:
+    body:
+      string: '{"hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
+        "name": "main", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '110'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/entries
   response:
@@ -633,12 +767,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -658,12 +792,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -683,16 +817,16 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log?maxRecords=1
   response:
     body:
       string: '{"hasMore": true, "logEntries": [{"commitMeta": {"author": "nessie_user2",
-        "authorTime": "2021-12-07T10:04:01.932835Z", "commitTime": "2021-12-07T10:04:01.932835Z",
-        "committer": "", "hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+        "authorTime": "2022-01-31T10:05:35.179289Z", "commitTime": "2022-01-31T10:05:35.179289Z",
+        "committer": "", "hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
-        null, "parentCommitHash": null}], "token": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df"}'
+        null, "parentCommitHash": null}], "token": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe"}'
     headers:
       Content-Type:
       - application/json
@@ -711,14 +845,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev_test_log/log
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.694058Z", "commitTime": "2021-12-07T10:04:01.694058Z",
-        "committer": "", "hash": "2a732b9ca6d092680cf6cb6fd7c4932d251a761be3df2a418d5277a41fee680d",
+        "authorTime": "2022-01-31T10:05:34.767346Z", "commitTime": "2022-01-31T10:05:34.767346Z",
+        "committer": "", "hash": "f3bb2fa6a832fade5b992499ed9c5ae2dadc8d9ed7a05c71cadd4421aead2efe",
         "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -739,12 +873,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -764,18 +898,18 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
-        "authorTime": "2021-12-07T10:04:01.932835Z", "commitTime": "2021-12-07T10:04:01.932835Z",
-        "committer": "", "hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+        "authorTime": "2022-01-31T10:05:35.179289Z", "commitTime": "2022-01-31T10:05:35.179289Z",
+        "committer": "", "hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -796,12 +930,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -821,14 +955,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1&endHash=df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2&endHash=317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -849,12 +983,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -874,18 +1008,18 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
-        "authorTime": "2021-12-07T10:04:01.932835Z", "commitTime": "2021-12-07T10:04:01.932835Z",
-        "committer": "", "hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+        "authorTime": "2022-01-31T10:05:35.179289Z", "commitTime": "2022-01-31T10:05:35.179289Z",
+        "committer": "", "hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -906,12 +1040,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -931,14 +1065,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log?filter=commit.author%3D%3D%27nessie_user1%27
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -959,12 +1093,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -984,14 +1118,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log?filter=commit.author%3D%3D%27nessie_user2%27
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
-        "authorTime": "2021-12-07T10:04:01.932835Z", "commitTime": "2021-12-07T10:04:01.932835Z",
-        "committer": "", "hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+        "authorTime": "2022-01-31T10:05:35.179289Z", "commitTime": "2022-01-31T10:05:35.179289Z",
+        "committer": "", "hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -1012,12 +1146,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1037,18 +1171,18 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log?filter=%28commit.author%3D%3D%27nessie_user2%27+%7C%7C+commit.author%3D%3D%27nessie_user1%27%29
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
-        "authorTime": "2021-12-07T10:04:01.932835Z", "commitTime": "2021-12-07T10:04:01.932835Z",
-        "committer": "", "hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+        "authorTime": "2022-01-31T10:05:35.179289Z", "commitTime": "2022-01-31T10:05:35.179289Z",
+        "committer": "", "hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -1069,12 +1203,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1094,18 +1228,18 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log?filter=commit.committer%3D%3D%27%27
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
-        "authorTime": "2021-12-07T10:04:01.932835Z", "commitTime": "2021-12-07T10:04:01.932835Z",
-        "committer": "", "hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+        "authorTime": "2022-01-31T10:05:35.179289Z", "commitTime": "2022-01-31T10:05:35.179289Z",
+        "committer": "", "hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -1126,12 +1260,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1151,14 +1285,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log?filter=commit.author+%3D%3D+%27nessie_user2%27+%7C%7C+commit.author+%3D%3D+%27non_existing%27
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
-        "authorTime": "2021-12-07T10:04:01.932835Z", "commitTime": "2021-12-07T10:04:01.932835Z",
-        "committer": "", "hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+        "authorTime": "2022-01-31T10:05:35.179289Z", "commitTime": "2022-01-31T10:05:35.179289Z",
+        "committer": "", "hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -1179,12 +1313,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+      string: '{"hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -1204,18 +1338,18 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log?filter=%28timestamp%28commit.commitTime%29+%3E+timestamp%28%272001-01-01T00%3A00%3A00%2B00%3A00%27%29+%26%26+timestamp%28commit.commitTime%29+%3C+timestamp%28%272999-12-30T23%3A00%3A00%2B00%3A00%27%29%29
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie_user2",
-        "authorTime": "2021-12-07T10:04:01.932835Z", "commitTime": "2021-12-07T10:04:01.932835Z",
-        "committer": "", "hash": "002fc650d490e9dbf95f92360732c7f9135503422acc7c3f3a56550acc7094a1",
+        "authorTime": "2022-01-31T10:05:35.179289Z", "commitTime": "2022-01-31T10:05:35.179289Z",
+        "committer": "", "hash": "8da88985f94952449ef1ecb02ace59cc9eaf144c5ab1cbfc642aa4f71dba84c2",
         "message": "delete_message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie_user1",
-        "authorTime": "2021-12-07T10:04:01.755144Z", "commitTime": "2021-12-07T10:04:01.755144Z",
-        "committer": "", "hash": "df6a41de17fc017b73deef976b6d1fb8935dd065d46f100b8cf70a26e6da75df",
+        "authorTime": "2022-01-31T10:05:34.861304Z", "commitTime": "2022-01-31T10:05:34.861304Z",
+        "committer": "", "hash": "317a67488635f04c55e84fbd8e930a68cb9fd068c3f0edf6d913b74c129b1bbe",
         "message": "commit to main", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -34,7 +34,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -89,7 +89,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
@@ -115,7 +115,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/merge.foo.bar?ref=dev
   response:
@@ -150,12 +150,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "50d087c6cceb6d3d1a6909af6eca960ac5bd8c5212e1362b2a78ec1b2e6fdfa1",
+      string: '{"hash": "53ee53773f337aa9791013ff9d9ea726038d2795f8888cc76dea1299b3e44ead",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -175,12 +175,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "50d087c6cceb6d3d1a6909af6eca960ac5bd8c5212e1362b2a78ec1b2e6fdfa1",
+      string: '{"hasMore": false, "references": [{"hash": "53ee53773f337aa9791013ff9d9ea726038d2795f8888cc76dea1299b3e44ead",
         "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
@@ -201,7 +201,33 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "53ee53773f337aa9791013ff9d9ea726038d2795f8888cc76dea1299b3e44ead",
+        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '272'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -226,62 +252,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: '{"hash": "50d087c6cceb6d3d1a6909af6eca960ac5bd8c5212e1362b2a78ec1b2e6fdfa1",
-        "name": "dev", "type": "BRANCH"}'
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '109'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fromHash": "50d087c6cceb6d3d1a6909af6eca960ac5bd8c5212e1362b2a78ec1b2e6fdfa1",
-      "fromRefName": "dev"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '102'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/merge?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "1735e959f3a112fd12b3baebf11123f3a224166c496e8d4ea8909b1cf6cd0ebb",
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -301,14 +277,89 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/dev
+  response:
+    body:
+      string: '{"hash": "53ee53773f337aa9791013ff9d9ea726038d2795f8888cc76dea1299b3e44ead",
+        "name": "dev", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '109'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fromHash": "53ee53773f337aa9791013ff9d9ea726038d2795f8888cc76dea1299b3e44ead",
+      "fromRefName": "dev"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/branch/main/merge?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+  response:
+    body:
+      string: ''
+    headers: {}
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree
+  response:
+    body:
+      string: '{"hash": "1fd3b13849c0a4818ac22f31a9b61e1bc13d748dc24baa85caf9738a4b365b03",
+        "name": "main", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '110'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main/log
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie
-        test", "authorTime": "2022-01-28T07:38:31.509936Z", "commitTime": "2022-01-28T07:38:31.543429Z",
-        "committer": "", "hash": "1735e959f3a112fd12b3baebf11123f3a224166c496e8d4ea8909b1cf6cd0ebb",
+        test", "authorTime": "2022-01-31T10:05:37.204995Z", "commitTime": "2022-01-31T10:05:37.282277Z",
+        "committer": "", "hash": "1fd3b13849c0a4818ac22f31a9b61e1bc13d748dc24baa85caf9738a4b365b03",
         "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
@@ -329,14 +380,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev/log
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie
-        test", "authorTime": "2022-01-28T07:38:31.509936Z", "commitTime": "2022-01-28T07:38:31.509936Z",
-        "committer": "", "hash": "50d087c6cceb6d3d1a6909af6eca960ac5bd8c5212e1362b2a78ec1b2e6fdfa1",
+        test", "authorTime": "2022-01-31T10:05:37.204995Z", "commitTime": "2022-01-31T10:05:37.204995Z",
+        "committer": "", "hash": "53ee53773f337aa9791013ff9d9ea726038d2795f8888cc76dea1299b3e44ead",
         "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:

--- a/python/tests/cassettes/test_nessie_cli/test_merge_detached.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge_detached.yaml
@@ -117,27 +117,27 @@ interactions:
       User-Agent:
       - python-requests/2.27.1
     method: GET
-    uri: http://localhost:19120/api/v1/contents/transplant.foo.bar?ref=dev
+    uri: http://localhost:19120/api/v1/contents/merge.foo.bar?ref=dev
   response:
     body:
       string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
-        for key ''transplant.foo.bar'' in reference ''dev''.", "reason": "Not Found",
-        "serverStackTrace": null, "status": 404}'
+        for key ''merge.foo.bar'' in reference ''dev''.", "reason": "Not Found", "serverStackTrace":
+        null, "status": 404}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '184'
+      - '179'
     status:
       code: 404
       message: Not Found
 - request:
     body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
       null, "committer": null, "hash": null, "message": "test message", "properties":
-      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_transplant_1",
+      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_merge_detached",
       "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
       45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
-      {"elements": ["transplant", "foo", "bar"]}, "type": "PUT"}]}'
+      {"elements": ["merge", "foo", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -146,7 +146,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '453'
+      - '450'
       Content-Type:
       - application/json
       User-Agent:
@@ -155,7 +155,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "3e28f22eb19b860ecfa52b94a5d0d31c2efa5a336a5bd0a88e8447c8b9767257",
+      string: '{"hash": "021eadb34b8d4ff07b1e75d9e6cc10dab76fcc631ca22ddbd6973c9822318791",
         "name": "dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -180,7 +180,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "3e28f22eb19b860ecfa52b94a5d0d31c2efa5a336a5bd0a88e8447c8b9767257",
+      string: '{"hasMore": false, "references": [{"hash": "021eadb34b8d4ff07b1e75d9e6cc10dab76fcc631ca22ddbd6973c9822318791",
         "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
@@ -188,66 +188,6 @@ interactions:
       - application/json
       content-length:
       - '272'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.27.1
-    method: GET
-    uri: http://localhost:19120/api/v1/contents/bar.bar?ref=dev
-  response:
-    body:
-      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
-        for key ''bar.bar'' in reference ''dev''.", "reason": "Not Found", "serverStackTrace":
-        null, "status": 404}'
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '173'
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
-      null, "committer": null, "hash": null, "message": "test message", "properties":
-      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_transplant_2",
-      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
-      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
-      {"elements": ["bar", "bar"]}, "type": "PUT"}]}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '439'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.27.1
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=3e28f22eb19b860ecfa52b94a5d0d31c2efa5a336a5bd0a88e8447c8b9767257
-  response:
-    body:
-      string: '{"hash": "b51dd4b2ca1179a07a7964106c14ec3457070976346f2a1a97698381dfe3e519",
-        "name": "dev", "type": "BRANCH"}'
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '109'
     status:
       code: 200
       message: OK
@@ -266,7 +206,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "b51dd4b2ca1179a07a7964106c14ec3457070976346f2a1a97698381dfe3e519",
+      string: '{"hasMore": false, "references": [{"hash": "021eadb34b8d4ff07b1e75d9e6cc10dab76fcc631ca22ddbd6973c9822318791",
         "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
@@ -274,128 +214,6 @@ interactions:
       - application/json
       content-length:
       - '272'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.27.1
-    method: GET
-    uri: http://localhost:19120/api/v1/contents/foo.baz?ref=dev
-  response:
-    body:
-      string: '{"errorCode": "CONTENT_NOT_FOUND", "message": "Could not find content
-        for key ''foo.baz'' in reference ''dev''.", "reason": "Not Found", "serverStackTrace":
-        null, "status": 404}'
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '173'
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
-      null, "committer": null, "hash": null, "message": "test message", "properties":
-      null, "signedOffBy": null}, "operations": [{"content": {"id": "test_transplant_3",
-      "metadataLocation": "/a/b/c", "schemaId": 43, "snapshotId": 42, "sortOrderId":
-      45, "specId": 44, "type": "ICEBERG_TABLE"}, "expectedContent": null, "key":
-      {"elements": ["foo", "baz"]}, "type": "PUT"}]}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '439'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.27.1
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=b51dd4b2ca1179a07a7964106c14ec3457070976346f2a1a97698381dfe3e519
-  response:
-    body:
-      string: '{"hash": "6c79f7a0e4991d154a9a915e756a78c151e1f593ea539f6bbb7818ba88962b98",
-        "name": "dev", "type": "BRANCH"}'
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '109'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.27.1
-    method: GET
-    uri: http://localhost:19120/api/v1/trees
-  response:
-    body:
-      string: '{"hasMore": false, "references": [{"hash": "6c79f7a0e4991d154a9a915e756a78c151e1f593ea539f6bbb7818ba88962b98",
-        "name": "dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}], "token": null}'
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '272'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.27.1
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev/log
-  response:
-    body:
-      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie
-        test", "authorTime": "2022-01-31T10:05:37.820273Z", "commitTime": "2022-01-31T10:05:37.820273Z",
-        "committer": "", "hash": "6c79f7a0e4991d154a9a915e756a78c151e1f593ea539f6bbb7818ba88962b98",
-        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
-        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie test",
-        "authorTime": "2022-01-31T10:05:37.768022Z", "commitTime": "2022-01-31T10:05:37.768022Z",
-        "committer": "", "hash": "b51dd4b2ca1179a07a7964106c14ec3457070976346f2a1a97698381dfe3e519",
-        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
-        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie test",
-        "authorTime": "2022-01-31T10:05:37.727736Z", "commitTime": "2022-01-31T10:05:37.727736Z",
-        "committer": "", "hash": "3e28f22eb19b860ecfa52b94a5d0d31c2efa5a336a5bd0a88e8447c8b9767257",
-        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
-        null, "parentCommitHash": null}], "token": null}'
-    headers:
-      Content-Type:
-      - application/json
-      content-length:
-      - '1063'
     status:
       code: 200
       message: OK
@@ -425,8 +243,33 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromRefName": "dev", "hashesToTransplant": ["b51dd4b2ca1179a07a7964106c14ec3457070976346f2a1a97698381dfe3e519",
-      "6c79f7a0e4991d154a9a915e756a78c151e1f593ea539f6bbb7818ba88962b98"]}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '110'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fromHash": "021eadb34b8d4ff07b1e75d9e6cc10dab76fcc631ca22ddbd6973c9822318791",
+      "fromRefName": "DETACHED"}'
     headers:
       Accept:
       - '*/*'
@@ -435,13 +278,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '182'
+      - '107'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.27.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/transplant?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+    uri: http://localhost:19120/api/v1/trees/branch/main/merge?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
       string: ''
@@ -464,7 +307,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: '{"hash": "f28b62730d8cc109eb04675ec65f01bf88ba1d0642b87377913eb3424c699b3b",
+      string: '{"hash": "6b0573ddcc8268ecd9c23d43c841df862b50cb25138b7ff4447d7b011a77686f",
         "name": "main", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -490,19 +333,43 @@ interactions:
   response:
     body:
       string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie
-        test", "authorTime": "2022-01-31T10:05:37.820273Z", "commitTime": "2022-01-31T10:05:37.881051Z",
-        "committer": "", "hash": "f28b62730d8cc109eb04675ec65f01bf88ba1d0642b87377913eb3424c699b3b",
-        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
-        null, "parentCommitHash": null}, {"commitMeta": {"author": "nessie test",
-        "authorTime": "2022-01-31T10:05:37.768022Z", "commitTime": "2022-01-31T10:05:37.881051Z",
-        "committer": "", "hash": "ccc200e7c7ad4feeb027b329970b76bafa641b48e55b4e6cb9617beac196d605",
+        test", "authorTime": "2022-01-31T10:05:37.481719Z", "commitTime": "2022-01-31T10:05:37.536576Z",
+        "committer": "", "hash": "6b0573ddcc8268ecd9c23d43c841df862b50cb25138b7ff4447d7b011a77686f",
         "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
         null, "parentCommitHash": null}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '725'
+      - '387'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/dev/log
+  response:
+    body:
+      string: '{"hasMore": false, "logEntries": [{"commitMeta": {"author": "nessie
+        test", "authorTime": "2022-01-31T10:05:37.481719Z", "commitTime": "2022-01-31T10:05:37.481719Z",
+        "committer": "", "hash": "021eadb34b8d4ff07b1e75d9e6cc10dab76fcc631ca22ddbd6973c9822318791",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "operations":
+        null, "parentCommitHash": null}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '387'
     status:
       code: 200
       message: OK

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
@@ -34,7 +34,32 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '161'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -64,7 +89,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -89,14 +114,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "dev-tag", "type": "TAG"}], "token": null}'
+        "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -115,7 +140,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -145,7 +170,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -170,20 +195,50 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "etl-tag", "type": "TAG"}], "token": null}'
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
       - '385'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "metadata": null, "name": "dev-hash-tag", "type": "TAG"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=DETACHED
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-hash-tag", "type": "TAG"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '115'
     status:
       code: 200
       message: OK
@@ -197,20 +252,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-hash-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "etl-tag", "type": "TAG"}], "token": null}'
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '385'
+      - '502'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "metadata": null, "name": "etl-hash-tag", "type": "TAG"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-hash-tag", "type": "TAG"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '115'
     status:
       code: 200
       message: OK
@@ -224,20 +310,22 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-hash-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-hash-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "etl-tag", "type": "TAG"}], "token": null}'
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '385'
+      - '619'
     status:
       code: 200
       message: OK
@@ -251,7 +339,65 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-hash-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-hash-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '619'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-hash-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-hash-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-tag", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '619'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/etl-tag
   response:
@@ -278,7 +424,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: DELETE
     uri: http://localhost:19120/api/v1/trees/tag/etl-tag?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
@@ -298,7 +444,54 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/etl-hash-tag
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "etl-hash-tag", "type": "TAG"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '115'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.27.1
+    method: DELETE
+    uri: http://localhost:19120/api/v1/trees/tag/etl-hash-tag?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+  response:
+    body:
+      string: ''
+    headers: {}
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/dev-tag
   response:
@@ -325,7 +518,7 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: DELETE
     uri: http://localhost:19120/api/v1/trees/tag/dev-tag?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
@@ -345,7 +538,54 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/dev-hash-tag
+  response:
+    body:
+      string: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "dev-hash-tag", "type": "TAG"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '115'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.27.1
+    method: DELETE
+    uri: http://localhost:19120/api/v1/trees/tag/dev-hash-tag?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+  response:
+    body:
+      string: ''
+    headers: {}
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
@@ -370,7 +610,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -395,7 +635,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -425,7 +665,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -450,14 +690,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "v1.0", "type": "TAG"}], "token": null}'
+        "name": "v1.0", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -476,14 +716,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "v1.0", "type": "TAG"}], "token": null}'
+        "name": "v1.0", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -502,7 +742,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -532,7 +772,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -557,15 +797,15 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
       string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "metadata_branch", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "v1.0", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "metadata_branch", "type": "BRANCH"}], "token": null}'
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
@@ -584,7 +824,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/test.tag.metadata?ref=metadata_branch
   response:
@@ -619,12 +859,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/metadata_branch/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "e044af405a40bd363de23e29b9983470c01a328aabd72136e82b790bd6dbbf33",
+      string: '{"hash": "e4cf089b878a8af0f3f586cf29c77704aa7536be752cb34a17c9fc09de5c7c95",
         "name": "metadata_branch", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -644,12 +884,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/metadata_branch
   response:
     body:
-      string: '{"hash": "e044af405a40bd363de23e29b9983470c01a328aabd72136e82b790bd6dbbf33",
+      string: '{"hash": "e4cf089b878a8af0f3f586cf29c77704aa7536be752cb34a17c9fc09de5c7c95",
         "name": "metadata_branch", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -660,7 +900,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "e044af405a40bd363de23e29b9983470c01a328aabd72136e82b790bd6dbbf33",
+    body: '{"hash": "e4cf089b878a8af0f3f586cf29c77704aa7536be752cb34a17c9fc09de5c7c95",
       "metadata": null, "name": "metadata_tag", "type": "TAG"}'
     headers:
       Accept:
@@ -674,12 +914,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=metadata_branch
   response:
     body:
-      string: '{"hash": "e044af405a40bd363de23e29b9983470c01a328aabd72136e82b790bd6dbbf33",
+      string: '{"hash": "e4cf089b878a8af0f3f586cf29c77704aa7536be752cb34a17c9fc09de5c7c95",
         "name": "metadata_tag", "type": "TAG"}'
     headers:
       Content-Type:
@@ -699,27 +939,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees?fetch=ALL
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "main", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-        "name": "v1.0", "type": "TAG"}, {"hash": "e044af405a40bd363de23e29b9983470c01a328aabd72136e82b790bd6dbbf33",
+      string: '{"hasMore": false, "references": [{"hash": "e4cf089b878a8af0f3f586cf29c77704aa7536be752cb34a17c9fc09de5c7c95",
         "metadata": {"commitMetaOfHEAD": {"author": "nessie_user1", "authorTime":
-        "2021-12-07T10:04:02.900709Z", "commitTime": "2021-12-07T10:04:02.900709Z",
-        "committer": "", "hash": "e044af405a40bd363de23e29b9983470c01a328aabd72136e82b790bd6dbbf33",
+        "2022-01-31T10:05:36.630532Z", "commitTime": "2022-01-31T10:05:36.630532Z",
+        "committer": "", "hash": "e4cf089b878a8af0f3f586cf29c77704aa7536be752cb34a17c9fc09de5c7c95",
+        "message": "test message", "properties": {}, "signedOffBy": null}, "commonAncestorHash":
+        null, "numCommitsAhead": null, "numCommitsBehind": null, "numTotalCommits":
+        1}, "name": "metadata_tag", "type": "TAG"}, {"hash": "e4cf089b878a8af0f3f586cf29c77704aa7536be752cb34a17c9fc09de5c7c95",
+        "metadata": {"commitMetaOfHEAD": {"author": "nessie_user1", "authorTime":
+        "2022-01-31T10:05:36.630532Z", "commitTime": "2022-01-31T10:05:36.630532Z",
+        "committer": "", "hash": "e4cf089b878a8af0f3f586cf29c77704aa7536be752cb34a17c9fc09de5c7c95",
         "message": "test message", "properties": {}, "signedOffBy": null}, "commonAncestorHash":
         "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d", "numCommitsAhead":
         1, "numCommitsBehind": 0, "numTotalCommits": 1}, "name": "metadata_branch",
-        "type": "BRANCH"}, {"hash": "e044af405a40bd363de23e29b9983470c01a328aabd72136e82b790bd6dbbf33",
-        "metadata": {"commitMetaOfHEAD": {"author": "nessie_user1", "authorTime":
-        "2021-12-07T10:04:02.900709Z", "commitTime": "2021-12-07T10:04:02.900709Z",
-        "committer": "", "hash": "e044af405a40bd363de23e29b9983470c01a328aabd72136e82b790bd6dbbf33",
-        "message": "test message", "properties": {}, "signedOffBy": null}, "commonAncestorHash":
-        null, "numCommitsAhead": null, "numCommitsBehind": null, "numTotalCommits":
-        1}, "name": "metadata_tag", "type": "TAG"}], "token": null}'
+        "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "v1.0", "type": "TAG"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_list.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -34,7 +34,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -89,7 +89,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
@@ -115,7 +115,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_list_dev
   response:
@@ -150,12 +150,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "3bec1242c7f9840b6088b135783ff2d8436a02f478454613ff0a5bfef3379cfc",
+      string: '{"hash": "bfb82093dcdf6433cfd68d9a7908ade2a17fcb4707d7d17b6bce0eaf901aca35",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -175,12 +175,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "3bec1242c7f9840b6088b135783ff2d8436a02f478454613ff0a5bfef3379cfc",
+      string: '{"hasMore": false, "references": [{"hash": "bfb82093dcdf6433cfd68d9a7908ade2a17fcb4707d7d17b6bce0eaf901aca35",
         "name": "contents_list_dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
@@ -201,7 +201,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_list_dev
   response:
@@ -221,9 +221,9 @@ interactions:
     body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
       null, "committer": null, "hash": null, "message": "test message", "properties":
       null, "signedOffBy": null}, "operations": [{"content": {"checkpointLocationHistory":
-      ["def"], "id": "uuid2", "lastCheckpoint": "x", "metadataLocationHistory": ["asd"],
-      "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "key": {"elements": ["this",
-      "is", "delta", "bar"]}, "type": "PUT"}]}'
+      ["def"], "id": "test_dl_table_list", "lastCheckpoint": "x", "metadataLocationHistory":
+      ["asd"], "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "key": {"elements":
+      ["this", "is", "delta", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -232,16 +232,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '446'
+      - '459'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=3bec1242c7f9840b6088b135783ff2d8436a02f478454613ff0a5bfef3379cfc
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=bfb82093dcdf6433cfd68d9a7908ade2a17fcb4707d7d17b6bce0eaf901aca35
   response:
     body:
-      string: '{"hash": "0a44e5a1dd2bc5b827fa8aff6f181bc51a4f2d3a1d0e4422f3d716d7ab9611cc",
+      string: '{"hash": "d36125a5d0bd40514190198b7454507628c164f99a90e608093787be54b8f23e",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -261,12 +261,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "0a44e5a1dd2bc5b827fa8aff6f181bc51a4f2d3a1d0e4422f3d716d7ab9611cc",
+      string: '{"hasMore": false, "references": [{"hash": "d36125a5d0bd40514190198b7454507628c164f99a90e608093787be54b8f23e",
         "name": "contents_list_dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
@@ -287,7 +287,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/this.is.sql.baz?ref=contents_list_dev
   response:
@@ -307,9 +307,9 @@ interactions:
     body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
       null, "committer": null, "hash": null, "message": "test message", "properties":
       null, "signedOffBy": null}, "operations": [{"content": {"dialect": "SPARK",
-      "id": "uuid3", "metadataLocation": "/a/b/c", "schemaId": 1, "sqlText": "SELECT
-      * FROM foo", "type": "ICEBERG_VIEW", "versionId": 1}, "expectedContent": null,
-      "key": {"elements": ["this", "is", "sql", "baz"]}, "type": "PUT"}]}'
+      "id": "test_iceberg_view_list", "metadataLocation": "/a/b/c", "schemaId": 1,
+      "sqlText": "SELECT * FROM foo", "type": "ICEBERG_VIEW", "versionId": 1}, "expectedContent":
+      null, "key": {"elements": ["this", "is", "sql", "baz"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -318,16 +318,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '456'
+      - '473'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=0a44e5a1dd2bc5b827fa8aff6f181bc51a4f2d3a1d0e4422f3d716d7ab9611cc
+    uri: http://localhost:19120/api/v1/trees/branch/contents_list_dev/commit?expectedHash=d36125a5d0bd40514190198b7454507628c164f99a90e608093787be54b8f23e
   response:
     body:
-      string: '{"hash": "717cff05e32c7eb52f13c2d625150cc4e417c4512177640f0612c5f9f26ee4b9",
+      string: '{"hash": "7536cd6505fc919207886b918f7c2309a2977361b54e2db22900aa36cb0d128c",
         "name": "contents_list_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -347,7 +347,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?filter=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
   response:
@@ -372,7 +372,83 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees
+  response:
+    body:
+      string: '{"hasMore": false, "references": [{"hash": "7536cd6505fc919207886b918f7c2309a2977361b54e2db22900aa36cb0d128c",
+        "name": "contents_list_dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '286'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/DETACHED/entries?hashOnRef=7536cd6505fc919207886b918f7c2309a2977361b54e2db22900aa36cb0d128c&filter=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
+  response:
+    body:
+      string: '{"entries": [{"name": {"elements": ["this", "is", "iceberg", "foo"]},
+        "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '129'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?hashOnRef=7536cd6505fc919207886b918f7c2309a2977361b54e2db22900aa36cb0d128c&filter=entry.contentType+in+%5B%27ICEBERG_TABLE%27%5D
+  response:
+    body:
+      string: '{"entries": [{"name": {"elements": ["this", "is", "iceberg", "foo"]},
+        "type": "ICEBERG_TABLE"}], "hasMore": false, "token": null}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '129'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?filter=entry.contentType+in+%5B%27DELTA_LAKE_TABLE%27%5D
   response:
@@ -397,7 +473,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?filter=entry.contentType+%3D%3D+%27ICEBERG_TABLE%27
   response:
@@ -422,7 +498,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?filter=entry.contentType+in+%5B%27ICEBERG_TABLE%27%2C+%27DELTA_LAKE_TABLE%27%5D
   response:
@@ -448,7 +524,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?filter=entry.namespace.startsWith%28%27this.is.del%27%29
   response:
@@ -473,7 +549,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/contents_list_dev/entries?filter=entry.namespace.startsWith%28%27this.is%27%29
   response:

--- a/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
+++ b/python/tests/cassettes/test_nessie_cli_content/test_content_view.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree
   response:
@@ -34,7 +34,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
@@ -89,7 +89,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
@@ -115,7 +115,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_view_dev
   response:
@@ -150,12 +150,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
     uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: '{"hash": "ea90941e2be0f5d7a9a2fbc20a318a05638a1e8fa5675b187bd476870e83535d",
+      string: '{"hash": "1149de3299fa2f336935d3e3ed0c086a1306338884822f2f84b3430888801b66",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -175,12 +175,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "ea90941e2be0f5d7a9a2fbc20a318a05638a1e8fa5675b187bd476870e83535d",
+      string: '{"hasMore": false, "references": [{"hash": "1149de3299fa2f336935d3e3ed0c086a1306338884822f2f84b3430888801b66",
         "name": "contents_view_dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
@@ -201,7 +201,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_view_dev
   response:
@@ -221,9 +221,9 @@ interactions:
     body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
       null, "committer": null, "hash": null, "message": "test message", "properties":
       null, "signedOffBy": null}, "operations": [{"content": {"checkpointLocationHistory":
-      ["def"], "id": "uuid2", "lastCheckpoint": "x", "metadataLocationHistory": ["asd"],
-      "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "key": {"elements": ["this",
-      "is", "delta", "bar"]}, "type": "PUT"}]}'
+      ["def"], "id": "test_dl_table", "lastCheckpoint": "x", "metadataLocationHistory":
+      ["asd"], "type": "DELTA_LAKE_TABLE"}, "expectedContent": null, "key": {"elements":
+      ["this", "is", "delta", "bar"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -232,16 +232,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '446'
+      - '454'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=ea90941e2be0f5d7a9a2fbc20a318a05638a1e8fa5675b187bd476870e83535d
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=1149de3299fa2f336935d3e3ed0c086a1306338884822f2f84b3430888801b66
   response:
     body:
-      string: '{"hash": "ce3a0d36f68bd2db170422bd64c1a292c4b22ce671cbe099d5844c31f0520921",
+      string: '{"hash": "125e3a1bcbcde88d01ed7fcd41f49b889c896f7c0194e73764c7b113b30bd4b5",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -261,12 +261,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"hasMore": false, "references": [{"hash": "ce3a0d36f68bd2db170422bd64c1a292c4b22ce671cbe099d5844c31f0520921",
+      string: '{"hasMore": false, "references": [{"hash": "125e3a1bcbcde88d01ed7fcd41f49b889c896f7c0194e73764c7b113b30bd4b5",
         "name": "contents_view_dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
         "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
@@ -287,7 +287,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/this.is.sql%00baz?ref=contents_view_dev
   response:
@@ -307,9 +307,9 @@ interactions:
     body: '{"commitMeta": {"author": "nessie test", "authorTime": null, "commitTime":
       null, "committer": null, "hash": null, "message": "test message", "properties":
       null, "signedOffBy": null}, "operations": [{"content": {"dialect": "SPARK",
-      "id": "uuid3", "metadataLocation": "/a/b/c", "schemaId": 1, "sqlText": "SELECT
-      * FROM foo", "type": "ICEBERG_VIEW", "versionId": 1}, "expectedContent": null,
-      "key": {"elements": ["this", "is", "sql.baz"]}, "type": "PUT"}]}'
+      "id": "test_iceberg_view", "metadataLocation": "/a/b/c", "schemaId": 1, "sqlText":
+      "SELECT * FROM foo", "type": "ICEBERG_VIEW", "versionId": 1}, "expectedContent":
+      null, "key": {"elements": ["this", "is", "sql.baz"]}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -318,16 +318,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '453'
+      - '465'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=ce3a0d36f68bd2db170422bd64c1a292c4b22ce671cbe099d5844c31f0520921
+    uri: http://localhost:19120/api/v1/trees/branch/contents_view_dev/commit?expectedHash=125e3a1bcbcde88d01ed7fcd41f49b889c896f7c0194e73764c7b113b30bd4b5
   response:
     body:
-      string: '{"hash": "44fd1af5ba71432c98a0c6f46cc0df2acd42ef85c47fe1cd5e40bc4a1fb7b874",
+      string: '{"hash": "6d7028f3ed8d5279c4babc78ff60f2064e954f4488217daf8160dd19c42e5943",
         "name": "contents_view_dev", "type": "BRANCH"}'
     headers:
       Content-Type:
@@ -347,7 +347,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
     uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_view_dev
   response:
@@ -372,18 +372,19 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
-    uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_view_dev
+    uri: http://localhost:19120/api/v1/trees
   response:
     body:
-      string: '{"checkpointLocationHistory": ["def"], "id": "uuid2", "lastCheckpoint":
-        "x", "metadataLocationHistory": ["asd"], "type": "DELTA_LAKE_TABLE"}'
+      string: '{"hasMore": false, "references": [{"hash": "6d7028f3ed8d5279c4babc78ff60f2064e954f4488217daf8160dd19c42e5943",
+        "name": "contents_view_dev", "type": "BRANCH"}, {"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+        "name": "main", "type": "BRANCH"}], "token": null}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '140'
+      - '286'
     status:
       code: 200
       message: OK
@@ -397,18 +398,94 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
     method: GET
-    uri: http://localhost:19120/api/v1/contents/this.is.sql%00baz?ref=contents_view_dev
+    uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=DETACHED&hashOnRef=6d7028f3ed8d5279c4babc78ff60f2064e954f4488217daf8160dd19c42e5943
   response:
     body:
-      string: '{"dialect": "SPARK", "id": "uuid3", "metadataLocation": "/a/b/c", "schemaId":
-        1, "sqlText": "SELECT * FROM foo", "type": "ICEBERG_VIEW", "versionId": 1}'
+      string: '{"id": "test_contents_view", "metadataLocation": "/a/b/c", "schemaId":
+        42, "snapshotId": 42, "sortOrderId": 42, "specId": 42, "type": "ICEBERG_TABLE"}'
     headers:
       Content-Type:
       - application/json
       content-length:
-      - '152'
+      - '150'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/contents/this.is.iceberg.foo?ref=contents_view_dev&hashOnRef=6d7028f3ed8d5279c4babc78ff60f2064e954f4488217daf8160dd19c42e5943
+  response:
+    body:
+      string: '{"id": "test_contents_view", "metadataLocation": "/a/b/c", "schemaId":
+        42, "snapshotId": 42, "sortOrderId": 42, "specId": 42, "type": "ICEBERG_TABLE"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '150'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/contents/this.is.delta.bar?ref=contents_view_dev
+  response:
+    body:
+      string: '{"checkpointLocationHistory": ["def"], "id": "test_dl_table", "lastCheckpoint":
+        "x", "metadataLocationHistory": ["asd"], "type": "DELTA_LAKE_TABLE"}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '148'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://localhost:19120/api/v1/contents/this.is.sql%00baz?ref=contents_view_dev
+  response:
+    body:
+      string: '{"dialect": "SPARK", "id": "test_iceberg_view", "metadataLocation":
+        "/a/b/c", "schemaId": 1, "sqlText": "SELECT * FROM foo", "type": "ICEBERG_VIEW",
+        "versionId": 1}'
+    headers:
+      Content-Type:
+      - application/json
+      content-length:
+      - '164'
     status:
       code: 200
       message: OK

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -84,6 +84,12 @@ def _run(args: List[str], input_data: Optional[str] = None, ret_val: int = 0) ->
     return result
 
 
+def ref_hash(ref: str) -> str:
+    """Get the hash for a reference."""
+    refs = ReferenceSchema().loads(execute_cli_command(["--json", "branch", "-l"]), many=True)
+    return next(i.hash_ for i in refs if i.name == ref)
+
+
 def make_commit(
     key: str, table: Content, branch: str, head_hash: str = None, message: str = "test message", author: str = "nessie test"
 ) -> None:

--- a/python/tests/test_reference_expressions.py
+++ b/python/tests/test_reference_expressions.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for `config_parser.py`."""
+
+from assertpy import assert_that
+
+from pynessie.model import DETACHED_REFERENCE_NAME, is_valid_hash, is_valid_reference_name, split_into_reference_and_hash
+
+
+def test_is_valid_reference_name() -> None:
+    """Validates is_valid_reference_name."""
+    assert_that(is_valid_reference_name("")).is_false()
+    assert_that(is_valid_reference_name("*")).is_false()
+    assert_that(is_valid_reference_name("@")).is_false()
+    assert_that(is_valid_reference_name("main")).is_true()
+    assert_that(is_valid_reference_name("abc/def")).is_true()
+
+
+def test_is_valid_hash() -> None:
+    """Validates is_valid_hash."""
+    assert_that(is_valid_hash(".cafe")).is_false()
+    assert_that(is_valid_hash("main")).is_false()
+    assert_that(is_valid_hash("1122334455667788990011223344556677889900112233445566778899001122")).is_true()
+    assert_that(is_valid_hash("abcDEF4242424242424242424242BEEF00DEAD42112233445566778899001122")).is_true()
+    assert_that(is_valid_hash("caffee20")).is_true()
+    assert_that(is_valid_hash("20caffee")).is_true()
+
+
+def test_split_into_reference_and_hash() -> None:
+    """Validates split_into_reference_and_hash."""
+    assert_that(split_into_reference_and_hash("main")).is_equal_to(("main", None))
+    assert_that(split_into_reference_and_hash("abcDEF4242424242424242424242BEEF00DEAD42112233445566778899001122")).is_equal_to(
+        (DETACHED_REFERENCE_NAME, "abcDEF4242424242424242424242BEEF00DEAD42112233445566778899001122")
+    )
+    assert_that(split_into_reference_and_hash("main@caffee20")).is_equal_to(("main", "caffee20"))
+    assert_that(split_into_reference_and_hash("main*caffee20")).is_equal_to(("main", "caffee20"))
+    assert_that(split_into_reference_and_hash("DETACHED@1596af9580555a9a8437553878546385b070440acc063ac4461770ebce763aa1")).is_equal_to(
+        (DETACHED_REFERENCE_NAME, "1596af9580555a9a8437553878546385b070440acc063ac4461770ebce763aa1")
+    )
+    assert_that(split_into_reference_and_hash("1596af9580555a9a8437553878546385b070440acc063ac4461770ebce763aa1")).is_equal_to(
+        (DETACHED_REFERENCE_NAME, "1596af9580555a9a8437553878546385b070440acc063ac4461770ebce763aa1")
+    )
+    assert_that(split_into_reference_and_hash(None)).is_equal_to(("<UNKNOWN>", None))


### PR DESCRIPTION
Allows detached commit-ids for:
* `nessie log` using detached commit-ids or "ref-name@commit-id" for the "ref" argument, "start-hash" (the log terminating commit-id) can be provided as before
* `nessie diff` using either detached commit-ids or "ref-name@commit-id"
* `nessie branch` (create + assign) using either detached commit-ids or "ref-name@commit-id"
* `nessie tag` (create + assign) using either detached commit-ids or "ref-name@commit-id"
* `nessie merge` additionally allowing "ref-name@commit-id" from from-ref and to-branch
* `nessie content view` / `list` additionally allow specifying detached commit id and "ref-name@commit-id"

Using a detached commit-id _and_ an explicit hash-on-ref argument causes an exception, if the commit-ids are not the same.
