### PR TITLE
Log fpp for merged ContentBloomFilters

### DIFF
--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
@@ -63,8 +63,9 @@ public class ContentBloomFilter implements Serializable {
   }
 
   /**
-   * @return true if other filters were merged into this instance, which might indicate decreased
-   *     filter quality
+   * A merged bloomfilter might indicate decreased filter quality.
+   *
+   * @return true if other filters were merged into this instance
    */
   public boolean wasMerged() {
     return wasMerged;

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
@@ -62,6 +62,10 @@ public class ContentBloomFilter implements Serializable {
     return filter.expectedFpp();
   }
 
+  /**
+   * @return true if other filters were merged into this instance, which might indicate decreased
+   *     filter quality
+   */
   public boolean wasMerged() {
     return wasMerged;
   }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
@@ -56,6 +56,10 @@ public class ContentBloomFilter implements Serializable {
     }
   }
 
+  public double getExpectedFpp() {
+    return filter.expectedFpp();
+  }
+
   private String getValue(Content content) {
     switch (content.getType()) {
       case ICEBERG_TABLE:

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
@@ -35,6 +35,7 @@ public class ContentBloomFilter implements Serializable {
   // as the consumer of GC results needs only this info for clean up.
   // String bloom filter with content type prefix + snapshot/version id.
   private final BloomFilter<String> filter;
+  private boolean wasMerged = false;
 
   public ContentBloomFilter(long expectedEntries, double bloomFilterFpp) {
     this.filter =
@@ -53,11 +54,16 @@ public class ContentBloomFilter implements Serializable {
   public void merge(ContentBloomFilter filter) {
     if (filter.filter != null) {
       this.filter.putAll(filter.filter);
+      this.wasMerged = true;
     }
   }
 
   public double getExpectedFpp() {
     return filter.expectedFpp();
+  }
+
+  public boolean wasMerged() {
+    return wasMerged;
   }
 
   private String getValue(Content content) {

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/DistributedIdentifyContents.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/DistributedIdentifyContents.java
@@ -17,17 +17,22 @@ package org.projectnessie.gc.base;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.projectnessie.model.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Identify the expired and live contents in a distributed way using the spark and bloom filter by
  * walking all the references (both dead and live).
  */
 public class DistributedIdentifyContents {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DistributedIdentifyContents.class);
 
   private final SparkSession session;
   private final GCParams gcParams;
@@ -54,7 +59,7 @@ public class DistributedIdentifyContents {
             .parallelize(references, getPartitionsCount(gcParams, references))
             .map(executor.computeLiveContentsFunc(bloomFilterSize, droppedRefTimeMap))
             .collect();
-    return mergeLiveContentResults(bloomFilterMaps);
+    return mergeLiveContentResults(bloomFilterMaps, gcParams.getBloomFilterFpp());
   }
 
   /**
@@ -87,7 +92,8 @@ public class DistributedIdentifyContents {
   }
 
   private static Map<String, ContentBloomFilter> mergeLiveContentResults(
-      List<Map<String, ContentBloomFilter>> bloomFilterMaps) {
+      List<Map<String, ContentBloomFilter>> bloomFilterMaps, double bloomFilterFpp) {
+    Set<String> mergedContentIds = new HashSet<>();
     Map<String, ContentBloomFilter> output = new HashMap<>();
     bloomFilterMaps.forEach(
         map ->
@@ -95,10 +101,23 @@ public class DistributedIdentifyContents {
                 (k, v) -> {
                   if (output.containsKey(k)) {
                     output.get(k).merge(v);
+                    mergedContentIds.add(k);
                   } else {
                     output.put(k, v);
                   }
                 }));
+    // Since we merged bloom filters log in case their quality deteriorated
+    mergedContentIds.stream()
+        .forEach(
+            contentId -> {
+              double fpp = output.get(contentId).getExpectedFpp();
+              if (fpp > bloomFilterFpp) {
+                LOGGER.info(
+                    "Fpp of ContentBloomFilter for '{}': {}",
+                    contentId,
+                    String.format("%.3f", fpp));
+              }
+            });
     return output;
   }
 }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/DistributedIdentifyContents.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/DistributedIdentifyContents.java
@@ -104,18 +104,16 @@ public class DistributedIdentifyContents {
                 }));
     // Since we merged bloom filters log in case their quality deteriorated
     output.entrySet().stream()
+        .filter(e -> e.getValue().wasMerged())
         .forEach(
             e -> {
-              ContentBloomFilter bloomFilter = e.getValue();
-              if (bloomFilter.wasMerged()) {
-                double fpp = bloomFilter.getExpectedFpp();
-                if (fpp > bloomFilterFpp) {
-                  String contentId = e.getKey();
-                  LOGGER.info(
-                      "Fpp of ContentBloomFilter for '{}': {}",
-                      contentId,
-                      String.format("%.3f", fpp));
-                }
+              double fpp = e.getValue().getExpectedFpp();
+              if (fpp > bloomFilterFpp) {
+                String contentId = e.getKey();
+                LOGGER.info(
+                    "Fpp of ContentBloomFilter for '{}': {}",
+                    contentId,
+                    String.format("%.3f", fpp));
               }
             });
     return output;

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
@@ -33,12 +33,15 @@ import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferenceMetadata;
 import org.projectnessie.model.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulates the logic to retrieve expired contents by walking over all commits in all
  * named-references.
  */
 public class GCImpl {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GCImpl.class);
   private final GCParams gcParams;
 
   /**
@@ -48,6 +51,7 @@ public class GCImpl {
    */
   public GCImpl(GCParams gcParams) {
     this.gcParams = gcParams;
+    LOGGER.info("GCImpl with params: {}", gcParams);
   }
 
   /**


### PR DESCRIPTION
just an idea to at least be aware in case the merging of bloom filters results in deteriorated filter quality

see also:
https://github.com/google/guava/blob/a0e2577de61a0d7e8a3dd075be66a31c93ea0446/guava/src/com/google/common/hash/BloomFilter.java#L244-L252

maybe this scenario can never happen or is very unlikely and not worth the computation / space effort everytime, idk