### PR TITLE
Pass `test.log.level` via surefire + failsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -700,6 +700,9 @@
               <user.country>US</user.country>
               <user.variant/>
             </systemProperties>
+            <systemPropertyVariables>
+              <test.log.level>${test.log.level}</test.log.level>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
         <plugin>
@@ -714,6 +717,9 @@
               <user.country>US</user.country>
               <user.variant/>
             </systemProperties>
+            <systemPropertyVariables>
+              <test.log.level>${test.log.level}</test.log.level>
+            </systemPropertyVariables>
             <useModulePath>false</useModulePath>
           </configuration>
         </plugin>


### PR DESCRIPTION
The `test.log.level` property needs to be passed to (integration) tests, so that a `src/test/resources/logback-test.xml` file can pick it up.