### PR TITLE
Remove Serializable from Reference

### DIFF
--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCUtil.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCUtil.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.gc.base;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Spliterator;
@@ -27,10 +29,31 @@ import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.Reference;
 
 public final class GCUtil {
 
   private GCUtil() {}
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  /** Serialize {@link Reference} object using JSON Serialization. */
+  public static String serializeReference(Reference reference) {
+    try {
+      return objectMapper.writeValueAsString(reference);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Deserialize JSON String to {@link Reference} object. */
+  public static Reference deserializeReference(String reference) {
+    try {
+      return objectMapper.readValue(reference, Reference.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   /**
    * Traverse the live commits stream till an entry is seen for each live content key and reached

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.io.Serializable;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -51,7 +50,7 @@ import org.immutables.value.Value;
     })
 @JsonSubTypes({@Type(Branch.class), @Type(Tag.class), @Type(Detached.class)})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-public interface Reference extends Base, Serializable {
+public interface Reference extends Base {
   /** Human-readable reference name. */
   @NotBlank
   @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)


### PR DESCRIPTION
We already have JSON serialization and should rely only on that method for serialization and not use/support Java serialization for the Nessie model.

Also for using these objects with spark dataframe (with java serialization), spark code-gen will fail because these objects don't have public constructor. Adding pubic constructor gives error in Immutables as these classes have validate annotation. 
So, better to remove java serialization for immutables objects and using Immutables built in JSON serialization. 

This partially fixes #3496 