### PR TITLE
Serialize NessieApi

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Serializable;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -28,7 +29,7 @@ import javax.net.ssl.SSLContext;
  * <p>Assumptions: - always send/receive JSON - set headers accordingly by default - very simple
  * interactions w/ API - no cookies - no caching of connections. Could be slow
  */
-public class HttpClient {
+public class HttpClient implements Serializable {
 
   private final HttpRuntimeConfig config;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpConfigClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpConfigClient.java
@@ -15,10 +15,11 @@
  */
 package org.projectnessie.client.http;
 
+import java.io.Serializable;
 import org.projectnessie.api.http.HttpConfigApi;
 import org.projectnessie.model.NessieConfiguration;
 
-class HttpConfigClient implements HttpConfigApi {
+class HttpConfigClient implements HttpConfigApi, Serializable {
   private final HttpClient client;
 
   HttpConfigClient(HttpClient client) {

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpContentClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpContentClient.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.http;
 
+import java.io.Serializable;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.api.http.HttpContentApi;
 import org.projectnessie.error.NessieNotFoundException;
@@ -23,7 +24,7 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.GetMultipleContentsRequest;
 import org.projectnessie.model.GetMultipleContentsResponse;
 
-class HttpContentClient implements HttpContentApi {
+class HttpContentClient implements HttpContentApi, Serializable {
 
   private final HttpClient client;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpDiffClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpDiffClient.java
@@ -15,13 +15,14 @@
  */
 package org.projectnessie.client.http;
 
+import java.io.Serializable;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.api.http.HttpDiffApi;
 import org.projectnessie.api.params.DiffParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.DiffResponse;
 
-class HttpDiffClient implements HttpDiffApi {
+class HttpDiffClient implements HttpDiffApi, Serializable {
 
   private final HttpClient client;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpNamespaceClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpNamespaceClient.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.http;
 
+import java.io.Serializable;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.api.http.HttpNamespaceApi;
 import org.projectnessie.api.params.MultipleNamespacesParams;
@@ -26,7 +27,7 @@ import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.GetNamespacesResponse;
 import org.projectnessie.model.Namespace;
 
-class HttpNamespaceClient implements HttpNamespaceApi {
+class HttpNamespaceClient implements HttpNamespaceApi, Serializable {
 
   private final HttpClient client;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpRefLogClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpRefLogClient.java
@@ -15,13 +15,14 @@
  */
 package org.projectnessie.client.http;
 
+import java.io.Serializable;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.api.http.HttpRefLogApi;
 import org.projectnessie.api.params.RefLogParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 
-class HttpRefLogClient implements HttpRefLogApi {
+class HttpRefLogClient implements HttpRefLogApi, Serializable {
 
   private final HttpClient client;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpRuntimeConfig.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpRuntimeConfig.java
@@ -16,19 +16,20 @@
 package org.projectnessie.client.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 import javax.net.ssl.SSLContext;
 
 /** Package-private HTTP configuration holder. */
-final class HttpRuntimeConfig {
+final class HttpRuntimeConfig implements Serializable {
   private final URI baseUri;
-  private final ObjectMapper mapper;
+  private final transient ObjectMapper mapper;
   private final int readTimeoutMillis;
   private final int connectionTimeoutMillis;
   private final boolean disableCompression;
-  private final SSLContext sslContext;
+  private final transient SSLContext sslContext;
   private final List<RequestFilter> requestFilters;
   private final List<ResponseFilter> responseFilters;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpTreeClient.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.http;
 
+import java.io.Serializable;
 import java.util.Locale;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -35,7 +36,7 @@ import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferencesResponse;
 import org.projectnessie.model.Transplant;
 
-class HttpTreeClient implements HttpTreeApi {
+class HttpTreeClient implements HttpTreeApi, Serializable {
 
   private final HttpClient client;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/NessieApiClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/NessieApiClient.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http;
 
 import java.io.Closeable;
+import java.io.Serializable;
 import org.projectnessie.api.http.HttpConfigApi;
 import org.projectnessie.api.http.HttpContentApi;
 import org.projectnessie.api.http.HttpDiffApi;
@@ -23,7 +24,7 @@ import org.projectnessie.api.http.HttpNamespaceApi;
 import org.projectnessie.api.http.HttpRefLogApi;
 import org.projectnessie.api.http.HttpTreeApi;
 
-public class NessieApiClient implements Closeable {
+public class NessieApiClient implements Closeable, Serializable {
   private final HttpConfigApi config;
   private final HttpTreeApi tree;
   private final HttpContentApi content;

--- a/clients/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
@@ -27,6 +27,7 @@ import io.opentracing.propagation.TextMapAdapter;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -148,7 +149,7 @@ public class NessieHttpClient extends NessieApiClient {
    * This will rewrite exceptions, so they are correctly thrown by the api classes. (since the
    * filter will cause them to be wrapped in {@link javax.ws.rs.client.ResponseProcessingException})
    */
-  private static class ExceptionRewriter implements InvocationHandler {
+  private static class ExceptionRewriter implements InvocationHandler, Serializable {
 
     private final Object delegate;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.http.v1api;
 
+import java.io.Serializable;
 import org.projectnessie.client.api.AssignBranchBuilder;
 import org.projectnessie.client.api.AssignTagBuilder;
 import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
@@ -40,7 +41,7 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.NessieConfiguration;
 
-public final class HttpApiV1 implements NessieApiV1 {
+public final class HttpApiV1 implements NessieApiV1, Serializable {
 
   private final NessieApiClient client;
 

--- a/clients/client/src/main/java/org/projectnessie/client/rest/NessieHttpResponseFilter.java
+++ b/clients/client/src/main/java/org/projectnessie/client/rest/NessieHttpResponseFilter.java
@@ -16,13 +16,14 @@
 package org.projectnessie.client.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Serializable;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.ResponseFilter;
 
-public class NessieHttpResponseFilter implements ResponseFilter {
+public class NessieHttpResponseFilter implements ResponseFilter, Serializable {
 
-  private final ObjectMapper mapper;
+  private final transient ObjectMapper mapper;
 
   public NessieHttpResponseFilter(ObjectMapper mapper) {
     this.mapper = mapper;

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
@@ -116,9 +116,10 @@ public class GCImpl {
       // Identify the live contents and return the bloom filter per content-id
       Map<String, ContentBloomFilter> liveContentsBloomFilterMap =
           distributedIdentifyContents.getLiveContentsBloomFilters(
-              allRefs, bloomFilterSize, droppedReferenceTimeMap);
+              allRefs, bloomFilterSize, droppedReferenceTimeMap, api);
       // Identify the expired contents
-      return distributedIdentifyContents.getIdentifiedResults(liveContentsBloomFilterMap, allRefs);
+      return distributedIdentifyContents.getIdentifiedResults(
+          liveContentsBloomFilterMap, allRefs, api);
     }
   }
 


### PR DESCRIPTION
to pass from spark driver to executor.

After changing bunch of classes to Serializable and making `SSLContext` and `ObjectMapper` transient because of below errors.

SSLContext:
`java.io.NotSerializableException: javax.net.ssl.SSLContext
`
ObjectMapper:
`Caused by: java.io.NotSerializableException: com.fasterxml.jackson.databind.jsontype.impl.TypeNameIdResolver
`
**Also modified GC spark code to send the nessie api from driver to executor and (close the API in driver)**

TODO: probably need to reconstruct SSLContext at executor by taking config, else HTTPS connections doesn't work.
