### PR TITLE
Do not build GC with `-Dquickly`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,6 @@
     <module>model</module>
     <module>clients</module>
     <module>versioned</module>
-    <module>gc</module>
     <module>servers</module>
     <module>tools</module>
     <module>compatibility</module>
@@ -1511,6 +1510,7 @@ limitations under the License.
       <modules>
         <module>perftest</module>
         <module>ui</module>
+        <module>gc</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
Nessie GC modules depend on the Nessie Spark SQL Extensions, which aren't built
with `-Dquickly`, so the `gc` module can't be built with `-Dquickly` either.