### PR TITLE
Speed up `ui/` build (locally)

### DIFF
--- a/.github/actions/dev-tool-java/action.yml
+++ b/.github/actions/dev-tool-java/action.yml
@@ -32,7 +32,9 @@ runs:
     - name: Cache local NPM repository
       uses: actions/cache@v3
       with:
-        path: ~/.npm
+        path: | 
+          ~/.npm
+          .mvn/.babel-cache
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ dependency-reduced-pom.xml
 # node
 node_modules/
 ui/src/generated/
+.mvn/.babel-cache/
 
 # Eclipse IDE
 .classpath

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,29 @@ not necessary. Use one of these parameters to speed things up:
 * `-DskipTests` Compiles everything, runs no tests.
 * `-DskipITs` Compiles everything, runs unit tests, but no integration tests.
 
+If you do not (regularly) update the `ui/` module, you may want to use the properties
+`-Dui.disable-terser=true` and `-Dui.disable-es-lint=true` to speed up the build of the ui module by
+about 20 seconds.
+
+Hint: you can define a default set of properties in your `~/.m2/settings.xml` like this:
+```xml
+<settings>
+  <profiles>
+    <profile>
+      <id>nessie-props</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <test.log.level>WARN</test.log.level>
+        <ui.disable-terser>true</ui.disable-terser>
+        <ui.disable-es-lint>true</ui.disable-es-lint>
+      </properties>
+    </profile>
+  </profiles>
+</settings>
+```
+
 #### Parallel Maven Builds
 
 Building Nessie works fine with Maven Daemon [`mvnd`](https://github.com/apache/maven-mvnd).

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -29,6 +29,17 @@
 
   <name>Nessie - UI</name>
 
+  <properties>
+    <!-- sourcemap generation takes 11 seconds or more and isn't necessary for production -->
+    <ui.generate-sourcemap>false</ui.generate-sourcemap>
+    <!-- ES Lint takes 17 seconds or more, but should be enabled for CI -->
+    <ui.disable-es-lint>false</ui.disable-es-lint>
+    <!-- Terser takes 5 seconds or more, but should be enabled for CI -->
+    <ui.disable-terser>false</ui.disable-terser>
+    <!-- requires manual installation of `speed-measure-webpack-plugin` -->
+    <ui.profile-plugins>false</ui.profile-plugins>
+  </properties>
+
   <dependencies>
     <!-- The dependency is technically not needed, but parallel Maven builds (e.g. `mvn -T` or `mvnd`) require it. -->
     <dependency>
@@ -170,6 +181,12 @@
             </goals>
             <configuration>
               <arguments>run build</arguments>
+              <environmentVariables>
+                <GENERATE_SOURCEMAP>${ui.generate-sourcemap}</GENERATE_SOURCEMAP>
+                <DISABLE_ESLINT_PLUGIN>${ui.disable-es-lint}</DISABLE_ESLINT_PLUGIN>
+                <DISABLE_TERSER_PLUGIN>${ui.disable-terser}</DISABLE_TERSER_PLUGIN>
+                <PROFILE_PLUGINS>${ui.profile-plugins}</PROFILE_PLUGINS>
+              </environmentVariables>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
Using the [speed-measure-webpack-plugin](https://github.com/stephencookdev/speed-measure-webpack-plugin)
to figure out the webpack plugins and loaders that contribute to the build time.

Most expensive plugins/loaders:
* ESLint (17+ seconds)
* Terser (5+ seconds)
* babel-loader (7+ seconds)

ESLint + Terser plugins are required for production builds and cannot be disabled by default.
However, this change adds Maven properties to disable those plugins locally (see `CONTRIBUTING.md`).

Moving the cache for the babel-loader to a different directory that's not cleaned by `mvn clean`
speeds up rebuilds.