### PR TITLE
Refactor client setup in Gatling simulations.

### DIFF
--- a/perftest/gatling/src/main/scala/org/projectnessie/perftest/gatling/NessieProtocol.scala
+++ b/perftest/gatling/src/main/scala/org/projectnessie/perftest/gatling/NessieProtocol.scala
@@ -22,6 +22,7 @@ import io.gatling.core.protocol.{Protocol, ProtocolComponents, ProtocolKey}
 import io.gatling.core.scenario.Simulation
 import io.gatling.core.session.Session
 import org.projectnessie.client.api.NessieApiV1
+import org.projectnessie.client.http.HttpClientBuilder
 
 case class NessieProtocolBuilder() extends StrictLogging {
 
@@ -31,6 +32,14 @@ case class NessieProtocolBuilder() extends StrictLogging {
     */
   def client(client: NessieApiV1): NessieProtocol =
     NessieProtocol(client)
+
+  def clientFromSystemProperties(): NessieProtocol =
+    client(
+      HttpClientBuilder
+        .builder()
+        .fromSystemProperties()
+        .build(classOf[NessieApiV1])
+    )
 }
 
 case class NessieProtocol(

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationDifferentTables.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationDifferentTables.scala
@@ -177,13 +177,7 @@ class CommitToBranchSimulationDifferentTables extends Simulation {
     * maximum-duration.
     */
   private def doSetUp(): SetUp = {
-    val nessieProtocol: NessieProtocol = nessie()
-      .client(
-        HttpClientBuilder
-          .builder()
-          .fromSystemProperties()
-          .build(classOf[NessieApiV1])
-      )
+    val nessieProtocol: NessieProtocol = nessie().clientFromSystemProperties()
 
     System.out.println(params.asPrintableString())
 

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationSameTable.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulationSameTable.scala
@@ -176,13 +176,7 @@ class CommitToBranchSimulationSameTable extends Simulation {
     * maximum-duration.
     */
   private def doSetUp(): SetUp = {
-    val nessieProtocol: NessieProtocol = nessie()
-      .client(
-        HttpClientBuilder
-          .builder()
-          .fromSystemProperties()
-          .build(classOf[NessieApiV1])
-      )
+    val nessieProtocol: NessieProtocol = nessie().clientFromSystemProperties()
 
     System.out.println(params.asPrintableString())
 

--- a/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CreateManyBranchesSimulation.scala
+++ b/perftest/simulations/src/test/scala/org/projectnessie/perftest/gatling/CreateManyBranchesSimulation.scala
@@ -93,13 +93,7 @@ class CreateManyBranchesSimulation extends Simulation {
     * maximum-duration.
     */
   private def doSetUp(): SetUp = {
-    val nessieProtocol: NessieProtocol = nessie()
-      .client(
-        HttpClientBuilder
-          .builder()
-          .fromSystemProperties()
-          .build(classOf[NessieApiV1])
-      )
+    val nessieProtocol: NessieProtocol = nessie().clientFromSystemProperties()
 
     System.out.println(params.asPrintableString())
 


### PR DESCRIPTION
Move common code into NessieProtocol.clientFromSystemProperties() for reuse.