### PR TITLE
Add unique contentId & pass expectedContent when committing

### DIFF
--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchParams.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchParams.scala
@@ -20,7 +20,7 @@ import org.projectnessie.model.IcebergTable
 
 import java.util.concurrent.ThreadLocalRandom
 
-/** Parameters for the [[CommitToBranchSimulation]].
+/** Parameters for the [[CommitToBranchSimulationSameTable]].
   *
   * @param branch
   *   The Nessie branch name to use, the default include the current wall-clock

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
@@ -64,15 +64,15 @@ class CommitToBranchSimulation extends Simulation {
               contentId
             )
 
-          val globalStates = client.getContent.reference(branch).key(key).get()
-          val globalIcebergTable = globalStates.get(key)
+          val existingTable =
+            client.getContent.reference(branch).key(key).get().get(key)
 
           val op =
-            if (commitNum > 0 && globalIcebergTable != null)
+            if (commitNum > 0 && existingTable != null)
               Put.of(
                 key,
                 tableMeta,
-                globalIcebergTable
+                existingTable
               )
             else Put.of(key, tableMeta);
 

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
@@ -64,20 +64,15 @@ class CommitToBranchSimulation extends Simulation {
               contentId
             )
 
-          // TODO the expectedContent is wrong!! commitNum is for the session, but we need the actual global state!!
+          val globalStates = client.getContent.reference(branch).key(key).get()
+          val globalIcebergTable = globalStates.get(key)
+
           val op =
-            if (commitNum > 0)
+            if (commitNum > 0 && globalIcebergTable != null)
               Put.of(
                 key,
                 tableMeta,
-                IcebergTable.of(
-                  s"path_on_disk_${tableName}_${userId}_${commitNum - 1}",
-                  42,
-                  43,
-                  44,
-                  45,
-                  contentId
-                )
+                globalIcebergTable
               )
             else Put.of(key, tableMeta);
 

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
@@ -51,12 +51,12 @@ class CommitToBranchSimulation extends Simulation {
           val tableName = params.makeTableName(session)
 
           // Call the Nessie client operation to perform a commit
-          val key = ContentKey.of("name", "space", tableName, userId.toString)
+          val key = ContentKey.of("name", "space", tableName)
           val contentId = tableName + "_" + userId.toString
 
           val tableMeta = IcebergTable
             .of(
-              s"path_on_disk_${tableName}_${userId}_$commitNum",
+              s"path_on_disk_${tableName}_$commitNum",
               42,
               43,
               44,

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
@@ -51,12 +51,12 @@ class CommitToBranchSimulation extends Simulation {
           val tableName = params.makeTableName(session)
 
           // Call the Nessie client operation to perform a commit
-          val key = ContentKey.of("name", "space", tableName)
-          val contentId = tableName
+          val key = ContentKey.of("name", "space", tableName, userId.toString)
+          val contentId = tableName + "_" + userId.toString
 
           val tableMeta = IcebergTable
             .of(
-              s"path_on_disk_${tableName}_$commitNum",
+              s"path_on_disk_${tableName}_${userId}_$commitNum",
               42,
               43,
               44,
@@ -71,7 +71,7 @@ class CommitToBranchSimulation extends Simulation {
                 key,
                 tableMeta,
                 IcebergTable.of(
-                  s"path_on_disk_${tableName}_${commitNum - 1}",
+                  s"path_on_disk_${tableName}_${userId}_${commitNum - 1}",
                   42,
                   43,
                   44,

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationSameTable.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationSameTable.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration.{FiniteDuration, HOURS, NANOSECONDS, SECONDS}
 /** Gatling simulation to perform commits against Nessie. Has a bunch of
   * configurables, see the `val`s defined at the top of this class.
   */
-class CommitToBranchSimulation extends Simulation {
+class CommitToBranchSimulationSameTable extends Simulation {
 
   val params: CommitToBranchParams = CommitToBranchParams.fromSystemProperties()
 


### PR DESCRIPTION
My current findings:
I've tried to split the state per `user_id` by making the `val contentId = tableName + "_" + userId.toString` containing the `userId`. It reduced number of errors for the `CommitToBranchSimulation` simulation:
<img width="913" alt="Screenshot 2022-03-09 at 12 43 30" src="https://user-images.githubusercontent.com/2332235/157441164-d0ffb587-4a3d-4c14-8a4d-2051da20d946.png">
but there are still situations when the global state is not found/ or conflicts. Is this all we need to do to use the global state, or Am I missing something?

Regarding this comment in the codebase:
```         
// TODO the expectedContent is wrong!! commitNum is for the session, but we need the actual global state!!
```
However, Gatling does not give the possibility to share a state between runs for different sessions, and I think there is a good reason for that. If the `commitNumber` is global, but we have N threads, each inserting data for its own `user_id`, there will be race conditions and conflicts - for that scenario, there is no way that the expected state would match the inserted state.

Also, this test uses mode `BRANCH_PER_USER_SINGLE_TABLE`, so the same table is shared between all threads/users - is it expected? Because of that, the same table name is used for all sessions, and this is yet another place where conflicts occur. I've tried to fix it via making the table more granular: `path_on_disk_${tableName}_${userId}_${commitNum - 1}` but I am not sure if this is what we expect from this benchmark. Without those changes, the conflicts in the global state are also happening:
<img width="894" alt="Screenshot 2022-03-09 at 13 31 53" src="https://user-images.githubusercontent.com/2332235/157442607-3f31db61-0cb6-4482-90ee-b5c1160f7797.png">

Also, one general question to our Gatling tests:
Are they supposed to be run in isolation, or can they be run on the same instance of Nessie? I've noticed that when changing something in test A, test B may start having some errors. Is every test running in the fresh nessie instance, or are they reusing the same Nessie?
(@dimas-b @snazy thoughts?)


**Improvement**
With https://github.com/projectnessie/nessie/pull/3573/commits/433d5eb86598a09ce8bc985785bf852512e08102
I've added usage of a global state that fixes the conflicts. The run results look like this now:
<img width="1155" alt="Screenshot 2022-03-16 at 10 34 50" src="https://user-images.githubusercontent.com/2332235/158560829-bff27b47-5fa1-45de-9988-3a11561ea343.png">
However, the change with the global state only does not solve this problem. We need global state + content-id per user_id that is implemented in this PR


