### PR TITLE
Use externally maintained nessie-antlr-runtime

### DIFF
--- a/clients/spark-3.2-extensions/pom.xml
+++ b/clients/spark-3.2-extensions/pom.xml
@@ -338,41 +338,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>intellij-workaround</id>
-      <activation>
-        <property>
-          <name>idea.version</name>
-        </property>
-      </activation>
-      <!--
-        IntelliJ IDEA gets confused when a module builds a shaded jar.
-        It does not replace the original source with the shaded jar contents.
-        To avoid compile errors due to relocations we have to use a workaround here.
-
-        Partly taken from https://stackoverflow.com/a/59654377
-      -->
-      <dependencies>
-        <dependency>
-          <groupId>org.projectnessie</groupId>
-          <artifactId>nessie-spark-extensions-grammar</artifactId>
-          <version>${project.version}</version>
-          <!--
-          We need this dependency to build the shaded jar beforehand, but the runtime scope
-          makes it so intellij compilation does not use the original source (which references
-          non-relocated antlr classes).
-          -->
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>nessie-spark-extensions-grammar</artifactId>
-          <version>FAKE-VERSION</version>
-          <classifier>FAKE-CLASSIFIER</classifier>
-          <scope>system</scope>
-          <systemPath>${project.basedir}/../spark-antlr-grammar/target/nessie-spark-extensions-grammar-${project.version}.jar</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
   </profiles>
 </project>

--- a/clients/spark-antlr-grammar/pom.xml
+++ b/clients/spark-antlr-grammar/pom.xml
@@ -31,8 +31,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-antlr-runtime</artifactId>
     </dependency>
   </dependencies>
 
@@ -54,6 +54,7 @@
         <executions>
           <execution>
             <id>antlr</id>
+            <phase>generate-sources</phase>
             <goals>
               <goal>antlr4</goal>
             </goals>
@@ -61,52 +62,25 @@
         </executions>
       </plugin>
       <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-shade-plugin</artifactId>
-      <configuration>
-        <filters>
-          <!-- filter to address "Invalid signature file" issue - see https://stackoverflow.com/a/6743609/589215 -->
-          <filter>
-            <artifact>*:*</artifact>
-            <excludes>
-              <exclude>META-INF/*.SF</exclude>
-              <exclude>META-INF/*.DSA</exclude>
-              <exclude>META-INF/*.RSA</exclude>
-              <exclude>META-INF/jandex.idx</exclude>
-              <exclude>META-INF/LICENSE</exclude>
-              <exclude>LICENSE</exclude>
-              <exclude>META-INF/LICENSE.md</exclude>
-              <exclude>META-INF/LICENSE.txt</exclude>
-              <exclude>META-INF/NOTIC*</exclude>
-              <exclude>META-INF/DEPENDENCIES</exclude>
-            </excludes>
-          </filter>
-        </filters>
-        <transformers>
-          <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-        </transformers>
-        <artifactSet>
-          <includes>
-            <include>org.antlr</include>
-            <include>org.projectnessie</include>
-          </includes>
-        </artifactSet>
-        <relocations>
-          <relocation>
-            <pattern>org.antlr.v4.runtime</pattern>
-            <shadedPattern>org.projectnessie.shaded.org.antlr.v4.runtime</shadedPattern>
-          </relocation>
-        </relocations>
-      </configuration>
-      <executions>
-        <execution>
-          <phase>package</phase>
-          <goals>
-            <goal>shade</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <id>patch-antlr</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <replaceregexp flags="g" byline="true" match="import org.antlr.v4.runtime." replace="import org.projectnessie.shaded.org.antlr.v4.runtime.">
+                  <fileset dir="${project.build.directory}/generated-sources/antlr4" includes="**/*.java"/>
+                </replaceregexp>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -310,41 +310,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>intellij-workaround</id>
-      <activation>
-        <property>
-          <name>idea.version</name>
-        </property>
-      </activation>
-      <!--
-        IntelliJ IDEA gets confused when a module builds a shaded jar.
-        It does not replace the original source with the shaded jar contents.
-        To avoid compile errors due to relocations we have to use a workaround here.
-
-        Partly taken from https://stackoverflow.com/a/59654377
-      -->
-      <dependencies>
-        <dependency>
-          <groupId>org.projectnessie</groupId>
-          <artifactId>nessie-spark-extensions-grammar</artifactId>
-          <version>${project.version}</version>
-          <!--
-          We need this dependency to build the shaded jar beforehand, but the runtime scope
-          makes it so intellij compilation does not use the original source (which references
-          non-relocated antlr classes).
-          -->
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>nessie-spark-extensions-grammar</artifactId>
-          <version>FAKE-VERSION</version>
-          <classifier>FAKE-CLASSIFIER</classifier>
-          <scope>system</scope>
-          <systemPath>${project.basedir}/../spark-antlr-grammar/target/nessie-spark-extensions-grammar-${project.version}.jar</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
     <maven.resolver.version>1.7.3</maven.resolver.version>
     <maven.version>3.8.4</maven.version>
     <mockito.version>4.3.1</mockito.version>
+    <nessie.antlr.version>4.9.2</nessie.antlr.version>
     <nessie.version>${project.version}</nessie.version>
     <openapi.version>3.0</openapi.version>
     <picocli.version>4.6.3</picocli.version>
@@ -574,9 +575,9 @@
         <version>${maven.resolver.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-runtime</artifactId>
-        <version>${antlr.version}</version>
+        <groupId>org.projectnessie</groupId>
+        <artifactId>nessie-antlr-runtime</artifactId>
+        <version>${nessie.antlr.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey</groupId>


### PR DESCRIPTION
Uses the pre-generated and released `nessie-antlr-runtime` artifact instead of shading/relocating antlr runtime in the Nessie build, which makes it easier for IDEs to build w/o Maven.

Removes the "fake version workaround" to let IntelliJ import the project.

Updates the spark-grammar module to not use relocation but update the package name in the generated antlr java files.

With the above changes, it's possible to use `Maven --> Generate Sources and Update Folders` from the context menu of the top-level nessie module in IntelliJ IDEA project view.