### PR TITLE
Regenerate Python CLI docs

### DIFF
--- a/python/docs/branch.rst
+++ b/python/docs/branch.rst
@@ -1,42 +1,42 @@
 .. code-block:: bash
 
    Usage: nessie branch [OPTIONS] [BRANCH] [BASE_REF]
-   
+
      Branch operations.
-   
+
      BRANCH name of branch to list or create/assign
-   
+
      BASE_REF name of branch or tag from which to create/assign the new BRANCH
-   
+
      Examples:
-   
+
          nessie branch -> list all branches
-   
+
          nessie branch -l -> list all branches
-   
+
          nessie branch -l main -> list only main
-   
+
          nessie branch -d main -> delete main
-   
+
          nessie branch new_branch -> create new branch named 'new_branch' at
          current HEAD of the default branch
-   
+
          nessie branch new_branch main -> create new branch named 'new_branch' at
          head of reference named 'main'
-   
+
          nessie branch -o 12345678abcdef new_branch main -> create a branch named
          'new_branch' at hash 12345678abcdef on reference named 'main'
-   
+
          nessie branch new_branch main@12345678abcdef -> create a branch named
          'new_branch' at hash 12345678abcdef on reference named 'main', alternate
          syntax for the above
-   
+
          nessie branch -f existing_branch main -> assign branch named
          'existing_branch' to head of reference named 'main'
-   
+
          nessie branch -o 12345678abcdef -f existing_branch main -> assign branch
          named 'existing_branch' to hash 12345678abcdef on reference named 'main'
-   
+
    Options:
      -l, --list              list branches
      -d, --delete            delete a branch
@@ -51,6 +51,5 @@
                              commit, number of total commits, or the common
                              ancestor hash.
      --help                  Show this message and exit.
-   
-   
+
 

--- a/python/docs/branch.rst
+++ b/python/docs/branch.rst
@@ -27,6 +27,10 @@
          nessie branch -o 12345678abcdef new_branch main -> create a branch named
          'new_branch' at hash 12345678abcdef on reference named 'main'
    
+         nessie branch new_branch main@12345678abcdef -> create a branch named
+         'new_branch' at hash 12345678abcdef on reference named 'main', alternate
+         syntax for the above
+   
          nessie branch -f existing_branch main -> assign branch named
          'existing_branch' to head of reference named 'main'
    

--- a/python/docs/cherry-pick.rst
+++ b/python/docs/cherry-pick.rst
@@ -1,23 +1,23 @@
 .. code-block:: bash
 
    Usage: nessie cherry-pick [OPTIONS] [HASHES]...
-   
+
      Cherry-pick HASHES onto another branch.
-   
+
      HASHES commit hashes to be cherry-picked from the source reference.
-   
+
      Examples:
-   
+
          nessie cherry-pick -c 12345678abcdef -s dev 21345678abcdef 31245678abcdef
          -> cherry pick 2 commits with commit hash '21345678abcdef'
          '31245678abcdef' from dev branch to default branch with default branch's
          expected hash '12345678abcdef'
-   
+
          nessie cherry-pick -b main -c 12345678abcdef -s dev 21345678abcdef
          31245678abcdef -> cherry pick 2 commits with commit hash '21345678abcdef'
          '31245678abcdef' from dev branch to a branch named main with main branch's
          expected hash '12345678abcdef'
-   
+
    Options:
      -b, --branch TEXT      branch to cherry-pick onto. If not supplied the default
                             branch from config is used
@@ -27,6 +27,5 @@
      -s, --source-ref TEXT  Name of the reference used to read the hashes from.
                             [required]
      --help                 Show this message and exit.
-   
-   
+
 

--- a/python/docs/config.rst
+++ b/python/docs/config.rst
@@ -1,9 +1,9 @@
 .. code-block:: bash
 
    Usage: nessie config [OPTIONS] [KEY]
-   
+
      Set and view config.
-   
+
    Options:
      --get TEXT    get config parameter
      --add TEXT    set config parameter
@@ -12,6 +12,5 @@
      --type TEXT   type to interpret config value to set or get. Allowed options:
                    bool, int
      -h, --help    Show this message and exit.
