### PR TITLE
Squash merge

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
@@ -16,23 +16,17 @@
 package org.projectnessie.client.api;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
-import org.projectnessie.model.Validation;
 
 /**
  * Request builder for "merge reference".
  *
  * @since {@link NessieApiV1}
  */
-public interface MergeReferenceBuilder extends OnBranchBuilder<MergeReferenceBuilder> {
+public interface MergeReferenceBuilder extends MergeTransplantBuilder<MergeReferenceBuilder> {
   MergeReferenceBuilder fromHash(@NotBlank String fromHash);
-
-  MergeReferenceBuilder fromRefName(
-      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-          String fromRefName);
 
   /**
    * Convenience for {@link #fromRefName(String) fromRefName(fromRef.getName())}{@code .}{@link

--- a/clients/client/src/main/java/org/projectnessie/client/api/MergeTransplantBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/MergeTransplantBuilder.java
@@ -13,21 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.adapter;
+package org.projectnessie.client.api;
 
-import com.google.protobuf.ByteString;
-import java.util.List;
-import java.util.function.Function;
-import org.immutables.value.Value;
+import javax.validation.constraints.Pattern;
+import org.projectnessie.model.Validation;
 
-public interface MetadataRewriteParams extends ToBranchParams {
+public interface MergeTransplantBuilder<R extends MergeTransplantBuilder<R>>
+    extends OnBranchBuilder<R> {
+  R fromRefName(
+      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+          String fromRefName);
 
-  /** Whether to keep the individual commits and do not squash the commits to merge. */
-  @Value.Default
-  default boolean keepIndividualCommits() {
-    return false;
-  }
-
-  /** Function to rewrite the commit-metadata. */
-  Function<List<ByteString>, ByteString> getUpdateCommitMetadata();
+  R keepIndividualCommits(boolean keepIndividualCommits);
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/TransplantCommitsBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/TransplantCommitsBuilder.java
@@ -17,23 +17,17 @@ package org.projectnessie.client.api;
 
 import java.util.List;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.Validation;
 
 /**
  * Request builder for "transplant commits".
  *
  * @since {@link NessieApiV1}
  */
-public interface TransplantCommitsBuilder extends OnBranchBuilder<TransplantCommitsBuilder> {
+public interface TransplantCommitsBuilder extends MergeTransplantBuilder<TransplantCommitsBuilder> {
   TransplantCommitsBuilder message(String message);
-
-  TransplantCommitsBuilder fromRefName(
-      @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-          String fromRefName);
 
   TransplantCommitsBuilder hashesToTransplant(
       @NotNull @Size(min = 1) List<String> hashesToTransplant);

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
@@ -43,6 +43,12 @@ final class HttpMergeReference extends BaseHttpOnBranchRequest<MergeReferenceBui
   }
 
   @Override
+  public MergeReferenceBuilder keepIndividualCommits(boolean keepIndividualCommits) {
+    merge.keepIndividualCommits(keepIndividualCommits);
+    return this;
+  }
+
+  @Override
   public void merge() throws NessieNotFoundException, NessieConflictException {
     client.getTreeApi().mergeRefIntoBranch(branchName, hash, merge.build());
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
@@ -51,6 +51,12 @@ final class HttpTransplantCommits extends BaseHttpOnBranchRequest<TransplantComm
   }
 
   @Override
+  public TransplantCommitsBuilder keepIndividualCommits(boolean keepIndividualCommits) {
+    transplant.keepIndividualCommits(keepIndividualCommits);
+    return this;
+  }
+
+  @Override
   public void transplant() throws NessieNotFoundException, NessieConflictException {
     client.getTreeApi().transplantCommitsIntoBranch(branchName, hash, message, transplant.build());
   }

--- a/model/src/main/java/org/projectnessie/model/BaseMergeTransplant.java
+++ b/model/src/main/java/org/projectnessie/model/BaseMergeTransplant.java
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.adapter;
+package org.projectnessie.model;
 
-import com.google.protobuf.ByteString;
-import java.util.List;
-import java.util.function.Function;
-import org.immutables.value.Value;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
-public interface MetadataRewriteParams extends ToBranchParams {
+public interface BaseMergeTransplant {
 
-  /** Whether to keep the individual commits and do not squash the commits to merge. */
-  @Value.Default
-  default boolean keepIndividualCommits() {
-    return false;
-  }
+  @NotBlank
+  @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+  String getFromRefName();
 
-  /** Function to rewrite the commit-metadata. */
-  Function<List<ByteString>, ByteString> getUpdateCommitMetadata();
+  @Nullable
+  @JsonInclude(Include.NON_NULL)
+  Boolean keepIndividualCommits();
 }

--- a/model/src/main/java/org/projectnessie/model/Merge.java
+++ b/model/src/main/java/org/projectnessie/model/Merge.java
@@ -37,15 +37,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableMerge.class)
 @JsonDeserialize(as = ImmutableMerge.class)
-public interface Merge {
+public interface Merge extends BaseMergeTransplant {
 
   @NotBlank
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
   String getFromHash();
-
-  @NotBlank
-  @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-  String getFromRefName();
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateHash(String)}

--- a/model/src/main/java/org/projectnessie/model/Transplant.java
+++ b/model/src/main/java/org/projectnessie/model/Transplant.java
@@ -20,9 +20,7 @@ import static org.projectnessie.model.Validation.validateHash;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -45,10 +43,6 @@ public interface Transplant extends BaseMergeTransplant {
   @NotNull
   @Size(min = 1)
   List<String> getHashesToTransplant();
-
-  @NotBlank
-  @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-  String getFromRefName();
 
   /**
    * Validation rule using {@link org.projectnessie.model.Validation#validateHash(String)}

--- a/model/src/main/java/org/projectnessie/model/Transplant.java
+++ b/model/src/main/java/org/projectnessie/model/Transplant.java
@@ -40,7 +40,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableTransplant.class)
 @JsonDeserialize(as = ImmutableTransplant.class)
-public interface Transplant {
+public interface Transplant extends BaseMergeTransplant {
 
   @NotNull
   @Size(min = 1)

--- a/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -81,6 +81,16 @@ public class TestModelObjectsSerialization {
             Transplant.class,
             Json.arr("hashesToTransplant", HASH).add("fromRefName", "testBranch")),
         new Case(
+            ImmutableTransplant.builder()
+                .addHashesToTransplant(HASH)
+                .fromRefName(branchName)
+                .keepIndividualCommits(true)
+                .build(),
+            Transplant.class,
+            Json.noQuotes("keepIndividualCommits", "true")
+                .addArr("hashesToTransplant", HASH)
+                .add("fromRefName", "testBranch")),
+        new Case(
             EntriesResponse.builder()
                 .addEntries(
                     ImmutableEntry.builder()
@@ -136,7 +146,17 @@ public class TestModelObjectsSerialization {
         new Case(
             ImmutableMerge.builder().fromHash(HASH).fromRefName(branchName).build(),
             Merge.class,
-            Json.from("fromHash", HASH).add("fromRefName", "testBranch")));
+            Json.from("fromRefName", "testBranch").add("fromHash", HASH)),
+        new Case(
+            ImmutableMerge.builder()
+                .fromHash(HASH)
+                .fromRefName(branchName)
+                .keepIndividualCommits(true)
+                .build(),
+            Merge.class,
+            Json.from("fromRefName", "testBranch")
+                .addNoQuotes("keepIndividualCommits", "true")
+                .add("fromHash", HASH)));
   }
 
   static List<Case> negativeCases() {
@@ -216,6 +236,15 @@ public class TestModelObjectsSerialization {
 
     public Json add(String key, String val) {
       this.currentContent = String.format(STR_KV_FORMAT, currentContent, key, val);
+      return this;
+    }
+
+    public Json addArr(String key, String... val) {
+      String keyContent =
+          Stream.of(val)
+              .map(v -> String.format("\"%s\"", v))
+              .collect(Collectors.joining(",", String.format("\"%s\":[", key), "]"));
+      this.currentContent = String.format("%s,%s", currentContent, keyContent);
       return this;
     }
 

--- a/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -79,7 +79,7 @@ public class TestModelObjectsSerialization {
                 .fromRefName(branchName)
                 .build(),
             Transplant.class,
-            Json.arr("hashesToTransplant", HASH).add("fromRefName", "testBranch")),
+            Json.from("fromRefName", "testBranch").addArr("hashesToTransplant", HASH)),
         new Case(
             ImmutableTransplant.builder()
                 .addHashesToTransplant(HASH)
@@ -87,9 +87,9 @@ public class TestModelObjectsSerialization {
                 .keepIndividualCommits(true)
                 .build(),
             Transplant.class,
-            Json.noQuotes("keepIndividualCommits", "true")
-                .addArr("hashesToTransplant", HASH)
-                .add("fromRefName", "testBranch")),
+            Json.from("fromRefName", "testBranch")
+                .addNoQuotes("keepIndividualCommits", "true")
+                .addArr("hashesToTransplant", HASH)),
         new Case(
             EntriesResponse.builder()
                 .addEntries(

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
@@ -18,10 +18,14 @@ package org.projectnessie.jaxrs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ThrowingConsumer;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
@@ -32,107 +36,73 @@ import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.model.Operation.Put;
+import org.projectnessie.model.Reference;
 
 /** See {@link AbstractTestRest} for details about and reason for the inheritance model. */
 public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWithHttp {
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void transplant(boolean withDetachedCommit) throws BaseNessieClientServerException {
-    Branch base = createBranch("transplant-base");
-    Branch branch = createBranch("transplant-branch");
-
-    IcebergTable table1 = IcebergTable.of("transplant-table1", 42, 42, 42, 42);
-    IcebergTable table2 = IcebergTable.of("transplant-table2", 43, 43, 43, 43);
-
-    Branch committed1 =
-        getApi()
-            .commitMultipleOperations()
-            .branchName(branch.getName())
-            .hash(branch.getHash())
-            .commitMeta(CommitMeta.fromMessage("test-transplant-branch1"))
-            .operation(Put.of(ContentKey.of("key1"), table1))
-            .commit();
-    assertThat(committed1.getHash()).isNotNull();
-
-    Branch committed2 =
-        getApi()
-            .commitMultipleOperations()
-            .branchName(branch.getName())
-            .hash(committed1.getHash())
-            .commitMeta(CommitMeta.fromMessage("test-transplant-branch2"))
-            .operation(Put.of(ContentKey.of("key1"), table1, table1))
-            .commit();
-    assertThat(committed2.getHash()).isNotNull();
-
-    int commitsToTransplant = 2;
-
-    LogResponse logBranch =
-        getApi()
-            .getCommitLog()
-            .refName(branch.getName())
-            .untilHash(branch.getHash())
-            .maxRecords(commitsToTransplant)
-            .get();
-
-    getApi()
-        .commitMultipleOperations()
-        .branchName(base.getName())
-        .hash(base.getHash())
-        .commitMeta(CommitMeta.fromMessage("test-transplant-main"))
-        .operation(Put.of(ContentKey.of("key2"), table2))
-        .commit();
-
-    getApi()
-        .transplantCommitsIntoBranch()
-        .hashesToTransplant(ImmutableList.of(committed1.getHash(), committed2.getHash()))
-        .fromRefName(maybeAsDetachedName(withDetachedCommit, branch))
-        .branch(base)
-        .transplant();
-
-    LogResponse log =
-        getApi().getCommitLog().refName(base.getName()).untilHash(base.getHash()).get();
-    assertThat(
-            log.getLogEntries().stream().map(LogEntry::getCommitMeta).map(CommitMeta::getMessage))
-        .containsExactly(
-            "test-transplant-branch2", "test-transplant-branch1", "test-transplant-main");
-
-    // Verify that the commit-timestamp was updated
-    LogResponse logOfTransplanted =
-        getApi().getCommitLog().refName(base.getName()).maxRecords(commitsToTransplant).get();
-    assertThat(
-            logOfTransplanted.getLogEntries().stream()
-                .map(LogEntry::getCommitMeta)
-                .map(CommitMeta::getCommitTime))
-        .isNotEqualTo(
-            logBranch.getLogEntries().stream()
-                .map(LogEntry::getCommitMeta)
-                .map(CommitMeta::getCommitTime));
-
-    assertThat(
-            getApi().getEntries().refName(base.getName()).get().getEntries().stream()
-                .map(e -> e.getName().getName()))
-        .containsExactlyInAnyOrder("key1", "key2");
+  @CsvSource(
+      value = {"true,true", "true,false", "false,true", "false,false"}) // merge requires the hash
+  public void transplant(boolean withDetachedCommit, boolean keepIndividualCommits)
+      throws BaseNessieClientServerException {
+    mergeTransplant(
+        keepIndividualCommits,
+        t -> {
+          List<Object> objects = t.toList();
+          Branch base = (Branch) objects.get(0);
+          Branch branch = (Branch) objects.get(1);
+          Reference committed1 = (Reference) objects.get(2);
+          Reference committed2 = (Reference) objects.get(3);
+          getApi()
+              .transplantCommitsIntoBranch()
+              .hashesToTransplant(ImmutableList.of(committed1.getHash(), committed2.getHash()))
+              .fromRefName(maybeAsDetachedName(withDetachedCommit, branch))
+              .branch(base)
+              .keepIndividualCommits(keepIndividualCommits)
+              .transplant();
+        });
   }
 
   @ParameterizedTest
-  @EnumSource(
-      value = ReferenceMode.class,
-      mode = Mode.EXCLUDE,
-      names = "NAME_ONLY") // merge requires the hash
-  public void merge(ReferenceMode refMode) throws BaseNessieClientServerException {
-    Branch base = createBranch("merge-base");
-    Branch branch = createBranch("merge-branch");
+  @CsvSource(
+      value = {
+        "UNCHANGED,true",
+        "UNCHANGED,false",
+        "DETACHED,true",
+        "DETACHED,false"
+      }) // merge requires the hash
+  public void merge(ReferenceMode refMode, boolean keepIndividualCommits)
+      throws BaseNessieClientServerException {
+    mergeTransplant(
+        keepIndividualCommits,
+        t -> {
+          List<Object> objects = t.toList();
+          Branch base = (Branch) objects.get(0);
+          Reference committed2 = (Reference) objects.get(3);
+          getApi()
+              .mergeRefIntoBranch()
+              .branch(base)
+              .fromRef(refMode.transform(committed2))
+              .keepIndividualCommits(keepIndividualCommits)
+              .merge();
+        });
+  }
 
-    IcebergTable table1 = IcebergTable.of("merge-table1", 42, 42, 42, 42);
-    IcebergTable table2 = IcebergTable.of("merge-table2", 43, 43, 43, 43);
+  private void mergeTransplant(boolean keepIndividualCommits, ThrowingConsumer<Tuple> actor)
+      throws BaseNessieClientServerException {
+    Branch base = createBranch("base");
+    Branch branch = createBranch("branch");
+
+    IcebergTable table1 = IcebergTable.of("table1", 42, 42, 42, 42);
+    IcebergTable table2 = IcebergTable.of("table2", 43, 43, 43, 43);
 
     Branch committed1 =
         getApi()
             .commitMultipleOperations()
             .branchName(branch.getName())
             .hash(branch.getHash())
-            .commitMeta(CommitMeta.fromMessage("test-merge-branch1"))
+            .commitMeta(CommitMeta.fromMessage("test-branch1"))
             .operation(Put.of(ContentKey.of("key1"), table1))
             .commit();
     assertThat(committed1.getHash()).isNotNull();
@@ -142,40 +112,50 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
             .commitMultipleOperations()
             .branchName(branch.getName())
             .hash(committed1.getHash())
-            .commitMeta(CommitMeta.fromMessage("test-merge-branch2"))
+            .commitMeta(CommitMeta.fromMessage("test-branch2"))
             .operation(Put.of(ContentKey.of("key1"), table1, table1))
             .commit();
     assertThat(committed2.getHash()).isNotNull();
 
-    int commitsToMerge = 2;
+    int commitCount = 2;
 
     LogResponse logBranch =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .untilHash(branch.getHash())
-            .maxRecords(commitsToMerge)
+            .maxRecords(commitCount)
             .get();
 
     getApi()
         .commitMultipleOperations()
         .branchName(base.getName())
         .hash(base.getHash())
-        .commitMeta(CommitMeta.fromMessage("test-merge-main"))
+        .commitMeta(CommitMeta.fromMessage("test-main"))
         .operation(Put.of(ContentKey.of("key2"), table2))
         .commit();
 
-    getApi().mergeRefIntoBranch().branch(base).fromRef(refMode.transform(committed2)).merge();
+    actor.accept(Tuple.tuple(base, branch, committed1, committed2));
 
     LogResponse log =
         getApi().getCommitLog().refName(base.getName()).untilHash(base.getHash()).get();
-    assertThat(
-            log.getLogEntries().stream().map(LogEntry::getCommitMeta).map(CommitMeta::getMessage))
-        .containsExactly("test-merge-branch2", "test-merge-branch1", "test-merge-main");
+    if (keepIndividualCommits) {
+      assertThat(
+              log.getLogEntries().stream().map(LogEntry::getCommitMeta).map(CommitMeta::getMessage))
+          .hasSize(3)
+          .containsExactly("test-branch2", "test-branch1", "test-main");
+    } else {
+      assertThat(
+              log.getLogEntries().stream().map(LogEntry::getCommitMeta).map(CommitMeta::getMessage))
+          .hasSize(2)
+          .first(InstanceOfAssertFactories.STRING)
+          .contains("test-branch2")
+          .contains("test-branch1");
+    }
 
     // Verify that the commit-timestamp was updated
     LogResponse logOfMerged =
-        getApi().getCommitLog().refName(base.getName()).maxRecords(commitsToMerge).get();
+        getApi().getCommitLog().refName(base.getName()).maxRecords(commitCount).get();
     assertThat(
             logOfMerged.getLogEntries().stream()
                 .map(LogEntry::getCommitMeta)
@@ -204,8 +184,8 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
     getApi().createNamespace().namespace(ns).refName(branch.getName()).create();
     getApi().createNamespace().namespace(ns).refName(base.getName()).create();
 
-    IcebergTable table1 = IcebergTable.of("merge-table1", 42, 42, 42, 42);
-    IcebergTable table2 = IcebergTable.of("merge-table2", 43, 43, 43, 43);
+    IcebergTable table1 = IcebergTable.of("table1", 42, 42, 42, 42);
+    IcebergTable table2 = IcebergTable.of("table2", 43, 43, 43, 43);
 
     ContentKey key1 = ContentKey.of(ns, "key1");
     ContentKey key2 = ContentKey.of(ns, "key2");
@@ -214,7 +194,7 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
             .commitMultipleOperations()
             .branchName(branch.getName())
             .hash(branch.getHash())
-            .commitMeta(CommitMeta.fromMessage("test-merge-branch1"))
+            .commitMeta(CommitMeta.fromMessage("test-branch1"))
             .operation(Put.of(key1, table1))
             .commit();
     assertThat(committed1.getHash()).isNotNull();
@@ -224,7 +204,7 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
             .commitMultipleOperations()
             .branchName(branch.getName())
             .hash(committed1.getHash())
-            .commitMeta(CommitMeta.fromMessage("test-merge-branch2"))
+            .commitMeta(CommitMeta.fromMessage("test-branch2"))
             .operation(Put.of(key1, table1, table1))
             .commit();
     assertThat(committed2.getHash()).isNotNull();
@@ -233,21 +213,26 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
         .commitMultipleOperations()
         .branchName(base.getName())
         .hash(base.getHash())
-        .commitMeta(CommitMeta.fromMessage("test-merge-main"))
+        .commitMeta(CommitMeta.fromMessage("test-main"))
         .operation(Put.of(key2, table2))
         .commit();
 
-    getApi().mergeRefIntoBranch().branch(base).fromRef(refMode.transform(committed2)).merge();
+    getApi()
+        .mergeRefIntoBranch()
+        .branch(base)
+        .fromRef(refMode.transform(committed2))
+        .keepIndividualCommits(true)
+        .merge();
 
     LogResponse log =
         getApi().getCommitLog().refName(base.getName()).untilHash(base.getHash()).get();
     assertThat(
             log.getLogEntries().stream().map(LogEntry::getCommitMeta).map(CommitMeta::getMessage))
         .containsExactly(
-            "test-merge-branch2",
-            "test-merge-branch1",
+            "test-branch2",
+            "test-branch1",
             "create namespace a.b.c",
-            "test-merge-main",
+            "test-main",
             "create namespace a.b.c");
 
     assertThat(

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -304,7 +304,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceApi {
         .commit(
             branch,
             Optional.empty(),
-            commitMetaUpdateSingle().apply(CommitMeta.fromMessage(commitMsg)),
+            commitMetaUpdate().rewriteSingle(CommitMeta.fromMessage(commitMsg)),
             Collections.singletonList(contentOperation),
             validator);
   }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -304,7 +304,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceApi {
         .commit(
             branch,
             Optional.empty(),
-            commitMetaUpdate().apply(CommitMeta.fromMessage(commitMsg)),
+            commitMetaUpdateSingle().apply(CommitMeta.fromMessage(commitMsg)),
             Collections.singletonList(contentOperation),
             validator);
   }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -395,7 +395,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
               BranchName.of(branchName),
               toHash(hash, true),
               transplants,
-              commitMetaUpdate(keepIndividual),
+              commitMetaUpdate(),
               keepIndividual);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
@@ -416,7 +416,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
               toHash(merge.getFromRefName(), merge.getFromHash()),
               BranchName.of(branchName),
               toHash(hash, true),
-              commitMetaUpdate(keepIndividual),
+              commitMetaUpdate(),
               keepIndividual);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
@@ -539,7 +539,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
               .commit(
                   BranchName.of(Optional.ofNullable(branch).orElse(getConfig().getDefaultBranch())),
                   Optional.ofNullable(hash).map(Hash::of),
-                  commitMetaUpdateSingle().apply(commitMeta),
+                  commitMetaUpdate().rewriteSingle(commitMeta),
                   ops);
 
       return Branch.of(branch, newHash.asString());

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -294,7 +294,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
                         .getOperations()
                         .forEach(
                             op -> {
-                              ContentKey key = ContentKey.of(op.getKey().getElements());
+                              ContentKey key = fromKey(op.getKey());
                               if (op instanceof Put) {
                                 Content content = ((Put<Content>) op).getValue();
                                 logEntry.addOperations(Operation.Put.of(key, content));
@@ -384,13 +384,19 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
       String branchName, String hash, String message, Transplant transplant)
       throws NessieNotFoundException, NessieConflictException {
     try {
+      Boolean keep = transplant.keepIndividualCommits();
+      boolean keepIndividual = keep != null && keep;
       List<Hash> transplants;
       try (Stream<Hash> s = transplant.getHashesToTransplant().stream().map(Hash::of)) {
         transplants = s.collect(Collectors.toList());
       }
       getStore()
           .transplant(
-              BranchName.of(branchName), toHash(hash, true), transplants, commitMetaUpdate());
+              BranchName.of(branchName),
+              toHash(hash, true),
+              transplants,
+              commitMetaUpdate(keepIndividual),
+              keepIndividual);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     } catch (ReferenceConflictException e) {
@@ -402,12 +408,16 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
   public void mergeRefIntoBranch(String branchName, String hash, Merge merge)
       throws NessieNotFoundException, NessieConflictException {
     try {
+      Boolean keep = merge.keepIndividualCommits();
+      boolean keepIndividual = keep != null && keep;
+
       getStore()
           .merge(
               toHash(merge.getFromRefName(), merge.getFromHash()),
               BranchName.of(branchName),
               toHash(hash, true),
-              commitMetaUpdate());
+              commitMetaUpdate(keepIndividual),
+              keepIndividual);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     } catch (ReferenceConflictException e) {
@@ -529,7 +539,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
               .commit(
                   BranchName.of(Optional.ofNullable(branch).orElse(getConfig().getDefaultBranch())),
                   Optional.ofNullable(hash).map(Hash::of),
-                  commitMetaUpdate().apply(commitMeta),
+                  commitMetaUpdateSingle().apply(commitMeta),
                   ops);
 
       return Branch.of(branch, newHash.asString());
@@ -595,6 +605,10 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
     return ContentKey.of(key.getElements());
   }
 
+  protected static Key toKey(ContentKey key) {
+    return Key.of(key.getElements());
+  }
+
   private static Reference makeReference(
       ReferenceInfo<CommitMeta> refWithHash, boolean fetchMetadata) {
     NamedRef ref = refWithHash.getNamedRef();
@@ -646,7 +660,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
   }
 
   protected static org.projectnessie.versioned.Operation<Content> toOp(Operation o) {
-    Key key = Key.of(o.getKey().getElements().toArray(new String[0]));
+    Key key = toKey(o.getKey());
     if (o instanceof Operation.Delete) {
       return Delete.of(key);
     } else if (o instanceof Operation.Put) {

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -217,6 +217,11 @@ public abstract class NonTransactionalDatabaseAdapter<
                 mergeAttempt(
                     ctx, timeInMicros, currentHead, branchCommits, newKeyLists, mergeParams);
 
+            if (newHead.equals(currentHead)) {
+              // nothing done
+              return pointer;
+            }
+
             GlobalStateLogEntry newGlobalHead =
                 writeGlobalCommit(ctx, timeInMicros, pointer, Collections.emptyList());
 
@@ -260,6 +265,11 @@ public abstract class NonTransactionalDatabaseAdapter<
             Hash newHead =
                 transplantAttempt(
                     ctx, timeInMicros, currentHead, branchCommits, newKeyLists, transplantParams);
+
+            if (newHead.equals(currentHead)) {
+              // nothing done
+              return pointer;
+            }
 
             GlobalStateLogEntry newGlobalHead =
                 writeGlobalCommit(ctx, timeInMicros, pointer, Collections.emptyList());

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -241,6 +241,12 @@ public abstract class TxDatabaseAdapter
 
             Hash toHead =
                 mergeAttempt(conn, timeInMicros, currentHead, h -> {}, h -> {}, mergeParams);
+
+            if (toHead.equals(currentHead)) {
+              // nothing done
+              return currentHead;
+            }
+
             Hash resultHash =
                 tryMoveNamedReference(conn, mergeParams.getToBranch(), currentHead, toHead);
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetadataRewriter.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetadataRewriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.adapter;
+package org.projectnessie.versioned;
 
-import com.google.protobuf.ByteString;
-import org.immutables.value.Value;
-import org.projectnessie.versioned.MetadataRewriter;
+import java.util.List;
 
-public interface MetadataRewriteParams extends ToBranchParams {
+public interface MetadataRewriter<T> {
+  T rewriteSingle(T metadata);
 
-  /** Whether to keep the individual commits and do not squash the commits to merge. */
-  @Value.Default
-  default boolean keepIndividualCommits() {
-    return false;
-  }
-
-  /** Function to rewrite the commit-metadata. */
-  MetadataRewriter<ByteString> getUpdateCommitMetadata();
+  T squash(List<T> metadata);
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
@@ -93,7 +92,7 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
       BranchName targetBranch,
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
-      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      MetadataRewriter<METADATA> updateCommitMetadata,
       boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(
@@ -112,7 +111,7 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
       Hash fromHash,
       BranchName toBranch,
       Optional<Hash> expectedHash,
-      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      MetadataRewriter<METADATA> updateCommitMetadata,
       boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -93,13 +93,18 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
       BranchName targetBranch,
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
-      Function<METADATA, METADATA> updateCommitMetadata)
+      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(
         "transplant",
         () ->
             delegate.transplant(
-                targetBranch, referenceHash, sequenceToTransplant, updateCommitMetadata));
+                targetBranch,
+                referenceHash,
+                sequenceToTransplant,
+                updateCommitMetadata,
+                keepIndividualCommits));
   }
 
   @Override
@@ -107,10 +112,14 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
       Hash fromHash,
       BranchName toBranch,
       Optional<Hash> expectedHash,
-      Function<METADATA, METADATA> updateCommitMetadata)
+      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(
-        "merge", () -> delegate.merge(fromHash, toBranch, expectedHash, updateCommitMetadata));
+        "merge",
+        () ->
+            delegate.merge(
+                fromHash, toBranch, expectedHash, updateCommitMetadata, keepIndividualCommits));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
@@ -111,7 +110,7 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
       BranchName targetBranch,
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
-      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      MetadataRewriter<METADATA> updateCommitMetadata,
       boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
@@ -134,7 +133,7 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
       Hash fromHash,
       BranchName toBranch,
       Optional<Hash> expectedHash,
-      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      MetadataRewriter<METADATA> updateCommitMetadata,
       boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -111,7 +111,8 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
       BranchName targetBranch,
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
-      Function<METADATA, METADATA> updateCommitMetadata)
+      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
         "Transplant",
@@ -121,7 +122,11 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
                 .withTag(TAG_TRANSPLANTS, safeSize(sequenceToTransplant)),
         () ->
             delegate.transplant(
-                targetBranch, referenceHash, sequenceToTransplant, updateCommitMetadata));
+                targetBranch,
+                referenceHash,
+                sequenceToTransplant,
+                updateCommitMetadata,
+                keepIndividualCommits));
   }
 
   @Override
@@ -129,7 +134,8 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
       Hash fromHash,
       BranchName toBranch,
       Optional<Hash> expectedHash,
-      Function<METADATA, METADATA> updateCommitMetadata)
+      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
         "Merge",
@@ -137,7 +143,9 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
             b.withTag(TAG_FROM_HASH, safeToString(fromHash))
                 .withTag(TAG_TO_BRANCH, safeRefName(toBranch))
                 .withTag(TAG_EXPECTED_HASH, safeToString(expectedHash)),
-        () -> delegate.merge(fromHash, toBranch, expectedHash, updateCommitMetadata));
+        () ->
+            delegate.merge(
+                fromHash, toBranch, expectedHash, updateCommitMetadata, keepIndividualCommits));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -111,7 +111,10 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * @param referenceHash The hash to use as a reference for conflict detection. If not present, do
    *     not perform conflict detection
    * @param sequenceToTransplant The sequence of hashes to transplant.
-   * @param updateCommitMetadata
+   * @param updateCommitMetadata function that rewrites the commit metadata, gets a multiple commit
+   *     metadata if {@code keepIndividualCommits} is {@code false}
+   * @param keepIndividualCommits whether to keep the individual commits and do not squash the
+   *     commits to transplant
    * @throws ReferenceConflictException if {@code referenceHash} values do not match the stored
    *     values for {@code branch}
    * @throws ReferenceNotFoundException if {@code branch} or if any of the hashes from {@code
@@ -121,7 +124,8 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
       BranchName targetBranch,
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
-      Function<METADATA, METADATA> updateCommitMetadata)
+      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
@@ -142,7 +146,10 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    * @param fromHash The hash we are using to get additional commits
    * @param toBranch The branch that we are merging into
    * @param expectedHash The current head of the branch to validate before updating (optional).
-   * @param updateCommitMetadata
+   * @param updateCommitMetadata function that rewrites the commit metadata, gets a multiple commit
+   *     metadata if {@code keepIndividualCommits} is {@code false}
+   * @param keepIndividualCommits whether to keep the individual commits and do not squash the
+   *     commits to merge
    * @throws ReferenceConflictException if {@code expectedBranchHash} doesn't match the stored hash
    *     for {@code toBranch}
    * @throws ReferenceNotFoundException if {@code toBranch} or {@code fromHash} is not present in
@@ -152,7 +159,8 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
       Hash fromHash,
       BranchName toBranch,
       Optional<Hash> expectedHash,
-      Function<METADATA, METADATA> updateCommitMetadata)
+      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
@@ -124,7 +123,7 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
       BranchName targetBranch,
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
-      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      MetadataRewriter<METADATA> updateCommitMetadata,
       boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
@@ -159,7 +158,7 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
       Hash fromHash,
       BranchName toBranch,
       Optional<Hash> expectedHash,
-      Function<List<METADATA>, METADATA> updateCommitMetadata,
+      MetadataRewriter<METADATA> updateCommitMetadata,
       boolean keepIndividualCommits)
       throws ReferenceNotFoundException, ReferenceConflictException;
 

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -52,7 +52,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
@@ -121,7 +120,8 @@ class TestMetricsVersionStore {
                         BranchName.of("mock-branch"),
                         Optional.empty(),
                         Collections.emptyList(),
-                        Function.identity()),
+                        l -> l.get(0),
+                        false),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(
                 "merge",
@@ -130,7 +130,8 @@ class TestMetricsVersionStore {
                         Hash.of("42424242"),
                         BranchName.of("mock-branch"),
                         Optional.empty(),
-                        Function.identity()),
+                        l -> l.get(0),
+                        false),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(
                 "assign",

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -93,6 +93,19 @@ class TestMetricsVersionStore {
             new ReferenceNotFoundException("not-found"),
             new ReferenceAlreadyExistsException("already exists"));
 
+    MetadataRewriter<String> metadataRewriter =
+        new MetadataRewriter<String>() {
+          @Override
+          public String rewriteSingle(String metadata) {
+            return metadata;
+          }
+
+          @Override
+          public String squash(List<String> metadata) {
+            return String.join(", ", metadata);
+          }
+        };
+
     // "Declare" test-invocations for all VersionStore functions with their respective outcomes
     // and exceptions.
     Stream<VersionStoreInvocation<?>> versionStoreFunctions =
@@ -120,7 +133,7 @@ class TestMetricsVersionStore {
                         BranchName.of("mock-branch"),
                         Optional.empty(),
                         Collections.emptyList(),
-                        l -> l.get(0),
+                        metadataRewriter,
                         false),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(
@@ -130,7 +143,7 @@ class TestMetricsVersionStore {
                         Hash.of("42424242"),
                         BranchName.of("mock-branch"),
                         Optional.empty(),
-                        l -> l.get(0),
+                        metadataRewriter,
                         false),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -113,7 +112,8 @@ class TestTracingVersionStore {
                                 BranchName.of("mock-branch"),
                                 Optional.empty(),
                                 Collections.emptyList(),
-                                Function.identity())),
+                                l -> l.get(0),
+                                true)),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Merge", refNotFoundAndRefConflictThrows)
                     .tag("nessie.version-store.to-branch", "mock-branch")
