### PR TITLE
Revert "Revert #3358"

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -297,3 +297,11 @@ jobs:
           "${QUARKUS_UBER_JAR}" \
           "${NESSIE_OPENAPI}" \
           "${NESSIE_HELM_CHART}"
+    - name: Update SwaggerHub
+      if: ${{ !env.ACT }}
+      uses: smartbear/swaggerhub-cli@v0.6.1
+      env:
+        SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
+        SWAGGERHUB_URL: "https://api.swaggerhub.com"
+      with:
+        args: api:create projectnessie/nessie -f ${{ steps.build_maven.outputs.NESSIE_OPENAPI }} --published=publish --setdefault --visibility=public


### PR DESCRIPTION
Re-add swaggerhub action to the release-publish workflow.

It was accidentally ("over eagerly") totally reverted - shame on me.

The original PR had an issue in the `uses:` clause and after fixing that, I got "alarmed" because main-CI didn't run - but that's fine, because main-CI doesn't run for certain workflow changes.