### PR TITLE
global-log compaction

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -312,6 +312,8 @@ public interface DatabaseAdapter {
    */
   Optional<ContentIdAndBytes> globalContent(ContentId contentId);
 
+  Map<String, Map<String, String>> repoMaintenance();
+
   /**
    * Retrieve the refLog starting at the refLog referenced by {@code offset}.
    *

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -312,7 +312,7 @@ public interface DatabaseAdapter {
    */
   Optional<ContentIdAndBytes> globalContent(ContentId contentId);
 
-  Map<String, Map<String, String>> repoMaintenance();
+  Map<String, Map<String, String>> repoMaintenance(RepoMaintenanceParams repoMaintenanceParams);
 
   /**
    * Retrieve the refLog starting at the refLog referenced by {@code offset}.

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/GlobalLogCompactionParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/GlobalLogCompactionParams.java
@@ -23,6 +23,11 @@ public interface GlobalLogCompactionParams {
   int DEFAULT_NO_COMPACTION_WHEN_COMPACTED_WITHIN = 50;
   int DEFAULT_NO_COMPACTION_UP_TO_LENGTH = 50;
 
+  @Value.Default
+  default boolean isEnabled() {
+    return true;
+  }
+
   /**
    * When the global-log contains a compacted entry within this number of entries, global-log
    * compaction will not happen, defaults to {@value #DEFAULT_NO_COMPACTION_WHEN_COMPACTED_WITHIN}.

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/GlobalLogCompactionParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/GlobalLogCompactionParams.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface GlobalLogCompactionParams {
+
+  int DEFAULT_NO_COMPACTION_WHEN_COMPACTED_WITHIN = 50;
+  int DEFAULT_NO_COMPACTION_UP_TO_LENGTH = 50;
+
+  /**
+   * When the global-log contains a compacted entry within this number of entries, global-log
+   * compaction will not happen, defaults to {@value #DEFAULT_NO_COMPACTION_WHEN_COMPACTED_WITHIN}.
+   */
+  @Value.Default
+  default int getNoCompactionWhenCompactedWithin() {
+    return DEFAULT_NO_COMPACTION_WHEN_COMPACTED_WITHIN;
+  }
+
+  /**
+   * When the global-log contains only up to this number of entries, global-log compaction will not
+   * happen, defaults to {@value #DEFAULT_NO_COMPACTION_UP_TO_LENGTH}.
+   */
+  @Value.Default
+  default int getNoCompactionUpToLength() {
+    return DEFAULT_NO_COMPACTION_UP_TO_LENGTH;
+  }
+
+  static ImmutableGlobalLogCompactionParams.Builder builder() {
+    return ImmutableGlobalLogCompactionParams.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/RepoMaintenanceParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/RepoMaintenanceParams.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface RepoMaintenanceParams {
+  GlobalLogCompactionParams getGlobalLogCompactionParams();
+
+  static ImmutableRepoMaintenanceParams.Builder builder() {
+    return ImmutableRepoMaintenanceParams.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
@@ -141,6 +141,10 @@ public final class DatabaseAdapterUtil {
         assignTo.asString());
   }
 
+  public static String maintenanceConflictMessage(String err, String msg) {
+    return String.format("%s during %s", err, msg);
+  }
+
   public static String repoDescUpdateConflictMessage(String err) {
     return String.format("%s during update of the repository description", err);
   }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -46,6 +46,7 @@ import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams;
 
 public final class TracingDatabaseAdapter implements DatabaseAdapter {
   private static final String TAG_COUNT = "count";
@@ -244,9 +245,10 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   }
 
   @Override
-  public Map<String, Map<String, String>> repoMaintenance() {
+  public Map<String, Map<String, String>> repoMaintenance(
+      RepoMaintenanceParams repoMaintenanceParams) {
     try (Traced ignore = trace("repoMaintenance")) {
-      return delegate.repoMaintenance();
+      return delegate.repoMaintenance(repoMaintenanceParams);
     }
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -242,4 +242,11 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
       return delegate.refLog(offset);
     }
   }
+
+  @Override
+  public Map<String, Map<String, String>> repoMaintenance() {
+    try (Traced ignore = trace("repoMaintenance")) {
+      return delegate.repoMaintenance();
+    }
+  }
 }

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -296,6 +296,13 @@ public class DynamoDatabaseAdapter
     }
   }
 
