### PR TITLE
Add parameters for content-keys to "drop" and "force" during merge

### DIFF
--- a/model/src/main/java/org/projectnessie/model/BaseMergeTransplant.java
+++ b/model/src/main/java/org/projectnessie/model/BaseMergeTransplant.java
@@ -17,9 +17,13 @@ package org.projectnessie.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+import org.immutables.value.Value;
 
 public interface BaseMergeTransplant {
 
@@ -30,4 +34,38 @@ public interface BaseMergeTransplant {
   @Nullable
   @JsonInclude(Include.NON_NULL)
   Boolean keepIndividualCommits();
+
+  @Nullable
+  @JsonInclude(Include.NON_NULL)
+  List<MergeKeyBehavior> getKeyMergeModes();
+
+  @Nullable
+  @JsonInclude(Include.NON_NULL)
+  MergeBehavior getDefaultKeyMergeMode();
+
+  @Value.Immutable
+  @JsonSerialize(as = ImmutableMergeKeyBehavior.class)
+  @JsonDeserialize(as = ImmutableMergeKeyBehavior.class)
+  interface MergeKeyBehavior {
+    ContentKey getKey();
+
+    MergeBehavior getMergeBehavior();
+
+    static ImmutableMergeKeyBehavior.Builder builder() {
+      return ImmutableMergeKeyBehavior.builder();
+    }
+
+    static MergeKeyBehavior of(ContentKey key, MergeBehavior mergeBehavior) {
+      return builder().key(key).mergeBehavior(mergeBehavior).build();
+    }
+  }
+
+  enum MergeBehavior {
+    /** Keys with this merge mode will be merged, conflict detection takes place. */
+    NORMAL,
+    /** Keys with this merge mode will be merged unconditionally, no conflict detection. */
+    FORCE,
+    /** Keys with this merge mode will not be merged. */
+    DROP
+  }
 }

--- a/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.model.BaseMergeTransplant.MergeBehavior;
+import org.projectnessie.model.BaseMergeTransplant.MergeKeyBehavior;
 import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.LogResponse.LogEntry;
 
@@ -156,6 +158,44 @@ public class TestModelObjectsSerialization {
             Merge.class,
             Json.from("fromRefName", "testBranch")
                 .addNoQuotes("keepIndividualCommits", "true")
+                .add("fromHash", HASH)),
+        new Case(
+            ImmutableMerge.builder()
+                .fromHash(HASH)
+                .fromRefName(branchName)
+                .defaultKeyMergeMode(MergeBehavior.FORCE)
+                .addKeyMergeModes(
+                    MergeKeyBehavior.of(ContentKey.of("merge", "me"), MergeBehavior.NORMAL),
+                    MergeKeyBehavior.of(ContentKey.of("ignore", "this"), MergeBehavior.DROP))
+                .build(),
+            Merge.class,
+            Json.from("fromRefName", "testBranch")
+                .addArrNoQuotes(
+                    "keyMergeModes",
+                    Json.noQuotes("key", Json.arr("elements", "merge", "me"))
+                        .add("mergeBehavior", "NORMAL"),
+                    Json.noQuotes("key", Json.arr("elements", "ignore", "this"))
+                        .add("mergeBehavior", "DROP"))
+                .add("defaultKeyMergeMode", "FORCE")
+                .add("fromHash", HASH)),
+        new Case(
+            ImmutableMerge.builder()
+                .fromHash(HASH)
+                .fromRefName(branchName)
+                .keepIndividualCommits(true)
+                .addKeyMergeModes(
+                    MergeKeyBehavior.of(ContentKey.of("merge", "me"), MergeBehavior.NORMAL),
+                    MergeKeyBehavior.of(ContentKey.of("ignore", "this"), MergeBehavior.DROP))
+                .build(),
+            Merge.class,
+            Json.from("fromRefName", "testBranch")
+                .addNoQuotes("keepIndividualCommits", "true")
+                .addArrNoQuotes(
+                    "keyMergeModes",
+                    Json.noQuotes("key", Json.arr("elements", "merge", "me"))
+                        .add("mergeBehavior", "NORMAL"),
+                    Json.noQuotes("key", Json.arr("elements", "ignore", "this"))
+                        .add("mergeBehavior", "DROP"))
                 .add("fromHash", HASH)));
   }
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MetadataRewriteParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MetadataRewriteParams.java
@@ -16,7 +16,10 @@
 package org.projectnessie.versioned.persist.adapter;
 
 import com.google.protobuf.ByteString;
