### PR TITLE
Fix nessie catalog check for delta

### DIFF
--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/AbstractDeltaTest.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/AbstractDeltaTest.java
@@ -75,9 +75,6 @@ public class AbstractDeltaTest {
         .set("spark.testing", "true")
         .set("spark.sql.shuffle.partitions", "4");
 
-    // the following is required until https://github.com/projectnessie/nessie/issues/3552 is fixed
-    conf.set("spark.sql.catalog.spark_catalog.catalog-impl", "workaround.NessieCatalog");
-
     spark = SparkSession.builder().master("local[2]").config(conf).getOrCreate();
     spark.sparkContext().setLogLevel("WARN");
 

--- a/site/docs/tools/deltalake/spark.md
+++ b/site/docs/tools/deltalake/spark.md
@@ -3,21 +3,22 @@
 !!! note
     Detailed steps on how to set up Pyspark + Delta Lake + Nessie with Python is available on [Binder](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=notebooks/nessie-delta-demo-nba.ipynb).
 
-To access Nessie from a spark cluster make sure the `spark.jars` spark option is set to include the [Nessie Deltalake Client for Spark 3](https://repo.maven.apache.org/maven2/org/projectnessie/nessie-deltalake/{{ versions.java}}/nessie-deltalake-{{ versions.java}}.jar)
+To access Nessie from a spark cluster make sure the `spark.jars.packages` option is set to include the [Nessie Deltalake Client for Spark 3](https://repo.maven.apache.org/maven2/org/projectnessie/nessie-deltalake/{{ versions.java }}/nessie-deltalake-{{ versions.java }}.jar)
 jar. These jars contain all Nessie **and** Delta Lake libraries required for operation.
-
-!!! note
-    the `spark3` jar is for Delta versions >0.7.0 on Spark3 and the `spark2` jar is for Delta versions 0.6.x on Spark2.4
 
 In pyspark this would look like
 
 ``` python
 SparkSession.builder
     .config('spark.jars.packages',
-            'org.projectnessie:nessie-deltalake:{{ versions.java}}')
+            'org.projectnessie:nessie-deltalake:{{ versions.java }}')
     ... rest of spark config
     .getOrCreate()
 ```
+
+In order to utilize the additional SQL grammar from the Nessie Spark SQL Extensions make sure to
+also include `org.projectnessie:nessie-spark-3.2-extensions:{{ versions.java }}` and
+to set the `spark.sql.extensions` config option accordingly (see examples below).
 
 The Nessie LogStore needs the following parameters set in the Spark/Hadoop config.
 
@@ -34,14 +35,14 @@ These are set as follows in code (or through other methods as described [here](h
     ``` java
     //for a local spark instance
     conf.set("spark.jars.packages",
-            "org.projectnessie:nessie-deltalake:{{ versions.java}}")
+            "org.projectnessie:nessie-deltalake:{{ versions.java }},org.projectnessie:nessie-spark-3.2-extensions:{{ versions.java }}")
         .set("spark.hadoop.nessie.url", url)
         .set("spark.hadoop.nessie.ref", branch)
         .set("spark.hadoop.nessie.authentication.type", authType)
         .set("spark.sql.catalog.spark_catalog",
             "org.apache.spark.sql.delta.catalog.DeltaCatalog")
         .set("spark.sql.extensions",
-            "io.delta.sql.DeltaSparkSessionExtension")
+            "io.delta.sql.DeltaSparkSessionExtension,org.projectnessie.spark.extensions.NessieSpark32SessionExtensions")
         .set("spark.delta.logStore.class",
             "org.projectnessie.deltalake.NessieLogStore")
         .set("spark.delta.logFileHandler.class",
@@ -56,14 +57,14 @@ These are set as follows in code (or through other methods as described [here](h
     # here we are assuming NONE authorisation
     spark = SparkSession.builder \
             .config("spark.jars.packages",
-                "org.projectnessie:nessie-deltalake:{{ versions.java}}") \
+                "org.projectnessie:nessie-deltalake:{{ versions.java }},org.projectnessie:nessie-spark-3.2-extensions:{{ versions.java }}") \
             .config("spark.hadoop.nessie.url",
                 "http://localhost:19120/api/v1") \
             .config("spark.hadoop.nessie.ref", "main") \
             .config("spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
             .config("spark.sql.extensions",
-                "io.delta.sql.DeltaSparkSessionExtension") \
+                "io.delta.sql.DeltaSparkSessionExtension,org.projectnessie.spark.extensions.NessieSpark32SessionExtensions") \
             .config("spark.delta.logFileHandler.class",
                 "org.projectnessie.deltalake.NessieLogFileMetaParser") \
             .config("spark.delta.logStore.class",


### PR DESCRIPTION
Follow-up to https://github.com/projectnessie/nessie/pull/3557

Fixes #3552

Original problem:
After https://github.com/projectnessie/nessie/pull/2377 the nessie spark sql extensions could no longer be used with delta.

Also updates the deltalake spark docs removing "spark 2" references and adding info about the nessie spark sql extenions.


