### PR TITLE
Shave off two database reads reads per Nessie operation

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -710,6 +710,22 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
       T initial,
       BiFunction<OP_CONTEXT, List<Hash>, List<T>> fetcher,
       Function<T, List<Hash>> nextPage) {
+    return logFetcherCommon(ctx, Collections.singletonList(initial), fetcher, nextPage);
+  }
+
+  protected <T> Spliterator<T> logFetcherWithPage(
+      OP_CONTEXT ctx,
+      List<Hash> initialPage,
+      BiFunction<OP_CONTEXT, List<Hash>, List<T>> fetcher,
+      Function<T, List<Hash>> nextPage) {
+    return logFetcherCommon(ctx, fetcher.apply(ctx, initialPage), fetcher, nextPage);
+  }
+
+  private <T> Spliterator<T> logFetcherCommon(
+      OP_CONTEXT ctx,
+      List<T> initial,
+      BiFunction<OP_CONTEXT, List<Hash>, List<T>> fetcher,
+      Function<T, List<Hash>> nextPage) {
     return new AbstractSpliterator<T>(Long.MAX_VALUE, 0) {
       private Iterator<T> currentBatch;
       private boolean eof;
@@ -720,7 +736,7 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
         if (eof) {
           return false;
         } else if (currentBatch == null) {
-          currentBatch = Collections.singletonList(initial).iterator();
+          currentBatch = initial.iterator();
         } else if (!currentBatch.hasNext()) {
           if (previous == null) {
             eof = true;

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -85,6 +85,8 @@ import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLog
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.NamedReference;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.Operation;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.RefType;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer.Type;
 import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
@@ -220,24 +222,22 @@ public abstract class NonTransactionalDatabaseAdapter<
                     newKeyLists,
                     updateCommitMetadata);
 
-            Hash newGlobalHead =
-                writeGlobalCommit(
-                    ctx, timeInMicros, Hash.of(pointer.getGlobalId()), Collections.emptyList());
+            GlobalStateLogEntry newGlobalHead =
+                writeGlobalCommit(ctx, timeInMicros, pointer, Collections.emptyList());
 
-            Hash newRefLogId =
+            RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
+                    pointer,
                     toBranch.getName(),
                     RefLogEntry.RefType.Branch,
-                    Hash.of(pointer.getRefLogId()),
                     toHead,
                     RefLogEntry.Operation.MERGE,
                     timeInMicros,
                     Collections.singletonList(from));
 
             // Return hash of last commit (toHead) added to 'targetBranch' (via the casOpLoop)
-            return updateGlobalStatePointer(
-                toBranch, pointer, toHead, newGlobalHead, newRefLogId.asBytes());
+            return updateGlobalStatePointer(toBranch, pointer, toHead, newGlobalHead, newRefLog);
           },
           () -> mergeConflictMessage("Retry-failure", from, toBranch, expectedHead));
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
@@ -277,16 +277,15 @@ public abstract class NonTransactionalDatabaseAdapter<
                     newKeyLists,
                     updateCommitMetadata);
 
-            Hash newGlobalHead =
-                writeGlobalCommit(
-                    ctx, timeInMicros, Hash.of(pointer.getGlobalId()), Collections.emptyList());
+            GlobalStateLogEntry newGlobalHead =
+                writeGlobalCommit(ctx, timeInMicros, pointer, Collections.emptyList());
 
-            Hash newRefLogId =
+            RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
+                    pointer,
                     targetBranch.getName(),
                     RefLogEntry.RefType.Branch,
-                    Hash.of(pointer.getRefLogId()),
                     targetHead,
                     RefLogEntry.Operation.TRANSPLANT,
                     timeInMicros,
