### PR TITLE
Load correct view metadata for a given ref

### DIFF
--- a/clients/iceberg-views/src/main/java/org/apache/iceberg/view/ViewVersionMetadata.java
+++ b/clients/iceberg-views/src/main/java/org/apache/iceberg/view/ViewVersionMetadata.java
@@ -41,6 +41,17 @@ public class ViewVersionMetadata {
       BaseVersion version,
       String location,
       ViewDefinition definition,
+      Map<String, String> properties,
+      List<Version> versions,
+      List<HistoryEntry> history) {
+
+    return new ViewVersionMetadata(version, location, definition, properties, versions, history);
+  }
+
+  public static ViewVersionMetadata newViewVersionMetadata(
+      BaseVersion version,
+      String location,
+      ViewDefinition definition,
       ViewVersionMetadata viewVersionMetadata,
       Map<String, String> properties) {
     return new ViewVersionMetadata(


### PR DESCRIPTION
This makes sure that we load the correct view metadata when specifying a
particular reference.

fixes #3734