@@ -125,7 +125,8 @@ class TestTracingVersionStore {
                                 Hash.of("42424242"),
                                 BranchName.of("mock-branch"),
                                 Optional.empty(),
-                                Function.identity())),
+                                l -> l.get(0),
+                                false)),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Assign", refNotFoundAndRefConflictThrows)
                     .tag("nessie.version-store.ref", "BranchName{name=mock-branch}")

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -76,6 +76,19 @@ class TestTracingVersionStore {
             new ReferenceNotFoundException("not-found"),
             new ReferenceAlreadyExistsException("already exists"));
 
+    MetadataRewriter<String> metadataRewriter =
+        new MetadataRewriter<String>() {
+          @Override
+          public String rewriteSingle(String metadata) {
+            return metadata;
+          }
+
+          @Override
+          public String squash(List<String> metadata) {
+            return String.join(", ", metadata);
+          }
+        };
+
     // "Declare" test-invocations for all VersionStore functions with their respective outcomes
     // and exceptions.
     Stream<TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>>
@@ -112,7 +125,7 @@ class TestTracingVersionStore {
                                 BranchName.of("mock-branch"),
                                 Optional.empty(),
                                 Collections.emptyList(),
-                                l -> l.get(0),
+                                metadataRewriter,
                                 true)),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Merge", refNotFoundAndRefConflictThrows)