-   
-   
+
 

--- a/python/docs/content.rst
+++ b/python/docs/content.rst
@@ -1,18 +1,17 @@
 .. code-block:: bash
 
    Usage: nessie content [OPTIONS] COMMAND [ARGS]...
-   
+
      View, list content, and commit changes.
-   
+
    Options:
      --help  Show this message and exit.
-   
+
    Commands:
      commit  Commit content.
      list    List content.
      view    View content.
-   
-   
+
 
 It contains the following sub-commands:
 

--- a/python/docs/content_commit.rst
+++ b/python/docs/content_commit.rst
@@ -1,30 +1,30 @@
 .. code-block:: bash
 
    Usage: nessie content commit [OPTIONS] KEY...
-   
+
      Commit content.
-   
+
          KEY is the content key that is associated with a specific content to
          commit. This accepts as well multiple keys with space in between. The key
          can be in this format: 'table.key' or 'namespace."table.key"'.
-   
+
      Examples:
-   
+
          nessie content commit -m "my awesome commit message" -r dev -c 122345abcd
          my_table -> Commit to branch 'dev' on expected hash '122345abcd' (head of
          the branch) the content from the interactive editor with the commit
          message "my awesome commit message" for content "my_table".
-   
+
          nessie content commit -i -r dev -c 122345abcd my_table -> Commit to branch
          'dev' on expected hash '122345abcd' (head of the branch) the content from
          STDIN with the commit message from the interactive editor for content
          "my_table".
-   
+
          nessie content commit -m "my awesome commit message" -R -r dev -c
          122345abcd my_table_1 my_table_2 -> Delete contents "my_table_1" and
          "my_table_2" from branch 'dev' on expected hash '122345abcd' and commit to
          branch 'dev" with the commit message "my awesome commit message".
-   
+
    Options:
      -r, --ref TEXT             Branch to commit content to. If not supplied the
                                 default branch from config is used.
@@ -39,6 +39,5 @@
      -m, --message TEXT         Commit message.
      --author TEXT              The author to use for the commit
      --help                     Show this message and exit.
-   
-   
+
 

--- a/python/docs/content_list.rst
+++ b/python/docs/content_list.rst
@@ -1,39 +1,35 @@
 .. code-block:: bash
 
    Usage: nessie content list [OPTIONS]
-
+   
      List content.
-
+   
      Examples:
-
+   
          nessie content list -r dev -> List all contents in 'dev' branch.
-
+   
          nessie content list -r dev -t DELTA_LAKE_TABLE ->  List all contents in
          'dev' branch with type `DELTA_LAKE_TABLE`.
-
+   
          nessie content list -r dev --filter
          "entry.namespace.startsWith('some.name.space')" -> List all contents in
          'dev' branch that start with 'some.name.space'
-
+   
    Options:
-     -r, --ref TEXT                  Branch to list from. If not supplied the
-                                     default branch from config is used
-     -t, --type TEXT                 entity types to filter on, if no entity types
-                                     are passed then all types are returned
-     --filter TEXT
-                                     Allows advanced filtering using the Common
-                                     Expression Language (CEL). An intro to CEL can
-                                     be found at https://github.com/google/cel-
-                                     spec/blob/master/doc/intro.md. Some examples
-                                     with usable variables 'entry.namespace'
-                                     (string) & 'entry.contentType' (string) are:
-                                     entry.namespace.startsWith('a.b.c')
-                                     entry.contentType in
-                                     ['ICEBERG_TABLE','DELTA_LAKE_TABLE']
-                                     entry.namespace.startsWith('some.name.space')
-                                     && entry.contentType in
-                                     ['ICEBERG_TABLE','DELTA_LAKE_TABLE']
-     --help                          Show this message and exit.
-
-
+     -r, --ref TEXT   Branch to list from. If not supplied the default branch from
+                      config is used
+     -t, --type TEXT  entity types to filter on, if no entity types are passed then
+                      all types are returned
+     --filter TEXT    Allows advanced filtering using the Common Expression
+                      Language (CEL). An intro to CEL can be found at
+                      https://github.com/google/cel-spec/blob/master/doc/intro.md.
+                      Some examples with usable variables 'entry.namespace'
+                      (string) & 'entry.contentType' (string) are:
+                      entry.namespace.startsWith('a.b.c') entry.contentType in
+                      ['ICEBERG_TABLE','DELTA_LAKE_TABLE']
+                      entry.namespace.startsWith('some.name.space') &&
+                      entry.contentType in ['ICEBERG_TABLE','DELTA_LAKE_TABLE']
+     --help           Show this message and exit.
+   
+   
 

