### PR TITLE
Finish spans in TracingVersionStore

### DIFF
--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -306,7 +306,8 @@ class TestTracingVersionStore {
                 tracer.getActiveSpan().getTags(),
                 "expected tags don't match"),
         () -> assertTrue(tracer.isParentSet(), "Span-parent not set"),
-        () -> assertTrue(tracer.isClosed(), "Scope not closed"));
+        () -> assertTrue(tracer.isClosed(), "Scope not closed"),
+        () -> assertTrue(tracer.getActiveSpan().finished(), "Span did not finish"));
   }
 
   @Test

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/test/tracing/TestTracer.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/test/tracing/TestTracer.java
@@ -181,9 +181,14 @@ public class TestTracer implements Tracer {
 
     private final Map<String, Object> tags = new HashMap<>();
     private final List<Map<String, ?>> logs = new ArrayList<>();
+    private boolean finished;
 
     TestSpan(Map<String, Object> tags) {
       this.tags.putAll(tags);
+    }
+
+    public boolean finished() {
+      return finished;
     }
 
     public Map<String, Object> getTags() {
@@ -261,7 +266,7 @@ public class TestTracer implements Tracer {
 
     @Override
     public void finish() {
-      throw new UnsupportedOperationException();
+      finished = true;
     }
 
     @Override


### PR DESCRIPTION
* Add a Closable internal SpanHolder class to support
  the try-with-resources pattern for spans

* Close/finish spans created by TracingVersionStore

* Correct Scope/Span tracking in methods that return Streams

Fixes #3234