@@ -125,7 +138,7 @@ class TestTracingVersionStore {
                                 Hash.of("42424242"),
                                 BranchName.of("mock-branch"),
                                 Optional.empty(),
-                                l -> l.get(0),
+                                metadataRewriter,
                                 false)),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Assign", refNotFoundAndRefConflictThrows)

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -27,9 +27,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.Hash;
@@ -95,16 +96,42 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
     commits = commitsList(branch, false).subList(0, 3);
   }
 
-  private CommitMessage merged(CommitMessage commitMessage) {
-    return commitMessage(commitMessage.getMessage() + ", merged");
+  private CommitMessage merged(List<CommitMessage> commitMessages) {
+    if (commitMessages.size() == 1) {
+      return commitMessage(commitMessages.get(0).getMessage() + ", merged");
+    }
+
+    return CommitMessage.commitMessage(
+        commitMessages.stream()
+            .map(cm -> cm.getMessage() + ", merged")
+            .collect(Collectors.joining("\n-----------------------------------\n")));
   }
 
-  @Test
-  protected void mergeIntoEmptyBranch() throws VersionStoreException {
-    final BranchName newBranch = BranchName.of("mergeIntoEmptyBranch");
+  private CommitMessage mergeCommitMessages(List<CommitMessage> commitMessages) {
+    if (commitMessages.size() == 1) {
+      return commitMessages.get(0);
+    }
+
+    return CommitMessage.commitMessage(
+        commitMessages.stream()
+            .map(CommitMessage::getMessage)
+            .collect(Collectors.joining("\n-----------------------------------\n")));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeIntoEmptyBranch3Commits(boolean individualCommits)
+      throws VersionStoreException {
+    final BranchName newBranch = BranchName.of("mergeIntoEmptyBranch3Commits");
     store().create(newBranch, Optional.of(initialHash));
 
-    store().merge(thirdCommit, newBranch, Optional.of(initialHash), Function.identity());
+    store()
+        .merge(
+            thirdCommit,
+            newBranch,
+            Optional.of(initialHash),
+            this::mergeCommitMessages,
+            individualCommits);
     assertThat(
             store()
                 .getValues(
@@ -116,18 +143,72 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                 Key.of("t2"), V_2_2,
                 Key.of("t4"), V_4_1));
 
-    // not modifying commit meta, will just "fast forward"
-    assertThat(store().hashOnReference(newBranch, Optional.empty())).isEqualTo(thirdCommit);
+    if (individualCommits) {
+      // not modifying commit meta, will just "fast forward"
+      assertThat(store().hashOnReference(newBranch, Optional.empty())).isEqualTo(thirdCommit);
 
-    assertCommitMeta(commitsList(newBranch, false).subList(0, 3), commits, Function.identity());
+      assertCommitMeta(
+          commitsList(newBranch, false).subList(0, 3), commits, this::mergeCommitMessages);
+    } else {
+      // must modify commit meta, it's more than one commit
+      assertThat(store().hashOnReference(newBranch, Optional.empty())).isNotEqualTo(thirdCommit);
+
+      assertThat(commitsList(newBranch, false))
+          .first()
+          .extracting(Commit::getCommitMeta)
+          .extracting(CommitMessage::getMessage)
+          .asString()
+          .contains(
+              commits.stream()
+                  .map(Commit::getCommitMeta)
+                  .map(CommitMessage::getMessage)
+                  .toArray(String[]::new));
+    }
   }
 
-  @Test
-  protected void mergeIntoEmptyBranchModifying() throws VersionStoreException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeIntoEmptyBranch1Commit(boolean individualCommits)
+      throws VersionStoreException {
+    final BranchName newBranch = BranchName.of("mergeIntoEmptyBranch1Commit");
+    store().create(newBranch, Optional.of(initialHash));
+
+    store()
+        .merge(
+            firstCommit,
+            newBranch,
+            Optional.of(initialHash),
+            this::mergeCommitMessages,
+            individualCommits);
+    assertThat(
+            store()
+                .getValues(
+                    newBranch,
+                    Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                Key.of("t1"), V_1_1,
+                Key.of("t2"), V_2_1,
+                Key.of("t3"), V_3_1));
+
+    // not modifying commit meta, will just "fast forward"
+    assertThat(store().hashOnReference(newBranch, Optional.empty())).isEqualTo(firstCommit);
+
+    assertCommitMeta(
+        commitsList(newBranch, false).subList(0, 1),
+        commits.subList(2, 3),
+        this::mergeCommitMessages);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeIntoEmptyBranchModifying(boolean individualCommits)
+      throws VersionStoreException {
     final BranchName newBranch = BranchName.of("mergeIntoEmptyBranchModifying");
     store().create(newBranch, Optional.of(initialHash));
 
-    store().merge(thirdCommit, newBranch, Optional.of(initialHash), this::merged);
+    store()
+        .merge(thirdCommit, newBranch, Optional.of(initialHash), this::merged, individualCommits);
     assertThat(
             store()
                 .getValues(
@@ -142,16 +223,33 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
     // modify the commit meta, will generate new commits and therefore new commit hashes
     assertThat(store().hashOnReference(newBranch, Optional.empty())).isNotEqualTo(thirdCommit);
 
-    assertCommitMeta(commitsList(newBranch, false).subList(0, 3), commits, this::merged);
+    if (individualCommits) {
+      assertCommitMeta(commitsList(newBranch, false).subList(0, 3), commits, this::merged);
+    } else {
+      assertThat(commitsList(newBranch, false))
+          .first()
+          .extracting(Commit::getCommitMeta)
+          .extracting(CommitMessage::getMessage)
+          .asString()
+          .contains(
+              commits.stream()
+                  .map(Commit::getCommitMeta)
+                  .map(CommitMessage::getMessage)
+                  .toArray(String[]::new));
+    }
   }
 
-  @Test
-  protected void mergeIntoNonConflictingBranch() throws VersionStoreException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeIntoNonConflictingBranch(boolean individualCommits)
+      throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_2");
     store().create(newBranch, Optional.of(initialHash));
     final Hash newCommit = commit("Unrelated commit").put("t5", V_5_1).toBranch(newBranch);
 
-    store().merge(thirdCommit, newBranch, Optional.empty(), Function.identity());
+    store()
+        .merge(
+            thirdCommit, newBranch, Optional.empty(), this::mergeCommitMessages, individualCommits);
     assertThat(
             store()
                 .getValues(
@@ -166,26 +264,40 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                 Key.of("t5"), V_5_1));
 
     final List<Commit<CommitMessage, BaseContent>> commits = commitsList(newBranch, false);
-    assertThat(commits)
-        .satisfiesExactly(
-            c0 ->
-                assertThat(c0)
-                    .extracting(Commit::getCommitMeta)
-                    .isEqualTo(commitMessage("Third Commit")),
-            c1 ->
-                assertThat(c1)
-                    .extracting(Commit::getCommitMeta)
-                    .isEqualTo(commitMessage("Second Commit")),
-            c2 ->
-                assertThat(c2)
-                    .extracting(Commit::getCommitMeta)
-                    .isEqualTo(commitMessage("First Commit")),
-            c3 -> assertThat(c3).extracting(Commit::getHash).isEqualTo(newCommit),
-            c4 -> assertThat(c4).extracting(Commit::getHash).isEqualTo(initialHash));
+    if (individualCommits) {
+      assertThat(commits)
+          .satisfiesExactly(
+              c0 ->
+                  assertThat(c0)
+                      .extracting(Commit::getCommitMeta)
+                      .isEqualTo(commitMessage("Third Commit")),
+              c1 ->
+                  assertThat(c1)
+                      .extracting(Commit::getCommitMeta)
+                      .isEqualTo(commitMessage("Second Commit")),
+              c2 ->
+                  assertThat(c2)
+                      .extracting(Commit::getCommitMeta)
+                      .isEqualTo(commitMessage("First Commit")),
+              c3 -> assertThat(c3).extracting(Commit::getHash).isEqualTo(newCommit),
+              c4 -> assertThat(c4).extracting(Commit::getHash).isEqualTo(initialHash));
+    } else {
+      assertThat(commits)
+          .satisfiesExactly(
+              c0 ->
+                  assertThat(c0)
+                      .extracting(Commit::getCommitMeta)
+                      .extracting(CommitMessage::getMessage)
+                      .asString()
+                      .contains("Third Commit", "Second Commit", "First Commit"),
+              c3 -> assertThat(c3).extracting(Commit::getHash).isEqualTo(newCommit),
+              c4 -> assertThat(c4).extracting(Commit::getHash).isEqualTo(initialHash));
+    }
   }
 
-  @Test
-  protected void nonEmptyFastForwardMerge() throws VersionStoreException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void nonEmptyFastForwardMerge(boolean individualCommits) throws VersionStoreException {
     final Key key = Key.of("t1");
     final BranchName etl = BranchName.of("etl");
     final BranchName review = BranchName.of("review");
@@ -202,7 +314,8 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
             store().hashOnReference(etl, Optional.empty()),
             review,
             Optional.empty(),
-            Function.identity());
+            this::mergeCommitMessages,
+            individualCommits);
     store()
         .commit(
             etl,
@@ -214,18 +327,22 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
             store().hashOnReference(etl, Optional.empty()),
             review,
             Optional.empty(),
-            Function.identity());
+            this::mergeCommitMessages,
+            individualCommits);
     assertEquals(store().getValue(review, key), VALUE_2);
   }
 
-  @Test
-  protected void mergeWithCommonAncestor() throws VersionStoreException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeWithCommonAncestor(boolean individualCommits) throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_2");
     store().create(newBranch, Optional.of(firstCommit));
 
     final Hash newCommit = commit("Unrelated commit").put("t5", V_5_1).toBranch(newBranch);
 
-    store().merge(thirdCommit, newBranch, Optional.empty(), Function.identity());
+    store()
+        .merge(
+            thirdCommit, newBranch, Optional.empty(), this::mergeCommitMessages, individualCommits);
     assertThat(
             store()
                 .getValues(
@@ -240,16 +357,31 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                 Key.of("t5"), V_5_1));
 
     final List<Commit<CommitMessage, BaseContent>> commits = commitsList(newBranch, false);
-    assertThat(commits).hasSize(5);
-    assertThat(commits.get(4).getHash()).isEqualTo(initialHash);
-    assertThat(commits.get(3).getHash()).isEqualTo(firstCommit);
-    assertThat(commits.get(2).getHash()).isEqualTo(newCommit);
-    assertThat(commits.get(1).getCommitMeta()).isEqualTo(commitMessage("Second Commit"));
-    assertThat(commits.get(0).getCommitMeta()).isEqualTo(commitMessage("Third Commit"));
+    if (individualCommits) {
+      assertThat(commits)
+          .hasSize(5)
+          .satisfiesExactly(
+              c -> assertThat(c.getCommitMeta().getMessage()).isEqualTo("Third Commit"),
+              c -> assertThat(c.getCommitMeta().getMessage()).isEqualTo("Second Commit"),
+              c -> assertThat(c.getHash()).isEqualTo(newCommit),
+              c -> assertThat(c.getHash()).isEqualTo(firstCommit),
+              c -> assertThat(c.getHash()).isEqualTo(initialHash));
+    } else {
+      assertThat(commits)
+          .hasSize(4)
+          .satisfiesExactly(
+              c ->
+                  assertThat(c.getCommitMeta().getMessage())
+                      .contains("Second Commit", "Third Commit"),
+              c -> assertThat(c.getHash()).isEqualTo(newCommit),
+              c -> assertThat(c.getHash()).isEqualTo(firstCommit),
+              c -> assertThat(c.getHash()).isEqualTo(initialHash));
+    }
   }
 
-  @Test
-  protected void mergeWithConflictingKeys() throws VersionStoreException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeWithConflictingKeys(boolean individualCommits) throws VersionStoreException {
     final BranchName foo = BranchName.of("foofoo");
     final BranchName bar = BranchName.of("barbar");
     store().create(foo, Optional.of(this.initialHash));
@@ -286,34 +418,61 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                 commitMessage("commit 4"),
                 Collections.singletonList(Put.of(key2, VALUE_4)));
 
-    assertThatThrownBy(() -> store().merge(barHash, foo, Optional.empty(), Function.identity()))
+    assertThatThrownBy(
+            () ->
+                store()
+                    .merge(
+                        barHash,
+                        foo,
+                        Optional.empty(),
+                        this::mergeCommitMessages,
+                        individualCommits))
         .isInstanceOf(ReferenceConflictException.class)
         .hasMessageContaining("The following keys have been changed in conflict:")
         .hasMessageContaining(key1.toString())
         .hasMessageContaining(key2.toString());
   }
 