--- a/python/docs/content_list.rst
+++ b/python/docs/content_list.rst
@@ -1,20 +1,20 @@
 .. code-block:: bash
 
    Usage: nessie content list [OPTIONS]
-   
+
      List content.
-   
+
      Examples:
-   
+
          nessie content list -r dev -> List all contents in 'dev' branch.
-   
+
          nessie content list -r dev -t DELTA_LAKE_TABLE ->  List all contents in
          'dev' branch with type `DELTA_LAKE_TABLE`.
-   
+
          nessie content list -r dev --filter
          "entry.namespace.startsWith('some.name.space')" -> List all contents in
          'dev' branch that start with 'some.name.space'
-   
+
    Options:
      -r, --ref TEXT   Branch to list from. If not supplied the default branch from
                       config is used
@@ -30,6 +30,5 @@
                       entry.namespace.startsWith('some.name.space') &&
                       entry.contentType in ['ICEBERG_TABLE','DELTA_LAKE_TABLE']
      --help           Show this message and exit.
-   
-   
+
 

--- a/python/docs/content_view.rst
+++ b/python/docs/content_view.rst
@@ -1,22 +1,21 @@
 .. code-block:: bash
 
    Usage: nessie content view [OPTIONS] KEY...
-   
+
      View content.
-   
+
          KEY is the content key that is associated with a specific content to view.
          This accepts as well multiple keys with space in between. The key can be
          in this format: 'table.key' or 'namespace."table.key"'.
-   
+
      Examples:
-   
+
          nessie content view -r dev my_table -> View content details for content
          "my_table" in 'dev' branch.
-   
+
    Options:
      -r, --ref TEXT  Branch to list from. If not supplied the default branch from
                      config is used.
      --help          Show this message and exit.
-   
-   
+
 

--- a/python/docs/diff.rst
+++ b/python/docs/diff.rst
@@ -1,34 +1,33 @@
 .. code-block:: bash
 
    Usage: nessie diff [OPTIONS] FROM_REF TO_REF
-   
+
      Show diff between two given references.
-   
+
      'from_ref'/'to_ref': name of branch or tag to use to show the diff
-   
+
      'from_ref' and 'to_ref' can be either:
-   
+
          The name of a reference (branch or tag), resolving to the HEAD of the
          named reference.
-   
+
          The name of a reference (branch or tag) with a commit-id on that named
          reference.
-   
+
          A detached commit-id/hash. Example:
-   
+
      Examples:
-   
+
          nessie diff from_ref to_ref -> show diff between 'from_ref' and 'to_ref',
          using the HEADs of both references
-   
+
          nessie diff main@1234567890abcdef my-branch -> compare main branch at
          commit-id 1234567890abcdef with the HEAD of my-branch
-   
+
          nessie diff 1234567890abcdef main -> compare the main branch w/ commit-id
          1234567890abcdef
-   
+
    Options:
      --help  Show this message and exit.
-   
-   
+
 

--- a/python/docs/diff.rst
+++ b/python/docs/diff.rst
@@ -4,11 +4,28 @@
    
      Show diff between two given references.
    
-     from_ref/to_ref: name of branch or tag to use to show the diff
+     'from_ref'/'to_ref': name of branch or tag to use to show the diff
+   
+     'from_ref' and 'to_ref' can be either:
+   
+         The name of a reference (branch or tag), resolving to the HEAD of the
+         named reference.
+   
+         The name of a reference (branch or tag) with a commit-id on that named
+         reference.
+   
+         A detached commit-id/hash. Example:
    
      Examples:
    
