### PR TITLE
Refactor gc-base module to be reusable for gc-iceberg module

### DIFF
--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.spark.sql.SparkSession;
@@ -177,12 +176,12 @@ public class GCImpl {
             case RefLogResponse.RefLogResponseEntry.BRANCH:
               droppedReferenceTimeMap.put(
                   GCUtil.serializeReference(Branch.of(entry.getRefName(), hash)),
-                  getInstantFromMicros(entry.getOperationTime()));
+                  GCUtil.getInstantFromMicros(entry.getOperationTime()));
               break;
             case RefLogResponse.RefLogResponseEntry.TAG:
               droppedReferenceTimeMap.put(
                   GCUtil.serializeReference(Tag.of(entry.getRefName(), hash)),
-                  getInstantFromMicros(entry.getOperationTime()));
+                  GCUtil.getInstantFromMicros(entry.getOperationTime()));
               break;
             default:
               throw new RuntimeException(
@@ -190,13 +189,6 @@ public class GCImpl {
           }
         });
     return droppedReferenceTimeMap;
-  }
-
-  private static Instant getInstantFromMicros(Long microsSinceEpoch) {
-    return Instant.ofEpochSecond(
-        TimeUnit.MICROSECONDS.toSeconds(microsSinceEpoch),
-        TimeUnit.MICROSECONDS.toNanos(
-            Math.floorMod(microsSinceEpoch, TimeUnit.SECONDS.toMicros(1))));
   }
 
   private static void getOrCreateEmptyBranch(NessieApiV1 api, String branchName) {

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCUtil.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCUtil.java
@@ -18,9 +18,11 @@ package org.projectnessie.gc.base;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -53,6 +55,13 @@ public final class GCUtil {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public static Instant getInstantFromMicros(Long microsSinceEpoch) {
+    return Instant.ofEpochSecond(
+        TimeUnit.MICROSECONDS.toSeconds(microsSinceEpoch),
+        TimeUnit.MICROSECONDS.toNanos(
+            Math.floorMod(microsSinceEpoch, TimeUnit.SECONDS.toMicros(1))));
   }
 
   /**

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
@@ -90,7 +90,7 @@ public abstract class AbstractRestGC extends AbstractRest {
             });
   }
 
-  void performGc(
+  protected void performGc(
       String prefix,
       Instant cutoffTimeStamp,
       Map<String, Instant> cutOffTimeStampPerRef,
@@ -134,7 +134,7 @@ public abstract class AbstractRestGC extends AbstractRest {
     }
   }
 
-  SparkSession getSparkSession() {
+  protected SparkSession getSparkSession() {
     SparkConf conf = new SparkConf();
     conf.set("spark.sql.catalog.nessie.uri", getUri().toString())
         .set("spark.sql.catalog.nessie.ref", "main")
@@ -155,7 +155,7 @@ public abstract class AbstractRestGC extends AbstractRest {
     return spark;
   }
 
-  private void verify(
+  protected void verify(
       Dataset<Row> actual, List<Row> expectedRows, SparkSession session, StructType schema) {
     Dataset<Row> expected = session.createDataFrame(expectedRows, schema);
     Dataset<Row> dfActual = actual.select("referenceName", "contentId", "snapshotId");

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/base/TestInstantConversion.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/base/TestInstantConversion.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class TestInstantConversion {
+
+  @Test
+  void testInstantConversion() {
+    Instant now = Instant.now();
+    long time = now.getEpochSecond();
+    long nano = now.getNano();
+    // current time in microseconds since epoch
+    long micro = TimeUnit.SECONDS.toMicros(time) + TimeUnit.NANOSECONDS.toMicros(nano);
+    Instant instantFromMicros = GCUtil.getInstantFromMicros(micro);
+    // Even though instant is capable of nanosecond precision,
+    // Instant.now() gives micro second precision by default.
+    // Because of that the below validation can pass.
+    assertThat(instantFromMicros).isEqualTo(now);
+  }
+}


### PR DESCRIPTION
gc-iceberg module will depend on the gc-base module test jar and reuses its test cases by overriding the performGC to use call procedure instead of api as in https://github.com/projectnessie/nessie/pull/3626

- Make some private test methods to be protected for overriding.
- Move the timestamp to instant conversion to GCUtil to be reused in stored procedure.
