### PR TITLE
Run unit tests in selected modules concurrently

### DIFF
--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -117,6 +117,19 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>de.sormuras.junit</groupId>
+        <artifactId>junit-platform-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
         <executions>

--- a/clients/client/src/test/java/org/projectnessie/client/TestResultStreamPaginator.java
+++ b/clients/client/src/test/java/org/projectnessie/client/TestResultStreamPaginator.java
@@ -28,9 +28,12 @@ import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.PaginatedResponse;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestResultStreamPaginator {
   @Test
   void testNotFoundException() {

--- a/clients/client/src/test/java/org/projectnessie/client/auth/TestBasicAuthProvider.java
+++ b/clients/client/src/test/java/org/projectnessie/client/auth/TestBasicAuthProvider.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mockito;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.http.HttpAuthentication;
@@ -33,6 +35,7 @@ import org.projectnessie.client.http.HttpHeaders;
 import org.projectnessie.client.http.RequestContext;
 import org.projectnessie.client.http.RequestFilter;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestBasicAuthProvider {
   @Test
   void testNullParams() {

--- a/clients/client/src/test/java/org/projectnessie/client/auth/TestBearerAuthenticationProvider.java
+++ b/clients/client/src/test/java/org/projectnessie/client/auth/TestBearerAuthenticationProvider.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mockito;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.http.HttpAuthentication;
@@ -32,6 +34,7 @@ import org.projectnessie.client.http.HttpHeaders;
 import org.projectnessie.client.http.RequestContext;
 import org.projectnessie.client.http.RequestFilter;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestBearerAuthenticationProvider {
   private BearerAuthenticationProvider provider() {
     return new BearerAuthenticationProvider();

--- a/clients/client/src/test/java/org/projectnessie/client/auth/TestNoneAuthProvider.java
+++ b/clients/client/src/test/java/org/projectnessie/client/auth/TestNoneAuthProvider.java
@@ -21,8 +21,11 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.client.NessieConfigConstants;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestNoneAuthProvider {
   @Test
   void testNone() {

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
@@ -39,9 +39,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPInputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.client.util.TestServer;
 import org.projectnessie.model.CommitMeta;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class TestHttpClient {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.client.NessieConfigConstants;
@@ -37,6 +39,7 @@ import org.projectnessie.client.auth.BasicAuthenticationProvider;
 import org.projectnessie.client.auth.NessieAuthentication;
 import org.projectnessie.client.util.TestServer;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class TestHttpClientBuilder {
   interface IncompatibleApiInterface extends NessieApi {}
 

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpHeaders.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpHeaders.java
@@ -25,8 +25,11 @@ import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.ArgumentCaptor;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class TestHttpHeaders {
   @Test
   public void multipleValues() {

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
@@ -55,10 +55,13 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.client.util.TestServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestHttpsClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(TestHttpsClient.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestUriBuilder.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestUriBuilder.java
@@ -21,7 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestUriBuilder {
 
   @Test

--- a/clients/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/clients/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,6 +44,7 @@ import org.projectnessie.error.NessieForbiddenException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import software.amazon.awssdk.utils.StringInputStream;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class TestResponseFilter {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -105,6 +105,19 @@
     </resources>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>de.sormuras.junit</groupId>
+        <artifactId>junit-platform-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-maven-plugin</artifactId>
         <configuration>

--- a/model/src/test/java/org/projectnessie/api/params/CommitLogParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/CommitLogParamsTest.java
@@ -19,7 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class CommitLogParamsTest {
 
   @Test

--- a/model/src/test/java/org/projectnessie/api/params/DiffParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/DiffParamsTest.java
@@ -19,7 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class DiffParamsTest {
 
   @Test

--- a/model/src/test/java/org/projectnessie/api/params/EntriesParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/EntriesParamsTest.java
@@ -18,7 +18,10 @@ package org.projectnessie.api.params;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class EntriesParamsTest {
 
   @Test

--- a/model/src/test/java/org/projectnessie/api/params/GetReferenceParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/GetReferenceParamsTest.java
@@ -19,7 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class GetReferenceParamsTest {
 
   @Test

--- a/model/src/test/java/org/projectnessie/api/params/MultipleNamespacesParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/MultipleNamespacesParamsTest.java
@@ -19,8 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.Namespace;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class MultipleNamespacesParamsTest {
 
   @Test

--- a/model/src/test/java/org/projectnessie/api/params/NamespaceParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/NamespaceParamsTest.java
@@ -19,8 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.Namespace;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class NamespaceParamsTest {
 
   @Test

--- a/model/src/test/java/org/projectnessie/api/params/RefLogParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/RefLogParamsTest.java
@@ -19,7 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class RefLogParamsTest {
 
   @Test

--- a/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
+++ b/model/src/test/java/org/projectnessie/api/params/ReferencesParamsTest.java
@@ -18,7 +18,10 @@ package org.projectnessie.api.params;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class ReferencesParamsTest {
 
   @Test

--- a/model/src/test/java/org/projectnessie/error/TestErrorCode.java
+++ b/model/src/test/java/org/projectnessie/error/TestErrorCode.java
@@ -19,9 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestErrorCode {
 
   private Optional<Exception> ex(ErrorCode errorCode) {

--- a/model/src/test/java/org/projectnessie/model/TestCommitMetaSerde.java
+++ b/model/src/test/java/org/projectnessie/model/TestCommitMetaSerde.java
@@ -30,7 +30,10 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestCommitMetaSerde {
 
   @Test

--- a/model/src/test/java/org/projectnessie/model/TestContentKey.java
+++ b/model/src/test/java/org/projectnessie/model/TestContentKey.java
@@ -27,9 +27,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestContentKey {
 
   @ParameterizedTest

--- a/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.model.BaseMergeTransplant.MergeBehavior;
@@ -35,6 +37,7 @@ import org.projectnessie.model.LogResponse.LogEntry;
  * This test merely checks the JSON serialization/deserialization of the model classes, with an
  * intention to identify breaking cases whenever jackson version varies.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class TestModelObjectsSerialization {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/model/src/test/java/org/projectnessie/model/TestNamespace.java
+++ b/model/src/test/java/org/projectnessie/model/TestNamespace.java
@@ -26,11 +26,14 @@ import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class TestNamespace {
 
   @Test

--- a/model/src/test/java/org/projectnessie/model/TestTableReference.java
+++ b/model/src/test/java/org/projectnessie/model/TestTableReference.java
@@ -21,10 +21,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class TestTableReference {
 
   static List<Object[]> fromContentKeyTestCases() {

--- a/model/src/test/java/org/projectnessie/model/TestValidation.java
+++ b/model/src/test/java/org/projectnessie/model/TestValidation.java
@@ -28,10 +28,13 @@ import static org.projectnessie.model.Validation.validateReferenceName;
 import static org.projectnessie.model.Validation.validateReferenceNameOrHash;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TestValidation {
 
   @ParameterizedTest

--- a/pom.xml
+++ b/pom.xml
@@ -764,6 +764,33 @@
         </plugin>
 
         <!-- 3rd party plugins -->
+        <plugin><!-- Using the junit-platform-maven-plugin as it "knows JUnit platform inside out"...
+           The Maven Surefire + Failsafe plugins don't really work well with parallel +
+           concurrent test execution.
+           -->
+          <groupId>de.sormuras.junit</groupId>
+          <artifactId>junit-platform-maven-plugin</artifactId>
+          <version>1.1.6</version>
+          <extensions>false</extensions> <!-- Neither install this plugin into `test` phase, nor touch Surefire. -->
+          <executions>
+            <execution>
+              <id>Launch JUnit Platform</id>
+              <phase>test</phase>
+              <goals>
+                <goal>launch</goal>
+              </goals>
+              <configuration>
+                <skip>${skipTests}</skip>
+                <classNamePatterns>
+                  <pattern>^(Test.*|.+[.$]Test.*|.*Tests?)$</pattern>
+                </classNamePatterns>
+                <parameters>
+                  <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                </parameters>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>org.antlr</groupId>
           <artifactId>antlr4-maven-plugin</artifactId>

--- a/servers/services/pom.xml
+++ b/servers/services/pom.xml
@@ -68,4 +68,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>de.sormuras.junit</groupId>
+        <artifactId>junit-platform-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/servers/services/src/test/java/org/projectnessie/services/authz/BatchAccessCheckerTest.java
+++ b/servers/services/src/test/java/org/projectnessie/services/authz/BatchAccessCheckerTest.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.services.authz.Check.CheckType;
 import org.projectnessie.services.authz.ImmutableCheck.Builder;
@@ -38,6 +40,7 @@ import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.DetachedRef;
 import org.projectnessie.versioned.TagName;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class BatchAccessCheckerTest {
 
   @Test

--- a/servers/services/src/test/java/org/projectnessie/services/impl/NamespaceApiTest.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/NamespaceApiTest.java
@@ -18,9 +18,12 @@ package org.projectnessie.services.impl;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.api.params.NamespaceParams;
 import org.projectnessie.model.Namespace;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class NamespaceApiTest {
 
   @Test

--- a/servers/services/src/test/java/org/projectnessie/services/impl/RefUtilTest.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/RefUtilTest.java
@@ -21,6 +21,8 @@ import static org.projectnessie.services.impl.RefUtil.toReference;
 
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Detached;
 import org.projectnessie.model.Reference;
@@ -32,6 +34,7 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.TagName;
 
+@Execution(ExecutionMode.CONCURRENT)
 class RefUtilTest {
 
   public static final String HASH_VALUE = "deadbeeffeedcafe";

--- a/servers/services/src/test/java/org/projectnessie/services/impl/StreamUtilTest.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/StreamUtilTest.java
@@ -19,7 +19,10 @@ import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class StreamUtilTest {
 
   @Test

--- a/versioned/spi/pom.xml
+++ b/versioned/spi/pom.xml
@@ -81,4 +81,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>de.sormuras.junit</groupId>
+        <artifactId>junit-platform-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Use `junit-platform-maven-plugin` instead of `maven-surefire-plugin` for selected modules,
enable parallel (class level) execution by default, enable concurrent (method level) execution
where appropriate.

Without this change (from CI):
```
[INFO] Nessie - Model ..................................... SUCCESS [ 44.331 s]
[INFO] Nessie - Client .................................... SUCCESS [ 40.998 s]
[INFO] Nessie - Services .................................. SUCCESS [ 23.074 s]
[INFO] Nessie - Versioned Store SPI ....................... SUCCESS [ 29.017 s]
```

With this change (from CI):
```
[INFO] Nessie - Model ..................................... SUCCESS [ 29.581 s]
[INFO] Nessie - Client .................................... SUCCESS [ 22.951 s]
[INFO] Nessie - Services .................................. SUCCESS [ 15.026 s]
[INFO] Nessie - Versioned Store SPI ....................... SUCCESS [ 17.495 s]
```