-         nessie diff from_ref to_ref -> show diff between 'from_ref' and 'to_ref'
+         nessie diff from_ref to_ref -> show diff between 'from_ref' and 'to_ref',
+         using the HEADs of both references
+   
+         nessie diff main@1234567890abcdef my-branch -> compare main branch at
+         commit-id 1234567890abcdef with the HEAD of my-branch
+   
+         nessie diff 1234567890abcdef main -> compare the main branch w/ commit-id
+         1234567890abcdef
    
    Options:
      --help  Show this message and exit.

--- a/python/docs/log.rst
+++ b/python/docs/log.rst
@@ -1,42 +1,42 @@
 .. code-block:: bash
 
    Usage: nessie log [OPTIONS] [REF]
-   
+
      Show commit log.
-   
+
      REF name of branch or tag to use to show the commit logs
-   
+
      Examples:
-   
+
          nessie log -> show commit logs using the configured default branch
-   
+
          nessie log 1234567890abcdef -> show commit logs starting at commit
          1234567890abcdef
-   
+
          nessie log dev -> show commit logs for 'dev' branch, starting at the most
          recent (HEAD) commit of 'dev'
-   
+
          nessie log dev@1234567890abcdef -> show commit logs for 'dev' branch,
          starting at commit 1234567890abcdef in 'dev'
-   
+
          nessie log -n 5 dev -> show commit logs for 'dev' branch limited by 5
          commits
-   
+
          nessie log --revision-range 12345678abcdef..12345678efghj dev -> show
          commit logs in range of hash '12345678abcdef' and '12345678efghj' in 'dev'
          branch
-   
+
          nessie log --author nessie.user dev -> show commit logs for user
          'nessie.user' in 'dev' branch
-   
+
          nessie log --filter "commit.author == 'nessie_user2' || commit.author ==
          'non_existing'" dev -> show commit logs using query in 'dev' branch
-   
+
          nessie log --after "2019-01-01T00:00:00+00:00" --before
          "2021-01-01T00:00:00+00:00" dev -> show commit logs between
          "2019-01-01T00:00:00+00:00" and "2021-01-01T00:00:00+00:00" in 'dev'
          branch
-   
+
    Options:
      -n, --number INTEGER       number of log entries to return
      --since, --after TEXT      Only include commits newer than specific date, such
@@ -74,6 +74,5 @@
                                 of LogEntrySchema, otherwise a list of
                                 CommitMetaSchema.
      --help                     Show this message and exit.
-   
-   
+
 

--- a/python/docs/log.rst
+++ b/python/docs/log.rst
@@ -1,74 +1,79 @@
 .. code-block:: bash
 
    Usage: nessie log [OPTIONS] [REF]
-
+   
      Show commit log.
-
+   
      REF name of branch or tag to use to show the commit logs
-
+   
      Examples:
-
+   
          nessie log -> show commit logs using the configured default branch
-
-         nessie log dev -> show commit logs for 'dev' branch
-
+   
+         nessie log 1234567890abcdef -> show commit logs starting at commit
+         1234567890abcdef
+   
+         nessie log dev -> show commit logs for 'dev' branch, starting at the most
+         recent (HEAD) commit of 'dev'
+   
+         nessie log dev@1234567890abcdef -> show commit logs for 'dev' branch,
+         starting at commit 1234567890abcdef in 'dev'
+   
          nessie log -n 5 dev -> show commit logs for 'dev' branch limited by 5
          commits
-
+   
          nessie log --revision-range 12345678abcdef..12345678efghj dev -> show
          commit logs in range of hash '12345678abcdef' and '12345678efghj' in 'dev'
          branch
-
+   
          nessie log --author nessie.user dev -> show commit logs for user
          'nessie.user' in 'dev' branch
-
+   
          nessie log --filter "commit.author == 'nessie_user2' || commit.author ==
          'non_existing'" dev -> show commit logs using query in 'dev' branch
-
+   
          nessie log --after "2019-01-01T00:00:00+00:00" --before
          "2021-01-01T00:00:00+00:00" dev -> show commit logs between
          "2019-01-01T00:00:00+00:00" and "2021-01-01T00:00:00+00:00" in 'dev'
          branch
-
+   
    Options:
