### PR TITLE
Use Kryo serialization for Spark processing

### DIFF
--- a/gc/gc-base/pom.xml
+++ b/gc/gc-base/pom.xml
@@ -41,6 +41,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!--- We cannot use version > 0.43 beacuse it uses a kryo version 5.x that is incompatible with out spark (requires 4.x) -->
+    <dependency>
+      <groupId>de.javakaffee</groupId>
+      <artifactId>kryo-serializers</artifactId>
+      <version>0.43</version>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>

--- a/gc/gc-base/pom.xml
+++ b/gc/gc-base/pom.xml
@@ -29,6 +29,11 @@
 
   <name>Nessie - GC - Base Implementation</name>
 
+  <properties>
+    <!--- We cannot use version > 0.43 beacuse it uses a kryo version 5.x that is incompatible with out spark (requires 4.x) -->
+    <kryo.serializers.version>0.43</kryo.serializers.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.immutables</groupId>
@@ -41,11 +46,10 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <!--- We cannot use version > 0.43 beacuse it uses a kryo version 5.x that is incompatible with out spark (requires 4.x) -->
     <dependency>
       <groupId>de.javakaffee</groupId>
       <artifactId>kryo-serializers</artifactId>
-      <version>0.43</version>
+      <version>${kryo.serializers.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/gc/gc-base/pom.xml
+++ b/gc/gc-base/pom.xml
@@ -29,11 +29,6 @@
 
   <name>Nessie - GC - Base Implementation</name>
 
-  <properties>
-    <!--- We cannot use version > 0.43 beacuse it uses a kryo version 5.x that is incompatible with out spark (requires 4.x) -->
-    <kryo.serializers.version>0.43</kryo.serializers.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.immutables</groupId>
@@ -49,7 +44,6 @@
     <dependency>
       <groupId>de.javakaffee</groupId>
       <artifactId>kryo-serializers</artifactId>
-      <version>${kryo.serializers.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/ContentBloomFilter.java
@@ -43,6 +43,11 @@ public class ContentBloomFilter implements Serializable {
             Funnels.stringFunnel(StandardCharsets.UTF_8), expectedEntries, bloomFilterFpp);
   }
 
+  public ContentBloomFilter(boolean wasMerged, BloomFilter<String> filter) {
+    this.wasMerged = wasMerged;
+    this.filter = filter;
+  }
+
   public void put(Content content) {
     filter.put(getValue(content));
   }
@@ -80,5 +85,9 @@ public class ContentBloomFilter implements Serializable {
       default:
         throw new RuntimeException("Unsupported type " + content.getType());
     }
+  }
+
+  public BloomFilter<String> getFilter() {
+    return filter;
   }
 }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/DistributedIdentifyContents.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/DistributedIdentifyContents.java
