### PR TITLE
Use provided scope for maven-plugin-api

### DIFF
--- a/tools/apprunner-maven-plugin/pom.xml
+++ b/tools/apprunner-maven-plugin/pom.xml
@@ -34,6 +34,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This also fixes the following ERROR during compilation:

```
Some dependencies of Maven Plugins are expected to be in provided scope.
Please make sure that dependencies listed below declared in POM
have set '<scope>provided</scope>' as well.

The following dependencies are in wrong scope:
 * org.apache.maven:maven-plugin-api:jar:3.8.4:compile
 * org.apache.maven:maven-model:jar:3.8.4:compile
 * org.apache.maven:maven-artifact:jar:3.8.4:compile
```