### PR TITLE
Nessie SQL extensions: Fix Use reference at hash

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/clients/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -57,8 +57,15 @@ public final class NessieConfigConstants {
    * <p>Note that "basic" HTTP authentication is not considered secure, use {@code BEARER} instead.
    */
   public static final String CONF_NESSIE_AUTH_TYPE = "nessie.authentication.type";
-  /** Config property name ({@value #CONF_NESSIE_REF}) for the nessie reference used by clients. */
+  /**
+   * Config property name ({@value #CONF_NESSIE_REF}) for the nessie reference name used by clients.
+   */
   public static final String CONF_NESSIE_REF = "nessie.ref";
+  /**
+   * Config property name ({@value #CONF_NESSIE_REF_HASH}) for the nessie reference hash used by
+   * clients.
+   */
+  public static final String CONF_NESSIE_REF_HASH = "nessie.ref.hash";
   /**
    * Config property name ({@value #CONF_NESSIE_TRACING}) to enable adding the HTTP headers of an
    * active OpenTracing span to all Nessie requests. Valid values are {@code true} and {@code

--- a/clients/iceberg-views/src/main/java/org/apache/iceberg/nessie/NessieViewCatalog.java
+++ b/clients/iceberg-views/src/main/java/org/apache/iceberg/nessie/NessieViewCatalog.java
@@ -97,7 +97,9 @@ public class NessieViewCatalog extends BaseMetastoreViews implements AutoCloseab
     }
     final String requestedRef =
         options.get(removePrefix.apply(NessieConfigConstants.CONF_NESSIE_REF));
-    this.reference = loadReference(requestedRef, null);
+    final String hashOnRef =
+        options.get(removePrefix.apply(NessieConfigConstants.CONF_NESSIE_REF_HASH));
+    this.reference = loadReference(requestedRef, hashOnRef);
   }
 
   private static NessieClientBuilder<?> createNessieClientBuilder(String customBuilder) {

--- a/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/NessieUtils.scala
+++ b/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/NessieUtils.scala
@@ -191,6 +191,8 @@ object NessieUtils {
       SparkSession.active.sessionState.catalogManager.catalog(catalogName)
     SparkSession.active.sparkContext.conf
       .set(s"spark.sql.catalog.$catalogName.ref", ref.getName)
+    SparkSession.active.sparkContext.conf
+      .set(s"spark.sql.catalog.$catalogName.ref.hash", ref.getHash)
     val catalogConf = SparkSession.active.sparkContext.conf
       .getAllWithPrefix(s"spark.sql.catalog.$catalogName.")
       .toMap


### PR DESCRIPTION
for `use reference @ hash` sql command, we are calculating/validating the ref+ hash. But in the end we are not setting hash to the catalog. only ref name is set to the catalog. Hence the issue.

These are changes from Nessie side for #3439 
Once this is merged and release is made, need to fix at Iceberg side using this configuration. 
Later end to end test has to be updated in `ITNessieStatements` once Iceberg releases it.