@@ -294,7 +293,7 @@ public abstract class NonTransactionalDatabaseAdapter<
 
             // Return hash of last commit (targetHead) added to 'targetBranch' (via the casOpLoop)
             return updateGlobalStatePointer(
-                targetBranch, pointer, targetHead, newGlobalHead, newRefLogId.asBytes());
+                targetBranch, pointer, targetHead, newGlobalHead, newRefLog);
           },
           () ->
               transplantConflictMessage(
@@ -323,21 +322,21 @@ public abstract class NonTransactionalDatabaseAdapter<
             CommitLogEntry newBranchCommit =
                 commitAttempt(ctx, timeInMicros, branchHead, commitAttempt, newKeyLists);
 
-            Hash newGlobalHead =
+            GlobalStateLogEntry newGlobalHead =
                 writeGlobalCommit(
                     ctx,
                     timeInMicros,
-                    Hash.of(pointer.getGlobalId()),
+                    pointer,
                     commitAttempt.getGlobal().entrySet().stream()
                         .map(e -> ContentIdAndBytes.of(e.getKey(), (byte) 0, e.getValue()))
                         .collect(Collectors.toList()));
 
-            Hash newRefLogId =
+            RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
+                    pointer,
                     commitAttempt.getCommitToBranch().getName(),
                     RefLogEntry.RefType.Branch,
-                    Hash.of(pointer.getRefLogId()),
                     newBranchCommit.getHash(),
                     RefLogEntry.Operation.COMMIT,
                     timeInMicros,
@@ -348,7 +347,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                 pointer,
                 newBranchCommit.getHash(),
                 newGlobalHead,
-                newRefLogId.asBytes());
+                newRefLog);
           },
           () ->
               commitConflictMessage(
@@ -385,23 +384,22 @@ public abstract class NonTransactionalDatabaseAdapter<
             validateHashExists(ctx, hash);
 
             // Need a new empty global-log entry to be able to CAS
-            Hash newGlobalHead = noopGlobalLogEntry(ctx, pointer);
+            GlobalStateLogEntry newGlobalHead = noopGlobalLogEntry(ctx, pointer);
 
             RefLogEntry.RefType refType =
                 ref instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
-            Hash newRefLogId =
+            RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
+                    pointer,
                     ref.getName(),
                     refType,
-                    Hash.of(pointer.getRefLogId()),
                     hash,
                     RefLogEntry.Operation.CREATE_REFERENCE,
                     commitTimeInMicros(),
                     Collections.emptyList());
 
-            return updateGlobalStatePointer(
-                ref, pointer, hash, newGlobalHead, newRefLogId.asBytes());
+            return updateGlobalStatePointer(ref, pointer, hash, newGlobalHead, newRefLog);
           },
           () -> createConflictMessage("Retry-Failure", ref, target));
     } catch (ReferenceAlreadyExistsException | ReferenceNotFoundException | RuntimeException e) {
@@ -422,23 +420,22 @@ public abstract class NonTransactionalDatabaseAdapter<
           (ctx, pointer, branchCommits, newKeyLists) -> {
             Hash branchHead = branchHead(pointer, reference);
             verifyExpectedHash(branchHead, reference, expectedHead);
-            Hash newGlobalHead = noopGlobalLogEntry(ctx, pointer);
+            GlobalStateLogEntry newGlobalHead = noopGlobalLogEntry(ctx, pointer);
 
             RefLogEntry.RefType refType =
                 reference instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
-            Hash newRefLogId =
+            RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
+                    pointer,
                     reference.getName(),
                     refType,
-                    Hash.of(pointer.getRefLogId()),
                     branchHead,
                     RefLogEntry.Operation.DELETE_REFERENCE,
                     commitTimeInMicros(),
                     Collections.emptyList());
 
-            return updateGlobalStatePointer(
-                reference, pointer, null, newGlobalHead, newRefLogId.asBytes());
+            return updateGlobalStatePointer(reference, pointer, null, newGlobalHead, newRefLog);
           },
           () -> deleteConflictMessage("Retry-Failure", reference, expectedHead));
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
@@ -462,23 +459,22 @@ public abstract class NonTransactionalDatabaseAdapter<
 
             validateHashExists(ctx, assignTo);
 
-            Hash newGlobalHead = noopGlobalLogEntry(ctx, pointer);
+            GlobalStateLogEntry newGlobalHead = noopGlobalLogEntry(ctx, pointer);
 
             RefLogEntry.RefType refType =
                 assignee instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
