### PR TITLE
parallel maven builds in workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,14 +35,14 @@ jobs:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         SPARK_LOCAL_IP: localhost
       if: ${{ env.MAVEN_USERNAME }}
-      run: ./mvnw -B deploy --file pom.xml -Pcode-coverage,release -DdeployAtEnd=true -Dtest.log.level=WARN
+      run: ./mvnw --batch-mode --threads 1C deploy -Pcode-coverage,release -DdeployAtEnd=true -Dtest.log.level=WARN
 
     - name: Build with Maven (Fork)
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
         SPARK_LOCAL_IP: localhost
       if: ${{ ! env.MAVEN_USERNAME }}
-      run: ./mvnw -B install --file pom.xml -Pcode-coverage,release -DskipGpg -Dtest.log.level=WARN
+      run: ./mvnw --batch-mode --threads 1C install -Pcode-coverage,release -DskipGpg -Dtest.log.level=WARN
 
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build
@@ -73,11 +73,11 @@ jobs:
         uses: ./.github/actions/dev-tool-java
 
       - name: Build with Maven
-        run: ./mvnw -B install -DskipTests -am -pl :nessie-quarkus -pl :nessie-lambda
+        run: ./mvnw --batch-mode --threads 1C install -DskipTests -am -pl :nessie-quarkus -pl :nessie-lambda
 
       - name: Test native with Maven
         run: |
-          ./mvnw -B install -Pnative,docker -Dtest.log.level=WARN -Dquarkus.native.native-image-xmx=6g -pl :nessie-quarkus -pl :nessie-lambda
+          ./mvnw --batch-mode install -Pnative,docker -Dtest.log.level=WARN -Dquarkus.native.native-image-xmx=6g -pl :nessie-quarkus -pl :nessie-lambda
 
       - name: Push Docker images
         env:

--- a/.github/workflows/pull-request-jackson.yml
+++ b/.github/workflows/pull-request-jackson.yml
@@ -51,7 +51,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Build with Maven ${{ matrix.target-library }}
         run: |
-          ./mvnw -B install -DskipTests -am -pl :nessie-quarkus -pl :nessie-lambda
+          ./mvnw --batch-mode --threads 1C install -DskipTests -am -pl :nessie-quarkus -pl :nessie-lambda
       - name: Jackson Integration Tests ${{ matrix.target-library }}
         run: |
-          ./mvnw verify -pl :nessie-client -am -Pjackson-tests -Djackson.test.version=${{ matrix.jackson-version }} -Dtest.log.level=WARN
+          ./mvnw --batch-mode verify -pl :nessie-client -am -Pjackson-tests -Djackson.test.version=${{ matrix.jackson-version }} -Dtest.log.level=WARN

--- a/.github/workflows/pull-request-native.yml
+++ b/.github/workflows/pull-request-native.yml
@@ -34,8 +34,8 @@ jobs:
       uses: ./.github/actions/dev-tool-java
 
     - name: Build with Maven
-      run: ./mvnw -B install -DskipTests -am -pl :nessie-quarkus -pl :nessie-lambda
+      run: ./mvnw --batch-mode --threads 1C install -DskipTests -am -pl :nessie-quarkus -pl :nessie-lambda
 
     - name: Test native with Maven
       run: |
-        ./mvnw -B install -Pnative,docker -Dtest.log.level=WARN -Dquarkus.native.native-image-xmx=6g -pl :nessie-quarkus -pl :nessie-lambda
+        ./mvnw --batch-mode install -Pnative,docker -Dtest.log.level=WARN -Dquarkus.native.native-image-xmx=6g -pl :nessie-quarkus -pl :nessie-lambda

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,7 @@ jobs:
       env:
         SPARK_LOCAL_IP: localhost
       run: |
-        ./mvnw -B install javadoc:javadoc-no-fork --file pom.xml -Pcode-coverage -Dtest.log.level=WARN
+        ./mvnw --batch-mode --threads 1C install javadoc:javadoc-no-fork -Pcode-coverage -Dtest.log.level=WARN
 
     - name: Build with Gradle
       run: ./gradlew --rerun-tasks --no-daemon --info build

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -121,7 +121,7 @@ jobs:
           BUILD_ARGS="${BUILD_ARGS} -Dmaven.deploy.skip -Dgpg.skip"
         fi
 
-        ./mvnw -B ${GOALS} --file pom.xml ${PROFILES} ${NEXUS_ARGS} ${BUILD_ARGS}
+        ./mvnw --batch-mode --threads 1C ${GOALS} ${PROFILES} ${NEXUS_ARGS} ${BUILD_ARGS}
 
         # Build the native-image, it's not released to Maven Central anyway
         PROFILES="-Pnative -Pdocker"
@@ -129,7 +129,7 @@ jobs:
         if [[ -n ${ACT} ]] ; then
           BUILD_ARGS="${BUILD_ARGS} -Dquarkus.native.remote-container-build=true -Dquarkus.native.container-build=false -Dquarkus.native.native-image-xmx=6g"
         fi
-        ./mvnw -B install --file pom.xml ${PROFILES} ${BUILD_ARGS} -pl servers/quarkus-server
+        ./mvnw --batch-mode --threads 1C install ${PROFILES} ${BUILD_ARGS} -pl servers/quarkus-server
 
         # Add version to the openapi file name
         cp model/target/classes/META-INF/openapi/openapi.yaml model/target/nessie-openapi-${RELEASE_VERSION}.yaml

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -121,7 +121,7 @@ jobs:
           BUILD_ARGS="${BUILD_ARGS} -Dmaven.deploy.skip -Dgpg.skip"
         fi
 