-  @Test
-  protected void mergeIntoConflictingBranch() throws VersionStoreException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeIntoConflictingBranch(boolean individualCommits)
+      throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_3");
     store().create(newBranch, Optional.of(initialHash));
     commit("Another commit").put("t1", V_1_4).toBranch(newBranch);
 
     assertThrows(
         ReferenceConflictException.class,
-        () -> store().merge(thirdCommit, newBranch, Optional.of(initialHash), Function.identity()));
+        () ->
+            store()
+                .merge(
+                    thirdCommit,
+                    newBranch,
+                    Optional.of(initialHash),
+                    this::mergeCommitMessages,
+                    individualCommits));
   }
 
-  @Test
-  protected void mergeIntoNonExistingBranch() {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeIntoNonExistingBranch(boolean individualCommits) {
     final BranchName newBranch = BranchName.of("bar_5");
     assertThrows(
         ReferenceNotFoundException.class,
-        () -> store().merge(thirdCommit, newBranch, Optional.of(initialHash), Function.identity()));
+        () ->
+            store()
+                .merge(
+                    thirdCommit,
+                    newBranch,
+                    Optional.of(initialHash),
+                    this::mergeCommitMessages,
+                    individualCommits));
   }
 
-  @Test
-  protected void mergeIntoNonExistingReference() throws VersionStoreException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  protected void mergeIntoNonExistingReference(boolean individualCommits)
+      throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_6");
     store().create(newBranch, Optional.of(initialHash));
     assertThrows(
@@ -324,6 +483,7 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                     Hash.of("1234567890abcdef"),
                     newBranch,
                     Optional.of(initialHash),
-                    Function.identity()));
+                    this::mergeCommitMessages,
+                    individualCommits));
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNestedVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNestedVersionStore.java
@@ -18,7 +18,6 @@ package org.projectnessie.versioned.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.versioned.testworker.CommitMessage.commitMessage;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -27,6 +26,7 @@ import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.Delete;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.Ref;
 import org.projectnessie.versioned.ReferenceInfo;
