### PR TITLE
Introduce gc-iceberg module to hold stored procedures based on gc-base

### DIFF
--- a/gc/gc-iceberg/pom.xml
+++ b/gc/gc-iceberg/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.projectnessie</groupId>
+    <artifactId>nessie-gc</artifactId>
+    <version>0.24.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nessie-gc-iceberg</artifactId>
+
+  <name>Nessie - GC - Iceberg</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-jaxrs-testextension</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-jaxrs-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!--    spark dependencies -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.12</artifactId>
+      <version>${spark31.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.parquet</groupId>
+          <artifactId>parquet-hadoop</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!--    Iceberg dependencies -->
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-nessie</artifactId>
+      <version>${iceberg.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.projectnessie</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-spark3</artifactId>
+      <version>${iceberg.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-spark3-extensions</artifactId>
+      <version>${iceberg.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/gc/gc-iceberg/src/main/java/org/apache/iceberg/spark/procedures/BaseGcProcedure.java
+++ b/gc/gc-iceberg/src/main/java/org/apache/iceberg/spark/procedures/BaseGcProcedure.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+/**
+ * This class is a "bridge" between the Iceberg-Spark package and the Nessie package, because {@link
+ * BaseProcedure} is declared as package private.
+ */
+public abstract class BaseGcProcedure extends BaseProcedure {
+  protected BaseGcProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+}

--- a/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/DummyProcedure.java
+++ b/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/DummyProcedure.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.iceberg;
+
+import org.apache.iceberg.spark.procedures.BaseGcProcedure;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/** Dummy procedure that accepts an input string and returns it. */
+public class DummyProcedure extends BaseGcProcedure {
+
+  public static final String PROCEDURE_NAME = "dummy";
+
+  private static final ProcedureParameter[] PARAMETERS =
+      new ProcedureParameter[] {ProcedureParameter.required("input_string", DataTypes.StringType)};
+
+  public static final String OUTPUT_RUN_ID = "output_string";
+
+  private static final StructType OUTPUT_TYPE =
+      new StructType(
+          new StructField[] {
+            new StructField(OUTPUT_RUN_ID, DataTypes.StringType, true, Metadata.empty())
+          });
+
+  private InternalRow resultRow(String runId) {
+    return GcProcedureUtil.internalRow(runId);
+  }
+
+  public DummyProcedure(TableCatalog currentCatalog) {
+    super(currentCatalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public String description() {
+    return "Dummy procedure that accepts an input string and returns it.";
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow internalRow) {
+    String inputString = internalRow.getString(0);
+    return new InternalRow[] {resultRow(inputString)};
+  }
+}

--- a/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/GcProcedureUtil.java
+++ b/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/GcProcedureUtil.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.iceberg;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.apache.iceberg.spark.procedures.BaseGcProcedure;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.unsafe.types.UTF8String;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+final class GcProcedureUtil {
+
+  private GcProcedureUtil() {}
+
+  static final String NAMESPACE = "nessie_gc";
+  static final String[] NAMESPACE_ARRAY = {NAMESPACE};
+
+  static boolean isGcNamespace(Identifier identifier) {
+    return Arrays.equals(NAMESPACE_ARRAY, identifier.namespace());
+  }
+
+  static BaseGcProcedure loadGcProcedure(Identifier procedureIdentifier, TableCatalog catalog)
+      throws NoSuchProcedureException {
+    if (DummyProcedure.PROCEDURE_NAME.equals(procedureIdentifier.name())) {
+      return new DummyProcedure(catalog);
+    }
+    throw new NoSuchProcedureException(procedureIdentifier);
+  }
+
+  static InternalRow internalRow(Object... columns) {
+    Seq<Object> seq =
+        JavaConverters.collectionAsScalaIterable(
+                Arrays.stream(columns)
+                    .map(
+                        object ->
+                            object instanceof String
+                                ? UTF8String.fromString((String) object)
+                                : object)
+                    .collect(Collectors.toList()))
+            .toSeq();
+    return InternalRow.fromSeq(seq);
+  }
+}

--- a/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/NessieIcebergGcSparkCatalog.java
+++ b/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/NessieIcebergGcSparkCatalog.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.iceberg;
+
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
+
+/**
+ * Extends {@link SparkCatalog} to load the Nessie GC procedures in "nessie_gc" namespace. As there
+ * is no other way to "plug in" custom procedures in Iceberg yet.
+ *
+ * <p>This extension can be removed after Iceberg supports pluggable stored procedures.
+ */
+@SuppressWarnings("unused")
+public class NessieIcebergGcSparkCatalog extends SparkCatalog {
+
+  public NessieIcebergGcSparkCatalog() {
+    super();
+  }
+
+  @Override
+  public Procedure loadProcedure(Identifier procedureIdentifier) throws NoSuchProcedureException {
+    if (GcProcedureUtil.isGcNamespace(procedureIdentifier)) {
+      return GcProcedureUtil.loadGcProcedure(procedureIdentifier, this);
+    }
+    return super.loadProcedure(procedureIdentifier);
+  }
+}

--- a/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/NessieIcebergGcSparkSessionCatalog.java
+++ b/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/NessieIcebergGcSparkSessionCatalog.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.iceberg;
+
+import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
+
+/**
+ * Extends {@link SparkSessionCatalog} to load the Nessie GC procedures in "nessie_gc" namespace. As
+ * there is no other way to "plug in" custom procedures in Iceberg yet.
+ *
+ * <p>This extension can be removed after Iceberg supports pluggable stored procedures.
+ */
+@SuppressWarnings("unused")
+public class NessieIcebergGcSparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
+    extends SparkSessionCatalog<T> {
+
+  public NessieIcebergGcSparkSessionCatalog() {
+    super();
+  }
+
+  @Override
+  public Procedure loadProcedure(Identifier procedureIdentifier) throws NoSuchProcedureException {
+    if (GcProcedureUtil.isGcNamespace(procedureIdentifier)) {
+      return GcProcedureUtil.loadGcProcedure(procedureIdentifier, this);
+    }
+    return super.loadProcedure(procedureIdentifier);
+  }
+}

--- a/gc/gc-iceberg/src/test/java/org/projectnessie/gc/iceberg/ProcedureTestUtil.java
+++ b/gc/gc-iceberg/src/test/java/org/projectnessie/gc/iceberg/ProcedureTestUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.iceberg;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.SparkSession;
+
+final class ProcedureTestUtil {
+
+  private ProcedureTestUtil() {}
+
+  static SparkSession getSessionWithGcCatalog(String uri, String location, String catalogClass) {
+    SparkConf conf = new SparkConf();
+    conf.set("spark.sql.catalog.nessie.uri", uri)
+        .set("spark.sql.catalog.nessie.ref", "main")
+        .set("spark.sql.catalog.nessie.warehouse", location)
+        .set("spark.sql.catalog.nessie.catalog-impl", "org.apache.iceberg.nessie.NessieCatalog")
+        // Use the catalogClass which is loaded with the GC stored procedures in
+        // "nessie_gc" namespace.
+        .set("spark.sql.catalog.nessie", catalogClass)
+        .set(
+            "spark.sql.extensions",
+            "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions");
+    SparkSession spark =
+        SparkSession.builder()
+            .appName("test-nessie-gc")
+            .master("local[2]")
+            .config(conf)
+            .getOrCreate();
+    spark.sparkContext().setLogLevel("WARN");
+    return spark;
+  }
+}

--- a/gc/gc-iceberg/src/test/java/org/projectnessie/gc/iceberg/TestDummyProcedure.java
+++ b/gc/gc-iceberg/src/test/java/org/projectnessie/gc/iceberg/TestDummyProcedure.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
+import org.projectnessie.jaxrs.ext.NessieUri;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
+import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
+
+@NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
+@ExtendWith(DatabaseAdapterExtension.class)
+public class TestDummyProcedure {
+
+  @NessieDbAdapter static DatabaseAdapter databaseAdapter;
+
+  @RegisterExtension
+  static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
+
+  private static URI nessieUri;
+
+  @BeforeAll
+  static void setNessieUri(@NessieUri URI uri) {
+    nessieUri = uri;
+  }
+
+  @TempDir File tempDir;
+
+  static final String CATALOG_NAME = "nessie";
+  static final String GC_SPARK_CATALOG = "org.projectnessie.gc.iceberg.NessieIcebergGcSparkCatalog";
+  static final String GC_SPARK_SESSION_CATALOG =
+      "org.projectnessie.gc.iceberg.NessieIcebergGcSparkSessionCatalog";
+  static final String SPARK_CATALOG = "org.apache.iceberg.spark.SparkCatalog";
+  static final String SPARK_SESSION_CATALOG = "org.apache.iceberg.spark.SparkSessionCatalog";
+  static final String GC_NAMESPACE = "nessie_gc";
+  static final String OTHER_NAMESPACE = "system";
+  static final HashSet<String> gcCatalog =
+      new HashSet<>(Arrays.asList(GC_SPARK_CATALOG, GC_SPARK_SESSION_CATALOG));
+
+  private SparkSession getSparkSessionWithCatalogClass(String catalogClass) {
+    return ProcedureTestUtil.getSessionWithGcCatalog(
+        nessieUri.toString(), tempDir.toURI().toString(), catalogClass);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    GC_SPARK_CATALOG + "," + GC_NAMESPACE,
+    GC_SPARK_CATALOG + "," + OTHER_NAMESPACE,
+    GC_SPARK_SESSION_CATALOG + "," + GC_NAMESPACE,
+    GC_SPARK_SESSION_CATALOG + "," + OTHER_NAMESPACE,
+    SPARK_CATALOG + "," + GC_NAMESPACE,
+    SPARK_CATALOG + "," + OTHER_NAMESPACE,
+    SPARK_SESSION_CATALOG + "," + GC_NAMESPACE,
+    SPARK_SESSION_CATALOG + "," + OTHER_NAMESPACE
+  })
+  public void testDummyProcedure(String catalog, String namespace) {
+    try (SparkSession sparkSession = getSparkSessionWithCatalogClass(catalog)) {
+      String inputString = "sample_string";
+      if (gcCatalog.contains(catalog) && namespace.equals(GC_NAMESPACE)) {
+        List<Row> rows = callProcedure(sparkSession, namespace, inputString);
+        assertThat(rows.size()).isEqualTo(1);
+        assertThat(rows.get(0).getString(0)).isEqualTo(inputString);
+      } else {
+        assertThatThrownBy(() -> callProcedure(sparkSession, namespace, inputString))
+            .isInstanceOf(NoSuchProcedureException.class)
+            .hasMessage(String.format("Procedure %s.dummy not found", namespace));
+      }
+    }
+  }
+
+  private List<Row> callProcedure(SparkSession sparkSession, String namespace, String inputString) {
+    // Example query:
+    // CALL nessie.nessie_gc.dummy(input_string => 'sample_string')
+    return sparkSession
+        .sql(
+            String.format(
+                "CALL %s.%s.%s(input_string => '%s')",
+                CATALOG_NAME,
+                namespace,
+                DummyProcedure.PROCEDURE_NAME,
+                //
+                inputString))
+        .collectAsList();
+  }
+}

--- a/gc/gc-iceberg/src/test/resources/logback-test.xml
+++ b/gc/gc-iceberg/src/test/resources/logback-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration debug="true">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="org.apache.spark.sql.delta" level="${test.log.level:-INFO}"/>
+  <root>
+    <level value="${test.log.level:-INFO}"/>
+    <appender-ref ref="console"/>
+  </root>
+</configuration>

--- a/gc/pom.xml
+++ b/gc/pom.xml
@@ -32,5 +32,6 @@
 
   <modules>
     <module>gc-base</module>
+    <module>gc-iceberg</module>
   </modules>
 </project>


### PR DESCRIPTION
- Introduce `gc-Iceberg` module to handle Iceberg specific procedures.
- Supported `NessieIcebergGcSparkCatalog` and `NessieIcebergGcSparkSessionCatalog` to store the GC procedures under "nessie_gc" namespace.
- Added a dummy procedure to verify the framework.