-            Hash newRefLogId =
+            RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
+                    pointer,
                     assignee.getName(),
                     refType,
-                    Hash.of(pointer.getRefLogId()),
                     assignTo,
                     RefLogEntry.Operation.ASSIGN_REFERENCE,
                     commitTimeInMicros(),
                     Collections.singletonList(beforeAssign));
 
-            return updateGlobalStatePointer(
-                assignee, pointer, assignTo, newGlobalHead, newRefLogId.asBytes());
+            return updateGlobalStatePointer(assignee, pointer, assignTo, newGlobalHead, newRefLog);
           },
           () -> assignConflictMessage("Retry-Failure", assignee, expectedHead, assignTo));
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
@@ -498,18 +494,25 @@ public abstract class NonTransactionalDatabaseAdapter<
   public void initializeRepo(String defaultBranchName) {
     NonTransactionalOperationContext ctx = NON_TRANSACTIONAL_OPERATION_CONTEXT;
     if (fetchGlobalPointer(ctx) == null) {
-      Hash globalHead;
-      Hash newRefLogId;
+      GlobalStateLogEntry globalHead;
+      RefLogEntry newRefLog;
       try {
         long timeInMicros = commitTimeInMicros();
-        globalHead = writeGlobalCommit(ctx, timeInMicros, NO_ANCESTOR, Collections.emptyList());
+        GlobalStatePointer dummyPointer =
+            GlobalStatePointer.newBuilder()
+                .setGlobalId(NO_ANCESTOR.asBytes())
+                .addGlobalParentsInclHead(NO_ANCESTOR.asBytes())
+                .setRefLogId(NO_ANCESTOR.asBytes())
+                .addRefLogParentsInclHead(NO_ANCESTOR.asBytes())
+                .build();
+        globalHead = writeGlobalCommit(ctx, timeInMicros, dummyPointer, Collections.emptyList());
 
-        newRefLogId =
+        newRefLog =
             writeRefLogEntry(
                 ctx,
+                dummyPointer,
                 defaultBranchName,
                 RefLogEntry.RefType.Branch,
-                NO_ANCESTOR,
                 NO_ANCESTOR,
                 RefLogEntry.Operation.CREATE_REFERENCE,
                 commitTimeInMicros(),
@@ -521,7 +524,7 @@ public abstract class NonTransactionalDatabaseAdapter<
       unsafeWriteGlobalPointer(
           ctx,
           GlobalStatePointer.newBuilder()
-              .setGlobalId(globalHead.asBytes())
+              .setGlobalId(globalHead.getId())
               .addNamedReferences(
                   NamedReference.newBuilder()
                       .setName(defaultBranchName)
@@ -529,21 +532,18 @@ public abstract class NonTransactionalDatabaseAdapter<
                           RefPointer.newBuilder()
                               .setType(Type.Branch)
                               .setHash(NO_ANCESTOR.asBytes())))
-              .setRefLogId(newRefLogId.asBytes())
+              .setRefLogId(newRefLog.getRefLogId())
+              .addRefLogParentsInclHead(newRefLog.getRefLogId())
+              .addRefLogParentsInclHead(NO_ANCESTOR.asBytes())
+              .addGlobalParentsInclHead(globalHead.getId())
+              .addGlobalParentsInclHead(NO_ANCESTOR.asBytes())
               .build());
     }
   }
 
   @Override
   public Stream<ContentIdWithType> globalKeys(ToIntFunction<ByteString> contentTypeExtractor) {
-    NonTransactionalOperationContext ctx = NON_TRANSACTIONAL_OPERATION_CONTEXT;
-
-    GlobalStatePointer pointer = fetchGlobalPointer(ctx);
-    if (pointer == null) {
-      return Stream.empty();
-    }
-
-    return globalLogFetcher(ctx, Hash.of(pointer.getGlobalId()))
+    return globalLogFetcher(NON_TRANSACTIONAL_OPERATION_CONTEXT)
         .flatMap(e -> e.getPutsList().stream())
         .map(ProtoSerialization::protoToContentIdAndBytes)
         .map(ContentIdAndBytes::asIdWithType)
@@ -553,14 +553,7 @@ public abstract class NonTransactionalDatabaseAdapter<
   @Override
   public Optional<ContentIdAndBytes> globalContent(
       ContentId contentId, ToIntFunction<ByteString> contentTypeExtractor) {
-    NonTransactionalOperationContext ctx = NON_TRANSACTIONAL_OPERATION_CONTEXT;
-
-    GlobalStatePointer pointer = fetchGlobalPointer(ctx);
-    if (pointer == null) {
-      return Optional.empty();
-    }
-
-    return globalLogFetcher(ctx, Hash.of(pointer.getGlobalId()))
+    return globalLogFetcher(NON_TRANSACTIONAL_OPERATION_CONTEXT)
         .flatMap(e -> e.getPutsList().stream())
         .map(ProtoSerialization::protoToContentIdAndBytes)
         .filter(entry -> contentId.equals(entry.getContentId()))
@@ -576,16 +569,9 @@ public abstract class NonTransactionalDatabaseAdapter<
   @Override
   public Stream<ContentIdAndBytes> globalContent(
       Set<ContentId> keys, ToIntFunction<ByteString> contentTypeExtractor) {
-    NonTransactionalOperationContext ctx = NON_TRANSACTIONAL_OPERATION_CONTEXT;
-
-    GlobalStatePointer pointer = fetchGlobalPointer(ctx);
-    if (pointer == null) {
-      return Stream.empty();
-    }
-
     HashSet<ContentId> remaining = new HashSet<>(keys);
 
-    Stream<GlobalStateLogEntry> stream = globalLogFetcher(ctx, Hash.of(pointer.getGlobalId()));
+    Stream<GlobalStateLogEntry> stream = globalLogFetcher(NON_TRANSACTIONAL_OPERATION_CONTEXT);
 
     return takeUntilIncludeLast(stream, x -> remaining.isEmpty())
         .flatMap(e -> e.getPutsList().stream())
@@ -674,13 +660,13 @@ public abstract class NonTransactionalDatabaseAdapter<
       NamedRef target,
       GlobalStatePointer pointer,
       @Nullable Hash toHead,
-      Hash newGlobalHead,
-      ByteString newRefLogId) {
+      GlobalStateLogEntry newGlobalHead,
+      RefLogEntry newRefLog) {
 
     GlobalStatePointer.Builder newPointer =
         GlobalStatePointer.newBuilder()
-            .setGlobalId(newGlobalHead.asBytes())
-            .setRefLogId(newRefLogId);
+            .setGlobalId(newGlobalHead.getId())
+            .setRefLogId(newRefLog.getRefLogId());
     String refName = target.getName();
     if (toHead != null) {
       // Most recently updated references first
@@ -695,6 +681,11 @@ public abstract class NonTransactionalDatabaseAdapter<
     pointer.getNamedReferencesList().stream()
         .filter(namedRef -> !refName.equals(namedRef.getName()))
         .forEach(newPointer::addNamedReferences);
+    newPointer
+        .addRefLogParentsInclHead(newRefLog.getRefLogId())
+        .addAllRefLogParentsInclHead(newRefLog.getParentsList())
+        .addGlobalParentsInclHead(newGlobalHead.getId())
+        .addAllGlobalParentsInclHead(newGlobalHead.getParentsList());
     return newPointer.build();
   }
 
@@ -932,32 +923,45 @@ public abstract class NonTransactionalDatabaseAdapter<
   protected abstract void unsafeWriteGlobalPointer(
       NonTransactionalOperationContext ctx, GlobalStatePointer pointer);
 
-  protected Hash writeGlobalCommit(
+  protected GlobalStateLogEntry writeGlobalCommit(
       NonTransactionalOperationContext ctx,
       long timeInMicros,
-      Hash parentHash,
+      GlobalStatePointer pointer,
       List<ContentIdAndBytes> globals)
       throws ReferenceConflictException {
-    GlobalStateLogEntry currentEntry = fetchFromGlobalLog(ctx, parentHash);
 
-    Stream<Hash> newParents = Stream.of(parentHash);
-    if (currentEntry != null) {
+    Hash parentHash = Hash.of(pointer.getGlobalId());
+    Hash hash = randomHash();
+
+    Stream<ByteString> newParents;
+    if (pointer.getGlobalParentsInclHeadCount() == 0
+        || !pointer.getGlobalId().equals(pointer.getGlobalParentsInclHead(0))) {
+      // Before Nessie 0.21.0
+
+      newParents = Stream.of(parentHash.asBytes());
+      GlobalStateLogEntry currentEntry = fetchFromGlobalLog(ctx, parentHash);
+      if (currentEntry != null) {
+        newParents =
+            Stream.concat(
+                newParents,
+                currentEntry.getParentsList().stream()
+                    .limit(config.getParentsPerGlobalCommit() - 1));
+      }
+    } else {
+      // Since Nessie 0.21.0
+
       newParents =
-          Stream.concat(
-              newParents,
-              currentEntry.getParentsList().stream()
-                  .limit(config.getParentsPerGlobalCommit() - 1)
-                  .map(Hash::of));
+          pointer.getGlobalParentsInclHeadList().stream().limit(config.getParentsPerGlobalCommit());
     }
 
-    Hash hash = randomHash();
     GlobalStateLogEntry.Builder entry =
         GlobalStateLogEntry.newBuilder().setCreatedTime(timeInMicros).setId(hash.asBytes());
-    newParents.forEach(p -> entry.addParents(p.asBytes()));
+    newParents.forEach(entry::addParents);
     globals.forEach(g -> entry.addPuts(ProtoSerialization.toProto(g)));
-    writeGlobalCommit(ctx, entry.build());
+    GlobalStateLogEntry globalLogEntry = entry.build();
+    writeGlobalCommit(ctx, globalLogEntry);
 
-    return hash;
+    return globalLogEntry;
   }
 
   /**
@@ -1014,12 +1018,11 @@ public abstract class NonTransactionalDatabaseAdapter<
    */
   // TODO maybe replace with a 2nd-ary value in global-state-pointer to prevent the empty
   //  global-log-entry
-  protected Hash noopGlobalLogEntry(
+  protected GlobalStateLogEntry noopGlobalLogEntry(
       NonTransactionalOperationContext ctx, GlobalStatePointer pointer)
       throws ReferenceConflictException {
     // Need a new empty global-log entry to be able to CAS
-    return writeGlobalCommit(
-        ctx, commitTimeInMicros(), Hash.of(pointer.getGlobalId()), Collections.emptyList());
+    return writeGlobalCommit(ctx, commitTimeInMicros(), pointer, Collections.emptyList());
   }
 
   /**
@@ -1088,14 +1091,9 @@ public abstract class NonTransactionalDatabaseAdapter<
       return Collections.emptyMap();
     }
 
-    Set<ContentId> remainingIds = new HashSet<>(contentIds);
-    GlobalStatePointer pointer = fetchGlobalPointer(ctx);
-    if (pointer == null) {
-      return Collections.emptyMap();
-    }
-    Hash globalHead = Hash.of(pointer.getGlobalId());
+    Stream<GlobalStateLogEntry> log = globalLogFetcher(ctx);
 
-    Stream<GlobalStateLogEntry> log = globalLogFetcher(ctx, globalHead);
+    Set<ContentId> remainingIds = new HashSet<>(contentIds);
 
     return takeUntilExcludeLast(log, x -> remainingIds.isEmpty())
         .flatMap(e -> e.getPutsList().stream())
@@ -1106,20 +1104,45 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   /** Reads from the global-state-log starting at the given global-state-log-ID. */
-  private Stream<GlobalStateLogEntry> globalLogFetcher(
-      NonTransactionalOperationContext ctx, Hash initialId) {
+  private Stream<GlobalStateLogEntry> globalLogFetcher(NonTransactionalOperationContext ctx) {
+    GlobalStatePointer pointer = fetchGlobalPointer(ctx);
+    if (pointer == null) {
+      return Stream.empty();
+    }
+
+    Hash initialId = Hash.of(pointer.getGlobalId());
+
     GlobalStateLogEntry initial = fetchFromGlobalLog(ctx, initialId);
     if (initial == null) {
       throw new RuntimeException(
           new ReferenceNotFoundException(
               String.format("Global log entry '%s' not does not exist.", initialId.asString())));
     }
-    Spliterator<GlobalStateLogEntry> split =
-        logFetcher(
-            ctx,
-            initial,
-            this::fetchPageFromGlobalLog,
-            e -> e.getParentsList().stream().map(Hash::of).collect(Collectors.toList()));
+    Spliterator<GlobalStateLogEntry> split;
+    if (pointer.getGlobalParentsInclHeadCount() == 0
+        || !pointer.getGlobalId().equals(pointer.getGlobalParentsInclHead(0))) {
+      // Before Nessie 0.21.0
+
+      split =
+          logFetcher(
+              ctx,
+              initial,
+              this::fetchPageFromGlobalLog,
+              e -> e.getParentsList().stream().map(Hash::of).collect(Collectors.toList()));
+    } else {
+      // Since Nessie 0.21.0
+
+      List<Hash> hashes =
+          pointer.getGlobalParentsInclHeadList().stream()
+              .map(Hash::of)
+              .collect(Collectors.toList());
+      split =
+          logFetcherWithPage(
+              ctx,
+              hashes,
+              this::fetchPageFromGlobalLog,
+              e -> e.getParentsList().stream().map(Hash::of).collect(Collectors.toList()));
+    }
     return StreamSupport.stream(split, false);
   }
 
@@ -1151,53 +1174,40 @@ public abstract class NonTransactionalDatabaseAdapter<
   protected abstract List<GlobalStateLogEntry> doFetchPageFromGlobalLog(
       NonTransactionalOperationContext ctx, List<Hash> hashes);
 
-  protected Hash writeRefLogEntry(
+  protected RefLogEntry writeRefLogEntry(
       NonTransactionalOperationContext ctx,
+      GlobalStatePointer pointer,
       String refName,
-      RefLogEntry.RefType refType,
-      Hash parentRefLogId,
+      RefType refType,
       Hash commitHash,
-      RefLogEntry.Operation operation,
+      Operation operation,
       long timeInMicros,
       List<Hash> sourceHashes)
       throws ReferenceConflictException {
 
+    Hash parentHash = Hash.of(pointer.getRefLogId());
     Hash currentRefLogId = randomHash();
-    RefLog parentEntry = fetchFromRefLog(ctx, parentRefLogId);
-    RefLogEntry refLogEntry =
-        buildRefLogEntry(
-            refName,
-            refType,
-            parentRefLogId,
-            commitHash,
-            operation,
-            timeInMicros,
-            sourceHashes,
-            currentRefLogId,
-            parentEntry);
 
-    writeRefLog(ctx, refLogEntry);
+    Stream<ByteString> newParents;
+    if (pointer.getRefLogParentsInclHeadCount() == 0
+        || !pointer.getRefLogId().equals(pointer.getRefLogParentsInclHead(0))) {
+      // Before Nessie 0.21.0
 
-    return currentRefLogId;
-  }
+      newParents = Stream.of(parentHash.asBytes());
+      RefLog currentEntry = fetchFromRefLog(ctx, parentHash);
+      if (currentEntry != null) {
+        newParents =
+            Stream.concat(
+                newParents,
+                currentEntry.getParents().stream()
+                    .limit(config.getParentsPerRefLogEntry() - 1)
+                    .map(Hash::asBytes));
+      }
+    } else {
+      // Since Nessie 0.21.0
 
-  private RefLogEntry buildRefLogEntry(
-      String refName,
-      RefLogEntry.RefType refType,
-      Hash parentRefLogId,
-      Hash commitHash,
-      RefLogEntry.Operation operation,
-      long timeInMicros,
-      List<Hash> sourceHashes,
-      Hash currentRefLogId,
-      RefLog parentEntry) {
-    Stream<Hash> newParents = Stream.of(parentRefLogId);
-
-    if (parentEntry != null) {
       newParents =
-          Stream.concat(
-              newParents,
-              parentEntry.getParents().stream().limit(config.getParentsPerRefLogEntry() - 1));
+          pointer.getRefLogParentsInclHeadList().stream().limit(config.getParentsPerRefLogEntry());
     }
 
     RefLogEntry.Builder entry =
@@ -1209,8 +1219,12 @@ public abstract class NonTransactionalDatabaseAdapter<
             .setOperationTime(timeInMicros)
             .setOperation(operation);
     sourceHashes.forEach(hash -> entry.addSourceHashes(hash.asBytes()));
-    newParents.forEach(p -> entry.addParents(p.asBytes()));
-    return entry.build();
+    newParents.forEach(entry::addParents);
+    RefLogEntry refLogEntry = entry.build();
+
+    writeRefLog(ctx, refLogEntry);
+
+    return refLogEntry;
   }
 
   @Override

--- a/versioned/persist/serialize/src/main/proto/persist.proto
+++ b/versioned/persist/serialize/src/main/proto/persist.proto
@@ -106,6 +106,13 @@ message GlobalStatePointer {
   // most recently updated named reference appears first
   repeated NamedReference named_references = 2;
   bytes ref_log_id = 3;
+  repeated bytes global_parents_incl_head = 4;
+  repeated bytes ref_log_parents_incl_head = 5;
+}
+
+// Used by transactional database-adapters
+message RefLogParents {
+  repeated bytes ref_log_parents_incl_head = 1;
 }
 
 message NamedReference {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
@@ -59,9 +59,7 @@ public abstract class AbstractTracing extends AbstractNestedVersionStore {
     12 (39000µs)          DatabaseAdapter.create {nessie.database-adapter.operation=create, nessie.database-adapter.hash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d, nessie.database-adapter.ref=traceCreateBranch}
     13 (36000µs)              DatabaseAdapter.try-loop.createRef {nessie.database-adapter.operation=try-loop.createRef, nessie.database-adapter.try-loop.attempt=0, nessie.database-adapter.try-loop.retries=0}
     14 (    0µs)                  DatabaseAdapter.fetchGlobalPointer {nessie.database-adapter.operation=fetchGlobalPointer}
-    15 ( 1000µs)                  DatabaseAdapter.fetchFromGlobalLog {nessie.database-adapter.operation=fetchFromGlobalLog, nessie.database-adapter.hash=969bf32b0de839ae0d5530d2e89d72971eef1843013c0389db902dd1e053805e}
     16 (    0µs)                  DatabaseAdapter.writeGlobalCommit {nessie.database-adapter.operation=writeGlobalCommit}
-    17 ( 7000µs)                  DatabaseAdapter.fetchFromRefLog {nessie.database-adapter.operation=fetchFromRefLog, nessie.database-adapter.hash=a40accab3397f9baf2b84f8c3f3ad867e71f30fe1d0bf5b812fbf8edd0455ef8}
     18 (    0µs)                  DatabaseAdapter.writeRefLog {nessie.database-adapter.operation=writeRefLog}
     19 (    0µs)                  DatabaseAdapter.globalPointerCas {nessie.database-adapter.operation=globalPointerCas}
     */
@@ -83,9 +81,7 @@ public abstract class AbstractTracing extends AbstractNestedVersionStore {
                                                 tryLoop ->
                                                     tryLoop
                                                         .add("DatabaseAdapter.fetchGlobalPointer")
-                                                        .add("DatabaseAdapter.fetchFromGlobalLog")
                                                         .add("DatabaseAdapter.writeGlobalCommit")
-                                                        .add("DatabaseAdapter.fetchFromRefLog")
                                                         .add("DatabaseAdapter.writeRefLog")
                                                         .add(
                                                             "DatabaseAdapter.globalPointerCas"))))),
@@ -108,7 +104,6 @@ public abstract class AbstractTracing extends AbstractNestedVersionStore {
                                                             "DatabaseAdapter.checkNamedRefExistence")
                                                         .add("DatabaseAdapter.insertNewReference")
                                                         .add("DatabaseAdapter.getRefLogHead")
-                                                        .add("DatabaseAdapter.fetchFromRefLog")
                                                         .add(
                                                             "DatabaseAdapter.updateRefLogHead"))))));
   }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/RefLogHead.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/RefLogHead.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx;
+
+import java.util.List;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.Hash;
+
+@Value.Immutable
+interface RefLogHead {
+  Hash getRefLogHead();
+
+  List<Hash> getRefLogParentsInclHead();
+
+  static ImmutableRefLogHead.Builder builder() {
+    return ImmutableRefLogHead.builder();
+  }
+}

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
@@ -167,18 +167,20 @@ public final class SqlStatements {
 
   public static final String TABLE_REF_LOG_HEAD = "ref_log_head";
   public static final String UPDATE_REF_LOG_HEAD =
-      String.format("UPDATE %s SET id = ? WHERE repo_id = ? AND id = ?", TABLE_REF_LOG_HEAD);
+      String.format(
+          "UPDATE %s SET id = ?, parents = ? WHERE repo_id = ? AND id = ?", TABLE_REF_LOG_HEAD);
   public static final String INSERT_REF_LOG_HEAD =
-      String.format("INSERT INTO %s (repo_id, id) VALUES (?, ?)", TABLE_REF_LOG_HEAD);
+      String.format("INSERT INTO %s (repo_id, id, parents) VALUES (?, ?, ?)", TABLE_REF_LOG_HEAD);
   public static final String DELETE_REF_LOG_HEAD_ALL =
       String.format("DELETE FROM %s WHERE repo_id = ?", TABLE_REF_LOG_HEAD);
   public static final String SELECT_REF_LOG_HEAD =
-      String.format("SELECT id FROM %s WHERE repo_id = ?", TABLE_REF_LOG_HEAD);
+      String.format("SELECT id, parents FROM %s WHERE repo_id = ?", TABLE_REF_LOG_HEAD);
   public static final String CREATE_TABLE_REF_LOG_HEAD =
       String.format(
           "CREATE TABLE %s (\n"
               + "  repo_id {2},\n"
               + "  id {1},\n"
+              + "  parents {0},\n"
               + "  PRIMARY KEY (repo_id, id)\n"
               + ")",
           TABLE_REF_LOG_HEAD);

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -1687,6 +1687,15 @@ public abstract class TxDatabaseAdapter
 
     ByteString newId = randomHash().asBytes();
 
+    // Before Nessie 0.21.0: only the "head" of the ref-log is maintained, so Nessie has to read
+    // the head entry of the ref-log to get the IDs of all the previous parents to fill the parents
+    // in the new ref-log-entry.
+    //
+    // Since Nessie 0.21.0: the "head" for the ref-log and PLUS the parents of if are persisted,
+    // so Nessie no longer need to read the head entries from the ref-log.
+    //
+    // The check of the first entry is there to ensure backwards compatibility and also
+    // rolling-upgrades work.
     Stream<ByteString> newParents;
     if (refLogHead.getRefLogParentsInclHead().isEmpty()
         || !refLogHead.getRefLogParentsInclHead().get(0).equals(refLogHead.getRefLogHead())) {


### PR DESCRIPTION
To write a new global log entry, Nessie reads the parent hashes from the current global log entry.
This can be avoided by storing the parent hashes in the `GlobalStatePointer` as well (nothing to do for transactional databases).

To write a new ref log entry, Nessie reads the parent hashes from the current ref log entry.
This can be avoided by storing the parent hashes in the `GlobalStatePointer` as well (transactional database: add the parent hashes to `TABLE_REF_LOG_HEAD`).

The change can easily be implemented to be backwards compatible:
* If the list or parent hashes is not present, read the parent hashes like the current implementation does.
* If the "head" of the parent hashes is not equal to the expected "head", a concurrently running Nessie server updated the `GlobalStatePointer` (or `TABLE_REF_LOG_HEAD`) -> fall back to the old behavior and read the parent hashes like the current implementation does.

Fixes #3448