-     -n, --number INTEGER            number of log entries to return
-     --since, --after TEXT           Only include commits newer than specific date,
-                                     such as '2001-01-01T00:00:00+00:00'
-     --until, --before TEXT          Only include commits older than specific date,
-                                     such as '2999-12-30T23:00:00+00:00'
-     --author TEXT                   Limit commits to a specific author (this is
-                                     the original committer). Supports specifying
-                                     multiple authors to filter by.
-     --committer TEXT                Limit commits to a specific committer (this is
-                                     the logged in user/account who performed the
-                                     commit). Supports specifying multiple
-                                     committers to filter by.
-     -r, --revision-range TEXT       Hash to start viewing log from. If of the form
-                                     '<start_hash>'..'<end_hash>' only show log for
-                                     given range on the particular ref that was
-                                     provided, the '<end_hash>' is inclusive and
-                                     '<start_hash>' is exclusive.
-     --filter TEXT
-                                     Allows advanced filtering using the Common
-                                     Expression Language (CEL). An intro to CEL can
-                                     be found at https://github.com/google/cel-
-                                     spec/blob/master/doc/intro.md. Some examples
-                                     with usable variables 'commit.author' (string)
-                                     / 'commit.committer' (string) /
-                                     'commit.commitTime' (timestamp) /
-                                     'commit.hash' (string) / 'commit.message'
-                                     (string) / 'commit.properties' (map) are:
-                                     commit.author=='nessie_author'
-                                     commit.committer=='nessie_committer'
-                                     timestamp(commit.commitTime) >
-                                     timestamp('2021-06-21T10:39:17.977922Z')
-     -x, --extended                  Retrieve all available information for the
-                                     commit entries. This option will also return
-                                     the operations for each commit and the parent
-                                     hash. The schema of the JSON output will then
-                                     produce a list of LogEntrySchema, otherwise a
-                                     list of CommitMetaSchema.
-     --help                          Show this message and exit.
-
-
+     -n, --number INTEGER       number of log entries to return
+     --since, --after TEXT      Only include commits newer than specific date, such
+                                as '2001-01-01T00:00:00+00:00'
+     --until, --before TEXT     Only include commits older than specific date, such
+                                as '2999-12-30T23:00:00+00:00'
+     --author TEXT              Limit commits to a specific author (this is the
+                                original committer). Supports specifying multiple
+                                authors to filter by.
+     --committer TEXT           Limit commits to a specific committer (this is the
+                                logged in user/account who performed the commit).
+                                Supports specifying multiple committers to filter
+                                by.
+     -r, --revision-range TEXT  Hash to start viewing log from. If of the form
+                                '<start_hash>'..'<end_hash>' only show log for
+                                given range on the particular ref that was
+                                provided, the '<end_hash>' is inclusive and
+                                '<start_hash>' is exclusive.
+     --filter TEXT              Allows advanced filtering using the Common
+                                Expression Language (CEL). An intro to CEL can be
+                                found at https://github.com/google/cel-
+                                spec/blob/master/doc/intro.md. Some examples with
+                                usable variables 'commit.author' (string) /
+                                'commit.committer' (string) / 'commit.commitTime'
+                                (timestamp) / 'commit.hash' (string) /
+                                'commit.message' (string) / 'commit.properties'
+                                (map) are: commit.author=='nessie_author'
+                                commit.committer=='nessie_committer'
+                                timestamp(commit.commitTime) >
+                                timestamp('2021-06-21T10:39:17.977922Z')
+     -x, --extended             Retrieve all available information for the commit
+                                entries. This option will also return the
+                                operations for each commit and the parent hash. The
+                                schema of the JSON output will then produce a list
+                                of LogEntrySchema, otherwise a list of
+                                CommitMetaSchema.
+     --help                     Show this message and exit.
+   
+   
 

--- a/python/docs/main.rst
+++ b/python/docs/main.rst
@@ -1,11 +1,11 @@
 .. code-block:: bash
 
    Usage: nessie [OPTIONS] COMMAND [ARGS]...
-   
+
      Nessie cli tool.
-   
+
      Interact with Nessie branches and tables via the command line
-   
+
    Options:
      --json             write output in json format.
      -v, --verbose      Verbose output.
