### PR TITLE
Fix warnings for relocated quarkus extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,8 @@
     <prometheus.version>0.9.0</prometheus.version>
     <protobuf.version>3.19.4</protobuf.version>
     <quarkus.version>2.7.2.Final</quarkus.version>
+    <!-- see https://github.com/quarkiverse/quarkus-logging-sentry -->
+    <quarkus.loggingsentry.version>1.0.2</quarkus.loggingsentry.version>
     <reactor.version>2020.0.16</reactor.version>
     <rocksdb.version>6.28.2</rocksdb.version>
     <scala2.12.version>2.12.13</scala2.12.version>
@@ -461,6 +463,20 @@
         <version>${quarkus.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6#extensions-included-inside-the-platform-with-their-own-bom -->
+      <dependency>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-amazon-services-bom</artifactId>
+        <version>${quarkus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6#extensions-moved-out-of-the-quarkus-platform -->
+      <dependency>
+        <groupId>io.quarkiverse.loggingsentry</groupId>
+        <artifactId>quarkus-logging-sentry</artifactId>
+        <version>${quarkus.loggingsentry.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/servers/quarkus-server/pom.xml
+++ b/servers/quarkus-server/pom.xml
@@ -148,7 +148,7 @@
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
+      <groupId>io.quarkiverse.loggingsentry</groupId>
       <artifactId>quarkus-logging-sentry</artifactId>
     </dependency>
     <dependency>
@@ -156,7 +156,7 @@
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
+      <groupId>io.quarkiverse.amazonservices</groupId>
       <artifactId>quarkus-amazon-dynamodb</artifactId>
     </dependency>
     <dependency>

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -63,7 +63,7 @@ When setting `nessie.version.store.type=DYNAMO` which enables DynamoDB as the ve
 | `quarkus.dynamodb.sync-client.type`     | `url`          | `url, apache` | Sets the type of the sync HTTP client implementation                                                                                                |
 
 !!! info
-    A complete set of DynamoDB configuration options for Quarkus can be found on [quarkus.io](https://quarkus.io/guides/all-config#quarkus-amazon-dynamodb_quarkus-amazon-dynamodb-amazon-dynamodb)
+    A complete set of DynamoDB configuration options for Quarkus can be found on [quarkiverse.github.io](https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/amazon-dynamodb.html#_configuration_reference)
 
 ### Version Store Advanced Settings
 


### PR DESCRIPTION
noticed these build warnings:
```
2022-02-28T10:11:15.4181184Z [WARNING] The artifact io.quarkus:quarkus-logging-sentry:jar:2.7.2.Final has been relocated to io.quarkiverse.loggingsentry:quarkus-logging-sentry:jar:1.0.1: io.quarkus:quarkus-logging-sentry:2.7.2.Final was relocated to io.quarkiverse.loggingsentry:quarkus-logging-sentry:1.0.1 and is not managed by io.quarkus.platform:quarkus-bom:2.7.2.Final anymore. Please, update the groupId and add the corresponding version to the dependency declaration in your project configuration. For more information about this change, please refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6
2022-02-28T10:11:15.5400959Z [WARNING] The artifact io.quarkus:quarkus-amazon-dynamodb:jar:2.7.2.Final has been relocated to io.quarkiverse.amazonservices:quarkus-amazon-dynamodb:jar:1.0.2: io.quarkus:quarkus-amazon-dynamodb was relocated to io.quarkiverse.amazonservices:quarkus-amazon-dynamodb and is now managed by the io.quarkus.platform:quarkus-amazon-services-bom:2.7.2.Final. Please, update its groupId in the dependency declaration and import io.quarkus.platform:quarkus-amazon-services-bom:2.7.2.Final in your project configuration. For more information about this change, please, refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6
```

seems like we missed following the migration guide when updating to quarkus 2.6+:
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6