### PR TITLE
Refactor AbstractTestRest to support parallel hierarchy

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestInvalidWithHttp.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestInvalidWithHttp.java
@@ -25,7 +25,6 @@ import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.error.NessieBadRequestException;
 import org.projectnessie.error.NessieConflictException;
@@ -40,8 +39,6 @@ public abstract class AbstractRestInvalidWithHttp extends AbstractRestInvalidRef
       ",1234567890123456789012345678901234567890123456789012345678901234";
   public static final String COMMA_VALID_HASH_2 = ",1234567890123456789012345678901234567890";
   public static final String COMMA_VALID_HASH_3 = ",1234567890123456";
-
-  protected abstract HttpClient getHttpClient();
 
   @ParameterizedTest
   @CsvSource({

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractTestRest.java
@@ -15,21 +15,6 @@
  */
 package org.projectnessie.jaxrs;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import java.net.URI;
-import java.util.Locale;
-import javax.annotation.Nullable;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.projectnessie.client.api.NessieApiV1;
-import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.client.http.HttpClientBuilder;
-import org.projectnessie.client.rest.NessieHttpResponseFilter;
-import org.projectnessie.model.Branch;
-import org.projectnessie.model.Reference;
-import org.projectnessie.model.Tag;
-
 /**
  * Base test class for Nessie REST APIs.
  *
@@ -70,66 +55,5 @@ import org.projectnessie.model.Tag;
  * groups of tests are kept in a single class.
  */
 public abstract class AbstractTestRest extends AbstractRestRefLog {
-
-  private NessieApiV1 api;
-  private HttpClient httpClient;
-
-  static {
-    // Note: REST tests validate some locale-specific error messages, but expect on the messages to
-    // be in ENGLISH. However, the JRE's startup classes (in particular class loaders) may cause the
-    // default Locale to be initialized before Maven is able to override the user.language system
-    // property. Therefore, we explicitly set the default Locale to ENGLISH here to match tests'
-    // expectations.
-    Locale.setDefault(Locale.ENGLISH);
-  }
-
-  protected void init(URI uri) {
-    NessieApiV1 api = HttpClientBuilder.builder().withUri(uri).build(NessieApiV1.class);
-
-    ObjectMapper mapper =
-        new ObjectMapper()
-            .enable(SerializationFeature.INDENT_OUTPUT)
-            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-    HttpClient.Builder httpClient = HttpClient.builder().setBaseUri(uri).setObjectMapper(mapper);
-    httpClient.addResponseFilter(new NessieHttpResponseFilter(mapper));
-
-    init(api, httpClient);
-  }
-
-  protected void init(NessieApiV1 api, @Nullable HttpClient.Builder httpClient) {
-    this.api = api;
-    this.httpClient = httpClient != null ? httpClient.build() : null;
-  }
-
-  @BeforeEach
-  public void setUp() {
-    init(URI.create("http://localhost:19121/api/v1"));
-  }
-
-  @AfterEach
-  public void tearDown() throws Exception {
-    Branch defaultBranch = api.getDefaultBranch();
-    for (Reference ref : api.getAllReferences().get().getReferences()) {
-      if (ref.getName().equals(defaultBranch.getName())) {
-        continue;
-      }
-      if (ref instanceof Branch) {
-        api.deleteBranch().branch((Branch) ref).delete();
-      } else if (ref instanceof Tag) {
-        api.deleteTag().tag((Tag) ref).delete();
-      }
-    }
-
-    api.close();
-  }
-
-  @Override
-  public NessieApiV1 getApi() {
-    return api;
-  }
-
-  @Override
-  public HttpClient getHttpClient() {
-    return httpClient;
-  }
+  // Entry class for the test hierarchy
 }

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyRestNaiveClientInMemory.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyRestNaiveClientInMemory.java
@@ -18,6 +18,7 @@ package org.projectnessie.jaxrs;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.projectnessie.client.http.HttpUtils.HEADER_ACCEPT;
 
+import java.net.URI;
 import org.jetbrains.annotations.Nullable;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpAuthentication;
@@ -48,7 +49,7 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
 class TestJerseyRestNaiveClientInMemory extends AbstractTestJerseyRest {
 
   @Override
-  protected void init(NessieApiV1 api, @Nullable HttpClient.Builder httpClient) {
+  protected void init(NessieApiV1 api, @Nullable HttpClient.Builder httpClient, URI uri) {
     assumeThat(httpClient).isNotNull();
 
     // Intentionally remove the `Accept` header from requests.
@@ -67,6 +68,6 @@ class TestJerseyRestNaiveClientInMemory extends AbstractTestJerseyRest {
             .withUri(httpClient.getBaseUri())
             .build(NessieApiV1.class);
 
-    super.init(api, httpClient);
+    super.init(api, httpClient, uri);
   }
 }


### PR DESCRIPTION
For GC, need to run only in-memory tests and also should use fresh Nessie server to avoid huge data processing from dropped references. Hence we need a parallel hierarchy for current test.

These changes just extracted from #3194 