### PR TITLE
Add Helm Service Annotation Support

### DIFF
--- a/helm/nessie/templates/service.yaml
+++ b/helm/nessie/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "nessie.fullname" . }}
   labels:
     {{- include "nessie.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -93,6 +93,8 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 19120
+  # Annotations to add to the service
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
Adds Annotation support for the Service created by the Helm Chart.

Fixes #3701 

**Testing**
Using the following values file 
```
service:
   annotations:
      myannotation: myvalue
```
The generated service shows:
```
# Source: nessie/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: nessie-test
  labels:
    helm.sh/chart: nessie-0.22.0
    app.kubernetes.io/name: nessie
    app.kubernetes.io/instance: nessie-test
    app.kubernetes.io/version: "0.22.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    myannotation: myvalue    <<<<<<<<<<<<<<<<<<<<<<
spec:
  type: ClusterIP
  ports:
    - port: 19120
      targetPort: 19120
      protocol: TCP
      name: nessie-server
  selector:
    app.kubernetes.io/name: nessie
    app.kubernetes.io/instance: nessie-test
```
With no annotations specified the generated service shows:
```
# Source: nessie/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: nessie-test
  labels:
    helm.sh/chart: nessie-0.22.0
    app.kubernetes.io/name: nessie
    app.kubernetes.io/instance: nessie-test
    app.kubernetes.io/version: "0.22.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 19120
      targetPort: 19120
      protocol: TCP
      name: nessie-server
  selector:
    app.kubernetes.io/name: nessie
    app.kubernetes.io/instance: nessie-test
```