### PR TITLE
workflows also cache maven wrapper

### DIFF
--- a/.github/actions/dev-tool-java/action.yml
+++ b/.github/actions/dev-tool-java/action.yml
@@ -25,7 +25,8 @@ runs:
         path: |
           ~/.m2/repository
           !~/.m2/repository/org/projectnessie
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          ~/.m2/wrapper
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/maven-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Cache local NPM repository
@@ -41,8 +42,8 @@ runs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties') }}
+        restore-keys: ${{ runner.os }}-gradle-
 
     - name: Set up Maven toolchains.xml
       shell: bash


### PR DESCRIPTION
i noticed that CI kept downloading the mvn wrapper each time

we can just also cache this dir:
```
$ ls -1 ~/.m2/wrapper/dists
apache-maven-3.8.2-bin
apache-maven-3.8.4-bin
```

also slightly improves the gradle caching