### PR TITLE
Record commit-id in key-lists

### DIFF
--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
@@ -65,6 +65,8 @@ import org.projectnessie.tools.compatibility.api.NessieVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.api.VersionCondition;
 import org.projectnessie.tools.compatibility.internal.NessieUpgradesExtension;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 
 @ExtendWith(NessieUpgradesExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -225,7 +227,11 @@ public class ITUpgradePath {
       new LinkedHashMap<>();
   private static int keysUpgradeSequence;
   // exceed both number-of-parents per commit-log-entry and per global-log-entry
-  private static final int keysUpgradeCommitsPerVersion = 65;
+  private static final int keysUpgradeCommitsPerVersion =
+      Math.max(
+              NonTransactionalDatabaseAdapterConfig.DEFAULT_PARENTS_PER_GLOBAL_COMMIT,
+              DatabaseAdapterConfig.DEFAULT_PARENTS_PER_COMMIT)
+          + 15;
 
   @Test
   @Order(201)

--- a/compatibility/compatibility-tests/src/test/resources/META-INF/nessie-compatibility.properties
+++ b/compatibility/compatibility-tests/src/test/resources/META-INF/nessie-compatibility.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-nessie.versions=0.15.0,0.18.0,0.19.0,0.20.1,current
+nessie.versions=0.15.0,0.18.0,0.19.0,0.20.1,0.21.2,current

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -121,7 +121,7 @@ public interface DatabaseAdapter {
    * @return Ordered stream with content-keys, content-ids and content-types
    * @throws ReferenceNotFoundException if {@code commit} does not exist.
    */
-  Stream<KeyWithType> keys(Hash commit, KeyFilterPredicate keyFilter)
+  Stream<KeyListEntry> keys(Hash commit, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException;
 
   /**

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
@@ -24,9 +24,9 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 public interface KeyList {
-  List<KeyWithType> getKeys();
+  List<KeyListEntry> getKeys();
 
-  static KeyList of(List<KeyWithType> keys) {
+  static KeyList of(List<KeyListEntry> keys) {
     return ImmutableKeyList.builder().keys(keys).build();
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntry.java
@@ -15,19 +15,29 @@
  */
 package org.projectnessie.versioned.persist.adapter;
 
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
+import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 
 /** Composite of key, content-id, content-type. */
 @Value.Immutable(lazyhash = true) // this type is used as a map-key in an expensive test
-public interface KeyWithType {
+public interface KeyListEntry {
   Key getKey();
 
   ContentId getContentId();
 
   byte getType();
 
-  static KeyWithType of(Key key, ContentId contentId, byte type) {
-    return ImmutableKeyWithType.builder().key(key).type(type).contentId(contentId).build();
+  @Nullable
+  Hash getCommitId();
+
+  static KeyListEntry of(Key key, ContentId contentId, byte type, Hash commitId) {
+    ImmutableKeyListEntry.Builder builder =
+        ImmutableKeyListEntry.builder().key(key).type(type).contentId(contentId);
+    if (commitId != null) {
+      builder.commitId(commitId);
+    }
+    return builder.build();
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntry.java
@@ -20,7 +20,7 @@ import org.immutables.value.Value;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 
-/** Composite of key, content-id, content-type. */
+/** Composite of key, content-id, content-type and commit-id. */
 @Value.Immutable(lazyhash = true) // this type is used as a map-key in an expensive test
 public interface KeyListEntry {
   Key getKey();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyWithBytes.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyWithBytes.java
@@ -38,8 +38,4 @@ public interface KeyWithBytes {
         .value(value)
         .build();
   }
-
-  default KeyWithType asKeyWithType() {
-    return KeyWithType.of(getKey(), getContentId(), getType());
-  }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -84,8 +84,8 @@ import org.projectnessie.versioned.persist.adapter.ImmutableKeyList;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 
 /**
@@ -381,10 +381,10 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
     // TODO this implementation works, but is definitely not the most efficient one.
 
     Set<Key> allKeys = new HashSet<>();
-    try (Stream<Key> s = keysForCommitEntry(ctx, from, keyFilter).map(KeyWithType::getKey)) {
+    try (Stream<Key> s = keysForCommitEntry(ctx, from, keyFilter).map(KeyListEntry::getKey)) {
       s.forEach(allKeys::add);
     }
-    try (Stream<Key> s = keysForCommitEntry(ctx, to, keyFilter).map(KeyWithType::getKey)) {
+    try (Stream<Key> s = keysForCommitEntry(ctx, to, keyFilter).map(KeyListEntry::getKey)) {
       s.forEach(allKeys::add);
     }
 
@@ -922,14 +922,14 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
       currentKeyList = ImmutableKeyList.builder();
     }
 
-    void addToKeyListEntity(KeyWithType keyWithType, int keyTypeSize) {
+    void addToKeyListEntity(KeyListEntry keyListEntry, int keyTypeSize) {
       currentSize += keyTypeSize;
-      currentKeyList.addKeys(keyWithType);
+      currentKeyList.addKeys(keyListEntry);
     }
 
-    void addToEmbedded(KeyWithType keyWithType, int keyTypeSize) {
+    void addToEmbedded(KeyListEntry keyListEntry, int keyTypeSize) {
       currentSize += keyTypeSize;
-      embeddedBuilder.addKeys(keyWithType);
+      embeddedBuilder.addKeys(keyListEntry);
     }
   }
 
@@ -1018,7 +1018,7 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
   protected abstract int entitySize(CommitLogEntry entry);
 
   /** Calculate the expected size of the given {@link CommitLogEntry} in the database. */
-  protected abstract int entitySize(KeyWithType entry);
+  protected abstract int entitySize(KeyListEntry entry);
 
   /**
    * If the current HEAD of the target branch for a commit/transplant/merge is not equal to the
@@ -1054,14 +1054,14 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
   }
 
   /** Retrieve the content-keys and their types for the commit-log-entry with the given hash. */
-  protected Stream<KeyWithType> keysForCommitEntry(
+  protected Stream<KeyListEntry> keysForCommitEntry(
       OP_CONTEXT ctx, Hash hash, KeyFilterPredicate keyFilter) throws ReferenceNotFoundException {
     return keysForCommitEntry(ctx, hash, NO_IN_MEMORY_COMMITS)
         .filter(kt -> keyFilter.check(kt.getKey(), kt.getContentId(), kt.getType()));
   }
 
   /** Retrieve the content-keys and their types for the commit-log-entry with the given hash. */
-  protected Stream<KeyWithType> keysForCommitEntry(
+  protected Stream<KeyListEntry> keysForCommitEntry(
       OP_CONTEXT ctx, Hash hash, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
     // walk the commit-logs in reverse order - starting with the last persisted key-list
@@ -1076,15 +1076,18 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
           seen.addAll(e.getDeletes());
 
           // Return from CommitLogEntry.puts first
-          Stream<KeyWithType> stream =
+          Stream<KeyListEntry> stream =
               e.getPuts().stream()
-                  .filter(kt -> seen.add(kt.getKey()))
-                  .map(KeyWithBytes::asKeyWithType);
+                  .filter(put -> seen.add(put.getKey()))
+                  .map(
+                      put ->
+                          KeyListEntry.of(
+                              put.getKey(), put.getContentId(), put.getType(), e.getHash()));
 
           if (e.getKeyList() != null) {
 
             // Return from CommitLogEntry.keyList after the keys in CommitLogEntry.puts
-            Stream<KeyWithType> embedded =
+            Stream<KeyListEntry> embedded =
                 e.getKeyList().getKeys().stream().filter(kt -> seen.add(kt.getKey()));
 
             stream = Stream.concat(stream, embedded);
@@ -1098,8 +1101,8 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
                       Stream.of(e.getKeyListsIds())
                           .flatMap(ids -> fetchKeyLists(ctx, ids))
                           .map(KeyListEntity::getKeys)
-                          .flatMap(k -> k.getKeys().stream())
-                          .filter(kt -> seen.add(kt.getKey())));
+                          .flatMap(keyList -> keyList.getKeys().stream())
+                          .filter(keyListEntry -> seen.add(keyListEntry.getKey())));
             }
           }
 
@@ -1119,52 +1122,91 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
     Map<Key, ByteString> nonGlobal = new HashMap<>();
     Map<Key, ContentId> keyToContentIds = new HashMap<>();
     Set<ContentId> contentIdsForGlobal = new HashSet<>();
+
+    Consumer<CommitLogEntry> commitLogEntryHandler =
+        entry -> {
+          // remove deleted keys from keys to look for
+          entry.getDeletes().forEach(remainingKeys::remove);
+
+          // handle put operations
+          for (KeyWithBytes put : entry.getPuts()) {
+            if (!remainingKeys.remove(put.getKey())) {
+              continue;
+            }
+
+            if (!keyFilter.check(put.getKey(), put.getContentId(), put.getType())) {
+              continue;
+            }
+            nonGlobal.put(put.getKey(), put.getValue());
+            keyToContentIds.put(put.getKey(), put.getContentId());
+            ContentVariant contentVariant = contentVariantSupplier.getContentVariant(put.getType());
+            switch (contentVariant) {
+              case ON_REF:
+                break;
+              case WITH_GLOBAL:
+                contentIdsForGlobal.add(put.getContentId());
+                break;
+              default:
+                throw new IllegalStateException("Unknown content variant " + contentVariant);
+            }
+          }
+        };
+
+    // The algorithm is a bit complex, but not horribly complex.
+    //
+    // The commit-log `Stream` in the following try-with-resources fetches the commit-log until
+    // all requested keys have been seen.
+    //
+    // When a commit-log-entry with key-lists is encountered, use the key-lists to determine if
+    // and how the remaining keys need to be retrieved.
+    // - If any of the requested keys is not in the key-lists, ignore it - it doesn't exist.
+    // - If the `KeyListEntry` for a requested key contains the commit-ID, use the commit-ID to
+    //   directly access the commit that contains the `Put` operation for that key.
+    //
+    // Both the "outer" `Stream` and the result of the latter case (list of commit-log-entries)
+    // share common functionality implemented in the function `commitLogEntryHandler`, which
+    // handles the 'Put` operations.
+
     try (Stream<CommitLogEntry> log =
         takeUntilExcludeLast(readCommitLogStream(ctx, refHead), e -> remainingKeys.isEmpty())) {
-      log.peek(
-              entry -> {
-                // remove deleted keys from keys to look for
-                entry.getDeletes().forEach(remainingKeys::remove);
+      log.forEach(
+          entry -> {
+            commitLogEntryHandler.accept(entry);
 
-                if (entry.getKeyList() != null) {
-                  // CommitLogEntry has a KeyList.
-                  // All keys in 'remainingKeys', that are _not_ in the KeyList(s), can be removed,
-                  // because at this point we know that these do not exist.
+            if (entry.getKeyList() != null) {
+              // CommitLogEntry has a KeyList.
+              // All keys in 'remainingKeys', that are _not_ in the KeyList(s), can be removed,
+              // because at this point we know that these do not exist.
 
-                  Set<Key> remainingInKeyList = new HashSet<>();
-                  try (Stream<KeyList> keyLists =
-                      Stream.concat(
-                          Stream.of(entry.getKeyList()),
-                          fetchKeyLists(ctx, entry.getKeyListsIds()).map(KeyListEntity::getKeys))) {
-                    keyLists
-                        .flatMap(kl -> kl.getKeys().stream())
-                        .map(KeyWithType::getKey)
-                        .filter(remainingKeys::contains)
-                        .forEach(remainingInKeyList::add);
-                  }
+              Set<KeyListEntry> remainingInKeyList = new HashSet<>();
+              try (Stream<KeyList> keyLists =
+                  Stream.concat(
+                      Stream.of(entry.getKeyList()),
+                      fetchKeyLists(ctx, entry.getKeyListsIds()).map(KeyListEntity::getKeys))) {
+                keyLists
+                    .flatMap(keyList -> keyList.getKeys().stream())
+                    .filter(keyListEntry -> remainingKeys.contains(keyListEntry.getKey()))
+                    .forEach(remainingInKeyList::add);
+              }
 
-                  remainingKeys.retainAll(remainingInKeyList);
-                }
-              })
-          .flatMap(entry -> entry.getPuts().stream())
-          .filter(put -> remainingKeys.remove(put.getKey()))
-          .filter(put -> keyFilter.check(put.getKey(), put.getContentId(), put.getType()))
-          .forEach(
-              put -> {
-                nonGlobal.put(put.getKey(), put.getValue());
-                keyToContentIds.put(put.getKey(), put.getContentId());
-                ContentVariant contentVariant =
-                    contentVariantSupplier.getContentVariant(put.getType());
-                switch (contentVariant) {
-                  case ON_REF:
-                    break;
-                  case WITH_GLOBAL:
-                    contentIdsForGlobal.add(put.getContentId());
-                    break;
-                  default:
-                    throw new IllegalStateException("Unknown content variant " + contentVariant);
-                }
-              });
+              if (!remainingInKeyList.isEmpty()) {
+                List<CommitLogEntry> commitLogEntries =
+                    fetchMultipleFromCommitLog(
+                        ctx,
+                        remainingInKeyList.stream()
+                            .map(KeyListEntry::getCommitId)
+                            .filter(Objects::nonNull)
+                            .distinct()
+                            .collect(Collectors.toList()));
+                commitLogEntries.forEach(commitLogEntryHandler);
+              }
+
+              remainingKeys.retainAll(
+                  remainingInKeyList.stream()
+                      .map(KeyListEntry::getKey)
+                      .collect(Collectors.toSet()));
+            }
+          });
     }
 
     Map<ContentId, ByteString> globals = fetchGlobalStates(ctx, contentIdsForGlobal);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -43,7 +43,7 @@ import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams;
@@ -107,7 +107,7 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   }
 
   @Override
-  public Stream<KeyWithType> keys(Hash commit, KeyFilterPredicate keyFilter)
+  public Stream<KeyListEntry> keys(Hash commit, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
     try (Traced ignore = trace("keys.stream").tag(TAG_HASH, commit.asString())) {
       return delegate.keys(commit, keyFilter);

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -47,7 +47,7 @@ import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
@@ -392,7 +392,7 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  protected int entitySize(KeyWithType entry) {
+  protected int entitySize(KeyListEntry entry) {
     return toProto(entry).getSerializedSize();
   }
 

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -34,7 +34,7 @@ import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
@@ -231,7 +231,7 @@ public class InmemoryDatabaseAdapter
   }
 
   @Override
-  protected int entitySize(KeyWithType entry) {
+  protected int entitySize(KeyListEntry entry) {
     return toProto(entry).getSerializedSize();
   }
 

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -47,7 +47,7 @@ import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil;
@@ -339,7 +339,7 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected int entitySize(KeyWithType entry) {
+  protected int entitySize(KeyListEntry entry) {
     return toProto(entry).getSerializedSize();
   }
 

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -76,7 +76,7 @@ import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.GlobalLogCompactionParams;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams;
@@ -184,7 +184,7 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   @Override
-  public Stream<KeyWithType> keys(Hash commit, KeyFilterPredicate keyFilter)
+  public Stream<KeyListEntry> keys(Hash commit, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
     return keysForCommitEntry(NON_TRANSACTIONAL_OPERATION_CONTEXT, commit, keyFilter);
   }

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -40,7 +40,7 @@ import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
@@ -404,7 +404,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected int entitySize(KeyWithType entry) {
+  protected int entitySize(KeyListEntry entry) {
     return toProto(entry).getSerializedSize();
   }
 

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -28,19 +28,13 @@ message CommitLogEntry {
   repeated KeyWithBytes puts = 5;
   repeated Key deletes = 6;
   int32 key_list_distance = 7;
-  repeated KeyWithType key_list = 8;
+  repeated KeyListEntry key_list = 8;
   repeated bytes key_list_ids = 9;
   int64 commitSeq = 10;
 }
 
 message Key {
   repeated string element = 1;
-}
-
-message KeyWithType {
-  Key key = 1;
-  ContentId content_id = 2;
-  int32 type = 3;
 }
 
 message KeyWithBytes {
@@ -51,7 +45,14 @@ message KeyWithBytes {
 }
 
 message KeyList {
-  repeated KeyWithType keys = 1;
+  repeated KeyListEntry keys = 1;
+}
+
+message KeyListEntry {
+  Key key = 1;
+  ContentId content_id = 2;
+  int32 type = 3;
+  optional bytes commit_id = 4;
 }
 
 message ContentId {

--- a/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/serialize/TestSerialization.java
+++ b/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/serialize/TestSerialization.java
@@ -46,8 +46,8 @@ import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.ImmutableRepoDescription;
 import org.projectnessie.versioned.persist.adapter.ImmutableRepoDescription.Builder;
 import org.projectnessie.versioned.persist.adapter.KeyList;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
@@ -296,20 +296,21 @@ class TestSerialization {
             }));
     params.add(
         new TypeSerialization<>(
-            KeyWithType.class,
-            AdapterTypes.KeyWithType.class,
-            TestSerialization::createKeyWithType,
+            KeyListEntry.class,
+            AdapterTypes.KeyListEntry.class,
+            TestSerialization::createKeyListEntry,
             ProtoSerialization::toProto,
             v -> {
               try {
-                return AdapterTypes.KeyWithType.parseFrom(v);
+                return AdapterTypes.KeyListEntry.parseFrom(v);
               } catch (InvalidProtocolBufferException e) {
                 throw new RuntimeException(e);
               }
             },
             v -> {
               try {
-                return ProtoSerialization.protoToKeyWithType(AdapterTypes.KeyWithType.parseFrom(v));
+                return ProtoSerialization.protoToKeyListEntry(
+                    AdapterTypes.KeyListEntry.parseFrom(v));
               } catch (InvalidProtocolBufferException e) {
                 throw new RuntimeException(e);
               }
@@ -467,17 +468,9 @@ class TestSerialization {
         42,
         KeyList.of(
             IntStream.range(0, 20)
-                .mapToObj(
-                    i -> KeyWithType.of(randomKey(), ContentId.of(randomString(60)), (byte) 0))
+                .mapToObj(i -> createKeyListEntry())
                 .collect(Collectors.toList())),
         IntStream.range(0, 20).mapToObj(i -> randomHash()).collect(Collectors.toList()));
-  }
-
-  static KeyWithType createKeyWithType() {
-    return KeyWithType.of(
-        randomKey(),
-        ContentId.of(randomString(64)),
-        (byte) ThreadLocalRandom.current().nextInt(0, 127));
   }
 
   static KeyWithBytes createKeyWithBytes() {
@@ -486,6 +479,14 @@ class TestSerialization {
         ContentId.of(randomString(64)),
         (byte) ThreadLocalRandom.current().nextInt(0, 127),
         randomBytes(120));
+  }
+
+  static KeyListEntry createKeyListEntry() {
+    return KeyListEntry.of(
+        randomKey(),
+        ContentId.of(randomString(64)),
+        (byte) ThreadLocalRandom.current().nextInt(0, 127),
+        ThreadLocalRandom.current().nextBoolean() ? randomHash() : null);
   }
 
   static ContentId createContentId() {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
@@ -45,8 +45,8 @@ import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.testworker.BaseContent;
 import org.projectnessie.versioned.testworker.OnRefOnly;
 import org.projectnessie.versioned.testworker.SimpleStoreWorker;
@@ -260,7 +260,9 @@ public abstract class AbstractCommitScenarios {
         renameCommitVerify(
             Stream.concat(Stream.of(hashInitial), beforeRename.stream()),
             expectedCommitCount,
-            keys -> assertThat(keys).containsExactly(KeyWithType.of(oldKey, contentId, payload)));
+            keys ->
+                assertThat(keys)
+                    .containsExactly(KeyListEntry.of(oldKey, contentId, payload, hashInitial)));
 
     // Verify that the commits since the rename-operation and before the delete-operation return the
     // _new_ key
@@ -268,7 +270,9 @@ public abstract class AbstractCommitScenarios {
         renameCommitVerify(
             Stream.concat(Stream.of(hashRename), beforeDelete.stream()),
             expectedCommitCount,
-            keys -> assertThat(keys).containsExactly(KeyWithType.of(newKey, contentId, payload)));
+            keys ->
+                assertThat(keys)
+                    .containsExactly(KeyListEntry.of(newKey, contentId, payload, hashRename)));
 
     // Verify that the commits since the delete-operation return _no_ keys
     expectedCommitCount =
@@ -289,10 +293,10 @@ public abstract class AbstractCommitScenarios {
   }
 
   private int renameCommitVerify(
-      Stream<Hash> hashes, int expectedCommitCount, Consumer<Stream<KeyWithType>> keysStreamAssert)
+      Stream<Hash> hashes, int expectedCommitCount, Consumer<Stream<KeyListEntry>> keysStreamAssert)
       throws Exception {
     for (Hash hash : hashes.collect(Collectors.toList())) {
-      try (Stream<KeyWithType> keys = databaseAdapter.keys(hash, KeyFilterPredicate.ALLOW_ALL)) {
+      try (Stream<KeyListEntry> keys = databaseAdapter.keys(hash, KeyFilterPredicate.ALLOW_ALL)) {
         keysStreamAssert.accept(keys);
       }
       try (Stream<CommitLogEntry> log = databaseAdapter.commitLog(hash)) {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGlobalStates.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGlobalStates.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.protobuf.ByteString;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -44,7 +43,6 @@ import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
 
 /**
  * Verifies handling of global-states in the database-adapters using various combinations of number
@@ -184,7 +182,6 @@ public abstract class AbstractGlobalStates {
     Set<ContentId> usedContentIds = new HashSet<>();
 
     Map<ContentId, ByteString> expectedGlobalStates = new HashMap<>();
-    Map<KeyWithType, List<ByteString>> expectedContents = new HashMap<>();
 
     for (int commit = 0; commit < param.commitsPerBranch; commit++) {
       for (BranchName branch : branches) {
@@ -211,10 +208,6 @@ public abstract class AbstractGlobalStates {
                 .addPuts(KeyWithBytes.of(key, contentId, (byte) 0, put));
 
             expectedGlobalStates.put(contentId, global);
-
-            expectedContents
-                .computeIfAbsent(KeyWithType.of(key, contentId, (byte) 0), k -> new ArrayList<>())
-                .add(put);
 
             usedContentIds.add(contentId);
             currentStates.put(contentId, global);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
@@ -41,8 +41,8 @@ import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
 import org.projectnessie.versioned.testworker.SimpleStoreWorker;
 import org.projectnessie.versioned.testworker.WithGlobalStateContent;
 
@@ -166,8 +166,8 @@ public abstract class AbstractManyCommits {
       throw new RuntimeException(e);
     }
 
-    try (Stream<KeyWithType> keys = databaseAdapter.keys(commit, KeyFilterPredicate.ALLOW_ALL)) {
-      assertThat(keys.map(KeyWithType::getKey)).containsExactly(key);
+    try (Stream<KeyListEntry> keys = databaseAdapter.keys(commit, KeyFilterPredicate.ALLOW_ALL)) {
+      assertThat(keys.map(KeyListEntry::getKey)).containsExactly(key);
     } catch (ReferenceNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -36,8 +36,8 @@ import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
 
 /**
  * Verifies that a big-ish number of keys, split across multiple commits works and the correct
@@ -119,8 +119,8 @@ public abstract class AbstractManyKeys {
     }
 
     Hash mainHead = databaseAdapter.hashOnReference(main, Optional.empty());
-    try (Stream<KeyWithType> keys = databaseAdapter.keys(mainHead, KeyFilterPredicate.ALLOW_ALL)) {
-      List<Key> fetchedKeys = keys.map(KeyWithType::getKey).collect(Collectors.toList());
+    try (Stream<KeyListEntry> keys = databaseAdapter.keys(mainHead, KeyFilterPredicate.ALLOW_ALL)) {
+      List<Key> fetchedKeys = keys.map(KeyListEntry::getKey).collect(Collectors.toList());
 
       // containsExactlyInAnyOrderElementsOf() is quite expensive and slow with Key's
       // implementation of 'Key.equals()' since it uses a collator.

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -82,7 +82,7 @@ import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
-import org.projectnessie.versioned.persist.adapter.KeyWithType;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams;
@@ -202,12 +202,12 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  public Stream<KeyWithType> keys(Hash commit, KeyFilterPredicate keyFilter)
+  public Stream<KeyListEntry> keys(Hash commit, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
     ConnectionWrapper conn = borrowConnection();
     boolean failed = true;
     try {
-      Stream<KeyWithType> r = keysForCommitEntry(conn, commit, keyFilter);
+      Stream<KeyListEntry> r = keysForCommitEntry(conn, commit, keyFilter);
       failed = false;
       return r.onClose(conn::close);
     } finally {
@@ -701,7 +701,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  protected int entitySize(KeyWithType entry) {
+  protected int entitySize(KeyListEntry entry) {
     return toProto(entry).getSerializedSize();
   }
 


### PR DESCRIPTION
Fetching content values can become expensive as fetching the value from a
`Put` opartion may require reading a lot of commit-log-entries, the more
commit-log-entries the older the content.

This change adds the commit-id of the last `Put` operation to the already
existing entries in `KeyList`, which allows `DatabaseAdapter.fetchValues`
to quickly "navigate" to the commits that contain the most recent `Put`
operation that contains the content value for the requested content key.

Time/resource complexity for existing keys is reduced from "number of
commit log entries from HEAD to last Put operation" to at max two
bulk-fetch operations against the commit-log.

Updates & renames the type `KeyWithType` to `KeyListEntry`, adds the
commit-id to `KeyListEntry`.

This is not a breaking change and requires no data migration. Upgrade
tests are included. Although not tested, and therefore not guaranteed,
this change should also be safe to use during a rolling-upgrade.

Fixes #3591