+import java.util.Map;
 import org.immutables.value.Value;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
 
 public interface MetadataRewriteParams extends ToBranchParams {
@@ -25,6 +28,13 @@ public interface MetadataRewriteParams extends ToBranchParams {
   @Value.Default
   default boolean keepIndividualCommits() {
     return false;
+  }
+
+  Map<Key, MergeType> getMergeTypes();
+
+  @Value.Default
+  default MergeType getDefaultMergeType() {
+    return MergeType.NORMAL;
   }
 
   /** Function to rewrite the commit-metadata. */

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -38,6 +38,7 @@ import org.projectnessie.versioned.ImmutableCommit;
 import org.projectnessie.versioned.ImmutableRefLogDetails;
 import org.projectnessie.versioned.Key;
 import org.projectnessie.versioned.KeyEntry;
+import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.Operation;
@@ -186,7 +187,9 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
       MetadataRewriter<METADATA> updateCommitMetadata,
-      boolean keepIndividualCommits)
+      boolean keepIndividualCommits,
+      Map<Key, MergeType> mergeTypes,
+      MergeType defaultMergeType)
       throws ReferenceNotFoundException, ReferenceConflictException {
     databaseAdapter.transplant(
         TransplantParams.builder()
@@ -195,6 +198,8 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
             .sequenceToTransplant(sequenceToTransplant)
             .updateCommitMetadata(updateCommitMetadataFunction(updateCommitMetadata))
             .keepIndividualCommits(keepIndividualCommits)
+            .mergeTypes(mergeTypes)
+            .defaultMergeType(defaultMergeType)
             .build());
   }
 
@@ -204,7 +209,9 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
       BranchName toBranch,
       Optional<Hash> expectedHash,
       MetadataRewriter<METADATA> updateCommitMetadata,
-      boolean keepIndividualCommits)
+      boolean keepIndividualCommits,
+      Map<Key, MergeType> mergeTypes,
+      MergeType defaultMergeType)
       throws ReferenceNotFoundException, ReferenceConflictException {
     databaseAdapter.merge(
         MergeParams.builder()
@@ -213,6 +220,8 @@ public class PersistVersionStore<CONTENT, METADATA, CONTENT_TYPE extends Enum<CO
             .mergeFromHash(fromHash)
             .updateCommitMetadata(updateCommitMetadataFunction(updateCommitMetadata))
             .keepIndividualCommits(keepIndividualCommits)
+            .mergeTypes(mergeTypes)
+            .defaultMergeType(defaultMergeType)
             .build());
   }
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeType.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+public enum MergeType {
+  /** Keys with this merge mode will be merged, conflict detection takes place. */
+  NORMAL(false, true),
+  /** Keys with this merge mode will be merged unconditionally, no conflict detection. */
+  FORCE(true, true),
+  /** Keys with this merge mode will not be merged. */
+  DROP(true, false);
+
+  private final boolean skipCheck;
+  private final boolean merge;
+
+  MergeType(boolean skipCheck, boolean merge) {
+    this.skipCheck = skipCheck;
+    this.merge = merge;
+  }
+
+  public boolean isSkipCheck() {
+    return skipCheck;
+  }
+
+  public boolean isMerge() {
+    return merge;
+  }
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -93,7 +93,9 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
       MetadataRewriter<METADATA> updateCommitMetadata,
-      boolean keepIndividualCommits)
+      boolean keepIndividualCommits,
+      Map<Key, MergeType> mergeTypes,
+      MergeType defaultMergeType)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(
         "transplant",
@@ -103,7 +105,9 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
                 referenceHash,
                 sequenceToTransplant,
                 updateCommitMetadata,
-                keepIndividualCommits));
+                keepIndividualCommits,
+                mergeTypes,
+                defaultMergeType));
   }
 
   @Override
