### PR TITLE
Add generic ContentVariantSupplier

### DIFF
--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
@@ -33,8 +33,8 @@ import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.MetricsVersionStore;
 import org.projectnessie.versioned.TracingVersionStore;
 import org.projectnessie.versioned.VersionStore;
-import org.projectnessie.versioned.persist.adapter.ContentVariant;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,19 +86,7 @@ public class ConfigurableVersionStoreFactory {
           databaseAdapterBuilder
               .select(new Literal(versionStoreType))
               .get()
-              .newDatabaseAdapter(
-                  onRefContent -> {
-                    Content.Type t = storeWorker.getType(onRefContent);
-                    switch (t) {
-                      case ICEBERG_TABLE:
-                      case ICEBERG_VIEW:
-                        return ContentVariant.WITH_GLOBAL;
-                      case DELTA_LAKE_TABLE:
-                        return ContentVariant.ON_REF;
-                      default:
-                        throw new IllegalStateException("Unknown type " + t);
-                    }
-                  });
+              .newDatabaseAdapter(new GenericContentVariantSupplier<>(storeWorker));
       databaseAdapter.initializeRepo(serverConfig.getDefaultBranch());
 
       VersionStore<Content, CommitMeta, Content.Type> versionStore =

--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -50,13 +50,12 @@ import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceRetryFailureException;
 import org.projectnessie.versioned.persist.adapter.AdjustableDatabaseAdapterConfig;
-import org.projectnessie.versioned.persist.adapter.ContentVariant;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
 import org.projectnessie.versioned.persist.tests.SystemPropertiesConfigurer;
 import org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource;
@@ -152,22 +151,9 @@ public class CommitBench {
         throw new RuntimeException(e);
       }
 
-      ContentVariantSupplier contentVariantSupplier =
-          onRefContent -> {
-            switch (SimpleStoreWorker.INSTANCE.getType(onRefContent)) {
-              case ON_REF_ONLY:
-                return ContentVariant.ON_REF;
-              case WITH_GLOBAL_STATE:
-                return ContentVariant.WITH_GLOBAL;
-              default:
-                throw new IllegalStateException(
-                    "Unknown type " + SimpleStoreWorker.INSTANCE.getType(onRefContent));
-            }
-          };
-
       return builder
           .withConnector(providerSource.getConnectionProvider())
-          .build(contentVariantSupplier);
+          .build(new GenericContentVariantSupplier<>(SimpleStoreWorker.INSTANCE));
     }
 
     @TearDown

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/GenericContentVariantSupplier.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/GenericContentVariantSupplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.store;
+
+import org.projectnessie.versioned.StoreWorker;
+import org.projectnessie.versioned.persist.adapter.ContentVariant;
+import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+
+public class GenericContentVariantSupplier<
+        CONTENT, METADATA, CONTENT_TYPE extends Enum<CONTENT_TYPE>>
+    implements ContentVariantSupplier {
+
+  private final StoreWorker<CONTENT, METADATA, CONTENT_TYPE> storeWorker;
+
+  public GenericContentVariantSupplier(StoreWorker<CONTENT, METADATA, CONTENT_TYPE> storeWorker) {
+    this.storeWorker = storeWorker;
+  }
+
+  @Override
+  public ContentVariant getContentVariant(byte type) {
+    CONTENT_TYPE typeEnum = storeWorker.getType(type);
+    if (storeWorker.requiresGlobalState(typeEnum)) {
+      return ContentVariant.WITH_GLOBAL;
+    }
+    return ContentVariant.ON_REF;
+  }
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
@@ -49,11 +49,11 @@ import org.junit.platform.commons.util.ReflectionUtils;
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.persist.adapter.AdjustableDatabaseAdapterConfig;
-import org.projectnessie.versioned.persist.adapter.ContentVariant;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
 import org.projectnessie.versioned.persist.tests.SystemPropertiesConfigurer;
 
@@ -301,16 +301,7 @@ public class DatabaseAdapterExtension
         .configure(applyCustomConfig)
         .withConnector(getConnectionProvider(context));
 
-    return builder.build(onRefContent -> contentVariant(storeWorker, onRefContent));
-  }
-
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private static ContentVariant contentVariant(StoreWorker<?, ?, ?> storeWorker, byte type) {
-    Enum t = storeWorker.getType(type);
-    if (storeWorker.requiresGlobalState(t)) {
-      return ContentVariant.WITH_GLOBAL;
-    }
-    return ContentVariant.ON_REF;
+    return builder.build(new GenericContentVariantSupplier<>(storeWorker));
   }
 
   private static Function<AdjustableDatabaseAdapterConfig, DatabaseAdapterConfig>


### PR DESCRIPTION
The use of `ContentVariantSupplier` can easily become generic by delegating
to the actual `StoreWorker`. This prevents a lot of duplicated and
to-be-maintained code.