### PR TITLE
Add ContentTypeSupplier

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DatabaseAdapterBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.quarkus.providers;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 
@@ -27,6 +28,8 @@ public interface DatabaseAdapterBuilder {
    * @return new database adapter instance
    * @param contentVariantSupplier provides the kind of content, whether it's only stored on a
    *     reference or requires global state.
+   * @param contentTypeSupplier provides the type of content
    */
-  DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier);
+  DatabaseAdapter newDatabaseAdapter(
+      ContentVariantSupplier contentVariantSupplier, ContentTypeSupplier contentTypeSupplier);
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DatabaseAdapterProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DatabaseAdapterProvider.java
@@ -29,6 +29,7 @@ import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.spi.TracingDatabaseAdapter;
+import org.projectnessie.versioned.persist.store.GenericContentTypeSupplier;
 import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +67,9 @@ public class DatabaseAdapterProvider {
         databaseAdapterBuilder
             .select(new Literal(versionStoreType))
             .get()
-            .newDatabaseAdapter(new GenericContentVariantSupplier<>(storeWorker));
+            .newDatabaseAdapter(
+                new GenericContentVariantSupplier<>(storeWorker),
+                new GenericContentTypeSupplier<>(storeWorker));
     databaseAdapter.initializeRepo(serverConfig.getDefaultBranch());
 
     if (storeConfig.isTracingEnabled()) {

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DynamoDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DynamoDatabaseAdapterBuilder.java
@@ -19,6 +19,7 @@ import static org.projectnessie.quarkus.config.VersionStoreConfig.VersionStoreTy
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.dynamodb.DynamoDatabaseAdapterFactory;
@@ -35,7 +36,8 @@ public class DynamoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(
+      ContentVariantSupplier contentVariantSupplier, ContentTypeSupplier contentTypeSupplier) {
     DynamoDatabaseClient client = new DynamoDatabaseClient();
     client.configure(ProvidedDynamoClientConfig.of(dynamoConfig));
     client.initialize();
@@ -44,6 +46,6 @@ public class DynamoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
         .newBuilder()
         .withConfig(config)
         .withConnector(client)
-        .build(contentVariantSupplier);
+        .build(contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/InmemoryDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/InmemoryDatabaseAdapterBuilder.java
@@ -19,6 +19,7 @@ import static org.projectnessie.quarkus.config.VersionStoreConfig.VersionStoreTy
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
@@ -32,11 +33,12 @@ public class InmemoryDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(
+      ContentVariantSupplier contentVariantSupplier, ContentTypeSupplier contentTypeSupplier) {
     return new InmemoryDatabaseAdapterFactory()
         .newBuilder()
         .withConfig(config)
         .withConnector(new InmemoryStore())
-        .build(contentVariantSupplier);
+        .build(contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/MongoDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/MongoDatabaseAdapterBuilder.java
@@ -24,6 +24,7 @@ import io.quarkus.mongodb.runtime.MongoClients;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.mongodb.MongoClientConfig;
@@ -42,7 +43,8 @@ public class MongoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(
+      ContentVariantSupplier contentVariantSupplier, ContentTypeSupplier contentTypeSupplier) {
     MongoClients mongoClients = Arc.container().instance(MongoClients.class).get();
     MongoClient mongoClient =
         mongoClients.createMongoClient(MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME);
@@ -55,6 +57,6 @@ public class MongoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
         .newBuilder()
         .withConfig(config)
         .withConnector(client)
-        .build(contentVariantSupplier);
+        .build(contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/RocksDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/RocksDatabaseAdapterBuilder.java
@@ -19,6 +19,7 @@ import static org.projectnessie.quarkus.config.VersionStoreConfig.VersionStoreTy
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
@@ -33,11 +34,12 @@ public class RocksDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(
+      ContentVariantSupplier contentVariantSupplier, ContentTypeSupplier contentTypeSupplier) {
     return new RocksDatabaseAdapterFactory()
         .newBuilder()
         .withConfig(config)
         .withConnector(rocksDbInstance)
-        .build(contentVariantSupplier);
+        .build(contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentType.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+/** Determines the type of content that is stored in nessie. */
+public enum ContentType {
+  UNKNOWN,
+  ICEBERG_TABLE,
+  ICEBERG_VIEW,
+  DELTA_LAKE_TABLE
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentTypeSupplier.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentTypeSupplier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import com.google.protobuf.ByteString;
+
+@FunctionalInterface
+public interface ContentTypeSupplier {
+  ContentType getContentType(ByteString type);
+
+  default boolean isIcebergTable(ByteString type) {
+    return ContentType.ICEBERG_TABLE == getContentType(type);
+  }
+
+  default boolean isIcebergView(ByteString type) {
+    return ContentType.ICEBERG_VIEW == getContentType(type);
+  }
+
+  default boolean isDeltaLakeTable(ByteString type) {
+    return ContentType.DELTA_LAKE_TABLE == getContentType(type);
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterFactory.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterFactory.java
@@ -71,7 +71,8 @@ public interface DatabaseAdapterFactory<
       return connector;
     }
 
-    public abstract DatabaseAdapter build(ContentVariantSupplier contentVariantSupplier);
+    public abstract DatabaseAdapter build(
+        ContentVariantSupplier contentVariantSupplier, ContentTypeSupplier contentTypeSupplier);
 
     public Builder<Config, AdjustableConfig, Connector> configure(
         Function<AdjustableConfig, Config> configurator) {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -75,6 +75,7 @@ import org.projectnessie.versioned.persist.adapter.CommitAttempt;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariant;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
@@ -118,6 +119,7 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
   protected static final String TAG_COUNT = "count";
   protected final CONFIG config;
   protected final ContentVariantSupplier contentVariantSupplier;
+  protected final ContentTypeSupplier contentTypeSupplier;
 
   @SuppressWarnings("UnstableApiUsage")
   public static final Hash NO_ANCESTOR =
@@ -127,10 +129,14 @@ public abstract class AbstractDatabaseAdapter<OP_CONTEXT, CONFIG extends Databas
 
   protected static long COMMIT_LOG_HASH_SEED = 946928273206945677L;
 
-  protected AbstractDatabaseAdapter(CONFIG config, ContentVariantSupplier contentVariantSupplier) {
+  protected AbstractDatabaseAdapter(
+      CONFIG config,
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
     Objects.requireNonNull(config, "config parameter must not be null");
     this.config = config;
     this.contentVariantSupplier = contentVariantSupplier;
+    this.contentTypeSupplier = contentTypeSupplier;
   }
 
   @Override

--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -55,6 +55,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+import org.projectnessie.versioned.persist.store.GenericContentTypeSupplier;
 import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
 import org.projectnessie.versioned.persist.tests.SystemPropertiesConfigurer;
@@ -153,7 +154,9 @@ public class CommitBench {
 
       return builder
           .withConnector(providerSource.getConnectionProvider())
-          .build(new GenericContentVariantSupplier<>(SimpleStoreWorker.INSTANCE));
+          .build(
+              new GenericContentVariantSupplier<>(SimpleStoreWorker.INSTANCE),
+              new GenericContentTypeSupplier<>(SimpleStoreWorker.INSTANCE));
     }
 
     @TearDown

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -44,6 +44,7 @@ import org.projectnessie.versioned.BackendLimitExceededException;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
@@ -87,8 +88,9 @@ public class DynamoDatabaseAdapter
   public DynamoDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       DynamoDatabaseClient c,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    super(config, contentVariantSupplier, contentTypeSupplier);
 
     Objects.requireNonNull(
         c, "Requires a non-null DynamoDatabaseClient from DynamoDatabaseAdapterConfig");

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapterFactory.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.dynamodb;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
@@ -34,7 +35,9 @@ public class DynamoDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       DynamoDatabaseClient dynamoDatabaseClient,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new DynamoDatabaseAdapter(config, dynamoDatabaseClient, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    return new DynamoDatabaseAdapter(
+        config, dynamoDatabaseClient, contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
@@ -54,8 +55,9 @@ public class InmemoryDatabaseAdapter
   public InmemoryDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       InmemoryStore store,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    super(config, contentVariantSupplier, contentTypeSupplier);
 
     this.keyPrefix = ByteString.copyFromUtf8(config.getRepositoryId() + ':');
 

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapterFactory.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.inmem;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
@@ -34,7 +35,9 @@ public class InmemoryDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       InmemoryStore inmemoryStore,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new InmemoryDatabaseAdapter(config, inmemoryStore, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    return new InmemoryDatabaseAdapter(
+        config, inmemoryStore, contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -44,6 +44,7 @@ import org.bson.types.Binary;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
@@ -79,8 +80,9 @@ public class MongoDatabaseAdapter
   protected MongoDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       MongoDatabaseClient client,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    super(config, contentVariantSupplier, contentTypeSupplier);
 
     Objects.requireNonNull(client, "MongoDatabaseClient cannot be null");
     this.client = client;

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapterFactory.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.mongodb;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
@@ -34,7 +35,8 @@ public class MongoDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       MongoDatabaseClient client,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new MongoDatabaseAdapter(config, client, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    return new MongoDatabaseAdapter(config, client, contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -71,6 +71,7 @@ import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.GlobalLogCompactionParams;
@@ -118,8 +119,10 @@ public abstract class NonTransactionalDatabaseAdapter<
   public static final String TAG_KEY_LIST_COUNT = "key-list-count";
 
   protected NonTransactionalDatabaseAdapter(
-      CONFIG config, ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      CONFIG config,
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    super(config, contentVariantSupplier, contentTypeSupplier);
   }
 
   @Override

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterFactory.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.nontx;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
@@ -30,7 +31,8 @@ public abstract class NonTransactionalDatabaseAdapterFactory<
   protected abstract DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       CONNECTOR connector,
-      ContentVariantSupplier contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier);
 
   @Override
   public Builder<
@@ -60,8 +62,9 @@ public abstract class NonTransactionalDatabaseAdapterFactory<
     }
 
     @Override
-    public DatabaseAdapter build(ContentVariantSupplier contentVariantSupplier) {
-      return create(getConfig(), getConnector(), contentVariantSupplier);
+    public DatabaseAdapter build(
+        ContentVariantSupplier contentVariantSupplier, ContentTypeSupplier contentTypeSupplier) {
+      return create(getConfig(), getConnector(), contentVariantSupplier, contentTypeSupplier);
     }
   }
 }

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
@@ -70,8 +71,9 @@ public class RocksDatabaseAdapter
   public RocksDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       RocksDbInstance dbInstance,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    super(config, contentVariantSupplier, contentTypeSupplier);
 
     this.keyPrefix = ByteString.copyFromUtf8(config.getRepositoryId() + ':');
     this.globalPointerKey = ByteString.copyFromUtf8(config.getRepositoryId()).toByteArray();

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapterFactory.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.rocks;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
@@ -34,7 +35,9 @@ public class RocksDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       RocksDbInstance rocksDbInstance,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new RocksDatabaseAdapter(config, rocksDbInstance, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    return new RocksDatabaseAdapter(
+        config, rocksDbInstance, contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/GenericContentTypeSupplier.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/GenericContentTypeSupplier.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.store;
+
+import com.google.protobuf.ByteString;
+import org.projectnessie.versioned.StoreWorker;
+import org.projectnessie.versioned.persist.adapter.ContentType;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
+
+public class GenericContentTypeSupplier<CONTENT, METADATA, CONTENT_TYPE extends Enum<CONTENT_TYPE>>
+    implements ContentTypeSupplier {
+
+  private final StoreWorker<CONTENT, METADATA, CONTENT_TYPE> storeWorker;
+
+  public GenericContentTypeSupplier(StoreWorker<CONTENT, METADATA, CONTENT_TYPE> storeWorker) {
+    this.storeWorker = storeWorker;
+  }
+
+  @Override
+  public ContentType getContentType(ByteString type) {
+    CONTENT_TYPE typeEnum = storeWorker.getType(type);
+    if (typeEnum.name().equals("ICEBERG_TABLE")) {
+      return ContentType.ICEBERG_TABLE;
+    }
+    if (typeEnum.name().equals("ICEBERG_VIEW")) {
+      return ContentType.ICEBERG_VIEW;
+    }
+    if (typeEnum.name().equals("DELTA_LAKE_TABLE")) {
+      return ContentType.DELTA_LAKE_TABLE;
+    }
+    return ContentType.UNKNOWN;
+  }
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
@@ -56,6 +56,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
 import org.projectnessie.versioned.persist.adapter.spi.TracingDatabaseAdapter;
+import org.projectnessie.versioned.persist.store.GenericContentTypeSupplier;
 import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
 import org.projectnessie.versioned.persist.tests.SystemPropertiesConfigurer;
@@ -330,7 +331,9 @@ public class DatabaseAdapterExtension
         .configure(applyCustomConfig)
         .withConnector(getConnectionProvider(context));
 
-    return builder.build(new GenericContentVariantSupplier<>(storeWorker));
+    return builder.build(
+        new GenericContentVariantSupplier<>(storeWorker),
+        new GenericContentTypeSupplier<>(storeWorker));
   }
 
   private static Function<AdjustableDatabaseAdapterConfig, DatabaseAdapterConfig>

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -78,6 +78,7 @@ import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
@@ -112,8 +113,9 @@ public abstract class TxDatabaseAdapter
   public TxDatabaseAdapter(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<?> db,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    super(config, contentVariantSupplier, contentTypeSupplier);
 
     // get the externally configured TxConnectionProvider
     Objects.requireNonNull(

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.tx;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
@@ -27,7 +28,8 @@ public abstract class TxDatabaseAdapterFactory<CONNECTOR extends DatabaseConnect
   protected abstract DatabaseAdapter create(
       TxDatabaseAdapterConfig config,
       CONNECTOR connector,
-      ContentVariantSupplier contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier);
 
   @Override
   public Builder<TxDatabaseAdapterConfig, AdjustableTxDatabaseAdapterConfig, CONNECTOR>
@@ -48,8 +50,9 @@ public abstract class TxDatabaseAdapterFactory<CONNECTOR extends DatabaseConnect
     }
 
     @Override
-    public DatabaseAdapter build(ContentVariantSupplier contentVariantSupplier) {
-      return create(getConfig(), getConnector(), contentVariantSupplier);
+    public DatabaseAdapter build(
+        ContentVariantSupplier contentVariantSupplier, ContentTypeSupplier contentTypeSupplier) {
+      return create(getConfig(), getConnector(), contentVariantSupplier, contentTypeSupplier);
     }
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.tx.h2;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
@@ -27,8 +28,9 @@ public class H2DatabaseAdapter extends TxDatabaseAdapter {
   public H2DatabaseAdapter(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<?> db,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, db, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    super(config, db, contentVariantSupplier, contentTypeSupplier);
   }
 
   @Override

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.tx.h2;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxConnectionConfig;
@@ -36,7 +37,9 @@ public class H2DatabaseAdapterFactory
   protected DatabaseAdapter create(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<TxConnectionConfig> connectionProvider,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new H2DatabaseAdapter(config, connectionProvider, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    return new H2DatabaseAdapter(
+        config, connectionProvider, contentVariantSupplier, contentTypeSupplier);
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.tx.postgres;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
@@ -27,8 +28,9 @@ public class PostgresDatabaseAdapter extends TxDatabaseAdapter {
   public PostgresDatabaseAdapter(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<?> db,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, db, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    super(config, db, contentVariantSupplier, contentTypeSupplier);
   }
 
   @Override

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.tx.postgres;
 
+import org.projectnessie.versioned.persist.adapter.ContentTypeSupplier;
 import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxConnectionConfig;
@@ -36,7 +37,9 @@ public class PostgresDatabaseAdapterFactory
   protected DatabaseAdapter create(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<TxConnectionConfig> connectionProvider,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new PostgresDatabaseAdapter(config, connectionProvider, contentVariantSupplier);
+      ContentVariantSupplier contentVariantSupplier,
+      ContentTypeSupplier contentTypeSupplier) {
+    return new PostgresDatabaseAdapter(
+        config, connectionProvider, contentVariantSupplier, contentTypeSupplier);
   }
 }


### PR DESCRIPTION
The idea here is that we need a way to determine the actual content type
for a given `Key` within the DatabaseAdapters.

This is required for #3572 during key collision checks when merging/transplanting namespaces