### PR TITLE
Remove/cleanup duplicated code in Spark SQL Extensions

### DIFF
--- a/clients/spark-3.2-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AssignReferenceExec.scala
+++ b/clients/spark-3.2-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AssignReferenceExec.scala
@@ -15,12 +15,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
-import org.projectnessie.model.{Branch, Tag}
 
 case class AssignReferenceExec(
     output: Seq[Attribute],

--- a/clients/spark-3.2-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateReferenceExec.scala
+++ b/clients/spark-3.2-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateReferenceExec.scala
@@ -15,13 +15,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
-import org.projectnessie.error.NessieConflictException
-import org.projectnessie.model._
 
 case class CreateReferenceExec(
     output: Seq[Attribute],

--- a/clients/spark-3.2-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropReferenceExec.scala
+++ b/clients/spark-3.2-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropReferenceExec.scala
@@ -15,11 +15,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
 
 case class DropReferenceExec(
     output: Seq[Attribute],

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateReferenceExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateReferenceExec.scala
@@ -15,13 +15,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
-import org.projectnessie.error.NessieConflictException
-import org.projectnessie.model._
 
 case class CreateReferenceExec(
     output: Seq[Attribute],
@@ -39,40 +34,4 @@ case class CreateReferenceExec(
       catalog,
       createdFrom,
       failOnCreate
-    ) {
-
-  override protected def runInternal(
-      api: NessieApiV1
-  ): Seq[InternalRow] = {
-    val sourceRef = createdFrom
-      .map(x => api.getReference.refName(x).get)
-      .orElse(Option(api.getDefaultBranch))
-      .orNull
-    val ref =
-      if (isBranch) Branch.of(branch, sourceRef.getHash)
-      else Tag.of(branch, sourceRef.getHash)
-    try {
-      api.createReference.reference(ref).create()
-    } catch {
-      case e: NessieConflictException =>
-        if (failOnCreate) {
-          throw e
-        }
-    }
-    val branchResult = api.getReference.refName(ref.getName).get()
-
-    Seq(
-      InternalRow(
-        UTF8String.fromString(NessieUtils.getRefType(ref)),
-        UTF8String.fromString(branchResult.getName),
-        UTF8String.fromString(branchResult.getHash)
-      )
-    )
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    s"CreateReferenceExec ${catalog.getOrElse(currentCatalog.name())} ${if (isBranch) "BRANCH"
-    else "TAG"} ${branch} " +
-      s"${createdFrom}"
-  }
-}
+    ) {}

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropReferenceExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropReferenceExec.scala
@@ -15,11 +15,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
 
 case class DropReferenceExec(
     output: Seq[Attribute],
@@ -33,22 +30,4 @@ case class DropReferenceExec(
       currentCatalog,
       isBranch,
       catalog
-    ) {
-
-  override protected def runInternal(
-      api: NessieApiV1
-  ): Seq[InternalRow] = {
-    val hash = api.getReference.refName(branch).get().getHash
-    if (isBranch) {
-      api.deleteBranch().branchName(branch).hash(hash).delete()
-    } else {
-      api.deleteTag().tagName(branch).hash(hash).delete()
-    }
-    Seq(InternalRow(UTF8String.fromString("OK")))
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    s"DropReferenceExec ${catalog.getOrElse(currentCatalog.name())} ${if (isBranch) "BRANCH"
-    else "TAG"} ${branch} "
-  }
-}
+    ) {}

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ListReferenceExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ListReferenceExec.scala
@@ -15,37 +15,11 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
-
-import scala.collection.JavaConverters._
 
 case class ListReferenceExec(
     output: Seq[Attribute],
     currentCatalog: CatalogPlugin,
     catalog: Option[String]
-) extends BaseListReferenceExec(output, currentCatalog, catalog) {
-
-  override protected def runInternal(
-      api: NessieApiV1
-  ): Seq[InternalRow] = {
-    api.getAllReferences
-      .get()
-      .getReferences
-      .asScala
-      .map(ref => {
-        InternalRow(
-          UTF8String.fromString(NessieUtils.getRefType(ref)),
-          UTF8String.fromString(ref.getName),
-          UTF8String.fromString(ref.getHash)
-        )
-      })
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    s"ListReferenceExec ${catalog.getOrElse(currentCatalog.name())} "
-  }
-}
+) extends BaseListReferenceExec(output, currentCatalog, catalog) {}

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeBranchExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeBranchExec.scala
@@ -15,11 +15,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
 
 case class MergeBranchExec(
     output: Seq[Attribute],
@@ -33,41 +30,4 @@ case class MergeBranchExec(
       currentCatalog,
       toRefName,
       catalog
-    ) {
-
-  override protected def runInternal(
-      api: NessieApiV1
-  ): Seq[InternalRow] = {
-    val from = api.getReference
-      .refName(
-        branch.getOrElse(
-          NessieUtils.getCurrentRef(currentCatalog, catalog).getName
-        )
-      )
-    api
-      .mergeRefIntoBranch()
-      .branchName(toRefName.getOrElse(api.getDefaultBranch.getName))
-      .hash(
-        toRefName
-          .map(r => api.getReference.refName(r).get.getHash)
-          .getOrElse(api.getDefaultBranch.getHash)
-      )
-      .fromRef(from.get)
-      .merge()
-
-    val ref = api.getReference.refName(
-      toRefName.getOrElse(api.getDefaultBranch.getName)
-    )
-
-    Seq(
-      InternalRow(
-        UTF8String.fromString(ref.get.getName),
-        UTF8String.fromString(ref.get.getHash)
-      )
-    )
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    s"MergeBranchExec ${catalog.getOrElse(currentCatalog.name())} ${branch} "
-  }
-}
+    ) {}

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowLogExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowLogExec.scala
@@ -15,78 +15,12 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, MapData}
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
-import org.projectnessie.client.StreamingUtil
-
-import java.time.Instant
-import java.time.temporal.ChronoUnit
-import java.util.OptionalInt
-import scala.collection.JavaConverters._
 
 case class ShowLogExec(
     output: Seq[Attribute],
     branch: Option[String],
     currentCatalog: CatalogPlugin,
     catalog: Option[String]
-) extends BaseShowLogExec(output, branch, currentCatalog, catalog) {
-
-  override protected def runInternal(
-      api: NessieApiV1
-  ): Seq[InternalRow] = {
-    val refName = branch.getOrElse(
-      NessieUtils.getCurrentRef(currentCatalog, catalog).getName
-    )
-    val stream = StreamingUtil.getCommitLogStream(
-      api,
-      refName,
-      null,
-      null,
-      null,
-      OptionalInt.empty
-    )
-
-    stream.iterator.asScala
-      .map(entry =>
-        InternalRow(
-          convert(entry.getCommitMeta.getAuthor),
-          convert(entry.getCommitMeta.getCommitter),
-          convert(entry.getCommitMeta.getHash),
-          convert(entry.getCommitMeta.getMessage),
-          convert(entry.getCommitMeta.getSignedOffBy),
-          convert(entry.getCommitMeta.getAuthorTime),
-          convert(entry.getCommitMeta.getCommitTime),
-          convert(entry.getCommitMeta.getProperties)
-        )
-      )
-      .toSeq
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    s"ShowLogExec ${catalog.getOrElse(currentCatalog.name())} ${branch} "
-  }
-
-  private def convert(input: String): UTF8String = {
-    UTF8String.fromString(if (input == null) "" else input)
-  }
-
-  private def convert(input: Instant): Long = {
-    ChronoUnit.MICROS.between(Instant.EPOCH, input)
-  }
-
-  private def convert(input: java.util.Map[String, String]): MapData = {
-    ArrayBasedMapData(input, x => convertMapKV(x), x => convertMapKV(x))
-  }
-
-  private def convertMapKV(input: Any): Any = {
-    input match {
-      case c: String  => convert(c)
-      case c: Instant => convert(c)
-      case c          => c
-    }
-  }
-}
+) extends BaseShowLogExec(output, branch, currentCatalog, catalog) {}

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowReferenceExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowReferenceExec.scala
@@ -15,34 +15,11 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
 
 case class ShowReferenceExec(
     output: Seq[Attribute],
     currentCatalog: CatalogPlugin,
     catalog: Option[String]
-) extends BaseShowReferenceExec(output, currentCatalog, catalog) {
-
-  override protected def runInternal(
-      api: NessieApiV1
-  ): Seq[InternalRow] = {
-
-    val ref = NessieUtils.getCurrentRef(currentCatalog, catalog)
-    // todo have to figure out if this is delta or iceberg and extract the ref accordingly
-    Seq(
-      InternalRow(
-        UTF8String.fromString(NessieUtils.getRefType(ref)),
-        UTF8String.fromString(ref.getName),
-        UTF8String.fromString(ref.getHash)
-      )
-    )
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    s"ShowReferenceExec ${catalog.getOrElse(currentCatalog.name())} "
-  }
-}
+) extends BaseShowReferenceExec(output, currentCatalog, catalog) {}

--- a/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UseReferenceExec.scala
+++ b/clients/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UseReferenceExec.scala
@@ -15,11 +15,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
 
 case class UseReferenceExec(
     output: Seq[Attribute],
@@ -33,25 +30,4 @@ case class UseReferenceExec(
       currentCatalog,
       timestampOrHash,
       catalog
-    ) {
-
-  override protected def runInternal(
-      api: NessieApiV1
-  ): Seq[InternalRow] = {
-
-    val ref = NessieUtils.calculateRef(branch, timestampOrHash, api)
-    NessieUtils.setCurrentRefForSpark(currentCatalog, catalog, ref)
-
-    Seq(
-      InternalRow(
-        UTF8String.fromString(NessieUtils.getRefType(ref)),
-        UTF8String.fromString(ref.getName),
-        UTF8String.fromString(ref.getHash)
-      )
-    )
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    s"UseReferenceExec ${catalog.getOrElse(currentCatalog.name())} ${branch} "
-  }
-}
+    ) {}


### PR DESCRIPTION
Removes the Duplicate code in spark-3.1 SQL Extensions and reuses the Base (common code)