@@ -105,14 +105,13 @@ public abstract class AbstractNestedVersionStore {
   protected static void assertCommitMeta(
       List<Commit<CommitMessage, BaseContent>> current,
       List<Commit<CommitMessage, BaseContent>> expected,
-      Function<List<CommitMessage>, CommitMessage> commitMetaModifier) {
+      MetadataRewriter<CommitMessage> commitMetaModifier) {
     assertThat(current)
         .map(Commit::getCommitMeta)
         .containsExactlyElementsOf(
             expected.stream()
                 .map(Commit::getCommitMeta)
-                .map(Collections::singletonList)
-                .map(commitMetaModifier)
+                .map(commitMetaModifier::rewriteSingle)
                 .collect(Collectors.toList()));
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNestedVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNestedVersionStore.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.versioned.testworker.CommitMessage.commitMessage;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -104,12 +105,13 @@ public abstract class AbstractNestedVersionStore {
   protected static void assertCommitMeta(
       List<Commit<CommitMessage, BaseContent>> current,
       List<Commit<CommitMessage, BaseContent>> expected,
-      Function<CommitMessage, CommitMessage> commitMetaModifier) {
+      Function<List<CommitMessage>, CommitMessage> commitMetaModifier) {
     assertThat(current)
         .map(Commit::getCommitMeta)
         .containsExactlyElementsOf(
             expected.stream()
                 .map(Commit::getCommitMeta)
+                .map(Collections::singletonList)
                 .map(commitMetaModifier)
                 .collect(Collectors.toList()));
   }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
@@ -22,7 +22,6 @@ import static org.projectnessie.versioned.testworker.CommitMessage.commitMessage
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
@@ -197,7 +196,8 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         BranchName.of("this-one-should-not-exist"),
                         Optional.empty(),
                         singletonList(s.hashOnReference(BranchName.of("main"), Optional.empty())),
-                        Function.identity())),
+                        l -> l.get(0),
+                        false)),
         new ReferenceNotFoundFunction("transplant/hash/empty")
             .msg(
                 "Could not find commit '12341234123412341234123412341234123412341234' in reference 'main'.")
