### PR TITLE
`AbstractDatabaseAdapter.fetchValues()` looking for non-existing keys

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1116,7 +1116,31 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
     Set<ContentId> contentIdsForGlobal = new HashSet<>();
     try (Stream<CommitLogEntry> log =
         takeUntilExcludeLast(readCommitLogStream(ctx, refHead), e -> remainingKeys.isEmpty())) {
-      log.peek(entry -> entry.getDeletes().forEach(remainingKeys::remove))
+      log.peek(
+              entry -> {
+                // remove deleted keys from keys to look for
+                entry.getDeletes().forEach(remainingKeys::remove);
+
+                if (entry.getKeyList() != null) {
+                  // CommitLogEntry has a KeyList.
+                  // All keys in 'remainingKeys', that are _not_ in the KeyList(s), can be removed,
+                  // because at this point we know that these do not exist.
+
+                  Set<Key> remainingInKeyList = new HashSet<>();
+                  try (Stream<KeyList> keyLists =
+                      Stream.concat(
+                          Stream.of(entry.getKeyList()),
+                          fetchKeyLists(ctx, entry.getKeyListsIds()).map(KeyListEntity::getKeys))) {
+                    keyLists
+                        .flatMap(kl -> kl.getKeys().stream())
+                        .map(KeyWithType::getKey)
+                        .filter(remainingKeys::contains)
+                        .forEach(remainingInKeyList::add);
+                  }
+
+                  remainingKeys.retainAll(remainingInKeyList);
+                }
+              })
           .flatMap(entry -> entry.getPuts().stream())
           .filter(put -> remainingKeys.remove(put.getKey()))
           .filter(put -> keyFilter.check(put.getKey(), put.getContentId(), put.getType()))

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1191,6 +1191,9 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
       OP_CONTEXT ctx, Set<ContentId> contentIds) throws ReferenceNotFoundException;
 
   protected final Stream<KeyListEntity> fetchKeyLists(OP_CONTEXT ctx, List<Hash> keyListsIds) {
+    if (keyListsIds.isEmpty()) {
+      return Stream.empty();
+    }
     try (Traced ignore = trace("fetchKeyLists").tag(TAG_COUNT, keyListsIds.size())) {
       return doFetchKeyLists(ctx, keyListsIds);
     }


### PR DESCRIPTION
A `ContentApi.getContents()` with keys that do not exist leads into
traversing the whole commit log.

The current code in `AbstractDatabaseAdapter.fetchValues()` is optimized to stop
traversing the commit log while looking for content-values when the values for
all requested keys have been found.

In turn this means that the commit-log-traversal will look into _every_ commit
for keys that do not exist.

It's is rather easy to prevent that unnecessary whole-commit-log-traversal for
non-existing keys: Every 20th (by default) commit contains the whole key-lists,
so all visible (think: existing + undeleted) keys. The set of all keys can be
inspected to stop looking for keys that are known to not exist.

While it sounds like a minor optimization, it's in fact a rather big one.