### PR TITLE
Use docker hostname for dynamodb integ test

### DIFF
--- a/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/LocalDynamoTestConnectionProviderSource.java
+++ b/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/LocalDynamoTestConnectionProviderSource.java
@@ -78,8 +78,9 @@ public class LocalDynamoTestConnectionProviderSource extends DynamoTestConnectio
     container.start();
 
     Integer port = container.getFirstMappedPort();
+    String host = container.getHost();
 
-    endpointURI = String.format("http://localhost:%d", port);
+    endpointURI = String.format("http://%s:%d", host, port);
   }
 
   @Override


### PR DESCRIPTION
Now that Docker Desktop is no longer free. Some of us are migrating to Minikube. Minikube doesn't expose ports in localhost, so defaulting to "localhost" seems to assume that the only docker engine is Docker Desktop. I still need to test if this change works with other docker engines (like the linux one and docker desktop)