@@ -207,7 +207,8 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         BranchName.of("main"),
                         Optional.of(Hash.of("12341234123412341234123412341234123412341234")),
                         singletonList(Hash.of("12341234123412341234123412341234123412341234")),
-                        Function.identity())),
+                        l -> l.get(0),
+                        true)),
         new ReferenceNotFoundFunction("transplant/empty/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
             .function(
@@ -216,7 +217,8 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         BranchName.of("main"),
                         Optional.empty(),
                         singletonList(Hash.of("12341234123412341234123412341234123412341234")),
-                        Function.identity())),
+                        l -> l.get(0),
+                        false)),
         // merge()
         new ReferenceNotFoundFunction("merge/hash/empty")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
@@ -226,7 +228,8 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         Hash.of("12341234123412341234123412341234123412341234"),
                         BranchName.of("main"),
                         Optional.empty(),
-                        Function.identity())),
+                        l -> l.get(0),
+                        true)),
         new ReferenceNotFoundFunction("merge/empty/hash")
             .msg(
                 "Could not find commit '12341234123412341234123412341234123412341234' in reference 'main'.")
@@ -236,7 +239,8 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         s.noAncestorHash(),
                         BranchName.of("main"),
                         Optional.of(Hash.of("12341234123412341234123412341234123412341234")),