+  @Override
+  protected void doCleanUpGlobalLog(NonTransactionalOperationContext ctx, List<Hash> globalIds) {
+    try (BatchDelete batchDelete = new BatchDelete()) {
+      globalIds.forEach(h -> batchDelete.add(TABLE_GLOBAL_LOG, h));
+    }
+  }
+
   private final class BatchDelete implements AutoCloseable {
     private final Map<String, List<WriteRequest>> requestItems = new HashMap<>();
     private int requests;

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -297,7 +298,8 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected void doCleanUpGlobalLog(NonTransactionalOperationContext ctx, List<Hash> globalIds) {
+  protected void doCleanUpGlobalLog(
+      NonTransactionalOperationContext ctx, Collection<Hash> globalIds) {
     try (BatchDelete batchDelete = new BatchDelete()) {
       globalIds.forEach(h -> batchDelete.add(TABLE_GLOBAL_LOG, h));
     }

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -141,6 +141,11 @@ public class InmemoryDatabaseAdapter
   }
 
   @Override
+  protected void doCleanUpGlobalLog(NonTransactionalOperationContext ctx, List<Hash> globalIds) {
+    globalIds.forEach(h -> store.globalStateLog.remove(dbKey(h)));
+  }
+
+  @Override
   protected GlobalStateLogEntry doFetchFromGlobalLog(
       NonTransactionalOperationContext ctx, Hash id) {
     ByteString serialized = store.globalStateLog.get(dbKey(id));

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -22,6 +22,7 @@ import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.t
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -141,7 +142,8 @@ public class InmemoryDatabaseAdapter
   }
 
   @Override
-  protected void doCleanUpGlobalLog(NonTransactionalOperationContext ctx, List<Hash> globalIds) {
+  protected void doCleanUpGlobalLog(
+      NonTransactionalOperationContext ctx, Collection<Hash> globalIds) {
     globalIds.forEach(h -> store.globalStateLog.remove(dbKey(h)));
   }
 

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -190,7 +190,7 @@ public class MongoDatabaseAdapter
     }
   }
 
-  private void delete(MongoCollection<Document> collection, Set<Hash> ids) {
+  private void delete(MongoCollection<Document> collection, Collection<Hash> ids) {
     DeleteResult result = collection.deleteMany(Filters.in(ID_PROPERTY_NAME, toIds(ids)));
 
     if (!result.wasAcknowledged()) {
@@ -447,6 +447,11 @@ public class MongoDatabaseAdapter
     delete(client.getCommitLog(), branchCommits);
     delete(client.getKeyLists(), newKeyLists);
     client.getRefLog().deleteOne(Filters.eq(toId(refLogId)));
+  }
+
+  @Override
+  protected void doCleanUpGlobalLog(NonTransactionalOperationContext ctx, List<Hash> globalIds) {
+    delete(client.getGlobalLog(), globalIds);
   }
 
   @Override

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -450,7 +450,8 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected void doCleanUpGlobalLog(NonTransactionalOperationContext ctx, List<Hash> globalIds) {
+  protected void doCleanUpGlobalLog(
+      NonTransactionalOperationContext ctx, Collection<Hash> globalIds) {
     delete(client.getGlobalLog(), globalIds);
   }
 

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/AdjustableNonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/AdjustableNonTransactionalDatabaseAdapterConfig.java
@@ -24,4 +24,6 @@ public interface AdjustableNonTransactionalDatabaseAdapterConfig
 
   AdjustableNonTransactionalDatabaseAdapterConfig withParentsPerGlobalCommit(
       int parentsPerGlobalCommit);
+
+  AdjustableNonTransactionalDatabaseAdapterConfig withGlobalLogEntrySize(int globalLogEntrySize);
 }

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
@@ -36,7 +36,7 @@ public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterCo
    * Maximum size of a database object/row.
    *
    * <p>This parameter is respected when compacting the global log via {@link
-   * org.projectnessie.versioned.persist.adapter.DatabaseAdapter#repoMaintenance()}.
+   * org.projectnessie.versioned.persist.adapter.DatabaseAdapter#repoMaintenance(org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams)}.
    *
    * <p>Not all kinds of databases have hard limits on the maximum size of a database object/row.
    *

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
@@ -20,6 +20,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 
 public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterConfig {
   int DEFAULT_PARENTS_PER_GLOBAL_COMMIT = 50;
+  int DEFAULT_GLOBAL_LOG_ENTRY_SIZE = 250_000;
 
   /**
    * The number of parent-global-commit-hashes stored in {@link
@@ -29,5 +30,38 @@ public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterCo
   @Value.Default
   default int getParentsPerGlobalCommit() {
     return DEFAULT_PARENTS_PER_GLOBAL_COMMIT;
+  }
+
+  /**
+   * Maximum size of a database object/row.
+   *
+   * <p>This parameter is respected when compacting the global log via {@link
+   * org.projectnessie.versioned.persist.adapter.DatabaseAdapter#repoMaintenance()}.
+   *
+   * <p>Not all kinds of databases have hard limits on the maximum size of a database object/row.
+   *
+   * <p>This value must not be "on the edge" - means: it must leave enough room for a somewhat
+   * large-ish list,, database-serialization overhead and similar.
+   *
+   * <p>Values {@code <=0} are illegal, defaults to {@link #getDefaultMaxKeyListSize()}.
+   */
+  @Value.Default
+  default int getGlobalLogEntrySize() {
+    return getDefaultGlobalLogEntrySize();
+  }
+
+  /**
+   * Database adapter implementations that actually do have a hard technical or highly recommended
+   * limit on a maximum db-object / db-row size limitation should override this method and return a
+   * "good" value.
+   *
+   * <p>As for {@link #getGlobalLogEntrySize()}, this value must not be "on the edge" - means: it
+   * must leave enough room for a somewhat large-ish list, database-serialization overhead * and
+   * similar.
+   *
+   * <p>Defaults to {@value #DEFAULT_GLOBAL_LOG_ENTRY_SIZE}.
+   */
+  default int getDefaultGlobalLogEntrySize() {
+    return DEFAULT_GLOBAL_LOG_ENTRY_SIZE;
   }
 }

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -253,6 +253,23 @@ public class RocksDatabaseAdapter
   }
 
   @Override
+  protected void doCleanUpGlobalLog(NonTransactionalOperationContext ctx, List<Hash> globalIds) {
+    Lock lock = dbInstance.getLock().writeLock();
+    lock.lock();
+    try {
+      WriteBatch batch = new WriteBatch();
+      for (Hash h : globalIds) {
+        batch.delete(dbInstance.getCfGlobalLog(), dbKey(h));
+      }
+      db.write(new WriteOptions(), batch);
+    } catch (RocksDBException e) {
+      throw new RuntimeException(e);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
   protected GlobalStateLogEntry doFetchFromGlobalLog(
       NonTransactionalOperationContext ctx, Hash id) {
     try {

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -26,6 +26,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -253,7 +254,8 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected void doCleanUpGlobalLog(NonTransactionalOperationContext ctx, List<Hash> globalIds) {
+  protected void doCleanUpGlobalLog(
+      NonTransactionalOperationContext ctx, Collection<Hash> globalIds) {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
     try {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.persist.adapter.ContentId;
+import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+import org.projectnessie.versioned.testworker.SimpleStoreWorker;
+import org.projectnessie.versioned.testworker.WithGlobalStateContent;
+
+public abstract class AbstractCompactGlobalLog {
+
+  private final DatabaseAdapter databaseAdapter;
+
+  protected AbstractCompactGlobalLog(DatabaseAdapter databaseAdapter) {
+    this.databaseAdapter = databaseAdapter;
+  }
+
+  public static Stream<Arguments> compactGlobalLog() {
+    return Stream.of(
+        Arguments.of(10, 0d),
+        Arguments.of(10, .1d),
+        Arguments.of(10, .9d),
+        Arguments.of(100, 0d),
+        Arguments.of(100, .1d),
+        Arguments.of(100, .9d));
+  }
+
+  @ParameterizedTest
+  @MethodSource("compactGlobalLog")
+  public void compactGlobalLog(int commits, double contentReuseProbability) throws Exception {
+    // sneak peak, whether the database-adapter supports global-log-compaction
+    assumeThat(databaseAdapter.repoMaintenance()).containsKey("compactGlobalLog");
+
+    BranchName branch = BranchName.of("compactGlobalLog");
+    List<ContentId> contentIds = new ArrayList<>();
+    ThreadLocalRandom rand = ThreadLocalRandom.current();
+    Map<ContentId, ByteString> currentGlobal = new HashMap<>();
+
+    databaseAdapter.create(branch, databaseAdapter.noAncestorHash());
+
+    for (int i = 0; i < commits; i++) {
+      ContentId contentId;
+      if (contentReuseProbability > rand.nextDouble() && !contentIds.isEmpty()) {
+        contentId = contentIds.get(rand.nextInt(contentIds.size()));
+      } else {
+        contentId = ContentId.of("cid-" + i);
+        contentIds.add(contentId);
+      }
+
+      Key key = Key.of("commit", Integer.toString(i));
+      WithGlobalStateContent c =
+          WithGlobalStateContent.withGlobal(
+              "state for #" + i + " of " + commits,
+              "value for #" + i + " of " + commits,
+              contentId.getId());
+      byte payload = SimpleStoreWorker.INSTANCE.getPayload(c);
+      ByteString global = SimpleStoreWorker.INSTANCE.toStoreGlobalState(c);
+
+      ImmutableCommitAttempt.Builder commit =
+          ImmutableCommitAttempt.builder()
+              .commitToBranch(branch)
+              .commitMetaSerialized(ByteString.copyFromUtf8("commit#" + i))
+              .addPuts(
+                  KeyWithBytes.of(
+                      key,
+                      contentId,
+                      payload,
+                      SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)))
+              .putGlobal(contentId, global);
+
+      currentGlobal.put(contentId, global);
+
+      databaseAdapter.commit(commit.build());
+    }
+
+    // Verify
+    try (Stream<ContentIdAndBytes> globals =
+        databaseAdapter.globalContent(new HashSet<>(contentIds))) {
+      assertThat(globals)
+          .hasSize(contentIds.size())
+          .allSatisfy(
+              cb -> assertThat(currentGlobal.get(cb.getContentId())).isEqualTo(cb.getValue()));
+    }
+
+    Map<String, Map<String, String>> statistics = databaseAdapter.repoMaintenance();
+    Map<String, String> compactStats = statistics.get("compactGlobalLog");
+
+    assertThat(compactStats)
+        .containsEntry("entries.puts", Long.toString(contentIds.size()))
+        .containsEntry("entries.read", Long.toString(commits + 2))
+        .containsEntry("entries.read.total", Long.toString(commits + 2));
+
+    // Verify again
+    try (Stream<ContentIdAndBytes> globals =
+        databaseAdapter.globalContent(new HashSet<>(contentIds))) {
+      assertThat(globals)
+          .hasSize(contentIds.size())
+          .allSatisfy(
+              cb -> assertThat(currentGlobal.get(cb.getContentId())).isEqualTo(cb.getValue()));
+    }
+  }
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
@@ -26,11 +26,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
@@ -48,20 +51,23 @@ public abstract class AbstractCompactGlobalLog {
   }
 
   public static Stream<Arguments> compactGlobalLog() {
-    return Stream.of(
-        Arguments.of(10, 0d),
-        Arguments.of(10, .1d),
-        Arguments.of(10, .9d),
-        Arguments.of(100, 0d),
-        Arguments.of(100, .1d),
-        Arguments.of(100, .9d));
+    return Stream.of(Arguments.of(30, 0d), Arguments.of(30, .1d), Arguments.of(30, .9d));
   }
 
   @ParameterizedTest
   @MethodSource("compactGlobalLog")
   public void compactGlobalLog(int commits, double contentReuseProbability) throws Exception {
-    // sneak peak, whether the database-adapter supports global-log-compaction
-    assumeThat(databaseAdapter.repoMaintenance()).containsKey("compactGlobalLog");
+    Map<String, Map<String, String>> statistics = databaseAdapter.repoMaintenance();
+
+    // If there's no statistics entry for global-log-compaction, then it's not a non-transactional
+    // database adapter, so no global-log to compact.
+    assumeThat(statistics).containsKey("compactGlobalLog");
+
+    // An "empty repository" should not require compaction
+    assertThat(statistics)
+        .containsKey("compactGlobalLog")
+        .extracting("compactGlobalLog", InstanceOfAssertFactories.map(String.class, String.class))
+        .containsEntry("compacted", "false");
 
     BranchName branch = BranchName.of("compactGlobalLog");
     List<ContentId> contentIds = new ArrayList<>();
@@ -70,66 +76,140 @@ public abstract class AbstractCompactGlobalLog {
 
     databaseAdapter.create(branch, databaseAdapter.noAncestorHash());
 
+    Runnable verify =
+        () -> {
+          try (Stream<ContentIdAndBytes> globals =
+              databaseAdapter.globalContent(new HashSet<>(contentIds))) {
+            assertThat(globals)
+                .hasSize(contentIds.size())
+                .allSatisfy(
+                    cb ->
+                        assertThat(currentGlobal.get(cb.getContentId())).isEqualTo(cb.getValue()));
+          }
+        };
+
     for (int i = 0; i < commits; i++) {
-      ContentId contentId;
-      if (contentReuseProbability > rand.nextDouble() && !contentIds.isEmpty()) {
-        contentId = contentIds.get(rand.nextInt(contentIds.size()));
-      } else {
-        contentId = ContentId.of("cid-" + i);
-        contentIds.add(contentId);
-      }
-
-      Key key = Key.of("commit", Integer.toString(i));
-      WithGlobalStateContent c =
-          WithGlobalStateContent.withGlobal(
-              "state for #" + i + " of " + commits,
-              "value for #" + i + " of " + commits,
-              contentId.getId());
-      byte payload = SimpleStoreWorker.INSTANCE.getPayload(c);
-      ByteString global = SimpleStoreWorker.INSTANCE.toStoreGlobalState(c);
-
-      ImmutableCommitAttempt.Builder commit =
-          ImmutableCommitAttempt.builder()
-              .commitToBranch(branch)
-              .commitMetaSerialized(ByteString.copyFromUtf8("commit#" + i))
-              .addPuts(
-                  KeyWithBytes.of(
-                      key,
-                      contentId,
-                      payload,
-                      SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)))
-              .putGlobal(contentId, global);
-
-      currentGlobal.put(contentId, global);
-
-      databaseAdapter.commit(commit.build());
+      commitForGlobalLogCompaction(
+          commits, contentReuseProbability, branch, contentIds, rand, currentGlobal, i);
     }
 
     // Verify
-    try (Stream<ContentIdAndBytes> globals =
-        databaseAdapter.globalContent(new HashSet<>(contentIds))) {
-      assertThat(globals)
-          .hasSize(contentIds.size())
-          .allSatisfy(
-              cb -> assertThat(currentGlobal.get(cb.getContentId())).isEqualTo(cb.getValue()));
-    }
+    verify.run();
 
-    Map<String, Map<String, String>> statistics = databaseAdapter.repoMaintenance();
-    Map<String, String> compactStats = statistics.get("compactGlobalLog");
+    statistics = databaseAdapter.repoMaintenance();
 
-    assertThat(compactStats)
+    assertThat(statistics)
+        .containsKey("compactGlobalLog")
+        .extracting("compactGlobalLog", InstanceOfAssertFactories.map(String.class, String.class))
+        .containsEntry("compacted", "true")
         .containsEntry("entries.puts", Long.toString(commits))
         .containsEntry("entries.uniquePuts", Long.toString(contentIds.size()))
         .containsEntry("entries.read", Long.toString(commits + 2))
         .containsEntry("entries.read.total", Long.toString(commits + 2));
 
     // Verify again
-    try (Stream<ContentIdAndBytes> globals =
-        databaseAdapter.globalContent(new HashSet<>(contentIds))) {
-      assertThat(globals)
-          .hasSize(contentIds.size())
-          .allSatisfy(
-              cb -> assertThat(currentGlobal.get(cb.getContentId())).isEqualTo(cb.getValue()));
+    verify.run();
+
+    // Compact again, compaction must not run, because there is at least one compacted
+    // global-log-entry in the first page (above only added 5 "uncompacted" global-log-entries).
+
+    statistics = databaseAdapter.repoMaintenance();
+
+    assertThat(statistics)
+        .containsKey("compactGlobalLog")
+        .extracting("compactGlobalLog", InstanceOfAssertFactories.map(String.class, String.class))
+        .containsEntry("compacted", "false");
+
+    // Add some more commits, but not enough to trigger compaction
+
+    int additionalCommits = 5;
+    for (int i = 0; i < additionalCommits; i++) {
+      commitForGlobalLogCompaction(
+          commits + additionalCommits,
+          contentReuseProbability,
+          branch,
+          contentIds,
+          rand,
+          currentGlobal,
+          i + commits);
     }
+
+    // Compact again, compaction must not run, because there is at least one compacted
+    // global-log-entry in the first page (above only added 5 "uncompacted" global-log-entries).
+
+    statistics = databaseAdapter.repoMaintenance();
+
+    assertThat(statistics)
+        .containsKey("compactGlobalLog")
+        .extracting("compactGlobalLog", InstanceOfAssertFactories.map(String.class, String.class))
+        .containsEntry("compacted", "false");
+
+    // Add some more commits, enough to trigger compaction again
+
+    int additionalCommits2 = 15;
+    for (int i = 0; i < additionalCommits2; i++) {
+      commitForGlobalLogCompaction(
+          commits + additionalCommits + additionalCommits2,
+          contentReuseProbability,
+          branch,
+          contentIds,
+          rand,
+          currentGlobal,
+          i + commits + additionalCommits);
+    }
+
+    // Compact again, compaction must run, because there is no compacted global-log-entry in the
+    // first page of the global log.
+
+    statistics = databaseAdapter.repoMaintenance();
+
+    assertThat(statistics)
+        .containsKey("compactGlobalLog")
+        .extracting("compactGlobalLog", InstanceOfAssertFactories.map(String.class, String.class))
+        .containsEntry("compacted", "true")
+        .containsEntry("entries.uniquePuts", Long.toString(contentIds.size()));
+
+    // Verify again
+    verify.run();
+  }
+
+  private void commitForGlobalLogCompaction(
+      int commits,
+      double contentReuseProbability,
+      BranchName branch,
+      List<ContentId> contentIds,
+      ThreadLocalRandom rand,
+      Map<ContentId, ByteString> currentGlobal,
+      int i)
+      throws ReferenceConflictException, ReferenceNotFoundException {
+    ContentId contentId;
+    if (contentReuseProbability > rand.nextDouble() && !contentIds.isEmpty()) {
+      contentId = contentIds.get(rand.nextInt(contentIds.size()));
+    } else {
+      contentId = ContentId.of("cid-" + i);
+      contentIds.add(contentId);
+    }
+
+    Key key = Key.of("commit", Integer.toString(i));
+    WithGlobalStateContent c =
+        WithGlobalStateContent.withGlobal(
+            "state for #" + i + " of " + commits,
+            "value for #" + i + " of " + commits,
+            contentId.getId());
+    byte payload = SimpleStoreWorker.INSTANCE.getPayload(c);
+    ByteString global = SimpleStoreWorker.INSTANCE.toStoreGlobalState(c);
+
+    ImmutableCommitAttempt.Builder commit =
+        ImmutableCommitAttempt.builder()
+            .commitToBranch(branch)
+            .commitMetaSerialized(ByteString.copyFromUtf8("commit#" + i))
+            .addPuts(
+                KeyWithBytes.of(
+                    key, contentId, payload, SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)))
+            .putGlobal(contentId, global);
+
+    currentGlobal.put(contentId, global);
+
+    databaseAdapter.commit(commit.build());
   }
 }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
@@ -118,7 +118,8 @@ public abstract class AbstractCompactGlobalLog {
     Map<String, String> compactStats = statistics.get("compactGlobalLog");
 
     assertThat(compactStats)
-        .containsEntry("entries.puts", Long.toString(contentIds.size()))
+        .containsEntry("entries.puts", Long.toString(commits))
+        .containsEntry("entries.uniquePuts", Long.toString(contentIds.size()))
         .containsEntry("entries.read", Long.toString(commits + 2))
         .containsEntry("entries.read.total", Long.toString(commits + 2));
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -102,6 +102,13 @@ public abstract class AbstractDatabaseAdapterTest {
     }
   }
 
+  @Nested
+  public class CompactGlobalLog extends AbstractCompactGlobalLog {
+    CompactGlobalLog() {
+      super(databaseAdapter);
+    }
+  }
+
   @Test
   void createBranch() throws Exception {
     BranchName create = BranchName.of("createBranch");

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -58,6 +58,7 @@ import org.projectnessie.versioned.testworker.WithGlobalStateContent;
 @ExtendWith(DatabaseAdapterExtension.class)
 @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "2048")
 @NessieDbAdapterConfigItem(name = "global.log.entry.size", value = "2048")
+@NessieDbAdapterConfigItem(name = "parents.per.global.commit", value = "20")
 public abstract class AbstractDatabaseAdapterTest {
   @NessieDbAdapter protected static DatabaseAdapter databaseAdapter;
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -58,7 +58,6 @@ import org.projectnessie.versioned.testworker.WithGlobalStateContent;
 @ExtendWith(DatabaseAdapterExtension.class)
 @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "2048")
 @NessieDbAdapterConfigItem(name = "global.log.entry.size", value = "2048")
-@NessieDbAdapterConfigItem(name = "parents.per.global.commit", value = "20")
 public abstract class AbstractDatabaseAdapterTest {
   @NessieDbAdapter protected static DatabaseAdapter databaseAdapter;
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -57,6 +57,7 @@ import org.projectnessie.versioned.testworker.WithGlobalStateContent;
  */
 @ExtendWith(DatabaseAdapterExtension.class)
 @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "2048")
+@NessieDbAdapterConfigItem(name = "global.log.entry.size", value = "2048")
 public abstract class AbstractDatabaseAdapterTest {
   @NessieDbAdapter protected static DatabaseAdapter databaseAdapter;
 

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -85,6 +85,7 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams;
 import org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.spi.Traced;
 import org.projectnessie.versioned.persist.adapter.spi.TryLoopState;
@@ -670,7 +671,8 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  public Map<String, Map<String, String>> repoMaintenance() {
+  public Map<String, Map<String, String>> repoMaintenance(
+      RepoMaintenanceParams repoMaintenanceParams) {
     // Nothing to do
     return Collections.emptyMap();
   }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -669,6 +669,12 @@ public abstract class TxDatabaseAdapter
     }
   }
 
+  @Override
+  public Map<String, Map<String, String>> repoMaintenance() {
+    // Nothing to do
+    return Collections.emptyMap();
+  }
+
   private ContentIdAndBytes globalContentFromRow(ResultSet rs) throws SQLException {
     ContentId cid = ContentId.of(rs.getString(1));
     ByteString value = UnsafeByteOperations.unsafeWrap(rs.getBytes(2));


### PR DESCRIPTION
Compacts global-log-entries, for non-transactional database-adapters.

Every "put operation" for an Iceberg table generates a new entry in the global log. When the "value" for a "content object" (aka the Iceberg table metadata pointer) is retrieved, the implementation searches for the most recent occurrence of the content-ID in the global-log.

This change optimizes the effort to query the global-log by compacting multiple global-log-entries, which was already supported by the data model of the global-log.

This PR does not include a way to trigger global-log compaction, which will be part of a follow-up PR.