### PR TITLE
Specify `quarkus.http.port` when running gatling simulations

### DIFF
--- a/perftest/simulations/pom.xml
+++ b/perftest/simulations/pom.xml
@@ -57,6 +57,9 @@
           <environment>
             <HTTP_ACCESS_LOG_LEVEL>${test.log.level}</HTTP_ACCESS_LOG_LEVEL>
           </environment>
+          <jvmArguments>
+            <jvmArgument>-Dquarkus.http.port=19120</jvmArgument>
+          </jvmArguments>
         </configuration>
         <dependencies>
           <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <maven.version>3.8.5</maven.version>
     <mockito.version>4.4.0</mockito.version>
     <nessie.version>${project.version}</nessie.version>
-    <nessie-apprunner.version>0.21.4</nessie-apprunner.version>
+    <nessie-apprunner.version>0.21.5</nessie-apprunner.version>
     <openapi.version>3.0</openapi.version>
     <picocli.version>4.6.3</picocli.version>
     <prometheus.version>0.9.0</prometheus.version>


### PR DESCRIPTION
Requires: https://github.com/projectnessie/nessie-apprunner/pull/8