### PR TITLE
Use the right `StoreWorker` in tests

### DIFF
--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyRest.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyRest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.jaxrs.ext.NessieUri;
+import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
@@ -30,7 +31,8 @@ import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
 @ExtendWith(DatabaseAdapterExtension.class)
 abstract class AbstractTestJerseyRest extends AbstractRestSecurityContext {
 
-  @NessieDbAdapter static DatabaseAdapter databaseAdapter;
+  @NessieDbAdapter(storeWorker = TableCommitMetaStoreWorker.class)
+  static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
   static org.projectnessie.jaxrs.ext.NessieJaxRsExtension server =

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyResteasy.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyResteasy.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.jaxrs.ext.NessieUri;
+import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
@@ -31,7 +32,8 @@ import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
 @ExtendWith(DatabaseAdapterExtension.class)
 abstract class AbstractTestJerseyResteasy extends AbstractResteasyTest {
 
-  @NessieDbAdapter static DatabaseAdapter databaseAdapter;
+  @NessieDbAdapter(storeWorker = TableCommitMetaStoreWorker.class)
+  static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
   static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbAdapter.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbAdapter.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.projectnessie.versioned.StoreWorker;
+import org.projectnessie.versioned.testworker.SimpleStoreWorker;
 
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
@@ -56,4 +58,6 @@ public @interface NessieDbAdapter {
 
   /** Whether to initialize the adapter, defaults to {@code true}. */
   boolean initializeRepo() default true;
+
+  Class<? extends StoreWorker<?, ?, ?>> storeWorker() default SimpleStoreWorker.class;
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/SimpleStoreWorker.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/SimpleStoreWorker.java
@@ -48,8 +48,6 @@ public final class SimpleStoreWorker
         }
       };
 
-  private SimpleStoreWorker() {}
-
   @Override
   public ByteString toStoreOnReferenceState(BaseContent content) {
     BaseContent.Type type = getType(content);


### PR DESCRIPTION
`DatabaseAdapterExtension` always used the `SimpleStoreWorker`, which is
actually wrong for `Abstract*Rest*` tests, because those must use
`TableCommitStoreWorker`.

Adds a new property `storeWorker` to the `@NessieDbAdapter` annotation,
so the affected tests (those using Jersey) use the right store-worker.