### PR TITLE
Remove output_string from execute_cli_command

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -64,21 +64,20 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     shutil.rmtree(nessie_test_config.config_dir)
 
 
-def execute_cli_command(args: List[str], input_data: Optional[str] = None, ret_val: int = 0, output_string: bool = True) -> Any:
+def execute_cli_command_raw(args: List[str], input_data: Optional[str] = None, ret_val: int = 0) -> Result:
     """Execute a Nessie CLI command."""
-    if output_string:
-        return _run(args, input_data, ret_val).output
-
-    return _run(args, input_data, ret_val)
-
-
-def _run(args: List[str], input_data: Optional[str] = None, ret_val: int = 0) -> Result:
     result = CliRunner().invoke(cli.cli, args, input=input_data)
     if result.exit_code != ret_val:
-        print(result.output)
-        print(result)
+        print(result.stdout)
+        print(result.stderr)
+        print(result)  # exception
     assert_that(result.exit_code).is_equal_to(ret_val)
     return result
+
+
+def execute_cli_command(args: List[str], input_data: Optional[str] = None, ret_val: int = 0) -> str:
+    """Execute a Nessie CLI command and return its STDOUT."""
+    return execute_cli_command_raw(args, input_data=input_data, ret_val=ret_val).stdout
 
 
 def ref_hash(ref: str) -> str:

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -38,7 +38,7 @@ from pynessie.model import LogEntrySchema
 from pynessie.model import ReferenceSchema
 from pynessie.model import ReflogEntry
 from pynessie.model import ReflogEntrySchema
-from .conftest import execute_cli_command, make_commit, ref_hash
+from .conftest import execute_cli_command, execute_cli_command_raw, make_commit, ref_hash
 
 
 @pytest.mark.vcr
@@ -80,8 +80,8 @@ def test_remote() -> None:
     execute_cli_command(["remote", "set-head", "dev"])
     assert execute_cli_command(["config", "default_branch"]) == "dev\n"
     execute_cli_command(["remote", "set-head", "dev", "-d"])
-    result = execute_cli_command(["config", "default_branch"], ret_val=1, output_string=False)
-    assert result.output == ""
+    result = execute_cli_command_raw(["config", "default_branch"], ret_val=1)
+    assert result.stdout == ""
     assert isinstance(result.exception, confuse.exceptions.ConfigTypeError)
 
 


### PR DESCRIPTION
this is less verbose and has improved type hints.
also make distinction between stdout and stderr of cli cmds.