### PR TITLE
Run scala:doc-jar on PRs along with javadoc task

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,7 +53,7 @@ jobs:
       env:
         SPARK_LOCAL_IP: localhost
       run: |
-        ./mvnw --batch-mode --threads 1C install javadoc:javadoc-no-fork -Pcode-coverage -Dtest.log.level=WARN
+        ./mvnw --batch-mode --threads 1C install scala:doc-jar javadoc:javadoc-no-fork -Pcode-coverage -Dtest.log.level=WARN
 
     - name: Capture Test Reports
       if: ${{ failure() }}

--- a/clients/deltalake/pom.xml
+++ b/clients/deltalake/pom.xml
@@ -308,6 +308,9 @@
                 <goals>
                   <goal>doc-jar</goal>
                 </goals>
+                <configuration>
+                  <scalaVersion>${scala2.12.version}</scalaVersion>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -818,7 +818,6 @@
           <version>4.6.1</version>
           <configuration>
             <sendJavaToScalac>false</sendJavaToScalac>
-            <scalaVersion>${scala2.12.version}</scalaVersion>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
We had PRs fail after being merged to main because the `doc-jar` task
failed (since it is only part of the `release` profile).
However, given that we already run `javadoc` on PRs, we should do the
same for scala.