-                        Function.identity())));
+                        l -> l.get(0),
+                        true)));
   }
 
   @ParameterizedTest

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
@@ -28,6 +28,7 @@ import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Delete;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.VersionStore;
@@ -80,6 +81,18 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
   }
 
   static List<ReferenceNotFoundFunction> referenceNotFoundFunctions() {
+    MetadataRewriter<CommitMessage> metadataRewriter =
+        new MetadataRewriter<CommitMessage>() {
+          @Override
+          public CommitMessage rewriteSingle(CommitMessage metadata) {
+            return null;
+          }
+
+          @Override
+          public CommitMessage squash(List<CommitMessage> metadata) {
+            return null;
+          }
+        };
     return Arrays.asList(
         // getCommits()
         new ReferenceNotFoundFunction("getCommits/branch")
@@ -196,7 +209,7 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         BranchName.of("this-one-should-not-exist"),
                         Optional.empty(),
                         singletonList(s.hashOnReference(BranchName.of("main"), Optional.empty())),
-                        l -> l.get(0),
+                        metadataRewriter,
                         false)),
         new ReferenceNotFoundFunction("transplant/hash/empty")
             .msg(
@@ -207,7 +220,7 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         BranchName.of("main"),
                         Optional.of(Hash.of("12341234123412341234123412341234123412341234")),
                         singletonList(Hash.of("12341234123412341234123412341234123412341234")),
-                        l -> l.get(0),
+                        metadataRewriter,
                         true)),
         new ReferenceNotFoundFunction("transplant/empty/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
@@ -217,7 +230,7 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         BranchName.of("main"),
                         Optional.empty(),
                         singletonList(Hash.of("12341234123412341234123412341234123412341234")),
-                        l -> l.get(0),
+                        metadataRewriter,
                         false)),
         // merge()
         new ReferenceNotFoundFunction("merge/hash/empty")
