### PR TITLE
remove doc references to Reviewable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ contains all modules that shall be measured. New modules must be added there as 
 
 ### Submitting a pull request
 
-Upon submission of a pull request you will be asked to sign our contributor license agreement. We use [Reviewable.io](https://reviewable.io/) for reviews.
+Upon submission of a pull request you will be asked to sign our contributor license agreement.
 Anyone can take part in the review process and once the community is happy and the build actions are passing a Pull Request will be merged. Support 
 must be unanimous for a change to be merged.
 

--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -33,10 +33,6 @@ Google Groups as a mailing list.
 : Our website is all maintained in our source repository. If there is something you think
   can be improved, feel free to fork our repository and post a pull request.
 
-[Reviewable](https://reviewable.io/)
-: We use Reviewable (in addition to GitHub reviews) to collaborate on code and docs. They are
-  a great service and support OSS projects.
-
 ## Contribution
 
 All contributors are welcome to Project Nessie. To get started, feel free to introduce yourself


### PR DESCRIPTION
since it is no longer used

greping finds no other places:
```
~/code/nessie$ ag reviewable
~/code/nessie$ 
```