### PR TITLE
Make sure Namespace/ContentKey don't have empty strings in between

### DIFF
--- a/clients/deltalake/src/main/scala/org/projectnessie/deltalake/NessieLogStore.scala
+++ b/clients/deltalake/src/main/scala/org/projectnessie/deltalake/NessieLogStore.scala
@@ -34,6 +34,7 @@ import org.projectnessie.model.{
   TableReference
 }
 import org.apache.commons.io.IOUtils
+import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.SparkConf
@@ -364,7 +365,11 @@ class NessieLogStore(sparkConf: SparkConf, hadoopConf: Configuration)
   }
 
   def pathToKey(path: String): ContentKey = {
-    val parts = path.split("/").toList
+    // we can't simply do a path.toString.split("/") as that would result with
+    // "/tmp/a/b/c in a string array where the first element is an empty string,
+    // which isn't supported by ContentKey
+    val p = StringUtils.stripEnd(StringUtils.stripStart(path, "/"), "/")
+    val parts = p.split("/").toList
     ContentKey.of(parts.asJava)
   }
 

--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/ITDeltaLogBranches.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoder;
@@ -98,7 +99,12 @@ class ITDeltaLogBranches extends AbstractDeltaTest {
     Assertions.assertEquals(64, expectedSize);
 
     String tableName = tempPath.getAbsolutePath() + "/_delta_log";
-    ContentKey key = ContentKey.of(tableName.split("/"));
+    // we can't simply do a tableName.split("/") as that would result with
+    // "/tmp/a/b/c in a string array where the first element is an empty string,
+    // which isn't supported by ContentKey
+    String[] elements =
+        StringUtils.stripEnd(StringUtils.stripStart(tableName, "/"), "/").split("/");
+    ContentKey key = ContentKey.of(elements);
     Content content = api.getContent().key(key).refName("main").get().get(key);
     Optional<DeltaLakeTable> table = content.unwrap(DeltaLakeTable.class);
     Assertions.assertTrue(table.isPresent());

--- a/model/src/main/java/org/projectnessie/model/ContentKey.java
+++ b/model/src/main/java/org/projectnessie/model/ContentKey.java
@@ -89,15 +89,17 @@ public abstract class ContentKey {
     List<String> elements = getElements();
     for (String e : elements) {
       if (e == null) {
-        throw new IllegalArgumentException("An object key must not contain a null element.");
+        throw new IllegalArgumentException(
+            String.format("Content key '%s' must not contain a null element.", elements));
       }
       if (e.contains(ZERO_BYTE_STRING)) {
-        throw new IllegalArgumentException("An object key must not contain a zero byte.");
+        throw new IllegalArgumentException(
+            String.format("Content key '%s' must not contain a zero byte.", elements));
       }
-    }
-    if (elements.get(elements.size() - 1).isEmpty()) {
-      throw new IllegalArgumentException(
-          "An object key must not contain an empty name (last element).");
+      if ("".equals(e)) {
+        throw new IllegalArgumentException(
+            String.format("Content key '%s' must not contain an empty element.", elements));
+      }
     }
   }
 

--- a/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -86,16 +86,25 @@ public abstract class Namespace extends Content {
    */
   public static Namespace of(String... elements) {
     Objects.requireNonNull(elements, "elements must be non-null");
-    if (elements.length == 0 || "".equals(elements[0])) {
+    if (elements.length == 0 || (elements.length == 1 && "".equals(elements[0]))) {
       return EMPTY;
     }
 
     for (String e : elements) {
       if (e == null) {
-        throw new IllegalArgumentException("A namespace must not contain a null element.");
+        throw new IllegalArgumentException(
+            String.format(
+                "Namespace '%s' must not contain a null element.", Arrays.toString(elements)));
       }
       if (e.contains(ZERO_BYTE_STRING)) {
-        throw new IllegalArgumentException("A namespace must not contain a zero byte.");
+        throw new IllegalArgumentException(
+            String.format(
+                "Namespace '%s' must not contain a zero byte.", Arrays.toString(elements)));
+      }
+      if ("".equals(e)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Namespace '%s' must not contain an empty element.", Arrays.toString(elements)));
       }
     }
 

--- a/model/src/test/java/org/projectnessie/model/TestContentKey.java
+++ b/model/src/test/java/org/projectnessie/model/TestContentKey.java
@@ -230,7 +230,7 @@ class TestContentKey {
   public void validation() {
     assertThatThrownBy(() -> ContentKey.of("a", "b", "\u0000", "c", "d"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("An object key must not contain a zero byte.");
+        .hasMessage("Content key '[a, b, \u0000, c, d]' must not contain a zero byte.");
   }
 
   @Test
@@ -294,19 +294,27 @@ class TestContentKey {
         () ->
             assertThatThrownBy(() -> ContentKey.of(null, ""))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("An object key must not contain an empty name (last element)."),
+                .hasMessage("Content key '[]' must not contain an empty element."),
         () ->
             assertThatThrownBy(() -> ContentKey.of("a", ""))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("An object key must not contain an empty name (last element)."),
+                .hasMessage("Content key '[a, ]' must not contain an empty element."),
         () ->
             assertThatThrownBy(() -> ContentKey.of(singletonList("")))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("An object key must not contain an empty name (last element)."),
+                .hasMessage("Content key '[]' must not contain an empty element."),
         () ->
             assertThatThrownBy(() -> ContentKey.of(asList("a", "")))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("An object key must not contain an empty name (last element)."));
+                .hasMessage("Content key '[a, ]' must not contain an empty element."),
+        () ->
+            assertThatThrownBy(() -> ContentKey.of("", "something"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Content key '[, something]' must not contain an empty element."),
+        () ->
+            assertThatThrownBy(() -> ContentKey.of("", "something", "x"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Content key '[, something, x]' must not contain an empty element."));
   }
 
   private void assertRoundTrip(String... elements) {

--- a/model/src/test/java/org/projectnessie/model/TestNamespace.java
+++ b/model/src/test/java/org/projectnessie/model/TestNamespace.java
@@ -56,6 +56,21 @@ public class TestNamespace {
     assertThat(Namespace.of("")).isEqualTo(Namespace.EMPTY);
     assertThat(Namespace.of(Collections.emptyList())).isEqualTo(Namespace.EMPTY);
     assertThat(Namespace.of(singletonList(""))).isEqualTo(Namespace.EMPTY);
+
+    assertThatThrownBy(() -> Namespace.of("", "something"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Namespace '[, something]' must not contain an empty element.");
+    assertThatThrownBy(() -> Namespace.of("", "something", "x"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Namespace '[, something, x]' must not contain an empty element.");
+
+    assertThatThrownBy(() -> Namespace.of("something", "", "x"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Namespace '[something, , x]' must not contain an empty element.");
+
+    assertThatThrownBy(() -> Namespace.of("something", "x", ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Namespace '[something, x, ]' must not contain an empty element.");
   }
 
   @Test
@@ -132,7 +147,9 @@ public class TestNamespace {
   void testZeroByteUsage(String identifier) {
     assertThatThrownBy(() -> Namespace.of(identifier))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("A namespace must not contain a zero byte.");
+        .hasMessage(
+            String.format(
+                "Namespace '%s' must not contain a zero byte.", singletonList(identifier)));
   }
 
   @ParameterizedTest
@@ -140,7 +157,9 @@ public class TestNamespace {
   void testNullsInElements(String[] elements) {
     assertThatThrownBy(() -> Namespace.of(elements))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("A namespace must not contain a null element.");
+        .hasMessage(
+            String.format(
+                "Namespace '%s' must not contain a null element.", Arrays.toString(elements)));
   }
 
   private static Stream<Arguments> elementsProvider() {


### PR DESCRIPTION
This also required some changes to `NessieLogStore` because that part of
the code would simply do a `path.split("/")` where the first element
would then end up being an empty string if `path` started with a `/`.

The error messages have also been improved because if the check fails,
then it's difficult to tell exactly why it failed.