### PR TITLE
Remove global state for Iceberg tables + views

### DIFF
--- a/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergViews.java
+++ b/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergViews.java
@@ -271,7 +271,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
     IcebergView original = getIcebergView(VIEW_IDENTIFIER, BRANCH);
     IcebergView updated = getIcebergView(VIEW_IDENTIFIER, branch1);
     assertThat(updated).isNotEqualTo(original);
-    assertThat(updated.getMetadataLocation()).isEqualTo(original.getMetadataLocation());
+    assertThat(updated.getMetadataLocation()).isNotEqualTo(original.getMetadataLocation());
     assertThat(original.getVersionId()).isEqualTo(1);
     assertThat(updated.getVersionId()).isEqualTo(2);
     assertThat(original.getSqlText()).isEqualTo(SQL);

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -82,5 +82,8 @@ public abstract class AbstractCompatibilityTests {
         .map(LogEntry::getCommitMeta)
         .map(CommitMeta::getMessage)
         .containsExactly(commitMessage);
+
+    assertThat(api.getContent().refName(branch.getName()).key(key).get())
+        .containsEntry(key, content);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -38,17 +38,14 @@ import org.immutables.value.Value;
  */
 @Schema(
     type = SchemaType.OBJECT,
-    title = "Iceberg table global state",
+    title = "Iceberg table state",
     description =
-        "Represents the global state of an Iceberg table in Nessie. An Iceberg table is globally "
+        "Represents the state of an Iceberg table in Nessie. An Iceberg table is globally "
             + "identified via its unique 'Content.id'.\n"
             + "\n"
             + "A Nessie commit-operation, performed via 'TreeApi.commitMultipleOperations',"
             + "for Iceberg consists of a 'Operation.Put' with an 'IcebergTable' as in the 'content' "
-            + "field and the previous value of 'IcebergTable' in the 'expectedContent' field.\n"
-            + "\n"
-            + "During a commit-operation, Nessie checks whether the known global state of the "
-            + "Iceberg table is compatible (think: equal) to 'Operation.Put.expectedContent'.")
+            + "field and the previous value of 'IcebergTable' in the 'expectedContent' field.")
 @Value.Immutable
 @JsonSerialize(as = ImmutableIcebergTable.class)
 @JsonDeserialize(as = ImmutableIcebergTable.class)

