### PR TITLE
Enhance authorization checks

### DIFF
--- a/clients/client/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/clients/client/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -81,7 +81,7 @@ public class TestModelObjectsSerialization {
             Transplant.class,
             Json.arr("hashesToTransplant", HASH).add("fromRefName", "testBranch")),
         new Case(
-            ImmutableEntriesResponse.builder()
+            EntriesResponse.builder()
                 .addEntries(
                     ImmutableEntry.builder()
                         .type(Type.ICEBERG_TABLE)
@@ -98,7 +98,7 @@ public class TestModelObjectsSerialization {
                         .addNoQuotes("name", Json.arr("elements", "/tmp/testpath")))
                 .addNoQuotes("hasMore", true)),
         new Case(
-            ImmutableLogResponse.builder()
+            LogResponse.builder()
                 .token(HASH)
                 .addLogEntries(
                     LogEntry.builder()

--- a/model/src/main/java/org/projectnessie/model/LogResponse.java
+++ b/model/src/main/java/org/projectnessie/model/LogResponse.java
@@ -33,6 +33,10 @@ public interface LogResponse extends PaginatedResponse {
   @NotNull
   List<LogEntry> getLogEntries();
 
+  static ImmutableLogResponse.Builder builder() {
+    return ImmutableLogResponse.builder();
+  }
+
   @Value.Immutable
   @Schema(type = SchemaType.OBJECT, title = "LogEntry")
   @JsonSerialize(as = ImmutableLogEntry.class)

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractRestAccessChecks.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractRestAccessChecks.java
@@ -20,19 +20,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.api.params.CommitLogParams;
+import org.projectnessie.api.params.EntriesParams;
+import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.error.NessieForbiddenException;
 import org.projectnessie.jaxrs.ext.NessieAccessChecker;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Detached;
+import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.Operation;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Tag;
 import org.projectnessie.services.authz.AbstractBatchAccessChecker;
@@ -44,7 +55,7 @@ import org.projectnessie.versioned.DetachedRef;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 /** See {@link AbstractTestRest} for details about and reason for the inheritance model. */
-public abstract class AbstractRestAccessCheckDetached extends AbstractTestRest {
+public abstract class AbstractRestAccessChecks extends AbstractTestRest {
 
   private static final String VIEW_MSG = "Must not view detached references";
   private static final String COMMITS_MSG = "Must not list from detached references";
@@ -58,26 +69,74 @@ public abstract class AbstractRestAccessCheckDetached extends AbstractTestRest {
           CheckType.READ_ENTITY_VALUE, ENTITIES_MSG,
           CheckType.READ_ENTRIES, READ_MSG);
 
-  private BatchAccessChecker newAccessChecker() {
-    return new AbstractBatchAccessChecker() {
-      @Override
-      public Map<Check, String> check() {
-        Map<Check, String> failed = new LinkedHashMap<>();
-        getChecks()
-            .forEach(
-                check -> {
-                  String msg = CHECK_TYPE_MSG.get(check.type());
-                  if (msg != null) {
-                    if (check.ref() instanceof DetachedRef) {
-                      failed.put(check, msg);
-                    } else {
-                      assertThat(check.ref().getName()).isNotEqualTo(DetachedRef.REF_NAME);
-                    }
-                  }
-                });
-        return failed;
-      }
-    };
+  /**
+   * Verify that response filtering for {@link org.projectnessie.api.TreeApi#getCommitLog(String,
+   * CommitLogParams)} and {@link org.projectnessie.api.TreeApi#getEntries(String, EntriesParams)}
+   * does not return disallowed commit-log entries / commit-operations.
+   */
+  @Test
+  public void forbiddenContentKeys(
+      @NessieAccessChecker
+          Consumer<Function<AccessContext, BatchAccessChecker>> accessCheckerConsumer)
+      throws Exception {
+    Branch main = createBranch("forbiddenContentKeys");
+
+    ContentKey keyForbidden1 = ContentKey.of("forbidden_1");
+    ContentKey keyForbidden2 = ContentKey.of("forbidden_2");
+    ContentKey keyAllowed1 = ContentKey.of("allowed_1");
+    ContentKey keyAllowed2 = ContentKey.of("allowed_2");
+
+    Branch commit =
+        getApi()
+            .commitMultipleOperations()
+            .branchName(main.getName())
+            .hash(main.getHash())
+            .commitMeta(CommitMeta.builder().message("no security context").build())
+            .operation(
+                Put.of(keyForbidden1, IcebergTable.of(keyForbidden1.getName(), 42, 42, 42, 42)))
+            .operation(Put.of(keyAllowed1, IcebergTable.of(keyAllowed1.getName(), 42, 42, 42, 42)))
+            .operation(
+                Put.of(keyForbidden2, IcebergTable.of(keyForbidden2.getName(), 42, 42, 42, 42)))
+            .operation(Put.of(keyAllowed2, IcebergTable.of(keyAllowed2.getName(), 42, 42, 42, 42)))
+            .commit();
+
+    ThrowingConsumer<Collection<ContentKey>> assertKeys =
+        expectedKeys -> {
+          assertThat(getApi().getEntries().reference(commit).get().getEntries())
+              .extracting(EntriesResponse.Entry::getName)
+              .containsExactlyInAnyOrderElementsOf(expectedKeys);
+          assertThat(
+                  getApi()
+                      .getCommitLog()
+                      .reference(commit)
+                      .fetch(FetchOption.ALL)
+                      .get()
+                      .getLogEntries())
+              .hasSize(1)
+              .element(0)
+              .extracting(LogResponse.LogEntry::getOperations)
+              .asInstanceOf(InstanceOfAssertFactories.list(Operation.class))
+              .map(Operation::getKey)
+              .containsExactlyInAnyOrderElementsOf(expectedKeys);
+        };
+
+    assertKeys.accept(Arrays.asList(keyAllowed1, keyAllowed2, keyForbidden1, keyForbidden2));
+
+    accessCheckerConsumer.accept(
+        x ->
+            new AbstractBatchAccessChecker() {
+              @Override
+              public Map<Check, String> check() {
+                return getChecks().stream()
+                    .filter(c -> c.type() == CheckType.READ_CONTENT_KEY)
+                    .filter(c -> c.key().getName().startsWith("forbidden"))
+                    .collect(
+                        Collectors.toMap(
+                            Function.identity(), c -> "Forbidden key " + c.key().getName()));
+              }
+            });
+
+    assertKeys.accept(Arrays.asList(keyAllowed1, keyAllowed2));
   }
 
   @Test
@@ -85,7 +144,29 @@ public abstract class AbstractRestAccessCheckDetached extends AbstractTestRest {
       @NessieAccessChecker
           Consumer<Function<AccessContext, BatchAccessChecker>> accessCheckerConsumer)
       throws Exception {
-    accessCheckerConsumer.accept(x -> newAccessChecker());
+
+    BatchAccessChecker accessChecker =
+        new AbstractBatchAccessChecker() {
+          @Override
+          public Map<Check, String> check() {
+            Map<Check, String> failed = new LinkedHashMap<>();
+            getChecks()
+                .forEach(
+                    check -> {
+                      String msg = CHECK_TYPE_MSG.get(check.type());
+                      if (msg != null) {
+                        if (check.ref() instanceof DetachedRef) {
+                          failed.put(check, msg);
+                        } else {
+                          assertThat(check.ref().getName()).isNotEqualTo(DetachedRef.REF_NAME);
+                        }
+                      }
+                    });
+            return failed;
+          }
+        };
+
+    accessCheckerConsumer.accept(x -> accessChecker);
 
     Branch main = createBranch("committerAndAuthor");
     Branch merge = createBranch("committerAndAuthorMerge");

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractRestSecurityContext.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractRestSecurityContext.java
@@ -32,7 +32,7 @@ import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Operation.Put;
 
 /** See {@link AbstractTestRest} for details about and reason for the inheritance model. */
-public abstract class AbstractRestSecurityContext extends AbstractRestAccessCheckDetached {
+public abstract class AbstractRestSecurityContext extends AbstractRestAccessChecks {
   @Test
   public void committerAndAuthor(
       @NessieSecurityContext Consumer<SecurityContext> securityContextConsumer) throws Exception {

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/authz/CelBatchAccessChecker.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/authz/CelBatchAccessChecker.java
@@ -62,7 +62,8 @@ final class CelBatchAccessChecker extends AbstractBatchAccessChecker {
   private void canPerformOp(Check check, Map<Check, String> failed) {
     String roleName = getRoleName();
     ImmutableMap<String, Object> arguments =
-        ImmutableMap.of("role", roleName, "op", check.type().name(), "path", "", "ref", "");
+        ImmutableMap.of(
+            "role", roleName, "op", check.type().name(), "path", "", "ref", "", "contentType", "");
 
     Supplier<String> errorMsgSupplier =
         () -> String.format("'%s' is not allowed for role '%s' ", check.type(), roleName);
@@ -73,7 +74,16 @@ final class CelBatchAccessChecker extends AbstractBatchAccessChecker {
     String roleName = getRoleName();
     ImmutableMap<String, Object> arguments =
         ImmutableMap.of(
-            "ref", check.ref().getName(), "role", roleName, "op", check.type().name(), "path", "");
+            "ref",
+            check.ref().getName(),
+            "role",
+            roleName,
+            "op",
+            check.type().name(),
+            "path",
+            "",
+            "contentType",
+            "");
 
     Supplier<String> errorMsgSupplier =
         () ->
@@ -94,7 +104,9 @@ final class CelBatchAccessChecker extends AbstractBatchAccessChecker {
             "role",
             roleName,
             "op",
-            check.type().name());
+            check.type().name(),
+            "contentType",
+            check.contentType() != null ? check.contentType().name() : "");
 
     Supplier<String> errorMsgSupplier =
         () ->

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -25,7 +25,7 @@ nessie.server.send-stacktrace-to-client=false
 ### Rule definitions are of the form nessie.server.authorization.rules.<ruleId>=<rule_expression>
 ### Available variables within the <rule_expression> are: 'op' / 'role' / 'ref' / 'path'
 ### The 'op' variable in the <rule_expression> can be any of:
-### 'VIEW_REFERENCE', 'CREATE_REFERENCE', 'DELETE_REFERENCE', 'READ_ENTRIES', 'LIST_COMMIT_LOG',
+### 'VIEW_REFERENCE', 'CREATE_REFERENCE', 'DELETE_REFERENCE', 'READ_ENTRIES', 'READ_CONTENT_KEY', 'LIST_COMMIT_LOG',
 ### 'COMMIT_CHANGE_AGAINST_REFERENCE', 'ASSIGN_REFERENCE_TO_HASH', 'UPDATE_ENTITY', 'READ_ENTITY_VALUE', 'DELETE_ENTITY', 'VIEW_REFLOG'
 ### The 'role' refers to the user's role and can be any string
 ### The 'ref' refers to a string representing a branch/tag name

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
@@ -31,58 +31,34 @@ public class NessieAuthorizationTestProfile extends AuthenticationEnabledProfile
       ImmutableMap.<String, String>builder()
           .put(
               "nessie.server.authorization.rules.allow_all",
-              "op in ['VIEW_REFERENCE','CREATE_REFERENCE','DELETE_REFERENCE',"
-                  + "'LIST_COMMITLOG','READ_ENTRIES','LIST_COMMIT_LOG','COMMIT_CHANGE_AGAINST_REFERENCE',"
+              "op in ['VIEW_REFERENCE','CREATE_REFERENCE','DELETE_REFERENCE','VIEW_REFLOG','DELETE_DEFAULT_BRANCH',"
+                  + "'LIST_COMMITLOG','READ_ENTRIES','READ_CONTENT_KEY','LIST_COMMIT_LOG','COMMIT_CHANGE_AGAINST_REFERENCE',"
                   + "'ASSIGN_REFERENCE_TO_HASH','UPDATE_ENTITY','READ_ENTITY_VALUE','DELETE_ENTITY'] && role=='admin_user'")
           .put(
               "nessie.server.authorization.rules.allow_branch_listing",
               "op=='VIEW_REFERENCE' && role.startsWith('test_user') && ref.matches('.*')")
           .put(
-              "nessie.server.authorization.rules.allow_branch_creation",
-              "op=='CREATE_REFERENCE' && role.startsWith('test_user') && ref.startsWith('allowedBranch')")
-          .put(
-              "nessie.server.authorization.rules.allow_branch_deletion",
-              "op=='DELETE_REFERENCE' && role.startsWith('test_user') && ref.startsWith('allowedBranch')")
-          .put(
-              "nessie.server.authorization.rules.allow_listing_commitlog",
-              "op=='LIST_COMMIT_LOG' && role.startsWith('test_user') && ref.startsWith('allowedBranch')")
-          .put(
-              "nessie.server.authorization.rules.allow_entries_reading",
-              "op=='READ_ENTRIES' && role.startsWith('test_user') && ref.startsWith('allowedBranch')")
-          .put(
-              "nessie.server.authorization.rules.allow_assigning_ref_to_hash",
-              "op=='ASSIGN_REFERENCE_TO_HASH' && role.startsWith('test_user') && ref.startsWith('allowedBranch')")
+              "nessie.server.authorization.rules.allow_test_user_allowed_branch",
+              "op in ['CREATE_REFERENCE','DELETE_REFERENCE','LIST_COMMIT_LOG','READ_ENTRIES','READ_CONTENT_KEY','ASSIGN_REFERENCE_TO_HASH'] "
+                  + "&& role.startsWith('test_user') && ref.startsWith('allowedBranch')")
           .put(
               "nessie.server.authorization.rules.allow_commits",
               ("op=='COMMIT_CHANGE_AGAINST_REFERENCE' && role.startsWith('test_user') && ref.startsWith"
                   + "('allowedBranch')"))
           .put(
-              "nessie.server.authorization.rules.allow_reading_entity_value",
-              "op in ['VIEW_REFERENCE', 'READ_ENTITY_VALUE'] && role=='test_user' && path.startsWith('allowed.') "
-                  + "&& ref.startsWith('allowedBranch')")
-          .put(
-              "nessie.server.authorization.rules.allow_updating_entity",
-              "op in ['VIEW_REFERENCE', 'UPDATE_ENTITY'] "
-                  + "&& role=='test_user' && path.startsWith('allowed.') && ref.startsWith('allowedBranch')")
-          .put(
-              "nessie.server.authorization.rules.allow_deleting_entity",
-              "op in ['VIEW_REFERENCE', 'DELETE_ENTITY'] "
+              "nessie.server.authorization.rules.allow_create_or_delete_entity",
+              "op in ['VIEW_REFERENCE', 'READ_ENTITY_VALUE', 'UPDATE_ENTITY', 'DELETE_ENTITY'] "
                   + "&& role=='test_user' && path.startsWith('allowed.') && ref.startsWith('allowedBranch')")
           .put(
               "nessie.server.authorization.rules.allow_commits_without_entity_changes",
               "op=='COMMIT_CHANGE_AGAINST_REFERENCE' && role=='test_user2' && ref.startsWith('allowedBranch')")
           .put(
-              "nessie.server.authorization.rules.allow_listing_reflog",
-              "op=='VIEW_REFLOG' && role=='admin_user'")
-          .put(
-              "nessie.server.authorization.rules.allow_deleting_default_branch",
-              "op=='DELETE_DEFAULT_BRANCH' && role=='admin_user'")
-          .put(
               "nessie.server.authorization.rules.allow_creation_user1",
               "op=='CREATE_REFERENCE' && role=='user1' && ref.matches('.*')")
           .put(
               "nessie.server.authorization.rules.allow_view_merge_delete_user1",
-              "op in ['VIEW_REFERENCE', 'ASSIGN_REFERENCE_TO_HASH', 'COMMIT_CHANGE_AGAINST_REFERENCE', 'DELETE_REFERENCE'] && role=='user1' && (ref.startsWith('allowedBranch') || ref == 'main')")
+              "op in ['VIEW_REFERENCE', 'ASSIGN_REFERENCE_TO_HASH', 'COMMIT_CHANGE_AGAINST_REFERENCE', 'DELETE_REFERENCE'] "
+                  + "&& role=='user1' && (ref.startsWith('allowedBranch') || ref == 'main')")
           .build();
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/authz/AbstractBatchAccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/AbstractBatchAccessChecker.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.services.authz.Check.CheckType;
 import org.projectnessie.versioned.NamedRef;
@@ -77,6 +78,12 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
   }
 
   @Override
+  public BatchAccessChecker canReadContentKey(NamedRef ref, ContentKey key) {
+    canViewReference(ref);
+    return add(Check.builder(CheckType.READ_CONTENT_KEY).ref(ref).key(key));
+  }
+
+  @Override
   public BatchAccessChecker canListCommitLog(NamedRef ref) {
     canViewReference(ref);
     return add(Check.builder(CheckType.LIST_COMMIT_LOG).ref(ref));
@@ -95,9 +102,15 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
   }
 
   @Override
-  public BatchAccessChecker canUpdateEntity(NamedRef ref, ContentKey key, String contentId) {
+  public BatchAccessChecker canUpdateEntity(
+      NamedRef ref, ContentKey key, String contentId, Content.Type contentType) {
     canViewReference(ref);
-    return add(Check.builder(CheckType.UPDATE_ENTITY).ref(ref).key(key).contentId(contentId));
+    return add(
+        Check.builder(CheckType.UPDATE_ENTITY)
+            .ref(ref)
+            .key(key)
+            .contentId(contentId)
+            .contentType(contentType));
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
@@ -17,9 +17,11 @@ package org.projectnessie.services.authz;
 
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
+import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.versioned.NamedRef;
 
+/** Describes a check operation. */
 @Value.Immutable
 public interface Check {
   CheckType type();
@@ -33,22 +35,41 @@ public interface Check {
   @Nullable
   String contentId();
 
+  @Nullable
+  Content.Type contentType();
+
   static ImmutableCheck.Builder builder(CheckType type) {
     return ImmutableCheck.builder().type(type);
   }
 
   enum CheckType {
+    /** See {@link BatchAccessChecker#canViewReference(NamedRef)}. */
     VIEW_REFERENCE(true, false),
+    /** See {@link BatchAccessChecker#canCreateReference(NamedRef)}. */
     CREATE_REFERENCE(true, false),
+    /** See {@link BatchAccessChecker#canAssignRefToHash(NamedRef)}. */
     ASSIGN_REFERENCE_TO_HASH(true, false),
+    /** See {@link BatchAccessChecker#canDeleteReference(NamedRef)}. */
     DELETE_REFERENCE(true, false),
+    /** See {@link BatchAccessChecker#canDeleteDefaultBranch()}. */
     DELETE_DEFAULT_BRANCH(false, false),
+    /** See {@link BatchAccessChecker#canReadEntries(NamedRef)}. */
     READ_ENTRIES(true, false),
+    /** See {@link BatchAccessChecker#canReadContentKey(NamedRef, ContentKey)}. */
+    READ_CONTENT_KEY(true, true),
+    /** See {@link BatchAccessChecker#canListCommitLog(NamedRef)}. */
     LIST_COMMIT_LOG(true, false),
+    /** See {@link BatchAccessChecker#canCommitChangeAgainstReference(NamedRef)}. */
     COMMIT_CHANGE_AGAINST_REFERENCE(true, false),
+    /** See {@link BatchAccessChecker#canReadEntityValue(NamedRef, ContentKey, String)}. */
     READ_ENTITY_VALUE(true, true),
+    /**
+     * See {@link BatchAccessChecker#canUpdateEntity(NamedRef, ContentKey, String, Content.Type)}.
+     */
     UPDATE_ENTITY(true, true),
+    /** See {@link BatchAccessChecker#canDeleteEntity(NamedRef, ContentKey, String)}. */
     DELETE_ENTITY(true, true),
+    /** See {@link BatchAccessChecker#canViewRefLog()}. */
     VIEW_REFLOG(false, false);
 
     private final boolean ref;

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -68,7 +68,6 @@ import org.projectnessie.model.Detached;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.ImmutableBranch;
 import org.projectnessie.model.ImmutableLogEntry;
-import org.projectnessie.model.ImmutableLogResponse;
 import org.projectnessie.model.ImmutableReferenceMetadata;
 import org.projectnessie.model.ImmutableReferencesResponse;
 import org.projectnessie.model.ImmutableTag;
@@ -313,13 +312,13 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
           filterCommitLog(logEntries, params.filter()).limit(max + 1).collect(Collectors.toList());
 
       if (items.size() == max + 1) {
-        return ImmutableLogResponse.builder()
+        return LogResponse.builder()
             .addAllLogEntries(items.subList(0, max))
             .isHasMore(true)
             .token(items.get(max).getCommitMeta().getHash())
             .build();
       }
-      return ImmutableLogResponse.builder().addAllLogEntries(items).build();
+      return LogResponse.builder().addAllLogEntries(items).build();
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     }

--- a/site/docs/features/metadata_authorization.md
+++ b/site/docs/features/metadata_authorization.md
@@ -73,10 +73,25 @@ Rule definitions are of the form `nessie.server.authorization.rules.<ruleId>=<ru
 
 Available variables within the `<rule_expression>` are: **'op'** / **'role'** / **'ref'** / **'path'**.
 
-* The **'op'** variable in the `<rule_expression>` refers to the type of operation can be any of: **'VIEW_REFERENCE'**, **'CREATE_REFERENCE'**, **'DELETE_REFERENCE'**, **'DELETE_DEFAULT_BRANCH'**, **'READ_ENTRIES'**, **'LIST_COMMIT_LOG'**, **'COMMIT_CHANGE_AGAINST_REFERENCE'**, **'ASSIGN_REFERENCE_TO_HASH'**, **'UPDATE_ENTITY'**, **'READ_ENTITY_VALUE'**, **'DELETE_ENTITY'**,**'VIEW_REFLOG'**.
+* The **'op'** variable in the `<rule_expression>` refers to the type of operation can be any of the following.
+  See [BatchAccessChecker](https://github.com/projectnessie/nessie/blob/main/servers/services/src/main/java/org/projectnessie/services/authz/BatchAccessChecker.java)
+  and [Check](https://github.com/projectnessie/nessie/blob/main/servers/services/src/main/java/org/projectnessie/services/authz/Check.java) types.
+  * `VIEW_REFERENCE`
+  * `CREATE_REFERENCE`
+  * `DELETE_REFERENCE`
+  * `DELETE_DEFAULT_BRANCH`
+  * `READ_ENTRIES`
+  * `READ_CONTENT_KEY`
+  * `LIST_COMMIT_LOG`
+  * `COMMIT_CHANGE_AGAINST_REFERENCE`
+  * `ASSIGN_REFERENCE_TO_HASH`
+  * `UPDATE_ENTITY`
+  * `READ_ENTITY_VALUE`
+  * `DELETE_ENTITY`
+  * `VIEW_REFLOG`.
 * The **'role'** refers to the user's role and can be any string.
-* The **'ref'** refers to a string representing a branch/tag name
-* The **'path'** refers to the Key for the contents of an object and can be any string
+* The **'ref'** refers to a string representing a branch/tag name or `DETATCHED` for direct access to a commit id.
+* The **'path'** refers to the [content key](https://github.com/projectnessie/nessie/blob/main/model/src/main/java/org/projectnessie/model/ContentKey.java) for the contents of an object and can be any string
 
 Since all available authorization rule variables are strings, the relevant CEL-specific things that are worth mentioning are shown below:
 


### PR DESCRIPTION
Adds `Content.Type` to `canUpdateEntity`, introduces `canReadContentKey` to
filter the results for `TreeApi.getCommitLog()` and `TreeApi.getEntries()`.
