### PR TITLE
Use Immutable Builder functionality in HTTP Param classes to generate Builders

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
@@ -17,13 +17,14 @@ package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.api.params.ReferencesParams;
+import org.projectnessie.api.params.ReferencesParamsBuilder;
 import org.projectnessie.client.api.GetAllReferencesBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.model.ReferencesResponse;
 
 final class HttpGetAllReferences extends BaseHttpRequest implements GetAllReferencesBuilder {
 
-  private final ReferencesParams.Builder params = ReferencesParams.builder();
+  private final ReferencesParamsBuilder params = ReferencesParams.builder();
 
   HttpGetAllReferences(NessieApiClient client) {
     super(client);
@@ -43,7 +44,7 @@ final class HttpGetAllReferences extends BaseHttpRequest implements GetAllRefere
 
   @Override
   public GetAllReferencesBuilder fetch(FetchOption fetchOption) {
-    params.fetch(fetchOption);
+    params.fetchOption(fetchOption);
     return this;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetCommitLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetCommitLog.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.CommitLogParams;
+import org.projectnessie.api.params.CommitLogParamsBuilder;
 import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.client.api.GetCommitLogBuilder;
 import org.projectnessie.client.http.NessieApiClient;
@@ -25,7 +26,7 @@ import org.projectnessie.model.LogResponse;
 final class HttpGetCommitLog extends BaseHttpOnReferenceRequest<GetCommitLogBuilder>
     implements GetCommitLogBuilder {
 
-  private final CommitLogParams.Builder params = CommitLogParams.builder();
+  private final CommitLogParamsBuilder params = CommitLogParams.builder();
 
   HttpGetCommitLog(NessieApiClient client) {
     super(client);
@@ -33,7 +34,7 @@ final class HttpGetCommitLog extends BaseHttpOnReferenceRequest<GetCommitLogBuil
 
   @Override
   public GetCommitLogBuilder fetch(FetchOption fetchOption) {
-    params.fetch(fetchOption);
+    params.fetchOption(fetchOption);
     return this;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetDiff.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetDiff.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.DiffParams;
+import org.projectnessie.api.params.DiffParamsBuilder;
 import org.projectnessie.client.api.GetDiffBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
@@ -23,7 +24,7 @@ import org.projectnessie.model.DiffResponse;
 
 final class HttpGetDiff extends BaseHttpRequest implements GetDiffBuilder {
 
-  DiffParams.Builder builder = DiffParams.builder();
+  DiffParamsBuilder builder = DiffParams.builder();
 
   HttpGetDiff(NessieApiClient client) {
     super(client);

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.EntriesParams;
+import org.projectnessie.api.params.EntriesParamsBuilder;
 import org.projectnessie.client.api.GetEntriesBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
@@ -24,7 +25,7 @@ import org.projectnessie.model.EntriesResponse;
 final class HttpGetEntries extends BaseHttpOnReferenceRequest<GetEntriesBuilder>
     implements GetEntriesBuilder {
 
-  private final EntriesParams.Builder params = EntriesParams.builder();
+  private final EntriesParamsBuilder params = EntriesParams.builder();
 
   HttpGetEntries(NessieApiClient client) {
     super(client);

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.RefLogParams;
+import org.projectnessie.api.params.RefLogParamsBuilder;
 import org.projectnessie.client.api.GetRefLogBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
@@ -23,7 +24,7 @@ import org.projectnessie.model.RefLogResponse;
 
 final class HttpGetRefLog extends BaseHttpRequest implements GetRefLogBuilder {
 
-  private final RefLogParams.Builder params = RefLogParams.builder();
+  private final RefLogParamsBuilder params = RefLogParams.builder();
 
   HttpGetRefLog(NessieApiClient client) {
     super(client);

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetReference.java
@@ -17,13 +17,14 @@ package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.api.params.GetReferenceParams;
+import org.projectnessie.api.params.GetReferenceParamsBuilder;
 import org.projectnessie.client.api.GetReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
 final class HttpGetReference extends BaseHttpRequest implements GetReferenceBuilder {
-  private GetReferenceParams.Builder builder = GetReferenceParams.builder();
+  private GetReferenceParamsBuilder builder = GetReferenceParams.builder();
 
   HttpGetReference(NessieApiClient client) {
     super(client);
@@ -37,7 +38,7 @@ final class HttpGetReference extends BaseHttpRequest implements GetReferenceBuil
 
   @Override
   public GetReferenceBuilder fetch(FetchOption fetchOption) {
-    builder.fetch(fetchOption);
+    builder.fetchOption(fetchOption);
     return this;
   }
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -70,6 +70,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>builder</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/model/src/main/java/org/projectnessie/api/params/AbstractParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/AbstractParams.java
@@ -41,10 +41,12 @@ public abstract class AbstractParams {
     this.pageToken = pageToken;
   }
 
+  @Nullable
   public Integer maxRecords() {
     return maxRecords;
   }
 
+  @Nullable
   public String pageToken() {
     return pageToken;
   }

--- a/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
@@ -79,28 +79,19 @@ public class CommitLogParams extends AbstractParams {
 
   public CommitLogParams() {}
 
-  private CommitLogParams(
-      String startHash,
-      String endHash,
-      Integer maxRecords,
-      String pageToken,
-      String filter,
-      FetchOption fetchOption) {
+  @org.immutables.builder.Builder.Constructor
+  CommitLogParams(
+      @Nullable String startHash,
+      @Nullable String endHash,
+      @Nullable Integer maxRecords,
+      @Nullable String pageToken,
+      @Nullable String filter,
+      @Nullable FetchOption fetchOption) {
     super(maxRecords, pageToken);
     this.startHash = startHash;
     this.endHash = endHash;
     this.filter = filter;
     this.fetchOption = fetchOption;
-  }
-
-  private CommitLogParams(Builder builder) {
-    this(
-        builder.startHash,
-        builder.endHash,
-        builder.maxRecords,
-        builder.pageToken,
-        builder.filter,
-        builder.fetchOption);
   }
 
   @Nullable
@@ -113,20 +104,22 @@ public class CommitLogParams extends AbstractParams {
     return endHash;
   }
 
+  @Nullable
   public String filter() {
     return filter;
   }
 
+  @Nullable
   public FetchOption fetchOption() {
     return fetchOption;
   }
 
-  public static CommitLogParams.Builder builder() {
-    return new CommitLogParams.Builder();
+  public static CommitLogParamsBuilder builder() {
+    return new CommitLogParamsBuilder();
   }
 
   public static CommitLogParams empty() {
-    return new CommitLogParams.Builder().build();
+    return builder().build();
   }
 
   @Override
@@ -161,51 +154,5 @@ public class CommitLogParams extends AbstractParams {
   @Override
   public int hashCode() {
     return Objects.hash(startHash, endHash, maxRecords(), pageToken(), filter, fetchOption);
-  }
-
-  public static class Builder extends AbstractParams.Builder<Builder> {
-
-    private String startHash;
-    private String endHash;
-    private String filter;
-    private FetchOption fetchOption;
-
-    private Builder() {}
-
-    public Builder startHash(String startHash) {
-      this.startHash = startHash;
-      return this;
-    }
-
-    public Builder endHash(String endHash) {
-      this.endHash = endHash;
-      return this;
-    }
-
-    public Builder filter(String filter) {
-      this.filter = filter;
-      return this;
-    }
-
-    public Builder fetch(FetchOption fetchOption) {
-      this.fetchOption = fetchOption;
-      return this;
-    }
-
-    public Builder from(CommitLogParams params) {
-      return startHash(params.startHash)
-          .endHash(params.endHash)
-          .maxRecords(params.maxRecords())
-          .pageToken(params.pageToken())
-          .filter(params.filter)
-          .fetch(params.fetchOption);
-    }
-
-    private void validate() {}
-
-    public CommitLogParams build() {
-      validate();
-      return new CommitLogParams(this);
-    }
   }
 }

--- a/model/src/main/java/org/projectnessie/api/params/DiffParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/DiffParams.java
@@ -62,21 +62,23 @@ public class DiffParams {
 
   public DiffParams() {}
 
-  private DiffParams(String fromRef, String fromHashOnRef, String toRef, String toHashOnRef) {
+  @org.immutables.builder.Builder.Constructor
+  DiffParams(
+      @NotNull String fromRef,
+      @Nullable String fromHashOnRef,
+      @NotNull String toRef,
+      @Nullable String toHashOnRef) {
     this.fromRef = fromRef;
     this.fromHashOnRef = fromHashOnRef;
     this.toRef = toRef;
     this.toHashOnRef = toHashOnRef;
   }
 
-  private DiffParams(Builder builder) {
-    this(builder.fromRef, builder.fromHashOnRef, builder.toRef, builder.toHashOnRef);
-  }
-
   public String getFromRef() {
     return fromRef;
   }
 
+  @Nullable
   public String getFromHashOnRef() {
     return emptyToNull(fromHashOnRef);
   }
@@ -85,6 +87,7 @@ public class DiffParams {
     return toRef;
   }
 
+  @Nullable
   public String getToHashOnRef() {
     return emptyToNull(toHashOnRef);
   }
@@ -102,8 +105,8 @@ public class DiffParams {
     return s;
   }
 
-  public static DiffParams.Builder builder() {
-    return new Builder();
+  public static DiffParamsBuilder builder() {
+    return new DiffParamsBuilder();
   }
 
   @Override
@@ -124,51 +127,5 @@ public class DiffParams {
   @Override
   public int hashCode() {
     return Objects.hash(fromRef, fromHashOnRef, toRef, toHashOnRef);
-  }
-
-  public static class Builder {
-    private String fromRef;
-    private String fromHashOnRef;
-    private String toRef;
-    private String toHashOnRef;
-
-    public Builder() {}
-
-    public Builder from(DiffParams params) {
-      return fromRef(params.fromRef)
-          .fromHashOnRef(params.fromHashOnRef)
-          .toRef(params.toRef)
-          .toHashOnRef(params.toHashOnRef);
-    }
-
-    public Builder fromRef(String fromRef) {
-      this.fromRef = fromRef;
-      return this;
-    }
-
-    public Builder fromHashOnRef(String fromHashOnRef) {
-      this.fromHashOnRef = fromHashOnRef;
-      return this;
-    }
-
-    public Builder toRef(String toRef) {
-      this.toRef = toRef;
-      return this;
-    }
-
-    public Builder toHashOnRef(String toHashOnRef) {
-      this.toHashOnRef = toHashOnRef;
-      return this;
-    }
-
-    private void validate() {
-      Objects.requireNonNull(fromRef, "fromRef must be non-null");
-      Objects.requireNonNull(toRef, "toRef must be non-null");
-    }
-
-    public DiffParams build() {
-      validate();
-      return new DiffParams(this);
-    }
   }
 }

--- a/model/src/main/java/org/projectnessie/api/params/EntriesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/EntriesParams.java
@@ -64,33 +64,25 @@ public class EntriesParams extends AbstractParams {
 
   public EntriesParams() {}
 
-  private EntriesParams(
-      String hashOnRef,
-      Integer maxRecords,
-      String pageToken,
-      Integer namespaceDepth,
-      String filter) {
+  @org.immutables.builder.Builder.Constructor
+  EntriesParams(
+      @Nullable String hashOnRef,
+      @Nullable Integer maxRecords,
+      @Nullable String pageToken,
+      @Nullable Integer namespaceDepth,
+      @Nullable String filter) {
     super(maxRecords, pageToken);
     this.hashOnRef = hashOnRef;
     this.namespaceDepth = namespaceDepth;
     this.filter = filter;
   }
 
-  private EntriesParams(Builder builder) {
-    this(
-        builder.hashOnRef,
-        builder.maxRecords,
-        builder.pageToken,
-        builder.namespaceDepth,
-        builder.filter);
-  }
-
-  public static EntriesParams.Builder builder() {
-    return new EntriesParams.Builder();
+  public static EntriesParamsBuilder builder() {
+    return new EntriesParamsBuilder();
   }
 
   public static EntriesParams empty() {
-    return new EntriesParams.Builder().build();
+    return builder().build();
   }
 
   @Nullable
@@ -98,10 +90,12 @@ public class EntriesParams extends AbstractParams {
     return hashOnRef;
   }
 
+  @Nullable
   public String filter() {
     return filter;
   }
 
+  @Nullable
   public Integer namespaceDepth() {
     return namespaceDepth;
   }
@@ -136,44 +130,5 @@ public class EntriesParams extends AbstractParams {
   @Override
   public int hashCode() {
     return Objects.hash(hashOnRef, maxRecords(), pageToken(), namespaceDepth, filter);
-  }
-
-  public static class Builder extends AbstractParams.Builder<Builder> {
-
-    private String hashOnRef;
-    private String filter;
-    private Integer namespaceDepth;
-
-    private Builder() {}
-
-    public EntriesParams.Builder hashOnRef(String hashOnRef) {
-      this.hashOnRef = hashOnRef;
-      return this;
-    }
-
-    public EntriesParams.Builder filter(String filter) {
-      this.filter = filter;
-      return this;
-    }
-
-    public Builder namespaceDepth(Integer namespaceDepth) {
-      this.namespaceDepth = namespaceDepth;
-      return this;
-    }
-
-    public EntriesParams.Builder from(EntriesParams params) {
-      return hashOnRef(params.hashOnRef)
-          .maxRecords(params.maxRecords())
-          .pageToken(params.pageToken())
-          .namespaceDepth(params.namespaceDepth)
-          .filter(params.filter);
-    }
-
-    private void validate() {}
-
-    public EntriesParams build() {
-      validate();
-      return new EntriesParams(this);
-    }
   }
 }

--- a/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/GetReferenceParams.java
@@ -24,6 +24,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.immutables.builder.Builder;
 import org.projectnessie.model.Validation;
 
 public class GetReferenceParams {
@@ -53,15 +54,13 @@ public class GetReferenceParams {
 
   public GetReferenceParams() {}
 
-  private GetReferenceParams(String refName, FetchOption fetchOption) {
+  @Builder.Constructor
+  GetReferenceParams(@NotNull String refName, @Nullable FetchOption fetchOption) {
     this.refName = refName;
     this.fetchOption = fetchOption;
   }
 
-  private GetReferenceParams(Builder builder) {
-    this(builder.refName, builder.fetchOption);
-  }
-
+  @Nullable
   public FetchOption fetchOption() {
     return fetchOption;
   }
@@ -70,8 +69,8 @@ public class GetReferenceParams {
     return refName;
   }
 
-  public static GetReferenceParams.Builder builder() {
-    return new GetReferenceParams.Builder();
+  public static GetReferenceParamsBuilder builder() {
+    return new GetReferenceParamsBuilder();
   }
 
   @Override
@@ -97,31 +96,5 @@ public class GetReferenceParams {
         .add("refName='" + refName + "'")
         .add("fetchOption=" + fetchOption)
         .toString();
-  }
-
-  public static class Builder {
-    private String refName;
-    private FetchOption fetchOption;
-
-    private Builder() {}
-
-    public Builder refName(String refName) {
-      this.refName = refName;
-      return this;
-    }
-
-    public Builder fetch(FetchOption fetchOption) {
-      this.fetchOption = fetchOption;
-      return this;
-    }
-
-    private void validate() {
-      Objects.requireNonNull(refName, "refName must be non-null");
-    }
-
-    public GetReferenceParams build() {
-      validate();
-      return new GetReferenceParams(this);
-    }
   }
 }

--- a/model/src/main/java/org/projectnessie/api/params/RefLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/RefLogParams.java
@@ -67,16 +67,17 @@ public class RefLogParams extends AbstractParams {
 
   public RefLogParams() {}
 
-  private RefLogParams(
-      String startHash, String endHash, Integer maxRecords, String pageToken, String filter) {
+  @org.immutables.builder.Builder.Constructor
+  RefLogParams(
+      @Nullable String startHash,
+      @Nullable String endHash,
+      @Nullable Integer maxRecords,
+      @Nullable String pageToken,
+      @Nullable String filter) {
     super(maxRecords, pageToken);
     this.startHash = startHash;
     this.endHash = endHash;
     this.filter = filter;
-  }
-
-  private RefLogParams(Builder builder) {
-    this(builder.startHash, builder.endHash, builder.maxRecords, builder.pageToken, builder.filter);
   }
 
   @Nullable
@@ -94,12 +95,12 @@ public class RefLogParams extends AbstractParams {
     return filter;
   }
 
-  public static RefLogParams.Builder builder() {
-    return new RefLogParams.Builder();
+  public static RefLogParamsBuilder builder() {
+    return new RefLogParamsBuilder();
   }
 
   public static RefLogParams empty() {
-    return new RefLogParams.Builder().build();
+    return builder().build();
   }
 
   @Override
@@ -132,41 +133,5 @@ public class RefLogParams extends AbstractParams {
   @Override
   public int hashCode() {
     return Objects.hash(startHash, endHash, filter, maxRecords(), pageToken());
-  }
-
-  public static class Builder extends AbstractParams.Builder<Builder> {
-
-    private String startHash;
-    private String endHash;
-    private String filter;
-
-    private Builder() {}
-
-    public Builder startHash(String startHash) {
-      this.startHash = startHash;
-      return this;
-    }
-
-    public Builder endHash(String endHash) {
-      this.endHash = endHash;
-      return this;
-    }
-
-    public Builder filter(String filter) {
-      this.filter = filter;
-      return this;
-    }
-
-    public Builder from(RefLogParams params) {
-      return startHash(params.startHash)
-          .endHash(params.endHash)
-          .filter(params.filter)
-          .maxRecords(params.maxRecords())
-          .pageToken(params.pageToken());
-    }
-
-    public RefLogParams build() {
-      return new RefLogParams(this);
-    }
   }
 }

--- a/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
@@ -67,31 +67,33 @@ public class ReferencesParams extends AbstractParams {
 
   public ReferencesParams() {}
 
-  private ReferencesParams(
-      Integer maxRecords, String pageToken, FetchOption fetchOption, String filter) {
+  @org.immutables.builder.Builder.Constructor
+  ReferencesParams(
+      @Nullable Integer maxRecords,
+      @Nullable String pageToken,
+      @Nullable FetchOption fetchOption,
+      @Nullable String filter) {
     super(maxRecords, pageToken);
     this.fetchOption = fetchOption;
     this.filter = filter;
   }
 
-  private ReferencesParams(Builder builder) {
-    this(builder.maxRecords, builder.pageToken, builder.fetchOption, builder.filter);
-  }
-
+  @Nullable
   public FetchOption fetchOption() {
     return fetchOption;
   }
 
+  @Nullable
   public String filter() {
     return filter;
   }
 
-  public static ReferencesParams.Builder builder() {
-    return new ReferencesParams.Builder();
+  public static ReferencesParamsBuilder builder() {
+    return new ReferencesParamsBuilder();
   }
 
   public static ReferencesParams empty() {
-    return new ReferencesParams.Builder().build();
+    return builder().build();
   }
 
   @Override
@@ -122,37 +124,5 @@ public class ReferencesParams extends AbstractParams {
   @Override
   public int hashCode() {
     return Objects.hash(maxRecords(), pageToken(), fetchOption, filter);
-  }
-
-  public static class Builder extends AbstractParams.Builder<Builder> {
-
-    private Builder() {}
-
-    private FetchOption fetchOption;
-    private String filter;
-
-    public ReferencesParams.Builder from(ReferencesParams params) {
-      return maxRecords(params.maxRecords())
-          .pageToken(params.pageToken())
-          .fetch(params.fetchOption)
-          .filter(params.filter);
-    }
-
-    public Builder fetch(FetchOption fetchOption) {
-      this.fetchOption = fetchOption;
-      return this;
-    }
-
-    public Builder filter(String filter) {
-      this.filter = filter;
-      return this;
-    }
-
-    private void validate() {}
-
-    public ReferencesParams build() {
-      validate();
-      return new ReferencesParams(this);
-    }
   }
 }

--- a/model/src/test/java/org/projectnessie/api/params/CommitLogParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/CommitLogParamsTest.java
@@ -39,7 +39,7 @@ public class CommitLogParamsTest {
                 .pageToken(pageToken)
                 .startHash(startHash)
                 .endHash(endHash)
-                .fetch(fetchOption)
+                .fetchOption(fetchOption)
                 .build();
 
     verify(maxRecords, startHash, endHash, pageToken, filter, fetchOption, generator);

--- a/model/src/test/java/org/projectnessie/api/params/DiffParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/DiffParamsTest.java
@@ -59,11 +59,11 @@ public class DiffParamsTest {
   @Test
   public void testValidation() {
     assertThatThrownBy(() -> DiffParams.builder().fromRef("x").build())
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("toRef must be non-null");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot build DiffParams, some of required attributes are not set [toRef]");
 
     assertThatThrownBy(() -> DiffParams.builder().toRef("x").build())
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("fromRef must be non-null");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot build DiffParams, some of required attributes are not set [fromRef]");
   }
 }

--- a/model/src/test/java/org/projectnessie/api/params/GetReferenceParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/GetReferenceParamsTest.java
@@ -25,7 +25,7 @@ public class GetReferenceParamsTest {
   @Test
   public void testBuilder() {
     GetReferenceParams params =
-        GetReferenceParams.builder().refName("xx").fetch(FetchOption.ALL).build();
+        GetReferenceParams.builder().refName("xx").fetchOption(FetchOption.ALL).build();
     assertThat(params.getRefName()).isEqualTo("xx");
     assertThat(params.fetchOption()).isEqualTo(FetchOption.ALL);
 
@@ -37,11 +37,12 @@ public class GetReferenceParamsTest {
   @Test
   public void testValidation() {
     assertThatThrownBy(() -> GetReferenceParams.builder().build())
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("refName must be non-null");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Cannot build GetReferenceParams, some of required attributes are not set [refName]");
 
     assertThatThrownBy(() -> GetReferenceParams.builder().refName(null).build())
         .isInstanceOf(NullPointerException.class)
-        .hasMessage("refName must be non-null");
+        .hasMessage("refName");
   }
 }

--- a/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
@@ -28,7 +28,7 @@ public class ReferencesParamsTest {
             .maxRecords(23)
             .pageToken("abc")
             .filter("some_expression")
-            .fetch(FetchOption.ALL)
+            .fetchOption(FetchOption.ALL)
             .build();
     assertThat(params.maxRecords()).isEqualTo(23);
     assertThat(params.pageToken()).isEqualTo("abc");

--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,11 @@
         <version>${immutables.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>builder</artifactId>
+        <version>${immutables.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>
         <version>${quarkus.version}</version>


### PR DESCRIPTION

The only reason we can't fully move those classes to true Immutables is
because of bean validation requiring those classes to have a default
constructor. Note that bean validation on those classes is done via
`@BeanParam`, such as in `getXyz(@BeanParam EntriesParams params)`.

At the very least, we can remove the hand-written builders and let the
Immutables lib do the work of generating those (since we already have
tests in place that make sure objects are properly constructed and
validated).