### PR TITLE
Revert "Bump error_prone_core from 2.10.0 to 2.11.0 (#3159)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <flapdoodle.version>3.1.4</flapdoodle.version>
     <gatling.maven.version>4.1.1</gatling.maven.version>
     <gatling.version>3.7.4</gatling.version>
-    <google-error-prone.version>2.11.0</google-error-prone.version>
+    <google-error-prone.version>2.10.0</google-error-prone.version>
     <google-java-format.version>1.13.0</google-java-format.version>
     <guava.version>31.0.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>


### PR DESCRIPTION
This reverts commit 1d789f198be3b0e46310eb18ac1de5ab06e92f84.

Due to the below problem.
<img width="1777" alt="Screenshot 2022-02-01 at 8 05 01 AM" src="https://user-images.githubusercontent.com/5889404/151932514-b4815149-c3a9-4446-bd83-50f9822ffeee.png">

