### PR TITLE
Use group separator (u001D) character instead of zero byte for Namespace/ContentKey

### DIFF
--- a/model/src/main/java/org/projectnessie/model/ContentKey.java
+++ b/model/src/main/java/org/projectnessie/model/ContentKey.java
@@ -15,6 +15,10 @@
  */
 package org.projectnessie.model;
 
+import static org.projectnessie.model.UriUtil.DOT_STRING;
+import static org.projectnessie.model.UriUtil.GROUP_SEPARATOR_STRING;
+import static org.projectnessie.model.UriUtil.ZERO_BYTE_STRING;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,9 +41,6 @@ import org.projectnessie.model.ImmutableContentKey.Builder;
 @JsonSerialize(as = ImmutableContentKey.class)
 @JsonDeserialize(as = ImmutableContentKey.class)
 public abstract class ContentKey {
-
-  private static final char ZERO_BYTE = '\u0000';
-  private static final String ZERO_BYTE_STRING = Character.toString(ZERO_BYTE);
 
   @NotNull
   @Size(min = 1)
@@ -91,9 +92,11 @@ public abstract class ContentKey {
         throw new IllegalArgumentException(
             String.format("Content key '%s' must not contain a null element.", elements));
       }
-      if (e.contains(ZERO_BYTE_STRING)) {
+      if (e.contains(ZERO_BYTE_STRING) || e.contains(GROUP_SEPARATOR_STRING)) {
         throw new IllegalArgumentException(
-            String.format("Content key '%s' must not contain a zero byte.", elements));
+            String.format(
+                "Content key '%s' must not contain a zero byte (\\u0000) / group separator (\\u001D).",
+                elements));
       }
       if ("".equals(e)) {
         throw new IllegalArgumentException(
@@ -123,6 +126,6 @@ public abstract class ContentKey {
 
   @Override
   public String toString() {
-    return String.join(".", getElements());
+    return String.join(DOT_STRING, getElements());
   }
 }

--- a/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.model;
 
+import static org.projectnessie.model.UriUtil.DOT_STRING;
+import static org.projectnessie.model.UriUtil.GROUP_SEPARATOR_STRING;
 import static org.projectnessie.model.UriUtil.ZERO_BYTE_STRING;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -41,7 +43,6 @@ import org.immutables.value.Value.Derived;
 @JsonTypeName("NAMESPACE")
 public abstract class Namespace extends Content {
 
-  private static final String DOT = ".";
   static final String ERROR_MSG_TEMPLATE =
       "'%s' is not a valid namespace identifier (should not end with '.')";
 
@@ -96,10 +97,11 @@ public abstract class Namespace extends Content {
             String.format(
                 "Namespace '%s' must not contain a null element.", Arrays.toString(elements)));
       }
-      if (e.contains(ZERO_BYTE_STRING)) {
+      if (e.contains(ZERO_BYTE_STRING) || e.contains(GROUP_SEPARATOR_STRING)) {
         throw new IllegalArgumentException(
             String.format(
-                "Namespace '%s' must not contain a zero byte.", Arrays.toString(elements)));
+                "Namespace '%s' must not contain a zero byte (\\u0000) / group separator (\\u001D).",
+                Arrays.toString(elements)));
       }
       if ("".equals(e)) {
         throw new IllegalArgumentException(
@@ -108,7 +110,7 @@ public abstract class Namespace extends Content {
       }
     }
 
-    if (DOT.equals(elements[elements.length - 1])) {
+    if (DOT_STRING.equals(elements[elements.length - 1])) {
       throw new IllegalArgumentException(
           String.format(ERROR_MSG_TEMPLATE, Arrays.toString(elements)));
     }
@@ -142,7 +144,7 @@ public abstract class Namespace extends Content {
     if (identifier.isEmpty()) {
       return EMPTY;
     }
-    if (identifier.endsWith(DOT)) {
+    if (identifier.endsWith(DOT_STRING)) {
       throw new IllegalArgumentException(String.format(ERROR_MSG_TEMPLATE, identifier));
     }
     return Namespace.of(UriUtil.fromPathString(identifier));

--- a/model/src/main/java/org/projectnessie/model/UriUtil.java
+++ b/model/src/main/java/org/projectnessie/model/UriUtil.java
@@ -24,7 +24,11 @@ final class UriUtil {
   private UriUtil() {}
 
   public static final char ZERO_BYTE = '\u0000';
+  public static final char DOT = '.';
+  public static final char GROUP_SEPARATOR = '\u001D';
+  public static final String DOT_STRING = ".";
   public static final String ZERO_BYTE_STRING = Character.toString(ZERO_BYTE);
+  public static final String GROUP_SEPARATOR_STRING = Character.toString(GROUP_SEPARATOR);
 
   /**
    * Convert from path encoded string to normal string.
@@ -34,7 +38,7 @@ final class UriUtil {
    */
   public static List<String> fromPathString(String encoded) {
     return Arrays.stream(encoded.split("\\."))
-        .map(x -> x.replace('\u0000', '.'))
+        .map(x -> x.replace(GROUP_SEPARATOR, DOT).replace(ZERO_BYTE, DOT))
         .collect(Collectors.toList());
   }
 
@@ -44,6 +48,8 @@ final class UriUtil {
    * @return String encoded for path use.
    */
   public static String toPathString(List<String> elements) {
-    return elements.stream().map(x -> x.replace('.', '\u0000')).collect(Collectors.joining("."));
+    return elements.stream()
+        .map(x -> x.replace(DOT, GROUP_SEPARATOR).replace(ZERO_BYTE, GROUP_SEPARATOR))
+        .collect(Collectors.joining("."));
   }
 }

--- a/servers/rest-services/src/test/java/org/projectnessie/services/rest/TestContentKeyParamConverterProvider.java
+++ b/servers/rest-services/src/test/java/org/projectnessie/services/rest/TestContentKeyParamConverterProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.ws.rs.ext.ParamConverter;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.model.ContentKey;
+
+public class TestContentKeyParamConverterProvider {
+
+  private final ParamConverter<ContentKey> converter =
+      new ContentKeyParamConverterProvider().getConverter(ContentKey.class, null, null);
+
+  @Test
+  public void testNulls() {
+    assertThat(converter.fromString(null)).isNull();
+    assertThat(converter.toString(null)).isNull();
+  }
+
+  @Test
+  public void testValid() {
+    ContentKey key = ContentKey.of("a.b.c");
+    String name = "a\u001Db\u001Dc";
+    assertThat(converter.fromString(name)).isEqualTo(key);
+    assertThat(converter.toString(key)).isEqualTo(name);
+  }
+}

--- a/servers/rest-services/src/test/java/org/projectnessie/services/rest/TestInstantParamConverterProvider.java
+++ b/servers/rest-services/src/test/java/org/projectnessie/services/rest/TestInstantParamConverterProvider.java
@@ -22,7 +22,7 @@ import javax.ws.rs.ext.ParamConverter;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class InstantParamConverterProviderTest {
+public class TestInstantParamConverterProvider {
 
   private final ParamConverter<Instant> converter =
       new InstantParamConverterProvider().getConverter(Instant.class, null, null);

--- a/servers/rest-services/src/test/java/org/projectnessie/services/rest/TestNamespaceParamConverterProvider.java
+++ b/servers/rest-services/src/test/java/org/projectnessie/services/rest/TestNamespaceParamConverterProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.ws.rs.ext.ParamConverter;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.model.Namespace;
+
+public class TestNamespaceParamConverterProvider {
+
+  private final ParamConverter<Namespace> converter =
+      new NamespaceParamConverterProvider().getConverter(Namespace.class, null, null);
+
+  @Test
+  public void testNulls() {
+    assertThat(converter.fromString(null)).isNull();
+    assertThat(converter.toString(null)).isNull();
+  }
+
+  @Test
+  public void testValid() {
+    Namespace namespace = Namespace.of("a.b.c");
+    String name = "a\u001Db\u001Dc";
+    assertThat(converter.fromString(name)).isEqualTo(namespace);
+    assertThat(converter.toString(namespace)).isEqualTo(name);
+  }
+}


### PR DESCRIPTION
For backward-compatibility we still allow the zero byte, but convert it
to the group sep. character, since that's our new canonical representation
of a "." delimiter within a single element name.

Note that this also means that
`Namespace.parse("a.b\u001Dc.d")` is the same as `Namespace.parse("a.b\u0000c.d")`.

The reason for changing from the zero byte to the group sep. character is
because certain webservers (Jetty) don't allow the zero byte to be used
in the URL path
(https://github.com/eclipse/jetty.project/blob/jetty-10.0.x/jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java#L1203-L1206).
This means that the mentioned path check in Jetty fails even before for
example the `NamespaceParamConverter` gets called. Due to that we
decided to switch our canonical representation of a ContentKey/Namespace
to use a new character instead of the zero byte.