--- a/servers/store-proto/src/main/proto/table.proto
+++ b/servers/store-proto/src/main/proto/table.proto
@@ -40,6 +40,11 @@ message IcebergRefState {
   int32 schema_id = 2;
   int32 spec_id = 3;
   int32 sort_order_id = 4;
+  // If metadata_location is present, the state of the Iceberg view is
+  // maintained purely on the reference/commit.
+  // If metadata_location not present, the location needs to be fetched
+  // from global state.
+  optional string metadata_location = 5;
 }
 
 message IcebergViewState {
@@ -47,6 +52,11 @@ message IcebergViewState {
   int32 schema_id = 2;
   string sql_text = 3;
   string dialect = 4;
+  // If metadata_location is present, the state of the Iceberg view is
+  // maintained purely on the reference/commit.
+  // If metadata_location not present, the location needs to be fetched
+  // from global state.
+  optional string metadata_location = 5;
 }
 
 message DeltaLakeTable {

--- a/site/docs/develop/kernel.md
+++ b/site/docs/develop/kernel.md
@@ -75,7 +75,7 @@ The data model for non-transactional key-value databases relies on a single _glo
 which is technically a table with a single row pointing to the _current_ entry in the _global-log_,
 _current_ entry in the _ref-log_ and the "HEAD"s of all named references (branches and tags).
 
-The _global-log_ contains the changes of the _global-state_.
+The _global-log_ contains changes to _global-state_, which is needed for backwards compatibility.
 
 The _ref-log_ contains the history with details of operations 
 like COMMIT, MERGE, TRANSPLANT, CREATE_REFERENCE, DELETE_REFERENCE, ASSIGN_REFERENCE.
@@ -190,7 +190,7 @@ support atomic CAS (compare-and-swap) operations against a single row/record, bu
 conditional updates to multiple rows/records is either not supported at all or extremely slow.
 
 Nessie differentiates between content types that do require so called _global-state_ and those
-that do not. _Global-state_ is maintained globally and evaluated when a convent value object is
+that do not. _Global-state_ is maintained globally and evaluated when a content value object is
 being retrieved, combined with the requested on-reference state on a Nessie commit.
 For _Nessie commits_, which are atomic, this means that
 Nessie has to update both the global-state and the on-reference-state for a content type that

--- a/site/docs/develop/kernel.md
+++ b/site/docs/develop/kernel.md
@@ -27,9 +27,9 @@ current state of a table in a data lake. Whenever a table has changed via for ex
 a so-called commit operation instructs Nessie to record the new state in a Nessie commit, which
 carries the `Content` object(s).
 
-`IcebergTable` contains the _current_ and _global_ pointer to Iceberg's table metadata plus the
+`IcebergTable` contains the pointer to Iceberg's table metadata plus the
 IDs of the snapshot, schema, partition spec, sort order defined in the table metadata.
-- Since Iceberg's table metadata manages information that must be consistent across all branches in Nessie, it is stored as so-called _global state_.
+- Iceberg's table metadata manages information is stored in the Nessie commit.
 - The value of the snapshot-ID, schema-ID, partition-spec-ID, sort-order-ID is stored per Nessie named reference (branch or tag).
 For more information, please refer the spec [On Reference State vs Global State](spec.md#on-reference-state-vs-global-state)
 
@@ -75,8 +75,7 @@ The data model for non-transactional key-value databases relies on a single _glo
 which is technically a table with a single row pointing to the _current_ entry in the _global-log_,
 _current_ entry in the _ref-log_ and the "HEAD"s of all named references (branches and tags).
 
-The _global-log_ contains the changes of the _global-state_, like the location of Iceberg's
-table metadata.
+The _global-log_ contains the changes of the _global-state_.
 
 The _ref-log_ contains the history with details of operations 
 like COMMIT, MERGE, TRANSPLANT, CREATE_REFERENCE, DELETE_REFERENCE, ASSIGN_REFERENCE.
@@ -191,11 +190,11 @@ support atomic CAS (compare-and-swap) operations against a single row/record, bu
 conditional updates to multiple rows/records is either not supported at all or extremely slow.
 
 Nessie differentiates between content types that do require so called _global-state_ and those
-that do not. Apache Iceberg is currently the only content type that supports global state:
-the pointer to the Iceberg "Table Metadata" is tracked as "global state" and 
-the Iceberg snapshot ID, schema ID, partition spec ID, sort order ID
-is tracker per _Nessie named reference_. For _Nessie commits_, which are atomic, this means that
-Nessie has to update both the global-state and the on-reference-state for the Iceberg table. While
+that do not. _Global-state_ is maintained globally and evaluated when a convent value object is
+being retrieved, combined with the requested on-reference state on a Nessie commit.
+For _Nessie commits_, which are atomic, this means that
+Nessie has to update both the global-state and the on-reference-state for a content type that
+requires _global state_. While
 this is not an issue with a relational/transactional database, it is an issue in a key-value store.
 Nessie solves this with a single "global pointer", which is updated using a CAS operation.
 
@@ -213,7 +212,7 @@ The logical data model shared by all non-transactional database adapters consist
 * _Commit-log_ contains all commit log entries, identified by a deterministic hash. This is the same
   as for transactional databases.
 * _Global-state-log_ contains all changes to the global state for content types that do require
-  global state (currently Apache Iceberg). The row keys are random IDs.
+  global state. The row keys are random IDs.
 * _Key-lists_ acts as an "overflow" for large key lists that do not fit entirely into a single
   commit log entry's embedded key list.
 * _Ref-log_ contains the history with details of operations
@@ -231,7 +230,7 @@ The data for transactional database adapters consists of six tables:
 * _Named-references_ contains all named references and their current HEAD, the latter is used to
   guarantee consistent updates.
 * _Global-state_ contains the current global state for a contents ID for content types that require
-  global state (currently Apache Iceberg). Consistent changes are guaranteed by tracking a checksum
+  global state. Consistent changes are guaranteed by tracking a checksum
   + value of the contents of the value representing the global state.
 * _Commit-log_ contains all commit log entries, identified by a deterministic hash. This is the same
   as for non-transactional databases.

--- a/site/docs/develop/spec.md
+++ b/site/docs/develop/spec.md
@@ -42,9 +42,6 @@ Since different Nessie commits, think: on different branches in Nessie, can refe
 same physical table but with different state of the data and potentially different schema, some
 table formats require Nessie to refer to a single _Global State_.
 
-This _Global State_ is not versioned in Nessie, because it has to
-contain enough information to resolve all information in all Nessie commits.
-
 IDs of the _Iceberg snapshot_, _Iceberg schema_, _Iceberg partition spec_, _Iceberg sort order_ 
 within the Iceberg _table metadata_ are also stored per Nessie named reference (branch or tag),
 as the so-called _on-reference-state_.
@@ -120,20 +117,22 @@ within the Iceberg _table metadata_.  (so-called _On Reference State_)
     potentially serious issues regarding schema migrations in this model as well. Therefore, the
     Iceberg table spec should be considered subject to change in the near future.
 
+#### Iceberg View
+
+!!! note
+    Iceberg Views are experimental and subject to change!
+
+The state of an Iceberg view is represented using the attributes `versionId`, `schemaId`, `sqlText`
+and `dialect`.
+
+Iceberg views are handled similar to [Iceberg Tables](#iceberg-table).
+
 #### Delta Lake Table
 
 The state of a Delta Lake Table is represented using the Delta Lake Table attributes
 `metadataLocationHistory`, `checkpointLocationHistory` and `lastCheckpoint`.
 
 Delta Lake Tables are tracked without a _Global State_ in Nessie, i.e. those three attributes are
-recorded within the [_Put Operation_](#put-operation) of a Nessie commit.
-
-#### View
-
-The state of an SQL view is represented using the attributes
-`sqlText` and `dialect` (currently one of `HIVE`, `SPARK`, `DREMIO`, `PRESTO`).
-
-Views are tracked without a _Global State_ in Nessie, i.e. those three attributes are
 recorded within the [_Put Operation_](#put-operation) of a Nessie commit.
 
 ## Operations in a Nessie commit


### PR DESCRIPTION
Before this change, the location to the Iceberg table/view metadata was maintained
globally, so all commits/references/branches/tags shared the same metadata.
It was originally introduced to ensure that there can be no duplicate IDs for
column-ID, schema-ID, et al. On the flip side, the global metadata "leaked" all
table snapshots and schemas to all branches and even experimental branches could
(potentially) exhaust all possible column IDs for a table.

So this change moves the Iceberg metadata-pointer back to "per commit".
