### PR TITLE
Follow-up for "Use the right `StoreWorker` in tests"

### DIFF
--- a/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
+++ b/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
@@ -46,6 +46,7 @@ import org.projectnessie.jaxrs.ext.NessieUri;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
+import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
@@ -59,7 +60,8 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
 public class BaseIcebergTest {
 
-  @NessieDbAdapter static DatabaseAdapter databaseAdapter;
+  @NessieDbAdapter(storeWorker = TableCommitMetaStoreWorker.class)
+  static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
   static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);


### PR DESCRIPTION
Adds a change change that was missing in #3292