### PR TITLE
Add tracing to database-adapter internal operations

### DIFF
--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/providers/ConfigurableVersionStoreFactory.java
@@ -34,6 +34,7 @@ import org.projectnessie.versioned.MetricsVersionStore;
 import org.projectnessie.versioned.TracingVersionStore;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.spi.TracingDatabaseAdapter;
 import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
 import org.slf4j.Logger;
@@ -88,6 +89,10 @@ public class ConfigurableVersionStoreFactory {
               .get()
               .newDatabaseAdapter(new GenericContentVariantSupplier<>(storeWorker));
       databaseAdapter.initializeRepo(serverConfig.getDefaultBranch());
+
+      if (storeConfig.isTracingEnabled()) {
+        databaseAdapter = new TracingDatabaseAdapter(databaseAdapter);
+      }
 
       VersionStore<Content, CommitMeta, Content.Type> versionStore =
           new PersistVersionStore<>(databaseAdapter, storeWorker);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/Traced.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/Traced.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.spi;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import java.io.Closeable;
+
+public final class Traced implements Closeable {
+
+  private final Span span;
+  private final Scope scope;
+
+  public static Traced trace(String opName) {
+    return new Traced(opName);
+  }
+
+  private Traced(String opName) {
+    Tracer t = GlobalTracer.get();
+    String spanName = "DatabaseAdapter." + opName;
+    span =
+        t.buildSpan(spanName)
+            .asChildOf(t.activeSpan())
+            .withTag(tagName("operation"), opName)
+            .start();
+    scope = t.activateSpan(span);
+  }
+
+  @Override
+  public void close() {
+    scope.close();
+    span.finish();
+  }
+
+  public Traced tag(String tag, Number number) {
+    span.setTag(tagName(tag), number);
+    return this;
+  }
+
+  public Traced tag(String tag, String value) {
+    span.setTag(tagName(tag), value);
+    return this;
+  }
+
+  private static String tagName(String tag) {
+    return "nessie.database-adapter." + tag;
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.spi;
+
+import static org.projectnessie.versioned.persist.adapter.spi.Traced.trace;
+
+import com.google.protobuf.ByteString;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
+import java.util.stream.Stream;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.RefLogNotFoundException;
+import org.projectnessie.versioned.ReferenceAlreadyExistsException;
+import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceInfo;
+import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.persist.adapter.CommitAttempt;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ContentAndState;
+import org.projectnessie.versioned.persist.adapter.ContentId;
+import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
+import org.projectnessie.versioned.persist.adapter.ContentIdWithType;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.Difference;
+import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
+import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.adapter.RefLog;
+import org.projectnessie.versioned.persist.adapter.RepoDescription;
+
+public final class TracingDatabaseAdapter implements DatabaseAdapter {
+  private static final String TAG_COUNT = "count";
+  private static final String TAG_REF = "ref";
+  private static final String TAG_HASH = "hash";
+  private static final String TAG_FROM = "from";
+  private static final String TAG_TO = "to";
+
+  private final DatabaseAdapter delegate;
+
+  public TracingDatabaseAdapter(DatabaseAdapter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void initializeRepo(String defaultBranchName) {
+    try (Traced ignore = trace("initializeRepo").tag(TAG_REF, defaultBranchName)) {
+      delegate.initializeRepo(defaultBranchName);
+    }
+  }
+
+  @Override
+  public void eraseRepo() {
+    try (Traced ignore = trace("eraseRepo")) {
+      delegate.eraseRepo();
+    }
+  }
+
+  @Override
+  public Hash noAncestorHash() {
+    return delegate.noAncestorHash();
+  }
+
+  @Override
+  public Hash hashOnReference(NamedRef namedReference, Optional<Hash> hashOnReference)
+      throws ReferenceNotFoundException {
+    try (Traced ignore = trace("hashOnReference").tag(TAG_REF, namedReference.getName())) {
+      return delegate.hashOnReference(namedReference, hashOnReference);
+    }
+  }
+
+  @Override
+  public Map<Key, ContentAndState<ByteString>> values(
+      Hash commit, Collection<Key> keys, KeyFilterPredicate keyFilter)
+      throws ReferenceNotFoundException {
+    try (Traced ignore =
+        trace("values").tag(TAG_HASH, commit.asString()).tag(TAG_COUNT, keys.size())) {
+      return delegate.values(commit, keys, keyFilter);
+    }
+  }
+
+  @Override
+  public Stream<CommitLogEntry> commitLog(Hash offset) throws ReferenceNotFoundException {
+    Traced trace = trace("commitLog").tag(TAG_HASH, offset.asString());
+    try {
+      return delegate.commitLog(offset).onClose(trace::close);
+    } catch (RuntimeException | ReferenceNotFoundException e) {
+      trace.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public Stream<KeyWithType> keys(Hash commit, KeyFilterPredicate keyFilter)
+      throws ReferenceNotFoundException {
+    Traced trace = trace("keys").tag(TAG_HASH, commit.asString());
+    try {
+      return delegate.keys(commit, keyFilter).onClose(trace::close);
+    } catch (RuntimeException | ReferenceNotFoundException e) {
+      trace.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public Hash commit(CommitAttempt commitAttempt)
+      throws ReferenceConflictException, ReferenceNotFoundException {
+    try (Traced ignore =
+        trace("commit").tag(TAG_REF, commitAttempt.getCommitToBranch().getName())) {
+      return delegate.commit(commitAttempt);
+    }
+  }
+
+  @Override
+  public Hash transplant(
+      BranchName targetBranch,
+      Optional<Hash> expectedHead,
+      List<Hash> sequenceToTransplant,
+      Function<ByteString, ByteString> updateCommitMetadata)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    try (Traced ignore = trace("transplant").tag(TAG_REF, targetBranch.getName())) {
+      return delegate.transplant(
+          targetBranch, expectedHead, sequenceToTransplant, updateCommitMetadata);
+    }
+  }
+
+  @Override
+  public Hash merge(
+      Hash from,
+      BranchName toBranch,
+      Optional<Hash> expectedHead,
+      Function<ByteString, ByteString> updateCommitMetadata)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    try (Traced ignore =
+        trace("merge").tag(TAG_REF, toBranch.getName()).tag(TAG_HASH, from.asString())) {
+      return delegate.merge(from, toBranch, expectedHead, updateCommitMetadata);
+    }
+  }
+
+  @Override
+  public ReferenceInfo<ByteString> namedRef(String ref, GetNamedRefsParams params)
+      throws ReferenceNotFoundException {
+    try (Traced ignore = trace("namedRef").tag(TAG_REF, ref)) {
+      return delegate.namedRef(ref, params);
+    }
+  }
+
+  @Override
+  public Stream<ReferenceInfo<ByteString>> namedRefs(GetNamedRefsParams params)
+      throws ReferenceNotFoundException {
+    Traced trace = trace("namedRefs");
+    try {
+      return delegate.namedRefs(params).onClose(trace::close);
+    } catch (RuntimeException | ReferenceNotFoundException e) {
+      trace.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public Hash create(NamedRef ref, Hash target)
+      throws ReferenceAlreadyExistsException, ReferenceNotFoundException {
+    try (Traced ignore =
+        trace("create").tag(TAG_REF, ref.getName()).tag(TAG_HASH, target.asString())) {
+      return delegate.create(ref, target);
+    }
+  }
+
+  @Override
+  public void delete(NamedRef reference, Optional<Hash> expectedHead)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    try (Traced ignore = trace("delete").tag(TAG_REF, reference.getName())) {
+      delegate.delete(reference, expectedHead);
+    }
+  }
+
+  @Override
+  public void assign(NamedRef assignee, Optional<Hash> expectedHead, Hash assignTo)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    try (Traced ignore =
+        trace("assign").tag(TAG_HASH, assignTo.asString()).tag(TAG_REF, assignee.getName())) {
+      delegate.assign(assignee, expectedHead, assignTo);
+    }
+  }
+
+  @Override
+  public Stream<Difference> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
+      throws ReferenceNotFoundException {
+    Traced trace = trace("diff").tag(TAG_FROM, from.asString()).tag(TAG_TO, to.asString());
+    try {
+      return delegate.diff(from, to, keyFilter).onClose(trace::close);
+    } catch (RuntimeException | ReferenceNotFoundException e) {
+      trace.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public RepoDescription fetchRepositoryDescription() {
+    try (Traced ignore = trace("fetchRepositoryDescription")) {
+      return delegate.fetchRepositoryDescription();
+    }
+  }
+
+  @Override
+  public void updateRepositoryDescription(Function<RepoDescription, RepoDescription> updater)
+      throws ReferenceConflictException {
+    try (Traced ignore = trace("updateRepositoryDescription")) {
+      delegate.updateRepositoryDescription(updater);
+    }
+  }
+
+  @Override
+  public Stream<ContentIdWithType> globalKeys(ToIntFunction<ByteString> contentTypeExtractor) {
+    Traced trace = trace("globalKeys");
+    try {
+      return delegate.globalKeys(contentTypeExtractor).onClose(trace::close);
+    } catch (RuntimeException e) {
+      trace.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public Stream<ContentIdAndBytes> globalContent(
+      Set<ContentId> keys, ToIntFunction<ByteString> contentTypeExtractor) {
+    Traced trace = trace("globalContent").tag(TAG_COUNT, keys.size());
+    try {
+      return delegate.globalContent(keys, contentTypeExtractor).onClose(trace::close);
+    } catch (RuntimeException e) {
+      trace.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public Optional<ContentIdAndBytes> globalContent(
+      ContentId contentId, ToIntFunction<ByteString> contentTypeExtractor) {
+    try (Traced ignore = trace("globalContent")) {
+      return delegate.globalContent(contentId, contentTypeExtractor);
+    }
+  }
+
+  @Override
+  public Stream<RefLog> refLog(Hash offset) throws RefLogNotFoundException {
+    Traced trace = trace("refLog").tag(TAG_HASH, offset != null ? offset.asString() : "HEAD");
+    try {
+      return delegate.refLog(offset).onClose(trace::close);
+    } catch (RuntimeException | RefLogNotFoundException e) {
+      trace.close();
+      throw e;
+    }
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -55,6 +55,7 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   private static final String TAG_HASH = "hash";
   private static final String TAG_FROM = "from";
   private static final String TAG_TO = "to";
+  private static final String TAG_CONTENT_ID = "cid";
 
   private final DatabaseAdapter delegate;
 
@@ -233,7 +234,7 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   @Override
   public Optional<ContentIdAndBytes> globalContent(
       ContentId contentId, ToIntFunction<ByteString> contentTypeExtractor) {
-    try (Traced ignore = trace("globalContent")) {
+    try (Traced ignore = trace("globalContent").tag(TAG_CONTENT_ID, contentId.getId())) {
       return delegate.globalContent(contentId, contentTypeExtractor);
     }
   }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -101,24 +101,16 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
 
   @Override
   public Stream<CommitLogEntry> commitLog(Hash offset) throws ReferenceNotFoundException {
-    Traced trace = trace("commitLog").tag(TAG_HASH, offset.asString());
-    try {
-      return delegate.commitLog(offset).onClose(trace::close);
-    } catch (RuntimeException | ReferenceNotFoundException e) {
-      trace.close();
-      throw e;
+    try (Traced ignore = trace("commitLog.stream").tag(TAG_HASH, offset.asString())) {
+      return delegate.commitLog(offset);
     }
   }
 
   @Override
   public Stream<KeyWithType> keys(Hash commit, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
-    Traced trace = trace("keys").tag(TAG_HASH, commit.asString());
-    try {
-      return delegate.keys(commit, keyFilter).onClose(trace::close);
-    } catch (RuntimeException | ReferenceNotFoundException e) {
-      trace.close();
-      throw e;
+    try (Traced ignore = trace("keys.stream").tag(TAG_HASH, commit.asString())) {
+      return delegate.keys(commit, keyFilter);
     }
   }
 
@@ -168,12 +160,8 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   @Override
   public Stream<ReferenceInfo<ByteString>> namedRefs(GetNamedRefsParams params)
       throws ReferenceNotFoundException {
-    Traced trace = trace("namedRefs");
-    try {
-      return delegate.namedRefs(params).onClose(trace::close);
-    } catch (RuntimeException | ReferenceNotFoundException e) {
-      trace.close();
-      throw e;
+    try (Traced ignore = trace("namedRefs.stream")) {
+      return delegate.namedRefs(params);
     }
   }
 
@@ -206,12 +194,9 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   @Override
   public Stream<Difference> diff(Hash from, Hash to, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
-    Traced trace = trace("diff").tag(TAG_FROM, from.asString()).tag(TAG_TO, to.asString());
-    try {
-      return delegate.diff(from, to, keyFilter).onClose(trace::close);
-    } catch (RuntimeException | ReferenceNotFoundException e) {
-      trace.close();
-      throw e;
+    try (Traced ignore =
+        trace("diff.stream").tag(TAG_FROM, from.asString()).tag(TAG_TO, to.asString())) {
+      return delegate.diff(from, to, keyFilter);
     }
   }
 
@@ -232,24 +217,16 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
 
   @Override
   public Stream<ContentIdWithType> globalKeys(ToIntFunction<ByteString> contentTypeExtractor) {
-    Traced trace = trace("globalKeys");
-    try {
-      return delegate.globalKeys(contentTypeExtractor).onClose(trace::close);
-    } catch (RuntimeException e) {
-      trace.close();
-      throw e;
+    try (Traced ignore = trace("globalKeys.stream")) {
+      return delegate.globalKeys(contentTypeExtractor);
     }
   }
 
   @Override
   public Stream<ContentIdAndBytes> globalContent(
       Set<ContentId> keys, ToIntFunction<ByteString> contentTypeExtractor) {
-    Traced trace = trace("globalContent").tag(TAG_COUNT, keys.size());
-    try {
-      return delegate.globalContent(keys, contentTypeExtractor).onClose(trace::close);
-    } catch (RuntimeException e) {
-      trace.close();
-      throw e;
+    try (Traced ignore = trace("globalContent.stream").tag(TAG_COUNT, keys.size())) {
+      return delegate.globalContent(keys, contentTypeExtractor);
     }
   }
 
@@ -263,12 +240,9 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
 
   @Override
   public Stream<RefLog> refLog(Hash offset) throws RefLogNotFoundException {
-    Traced trace = trace("refLog").tag(TAG_HASH, offset != null ? offset.asString() : "HEAD");
-    try {
-      return delegate.refLog(offset).onClose(trace::close);
-    } catch (RuntimeException | RefLogNotFoundException e) {
-      trace.close();
-      throw e;
+    try (Traced ignore =
+        trace("refLog.stream").tag(TAG_HASH, offset != null ? offset.asString() : "HEAD")) {
+      return delegate.refLog(offset);
     }
   }
 }

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestTryLoopState.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestTryLoopState.java
@@ -52,6 +52,7 @@ class TestTryLoopState {
     long upper = 2;
     TryLoopState tryLoopState =
         new TryLoopState(
+            "test",
             this::retryErrorMessage,
             mockedConfig(retries, Long.MAX_VALUE, 1, upper, maxSleep),
             clock,
@@ -97,7 +98,11 @@ class TestTryLoopState {
 
     TryLoopState tryLoopState =
         new TryLoopState(
-            this::retryErrorMessage, mockedConfig(retries, 42L), clock, (success, tls) -> {});
+            "test",
+            this::retryErrorMessage,
+            mockedConfig(retries, 42L),
+            clock,
+            (success, tls) -> {});
 
     verify(clock, times(1)).currentNanos();
 
@@ -118,7 +123,11 @@ class TestTryLoopState {
 
     TryLoopState tryLoopState =
         new TryLoopState(
-            this::retryErrorMessage, mockedConfig(retries - 1, 42L), clock, (success, tls) -> {});
+            "test",
+            this::retryErrorMessage,
+            mockedConfig(retries - 1, 42L),
+            clock,
+            (success, tls) -> {});
 
     verify(clock, times(1)).currentNanos();
 
@@ -147,6 +156,7 @@ class TestTryLoopState {
 
     TryLoopState tryLoopState =
         new TryLoopState(
+            "test",
             this::retryErrorMessage,
             mockedConfig(retries, timeoutMillis),
             clock,
@@ -179,7 +189,11 @@ class TestTryLoopState {
 
     TryLoopState tryLoopState =
         new TryLoopState(
-            this::retryErrorMessage, mockedConfig(retries, 42L), clock, (success, tls) -> {});
+            "test",
+            this::retryErrorMessage,
+            mockedConfig(retries, 42L),
+            clock,
+            (success, tls) -> {});
 
     verify(clock, times(1)).currentNanos();
 

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -176,34 +176,35 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected GlobalStatePointer fetchGlobalPointer(NonTransactionalOperationContext ctx) {
+  protected GlobalStatePointer doFetchGlobalPointer(NonTransactionalOperationContext ctx) {
     return loadById(TABLE_GLOBAL_POINTER, "", GlobalStatePointer::parseFrom);
   }
 
   @Override
-  protected CommitLogEntry fetchFromCommitLog(NonTransactionalOperationContext ctx, Hash hash) {
+  protected CommitLogEntry doFetchFromCommitLog(NonTransactionalOperationContext ctx, Hash hash) {
     return loadById(TABLE_COMMIT_LOG, hash, ProtoSerialization::protoToCommitLogEntry);
   }
 
   @Override
-  protected GlobalStateLogEntry fetchFromGlobalLog(NonTransactionalOperationContext ctx, Hash id) {
+  protected GlobalStateLogEntry doFetchFromGlobalLog(
+      NonTransactionalOperationContext ctx, Hash id) {
     return loadById(TABLE_GLOBAL_LOG, id, GlobalStateLogEntry::parseFrom);
   }
 
   @Override
-  protected List<CommitLogEntry> fetchPageFromCommitLog(
+  protected List<CommitLogEntry> doFetchPageFromCommitLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPageResult(TABLE_COMMIT_LOG, hashes, ProtoSerialization::protoToCommitLogEntry);
   }
 
   @Override
-  protected List<GlobalStateLogEntry> fetchPageFromGlobalLog(
+  protected List<GlobalStateLogEntry> doFetchPageFromGlobalLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPageResult(TABLE_GLOBAL_LOG, hashes, GlobalStateLogEntry::parseFrom);
   }
 
   @Override
-  protected Stream<KeyListEntity> fetchKeyLists(
+  protected Stream<KeyListEntity> doFetchKeyLists(
       NonTransactionalOperationContext ctx, List<Hash> keyListsIds) {
     Map<Hash, KeyList> map =
         fetchPage(TABLE_KEY_LISTS, keyListsIds, ProtoSerialization::protoToKeyList);
@@ -212,13 +213,14 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected void writeGlobalCommit(
+  protected void doWriteGlobalCommit(
       NonTransactionalOperationContext ctx, GlobalStateLogEntry entry) {
     insert(TABLE_GLOBAL_LOG, Hash.of(entry.getId()).asString(), entry.toByteArray());
   }
 
   @Override
-  protected void writeIndividualCommit(NonTransactionalOperationContext ctx, CommitLogEntry entry) {
+  protected void doWriteIndividualCommit(
+      NonTransactionalOperationContext ctx, CommitLogEntry entry) {
     insert(TABLE_COMMIT_LOG, entry.getHash().asString(), toProto(entry).toByteArray());
   }
 
@@ -229,7 +231,7 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected void writeMultipleCommits(
+  protected void doWriteMultipleCommits(
       NonTransactionalOperationContext ctx, List<CommitLogEntry> entries) {
     batchWrite(
         TABLE_COMMIT_LOG,
@@ -239,7 +241,7 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected void writeKeyListEntities(
+  protected void doWriteKeyListEntities(
       NonTransactionalOperationContext ctx, List<KeyListEntity> newKeyListEntities) {
     batchWrite(
         TABLE_KEY_LISTS,
@@ -249,7 +251,7 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected boolean globalPointerCas(
+  protected boolean doGlobalPointerCas(
       NonTransactionalOperationContext ctx,
       GlobalStatePointer expected,
       GlobalStatePointer newPointer) {
@@ -280,7 +282,7 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected void cleanUpCommitCas(
+  protected void doCleanUpCommitCas(
       NonTransactionalOperationContext ctx,
       Hash globalId,
       Set<Hash> branchCommits,
@@ -316,12 +318,12 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected RepoDescription fetchRepositoryDescription(NonTransactionalOperationContext ctx) {
+  protected RepoDescription doFetchRepositoryDescription(NonTransactionalOperationContext ctx) {
     return loadById(TABLE_REPO_DESC, "", ProtoSerialization::protoToRepoDescription);
   }
 
   @Override
-  protected boolean tryUpdateRepositoryDescription(
+  protected boolean doTryUpdateRepositoryDescription(
       NonTransactionalOperationContext ctx, RepoDescription expected, RepoDescription updateTo) {
     AttributeValue updateToBytes =
         AttributeValue.builder().b(SdkBytes.fromByteArray(toProto(updateTo).toByteArray())).build();
@@ -449,13 +451,13 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected void writeRefLog(NonTransactionalOperationContext ctx, RefLogEntry entry)
+  protected void doWriteRefLog(NonTransactionalOperationContext ctx, RefLogEntry entry)
       throws ReferenceConflictException {
     insert(TABLE_REF_LOG, Hash.of(entry.getRefLogId()).asString(), entry.toByteArray());
   }
 
   @Override
-  protected RefLog fetchFromRefLog(NonTransactionalOperationContext ctx, Hash refLogId) {
+  protected RefLog doFetchFromRefLog(NonTransactionalOperationContext ctx, Hash refLogId) {
     if (refLogId == null) {
       // set the current head as refLogId
       refLogId = Hash.of(fetchGlobalPointer(ctx).getRefLogId());
@@ -464,7 +466,7 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected List<RefLog> fetchPageFromRefLog(
+  protected List<RefLog> doFetchPageFromRefLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPageResult(TABLE_REF_LOG, hashes, ProtoSerialization::protoToRefLog);
   }

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -275,7 +275,7 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected CommitLogEntry fetchFromCommitLog(NonTransactionalOperationContext ctx, Hash hash) {
+  protected CommitLogEntry doFetchFromCommitLog(NonTransactionalOperationContext ctx, Hash hash) {
     return loadById(client.getCommitLog(), hash, ProtoSerialization::protoToCommitLogEntry);
   }
 
@@ -298,19 +298,19 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected List<CommitLogEntry> fetchPageFromCommitLog(
+  protected List<CommitLogEntry> doFetchPageFromCommitLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPage(client.getCommitLog(), hashes, ProtoSerialization::protoToCommitLogEntry);
   }
 
   @Override
-  protected RepoDescription fetchRepositoryDescription(NonTransactionalOperationContext ctx) {
+  protected RepoDescription doFetchRepositoryDescription(NonTransactionalOperationContext ctx) {
     return loadById(
         client.getRepoDesc(), globalPointerKey, ProtoSerialization::protoToRepoDescription);
   }
 
   @Override
-  protected boolean tryUpdateRepositoryDescription(
+  protected boolean doTryUpdateRepositoryDescription(
       NonTransactionalOperationContext ctx, RepoDescription expected, RepoDescription updateTo) {
     Document doc = toDoc(toProto(updateTo));
 
@@ -344,7 +344,7 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected Stream<KeyListEntity> fetchKeyLists(
+  protected Stream<KeyListEntity> doFetchKeyLists(
       NonTransactionalOperationContext ctx, List<Hash> keyListsIds) {
     return fetchMappedPage(
         client.getKeyLists(),
@@ -358,13 +358,13 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected void writeIndividualCommit(NonTransactionalOperationContext ctx, CommitLogEntry entry)
+  protected void doWriteIndividualCommit(NonTransactionalOperationContext ctx, CommitLogEntry entry)
       throws ReferenceConflictException {
     insert(client.getCommitLog(), entry.getHash(), toProto(entry).toByteArray());
   }
 
   @Override
-  protected void writeMultipleCommits(
+  protected void doWriteMultipleCommits(
       NonTransactionalOperationContext ctx, List<CommitLogEntry> entries)
       throws ReferenceConflictException {
     List<Document> docs =
@@ -375,7 +375,7 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected void writeKeyListEntities(
+  protected void doWriteKeyListEntities(
       NonTransactionalOperationContext ctx, List<KeyListEntity> newKeyListEntities) {
     for (KeyListEntity keyList : newKeyListEntities) {
       try {
@@ -387,7 +387,8 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected void writeGlobalCommit(NonTransactionalOperationContext ctx, GlobalStateLogEntry entry)
+  protected void doWriteGlobalCommit(
+      NonTransactionalOperationContext ctx, GlobalStateLogEntry entry)
       throws ReferenceConflictException {
     Document id = toId(Hash.of(entry.getId()));
     insert(client.getGlobalLog(), toDoc(id, entry.toByteArray()));
@@ -413,7 +414,7 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected boolean globalPointerCas(
+  protected boolean doGlobalPointerCas(
       NonTransactionalOperationContext ctx,
       GlobalStatePointer expected,
       GlobalStatePointer newPointer) {
@@ -435,7 +436,7 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected void cleanUpCommitCas(
+  protected void doCleanUpCommitCas(
       NonTransactionalOperationContext ctx,
       Hash globalId,
       Set<Hash> branchCommits,
@@ -449,30 +450,31 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected GlobalStatePointer fetchGlobalPointer(NonTransactionalOperationContext ctx) {
+  protected GlobalStatePointer doFetchGlobalPointer(NonTransactionalOperationContext ctx) {
     return loadById(client.getGlobalPointers(), globalPointerKey, GlobalStatePointer::parseFrom);
   }
 
   @Override
-  protected GlobalStateLogEntry fetchFromGlobalLog(NonTransactionalOperationContext ctx, Hash id) {
+  protected GlobalStateLogEntry doFetchFromGlobalLog(
+      NonTransactionalOperationContext ctx, Hash id) {
     return loadById(client.getGlobalLog(), id, GlobalStateLogEntry::parseFrom);
   }
 
   @Override
-  protected List<GlobalStateLogEntry> fetchPageFromGlobalLog(
+  protected List<GlobalStateLogEntry> doFetchPageFromGlobalLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPage(client.getGlobalLog(), hashes, GlobalStateLogEntry::parseFrom);
   }
 
   @Override
-  protected void writeRefLog(NonTransactionalOperationContext ctx, AdapterTypes.RefLogEntry entry)
+  protected void doWriteRefLog(NonTransactionalOperationContext ctx, AdapterTypes.RefLogEntry entry)
       throws ReferenceConflictException {
     Document id = toId(Hash.of(entry.getRefLogId()));
     insert(client.getRefLog(), toDoc(id, entry.toByteArray()));
   }
 
   @Override
-  protected RefLog fetchFromRefLog(NonTransactionalOperationContext ctx, Hash refLogId) {
+  protected RefLog doFetchFromRefLog(NonTransactionalOperationContext ctx, Hash refLogId) {
     if (refLogId == null) {
       // set the current head as refLogId
       refLogId = Hash.of(fetchGlobalPointer(ctx).getRefLogId());
@@ -481,7 +483,7 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected List<RefLog> fetchPageFromRefLog(
+  protected List<RefLog> doFetchPageFromRefLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPage(client.getRefLog(), hashes, ProtoSerialization::protoToRefLog);
   }

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -132,7 +132,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected GlobalStatePointer fetchGlobalPointer(NonTransactionalOperationContext ctx) {
+  protected GlobalStatePointer doFetchGlobalPointer(NonTransactionalOperationContext ctx) {
     try {
       byte[] serialized = db.get(dbInstance.getCfGlobalPointer(), globalPointerKey());
       return serialized != null ? GlobalStatePointer.parseFrom(serialized) : null;
@@ -142,7 +142,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected void writeIndividualCommit(NonTransactionalOperationContext ctx, CommitLogEntry entry)
+  protected void doWriteIndividualCommit(NonTransactionalOperationContext ctx, CommitLogEntry entry)
       throws ReferenceConflictException {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
@@ -158,7 +158,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected void writeMultipleCommits(
+  protected void doWriteMultipleCommits(
       NonTransactionalOperationContext ctx, List<CommitLogEntry> entries) {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
@@ -177,7 +177,8 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected void writeGlobalCommit(NonTransactionalOperationContext ctx, GlobalStateLogEntry entry)
+  protected void doWriteGlobalCommit(
+      NonTransactionalOperationContext ctx, GlobalStateLogEntry entry)
       throws ReferenceConflictException {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
@@ -203,7 +204,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected boolean globalPointerCas(
+  protected boolean doGlobalPointerCas(
       NonTransactionalOperationContext ctx,
       GlobalStatePointer expected,
       GlobalStatePointer newPointer) {
@@ -225,7 +226,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected void cleanUpCommitCas(
+  protected void doCleanUpCommitCas(
       NonTransactionalOperationContext ctx,
       Hash globalId,
       Set<Hash> branchCommits,
@@ -252,7 +253,8 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected GlobalStateLogEntry fetchFromGlobalLog(NonTransactionalOperationContext ctx, Hash id) {
+  protected GlobalStateLogEntry doFetchFromGlobalLog(
+      NonTransactionalOperationContext ctx, Hash id) {
     try {
       byte[] v = db.get(dbInstance.getCfGlobalLog(), dbKey(id));
       return v != null ? GlobalStateLogEntry.parseFrom(v) : null;
@@ -262,7 +264,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected CommitLogEntry fetchFromCommitLog(NonTransactionalOperationContext ctx, Hash hash) {
+  protected CommitLogEntry doFetchFromCommitLog(NonTransactionalOperationContext ctx, Hash hash) {
     try {
       byte[] v = db.get(dbInstance.getCfCommitLog(), dbKey(hash));
       return protoToCommitLogEntry(v);
@@ -272,14 +274,14 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected List<CommitLogEntry> fetchPageFromCommitLog(
+  protected List<CommitLogEntry> doFetchPageFromCommitLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPage(
         dbInstance.getCfCommitLog(), hashes, ProtoSerialization::protoToCommitLogEntry);
   }
 
   @Override
-  protected List<GlobalStateLogEntry> fetchPageFromGlobalLog(
+  protected List<GlobalStateLogEntry> doFetchPageFromGlobalLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPage(
         dbInstance.getCfGlobalLog(),
@@ -309,7 +311,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected void writeKeyListEntities(
+  protected void doWriteKeyListEntities(
       NonTransactionalOperationContext ctx, List<KeyListEntity> newKeyListEntities) {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
@@ -326,7 +328,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected Stream<KeyListEntity> fetchKeyLists(
+  protected Stream<KeyListEntity> doFetchKeyLists(
       NonTransactionalOperationContext ctx, List<Hash> keyListsIds) {
     try {
       List<ColumnFamilyHandle> cf = new ArrayList<>(keyListsIds.size());
@@ -347,7 +349,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected RepoDescription fetchRepositoryDescription(NonTransactionalOperationContext ctx) {
+  protected RepoDescription doFetchRepositoryDescription(NonTransactionalOperationContext ctx) {
     try {
       byte[] bytes = db.get(dbInstance.getCfRepoProps(), globalPointerKey());
       return bytes != null ? protoToRepoDescription(bytes) : null;
@@ -357,7 +359,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected boolean tryUpdateRepositoryDescription(
+  protected boolean doTryUpdateRepositoryDescription(
       NonTransactionalOperationContext ctx, RepoDescription expected, RepoDescription updateTo) {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
@@ -388,7 +390,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected void writeRefLog(NonTransactionalOperationContext ctx, AdapterTypes.RefLogEntry entry)
+  protected void doWriteRefLog(NonTransactionalOperationContext ctx, AdapterTypes.RefLogEntry entry)
       throws ReferenceConflictException {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
@@ -404,7 +406,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected RefLog fetchFromRefLog(NonTransactionalOperationContext ctx, Hash refLogId) {
+  protected RefLog doFetchFromRefLog(NonTransactionalOperationContext ctx, Hash refLogId) {
     if (refLogId == null) {
       // set the current head as refLogId
       refLogId = Hash.of(fetchGlobalPointer(ctx).getRefLogId());
@@ -418,7 +420,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected List<RefLog> fetchPageFromRefLog(
+  protected List<RefLog> doFetchPageFromRefLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes) {
     return fetchPage(dbInstance.getCfRefLog(), hashes, ProtoSerialization::protoToRefLog);
   }

--- a/versioned/persist/tests/pom.xml
+++ b/versioned/persist/tests/pom.xml
@@ -64,5 +64,9 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterVersionStoreTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterVersionStoreTest.java
@@ -15,21 +15,28 @@
  */
 package org.projectnessie.versioned.persist.tests;
 
+import io.opentracing.mock.MockTracer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterConfigItem;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbTracer;
+import org.projectnessie.versioned.persist.tests.extension.NessieMockedTracingExtension;
 import org.projectnessie.versioned.tests.AbstractVersionStoreTestBase;
 import org.projectnessie.versioned.testworker.BaseContent;
 import org.projectnessie.versioned.testworker.CommitMessage;
 
 @ExtendWith(DatabaseAdapterExtension.class)
+@ExtendWith(NessieMockedTracingExtension.class)
 @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "2048")
 public abstract class AbstractDatabaseAdapterVersionStoreTest extends AbstractVersionStoreTestBase {
 
-  @NessieDbAdapter static VersionStore<BaseContent, CommitMessage, BaseContent.Type> store;
+  @NessieDbAdapter(withTracing = true)
+  static VersionStore<BaseContent, CommitMessage, BaseContent.Type> store;
+
+  @NessieDbTracer static MockTracer tracer;
 
   @Override
   protected VersionStore<BaseContent, CommitMessage, BaseContent.Type> store() {
@@ -46,6 +53,13 @@ public abstract class AbstractDatabaseAdapterVersionStoreTest extends AbstractVe
   @Nested
   public class DuplicateTable extends AbstractDuplicateTable {
     public DuplicateTable() {
+      super(AbstractDatabaseAdapterVersionStoreTest.store);
+    }
+  }
+
+  @Nested
+  public class Tracing extends AbstractTracing {
+    public Tracing() {
       super(AbstractDatabaseAdapterVersionStoreTest.store);
     }
   }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.base.Strings;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockSpan.MockContext;
+import io.opentracing.mock.MockTracer;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbTracer;
+import org.projectnessie.versioned.tests.AbstractNestedVersionStore;
+import org.projectnessie.versioned.testworker.BaseContent;
+import org.projectnessie.versioned.testworker.CommitMessage;
+
+public abstract class AbstractTracing extends AbstractNestedVersionStore {
+  @NessieDbTracer MockTracer tracer;
+
+  protected AbstractTracing(VersionStore<BaseContent, CommitMessage, BaseContent.Type> store) {
+    super(store);
+  }
+
+  @Test
+  void createBranch() throws Exception {
+    store().create(BranchName.of("traceCreateBranch"), Optional.empty());
+    assertThat(tracer.activeSpan()).isNull();
+    List<MockSpanHierarchy> hierarchy = spanHierarchy();
+    assertThat(hierarchy).hasSize(1);
+    MockSpanHierarchy root = hierarchy.get(0);
+    /*
+    11 (39000µs)      VersionStore.create  {nessie.version-store.operation=Create, nessie.version-store.target-hash=Optional.empty, nessie.version-store.ref=BranchName{name=traceCreateBranch}}
+    12 (39000µs)          DatabaseAdapter.create {nessie.database-adapter.operation=create, nessie.database-adapter.hash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d, nessie.database-adapter.ref=traceCreateBranch}
+    13 (36000µs)              DatabaseAdapter.try-loop.createRef {nessie.database-adapter.operation=try-loop.createRef, nessie.database-adapter.try-loop.attempt=0, nessie.database-adapter.try-loop.retries=0}
+    14 (    0µs)                  DatabaseAdapter.fetchGlobalPointer {nessie.database-adapter.operation=fetchGlobalPointer}
+    15 ( 1000µs)                  DatabaseAdapter.fetchFromGlobalLog {nessie.database-adapter.operation=fetchFromGlobalLog, nessie.database-adapter.hash=969bf32b0de839ae0d5530d2e89d72971eef1843013c0389db902dd1e053805e}
+    16 (    0µs)                  DatabaseAdapter.writeGlobalCommit {nessie.database-adapter.operation=writeGlobalCommit}
+    17 ( 7000µs)                  DatabaseAdapter.fetchFromRefLog {nessie.database-adapter.operation=fetchFromRefLog, nessie.database-adapter.hash=a40accab3397f9baf2b84f8c3f3ad867e71f30fe1d0bf5b812fbf8edd0455ef8}
+    18 (    0µs)                  DatabaseAdapter.writeRefLog {nessie.database-adapter.operation=writeRefLog}
+    19 (    0µs)                  DatabaseAdapter.globalPointerCas {nessie.database-adapter.operation=globalPointerCas}
+    */
+    assertThat(root.asOperationHierarchy(null))
+        .satisfiesAnyOf(
+            // 1st "satisfies()" - for non-transactional database adapters
+            h ->
+                assertThat(h)
+                    .isEqualTo(
+                        OperationHierarchy.create()
+                            .child(
+                                "VersionStore.create",
+                                vsCreate ->
+                                    vsCreate.child(
+                                        "DatabaseAdapter.create",
+                                        dbCreate ->
+                                            dbCreate.child(
+                                                "DatabaseAdapter.try-loop.createRef",
+                                                tryLoop ->
+                                                    tryLoop
+                                                        .add("DatabaseAdapter.fetchGlobalPointer")
+                                                        .add("DatabaseAdapter.fetchFromGlobalLog")
+                                                        .add("DatabaseAdapter.writeGlobalCommit")
+                                                        .add("DatabaseAdapter.fetchFromRefLog")
+                                                        .add("DatabaseAdapter.writeRefLog")
+                                                        .add(
+                                                            "DatabaseAdapter.globalPointerCas"))))),
+            // 2nd "satisfies()" - for transactional database adapters
+            h ->
+                assertThat(h)
+                    .isEqualTo(
+                        OperationHierarchy.create()
+                            .child(
+                                "VersionStore.create",
+                                vsCreate ->
+                                    vsCreate.child(
+                                        "DatabaseAdapter.create",
+                                        dbCreate ->
+                                            dbCreate.child(
+                                                "DatabaseAdapter.try-loop.createRef",
+                                                tryLoop ->
+                                                    tryLoop
+                                                        .add(
+                                                            "DatabaseAdapter.checkNamedRefExistence")
+                                                        .add("DatabaseAdapter.insertNewReference")
+                                                        .add("DatabaseAdapter.getRefLogHead")
+                                                        .add("DatabaseAdapter.fetchFromRefLog")
+                                                        .add(
+                                                            "DatabaseAdapter.updateRefLogHead"))))));
+  }
+
+  static class OperationHierarchy {
+    private final OperationHierarchy parent;
+    private final String name;
+    private final List<OperationHierarchy> children = new ArrayList<>();
+
+    OperationHierarchy(OperationHierarchy parent, String name) {
+      this.parent = parent;
+      this.name = name;
+    }
+
+    public static OperationHierarchy create() {
+      return new OperationHierarchy(null, "<root>");
+    }
+
+    public OperationHierarchy child(String name, Consumer<OperationHierarchy> childConsumer) {
+      OperationHierarchy ch = new OperationHierarchy(this, name);
+      children.add(ch);
+      childConsumer.accept(ch);
+      return this;
+    }
+
+    public OperationHierarchy add(String name) {
+      child(name, c -> {});
+      return this;
+    }
+
+    public OperationHierarchy parent() {
+      return parent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      OperationHierarchy that = (OperationHierarchy) o;
+      return Objects.equals(name, that.name) && Objects.equals(children, that.children);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, children);
+    }
+
+    @Override
+    public String toString() {
+      try (StringWriter sw = new StringWriter();
+          PrintWriter pw = new PrintWriter(sw)) {
+        toString(pw, 0);
+        return sw.toString();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    void toString(PrintWriter w, int indent) {
+      w.printf("%s %s%n", Strings.repeat("    ", indent), name);
+      for (OperationHierarchy child : children) {
+        child.toString(w, indent + 1);
+      }
+    }
+  }
+
+  static class MockSpanHierarchy {
+    private MockSpanHierarchy parent;
+    private MockSpan span;
+    private final List<MockSpan> childSpans = new ArrayList<>();
+    private final List<MockSpanHierarchy> children = new ArrayList<>();
+
+    private MockSpanHierarchy() {}
+
+    public OperationHierarchy asOperationHierarchy(OperationHierarchy parent) {
+      OperationHierarchy op =
+          new OperationHierarchy(parent, span != null ? span.operationName() : "<root>");
+      for (MockSpanHierarchy child : children) {
+        op.children.add(child.asOperationHierarchy(op));
+      }
+      return op;
+    }
+
+    @Override
+    public String toString() {
+      try (StringWriter sw = new StringWriter();
+          PrintWriter pw = new PrintWriter(sw)) {
+        toString(pw, 0);
+        return sw.toString();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    void toString(PrintWriter w, int indent) {
+      if (span != null) {
+        w.printf(
+            "%5d (%5dµs) %s %-20s %s%n",
+            span.context().spanId(),
+            span.finishMicros() - span.startMicros(),
+            Strings.repeat("    ", indent),
+            span.operationName(),
+            span.tags());
+      }
+      for (MockSpanHierarchy child : children) {
+        child.toString(w, indent + 1);
+      }
+    }
+  }
+
+  private List<MockSpanHierarchy> spanHierarchy() {
+    Map<Long, MockSpanHierarchy> byId = new HashMap<>();
+
+    for (MockSpan span : tracer.finishedSpans()) {
+      byId.computeIfAbsent(span.context().spanId(), id -> new MockSpanHierarchy()).span = span;
+      byId.computeIfAbsent(span.parentId(), id -> new MockSpanHierarchy()).childSpans.add(span);
+    }
+
+    for (MockSpanHierarchy span : byId.values()) {
+      if (span.span != null) {
+        span.parent = byId.get(span.span.parentId());
+      }
+      span.childSpans.stream()
+          .map(MockSpan::context)
+          .mapToLong(MockContext::spanId)
+          .mapToObj(byId::get)
+          .forEach(span.children::add);
+    }
+
+    return byId.values().stream().filter(h -> h.parent == null).collect(Collectors.toList());
+  }
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbAdapter.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbAdapter.java
@@ -59,5 +59,7 @@ public @interface NessieDbAdapter {
   /** Whether to initialize the adapter, defaults to {@code true}. */
   boolean initializeRepo() default true;
 
+  boolean withTracing() default false;
+
   Class<? extends StoreWorker<?, ?, ?>> storeWorker() default SimpleStoreWorker.class;
 }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbTracer.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbTracer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface NessieDbTracer {}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieMockedTracingExtension.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieMockedTracingExtension.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests.extension;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;
+import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
+
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.GlobalTracer;
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.util.ExceptionUtils;
+
+/**
+ * Extension that allows injecting a {@link MockTracer} on {@link NessieDbTracer} annotated fields
+ * and parameters.
+ *
+ * <p>Note that the {@link MockTracer} instance is constant per class - like a {@code static final}
+ * field.
+ */
+public class NessieMockedTracingExtension
+    implements BeforeAllCallback, BeforeEachCallback, ParameterResolver {
+  private static final Namespace NAMESPACE = Namespace.create(NessieMockedTracingExtension.class);
+
+  private static final MockTracer TRACER = new MockTracer();
+  private static volatile boolean tracerRegistered;
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    if (GlobalTracer.isRegistered() && !tracerRegistered) {
+      throw new ExtensionConfigurationException("GlobalTracer already has a registered Tracer");
+    }
+    tracerRegistered = true;
+    GlobalTracer.registerIfAbsent(TRACER);
+
+    injectTrace(context, TRACER);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    TRACER.reset();
+
+    injectTrace(context, TRACER);
+  }
+
+  private static void injectTrace(ExtensionContext context, MockTracer tracer) {
+    Class<?> testClass = context.getRequiredTestClass();
+
+    findAnnotatedFields(testClass, NessieDbTracer.class, f -> true)
+        .forEach(
+            field -> {
+              if (!Modifier.isStatic(field.getModifiers())
+                  && !context.getTestInstance().isPresent()) {
+                return;
+              }
+
+              if (!field.getType().isAssignableFrom(MockTracer.class)) {
+                throw new ExtensionConfigurationException(
+                    "@NessieDbTracer annotated fields must be of type "
+                        + MockTracer.class.getName());
+              }
+
+              try {
+                makeAccessible(field).set(context.getTestInstance().orElse(null), tracer);
+              } catch (IllegalAccessException e) {
+                ExceptionUtils.throwAsUncheckedException(e);
+              }
+            });
+  }
+
+  @Override
+  public boolean supportsParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return parameterContext.isAnnotated(NessieDbTracer.class);
+  }
+
+  @Override
+  public Object resolveParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return extensionContext.getStore(NAMESPACE).get("tracer", MockTracer.class);
+  }
+}

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -1269,23 +1269,18 @@ public abstract class TxDatabaseAdapter
 
   @Override
   protected Stream<KeyListEntity> doFetchKeyLists(Connection c, List<Hash> keyListsIds) {
-    Traced trace = trace("doFetchKeyLists");
-    try {
+    try (Traced ignore = trace("doFetchKeyLists.stream")) {
       return JdbcSelectSpliterator.buildStream(
-              c,
-              sqlForManyPlaceholders(SqlStatements.SELECT_KEY_LIST_MANY, keyListsIds.size()),
-              ps -> {
-                ps.setString(1, config.getRepositoryId());
-                int i = 2;
-                for (Hash id : keyListsIds) {
-                  ps.setString(i++, id.asString());
-                }
-              },
-              (rs) -> KeyListEntity.of(Hash.of(rs.getString(1)), protoToKeyList(rs.getBytes(2))))
-          .onClose(trace::close);
-    } catch (RuntimeException e) {
-      trace.close();
-      throw e;
+          c,
+          sqlForManyPlaceholders(SqlStatements.SELECT_KEY_LIST_MANY, keyListsIds.size()),
+          ps -> {
+            ps.setString(1, config.getRepositoryId());
+            int i = 2;
+            for (Hash id : keyListsIds) {
+              ps.setString(i++, id.asString());
+            }
+          },
+          (rs) -> KeyListEntity.of(Hash.of(rs.getString(1)), protoToKeyList(rs.getBytes(2))));
     }
   }
 

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -27,6 +27,7 @@ import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUti
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.repoDescUpdateConflictMessage;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.transplantConflictMessage;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.verifyExpectedHash;
+import static org.projectnessie.versioned.persist.adapter.spi.Traced.trace;
 import static org.projectnessie.versioned.persist.adapter.spi.TryLoopState.newTryLoopState;
 import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToCommitLogEntry;
 import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToKeyList;
@@ -86,6 +87,7 @@ import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.spi.Traced;
 import org.projectnessie.versioned.persist.adapter.spi.TryLoopState;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes;
 
@@ -240,6 +242,7 @@ public abstract class TxDatabaseAdapter
     // creates a new commit-tree that is decoupled from other commit-trees.
     try {
       return opLoop(
+          "merge",
           toBranch,
           false,
           (conn, currentHead) -> {
@@ -287,6 +290,7 @@ public abstract class TxDatabaseAdapter
       throws ReferenceNotFoundException, ReferenceConflictException {
     try {
       return opLoop(
+          "transplant",
           targetBranch,
           false,
           (conn, currentHead) -> {
@@ -331,6 +335,7 @@ public abstract class TxDatabaseAdapter
       throws ReferenceConflictException, ReferenceNotFoundException {
     try {
       return opLoop(
+          "commit",
           commitAttempt.getCommitToBranch(),
           false,
           (conn, branchHead) -> {
@@ -376,6 +381,7 @@ public abstract class TxDatabaseAdapter
       throws ReferenceAlreadyExistsException, ReferenceNotFoundException {
     try {
       return opLoop(
+          "createRef",
           ref,
           true,
           (conn, nullHead) -> {
@@ -418,14 +424,16 @@ public abstract class TxDatabaseAdapter
       throws ReferenceNotFoundException, ReferenceConflictException {
     try {
       opLoop(
+          "deleteRef",
           reference,
           false,
           (conn, pointer) -> {
             verifyExpectedHash(pointer, reference, expectedHead);
 
             Hash commitHash = fetchNamedRefHead(conn, reference);
-            try (PreparedStatement ps =
-                conn.prepareStatement(SqlStatements.DELETE_NAMED_REFERENCE)) {
+            try (Traced ignore = trace("deleteRefInDb");
+                PreparedStatement ps =
+                    conn.prepareStatement(SqlStatements.DELETE_NAMED_REFERENCE)) {
               ps.setString(1, config.getRepositoryId());
               ps.setString(2, reference.getName());
               ps.setString(3, pointer.asString());
@@ -458,6 +466,7 @@ public abstract class TxDatabaseAdapter
       throws ReferenceNotFoundException, ReferenceConflictException {
     try {
       opLoop(
+          "assignRef",
           assignee,
           true,
           (conn, assigneeHead) -> {
@@ -595,8 +604,9 @@ public abstract class TxDatabaseAdapter
       ContentId contentId, ToIntFunction<ByteString> contentTypeExtractor) {
     Connection conn = borrowConnection();
     try {
-      try (PreparedStatement ps =
-          conn.prepareStatement(String.format(SqlStatements.SELECT_GLOBAL_STATE_MANY, "?"))) {
+      try (Traced ignore = trace("globalContent");
+          PreparedStatement ps =
+              conn.prepareStatement(String.format(SqlStatements.SELECT_GLOBAL_STATE_MANY, "?"))) {
         ps.setString(1, config.getRepositoryId());
         ps.setString(2, contentId.getId());
         try (ResultSet rs = ps.executeQuery()) {
@@ -737,15 +747,15 @@ public abstract class TxDatabaseAdapter
      * @param conn current JDBC connection
      * @param targetRefHead current named-reference's HEAD
      * @return if non-{@code * null}, the JDBC transaction is committed and the hash returned from
-     *     {@link #opLoop(NamedRef, boolean, LoopOp, Supplier, Supplier)}. If {@code null}, the
-     *     {@code opLoop()} tries again.
+     *     {@link #opLoop(String, NamedRef, boolean, LoopOp, Supplier, Supplier)}. If {@code null},
+     *     the {@code opLoop()} tries again.
      * @throws RetryTransactionException (see {@link #isRetryTransaction(SQLException)}), the
-     *     current JDBC transaction is rolled back and {@link #opLoop(NamedRef, boolean, LoopOp,
-     *     Supplier, Supplier)} tries again
+     *     current JDBC transaction is rolled back and {@link #opLoop(String, NamedRef, boolean,
+     *     LoopOp, Supplier, Supplier)} tries again
      * @throws SQLException if this matches {@link #isIntegrityConstraintViolation(Throwable)}, the
      *     exception is re-thrown as a {@link ReferenceConflictException}
      * @throws VersionStoreException any other version-store exception
-     * @see #opLoop(NamedRef, boolean, LoopOp, Supplier, Supplier)
+     * @see #opLoop(String, NamedRef, boolean, LoopOp, Supplier, Supplier)
      */
     Hash apply(Connection conn, Hash targetRefHead) throws VersionStoreException, SQLException;
   }
@@ -779,6 +789,7 @@ public abstract class TxDatabaseAdapter
    * @see LoopOp#apply(Connection, Hash)
    */
   protected Hash opLoop(
+      String opName,
       NamedRef namedReference,
       boolean createRef,
       LoopOp loopOp,
@@ -789,6 +800,7 @@ public abstract class TxDatabaseAdapter
 
     try (TryLoopState tryState =
         newTryLoopState(
+            opName,
             ts ->
                 repoDescUpdateConflictMessage(
                     String.format(
@@ -862,7 +874,8 @@ public abstract class TxDatabaseAdapter
 
   /** Similar to {@link #fetchNamedRefHead(Connection, NamedRef)}, but just checks for existence. */
   protected boolean checkNamedRefExistence(Connection c, String refName) {
-    try (PreparedStatement ps = c.prepareStatement(SqlStatements.SELECT_NAMED_REFERENCE_NAME)) {
+    try (Traced ignore = trace("checkNamedRefExistence");
+        PreparedStatement ps = c.prepareStatement(SqlStatements.SELECT_NAMED_REFERENCE_NAME)) {
       ps.setString(1, config.getRepositoryId());
       ps.setString(2, refName);
       try (ResultSet rs = ps.executeQuery()) {
@@ -878,7 +891,8 @@ public abstract class TxDatabaseAdapter
    * reference does not exist.
    */
   protected Hash fetchNamedRefHead(Connection c, NamedRef ref) throws ReferenceNotFoundException {
-    try (PreparedStatement ps = c.prepareStatement(SqlStatements.SELECT_NAMED_REFERENCE)) {
+    try (Traced ignore = trace("fetchNamedRefHead");
+        PreparedStatement ps = c.prepareStatement(SqlStatements.SELECT_NAMED_REFERENCE)) {
       ps.setString(1, config.getRepositoryId());
       ps.setString(2, ref.getName());
       ps.setString(3, referenceTypeDiscriminator(ref));
@@ -895,7 +909,8 @@ public abstract class TxDatabaseAdapter
 
   protected ReferenceInfo<ByteString> fetchNamedRef(Connection c, String ref)
       throws ReferenceNotFoundException {
-    try (PreparedStatement ps = c.prepareStatement(SqlStatements.SELECT_NAMED_REFERENCE_ANY)) {
+    try (Traced ignore = trace("fetchNamedRef");
+        PreparedStatement ps = c.prepareStatement(SqlStatements.SELECT_NAMED_REFERENCE_ANY)) {
       ps.setString(1, config.getRepositoryId());
       ps.setString(2, ref);
       try (ResultSet rs = ps.executeQuery()) {
@@ -924,7 +939,8 @@ public abstract class TxDatabaseAdapter
 
   protected void insertNewReference(Connection conn, NamedRef ref, Hash hash)
       throws ReferenceAlreadyExistsException, SQLException {
-    try (PreparedStatement ps = conn.prepareStatement(SqlStatements.INSERT_NAMED_REFERENCE)) {
+    try (Traced ignore = trace("insertNewReference");
+        PreparedStatement ps = conn.prepareStatement(SqlStatements.INSERT_NAMED_REFERENCE)) {
       ps.setString(1, config.getRepositoryId());
       ps.setString(2, ref.getName());
       ps.setString(3, referenceTypeDiscriminator(ref));
@@ -998,7 +1014,8 @@ public abstract class TxDatabaseAdapter
 
     Set<ContentId> newKeys = new HashSet<>(commitAttempt.getGlobal().keySet());
 
-    try (PreparedStatement psSelect = conn.prepareStatement(sql);
+    try (Traced ignore = trace("upsertGlobalStates");
+        PreparedStatement psSelect = conn.prepareStatement(sql);
         PreparedStatement psUpdate = conn.prepareStatement(SqlStatements.UPDATE_GLOBAL_STATE);
         PreparedStatement psUpdateUnconditional =
             conn.prepareStatement(SqlStatements.UPDATE_GLOBAL_STATE_UNCOND)) {
@@ -1039,34 +1056,36 @@ public abstract class TxDatabaseAdapter
           String newHash = newHasher().putBytes(newStateBytes).hash().toString();
 
           // Perform a conditional update, if the client asked us to do so.
-          PreparedStatement ps = expected.isEmpty() ? psUpdateUnconditional : psUpdate;
-          ps.setBytes(1, newStateBytes);
-          ps.setString(2, newHash);
-          ps.setLong(3, newCreatedAt);
-          ps.setString(4, config.getRepositoryId());
-          ps.setString(5, contentId.getId());
-          if (!expected.isEmpty()) {
-            // Only perform a conditional update, if the client asked us to do so...
+          try (Traced ignored = trace("upsertGlobalStatesPerform")) {
+            PreparedStatement ps = expected.isEmpty() ? psUpdateUnconditional : psUpdate;
+            ps.setBytes(1, newStateBytes);
+            ps.setString(2, newHash);
+            ps.setLong(3, newCreatedAt);
+            ps.setString(4, config.getRepositoryId());
+            ps.setString(5, contentId.getId());
+            if (!expected.isEmpty()) {
+              // Only perform a conditional update, if the client asked us to do so...
 
-            @SuppressWarnings("UnstableApiUsage")
-            String expectedHash =
-                newHasher().putBytes(expected.asReadOnlyByteBuffer()).hash().toString();
-            ps.setString(6, expectedHash);
-          }
+              @SuppressWarnings("UnstableApiUsage")
+              String expectedHash =
+                  newHasher().putBytes(expected.asReadOnlyByteBuffer()).hash().toString();
+              ps.setString(6, expectedHash);
+            }
 
-          // Check whether the UPDATE worked. If not -> reference-conflict
-          if (ps.executeUpdate() != 1) {
-            // No need to continue, just throw a legit constraint-violation that will be
-            // converted to a "proper ReferenceConflictException" later up in the stack.
-            throw newIntegrityConstraintViolationException();
+            // Check whether the UPDATE worked. If not -> reference-conflict
+            if (ps.executeUpdate() != 1) {
+              // No need to continue, just throw a legit constraint-violation that will be
+              // converted to a "proper ReferenceConflictException" later up in the stack.
+              throw newIntegrityConstraintViolationException();
+            }
           }
         }
       }
 
       // 2. INSERT all global-state values for those keys that were not handled above.
       if (!newKeys.isEmpty()) {
-        try (PreparedStatement psInsert =
-            conn.prepareStatement(SqlStatements.INSERT_GLOBAL_STATE)) {
+        try (Traced ignored = trace("upsertGlobalStatesInsert")) {
+          PreparedStatement psInsert = conn.prepareStatement(SqlStatements.INSERT_GLOBAL_STATE);
           for (ContentId contentId : newKeys) {
             ByteString newGlob = commitAttempt.getGlobal().get(contentId);
             byte[] newGlobBytes = newGlob.toByteArray();
@@ -1098,7 +1117,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected Map<ContentId, ByteString> fetchGlobalStates(
+  protected Map<ContentId, ByteString> doFetchGlobalStates(
       Connection conn, Set<ContentId> contentIds) {
     if (contentIds.isEmpty()) {
       return Collections.emptyMap();
@@ -1131,7 +1150,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected CommitLogEntry fetchFromCommitLog(Connection c, Hash hash) {
+  protected CommitLogEntry doFetchFromCommitLog(Connection c, Hash hash) {
     try (PreparedStatement ps = c.prepareStatement(SqlStatements.SELECT_COMMIT_LOG)) {
       ps.setString(1, config.getRepositoryId());
       ps.setString(2, hash.asString());
@@ -1144,7 +1163,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected List<CommitLogEntry> fetchPageFromCommitLog(Connection c, List<Hash> hashes) {
+  protected List<CommitLogEntry> doFetchPageFromCommitLog(Connection c, List<Hash> hashes) {
     String sql = sqlForManyPlaceholders(SqlStatements.SELECT_COMMIT_LOG_MANY, hashes.size());
 
     try (PreparedStatement ps = c.prepareStatement(sql)) {
@@ -1167,7 +1186,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected void writeIndividualCommit(Connection c, CommitLogEntry entry)
+  protected void doWriteIndividualCommit(Connection c, CommitLogEntry entry)
       throws ReferenceConflictException {
     try (PreparedStatement ps = c.prepareStatement(SqlStatements.INSERT_COMMIT_LOG)) {
       ps.setString(1, config.getRepositoryId());
@@ -1185,7 +1204,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected void writeMultipleCommits(Connection c, List<CommitLogEntry> entries)
+  protected void doWriteMultipleCommits(Connection c, List<CommitLogEntry> entries)
       throws ReferenceConflictException {
     writeMany(
         c,
@@ -1196,7 +1215,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected void writeKeyListEntities(Connection c, List<KeyListEntity> newKeyListEntities) {
+  protected void doWriteKeyListEntities(Connection c, List<KeyListEntity> newKeyListEntities) {
     try {
       writeMany(
           c,
@@ -1249,18 +1268,25 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected Stream<KeyListEntity> fetchKeyLists(Connection c, List<Hash> keyListsIds) {
-    return JdbcSelectSpliterator.buildStream(
-        c,
-        sqlForManyPlaceholders(SqlStatements.SELECT_KEY_LIST_MANY, keyListsIds.size()),
-        ps -> {
-          ps.setString(1, config.getRepositoryId());
-          int i = 2;
-          for (Hash id : keyListsIds) {
-            ps.setString(i++, id.asString());
-          }
-        },
-        (rs) -> KeyListEntity.of(Hash.of(rs.getString(1)), protoToKeyList(rs.getBytes(2))));
+  protected Stream<KeyListEntity> doFetchKeyLists(Connection c, List<Hash> keyListsIds) {
+    Traced trace = trace("doFetchKeyLists");
+    try {
+      return JdbcSelectSpliterator.buildStream(
+              c,
+              sqlForManyPlaceholders(SqlStatements.SELECT_KEY_LIST_MANY, keyListsIds.size()),
+              ps -> {
+                ps.setString(1, config.getRepositoryId());
+                int i = 2;
+                for (Hash id : keyListsIds) {
+                  ps.setString(i++, id.asString());
+                }
+              },
+              (rs) -> KeyListEntity.of(Hash.of(rs.getString(1)), protoToKeyList(rs.getBytes(2))))
+          .onClose(trace::close);
+    } catch (RuntimeException e) {
+      trace.close();
+      throw e;
+    }
   }
 
   /**
@@ -1335,7 +1361,8 @@ public abstract class TxDatabaseAdapter
    */
   protected Hash tryMoveNamedReference(
       Connection conn, NamedRef ref, Hash expectedHead, Hash newHead) {
-    try (PreparedStatement ps = conn.prepareStatement(SqlStatements.UPDATE_NAMED_REFERENCE)) {
+    try (Traced ignore = trace("tryMoveNamedReference");
+        PreparedStatement ps = conn.prepareStatement(SqlStatements.UPDATE_NAMED_REFERENCE)) {
       ps.setString(1, newHead.asString());
       ps.setString(2, config.getRepositoryId());
       ps.setString(3, ref.getName());
@@ -1368,7 +1395,8 @@ public abstract class TxDatabaseAdapter
   }
 
   private byte[] fetchRepositoryDescriptionInternal(Connection conn) throws SQLException {
-    try (PreparedStatement ps = conn.prepareStatement(SqlStatements.SELECT_REPO_DESCRIPTION)) {
+    try (Traced ignore = trace("fetchRepositoryDescriptionInternal");
+        PreparedStatement ps = conn.prepareStatement(SqlStatements.SELECT_REPO_DESCRIPTION)) {
       ps.setString(1, config.getRepositoryId());
       try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
@@ -1386,6 +1414,7 @@ public abstract class TxDatabaseAdapter
 
     try {
       opLoop(
+          "updateRepositoryDescription",
           null,
           true,
           (conn, x) -> {
@@ -1554,44 +1583,51 @@ public abstract class TxDatabaseAdapter
 
   protected void updateRefLogHead(Hash newRefLogId, Hash parentRefLogId, Connection conn)
       throws SQLException {
-    PreparedStatement psUpdate = conn.prepareStatement(SqlStatements.UPDATE_REF_LOG_HEAD);
-    psUpdate.setString(1, newRefLogId.asString());
-    psUpdate.setString(2, config.getRepositoryId());
-    psUpdate.setString(3, parentRefLogId.asString());
-    if (psUpdate.executeUpdate() != 1) {
-      // retry the transaction with rebasing the parent id.
-      throw new RetryTransactionException();
+    try (Traced ignore = trace("updateRefLogHead");
+        PreparedStatement psUpdate = conn.prepareStatement(SqlStatements.UPDATE_REF_LOG_HEAD)) {
+      psUpdate.setString(1, newRefLogId.asString());
+      psUpdate.setString(2, config.getRepositoryId());
+      psUpdate.setString(3, parentRefLogId.asString());
+      if (psUpdate.executeUpdate() != 1) {
+        // retry the transaction with rebasing the parent id.
+        throw new RetryTransactionException();
+      }
     }
   }
 
   protected void insertRefLogHead(Hash newRefLogId, Connection conn) throws SQLException {
-    PreparedStatement selectStatement = conn.prepareStatement(SqlStatements.SELECT_REF_LOG_HEAD);
-    selectStatement.setString(1, config.getRepositoryId());
-    // insert if the table is empty
-    if (!selectStatement.executeQuery().next()) {
-      PreparedStatement psUpdate = conn.prepareStatement(SqlStatements.INSERT_REF_LOG_HEAD);
-      psUpdate.setString(1, config.getRepositoryId());
-      psUpdate.setString(2, newRefLogId.asString());
-      if (psUpdate.executeUpdate() != 1) {
-        // No need to continue, just throw a legit constraint-violation that will be
-        // converted to a "proper ReferenceConflictException" later up in the stack.
-        throw newIntegrityConstraintViolationException();
+    try (Traced ignore = trace("insertRefLogHead");
+        PreparedStatement selectStatement =
+            conn.prepareStatement(SqlStatements.SELECT_REF_LOG_HEAD)) {
+      selectStatement.setString(1, config.getRepositoryId());
+      // insert if the table is empty
+      if (!selectStatement.executeQuery().next()) {
+        PreparedStatement psUpdate = conn.prepareStatement(SqlStatements.INSERT_REF_LOG_HEAD);
+        psUpdate.setString(1, config.getRepositoryId());
+        psUpdate.setString(2, newRefLogId.asString());
+        if (psUpdate.executeUpdate() != 1) {
+          // No need to continue, just throw a legit constraint-violation that will be
+          // converted to a "proper ReferenceConflictException" later up in the stack.
+          throw newIntegrityConstraintViolationException();
+        }
       }
     }
   }
 
   protected Hash getRefLogHead(Connection conn) throws SQLException {
-    PreparedStatement psSelect = conn.prepareStatement(SqlStatements.SELECT_REF_LOG_HEAD);
-    psSelect.setString(1, config.getRepositoryId());
-    ResultSet resultSet = psSelect.executeQuery();
-    if (resultSet.next()) {
-      return Hash.of(resultSet.getString(1));
+    try (Traced ignore = trace("getRefLogHead");
+        PreparedStatement psSelect = conn.prepareStatement(SqlStatements.SELECT_REF_LOG_HEAD)) {
+      psSelect.setString(1, config.getRepositoryId());
+      ResultSet resultSet = psSelect.executeQuery();
+      if (resultSet.next()) {
+        return Hash.of(resultSet.getString(1));
+      }
+      return null;
     }
-    return null;
   }
 
   @Override
-  protected RefLog fetchFromRefLog(Connection connection, Hash refLogId) {
+  protected RefLog doFetchFromRefLog(Connection connection, Hash refLogId) {
     if (refLogId == null) {
       // set the current head as refLogId
       try {
@@ -1612,7 +1648,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected List<RefLog> fetchPageFromRefLog(Connection connection, List<Hash> hashes) {
+  protected List<RefLog> doFetchPageFromRefLog(Connection connection, List<Hash> hashes) {
     String sql = sqlForManyPlaceholders(SqlStatements.SELECT_REF_LOG_MANY, hashes.size());
 
     try (PreparedStatement ps = connection.prepareStatement(sql)) {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -253,11 +253,6 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
       Consumer<SpanBuilder> spanBuilder,
       InvokerWithOneException<Stream<R>, E1> invoker)
       throws E1 {
-    // We keep the span active (in scope) only for the duration of the call that creates the stream,
-    // but close it when the stream is closed. This is because the outer scopes may call other
-    // instrumented code during stream iteration, but those calls should be nested directly under
-    // the caller's span, not under this `span`. This may cause overlapping spans, but at the same
-    // time it allows tracking the total duration of the stream iteration process.
     try (SpanHolder span = createSpan(spanName + ".stream", spanBuilder);
         Scope ignore = activeScope(span.get())) {
       try {

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -154,7 +154,7 @@ class TestTracingVersionStore {
                             vs.delete(
                                 BranchName.of("mock-branch"), Optional.of(Hash.of("cafebabe")))),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
-                        "GetCommits", refNotFoundThrows)
+                        "GetCommits.stream", refNotFoundThrows)
                     .tag("nessie.version-store.ref", "BranchName{name=mock-branch}")
                     .function(
                         vs -> vs.getCommits(BranchName.of("mock-branch"), false),
@@ -169,13 +169,13 @@ class TestTracingVersionStore {
                                     .commitMeta("log#2")
                                     .build())),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
-                        "GetKeys", refNotFoundThrows)
+                        "GetKeys.stream", refNotFoundThrows)
                     .tag("nessie.version-store.ref", "Hash cafe4242")
                     .function(
                         vs -> vs.getKeys(Hash.of("cafe4242")),
                         () -> Stream.of(Key.of("hello", "world"))),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
-                        "GetNamedRefs", runtimeThrows)
+                        "GetNamedRefs.stream", runtimeThrows)
                     .function(
                         stringStringDummyEnumVersionStore ->
                             stringStringDummyEnumVersionStore.getNamedRefs(
@@ -202,7 +202,7 @@ class TestTracingVersionStore {
                                 Collections.singletonList(Key.of("some", "key"))),
                         Collections::emptyMap),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
-                        "GetDiffs", refNotFoundThrows)
+                        "GetDiffs.stream", refNotFoundThrows)
                     .tag("nessie.version-store.from", "BranchName{name=mock-branch}")
                     .tag("nessie.version-store.to", "BranchName{name=foo-branch}")
                     .function(


### PR DESCRIPTION
Tracing spans around:
* high-level `DatabaseAdapter` methods, via `TracingDatabaseAdapter`
* for each try-loop attempt ("CAS")
* low-level around all operations around database accesses

Adds a (rudimentary) test to compare spans produced via
`VersionStore` -> `DatabaseAdapter`.

No new configuration option, uses the existing "tracing-enabled"
option in `VersionStoreConfig`.