### PR TITLE
Create new Gatling scenario: `CommitToBranchSimulationDifferentTables`

### DIFF
--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationDifferentTables.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationDifferentTables.scala
@@ -28,8 +28,9 @@ import org.projectnessie.perftest.gatling.Predef.nessie
 import scala.concurrent.duration.{FiniteDuration, HOURS, NANOSECONDS, SECONDS}
 
 /** Gatling simulation to perform commits against Nessie. It commits the data to
-  * different table - each user has its own dedicated table. Has a bunch of
-  * configurables, see the `val`s defined at the top of this class.
+  * different table - each user has its own dedicated table. The ContentKey is
+  * created per userId. Has a bunch of configurables, see the `val`s defined at
+  * the top of this class.
   */
 class CommitToBranchSimulationDifferentTables extends Simulation {
 

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationDifferentTables.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationDifferentTables.scala
@@ -27,11 +27,11 @@ import org.projectnessie.perftest.gatling.Predef.nessie
 
 import scala.concurrent.duration.{FiniteDuration, HOURS, NANOSECONDS, SECONDS}
 
-/** Gatling simulation to perform commits against Nessie. Has a bunch of It
-  * commits the data the same table for all users. configurables, see the `val`s
-  * defined at the top of this class.
+/** Gatling simulation to perform commits against Nessie. It commits the data to
+  * different table - each user has its own dedicated table. Has a bunch of
+  * configurables, see the `val`s defined at the top of this class.
   */
-class CommitToBranchSimulationSameTable extends Simulation {
+class CommitToBranchSimulationDifferentTables extends Simulation {
 
   val params: CommitToBranchParams = CommitToBranchParams.fromSystemProperties()
 
@@ -52,12 +52,12 @@ class CommitToBranchSimulationSameTable extends Simulation {
           val tableName = params.makeTableName(session)
 
           // Call the Nessie client operation to perform a commit
-          val key = ContentKey.of("name", "space", tableName)
+          val key = ContentKey.of("name", "space", tableName, userId.toString)
           val contentId = tableName + "_" + userId.toString
 
           val tableMeta = IcebergTable
             .of(
-              s"path_on_disk_${tableName}_$commitNum",
+              s"path_on_disk_${tableName}_${userId}_$commitNum",
               42,
               43,
               44,

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationSameTable.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationSameTable.scala
@@ -27,8 +27,8 @@ import org.projectnessie.perftest.gatling.Predef.nessie
 
 import scala.concurrent.duration.{FiniteDuration, HOURS, NANOSECONDS, SECONDS}
 
-/** Gatling simulation to perform commits against Nessie. Has a bunch of It
-  * commits the data the same table for all users. configurables, see the `val`s
+/** Gatling simulation to perform commits against Nessie. It commits the data to
+  * the same table for all users. Has a bunch of configurables, see the `val`s
   * defined at the top of this class.
   */
 class CommitToBranchSimulationSameTable extends Simulation {


### PR DESCRIPTION
The https://github.com/projectnessie/nessie/pull/3573 fixed the `CommitToBranchSimulationSameTable` to use a global state and share a table between users - so it validates commits to the same table/branch.
This PR is adding a new scenario `CommitToBranchSimulationDifferentTables` that is creating N tables - each user has its own dedicated table and commits the data. Because the users have dedicates tables, there should be no conflicts between commits.