### PR TITLE
Reduce number of tags for micrometer

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -174,5 +174,10 @@ quarkus.micrometer.binder.http-server.match-patterns=\
   /api/v1/diffs/.*+=/api/v1/diffs/{diff_params},\
   /api/v1/trees/branch/.*/commit+=/api/v1/trees/branch/{branchName}/commit,\
   /api/v1/trees/branch/.*+=/api/v1/trees/branch/{ref},\
+  /api/v1/trees/branch/.*/transplant+=/api/v1/trees/branch/{branchName}/transplant, \
+  /api/v1/trees/branch/.*/merge+=/api/v1/trees/branch/{branchName}/merge, \
   /api/v1/trees/tree/.*/entries+=/api/v1/trees/tree/{ref}/entries,\
-  /api/v1/trees/tree/.*/log+=/api/v1/trees/tree/{ref}/log
+  /api/v1/trees/tree/.*/log+=/api/v1/trees/tree/{ref}/log, \
+  /api/v1/trees/tree/.*+=/api/v1/trees/tree/{ref}, \
+  /api/v1/trees/.*/.*+=/api/v1/trees/{referenceType}/{ref}
+

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -170,3 +170,9 @@ quarkus.container-image.name=nessie
 
 mp.openapi.extensions.smallrye.operationIdStrategy=METHOD
 
+quarkus.micrometer.binder.http-server.match-patterns=\
+  /api/v1/diffs/.*+=/api/v1/diffs/{diff_params},\
+  /api/v1/trees/branch/.*/commit+=/api/v1/trees/branch/{branchName}/commit,\
+  /api/v1/trees/branch/.*+=/api/v1/trees/branch/{ref},\
+  /api/v1/trees/tree/.*/entries+=/api/v1/trees/tree/{ref}/entries,\
+  /api/v1/trees/tree/.*/log+=/api/v1/trees/tree/{ref}/log

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -179,5 +179,6 @@ quarkus.micrometer.binder.http-server.match-patterns=\
   /api/v1/trees/tree/.*/entries+=/api/v1/trees/tree/{ref}/entries,\
   /api/v1/trees/tree/.*/log+=/api/v1/trees/tree/{ref}/log, \
   /api/v1/trees/tree/.*+=/api/v1/trees/tree/{ref}, \
-  /api/v1/trees/.*/.*+=/api/v1/trees/{referenceType}/{ref}
+  /api/v1/trees/.*/.*+=/api/v1/trees/{referenceType}/{ref}, \
+  /contents/.*+=/contents/{key}
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITMetrics.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITMetrics.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.jaxrs.AbstractTestRest;
+import org.projectnessie.server.profiles.QuarkusTestProfileInmemory;
+
+@QuarkusTest
+@TestProfile(value = QuarkusTestProfileInmemory.class)
+public class ITMetrics extends AbstractTestRest {
+  // We need to extend the AbstractTestRest because all Nessie metrics are created lazily.
+  // They will appear in the `/q/metrics` endpoint only when some REST actions are executed.
+
+  // this test is executed after all tests from the AbstractTestRest
+  @Test
+  void smokeTestMetrics() {
+    // when
+    String body =
+        RestAssured.given()
+            .when()
+            .basePath("/q/metrics")
+            .get()
+            .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+
+    // then
+    assertThat(body).contains("jvm_threads_live_threads");
+    assertThat(body).contains("jvm_memory_committed_bytes");
+    assertThat(body).contains("nessie_versionstore_request_seconds_max");
+    assertThat(body).contains("nessie_versionstore_request_seconds_bucket");
+    assertThat(body).contains("nessie_versionstore_request_seconds_count");
+    assertThat(body).contains("nessie_versionstore_request_seconds_sum");
+    assertThat(body).contains("/api/v1/diffs/{diff_params}");
+    assertThat(body).contains("/api/v1/trees/{referenceType}/{ref}");
+    assertThat(body).contains("/api/v1/trees/branch/{ref}");
+    assertThat(body).contains("/api/v1/trees/tree/{ref}/entries");
+    assertThat(body).contains("http_server_connections_seconds_max");
+    assertThat(body).contains("http_server_connections_seconds_active_count");
+    assertThat(body).contains("jvm_gc_live_data_size_bytes");
+  }
+}


### PR DESCRIPTION
Using the mechanism described in: https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/1.11/html/collecting_metrics_in_your_quarkus_applications/con-http-metrics_quarkus-collecting-metrics

It reduces the number of tags reported by the metrics registry, by using `{path_parameters}`.

After the fix, tags look like this:
```
0 = "/api/v1/diffs/{diff_params}"
1 = "/api/v1/trees/tree/{ref}/entries"
2 = "/api/v1/trees"
3 = "/api/v1/trees/tree/commitLogExtended"
4 = "/api/v1/contents"
5 = "/api/v1/trees/tree"
6 = "/api/v1/trees/tag/testTag"
7 = "/api/v1/trees/tree/commitLogExtendedUnchanged"
8 = "/api/v1/trees/tree/main"
9 = "/api/v1/trees/branch/{ref}"
10 = "/api/v1/trees/tree/testTag"
11 = "/api/v1/trees/tree/testBranch"
12 = "/api/v1/trees/branch/{branchName}/commit"
13 = "/api/v1/trees/tree/{ref}/log"
```
so the number of tags is substantially reduced and the warning is no longer emitted.