@@ -112,13 +116,21 @@ public final class MetricsVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<
       BranchName toBranch,
       Optional<Hash> expectedHash,
       MetadataRewriter<METADATA> updateCommitMetadata,
-      boolean keepIndividualCommits)
+      boolean keepIndividualCommits,
+      Map<Key, MergeType> mergeTypes,
+      MergeType defaultMergeType)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>delegate2Ex(
         "merge",
         () ->
             delegate.merge(
-                fromHash, toBranch, expectedHash, updateCommitMetadata, keepIndividualCommits));
+                fromHash,
+                toBranch,
+                expectedHash,
+                updateCommitMetadata,
+                keepIndividualCommits,
+                mergeTypes,
+                defaultMergeType));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -111,7 +111,9 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
       MetadataRewriter<METADATA> updateCommitMetadata,
-      boolean keepIndividualCommits)
+      boolean keepIndividualCommits,
+      Map<Key, MergeType> mergeTypes,
+      MergeType defaultMergeType)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
         "Transplant",
@@ -125,7 +127,9 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
                 referenceHash,
                 sequenceToTransplant,
                 updateCommitMetadata,
-                keepIndividualCommits));
+                keepIndividualCommits,
+                mergeTypes,
+                defaultMergeType));
   }
 
   @Override
@@ -134,7 +138,9 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
       BranchName toBranch,
       Optional<Hash> expectedHash,
       MetadataRewriter<METADATA> updateCommitMetadata,
-      boolean keepIndividualCommits)
+      boolean keepIndividualCommits,
+      Map<Key, MergeType> mergeTypes,
+      MergeType defaultMergeType)
       throws ReferenceNotFoundException, ReferenceConflictException {
     this.<ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
         "Merge",
@@ -144,7 +150,13 @@ public class TracingVersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_
                 .withTag(TAG_EXPECTED_HASH, safeToString(expectedHash)),
         () ->
             delegate.merge(
-                fromHash, toBranch, expectedHash, updateCommitMetadata, keepIndividualCommits));
+                fromHash,
+                toBranch,
+                expectedHash,
+                updateCommitMetadata,
+                keepIndividualCommits,
+                mergeTypes,
+                defaultMergeType));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -114,6 +114,8 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    *     metadata if {@code keepIndividualCommits} is {@code false}
    * @param keepIndividualCommits whether to keep the individual commits and do not squash the
    *     commits to transplant
+   * @param mergeTypes merge types per content key
+   * @param defaultMergeType default merge type for all keys not present in {@code mergeTypes}
    * @throws ReferenceConflictException if {@code referenceHash} values do not match the stored
    *     values for {@code branch}
    * @throws ReferenceNotFoundException if {@code branch} or if any of the hashes from {@code
@@ -124,7 +126,9 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
       Optional<Hash> referenceHash,
       List<Hash> sequenceToTransplant,
       MetadataRewriter<METADATA> updateCommitMetadata,
-      boolean keepIndividualCommits)
+      boolean keepIndividualCommits,
+      Map<Key, MergeType> mergeTypes,
+      MergeType defaultMergeType)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
@@ -149,6 +153,8 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
    *     metadata if {@code keepIndividualCommits} is {@code false}
    * @param keepIndividualCommits whether to keep the individual commits and do not squash the
    *     commits to merge
+   * @param mergeTypes merge types per content key
+   * @param defaultMergeType default merge type for all keys not present in {@code mergeTypes}
    * @throws ReferenceConflictException if {@code expectedBranchHash} doesn't match the stored hash
    *     for {@code toBranch}
    * @throws ReferenceNotFoundException if {@code toBranch} or {@code fromHash} is not present in
@@ -159,7 +165,9 @@ public interface VersionStore<VALUE, METADATA, VALUE_TYPE extends Enum<VALUE_TYP
       BranchName toBranch,
       Optional<Hash> expectedHash,
       MetadataRewriter<METADATA> updateCommitMetadata,
