### PR TITLE
Use parameter classes MergeParams + TransplantParams

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
@@ -77,13 +77,13 @@ public interface CommitLogEntry {
       long createdTime,
       Hash hash,
       long commitSeq,
-      List<Hash> parents,
+      Iterable<Hash> parents,
       ByteString metadata,
-      List<KeyWithBytes> puts,
-      List<Key> deletes,
+      Iterable<KeyWithBytes> puts,
+      Iterable<Key> deletes,
       int keyListDistance,
       KeyList keyList,
-      List<Hash> keyListIds) {
+      Iterable<Hash> keyListIds) {
     return ImmutableCommitLogEntry.builder()
         .createdTime(createdTime)
         .hash(hash)

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitParams.java
@@ -22,27 +22,11 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
-import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 
-/**
- * API helper method to encapsulate parameters for {@link DatabaseAdapter#commit(CommitAttempt)}.
- */
+/** API helper method to encapsulate parameters for {@link DatabaseAdapter#commit(CommitParams)}. */
 @Value.Immutable
-public interface CommitAttempt {
-
-  /**
-   * Branch to commit to. If {@link #getExpectedHead()} is present, the referenced branch's HEAD
-   * must be equal to this hash.
-   */
-  BranchName getCommitToBranch();
-
-  /** Expected HEAD of {@link #getCommitToBranch()}. */
-  @Value.Default
-  default Optional<Hash> getExpectedHead() {
-    return Optional.empty();
-  }
+public interface CommitParams extends ToBranchParams {
 
   /**
    * Mapping of content-ids to expected global content-state (think: Iceberg table-metadata), coming

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CopyCommitsParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CopyCommitsParams.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import com.google.protobuf.ByteString;
+import java.util.function.Function;
+
+public interface CopyCommitsParams extends ToBranchParams {
+
+  /** Function to rewrite the commit-metadata. */
+  Function<ByteString, ByteString> getUpdateCommitMetadata();
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -18,13 +18,11 @@ package org.projectnessie.versioned.persist.adapter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Diff;
 import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
@@ -125,29 +123,23 @@ public interface DatabaseAdapter {
       throws ReferenceNotFoundException;
 
   /**
-   * Commit operation, see {@link CommitAttempt} for a description of the parameters.
+   * Commit operation, see {@link CommitParams} for a description of the parameters.
    *
-   * @param commitAttempt parameters for the commit
+   * @param commitParams parameters for the commit
    * @return optimistically written commit-log-entry
    * @throws ReferenceNotFoundException if either the named reference in {@link
-   *     CommitAttempt#getCommitToBranch()} or the commit on that reference, if specified, does not
-   *     exist.
+   *     CommitParams#getToBranch()} or the commit on that reference, if specified, does not exist.
    * @throws ReferenceConflictException if any of the commits could not be committed onto the target
    *     branch due to a conflicting change or if the expected hash in {@link
-   *     CommitAttempt#getCommitToBranch()}is not its expected hEAD
+   *     CommitParams#getToBranch()}is not its expected hEAD
    */
-  Hash commit(CommitAttempt commitAttempt)
+  Hash commit(CommitParams commitParams)
       throws ReferenceConflictException, ReferenceNotFoundException;
 
   /**
    * Cherry-pick the commits with the hashes {@code sequenceToTransplant} from named reference
    * {@code source} onto the reference {@code targetBranch}.
    *
-   * @param targetBranch named-reference to commit to. If no value for the hash is specified, it
-   *     defaults to the named reference's HEAD.
-   * @param expectedHead if present, {@code target}'s current HEAD must be equal to this value
-   * @param sequenceToTransplant commits in {@code source} to cherry-pick onto {@code targetBranch}
-   * @param updateCommitMetadata function to rewrite the commit-metadata for copied commits
    * @return the hash of the last cherry-picked commit, in other words the new HEAD of the target
    *     branch
    * @throws ReferenceNotFoundException if either the named reference in {@code commitOnReference}
@@ -156,11 +148,7 @@ public interface DatabaseAdapter {
    *     branch due to a conflicting change or if the expected hash of {@code toBranch} is not its
    *     expected hEAD
    */
-  Hash transplant(
-      BranchName targetBranch,
-      Optional<Hash> expectedHead,
-      List<Hash> sequenceToTransplant,
-      Function<ByteString, ByteString> updateCommitMetadata)
+  Hash transplant(TransplantParams transplantParams)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
@@ -170,10 +158,6 @@ public interface DatabaseAdapter {
    * <p>The implementation first identifies the common-ancestor (the most-recent commit that is both
    * reachable via {@code from} and {@code to}).
    *
-   * @param from commit-hash to start reading commits from.
-   * @param toBranch target branch to commit to
-   * @param expectedHead if present, {@code toBranch}'s current HEAD must be equal to this value
-   * @param updateCommitMetadata function to rewrite the commit-metadata for copied commits
    * @return the hash of the last cherry-picked commit, in other words the new HEAD of the target
    *     branch
    * @throws ReferenceNotFoundException if either the named reference in {@code toBranch} or the
@@ -182,12 +166,7 @@ public interface DatabaseAdapter {
    *     branch due to a conflicting change or if the expected hash of {@code toBranch} is not its
    *     expected hEAD
    */
-  Hash merge(
-      Hash from,
-      BranchName toBranch,
-      Optional<Hash> expectedHead,
-      Function<ByteString, ByteString> updateCommitMetadata)
-      throws ReferenceNotFoundException, ReferenceConflictException;
+  Hash merge(MergeParams mergeParams) throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
    * Resolve the current HEAD of the given named-reference and optionally additional information.

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import org.immutables.value.Value;
+import org.projectnessie.versioned.Hash;
+
+/** API helper method to encapsulate parameters for {@link DatabaseAdapter#merge(MergeParams)}. */
+@Value.Immutable
+public interface MergeParams extends CopyCommitsParams {
+
+  /** Commit-hash to start reading commits from. */
+  Hash getMergeFromHash();
+
+  static ImmutableMergeParams.Builder builder() {
+    return ImmutableMergeParams.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
@@ -20,7 +20,7 @@ import org.projectnessie.versioned.Hash;
 
 /** API helper method to encapsulate parameters for {@link DatabaseAdapter#merge(MergeParams)}. */
 @Value.Immutable
-public interface MergeParams extends CopyCommitsParams {
+public interface MergeParams extends MetadataRewriteParams {
 
   /** Commit-hash to start reading commits from. */
   Hash getMergeFromHash();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MetadataRewriteParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MetadataRewriteParams.java
@@ -18,7 +18,7 @@ package org.projectnessie.versioned.persist.adapter;
 import com.google.protobuf.ByteString;
 import java.util.function.Function;
 
-public interface CopyCommitsParams extends ToBranchParams {
+public interface MetadataRewriteParams extends ToBranchParams {
 
   /** Function to rewrite the commit-metadata. */
   Function<ByteString, ByteString> getUpdateCommitMetadata();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ToBranchParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ToBranchParams.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import java.util.Optional;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Hash;
+
+public interface ToBranchParams {
+
+  /**
+   * Branch to commit to. If {@link #getExpectedHead()} is present, the referenced branch's HEAD
+   * must be equal to this hash.
+   */
+  BranchName getToBranch();
+
+  /** Expected HEAD of {@link #getToBranch()}. */
+  @Value.Default
+  default Optional<Hash> getExpectedHead() {
+    return Optional.empty();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
@@ -24,9 +24,9 @@ import org.projectnessie.versioned.Hash;
  * DatabaseAdapter#transplant(TransplantParams)}.
  */
 @Value.Immutable
-public interface TransplantParams extends CopyCommitsParams {
+public interface TransplantParams extends MetadataRewriteParams {
 
-  /** Commits to cherry-pick onto {@code targetBranch}. */
+  /** Commits to cherry-pick onto {@link #getToBranch()}. */
   List<Hash> getSequenceToTransplant();
 
   static ImmutableTransplantParams.Builder builder() {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import java.util.List;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.Hash;
+
+/**
+ * API helper method to encapsulate parameters for {@link
+ * DatabaseAdapter#transplant(TransplantParams)}.
+ */
+@Value.Immutable
+public interface TransplantParams extends CopyCommitsParams {
+
+  /** Commits to cherry-pick onto {@code targetBranch}. */
+  List<Hash> getSequenceToTransplant();
+
+  static ImmutableTransplantParams.Builder builder() {
+    return ImmutableTransplantParams.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
@@ -19,7 +19,6 @@ import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.protobuf.UnsafeByteOperations;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators.AbstractSpliterator;
@@ -36,6 +35,8 @@ import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.MergeParams;
+import org.projectnessie.versioned.persist.adapter.TransplantParams;
 
 /** Utility methods for {@link DatabaseAdapter} implementations. */
 public final class DatabaseAdapterUtil {
@@ -89,27 +90,22 @@ public final class DatabaseAdapterUtil {
         String.format("Named reference '%s' already exists.", ref.getName()));
   }
 
-  public static String mergeConflictMessage(
-      String err, Hash from, BranchName toBranch, Optional<Hash> expectedHead) {
+  public static String mergeConflictMessage(String err, MergeParams mergeParams) {
     return String.format(
         "%s during merge of '%s' into '%s%s' requiring a common ancestor",
         err,
-        from.asString(),
-        toBranch.getName(),
-        expectedHead.map(h -> "@" + h.asString()).orElse(""));
+        mergeParams.getMergeFromHash().asString(),
+        mergeParams.getToBranch().getName(),
+        mergeParams.getExpectedHead().map(h -> "@" + h.asString()).orElse(""));
   }
 
-  public static String transplantConflictMessage(
-      String err,
-      BranchName targetBranch,
-      Optional<Hash> expectedHead,
-      List<Hash> sequenceToTransplant) {
+  public static String transplantConflictMessage(String err, TransplantParams transplantParams) {
     return String.format(
         "%s during transplant of %d commits into '%s%s'",
         err,
-        sequenceToTransplant.size(),
-        targetBranch.getName(),
-        expectedHead.map(h -> "@" + h.asString()).orElse(""));
+        transplantParams.getSequenceToTransplant().size(),
+        transplantParams.getToBranch().getName(),
+        transplantParams.getExpectedHead().map(h -> "@" + h.asString()).orElse(""));
   }
 
   public static String commitConflictMessage(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
@@ -44,7 +44,7 @@ import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
@@ -140,8 +140,8 @@ public abstract class AbstractCommitScenarios {
         i -> {
           try {
             return databaseAdapter.commit(
-                ImmutableCommitAttempt.builder()
-                    .commitToBranch(branch)
+                ImmutableCommitParams.builder()
+                    .toBranch(branch)
                     .commitMetaSerialized(ByteString.copyFromUtf8("dummy commit meta " + i))
                     .addUnchanged(dummyKey)
                     .build());
@@ -155,7 +155,7 @@ public abstract class AbstractCommitScenarios {
             .mapToObj(performDummyCommit)
             .collect(Collectors.toList());
 
-    ImmutableCommitAttempt.Builder commit;
+    ImmutableCommitParams.Builder commit;
 
     BaseContent initialContent;
     BaseContent renamContent;
@@ -170,8 +170,8 @@ public abstract class AbstractCommitScenarios {
     byte payload = SimpleStoreWorker.INSTANCE.getPayload(initialContent);
 
     commit =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("initial commit meta"))
             .addPuts(
                 KeyWithBytes.of(
@@ -192,8 +192,8 @@ public abstract class AbstractCommitScenarios {
             .collect(Collectors.toList());
 
     commit =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("rename table"))
             .addDeletes(oldKey)
             .addPuts(
@@ -217,8 +217,8 @@ public abstract class AbstractCommitScenarios {
             .collect(Collectors.toList());
 
     commit =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("delete table"))
             .addDeletes(newKey);
     if (param.globalState) {
@@ -298,9 +298,9 @@ public abstract class AbstractCommitScenarios {
     BranchName branch = BranchName.of("main");
 
     ArrayList<Key> keys = new ArrayList<>(tablesPerCommit);
-    ImmutableCommitAttempt.Builder commit =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+    ImmutableCommitParams.Builder commit =
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("initial commit meta"));
     for (int i = 0; i < tablesPerCommit; i++) {
       Key key = Key.of("my", "table", "num" + i);
@@ -329,8 +329,8 @@ public abstract class AbstractCommitScenarios {
               keys,
               KeyFilterPredicate.ALLOW_ALL);
       commit =
-          ImmutableCommitAttempt.builder()
-              .commitToBranch(branch)
+          ImmutableCommitParams.builder()
+              .toBranch(branch)
               .commitMetaSerialized(ByteString.copyFromUtf8("initial commit meta"));
       for (int i = 0; i < tablesPerCommit; i++) {
         String currentState = values.get(keys.get(i)).getGlobalState().toStringUtf8();
@@ -403,9 +403,9 @@ public abstract class AbstractCommitScenarios {
     WithGlobalStateContent c =
         WithGlobalStateContent.withGlobal("0", "initial commit content", cid);
 
-    ImmutableCommitAttempt.Builder commit =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+    ImmutableCommitParams.Builder commit =
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("initial commit meta"))
             .addPuts(
                 KeyWithBytes.of(
@@ -433,9 +433,9 @@ public abstract class AbstractCommitScenarios {
         KeyWithBytes.of(key, contentsId, (byte) 0, ByteString.copyFromUtf8("no no"));
     KeyWithBytes createPut2 = KeyWithBytes.of(key, contentsId, (byte) 0, tableRefState);
 
-    ImmutableCommitAttempt.Builder commit1 =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+    ImmutableCommitParams.Builder commit1 =
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("initial"))
             .addPuts(createPut1)
             .addPuts(createPut2);
@@ -446,9 +446,9 @@ public abstract class AbstractCommitScenarios {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(key.toString());
 
-    ImmutableCommitAttempt.Builder commit2 =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+    ImmutableCommitParams.Builder commit2 =
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("initial"))
             .addDeletes(key)
             .addPuts(createPut2);
@@ -459,9 +459,9 @@ public abstract class AbstractCommitScenarios {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(key.toString());
 
-    ImmutableCommitAttempt.Builder commit3 =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+    ImmutableCommitParams.Builder commit3 =
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("initial"))
             .addDeletes(key)
             .addUnchanged(key);
@@ -472,9 +472,9 @@ public abstract class AbstractCommitScenarios {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(key.toString());
 
-    ImmutableCommitAttempt.Builder commit4 =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+    ImmutableCommitParams.Builder commit4 =
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("initial"))
             .addUnchanged(key)
             .addPuts(createPut2);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
@@ -39,7 +39,7 @@ import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.GlobalLogCompactionParams;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 import org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams;
 import org.projectnessie.versioned.testworker.SimpleStoreWorker;
@@ -225,9 +225,9 @@ public abstract class AbstractCompactGlobalLog {
     byte payload = SimpleStoreWorker.INSTANCE.getPayload(c);
     ByteString global = SimpleStoreWorker.INSTANCE.toStoreGlobalState(c);
 
-    ImmutableCommitAttempt.Builder commit =
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+    ImmutableCommitParams.Builder commit =
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.copyFromUtf8("commit#" + i))
             .addPuts(
                 KeyWithBytes.of(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
@@ -48,12 +48,12 @@ import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.ReferenceRetryFailureException;
-import org.projectnessie.versioned.persist.adapter.CommitAttempt;
+import org.projectnessie.versioned.persist.adapter.CommitParams;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt.Builder;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams.Builder;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 import org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterMetrics;
@@ -174,7 +174,7 @@ public abstract class AbstractConcurrency {
                           .map(ContentAndState::getGlobalState)
                           .collect(Collectors.toList());
 
-                  ImmutableCommitAttempt.Builder commitAttempt = ImmutableCommitAttempt.builder();
+                  ImmutableCommitParams.Builder commitAttempt = ImmutableCommitParams.builder();
 
                   for (int ki = 0; ki < keys.size(); ki++) {
                     Key key = keys.get(ki);
@@ -200,7 +200,7 @@ public abstract class AbstractConcurrency {
 
                   try {
                     commitAttempt
-                        .commitToBranch(branch)
+                        .toBranch(branch)
                         .commitMetaSerialized(
                             ByteString.copyFromUtf8(
                                 "commit #"
@@ -226,9 +226,9 @@ public abstract class AbstractConcurrency {
         BranchName branch = branchKeys.getKey();
         databaseAdapter.create(
             branch, databaseAdapter.hashOnReference(BranchName.of("main"), Optional.empty()));
-        ImmutableCommitAttempt.Builder commitAttempt =
-            ImmutableCommitAttempt.builder()
-                .commitToBranch(branchKeys.getKey())
+        ImmutableCommitParams.Builder commitAttempt =
+            ImmutableCommitParams.builder()
+                .toBranch(branchKeys.getKey())
                 .commitMetaSerialized(
                     ByteString.copyFromUtf8("initial commit for " + branch.getName()));
         for (Key k : branchKeys.getValue()) {
@@ -304,7 +304,7 @@ public abstract class AbstractConcurrency {
       BranchName branch,
       Builder commitAttempt)
       throws ReferenceConflictException, ReferenceNotFoundException {
-    CommitAttempt c = commitAttempt.build();
+    CommitParams c = commitAttempt.build();
     databaseAdapter.commit(c);
     globalStates.putAll(c.getGlobal());
     Map<Key, ByteString> onRef =

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -42,7 +42,7 @@ import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.Difference;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
@@ -191,8 +191,8 @@ public abstract class AbstractDatabaseAdapterTest {
 
     Hash unreachableHead =
         databaseAdapter.commit(
-            ImmutableCommitAttempt.builder()
-                .commitToBranch(unreachable)
+            ImmutableCommitParams.builder()
+                .toBranch(unreachable)
                 .commitMetaSerialized(ByteString.copyFromUtf8("commit meta"))
                 .addPuts(
                     KeyWithBytes.of(
@@ -215,8 +215,8 @@ public abstract class AbstractDatabaseAdapterTest {
             assertThatThrownBy(
                     () ->
                         databaseAdapter.commit(
-                            ImmutableCommitAttempt.builder()
-                                .commitToBranch(helper)
+                            ImmutableCommitParams.builder()
+                                .toBranch(helper)
                                 .expectedHead(Optional.of(unreachableHead))
                                 .commitMetaSerialized(ByteString.copyFromUtf8("commit meta"))
                                 .addPuts(
@@ -260,8 +260,8 @@ public abstract class AbstractDatabaseAdapterTest {
     for (int i = 0; i < commits.length; i++) {
       commits[i] =
           databaseAdapter.commit(
-              ImmutableCommitAttempt.builder()
-                  .commitToBranch(main)
+              ImmutableCommitParams.builder()
+                  .toBranch(main)
                   .commitMetaSerialized(ByteString.copyFromUtf8("commit meta " + i))
                   .addPuts(
                       KeyWithBytes.of(
@@ -304,9 +304,9 @@ public abstract class AbstractDatabaseAdapterTest {
 
     Hash[] commits = new Hash[3];
     for (int i = 0; i < commits.length; i++) {
-      ImmutableCommitAttempt.Builder commit =
-          ImmutableCommitAttempt.builder()
-              .commitToBranch(branch)
+      ImmutableCommitParams.Builder commit =
+          ImmutableCommitParams.builder()
+              .toBranch(branch)
               .commitMetaSerialized(ByteString.copyFromUtf8("commit " + i));
       for (int k = 0; k < 3; k++) {
         WithGlobalStateContent c =
@@ -482,16 +482,16 @@ public abstract class AbstractDatabaseAdapterTest {
     ByteString barCommitMeta = ByteString.copyFromUtf8("meta-bar");
 
     foo.commit(
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(main)
+        ImmutableCommitParams.builder()
+            .toBranch(main)
             .commitMetaSerialized(fooCommitMeta)
             .addPuts(
                 KeyWithBytes.of(
                     Key.of("foo"), ContentId.of("foo"), (byte) 0, ByteString.copyFromUtf8("foo")))
             .build());
     bar.commit(
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(main)
+        ImmutableCommitParams.builder()
+            .toBranch(main)
             .commitMetaSerialized(barCommitMeta)
             .addPuts(
                 KeyWithBytes.of(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGetNamedReferences.java
@@ -40,7 +40,7 @@ import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 
 public abstract class AbstractGetNamedReferences {
@@ -381,9 +381,9 @@ public abstract class AbstractGetNamedReferences {
 
   private Hash dummyCommit(BranchName branch, Hash expectedHash, int num) throws Exception {
     return databaseAdapter.commit(
-        ImmutableCommitAttempt.builder()
+        ImmutableCommitParams.builder()
             .commitMetaSerialized(commitMetaFor(branch, num))
-            .commitToBranch(branch)
+            .toBranch(branch)
             .expectedHead(Optional.of(expectedHash))
             .addPuts(
                 KeyWithBytes.of(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGlobalStates.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractGlobalStates.java
@@ -41,7 +41,7 @@ import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 
 /**
@@ -175,9 +175,9 @@ public abstract class AbstractGlobalStates {
 
     for (int commit = 0; commit < param.commitsPerBranch; commit++) {
       for (BranchName branch : branches) {
-        ImmutableCommitAttempt.Builder commitAttempt =
-            ImmutableCommitAttempt.builder()
-                .commitToBranch(branch)
+        ImmutableCommitParams.Builder commitAttempt =
+            ImmutableCommitParams.builder()
+                .toBranch(branch)
                 .expectedHead(Optional.of(heads.get(branch)))
                 .commitMetaSerialized(
                     ByteString.copyFromUtf8(
@@ -204,7 +204,7 @@ public abstract class AbstractGlobalStates {
           }
         }
 
-        ImmutableCommitAttempt attempt = commitAttempt.build();
+        ImmutableCommitParams attempt = commitAttempt.build();
         if (!attempt.getPuts().isEmpty()) {
           heads.put(branch, databaseAdapter.commit(attempt));
         }
@@ -243,8 +243,8 @@ public abstract class AbstractGlobalStates {
     Hash branchInitial = databaseAdapter.hashOnReference(branch, Optional.empty());
 
     databaseAdapter.commit(
-        ImmutableCommitAttempt.builder()
-            .commitToBranch(branch)
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
             .commitMetaSerialized(ByteString.EMPTY)
             .addPuts(
                 KeyWithBytes.of(
@@ -258,8 +258,8 @@ public abstract class AbstractGlobalStates {
     assertThatThrownBy(
             () ->
                 databaseAdapter.commit(
-                    ImmutableCommitAttempt.builder()
-                        .commitToBranch(branch)
+                    ImmutableCommitParams.builder()
+                        .toBranch(branch)
                         .expectedHead(Optional.of(branchInitial))
                         .commitMetaSerialized(ByteString.EMPTY)
                         .addPuts(
@@ -278,8 +278,8 @@ public abstract class AbstractGlobalStates {
     assertThatThrownBy(
             () ->
                 databaseAdapter.commit(
-                    ImmutableCommitAttempt.builder()
-                        .commitToBranch(branch)
+                    ImmutableCommitParams.builder()
+                        .toBranch(branch)
                         .commitMetaSerialized(ByteString.EMPTY)
                         .addPuts(
                             KeyWithBytes.of(
@@ -296,8 +296,8 @@ public abstract class AbstractGlobalStates {
     assertThatThrownBy(
             () ->
                 databaseAdapter.commit(
-                    ImmutableCommitAttempt.builder()
-                        .commitToBranch(branch)
+                    ImmutableCommitParams.builder()
+                        .toBranch(branch)
                         .commitMetaSerialized(ByteString.EMPTY)
                         .addPuts(
                             KeyWithBytes.of(
@@ -315,8 +315,8 @@ public abstract class AbstractGlobalStates {
     assertThatThrownBy(
             () ->
                 databaseAdapter.commit(
-                    ImmutableCommitAttempt.builder()
-                        .commitToBranch(branch)
+                    ImmutableCommitParams.builder()
+                        .toBranch(branch)
                         .expectedHead(Optional.of(branchInitial))
                         .commitMetaSerialized(ByteString.EMPTY)
                         .addPuts(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
@@ -39,7 +39,7 @@ import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
@@ -78,9 +78,9 @@ public abstract class AbstractManyCommits {
               "value for #" + i + " of " + numCommits,
               fixed.getId());
       byte payload = SimpleStoreWorker.INSTANCE.getPayload(c);
-      ImmutableCommitAttempt.Builder commit =
-          ImmutableCommitAttempt.builder()
-              .commitToBranch(branch)
+      ImmutableCommitParams.Builder commit =
+          ImmutableCommitParams.builder()
+              .toBranch(branch)
               .commitMetaSerialized(ByteString.copyFromUtf8("commit #" + i + " of " + numCommits))
               .addPuts(
                   KeyWithBytes.of(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -34,7 +34,7 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitAttempt;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
@@ -81,13 +81,13 @@ public abstract class AbstractManyKeys {
   void manyKeys(ManyKeysParams params) throws Exception {
     BranchName main = BranchName.of("main");
 
-    List<ImmutableCommitAttempt.Builder> commits =
+    List<ImmutableCommitParams.Builder> commits =
         IntStream.range(0, params.commits)
             .mapToObj(
                 i ->
-                    ImmutableCommitAttempt.builder()
+                    ImmutableCommitParams.builder()
                         .commitMetaSerialized(ByteString.copyFromUtf8("commit #" + i))
-                        .commitToBranch(main))
+                        .toBranch(main))
             .collect(Collectors.toList());
     AtomicInteger commitDist = new AtomicInteger();
 
@@ -110,7 +110,7 @@ public abstract class AbstractManyKeys {
             })
         .forEach(kb -> commits.get(commitDist.incrementAndGet() % params.commits).addPuts(kb));
 
-    for (ImmutableCommitAttempt.Builder commit : commits) {
+    for (ImmutableCommitParams.Builder commit : commits) {
       databaseAdapter.commit(commit.build());
     }
 

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -73,8 +73,8 @@ import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.ReferenceRetryFailureException;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.VersionStoreException;
-import org.projectnessie.versioned.persist.adapter.CommitAttempt;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.CommitParams;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
@@ -83,9 +83,11 @@ import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
+import org.projectnessie.versioned.persist.adapter.MergeParams;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams;
+import org.projectnessie.versioned.persist.adapter.TransplantParams;
 import org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.spi.Traced;
 import org.projectnessie.versioned.persist.adapter.spi.TryLoopState;
@@ -218,11 +220,7 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  public Hash merge(
-      Hash from,
-      BranchName toBranch,
-      Optional<Hash> expectedHead,
-      Function<ByteString, ByteString> updateCommitMetadata)
+  public Hash merge(MergeParams mergeParams)
       throws ReferenceNotFoundException, ReferenceConflictException {
     // The spec for 'VersionStore.merge' mentions "(...) until we arrive at a common ancestor",
     // but old implementations allowed a merge even if the "merge-from" and "merge-to" have no
@@ -236,36 +234,28 @@ public abstract class TxDatabaseAdapter
     try {
       return opLoop(
           "merge",
-          toBranch,
+          mergeParams.getToBranch(),
           false,
           (conn, currentHead) -> {
             long timeInMicros = commitTimeInMicros();
 
             Hash toHead =
-                mergeAttempt(
-                    conn,
-                    timeInMicros,
-                    from,
-                    toBranch,
-                    expectedHead,
-                    currentHead,
-                    h -> {},
-                    h -> {},
-                    updateCommitMetadata);
-            Hash resultHash = tryMoveNamedReference(conn, toBranch, currentHead, toHead);
+                mergeAttempt(conn, timeInMicros, currentHead, h -> {}, h -> {}, mergeParams);
+            Hash resultHash =
+                tryMoveNamedReference(conn, mergeParams.getToBranch(), currentHead, toHead);
 
             commitRefLog(
                 conn,
                 timeInMicros,
                 toHead,
-                toBranch,
+                mergeParams.getToBranch(),
                 RefLogEntry.Operation.MERGE,
-                Collections.singletonList(from));
+                Collections.singletonList(mergeParams.getMergeFromHash()));
 
             return resultHash;
           },
-          () -> mergeConflictMessage("Conflict", from, toBranch, expectedHead),
-          () -> mergeConflictMessage("Retry-failure", from, toBranch, expectedHead));
+          () -> mergeConflictMessage("Conflict", mergeParams),
+          () -> mergeConflictMessage("Retry-failure", mergeParams));
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
@@ -275,46 +265,36 @@ public abstract class TxDatabaseAdapter
 
   @SuppressWarnings("RedundantThrows")
   @Override
-  public Hash transplant(
-      BranchName targetBranch,
-      Optional<Hash> expectedHead,
-      List<Hash> commits,
-      Function<ByteString, ByteString> updateCommitMetadata)
+  public Hash transplant(TransplantParams transplantParams)
       throws ReferenceNotFoundException, ReferenceConflictException {
     try {
       return opLoop(
           "transplant",
-          targetBranch,
+          transplantParams.getToBranch(),
           false,
           (conn, currentHead) -> {
             long timeInMicros = commitTimeInMicros();
 
             Hash targetHead =
                 transplantAttempt(
-                    conn,
-                    timeInMicros,
-                    targetBranch,
-                    expectedHead,
-                    currentHead,
-                    commits,
-                    h -> {},
-                    h -> {},
-                    updateCommitMetadata);
+                    conn, timeInMicros, currentHead, h -> {}, h -> {}, transplantParams);
 
-            Hash resultHash = tryMoveNamedReference(conn, targetBranch, currentHead, targetHead);
+            Hash resultHash =
+                tryMoveNamedReference(
+                    conn, transplantParams.getToBranch(), currentHead, targetHead);
 
             commitRefLog(
                 conn,
                 timeInMicros,
                 targetHead,
-                targetBranch,
+                transplantParams.getToBranch(),
                 RefLogEntry.Operation.TRANSPLANT,
-                commits);
+                transplantParams.getSequenceToTransplant());
 
             return resultHash;
           },
-          () -> transplantConflictMessage("Conflict", targetBranch, expectedHead, commits),
-          () -> transplantConflictMessage("Retry-failure", targetBranch, expectedHead, commits));
+          () -> transplantConflictMessage("Conflict", transplantParams),
+          () -> transplantConflictMessage("Retry-failure", transplantParams));
 
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
@@ -324,30 +304,30 @@ public abstract class TxDatabaseAdapter
   }
 
   @Override
-  public Hash commit(CommitAttempt commitAttempt)
+  public Hash commit(CommitParams commitParams)
       throws ReferenceConflictException, ReferenceNotFoundException {
     try {
       return opLoop(
           "commit",
-          commitAttempt.getCommitToBranch(),
+          commitParams.getToBranch(),
           false,
           (conn, branchHead) -> {
             long timeInMicros = commitTimeInMicros();
 
             CommitLogEntry newBranchCommit =
-                commitAttempt(conn, timeInMicros, branchHead, commitAttempt, h -> {});
+                commitAttempt(conn, timeInMicros, branchHead, commitParams, h -> {});
 
-            upsertGlobalStates(commitAttempt, conn, newBranchCommit.getCreatedTime());
+            upsertGlobalStates(commitParams, conn, newBranchCommit.getCreatedTime());
 
             Hash resultHash =
                 tryMoveNamedReference(
-                    conn, commitAttempt.getCommitToBranch(), branchHead, newBranchCommit.getHash());
+                    conn, commitParams.getToBranch(), branchHead, newBranchCommit.getHash());
 
             commitRefLog(
                 conn,
                 timeInMicros,
                 newBranchCommit.getHash(),
-                commitAttempt.getCommitToBranch(),
+                commitParams.getToBranch(),
                 RefLogEntry.Operation.COMMIT,
                 Collections.emptyList());
 
@@ -355,12 +335,10 @@ public abstract class TxDatabaseAdapter
           },
           () ->
               commitConflictMessage(
-                  "Conflict", commitAttempt.getCommitToBranch(), commitAttempt.getExpectedHead()),
+                  "Conflict", commitParams.getToBranch(), commitParams.getExpectedHead()),
           () ->
               commitConflictMessage(
-                  "Retry-Failure",
-                  commitAttempt.getCommitToBranch(),
-                  commitAttempt.getExpectedHead()));
+                  "Retry-Failure", commitParams.getToBranch(), commitParams.getExpectedHead()));
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
@@ -990,16 +968,16 @@ public abstract class TxDatabaseAdapter
    * </ol>
    */
   protected void upsertGlobalStates(
-      CommitAttempt commitAttempt, ConnectionWrapper conn, long newCreatedAt) throws SQLException {
-    if (commitAttempt.getGlobal().isEmpty()) {
+      CommitParams commitParams, ConnectionWrapper conn, long newCreatedAt) throws SQLException {
+    if (commitParams.getGlobal().isEmpty()) {
       return;
     }
 
     String sql =
         sqlForManyPlaceholders(
-            SqlStatements.SELECT_GLOBAL_STATE_MANY_WITH_LOGS, commitAttempt.getGlobal().size());
+            SqlStatements.SELECT_GLOBAL_STATE_MANY_WITH_LOGS, commitParams.getGlobal().size());
 
-    Set<ContentId> newKeys = new HashSet<>(commitAttempt.getGlobal().keySet());
+    Set<ContentId> newKeys = new HashSet<>(commitParams.getGlobal().keySet());
 
     try (Traced ignore = trace("upsertGlobalStates");
         PreparedStatement psSelect = conn.conn().prepareStatement(sql);
@@ -1012,7 +990,7 @@ public abstract class TxDatabaseAdapter
 
       psSelect.setString(1, config.getRepositoryId());
       int i = 2;
-      for (ContentId cid : commitAttempt.getGlobal().keySet()) {
+      for (ContentId cid : commitParams.getGlobal().keySet()) {
         psSelect.setString(i++, cid.getId());
       }
 
@@ -1026,10 +1004,10 @@ public abstract class TxDatabaseAdapter
           // content-id exists -> not a new row
           newKeys.remove(contentId);
 
-          ByteString newState = commitAttempt.getGlobal().get(contentId);
+          ByteString newState = commitParams.getGlobal().get(contentId);
 
           ByteString expected =
-              commitAttempt
+              commitParams
                   .getExpectedStates()
                   .getOrDefault(contentId, Optional.empty())
                   .orElse(ByteString.EMPTY);
@@ -1076,7 +1054,7 @@ public abstract class TxDatabaseAdapter
             PreparedStatement psInsert =
                 conn.conn().prepareStatement(SqlStatements.INSERT_GLOBAL_STATE)) {
           for (ContentId contentId : newKeys) {
-            ByteString newGlob = commitAttempt.getGlobal().get(contentId);
+            ByteString newGlob = commitParams.getGlobal().get(contentId);
             byte[] newGlobBytes = newGlob.toByteArray();
             @SuppressWarnings("UnstableApiUsage")
             String newHash = newHasher().putBytes(newGlobBytes).hash().toString();


### PR DESCRIPTION
Also rename `CommitAttempts` to `CommitParams`.

This is just a refactoring, no change in functionality or public API.