### PR TITLE
Prevent maven-shade-plugin hang

### DIFF
--- a/clients/deltalake/pom.xml
+++ b/clients/deltalake/pom.xml
@@ -196,8 +196,12 @@
               <exclude>org.antlr:antlr-runtime</exclude>
               <exclude>org.antlr:antlr4-runtime</exclude>
               <exclude>org.antlr:ST4</exclude>
+              <exclude>org.assertj:*</exclude>
+              <exclude>org.junit.jupiter:*</exclude>
+              <exclude>org.projectnessie:nessie-spark-3.2-extensions</exclude>
               <exclude>org.scala-lang:scala-library</exclude>
               <exclude>org.scala-lang:scala-reflect</exclude>
+              <exclude>org.slf4j:log4j-over-slf4j</exclude>
             </excludes>
           </artifactSet>
         </configuration>

--- a/clients/spark-3.2-extensions/pom.xml
+++ b/clients/spark-3.2-extensions/pom.xml
@@ -271,8 +271,17 @@
           </transformers>
           <artifactSet>
             <includes>
-              <include>org.projectnessie</include>
+              <include>org.projectnessie:*</include>
             </includes>
+            <excludes>
+              <exclude>ch.qos.logback:*</exclude>
+              <exclude>org.apache.iceberg:*</exclude>
+              <exclude>org.apache.spark:*</exclude>
+              <exclude>org.assertj:*</exclude>
+              <exclude>org.junit.jupiter:*</exclude>
+              <exclude>org.projectnessie:nessie-spark-extensions-base</exclude>
+              <exclude>org.slf4j:log4j-over-slf4j</exclude>
+            </excludes>
           </artifactSet>
         </configuration>
         <executions>

--- a/clients/spark-extensions/pom.xml
+++ b/clients/spark-extensions/pom.xml
@@ -243,8 +243,17 @@
           </transformers>
           <artifactSet>
             <includes>
-              <include>org.projectnessie</include>
+              <include>org.projectnessie:*</include>
             </includes>
+            <excludes>
+              <exclude>ch.qos.logback:*</exclude>
+              <exclude>org.apache.iceberg:*</exclude>
+              <exclude>org.apache.spark:*</exclude>
+              <exclude>org.assertj:*</exclude>
+              <exclude>org.junit.jupiter:*</exclude>
+              <exclude>org.projectnessie:nessie-spark-extensions-base</exclude>
+              <exclude>org.slf4j:log4j-over-slf4j</exclude>
+            </excludes>
           </artifactSet>
         </configuration>
         <executions>

--- a/tools/content-generator/pom.xml
+++ b/tools/content-generator/pom.xml
@@ -126,6 +126,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
+          <artifactSet>
+            <excludes>
+              <exclude>com.google.code.findbugs:*</exclude>
+              <exclude>com.google.errorprone:*</exclude>
+              <exclude>org.assertj:*</exclude>
+              <exclude>org.junit.jupiter:*</exclude>
+            </excludes>
+          </artifactSet>
           <filters>
             <!-- filter to address "Invalid signature file" issue - see https://stackoverflow.com/a/6743609/589215 -->
             <filter>


### PR DESCRIPTION
The maven-shade-plugin is "allergic" to some dependency configurations, which cause
it to loop infinitely. This can be reproduced with `mvnd clean install -DskipTests`,
which ends up with the two spark extensions modules and the content generator tool
to "build forever".

There are two workarounds for this:
* do not generate a dependency reduced pom (not applicable)
* exclude problematic dependencies - the option that this PR implements by excluding
  test and some provided dependencies.

Note: the end result's still the same.

See also https://issues.apache.org/jira/browse/MSHADE-148 (open for ~9 years now).