### PR TITLE
Avoid confusion around hive catalog in tests

### DIFF
--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/AbstractDeltaTest.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/AbstractDeltaTest.java
@@ -67,8 +67,6 @@ public class AbstractDeltaTest {
     conf.set(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
         .set("spark.testing", "true")
         .set("spark.sql.shuffle.partitions", "4")
-        .set("spark.sql.catalog.hive", "org.apache.iceberg.spark.SparkCatalog")
-        .set("spark.sql.catalog.hive.catalog-impl", "org.apache.iceberg.hive.HiveCatalog")
         .set("spark.sql.catalog.nessie.catalog-impl", "org.apache.iceberg.nessie.NessieCatalog")
         .set("spark.sql.catalog.nessie", "org.apache.iceberg.spark.SparkCatalog");
     spark = SparkSession.builder().master("local[2]").config(conf).getOrCreate();


### PR DESCRIPTION
this is a suggestion to make it clearer why we have a hive catalog in the general setup logic of the spark tests.

also it removes the hive catalog from the delta test, since its existence only makes sense when testing with nessie extensions, which we dont currently do for delta (see https://github.com/projectnessie/nessie/issues/3552)