@@ -41,7 +41,6 @@ public class DistributedIdentifyContents {
    * @param droppedRefTimeMap map of dropped time for reference@hash
    * @return map of {@link ContentBloomFilter} per content-id.
    */
-  // here
   public static Map<String, ContentBloomFilter> getLiveContentsBloomFilters(
       List<Reference> references,
       long bloomFilterSize,
@@ -68,7 +67,6 @@ public class DistributedIdentifyContents {
    * @param references list of all the references to walk (live and dead)
    * @return {@link IdentifiedResult} object.
    */
-  // here
   public static IdentifiedResult getIdentifiedResults(
       Map<String, ContentBloomFilter> liveContentsBloomFilterMap,
       List<Reference> references,

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
@@ -16,12 +16,12 @@
 package org.projectnessie.gc.base;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.spark.sql.SparkSession;
 import org.projectnessie.api.params.FetchOption;
@@ -100,12 +100,8 @@ public class GCImpl {
       DistributedIdentifyContents distributedIdentifyContents =
           new DistributedIdentifyContents(session, gcParams);
       List<Reference> liveReferences = api.getAllReferences().get().getReferences();
-      Map<String, Instant> droppedReferenceTimeMap = collectDeadReferences(api);
-      // As this list of references is passed from Spark driver to executor,
-      // using available Immutables JSON serialization instead of adding java serialization to the
-      // classes.
-      List<String> allRefs =
-          liveReferences.stream().map(GCUtil::serializeReference).collect(Collectors.toList());
+      Map<Reference, Instant> droppedReferenceTimeMap = collectDeadReferences(api);
+      List<Reference> allRefs = new ArrayList<>(liveReferences);
       if (droppedReferenceTimeMap.size() > 0) {
         allRefs.addAll(droppedReferenceTimeMap.keySet());
       }
@@ -138,8 +134,8 @@ public class GCImpl {
     return defaultRefMetadata.getNumTotalCommits();
   }
 
-  private static Map<String, Instant> collectDeadReferences(NessieApiV1 api) {
-    Map<String, Instant> droppedReferenceTimeMap = new HashMap<>();
+  private static Map<Reference, Instant> collectDeadReferences(NessieApiV1 api) {
+    Map<Reference, Instant> droppedReferenceTimeMap = new HashMap<>();
     Stream<RefLogResponse.RefLogResponseEntry> reflogStream;
     try {
       reflogStream =
@@ -172,13 +168,12 @@ public class GCImpl {
           switch (entry.getRefType()) {
             case RefLogResponse.RefLogResponseEntry.BRANCH:
               droppedReferenceTimeMap.put(
-                  GCUtil.serializeReference(Branch.of(entry.getRefName(), hash)),
+                  Branch.of(entry.getRefName(), hash),
                   getInstantFromMicros(entry.getOperationTime()));
               break;
             case RefLogResponse.RefLogResponseEntry.TAG:
               droppedReferenceTimeMap.put(
-                  GCUtil.serializeReference(Tag.of(entry.getRefName(), hash)),
-                  getInstantFromMicros(entry.getOperationTime()));
+                  Tag.of(entry.getRefName(), hash), getInstantFromMicros(entry.getOperationTime()));
               break;
             default:
               throw new RuntimeException(

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCUtil.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCUtil.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.gc.base;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Spliterator;
@@ -29,31 +27,10 @@ import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.model.LogResponse;
-import org.projectnessie.model.Reference;
 
 public final class GCUtil {
 
   private GCUtil() {}
-
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
-  /** Serialize {@link Reference} object using JSON Serialization. */
-  public static String serializeReference(Reference reference) {
-    try {
-      return objectMapper.writeValueAsString(reference);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  /** Deserialize JSON String to {@link Reference} object. */
-  public static Reference deserializeReference(String reference) {
-    try {
-      return objectMapper.readValue(reference, Reference.class);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   /**
    * Traverse the live commits stream till an entry is seen for each live content key and reached

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifiedResult.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifiedResult.java
@@ -24,9 +24,9 @@ import org.apache.spark.sql.SparkSession;
 import org.projectnessie.model.Content;
 
 /**
- * Output of Identify GC action {@link GCImpl#identifyExpiredContents(SparkSession)}. Contains a map
- * of {@link ContentValues} which contains the globally expired contents per content id per
- * reference.
+ * Output of Identify GC action {@link GCImpl#identifyExpiredContents(SparkSession, GCParams)}.
+ * Contains a map of {@link ContentValues} which contains the globally expired contents per content
+ * id per reference.
  */
 public class IdentifiedResult implements Serializable {
 

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifyContentsPerExecutor.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifyContentsPerExecutor.java
@@ -41,7 +41,7 @@ import org.projectnessie.model.Reference;
 
 /**
  * Contains the methods that executes in spark executor for {@link
- * GCImpl#identifyExpiredContents(SparkSession)}.
+ * GCImpl#identifyExpiredContents(SparkSession, GCParams)}.
  */
 public class IdentifyContentsPerExecutor {
 

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifyContentsPerExecutor.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifyContentsPerExecutor.java
@@ -52,8 +52,8 @@ public class IdentifyContentsPerExecutor implements Serializable {
     this.gcParams = gcParams;
   }
 
-  protected Function<String, Map<String, ContentBloomFilter>> computeLiveContentsFunc(
-      long bloomFilterSize, Map<String, Instant> droppedRefTimeMap) {
+  protected Function<Reference, Map<String, ContentBloomFilter>> computeLiveContentsFunc(
+      long bloomFilterSize, Map<Reference, Instant> droppedRefTimeMap) {
     return reference ->
         computeLiveContents(
             getCutoffTimeForRef(reference, droppedRefTimeMap),
@@ -62,13 +62,13 @@ public class IdentifyContentsPerExecutor implements Serializable {
             bloomFilterSize);
   }
 
-  protected Function<String, IdentifiedResult> computeExpiredContentsFunc(
+  protected Function<Reference, IdentifiedResult> computeExpiredContentsFunc(
       Map<String, ContentBloomFilter> liveContentsBloomFilterMap) {
     return reference -> computeExpiredContents(liveContentsBloomFilterMap, reference);
   }
 
   private Map<String, ContentBloomFilter> computeLiveContents(
-      Instant cutOffTimestamp, String reference, Instant droppedRefTime, long bloomFilterSize) {
+      Instant cutOffTimestamp, Reference reference, Instant droppedRefTime, long bloomFilterSize) {
     try (NessieApiV1 api = GCUtil.getApi(gcParams.getNessieClientConfigs())) {
       boolean isRefDroppedAfterCutoffTimeStamp =
           droppedRefTime == null || droppedRefTime.compareTo(cutOffTimestamp) >= 0;
@@ -86,7 +86,7 @@ public class IdentifyContentsPerExecutor implements Serializable {
       ImmutableGCStateParamsPerTask gcStateParamsPerTask =
           ImmutableGCStateParamsPerTask.builder()
               .api(api)
-              .reference(GCUtil.deserializeReference(reference))
+              .reference(reference)
               .liveCommitPredicate(liveCommitPredicate)
               .bloomFilterSize(bloomFilterSize)
               .build();
@@ -96,10 +96,9 @@ public class IdentifyContentsPerExecutor implements Serializable {
   }
 
   private IdentifiedResult computeExpiredContents(
-      Map<String, ContentBloomFilter> liveContentsBloomFilterMap, String reference) {
+      Map<String, ContentBloomFilter> liveContentsBloomFilterMap, Reference reference) {
     try (NessieApiV1 api = GCUtil.getApi(gcParams.getNessieClientConfigs())) {
-      return walkAllCommitsInReference(
-          api, GCUtil.deserializeReference(reference), liveContentsBloomFilterMap);
+      return walkAllCommitsInReference(api, reference, liveContentsBloomFilterMap);
     }
   }
 
@@ -253,7 +252,8 @@ public class IdentifyContentsPerExecutor implements Serializable {
     }
   }
 
-  private Instant getCutoffTimeForRef(String reference, Map<String, Instant> droppedRefTimeMap) {
+  private Instant getCutoffTimeForRef(
+      Reference reference, Map<Reference, Instant> droppedRefTimeMap) {
     if (droppedRefTimeMap.containsKey(reference)
         && gcParams.getDeadReferenceCutOffTimeStamp() != null) {
       // if the reference is dropped and deadReferenceCutOffTimeStamp is configured, use it.
@@ -263,8 +263,6 @@ public class IdentifyContentsPerExecutor implements Serializable {
         ? gcParams.getDefaultCutOffTimestamp()
         : gcParams
             .getCutOffTimestampPerRef()
-            .getOrDefault(
-                GCUtil.deserializeReference(reference).getName(),
-                gcParams.getDefaultCutOffTimestamp());
+            .getOrDefault(reference.getName(), gcParams.getDefaultCutOffTimestamp());
   }
 }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ContentBloomFilterSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ContentBloomFilterSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.serialization;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.projectnessie.gc.base.ContentBloomFilter;
+
+public class ContentBloomFilterSerializer extends Serializer<ContentBloomFilter> {
+  @Override
+  @SuppressWarnings("UnstableApiUsage")
+  public void write(Kryo kryo, Output output, ContentBloomFilter contentBloomFilter) {
+    try {
+      output.writeBoolean(contentBloomFilter.wasMerged());
+      contentBloomFilter.getFilter().writeTo(output);
+    } catch (IOException e) {
+      throw new RuntimeException("Problem when writing to output", e);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("UnstableApiUsage")
+  public ContentBloomFilter read(Kryo kryo, Input input, Class<ContentBloomFilter> classType) {
+
+    try {
+      return new ContentBloomFilter(
+          input.readBoolean(),
+          BloomFilter.readFrom(input, Funnels.stringFunnel(StandardCharsets.UTF_8)));
+    } catch (IOException e) {
+      throw new RuntimeException("Problem when reading from input", e);
+    }
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableBranchSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableBranchSerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.serialization;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.projectnessie.model.ImmutableBranch;
+import org.projectnessie.model.ImmutableReferenceMetadata;
+
+public class ImmutableBranchSerializer extends Serializer<ImmutableBranch> {
+
+  @Override
+  public void write(Kryo kryo, Output output, ImmutableBranch immutableBranch) {
+    System.out.println("ImmutableBranchSerializer#write: " + immutableBranch);
+    output.writeString(immutableBranch.getName());
+    output.writeString(immutableBranch.getHash());
+    kryo.writeObjectOrNull(output, immutableBranch.getMetadata(), ImmutableReferenceMetadata.class);
+  }
+
+  @Override
+  public ImmutableBranch read(Kryo kryo, Input input, Class classType) {
+    System.out.println("ImmutableBranchSerializer#read: ");
+    return ImmutableBranch.builder()
+        .name(input.readString())
+        .hash(input.readString())
+        .metadata(kryo.readObjectOrNull(input, ImmutableReferenceMetadata.class))
+        .build();
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableBranchSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableBranchSerializer.java
@@ -21,12 +21,19 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.projectnessie.model.ImmutableBranch;
 import org.projectnessie.model.ImmutableReferenceMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ImmutableBranchSerializer extends Serializer<ImmutableBranch> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ImmutableBranchSerializer.class);
+
+  public ImmutableBranchSerializer() {
+    this.setImmutable(true);
+  }
 
   @Override
   public void write(Kryo kryo, Output output, ImmutableBranch immutableBranch) {
-    System.out.println("ImmutableBranchSerializer#write: " + immutableBranch);
+    LOGGER.info("ImmutableBranchSerializer#write: {}", immutableBranch);
     output.writeString(immutableBranch.getName());
     output.writeString(immutableBranch.getHash());
     kryo.writeObjectOrNull(output, immutableBranch.getMetadata(), ImmutableReferenceMetadata.class);
@@ -34,7 +41,7 @@ public class ImmutableBranchSerializer extends Serializer<ImmutableBranch> {
 
   @Override
   public ImmutableBranch read(Kryo kryo, Input input, Class classType) {
-    System.out.println("ImmutableBranchSerializer#read: ");
+    LOGGER.info("ImmutableBranchSerializer#read");
     return ImmutableBranch.builder()
         .name(input.readString())
         .hash(input.readString())

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableCommitMetaSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableCommitMetaSerializer.java
@@ -25,6 +25,10 @@ import org.projectnessie.model.ImmutableCommitMeta;
 
 public class ImmutableCommitMetaSerializer extends Serializer<ImmutableCommitMeta> {
 
+  public ImmutableCommitMetaSerializer() {
+    this.setImmutable(true);
+  }
+
   @Override
   public void write(Kryo kryo, Output output, ImmutableCommitMeta immutableCommitMeta) {
     output.writeString(immutableCommitMeta.getCommitter());

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableCommitMetaSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableCommitMetaSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.serialization;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.time.Instant;
+import java.util.Map;
+import org.projectnessie.model.ImmutableCommitMeta;
+
+public class ImmutableCommitMetaSerializer extends Serializer<ImmutableCommitMeta> {
+
+  @Override
+  public void write(Kryo kryo, Output output, ImmutableCommitMeta immutableCommitMeta) {
+    output.writeString(immutableCommitMeta.getCommitter());
+    output.writeString(immutableCommitMeta.getAuthor());
+    output.writeString(immutableCommitMeta.getHash());
+    output.writeString(immutableCommitMeta.getMessage());
+    output.writeString(immutableCommitMeta.getSignedOffBy());
+    kryo.writeClassAndObject(output, immutableCommitMeta.getProperties());
+    kryo.writeObjectOrNull(output, immutableCommitMeta.getCommitTime(), Instant.class);
+    kryo.writeObjectOrNull(output, immutableCommitMeta.getAuthorTime(), Instant.class);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public ImmutableCommitMeta read(Kryo kryo, Input input, Class<ImmutableCommitMeta> classType) {
+
+    return ImmutableCommitMeta.builder()
+        .committer(input.readString())
+        .author(input.readString())
+        .hash(input.readString())
+        .message(input.readString())
+        .signedOffBy(input.readString())
+        .properties((Map<String, String>) kryo.readClassAndObject(input))
+        .commitTime(kryo.readObjectOrNull(input, Instant.class))
+        .authorTime(kryo.readObjectOrNull(input, Instant.class))
+        .build();
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableDetachedSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableDetachedSerializer.java
@@ -19,27 +19,27 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import org.projectnessie.model.ImmutableDetached;
 import org.projectnessie.model.ImmutableReferenceMetadata;
-import org.projectnessie.model.ImmutableTag;
 
-public class ImmutableTagSerializer extends Serializer<ImmutableTag> {
-  public ImmutableTagSerializer() {
+public class ImmutableDetachedSerializer extends Serializer<ImmutableDetached> {
+
+  public ImmutableDetachedSerializer() {
     this.setImmutable(true);
   }
 
   @Override
-  public void write(Kryo kryo, Output output, ImmutableTag immutableTag) {
-    output.writeString(immutableTag.getName());
-    output.writeString(immutableTag.getHash());
-    kryo.writeObjectOrNull(output, immutableTag.getMetadata(), ImmutableReferenceMetadata.class);
+  public void write(Kryo kryo, Output output, ImmutableDetached immutableDetached) {
+    kryo.writeObjectOrNull(
+        output, immutableDetached.getMetadata(), ImmutableReferenceMetadata.class);
+    output.writeString(immutableDetached.getHash());
   }
 
   @Override
-  public ImmutableTag read(Kryo kryo, Input input, Class<ImmutableTag> classType) {
-    return ImmutableTag.builder()
-        .name(input.readString())
-        .hash(input.readString())
+  public ImmutableDetached read(Kryo kryo, Input input, Class<ImmutableDetached> classType) {
+    return ImmutableDetached.builder()
         .metadata(kryo.readObjectOrNull(input, ImmutableReferenceMetadata.class))
+        .hash(input.readString())
         .build();
   }
 }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableGCParamsSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableGCParamsSerializer.java
@@ -21,7 +21,7 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.Map;
 import org.projectnessie.gc.base.ImmutableGCParams;
 
 public class ImmutableGCParamsSerializer extends Serializer<ImmutableGCParams> {
@@ -46,13 +46,13 @@ public class ImmutableGCParamsSerializer extends Serializer<ImmutableGCParams> {
   @SuppressWarnings("unchecked")
   public ImmutableGCParams read(Kryo kryo, Input input, Class<ImmutableGCParams> classType) {
     return ImmutableGCParams.builder()
-        .nessieClientConfigs(kryo.readObject(input, HashMap.class))
-        .cutOffTimestampPerRef(kryo.readObject(input, HashMap.class))
+        .nessieClientConfigs((Map<String, ? extends String>) kryo.readClassAndObject(input))
+        .cutOffTimestampPerRef((Map<String, ? extends Instant>) kryo.readClassAndObject(input))
         .defaultCutOffTimestamp(kryo.readObject(input, Instant.class))
         .deadReferenceCutOffTimeStamp(kryo.readObjectOrNull(input, Instant.class))
         .sparkPartitionsCount(kryo.readObjectOrNull(input, Integer.class))
         .commitProtectionDuration(kryo.readObject(input, Duration.class))
-        .bloomFilterExpectedEntries(kryo.readObject(input, Long.class))
+        .bloomFilterExpectedEntries(kryo.readObjectOrNull(input, Long.class))
         .bloomFilterFpp(input.readDouble())
         .build();
   }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableGCParamsSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableGCParamsSerializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.serialization;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import org.projectnessie.gc.base.ImmutableGCParams;
+
+public class ImmutableGCParamsSerializer extends Serializer<ImmutableGCParams> {
+  public ImmutableGCParamsSerializer() {
+    this.setImmutable(true);
+  }
+
+  @Override
+  public void write(Kryo kryo, Output output, ImmutableGCParams immutableGCParams) {
+    kryo.writeClassAndObject(output, immutableGCParams.getNessieClientConfigs());
+    kryo.writeClassAndObject(output, immutableGCParams.getCutOffTimestampPerRef());
+    kryo.writeObject(output, immutableGCParams.getDefaultCutOffTimestamp());
+    kryo.writeObjectOrNull(
+        output, immutableGCParams.getDeadReferenceCutOffTimeStamp(), Instant.class);
+    kryo.writeObjectOrNull(output, immutableGCParams.getSparkPartitionsCount(), Integer.class);
+    kryo.writeObject(output, immutableGCParams.getCommitProtectionDuration());
+    kryo.writeObjectOrNull(output, immutableGCParams.getBloomFilterExpectedEntries(), Long.class);
+    output.writeDouble(immutableGCParams.getBloomFilterFpp());
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public ImmutableGCParams read(Kryo kryo, Input input, Class<ImmutableGCParams> classType) {
+    return ImmutableGCParams.builder()
+        .nessieClientConfigs(kryo.readObject(input, HashMap.class))
+        .cutOffTimestampPerRef(kryo.readObject(input, HashMap.class))
+        .defaultCutOffTimestamp(kryo.readObject(input, Instant.class))
+        .deadReferenceCutOffTimeStamp(kryo.readObjectOrNull(input, Instant.class))
+        .sparkPartitionsCount(kryo.readObjectOrNull(input, Integer.class))
+        .commitProtectionDuration(kryo.readObject(input, Duration.class))
+        .bloomFilterExpectedEntries(kryo.readObject(input, Long.class))
+        .bloomFilterFpp(input.readDouble())
+        .build();
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableReferenceMetadataSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableReferenceMetadataSerializer.java
@@ -23,6 +23,10 @@ import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.ImmutableReferenceMetadata;
 
 public class ImmutableReferenceMetadataSerializer extends Serializer<ImmutableReferenceMetadata> {
+  public ImmutableReferenceMetadataSerializer() {
+    this.setImmutable(true);
+  }
+
   @Override
   public void write(Kryo kryo, Output output, ImmutableReferenceMetadata referenceMetadata) {
     kryo.writeObject(output, referenceMetadata.getNumCommitsAhead());

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableReferenceMetadataSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableReferenceMetadataSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.serialization;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.projectnessie.model.ImmutableCommitMeta;
+import org.projectnessie.model.ImmutableReferenceMetadata;
+
+public class ImmutableReferenceMetadataSerializer extends Serializer<ImmutableReferenceMetadata> {
+  @Override
+  public void write(Kryo kryo, Output output, ImmutableReferenceMetadata referenceMetadata) {
+    kryo.writeObject(output, referenceMetadata.getNumCommitsAhead());
+    kryo.writeObject(output, referenceMetadata.getNumTotalCommits());
+    kryo.writeObject(output, referenceMetadata.getNumCommitsBehind());
+    kryo.writeObject(output, referenceMetadata.getCommitMetaOfHEAD());
+    output.writeString(referenceMetadata.getCommonAncestorHash());
+  }
+
+  @Override
+  public ImmutableReferenceMetadata read(
+      Kryo kryo, Input input, Class<ImmutableReferenceMetadata> classType) {
+    return ImmutableReferenceMetadata.builder()
+        .numCommitsAhead(kryo.readObject(input, Integer.class))
+        .numTotalCommits(kryo.readObject(input, Long.class))
+        .numCommitsBehind(kryo.readObject(input, Integer.class))
+        .commitMetaOfHEAD(kryo.readObject(input, ImmutableCommitMeta.class))
+        .commonAncestorHash(input.readString())
+        .build();
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableTagSerializer.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ImmutableTagSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.serialization;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.projectnessie.model.ImmutableReferenceMetadata;
+import org.projectnessie.model.ImmutableTag;
+
+public class ImmutableTagSerializer extends Serializer<ImmutableTag> {
+  @Override
+  public void write(Kryo kryo, Output output, ImmutableTag immutableTag) {
+    output.writeString(immutableTag.getName());
+    output.writeString(immutableTag.getHash());
+    kryo.writeObjectOrNull(output, immutableTag.getMetadata(), ImmutableReferenceMetadata.class);
+  }
+
+  @Override
+  public ImmutableTag read(Kryo kryo, Input input, Class<ImmutableTag> classType) {
+    return ImmutableTag.builder()
+        .name(input.readString())
+        .hash(input.readString())
+        .metadata(kryo.readObjectOrNull(input, ImmutableReferenceMetadata.class))
+        .build();
+  }
+}

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ReferencesKryoRegistrator.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ReferencesKryoRegistrator.java
@@ -16,16 +16,13 @@
 package org.projectnessie.gc.serialization;
 
 import com.esotericsoftware.kryo.Kryo;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.projectnessie.gc.base.ContentBloomFilter;
 import org.projectnessie.gc.base.ContentValues;
-import org.projectnessie.gc.base.DistributedIdentifyContents;
 import org.projectnessie.gc.base.IdentifiedResult;
-import org.projectnessie.gc.base.IdentifyContentsPerExecutor;
 import org.projectnessie.gc.base.ImmutableGCParams;
 import org.projectnessie.model.ImmutableBranch;
 import org.projectnessie.model.ImmutableCommitMeta;
@@ -41,10 +38,7 @@ public class ReferencesKryoRegistrator implements KryoRegistrator {
 
   @Override
   public void registerClasses(Kryo kryo) {
-    LOGGER.info(
-        "Registering classes for kryo: "
-            + kryo
-            + Arrays.toString(Thread.currentThread().getStackTrace()));
+    LOGGER.info("Registering classes for kryo: " + kryo);
     kryo.register(ImmutableBranch.class, new ImmutableBranchSerializer());
     kryo.register(ImmutableDetached.class, new ImmutableDetachedSerializer());
     kryo.register(ImmutableReferenceMetadata.class, new ImmutableReferenceMetadataSerializer());
@@ -58,20 +52,5 @@ public class ReferencesKryoRegistrator implements KryoRegistrator {
     kryo.register(ConcurrentHashMap.class);
     kryo.register(IdentifiedResult.class);
     kryo.register(ContentValues.class);
-    kryo.register(IdentifyContentsPerExecutor.class);
-    kryo.register(DistributedIdentifyContents.class);
-    //    kryo.register(Class.class);
-    //    kryo.register(java.lang.invoke.SerializedLambda.class);
-    //    kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
   }
-
-  //
-  //  private static MapSerializer referenceToInstantMapSerializer() {
-  //    MapSerializer serializer = new MapSerializer();
-  //    serializer.setKeysCanBeNull(false);
-  //    serializer.setKeyClass(ImmutableBranch.class, new ImmutableBranchSerializer());
-  //    serializer.setValuesCanBeNull(false);
-  //    serializer.setValueClass(Instant.class, new InstantSerializer());
-  //    return serializer;
-  //  }
 }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ReferencesKryoRegistrator.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ReferencesKryoRegistrator.java
@@ -16,18 +16,62 @@
 package org.projectnessie.gc.serialization;
 
 import com.esotericsoftware.kryo.Kryo;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.spark.serializer.KryoRegistrator;
+import org.projectnessie.gc.base.ContentBloomFilter;
+import org.projectnessie.gc.base.ContentValues;
+import org.projectnessie.gc.base.DistributedIdentifyContents;
+import org.projectnessie.gc.base.IdentifiedResult;
+import org.projectnessie.gc.base.IdentifyContentsPerExecutor;
+import org.projectnessie.gc.base.ImmutableGCParams;
 import org.projectnessie.model.ImmutableBranch;
 import org.projectnessie.model.ImmutableCommitMeta;
+import org.projectnessie.model.ImmutableDetached;
+import org.projectnessie.model.ImmutableIcebergTable;
 import org.projectnessie.model.ImmutableReferenceMetadata;
 import org.projectnessie.model.ImmutableTag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ReferencesKryoRegistrator implements KryoRegistrator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReferencesKryoRegistrator.class);
+
   @Override
   public void registerClasses(Kryo kryo) {
+    LOGGER.info(
+        "Registering classes for kryo: "
+            + kryo
+            + Arrays.toString(Thread.currentThread().getStackTrace()));
     kryo.register(ImmutableBranch.class, new ImmutableBranchSerializer());
+    kryo.register(ImmutableDetached.class, new ImmutableDetachedSerializer());
     kryo.register(ImmutableReferenceMetadata.class, new ImmutableReferenceMetadataSerializer());
     kryo.register(ImmutableCommitMeta.class, new ImmutableCommitMetaSerializer());
     kryo.register(ImmutableTag.class, new ImmutableTagSerializer());
+    kryo.register(ContentBloomFilter.class, new ContentBloomFilterSerializer());
+    kryo.register(ImmutableGCParams.class, new ImmutableGCParamsSerializer());
+    kryo.register(HashMap.class);
+    kryo.register(ImmutableIcebergTable.class);
+    kryo.register(HashSet.class);
+    kryo.register(ConcurrentHashMap.class);
+    kryo.register(IdentifiedResult.class);
+    kryo.register(ContentValues.class);
+    kryo.register(IdentifyContentsPerExecutor.class);
+    kryo.register(DistributedIdentifyContents.class);
+    //    kryo.register(Class.class);
+    //    kryo.register(java.lang.invoke.SerializedLambda.class);
+    //    kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
   }
+
+  //
+  //  private static MapSerializer referenceToInstantMapSerializer() {
+  //    MapSerializer serializer = new MapSerializer();
+  //    serializer.setKeysCanBeNull(false);
+  //    serializer.setKeyClass(ImmutableBranch.class, new ImmutableBranchSerializer());
+  //    serializer.setValuesCanBeNull(false);
+  //    serializer.setValueClass(Instant.class, new InstantSerializer());
+  //    return serializer;
+  //  }
 }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ReferencesKryoRegistrator.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/serialization/ReferencesKryoRegistrator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.serialization;
+
+import com.esotericsoftware.kryo.Kryo;
+import org.apache.spark.serializer.KryoRegistrator;
+import org.projectnessie.model.ImmutableBranch;
+import org.projectnessie.model.ImmutableCommitMeta;
+import org.projectnessie.model.ImmutableReferenceMetadata;
+import org.projectnessie.model.ImmutableTag;
+
+public class ReferencesKryoRegistrator implements KryoRegistrator {
+  @Override
+  public void registerClasses(Kryo kryo) {
+    kryo.register(ImmutableBranch.class, new ImmutableBranchSerializer());
+    kryo.register(ImmutableReferenceMetadata.class, new ImmutableReferenceMetadataSerializer());
+    kryo.register(ImmutableCommitMeta.class, new ImmutableCommitMetaSerializer());
+    kryo.register(ImmutableTag.class, new ImmutableTagSerializer());
+  }
+}

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
+import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
 import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
@@ -81,9 +82,19 @@ public abstract class AbstractRestGC extends AbstractRest {
       List<String> involvedRefs,
       boolean disableCommitProtection,
       Instant deadReferenceCutoffTime) {
-    SparkSession spark =
-        SparkSession.builder().appName("test-nessie-gc").master("local[2]").getOrCreate();
+    SparkConf conf =
+        new SparkConf()
+            .setAppName("test-nessie-gc")
+            .setMaster("local[2]")
+            .set(
+                "spark.kryo.registrator",
+                "org.projectnessie.gc.serialization.ReferencesKryoRegistrator")
+            .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+            .set("spark.kryo.registrationRequired", "false");
+
+    SparkSession spark = SparkSession.builder().config(conf).getOrCreate();
     spark.sparkContext().setLogLevel("WARN");
+    System.out.println("serializer: " + spark.conf().get("spark.serializer"));
     try {
       ImmutableGCParams.Builder builder = ImmutableGCParams.builder();
       final Map<String, String> options = new HashMap<>();

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/serialization/ReferencesSerializerTest.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/serialization/ReferencesSerializerTest.java
@@ -27,7 +27,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.zip.DeflaterOutputStream;
 import org.junit.jupiter.api.Test;
-import org.projectnessie.model.*;
+import org.projectnessie.model.ImmutableBranch;
+import org.projectnessie.model.ImmutableCommitMeta;
+import org.projectnessie.model.ImmutableReferenceMetadata;
+import org.projectnessie.model.ImmutableTag;
+import org.projectnessie.model.Reference;
 
 class ReferencesSerializerTest {
 

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/serialization/ReferencesSerializerTest.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/serialization/ReferencesSerializerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.serialization;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayOutputStream;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.DeflaterOutputStream;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.model.*;
+
+class ReferencesSerializerTest {
+
+  @Test
+  public void shouldSerializerAndDeserializerImmutableBranch() {
+    // given
+    Kryo kryo = new Kryo();
+    new ReferencesKryoRegistrator().registerClasses(kryo);
+    ImmutableBranch immutableBranch =
+        ImmutableBranch.builder()
+            .hash("0a62a2d020df785dfb3d34e9fb64d965e6e65220")
+            .name("name")
+            .metadata(
+                ImmutableReferenceMetadata.builder()
+                    .numTotalCommits(10L)
+                    .commonAncestorHash("0a62a2d020df785dfb3d34e9fb64d965e6e65223")
+                    .numCommitsAhead(1)
+                    .numCommitsBehind(5)
+                    .commitMetaOfHEAD(
+                        ImmutableCommitMeta.builder()
+                            .author("author_1")
+                            .message("msg")
+                            .committer("committer")
+                            .hash("0a62a2d020df785dfb3d34e9fb64d965e6e65226")
+                            .signedOffBy("author_signed")
+                            .commitTime(Instant.now())
+                            .authorTime(Instant.now().plusSeconds(10))
+                            .properties(ImmutableMap.of("key", "value"))
+                            .build())
+                    .build())
+            .build();
+
+    // when
+    Output output = createOutput();
+    kryo.writeObject(output, immutableBranch);
+
+    // then
+    ImmutableBranch immutableBranchDeserialized =
+        kryo.readObject(new Input(output.toBytes()), ImmutableBranch.class);
+    assertThat(immutableBranch).isEqualTo(immutableBranchDeserialized);
+  }
+
+  @Test
+  public void shouldSerializerAndDeserializerImmutableTag() {
+    // given
+    Kryo kryo = new Kryo();
+    new ReferencesKryoRegistrator().registerClasses(kryo);
+    ImmutableTag immutableTag =
+        ImmutableTag.builder()
+            .hash("0a62a2d020df785dfb3d34e9fb64d965e6e65220")
+            .name("name")
+            .metadata(
+                ImmutableReferenceMetadata.builder()
+                    .numTotalCommits(10L)
+                    .commonAncestorHash("0a62a2d020df785dfb3d34e9fb64d965e6e65223")
+                    .numCommitsAhead(1)
+                    .numCommitsBehind(5)
+                    .commitMetaOfHEAD(
+                        ImmutableCommitMeta.builder()
+                            .author("author_1")
+                            .message("msg")
+                            .committer("committer")
+                            .hash("0a62a2d020df785dfb3d34e9fb64d965e6e65226")
+                            .signedOffBy("author_signed")
+                            .commitTime(Instant.now())
+                            .authorTime(Instant.now().plusSeconds(10))
+                            .properties(ImmutableMap.of("key", "value"))
+                            .build())
+                    .build())
+            .build();
+
+    // when
+    Output output = createOutput();
+    kryo.writeObject(output, immutableTag);
+
+    // then
+    ImmutableTag immutableTagDeserialized =
+        kryo.readObject(new Input(output.toBytes()), ImmutableTag.class);
+    assertThat(immutableTag).isEqualTo(immutableTagDeserialized);
+  }
+
+  @Test
+  public void shouldSerializeAndDeserializeCollectionOfReferences() {
+    Kryo kryo = new Kryo();
+    new ReferencesKryoRegistrator().registerClasses(kryo);
+    ImmutableBranch immutableBranch =
+        ImmutableBranch.builder()
+            .hash("0a62a2d020df785dfb3d34e9fb64d965e6e65220")
+            .name("name")
+            .metadata(
+                ImmutableReferenceMetadata.builder()
+                    .numTotalCommits(10L)
+                    .commonAncestorHash("0a62a2d020df785dfb3d34e9fb64d965e6e65223")
+                    .numCommitsAhead(1)
+                    .numCommitsBehind(5)
+                    .commitMetaOfHEAD(
+                        ImmutableCommitMeta.builder()
+                            .author("author_1")
+                            .message("msg")
+                            .committer("committer")
+                            .hash("0a62a2d020df785dfb3d34e9fb64d965e6e65226")
+                            .signedOffBy("author_signed")
+                            .commitTime(Instant.now())
+                            .authorTime(Instant.now().plusSeconds(10))
+                            .properties(ImmutableMap.of("key", "value"))
+                            .build())
+                    .build())
+            .build();
+
+    // when
+    Output output = createOutput();
+    Map<Reference, Instant> map = new LinkedHashMap<>();
+    map.put(immutableBranch, Instant.now());
+    kryo.writeObject(output, map);
+
+    // then
+    Map<Reference, Instant> mapDeserialized =
+        kryo.readObject(new Input(output.toBytes()), LinkedHashMap.class);
+    assertThat(map).isEqualTo(mapDeserialized);
+  }
+
+  private Output createOutput() {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(16384);
+    DeflaterOutputStream deflaterOutputStream = new DeflaterOutputStream(byteArrayOutputStream);
+    return new Output(deflaterOutputStream);
+  }
+}

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/serialization/ReferencesSerializerTest.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/serialization/ReferencesSerializerTest.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.zip.DeflaterOutputStream;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.gc.base.ContentBloomFilter;
 import org.projectnessie.gc.base.ImmutableGCParams;
 import org.projectnessie.model.ImmutableBranch;
 import org.projectnessie.model.ImmutableCommitMeta;
@@ -198,6 +199,24 @@ class ReferencesSerializerTest {
     ImmutableGCParams immutableGCParamsDeserialized =
         kryo.readObject(new Input(output.toBytes()), ImmutableGCParams.class);
     assertThat(gcParams).isEqualTo(immutableGCParamsDeserialized);
+  }
+
+  @Test
+  public void shouldSerializeAndDeserializeContentBloomFilter() {
+    // given
+    Kryo kryo = new Kryo();
+    new ReferencesKryoRegistrator().registerClasses(kryo);
+    ContentBloomFilter bloomFilter = new ContentBloomFilter(100, 0.5);
+
+    // when
+    Output output = createOutput();
+    kryo.writeObject(output, bloomFilter);
+
+    // then
+    ContentBloomFilter bloomFilterDeserialized =
+        kryo.readObject(new Input(output.toBytes()), ContentBloomFilter.class);
+    assertThat(bloomFilter.getFilter()).isEqualTo(bloomFilterDeserialized.getFilter());
+    assertThat(bloomFilter.wasMerged()).isEqualTo(bloomFilterDeserialized.wasMerged());
   }
 
   private Output createOutput() {

--- a/model/src/main/java/org/projectnessie/model/Branch.java
+++ b/model/src/main/java/org/projectnessie/model/Branch.java
@@ -20,6 +20,7 @@ import static org.projectnessie.model.Validation.validateReferenceName;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.Serializable;
 import javax.annotation.Nullable;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -31,7 +32,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableBranch.class)
 @JsonDeserialize(as = ImmutableBranch.class)
 @JsonTypeName("BRANCH")
-public interface Branch extends Reference {
+public interface Branch extends Reference, Serializable {
 
   @Override
   @Nullable

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.io.Serializable;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -51,7 +50,7 @@ import org.immutables.value.Value;
     })
 @JsonSubTypes({@Type(Branch.class), @Type(Tag.class), @Type(Detached.class)})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-public interface Reference extends Base, Serializable {
+public interface Reference extends Base {
   /** Human-readable reference name. */
   @NotBlank
   @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serializable;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -50,7 +51,7 @@ import org.immutables.value.Value;
     })
 @JsonSubTypes({@Type(Branch.class), @Type(Tag.class), @Type(Detached.class)})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-public interface Reference extends Base {
+public interface Reference extends Base, Serializable {
   /** Human-readable reference name. */
   @NotBlank
   @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,8 @@
     <surefire.version>3.0.0-M5</surefire.version>
     <testcontainers.version>1.16.3</testcontainers.version>
     <weld.version>3.1.8.Final</weld.version>
+     <!--- We cannot use version > 0.43 beacuse it uses a kryo version 5.x that is incompatible with out spark (requires 4.x) -->
+    <kryo.serializers.version>0.43</kryo.serializers.version>
   </properties>
 
   <dependencyManagement>
@@ -542,6 +544,11 @@
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>de.javakaffee</groupId>
+        <artifactId>kryo-serializers</artifactId>
+        <version>${kryo.serializers.version}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>


### PR DESCRIPTION
It switches our spark serialization to kryo which provides better performance and lower memory footprint (https://spark.apache.org/docs/latest/tuning.html#:~:text=Kryo%20is%20significantly%20faster%20and,in%20advance%20for%20best%20performance) compared to standard java serialization.
The `ReferencesKryoRegistrator` is responsible for registering all the classes:
https://github.com/projectnessie/nessie/pull/3599/files#diff-eb8af2f0c5b82bcb9caa73ac36f984925c668b78b804ddf3324a85e07875db14R42

The Spark Session that uses this registration should be started with `spark.kryo.registrationRequired = true` to reduce the memory footprint of the processing. For more explanation, see the docs:
https://github.com/projectnessie/nessie/pull/3599/files#diff-eb8af2f0c5b82bcb9caa73ac36f984925c668b78b804ddf3324a85e07875db14R45-R55

To see how the `sparkSession` should be created, see: https://github.com/projectnessie/nessie/pull/3599/files#diff-10adbf0faca7bef7d4f4326aece9753dd532b5e64f8864f924ad981a2cff46a7R60-R74

This PR also refactors how the `SparkSession` is created and closed in a test - it reuses the same session and closes after all tests. It also simplifies the spark processing to make it stateless, for more info see: https://github.com/projectnessie/nessie/pull/3599/files#r825759507