-        ./mvnw --batch-mode --threads 1C ${GOALS} ${PROFILES} ${NEXUS_ARGS} ${BUILD_ARGS}
+        ./mvnw --batch-mode ${GOALS} ${PROFILES} ${NEXUS_ARGS} ${BUILD_ARGS}
 
         # Build the native-image, it's not released to Maven Central anyway
         PROFILES="-Pnative -Pdocker"
@@ -129,7 +129,7 @@ jobs:
         if [[ -n ${ACT} ]] ; then
           BUILD_ARGS="${BUILD_ARGS} -Dquarkus.native.remote-container-build=true -Dquarkus.native.container-build=false -Dquarkus.native.native-image-xmx=6g"
         fi
-        ./mvnw --batch-mode --threads 1C install ${PROFILES} ${BUILD_ARGS} -pl servers/quarkus-server
+        ./mvnw --batch-mode install ${PROFILES} ${BUILD_ARGS} -pl servers/quarkus-server
 
         # Add version to the openapi file name
         cp model/target/classes/META-INF/openapi/openapi.yaml model/target/nessie-openapi-${RELEASE_VERSION}.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,11 @@ on the new feature or improvement.
 ### Maven tips
 
 A `./mvnw --threads 1C clean install` runs basically "everything" except release/deployment stuff. This is often
-not necessary. Some tips:
+not necessary. Use one of these parameters to speed things up:
 
-* `./mvnw --threads 1C package -Dquickly` Just compiles code, no tests, does not build code under `ui/` and `perftest/`.
-* `./mvnw --threads 1C package -DskipTests` Compiles everything, runs no tests.
-* `./mvnw --threads 1C package -DskipITs` Compiles everything, runs unit tests, but no integration tests.
+* `-Dquickly` Just compiles code, no tests, does not build code under `ui/` and `perftest/`.
+* `-DskipTests` Compiles everything, runs no tests.
+* `-DskipITs` Compiles everything, runs unit tests, but no integration tests.
 
 ### Development process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,12 @@ on the new feature or improvement.
 
 ### Maven tips
 
-A `./mvnw clean install` runs basically "everything" except release/deployment stuff. This is often
+A `./mvnw --threads 1C clean install` runs basically "everything" except release/deployment stuff. This is often
 not necessary. Some tips:
 
-* `./mvnw -Dquickly` Just compiles code, no tests, does not build code under `ui/` and `perftest/`.
-* `./mvnw -DskipTests` Compiles everything, runs no tests.
-* `./mvnw -DskipITs` Compiles everything, runs unit tests, but no integration tests.
+* `./mvnw --threads 1C package -Dquickly` Just compiles code, no tests, does not build code under `ui/` and `perftest/`.
+* `./mvnw --threads 1C package -DskipTests` Compiles everything, runs no tests.
+* `./mvnw --threads 1C package -DskipITs` Compiles everything, runs unit tests, but no integration tests.
 
 ### Development process
 
@@ -75,7 +75,7 @@ to work. These options are harmless when using Java 11.
 Apache Spark does **only** work with Java 11 (or 8), so all tests using Spark use the Maven toolchain mechanism
 to force Java 11 for the execution of those tests.
 
-Maven Wrapper, Maven and Mavan Deamon automatically pick up the necessary JVM options from `.mvn/jvm.config` or `.mvn/mvnd.properties`.
+Maven Wrapper, Maven and Maven Daemon automatically pick up the necessary JVM options from `.mvn/jvm.config` or `.mvn/mvnd.properties`.
 
 ### Style guide
 


### PR DESCRIPTION
- we convert `-B` to `--batch-mode` in order to prefer meaningful argument names in scripts/code.
- we drop redundant `--file pom.xml`
- we use `--threads 1C` in CI mvn builds, which builds modules in parallel (should not impact test execution) which speeds up local builds for me by 33 % (I am aware we should use `mvnd` locally but this is not used in CI)

before:
```
~/code/nessie$ for i in {1..3}; do time bash -c './mvnw --batch-mode package -DskipTests >/dev/null 2>&1; echo $?'; done
0

real    1m29,632s
user    4m32,614s
sys     0m5,596s
0

real    1m34,567s
user    4m47,960s
sys     0m6,088s
0

real    1m36,726s
user    4m54,755s
sys     0m6,221s
```

after:
```
~/code/nessie$ for i in {1..3}; do time bash -c './mvnw --batch-mode --threads 1C package -DskipTests >/dev/null 2>&1; echo $?'; done
0

real    0m55,158s
user    4m49,586s
sys     0m6,825s
0

real    1m3,020s
user    5m33,859s
sys     0m8,042s
0

real    1m3,198s
user    5m35,195s
sys     0m8,650s
```

note that this warning will show up in the mvn output now:
```
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in Nessie - Content Generator:
[WARNING] org.codehaus.mojo:tidy-maven-plugin:1.1.0
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
```
but in https://github.com/mojohaus/tidy-maven-plugin/commit/95044bf04604365ef663235fa170ef3543f50bf9 you can see that the plugin was already threadsafe (there just hasnt been a release since declaring it)