@@ -13,7 +13,7 @@
      --auth-token TEXT  Optional bearer auth token, if different from config file.
      --version
      --help             Show this message and exit.
-   
+
    Commands:
      branch       Branch operations.
      cherry-pick  Cherry-pick HASHES onto another branch.
@@ -25,6 +25,5 @@
      reflog       Show reflog.
      remote       Set and view remote endpoint.
      tag          Tag operations.
-   
-   
+
 

--- a/python/docs/merge.rst
+++ b/python/docs/merge.rst
@@ -1,25 +1,25 @@
 .. code-block:: bash
 
    Usage: nessie merge [OPTIONS] [FROM_REF]
-   
+
      Merge FROM_REF into another branch.
-   
+
      FROM_REF can be a hash or branch.
-   
+
      Examples:
-   
+
          nessie merge -c 12345678abcdef dev -> merge dev to default branch with
          default branch's expected hash '12345678abcdef'
-   
+
          nessie merge -b main -c 12345678abcdef dev -> merge dev to a branch named
          main with main branch's expected hash '12345678abcdef'
-   
+
          nessie merge -b main -o 56781234abcdef -c 12345678abcdef dev -> merge dev
          at hash-on-ref '56781234abcdef' to main branch with main branch's expected
          hash '12345678abcdef'
-   
+
          nessie merge -f -b main dev -> forcefully merge dev to a branch named main
-   
+
    Options:
      -b, --branch TEXT       branch to merge onto. If not supplied the default
                              branch from config is used
@@ -28,6 +28,5 @@
                              currently points to the hash specified by this option.
      -o, --hash-on-ref TEXT  Hash on merge-from-reference
      --help                  Show this message and exit.
-   
-   
+
 

--- a/python/docs/reflog.rst
+++ b/python/docs/reflog.rst
@@ -1,22 +1,22 @@
 .. code-block:: bash
 
    Usage: nessie reflog [OPTIONS]
-   
+
      Show reflog.
-   
+
      Reflog entries from the current HEAD or from the specified revision_range.
-   
+
      Examples:
-   
+
          nessie reflog -> show reflog entries from the current HEAD
-   
+
          nessie reflog -n 5 -> show reflog entries from the current HEAD limited by
          5 entries
-   
+
          nessie reflog --revision-range 12345678abcdef..12345678efghj -> show
          reflog entries in range of hash '12345678abcdef' and '12345678efghj' (both
          inclusive)
-   
+
    Options:
      -n, --number INTEGER       number of reflog entries to return
      -r, --revision-range TEXT  Hash to start viewing reflog from. If of the form
@@ -25,6 +25,5 @@
                                 provided. Both the '<end_hash>' and '<start_hash>'
                                 is inclusive.
      --help                     Show this message and exit.
-   
-   
+
 

--- a/python/docs/remote.rst
+++ b/python/docs/remote.rst
@@ -1,18 +1,17 @@
 .. code-block:: bash
 
    Usage: nessie remote [OPTIONS] COMMAND [ARGS]...
-   
+
      Set and view remote endpoint.
-   
+
    Options:
      --help  Show this message and exit.
-   
+
    Commands:
      add       Set current remote.
      set-head  Set current default branch.
      show      Show current remote.
-   
-   
+
 
 It contains the following sub-commands:
 

--- a/python/docs/remote_add.rst
+++ b/python/docs/remote_add.rst
@@ -1,11 +1,10 @@
 .. code-block:: bash
 
    Usage: nessie remote add [OPTIONS] ENDPOINT
-   
+
      Set current remote.
-   
+
    Options:
      --help  Show this message and exit.
-   
-   
+
 

--- a/python/docs/remote_set-head.rst
+++ b/python/docs/remote_set-head.rst
@@ -1,12 +1,11 @@
 .. code-block:: bash
 
    Usage: nessie remote set-head [OPTIONS] HEAD
-   
+
      Set current default branch. If -d is passed it will remove the default branch.
-   
+
    Options:
      -d, --delete  delete the default branch
      --help        Show this message and exit.
-   
-   
+
 

--- a/python/docs/remote_show.rst
+++ b/python/docs/remote_show.rst
@@ -1,11 +1,10 @@
 .. code-block:: bash
 
    Usage: nessie remote show [OPTIONS]
