### PR TITLE
Use os-maven-plugin as extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -789,11 +789,6 @@
           <version>4.1</version>
         </plugin>
         <plugin>
-          <groupId>kr.motd.maven</groupId>
-          <artifactId>os-maven-plugin</artifactId>
-          <version>1.7.0</version>
-        </plugin>
-        <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
           <version>4.5.6</version>
@@ -887,18 +882,6 @@
             <configuration>
               <skipIfEmpty>true</skipIfEmpty>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <goals>
-              <goal>detect</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>
@@ -1237,6 +1220,13 @@ limitations under the License.
         <version>${gatling.maven.version}</version>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.7.0</version>
+      </extension>
+    </extensions>
   </build>
 
   <profiles>


### PR DESCRIPTION
```
This is the recommended way of running and has the benefit of not
running/logging the OS detection for every module.
We only use the `os.detected` properties in the main pom.xml.
```

this is the recommended way of running:
https://github.com/trustin/os-maven-plugin#enabling-os-maven-plugin-on-your-maven-project

running as a plugin is workaround for legacy IDEs:
https://github.com/trustin/os-maven-plugin#issues-with-eclipse-m2e-or-other-ides