### PR TITLE
CI: Capture test reports only on failure

### DIFF
--- a/.github/actions/ci-reports/action.yml
+++ b/.github/actions/ci-reports/action.yml
@@ -1,0 +1,14 @@
+name: 'Capture test reports'
+runs:
+  using: "composite"
+  steps:
+    - name: Capture test reports
+      uses: actions/upload-artifact@v3
+      if: ${{ inputs.include-reports != 'false' }}
+      with:
+        name: test-results
+        path: |
+          **/target/surefire-reports/*
+          **/target/failsafe-reports/*
+          **/build/reports/*
+          **/build/test-results/*

--- a/.github/actions/ci-results/action.yml
+++ b/.github/actions/ci-results/action.yml
@@ -2,15 +2,6 @@ name: 'Capture test results'
 runs:
   using: "composite"
   steps:
-    - name: Capture test results
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-results
-        path: |
-          **/target/surefire-reports/*
-          **/target/failsafe-reports/*
-          **/build/reports/*
-          **/build/test-results/*
     - name: Capture Gatling simulation logs
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,10 @@ jobs:
       if: ${{ ! env.MAVEN_USERNAME }}
       run: ./mvnw --batch-mode --threads 1C install -Pcode-coverage,release -DskipGpg -Dtest.log.level=WARN
 
+    - name: Capture Test Reports
+      if: ${{ failure() }}
+      uses: ./.github/actions/ci-reports
+
     - name: Capture Results
       uses: ./.github/actions/ci-results
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,6 +55,10 @@ jobs:
       run: |
         ./mvnw --batch-mode --threads 1C install javadoc:javadoc-no-fork -Pcode-coverage -Dtest.log.level=WARN
 
+    - name: Capture Test Reports
+      if: ${{ failure() }}
+      uses: ./.github/actions/ci-reports
+
     - name: Capture Results
       uses: ./.github/actions/ci-results
 


### PR DESCRIPTION
Saves ~ 40 seconds for successful CI runs.

See checks in #3876