-   
+
      Show current remote.
-   
+
    Options:
      --help  Show this message and exit.
-   
-   
+
 

--- a/python/docs/tag.rst
+++ b/python/docs/tag.rst
@@ -1,43 +1,43 @@
 .. code-block:: bash
 
    Usage: nessie tag [OPTIONS] [TAG_NAME] [BASE_REF]
-   
+
      Tag operations.
-   
+
      TAG_NAME name of branch to list or create/assign
-   
+
      BASE_REF name of branch or tag whose HEAD reference is to be used for the new
      tag
-   
+
      Examples:
-   
+
          nessie tag -> list all tags
-   
+
          nessie tag -l -> list all tags
-   
+
          nessie tag -l v1.0 -> list only tag "v1.0"
-   
+
          nessie tag -d v1.0 -> delete tag "v1.0"
-   
+
          nessie tag new_tag -> create new tag named 'new_tag' at current HEAD of
          the default branch
-   
+
          nessie tag new_tag main -> create new tag named 'new_tag' at head of
          reference named 'main' (branch or tag)
-   
+
          nessie tag -o 12345678abcdef new_tag test -> create new tag named
          'new_tag' at hash 12345678abcdef on reference named 'test'
-   
+
          nessie tag new_tag test@12345678abcdef -> create new tag named 'new_tag'
          at hash 12345678abcdef on reference named 'test', alternative syntax of
          the above
-   
+
          nessie tag -f existing_tag main -> assign tag named 'existing_tag' to head
          of reference named 'main'
-   
+
          nessie tag -o 12345678abcdef -f existing_tag main -> assign tag named
          'existing_tag' to hash 12345678abcdef on reference named 'main'
-   
+
    Options:
      -l, --list              list branches
      -d, --delete            delete a branches
@@ -51,6 +51,5 @@
                              of commits ahead/behind, info about the HEAD commit,
                              number of total commits, or the common ancestor hash.
      --help                  Show this message and exit.
-   
-   
+
 

--- a/python/docs/tag.rst
+++ b/python/docs/tag.rst
@@ -28,6 +28,10 @@
          nessie tag -o 12345678abcdef new_tag test -> create new tag named
          'new_tag' at hash 12345678abcdef on reference named 'test'
    
+         nessie tag new_tag test@12345678abcdef -> create new tag named 'new_tag'
+         at hash 12345678abcdef on reference named 'test', alternative syntax of
+         the above
+   
          nessie tag -f existing_tag main -> assign tag named 'existing_tag' to head
          of reference named 'main'
    

--- a/python/tools/generate_docs.py
+++ b/python/tools/generate_docs.py
@@ -55,10 +55,10 @@ def _get_file_name_from_command(command: List[str]) -> str:
 
 def _write_command_output_to_file(file_io: IO, command: List[str]) -> None:
     result = _run_cli(command)
-    space = "   "
-    file_io.write(f".. code-block:: bash\n\n{space}")
-    for line in result.split("\n"):
-        file_io.write(line + f"\n{space}")
+    file_io.write(f".. code-block:: bash\n\n")
+    for line in result.splitlines():
+        indent = "   " if line else ""
+        file_io.write(f"{indent}{line}\n")
     file_io.write("\n\n")
 
 

--- a/python/tools/generate_docs.py
+++ b/python/tools/generate_docs.py
@@ -55,7 +55,7 @@ def _get_file_name_from_command(command: List[str]) -> str:
 
 def _write_command_output_to_file(file_io: IO, command: List[str]) -> None:
     result = _run_cli(command)
-    file_io.write(f".. code-block:: bash\n\n")
+    file_io.write(".. code-block:: bash\n\n")
     for line in result.splitlines():
         indent = "   " if line else ""
         file_io.write(f"{indent}{line}\n")


### PR DESCRIPTION
Running `tox -e docs` locally i noticed that the docs were out of date after recent CLI changes like https://github.com/projectnessie/nessie/pull/3214

This also fixes a trailing whitespace indentation issue i noticed.

Later I will do another PR that will fail if docs are not up-to-date as part of CI to prevent this from happening again.