### PR TITLE
SQL Extension: Fix Create reference from a hash on non-default reference

### DIFF
--- a/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseCreateReferenceExec.scala
+++ b/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseCreateReferenceExec.scala
@@ -44,7 +44,10 @@ abstract class BaseCreateReferenceExec(
       if (isBranch) Branch.of(branch, sourceRef.getHash)
       else Tag.of(branch, sourceRef.getHash)
     try {
-      api.createReference.reference(ref).create()
+      api.createReference
+        .reference(ref)
+        .sourceRefName(sourceRef.getName)
+        .create()
     } catch {
       case e: NessieConflictException =>
         if (failOnCreate) {


### PR DESCRIPTION
_Steps to reproduce:_
CREATE BRANCH dev IN nessie FROM main;
USE REFERENCE dev IN nessie
CREATE TABLE nessie.db.tbl (id int, name string)
INSERT INTO nessie.db.tbl select 23, "test"
CREATE BRANCH test IN nessie FROM dev; --> fails as it looks for dev's latest hash in 'main' branch instead of 'dev' branch.

Could not find commit '0eed82af48bbb879055b477862d9f9ec0ac1c975ca46e1ff373463bc700a2568' in reference 'main'.

`Reason`: Source ref name is not set in the code. Hence, it is looking for default reference. There was no testcase to catch this scenario. 

Fixes #3659 