@@ -228,7 +241,7 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         Hash.of("12341234123412341234123412341234123412341234"),
                         BranchName.of("main"),
                         Optional.empty(),
-                        l -> l.get(0),
+                        metadataRewriter,
                         true)),
         new ReferenceNotFoundFunction("merge/empty/hash")
             .msg(
@@ -239,7 +252,7 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         s.noAncestorHash(),
                         BranchName.of("main"),
                         Optional.of(Hash.of("12341234123412341234123412341234123412341234")),
-                        l -> l.get(0),
+                        metadataRewriter,
                         true)));
   }
 


### PR DESCRIPTION
Updates the merge-operation to squash the commits to be merged, if there is more than 1
commit to be merged.

The most recent change to any content-key will be present in the squashed commit,
intermediate changes will not be present in the squashed commit.

Commit messages will be concatenated with a separating line consisting of a sequence of
`-` characters.

Commit properties are combined, last property value will be present in the squashed
commit.

Commit author will be reset to the user issuing the merge operation in a squashed
commit. Commit author-time will be reset to the current timestamp for a squashed commit.

This API-change is not changing the signature, but the behavior changes, as the default
is then to squash the commits to merge. I.e. not specifying the `keepIndividualCommits`
parameter for a merge operation means "squash" the commits. To use the previous behavior,
pass `keepIndividualCommits=true`.

Fixes #3809 