### PR TITLE
workaround intellj bug with shaded antlr

### DIFF
--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -286,5 +286,41 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>intellij-workaround</id>
+      <activation>
+        <property>
+          <name>idea.version</name>
+        </property>
+      </activation>
+      <!--
+        IntelliJ IDEA gets confused when a module builds a shaded jar.
+        It does not replace the original source with the shaded jar contents.
+        To avoid compile errors due to relocations we have to use a workaround here.
+
+        Partly taken from https://stackoverflow.com/a/59654377
+      -->
+      <dependencies>
+        <dependency>
+          <groupId>org.projectnessie</groupId>
+          <artifactId>nessie-spark-extensions-grammar</artifactId>
+          <version>${project.version}</version>
+          <!--
+          We need this dependency to build the shaded jar beforehand, but the runtime scope
+          makes it so intellij compilation does not use the original source (which references
+          non-relocated antlr classes).
+          -->
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>nessie-spark-extensions-grammar</artifactId>
+          <version>FAKE-VERSION</version>
+          <classifier>FAKE-CLASSIFIER</classifier>
+          <scope>system</scope>
+          <systemPath>${project.basedir}/../spark-antlr-grammar/target/nessie-spark-extensions-grammar-${project.version}.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
this fixes the following compile problem in intellij:
![intellj_shading_problem](https://user-images.githubusercontent.com/1204398/154247132-1ae9e16d-138e-4297-8c76-4fedcd7d515c.png)

the problem there is that intellj does not replace the original source with the shaded jar contents.... thus on compile it cant find some of the classes (that have been relocated in the shaded jar).
this works fine when using maven from the command line.

see also https://youtrack.jetbrains.com/issue/IDEA-126596 and https://youtrack.jetbrains.com/issue/IDEA-93855

Note that some of the workarounds mentioned in those tickets avoid the "class not found" problem, but not the "incompatible type" problem.

test to confirm the published pom is not negatively affected:
```
chris@xanadu:~/code/nessie$ rm ~/before.pom ~/after.pom; rm -rf ~/.m2/repository/org/projectnessie && git checkout main && ./mvnw --threads 0.5C clean install -DskipITs >/dev/null 2>&1 && cp -v ~/.m2/repository/org/projectnessie/nessie-spark-extensions/0.20.1-SNAPSHOT/nessie-spark-extensions-0.20.1-SNAPSHOT.pom ~/before.pom; rm -rf ~/.m2/repository/org/projectnessie && git checkout antlr-intellj-workaround && ./mvnw --threads 0.5C clean install -DskipITs >/dev/null 2>&1 && cp -v ~/.m2/repository/org/projectnessie/nessie-spark-extensions/0.20.1-SNAPSHOT/nessie-spark-extensions-0.20.1-SNAPSHOT.pom ~/after.pom; diff ~/before.pom ~/after.pom
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
'/home/chris/.m2/repository/org/projectnessie/nessie-spark-extensions/0.20.1-SNAPSHOT/nessie-spark-extensions-0.20.1-SNAPSHOT.pom' -> '/home/chris/before.pom'
Switched to branch 'antlr-intellj-workaround'
'/home/chris/.m2/repository/org/projectnessie/nessie-spark-extensions/0.20.1-SNAPSHOT/nessie-spark-extensions-0.20.1-SNAPSHOT.pom' -> '/home/chris/after.pom'
192a193,211
>     <profile>
>       <id>intellij-workaround</id>
>       <dependencies>
>         <dependency>
>           <groupId>org.projectnessie</groupId>
>           <artifactId>nessie-spark-extensions-grammar</artifactId>
>           <version>${project.version}</version>
>           <scope>runtime</scope>
>         </dependency>
>         <dependency>
>           <groupId>${project.groupId}</groupId>
>           <artifactId>nessie-spark-extensions-grammar</artifactId>
>           <version>FAKE-VERSION</version>
>           <classifier>FAKE-CLASSIFIER</classifier>
>           <scope>system</scope>
>           <systemPath>${project.basedir}/../spark-antlr-grammar/target/nessie-spark-extensions-grammar-${project.version}.jar</systemPath>
>         </dependency>
>       </dependencies>
>     </profile
```