### PR TITLE
Turn off the unicode check in ErrorProne

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1278,6 +1278,7 @@ limitations under the License.
             <configuration>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
+                <!-- Turning off Unicode check as it gives invalid errors in ErrorProne 2.11.0 -->
                 <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -XepExcludedPaths:.*/target/generated-*sources/.*</arg>
               </compilerArgs>
               <annotationProcessorPaths combine.children="append">

--- a/pom.xml
+++ b/pom.xml
@@ -1278,7 +1278,7 @@ limitations under the License.
             <configuration>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-*sources/.*</arg>
+                <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -XepExcludedPaths:.*/target/generated-*sources/.*</arg>
               </compilerArgs>
               <annotationProcessorPaths combine.children="append">
                 <path>


### PR DESCRIPTION
Turn off the unicode check in ErrorProne as it throws invalid error in IDE.

![image](https://user-images.githubusercontent.com/5889404/159643587-de4736b4-92f8-4bba-89ad-c019718b1c66.png)