-      boolean keepIndividualCommits)
+      boolean keepIndividualCommits,
+      Map<Key, MergeType> mergeTypes,
+      MergeType defaultMergeType)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -134,7 +134,9 @@ class TestMetricsVersionStore {
                         Optional.empty(),
                         Collections.emptyList(),
                         metadataRewriter,
-                        false),
+                        false,
+                        Collections.emptyMap(),
+                        MergeType.NORMAL),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(
                 "merge",
@@ -144,7 +146,9 @@ class TestMetricsVersionStore {
                         BranchName.of("mock-branch"),
                         Optional.empty(),
                         metadataRewriter,
-                        false),
+                        false,
+                        null,
+                        null),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(
                 "assign",

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -126,7 +126,9 @@ class TestTracingVersionStore {
                                 Optional.empty(),
                                 Collections.emptyList(),
                                 metadataRewriter,
-                                true)),
+                                true,
+                                Collections.emptyMap(),
+                                MergeType.NORMAL)),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Merge", refNotFoundAndRefConflictThrows)
                     .tag("nessie.version-store.to-branch", "mock-branch")
@@ -139,7 +141,9 @@ class TestTracingVersionStore {
                                 BranchName.of("mock-branch"),
                                 Optional.empty(),
                                 metadataRewriter,
-                                false)),
+                                false,
+                                null,
+                                null)),
                 new TestedTraceingStoreInvocation<VersionStore<String, String, DummyEnum>>(
                         "Assign", refNotFoundAndRefConflictThrows)
                     .tag("nessie.version-store.ref", "BranchName{name=mock-branch}")

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.projectnessie.versioned.testworker.CommitMessage.commitMessage;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +29,7 @@ import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Delete;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.TagName;
@@ -210,7 +212,9 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         Optional.empty(),
                         singletonList(s.hashOnReference(BranchName.of("main"), Optional.empty())),
                         metadataRewriter,
-                        false)),
+                        false,
+                        Collections.emptyMap(),
+                        MergeType.NORMAL)),
         new ReferenceNotFoundFunction("transplant/hash/empty")
             .msg(
                 "Could not find commit '12341234123412341234123412341234123412341234' in reference 'main'.")
@@ -221,7 +225,9 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         Optional.of(Hash.of("12341234123412341234123412341234123412341234")),
                         singletonList(Hash.of("12341234123412341234123412341234123412341234")),
                         metadataRewriter,
-                        true)),
+                        true,
+                        Collections.emptyMap(),
+                        MergeType.NORMAL)),
         new ReferenceNotFoundFunction("transplant/empty/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
             .function(
@@ -231,7 +237,9 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         Optional.empty(),
                         singletonList(Hash.of("12341234123412341234123412341234123412341234")),
                         metadataRewriter,
-                        false)),
+                        false,
+                        Collections.emptyMap(),
+                        MergeType.NORMAL)),
         // merge()
         new ReferenceNotFoundFunction("merge/hash/empty")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
@@ -242,7 +250,9 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         BranchName.of("main"),
                         Optional.empty(),
                         metadataRewriter,
-                        true)),
+                        true,
+                        Collections.emptyMap(),
+                        MergeType.NORMAL)),
         new ReferenceNotFoundFunction("merge/empty/hash")
             .msg(
                 "Could not find commit '12341234123412341234123412341234123412341234' in reference 'main'.")
@@ -253,7 +263,9 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                         BranchName.of("main"),
                         Optional.of(Hash.of("12341234123412341234123412341234123412341234")),
                         metadataRewriter,
-                        true)));
+                        true,
+                        Collections.emptyMap(),
+                        MergeType.NORMAL)));
   }
 
   @ParameterizedTest

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
@@ -32,6 +32,7 @@ import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
@@ -146,7 +147,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             Optional.of(initialHash),
             Arrays.asList(firstCommit, secondCommit, thirdCommit),
             commitMetaModify,
