### PR TITLE
Fix Namespace encoding and only use elements for the canonical representation of a Namespace

### DIFF
--- a/model/src/main/java/org/projectnessie/model/ContentKey.java
+++ b/model/src/main/java/org/projectnessie/model/ContentKey.java
@@ -68,7 +68,7 @@ public abstract class ContentKey {
   public static ContentKey of(Namespace namespace, String name) {
     Builder b = ImmutableContentKey.builder();
     if (namespace != null && !namespace.isEmpty()) {
-      b.addElements(namespace.getElements());
+      b.elements(namespace.getElements());
     }
     return b.addElements(name).build();
   }

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -84,10 +84,16 @@ components:
     namespacesResponse:
       value:
         namespaces:
-          - "type": "NAMESPACE"
-            "name": "a.b.c"
-          - "type": "NAMESPACE"
-            "name": "a.b.d"
+          - type: NAMESPACE
+            elements:
+              - a
+              - b.c
+              - d
+          - type: NAMESPACE
+            elements:
+              - a
+              - b
+              - d
 
     iceberg:
       value:

--- a/model/src/test/java/org/projectnessie/model/TestNamespace.java
+++ b/model/src/test/java/org/projectnessie/model/TestNamespace.java
@@ -15,11 +15,15 @@
  */
 package org.projectnessie.model;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,6 +52,10 @@ public class TestNamespace {
     assertThat(Namespace.of(""))
         .extracting(Namespace::name, Namespace::isEmpty)
         .containsExactly("", true);
+
+    assertThat(Namespace.of("")).isEqualTo(Namespace.EMPTY);
+    assertThat(Namespace.of(Collections.emptyList())).isEqualTo(Namespace.EMPTY);
+    assertThat(Namespace.of(singletonList(""))).isEqualTo(Namespace.EMPTY);
   }
 
   @Test
@@ -58,16 +66,37 @@ public class TestNamespace {
         .containsExactly("foo", false);
   }
 
+  @Test
+  public void testRoundTrip() {
+    List<String> elements = asList("a", "b.c", "namespace");
+    String pathString = UriUtil.toPathString(elements);
+    String expectedPathString = "a.b\u0000c.namespace";
+    assertThat(pathString).isEqualTo(expectedPathString);
+    Namespace namespace = Namespace.parse(pathString);
+    assertThat(namespace.name()).isEqualTo(pathString);
+    assertThat(namespace.getElements()).isEqualTo(elements);
+    assertThat(namespace.toString()).isEqualTo(pathString);
+    assertThat(namespace.toPathString()).isEqualTo(pathString);
+    assertThat(namespace.name()).startsWith("a.b");
+    assertThat(namespace.name()).startsWith("a.b\u0000");
+    assertThat(namespace.name()).startsWith("a.b\u0000c");
+    assertThat(namespace.name()).startsWith("a.b\u0000c.namespa");
+    assertThat(namespace.name()).doesNotStartWith("a.b.c");
+    assertThat(Namespace.parse("a.b.c").name()).doesNotStartWith("a.b\u0000");
+  }
+
   @ParameterizedTest
   @MethodSource("elementsProvider")
   void testNamespaceFromElements(String[] elements, String expectedNamespace) {
     Namespace namespace = Namespace.of(elements);
     assertThat(namespace.name()).isEqualTo(expectedNamespace);
     assertThat(namespace.isEmpty()).isFalse();
+    assertThat(namespace.getElements()).containsExactly(elements);
 
     namespace = Namespace.of(Arrays.asList(elements));
     assertThat(namespace.name()).isEqualTo(expectedNamespace);
     assertThat(namespace.isEmpty()).isFalse();
+    assertThat(namespace.getElements()).isEqualTo(Arrays.asList(elements));
   }
 
   @ParameterizedTest
@@ -100,8 +129,8 @@ public class TestNamespace {
 
   @ParameterizedTest
   @ValueSource(strings = {"\u0000", "a.\u0000", "a.b.c.\u0000"})
-  void testZeroByteUsage() {
-    assertThatThrownBy(() -> Namespace.of("\u0000"))
+  void testZeroByteUsage(String identifier) {
+    assertThatThrownBy(() -> Namespace.of(identifier))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("A namespace must not contain a zero byte.");
   }
@@ -117,7 +146,10 @@ public class TestNamespace {
   private static Stream<Arguments> elementsProvider() {
     return Stream.of(
         Arguments.of(new String[] {"a", "b"}, "a.b"),
-        Arguments.of(new String[] {"a", "b", "c"}, "a.b.c"));
+        Arguments.of(new String[] {"a", "b", "c"}, "a.b.c"),
+        Arguments.of(new String[] {"a", "b.c", "d"}, "a.b\u0000c.d"),
+        Arguments.of(new String[] {"a", "b_c", "d.e"}, "a.b_c.d\u0000e"),
+        Arguments.of(new String[] {"a.c", "b.d"}, "a\u0000c.b\u0000d"));
   }
 
   private static Stream<Arguments> identifierProvider() {
@@ -137,5 +169,69 @@ public class TestNamespace {
         Arguments.of(new String[] {null}, "x"),
         Arguments.of(new String[] {"a", ".", null}, "x"),
         Arguments.of(new String[] {"a", "b", "c", ".", null}, "x"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("namespaceOfAndParseCases")
+  void namespaceOfAndParse(NamespaceOfParse testCase) {
+    assertThat(testCase.namespace)
+        .extracting(
+            Namespace::getElements, Namespace::name, Namespace::toString, Namespace::toPathString)
+        .containsExactly(testCase.elements, testCase.name, testCase.name, testCase.name);
+  }
+
+  static class NamespaceOfParse {
+    final Namespace namespace;
+    final List<String> elements;
+    final String name;
+
+    NamespaceOfParse(Namespace namespace, List<String> elements, String name) {
+      this.namespace = namespace;
+      this.elements = elements;
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return new StringJoiner(", ", NamespaceOfParse.class.getSimpleName() + "[", "]")
+          .add("namespace=" + namespace)
+          .add("elements=" + elements)
+          .add("name='" + name + "'")
+          .toString();
+    }
+  }
+
+  static List<NamespaceOfParse> namespaceOfAndParseCases() {
+    return asList(
+        new NamespaceOfParse(
+            Namespace.fromPathString(UriUtil.toPathString(Arrays.asList("a", "b.c", "namespace"))),
+            Arrays.asList("a", "b.c", "namespace"),
+            UriUtil.toPathString(Arrays.asList("a", "b.c", "namespace"))),
+        new NamespaceOfParse(
+            Namespace.fromPathString(
+                UriUtil.toPathString(Arrays.asList("a", "b.c", "d.e.f.namespace"))),
+            Arrays.asList("a", "b.c", "d.e.f.namespace"),
+            UriUtil.toPathString(Arrays.asList("a", "b.c", "d.e.f.namespace"))),
+        new NamespaceOfParse(
+            Namespace.fromPathString("a.namespace"), asList("a", "namespace"), "a.namespace"),
+        new NamespaceOfParse(
+            Namespace.of("a", "namespace"), asList("a", "namespace"), "a.namespace"),
+        new NamespaceOfParse(
+            Namespace.of(asList("a", "namespace")), asList("a", "namespace"), "a.namespace"),
+        new NamespaceOfParse(
+            Namespace.fromPathString("a.b.namespace"),
+            asList("a", "b", "namespace"),
+            "a.b.namespace"),
+        new NamespaceOfParse(
+            Namespace.of("a", "b", "namespace"), asList("a", "b", "namespace"), "a.b.namespace"),
+        new NamespaceOfParse(
+            Namespace.of(asList("a", "b", "namespace")),
+            asList("a", "b", "namespace"),
+            "a.b.namespace"),
+        new NamespaceOfParse(Namespace.EMPTY, Collections.emptyList(), ""),
+        new NamespaceOfParse(
+            Namespace.of(singletonList("namespace")), singletonList("namespace"), "namespace"),
+        new NamespaceOfParse(
+            Namespace.fromPathString("namespace"), singletonList("namespace"), "namespace"));
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -110,7 +110,7 @@ public class CELUtil {
 
     String getKey();
 
-    String[] getNamespaceElements();
+    List<String> getNamespaceElements();
 
     String getName();
 
@@ -181,7 +181,7 @@ public class CELUtil {
         }
 
         @Override
-        public String[] getNamespaceElements() {
+        public List<String> getNamespaceElements() {
           return op.getKey().getNamespace().getElements();
         }
 

--- a/servers/store-proto/src/main/proto/table.proto
+++ b/servers/store-proto/src/main/proto/table.proto
@@ -56,5 +56,5 @@ message DeltaLakeTable {
 }
 
 message Namespace {
-  string name = 1;
+  repeated string elements = 1;
 }

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -76,8 +76,8 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
       }
       builder.setDeltaLakeTable(table);
     } else if (content instanceof Namespace) {
-      builder.setNamespace(
-          ObjectTypes.Namespace.newBuilder().setName(((Namespace) content).name()));
+      Namespace ns = (Namespace) content;
+      builder.setNamespace(ObjectTypes.Namespace.newBuilder().addAllElements(ns.getElements()));
     } else {
       throw new IllegalArgumentException("Unknown type " + content);
     }
@@ -159,7 +159,7 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
 
       case NAMESPACE:
         ObjectTypes.Namespace namespace = content.getNamespace();
-        return ImmutableNamespace.builder().id(content.getId()).name(namespace.getName()).build();
+        return ImmutableNamespace.builder().elements(namespace.getElementsList()).build();
 
       case OBJECTTYPE_NOT_SET:
       default:

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import java.time.Instant;
 import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -33,7 +35,7 @@ import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.IcebergView;
 import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.ImmutableDeltaLakeTable;
-import org.projectnessie.model.ImmutableNamespace;
+import org.projectnessie.model.Namespace;
 import org.projectnessie.store.ObjectTypes;
 import org.projectnessie.store.ObjectTypes.IcebergMetadataPointer;
 import org.projectnessie.store.ObjectTypes.IcebergRefState;
@@ -191,14 +193,14 @@ class TestStoreWorker {
   }
 
   private static Map.Entry<ByteString, Content> getNamespace() {
-    String name = "a.b.c";
-    Content content = ImmutableNamespace.builder().id(name).name(name).build();
+    List<String> elements = Arrays.asList("a", "b.c", "d");
+    Namespace namespace = Namespace.of(elements);
     ByteString bytes =
         ObjectTypes.Content.newBuilder()
-            .setId(name)
-            .setNamespace(ObjectTypes.Namespace.newBuilder().setName(name).build())
+            .setId(namespace.getId())
+            .setNamespace(ObjectTypes.Namespace.newBuilder().addAllElements(elements).build())
             .build()
             .toByteString();
-    return new AbstractMap.SimpleImmutableEntry<>(bytes, content);
+    return new AbstractMap.SimpleImmutableEntry<>(bytes, namespace);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Key.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Key.java
@@ -82,6 +82,10 @@ public abstract class Key implements Comparable<Key> {
     return ImmutableKey.builder().addElements(elements).build();
   }
 
+  public static Key of(List<String> elements) {
+    return ImmutableKey.builder().addAllElements(elements).build();
+  }
+
   @Override
   public String toString() {
     return String.join(".", getElements());


### PR DESCRIPTION
Our namespace encoding was wrong because if a single element would
contain a ".", then the elements within a Namespace weren't corrently
translated and stored.