### PR TITLE
Validation during atomic commit

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitAttempt.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitAttempt.java
@@ -19,6 +19,7 @@ import com.google.protobuf.ByteString;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Hash;
@@ -68,4 +69,7 @@ public interface CommitAttempt {
 
   /** Serialized commit-metadata. */
   ByteString getCommitMetaSerialized();
+
+  @Nullable
+  Runnable getValidator();
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -167,6 +167,11 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
       throws ReferenceNotFoundException, ReferenceConflictException {
     List<String> mismatches = new ArrayList<>();
 
+    Runnable validator = commitAttempt.getValidator();
+    if (validator != null) {
+      validator.run();
+    }
+
     // verify expected global-states
     checkExpectedGlobalStates(ctx, commitAttempt, mismatches::add);
 

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -90,11 +90,16 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
       @Nonnull BranchName branch,
       @Nonnull Optional<Hash> expectedHead,
       @Nonnull METADATA metadata,
-      @Nonnull List<Operation<CONTENT>> operations)
+      @Nonnull List<Operation<CONTENT>> operations,
+      @Nonnull Runnable validator)
       throws ReferenceNotFoundException, ReferenceConflictException {
 
     ImmutableCommitAttempt.Builder commitAttempt =
-        ImmutableCommitAttempt.builder().commitToBranch(branch).expectedHead(expectedHead);
+        ImmutableCommitAttempt.builder()
+            .commitToBranch(branch)
+            .expectedHead(expectedHead)
+            .commitMetaSerialized(serializeMetadata(metadata))
+            .validator(validator);
 
     for (Operation<CONTENT> operation : operations) {
       if (operation instanceof Put) {
@@ -147,8 +152,6 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
         throw new IllegalArgumentException(String.format("Unknown operation type '%s'", operation));
       }
     }
-
-    commitAttempt.commitMetaSerialized(serializeMetadata(metadata));
 
     return databaseAdapter.commit(commitAttempt.build());
   }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/ConnectionWrapper.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/ConnectionWrapper.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tx;
+
+import java.sql.Connection;
+import java.util.function.Supplier;
+
+public final class ConnectionWrapper implements AutoCloseable {
+  private static final ThreadLocal<ConnectionWrapper> INHERITED = new ThreadLocal<>();
+
+  private final Connection connection;
+  private int useCount;
+
+  public ConnectionWrapper(Connection connection) {
+    this.connection = connection;
+  }
+
+  public static ConnectionWrapper borrow(Supplier<Connection> newConnectionProducer) {
+    ConnectionWrapper current = INHERITED.get();
+    if (current != null) {
+      current.useCount++;
+    } else {
+      current = new ConnectionWrapper(newConnectionProducer.get());
+      INHERITED.set(current);
+    }
+    return current;
+  }
+
+  public Connection conn() {
+    return connection;
+  }
+
+  public void commit() {
+    try {
+      connection.commit();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void rollback() {
+    try {
+      connection.rollback();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (useCount > 0) {
+      useCount--;
+      return;
+    }
+    try {
+      try {
+        connection.rollback();
+      } finally {
+        INHERITED.set(null);
+        connection.close();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -80,10 +80,11 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
       @Nonnull BranchName branch,
       @Nonnull Optional<Hash> referenceHash,
       @Nonnull METADATA metadata,
-      @Nonnull List<Operation<VALUE>> operations)
+      @Nonnull List<Operation<VALUE>> operations,
+      @Nonnull Runnable validator)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return this.<Hash, ReferenceNotFoundException, ReferenceConflictException>delegate2ExR(
-        "commit", () -> delegate.commit(branch, referenceHash, metadata, operations));
+        "commit", () -> delegate.commit(branch, referenceHash, metadata, operations, validator));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -93,7 +93,8 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
       @Nonnull BranchName branch,
       @Nonnull Optional<Hash> referenceHash,
       @Nonnull METADATA metadata,
-      @Nonnull List<Operation<VALUE>> operations)
+      @Nonnull List<Operation<VALUE>> operations,
+      @Nonnull Runnable validator)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return this.<Hash, ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
         "Commit",
@@ -101,7 +102,7 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
             b.withTag(TAG_BRANCH, safeRefName(branch))
                 .withTag(TAG_HASH, safeToString(referenceHash))
                 .withTag(TAG_NUM_OPS, safeSize(operations)),
-        () -> delegate.commit(branch, referenceHash, metadata, operations));
+        () -> delegate.commit(branch, referenceHash, metadata, operations, validator));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -75,6 +75,8 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    *     not perform conflict detection
    * @param metadata The metadata associated with the commit.
    * @param operations The set of operations to apply.
+   * @param validator Gets called during the atomic commit operations, callers can implement
+   *     validation logic.
    * @throws ReferenceConflictException if {@code referenceHash} values do not match the stored
    *     values for {@code branch}
    * @throws ReferenceNotFoundException if {@code branch} is not present in the store
@@ -84,8 +86,18 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
       @Nonnull BranchName branch,
       @Nonnull Optional<Hash> referenceHash,
       @Nonnull METADATA metadata,
-      @Nonnull List<Operation<VALUE>> operations)
+      @Nonnull List<Operation<VALUE>> operations,
+      @Nonnull Runnable validator)
       throws ReferenceNotFoundException, ReferenceConflictException;
+
+  default Hash commit(
+      @Nonnull BranchName branch,
+      @Nonnull Optional<Hash> referenceHash,
+      @Nonnull METADATA metadata,
+      @Nonnull List<Operation<VALUE>> operations)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    return commit(branch, referenceHash, metadata, operations, () -> {});
+  }
 
   /**
    * Transplant a series of commits to a target branch.

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -110,7 +110,8 @@ class TestMetricsVersionStore {
                         BranchName.of("mock-branch"),
                         Optional.empty(),
                         "metadata",
-                        Collections.emptyList()),
+                        Collections.emptyList(),
+                        () -> {}),
                 () -> Hash.of("cafebabedeadbeef"),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -99,7 +99,8 @@ class TestTracingVersionStore {
                                 BranchName.of("mock-branch"),
                                 Optional.empty(),
                                 "metadata",
-                                Collections.emptyList()),
+                                Collections.emptyList(),
+                                () -> {}),
                         () -> Hash.of("deadbeefcafebabe")),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Transplant", refNotFoundAndRefConflictThrows)


### PR DESCRIPTION
PR #3572 performs some validations, which need to happen inside the atomic-CAS (or transaction) of a Nessie commit.

This change allows a callback from within the CAS/Op-loop so that the caller can perform atomic validations.

Lots of changes in `TxDatabaseAdapter`, but those are "boring changes". The change to `TxDatabaseAdapter` is to let "nested" operations (aka commit -> validation -> validations performing reads via the version store) use the same JDBC connection/transaction, which required the `ConnectionWrapper` class.