### PR TITLE
Fix merge issue for commits more than keylist distance

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -196,7 +195,7 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
             commitAttempt.getDeletes(),
             currentBranchEntry != null ? currentBranchEntry.getKeyListDistance() : 0,
             newKeyLists,
-            new LinkedList<>());
+            new ArrayList<>());
     writeIndividualCommit(ctx, newBranchCommit);
     return newBranchCommit;
   }
@@ -1313,7 +1312,7 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
 
     int keyListDistance = targetHeadCommit != null ? targetHeadCommit.getKeyListDistance() : 0;
 
-    List<CommitLogEntry> unwrittenEntriesForKeyList = new LinkedList<>();
+    List<CommitLogEntry> unwrittenEntriesForKeyList = new ArrayList<>();
     // Rewrite commits to transplant and store those in 'commitsToTransplantReverse'
     for (int i = commitsChronological.size() - 1; i >= 0; i--, commitSeq++) {
       CommitLogEntry sourceCommit = commitsChronological.get(i);


### PR DESCRIPTION
`AbstractDatabaseAdapter#copyCommits` is preparing new commit hashes for merged commits.
During this time, for new commits that are merging, if the keylist size is reached, we are writing the new keylist to backend store [buildIndividualCommit-> buildKeyList].
While writing keylist we are using common code that queries commit log from backend db. But these new unwritten commit (we write all commits at once for merge to provide multi table txn) hashes are not present in the backend db. Hence the error.

**solution**: Hybrid approach
On the branch that we are merging, new keylist to write can be from both old commits and new commits (commits that are coming from merge) for this branch.
So, for new commits, collect key list from the inmemory list of commits instead of querying backend. For old commits, query from backend and combine the result of both and write new key list to backend db.

Fixes #3466 