### PR TITLE
Improve reflog to store new commit hashes from merge/transplant

### DIFF
--- a/model/src/main/java/org/projectnessie/model/RefLogResponse.java
+++ b/model/src/main/java/org/projectnessie/model/RefLogResponse.java
@@ -84,8 +84,8 @@ public interface RefLogResponse extends PaginatedResponse {
     String getOperation();
 
     /**
-     * Single hash in case of MERGE or ASSIGN. One or more hashes in case of TRANSPLANT. Empty list
-     * for other operations.
+     * Single hash (hash from the source) in case of ASSIGN. One or more hashes that are merged or
+     * transplanted in case of MERGE/TRANSPLANT. Empty list for other operations.
      */
     @NotNull
     List<String> getSourceHashes();

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
@@ -18,6 +18,8 @@ package org.projectnessie.jaxrs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
@@ -111,6 +113,16 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
             getApi().getEntries().refName(base.getName()).get().getEntries().stream()
                 .map(e -> e.getName().getName()))
         .containsExactlyInAnyOrder("key1", "key2");
+
+    // validate reflog source hashes
+    List<String> sourceHashes =
+        getApi().getRefLog().maxRecords(1).get().getLogEntries().get(0).getSourceHashes();
+    assertThat(sourceHashes)
+        .isEqualTo(
+            logOfTransplanted.getLogEntries().stream()
+                .map(LogEntry::getCommitMeta)
+                .map(CommitMeta::getHash)
+                .collect(Collectors.toList()));
   }
 
   @ParameterizedTest
@@ -187,5 +199,15 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
             getApi().getEntries().refName(base.getName()).get().getEntries().stream()
                 .map(e -> e.getName().getName()))
         .containsExactlyInAnyOrder("key1", "key2");
+
+    // validate reflog source hashes
+    List<String> sourceHashes =
+        getApi().getRefLog().maxRecords(1).get().getLogEntries().get(0).getSourceHashes();
+    assertThat(sourceHashes)
+        .isEqualTo(
+            logOfMerged.getLogEntries().stream()
+                .map(LogEntry::getCommitMeta)
+                .map(CommitMeta::getHash)
+                .collect(Collectors.toList()));
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/RefLog.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/RefLog.java
@@ -45,8 +45,8 @@ public interface RefLog {
   String getOperation();
 
   /**
-   * Single hash in case of MERGE or ASSIGN. One or more hashes in case of TRANSPLANT. Empty list
-   * for other operations.
+   * Single hash (hash from the source) in case of ASSIGN. One or more hashes that are merged or
+   * transplanted in case of MERGE/TRANSPLANT. Empty list for other operations.
    */
   List<Hash> getSourceHashes();
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/RefLogDetails.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/RefLogDetails.java
@@ -44,8 +44,8 @@ public interface RefLogDetails {
   String getOperation();
 
   /**
-   * Single hash in case of MERGE or ASSIGN. One or more hashes in case of TRANSPLANT. Empty list
-   * for other operations.
+   * Single hash (hash from the source) in case of ASSIGN. One or more hashes that are merged or
+   * transplanted in case of MERGE/TRANSPLANT. Empty list for other operations.
    */
   List<Hash> getSourceHashes();
 }


### PR DESCRIPTION
Merge and transplants creates new commit hashes for each new merging or transplanting commits.
So, while debugging issues, we might have to know how these hashes came to the target branch.
So, store them in reflog.

a. For transplant, currently source commit hashes (with old commit hash id) are stored in reflogEntry#getSourceHashes
Need to store new commit hashes in that place.

b. For merge, only the new commit head is stored in reflogEntry#getSourceHashes.
Need to store all new commit hashes in that place.

fixes #3497 