-            individualCommits);
+            individualCommits,
+            Collections.emptyMap(),
+            MergeType.NORMAL);
     assertThat(
             store()
                 .getValues(
@@ -179,7 +182,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             Optional.of(initialHash),
             Arrays.asList(firstCommit, secondCommit, thirdCommit),
             createMetadataRewriter(""),
-            individualCommits);
+            individualCommits,
+            Collections.emptyMap(),
+            MergeType.NORMAL);
     assertThat(
             store()
                 .getValues(
@@ -211,7 +216,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                     Optional.of(initialHash),
                     Arrays.asList(firstCommit, secondCommit, thirdCommit),
                     createMetadataRewriter(""),
-                    individualCommits));
+                    individualCommits,
+                    Collections.emptyMap(),
+                    MergeType.NORMAL));
   }
 
   @ParameterizedTest
@@ -228,7 +235,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             Optional.of(initialHash),
             Arrays.asList(firstCommit, secondCommit, thirdCommit),
             createMetadataRewriter(""),
-            individualCommits);
+            individualCommits,
+            Collections.emptyMap(),
+            MergeType.NORMAL);
     assertThat(
             store()
                 .getValues(
@@ -254,7 +263,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                     Optional.of(initialHash),
                     Arrays.asList(firstCommit, secondCommit, thirdCommit),
                     createMetadataRewriter(""),
-                    individualCommits));
+                    individualCommits,
+                    Collections.emptyMap(),
+                    MergeType.NORMAL));
   }
 
   @ParameterizedTest
@@ -272,7 +283,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                     Optional.of(initialHash),
                     Collections.singletonList(Hash.of("1234567890abcdef")),
                     createMetadataRewriter(""),
-                    individualCommits));
+                    individualCommits,
+                    Collections.emptyMap(),
+                    MergeType.NORMAL));
   }
 
   @ParameterizedTest
@@ -290,7 +303,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             Optional.empty(),
             Arrays.asList(firstCommit, secondCommit, thirdCommit),
             createMetadataRewriter(""),
-            individualCommits);
+            individualCommits,
+            Collections.emptyMap(),
+            MergeType.NORMAL);
     assertThat(
             store()
                 .getValues(
@@ -321,7 +336,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                     Optional.empty(),
                     Arrays.asList(secondCommit, firstCommit, thirdCommit),
                     createMetadataRewriter(""),
-                    individualCommits));
+                    individualCommits,
+                    Collections.emptyMap(),
+                    MergeType.NORMAL));
   }
 
   @ParameterizedTest
@@ -348,7 +365,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                     Optional.of(unrelatedCommit),
                     Arrays.asList(firstCommit, secondCommit, thirdCommit),
                     createMetadataRewriter(""),
-                    individualCommits));
+                    individualCommits,
+                    Collections.emptyMap(),
+                    MergeType.NORMAL));
   }
 
   @ParameterizedTest
@@ -364,7 +383,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             Optional.of(initialHash),
             Arrays.asList(firstCommit, secondCommit),
             createMetadataRewriter(""),
-            individualCommits);
+            individualCommits,
+            Collections.emptyMap(),
+            MergeType.NORMAL);
     assertThat(
             store().getValues(newBranch, Arrays.asList(Key.of("t1"), Key.of("t4"), Key.of("t5"))))
         .containsExactlyInAnyOrderEntriesOf(


### PR DESCRIPTION
REST-API allows to specify the merge-behavior per content-key, plus a default merge-behavior.

Three different merge-behaviors are defined:
* `NORMAL`, the content-key will be merged and collision-check against the target branch will be performed.
* `FORCE`, the content-key will be merged but without any collision-check.
* `DROP`, the content-key will not be merged

If neither the default merge-behavior and no per-key merge behaviors are specified,
the implementation behaves exactly as before, no breaking API change.

This change allows `MERGE` via SQL like this:
```sql
MERGE dev_branch INTO main
  ONLY TABLE only.table.to.merge;
```
or
```sql
MERGE dev_branch INTO main
  EXCEPT TABLE not.this.table;
```
or
```sql
MERGE dev_branch INTO main
  FORCE TABLE blindly.apply.this.table.onto.main;
```

Fixes #3810 