### PR TITLE
Remove `ContentVariantSupplier` + replace with `StoreWorker`

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DatabaseAdapterBuilder.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.quarkus.providers;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 
 /** Factory interface for creating database adapter instances. */
@@ -25,8 +25,6 @@ public interface DatabaseAdapterBuilder {
    * Creates a new database adapter instance.
    *
    * @return new database adapter instance
-   * @param contentVariantSupplier provides the kind of content, whether it's only stored on a
-   *     reference or requires global state.
    */
-  DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier);
+  DatabaseAdapter newDatabaseAdapter(StoreWorker<?, ?, ?> storeWorker);
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DatabaseAdapterProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DatabaseAdapterProvider.java
@@ -29,7 +29,6 @@ import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.spi.TracingDatabaseAdapter;
-import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +65,7 @@ public class DatabaseAdapterProvider {
         databaseAdapterBuilder
             .select(new Literal(versionStoreType))
             .get()
-            .newDatabaseAdapter(new GenericContentVariantSupplier<>(storeWorker));
+            .newDatabaseAdapter(storeWorker);
     databaseAdapter.initializeRepo(serverConfig.getDefaultBranch());
 
     if (storeConfig.isTracingEnabled()) {

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DynamoDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/DynamoDatabaseAdapterBuilder.java
@@ -19,7 +19,7 @@ import static org.projectnessie.quarkus.config.VersionStoreConfig.VersionStoreTy
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.dynamodb.DynamoDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.dynamodb.DynamoDatabaseClient;
@@ -35,7 +35,7 @@ public class DynamoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(StoreWorker<?, ?, ?> storeWorker) {
     DynamoDatabaseClient client = new DynamoDatabaseClient();
     client.configure(ProvidedDynamoClientConfig.of(dynamoConfig));
     client.initialize();
@@ -44,6 +44,6 @@ public class DynamoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
         .newBuilder()
         .withConfig(config)
         .withConnector(client)
-        .build(contentVariantSupplier);
+        .build(storeWorker);
   }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/InmemoryDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/InmemoryDatabaseAdapterBuilder.java
@@ -19,7 +19,7 @@ import static org.projectnessie.quarkus.config.VersionStoreConfig.VersionStoreTy
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.inmem.InmemoryStore;
@@ -32,11 +32,11 @@ public class InmemoryDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(StoreWorker<?, ?, ?> storeWorker) {
     return new InmemoryDatabaseAdapterFactory()
         .newBuilder()
         .withConfig(config)
         .withConnector(new InmemoryStore())
-        .build(contentVariantSupplier);
+        .build(storeWorker);
   }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/MongoDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/MongoDatabaseAdapterBuilder.java
@@ -24,7 +24,7 @@ import io.quarkus.mongodb.runtime.MongoClients;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.mongodb.MongoClientConfig;
 import org.projectnessie.versioned.persist.mongodb.MongoDatabaseAdapterFactory;
@@ -42,7 +42,7 @@ public class MongoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(StoreWorker<?, ?, ?> storeWorker) {
     MongoClients mongoClients = Arc.container().instance(MongoClients.class).get();
     MongoClient mongoClient =
         mongoClients.createMongoClient(MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME);
@@ -55,6 +55,6 @@ public class MongoDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
         .newBuilder()
         .withConfig(config)
         .withConnector(client)
-        .build(contentVariantSupplier);
+        .build(storeWorker);
   }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/RocksDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/RocksDatabaseAdapterBuilder.java
@@ -19,7 +19,7 @@ import static org.projectnessie.quarkus.config.VersionStoreConfig.VersionStoreTy
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.rocks.RocksDatabaseAdapterFactory;
@@ -33,11 +33,11 @@ public class RocksDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(StoreWorker<?, ?, ?> storeWorker) {
     return new RocksDatabaseAdapterFactory()
         .newBuilder()
         .withConfig(config)
         .withConnector(rocksDbInstance)
-        .build(contentVariantSupplier);
+        .build(storeWorker);
   }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/TransactionalDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/TransactionalDatabaseAdapterBuilder.java
@@ -19,7 +19,7 @@ import static org.projectnessie.quarkus.config.VersionStoreConfig.VersionStoreTy
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxConnectionConfig;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
@@ -34,11 +34,11 @@ public class TransactionalDatabaseAdapterBuilder implements DatabaseAdapterBuild
   @Inject TxConnectionProvider<TxConnectionConfig> connector;
 
   @Override
-  public DatabaseAdapter newDatabaseAdapter(ContentVariantSupplier contentVariantSupplier) {
+  public DatabaseAdapter newDatabaseAdapter(StoreWorker<?, ?, ?> storeWorker) {
     return new PostgresDatabaseAdapterFactory()
         .newBuilder()
         .withConfig(config)
         .withConnector(connector)
-        .build(contentVariantSupplier);
+        .build(storeWorker);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterFactory.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterFactory.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import org.projectnessie.versioned.StoreWorker;
 
 /**
  * Each {@link org.projectnessie.versioned.persist.adapter.DatabaseAdapter} is configured and
@@ -71,7 +72,7 @@ public interface DatabaseAdapterFactory<
       return connector;
     }
 
-    public abstract DatabaseAdapter build(ContentVariantSupplier contentVariantSupplier);
+    public abstract DatabaseAdapter build(StoreWorker<?, ?, ?> storeWorker);
 
     public Builder<Config, AdjustableConfig, Connector> configure(
         Function<AdjustableConfig, Config> configurator) {

--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -55,7 +55,6 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
-import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
 import org.projectnessie.versioned.persist.tests.SystemPropertiesConfigurer;
 import org.projectnessie.versioned.persist.tests.extension.TestConnectionProviderSource;
@@ -153,7 +152,7 @@ public class CommitBench {
 
       return builder
           .withConnector(providerSource.getConnectionProvider())
-          .build(new GenericContentVariantSupplier<>(SimpleStoreWorker.INSTANCE));
+          .build(SimpleStoreWorker.INSTANCE);
     }
 
     @TearDown

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -43,8 +43,8 @@ import javax.annotation.Nonnull;
 import org.projectnessie.versioned.BackendLimitExceededException;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
@@ -87,8 +87,8 @@ public class DynamoDatabaseAdapter
   public DynamoDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       DynamoDatabaseClient c,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    super(config, storeWorker);
 
     Objects.requireNonNull(
         c, "Requires a non-null DynamoDatabaseClient from DynamoDatabaseAdapterConfig");

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapterFactory.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.persist.dynamodb;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterFactory;
@@ -34,7 +34,7 @@ public class DynamoDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       DynamoDatabaseClient dynamoDatabaseClient,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new DynamoDatabaseAdapter(config, dynamoDatabaseClient, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    return new DynamoDatabaseAdapter(config, dynamoDatabaseClient, storeWorker);
   }
 }

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -31,8 +31,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
@@ -54,8 +54,8 @@ public class InmemoryDatabaseAdapter
   public InmemoryDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       InmemoryStore store,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    super(config, storeWorker);
 
     this.keyPrefix = ByteString.copyFromUtf8(config.getRepositoryId() + ':');
 

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapterFactory.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.persist.inmem;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterFactory;
@@ -34,7 +34,7 @@ public class InmemoryDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       InmemoryStore inmemoryStore,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new InmemoryDatabaseAdapter(config, inmemoryStore, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    return new InmemoryDatabaseAdapter(config, inmemoryStore, storeWorker);
   }
 }

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -43,8 +43,8 @@ import org.bson.conversions.Bson;
 import org.bson.types.Binary;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
@@ -79,8 +79,8 @@ public class MongoDatabaseAdapter
   protected MongoDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       MongoDatabaseClient client,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    super(config, storeWorker);
 
     Objects.requireNonNull(client, "MongoDatabaseClient cannot be null");
     this.client = client;

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapterFactory.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.persist.mongodb;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterFactory;
@@ -34,7 +34,7 @@ public class MongoDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       MongoDatabaseClient client,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new MongoDatabaseAdapter(config, client, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    return new MongoDatabaseAdapter(config, client, storeWorker);
   }
 }

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -64,6 +64,7 @@ import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.VersionStoreException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
@@ -71,7 +72,6 @@ import org.projectnessie.versioned.persist.adapter.CommitParams;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.GlobalLogCompactionParams;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
@@ -119,9 +119,8 @@ public abstract class NonTransactionalDatabaseAdapter<
   public static final String TAG_COMMIT_COUNT = "commit-count";
   public static final String TAG_KEY_LIST_COUNT = "key-list-count";
 
-  protected NonTransactionalDatabaseAdapter(
-      CONFIG config, ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+  protected NonTransactionalDatabaseAdapter(CONFIG config, StoreWorker<?, ?, ?> storeWorker) {
+    super(config, storeWorker);
   }
 
   @Override

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterFactory.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.persist.nontx;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
@@ -30,7 +30,7 @@ public abstract class NonTransactionalDatabaseAdapterFactory<
   protected abstract DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       CONNECTOR connector,
-      ContentVariantSupplier contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker);
 
   @Override
   public Builder<
@@ -60,8 +60,8 @@ public abstract class NonTransactionalDatabaseAdapterFactory<
     }
 
     @Override
-    public DatabaseAdapter build(ContentVariantSupplier contentVariantSupplier) {
-      return create(getConfig(), getConnector(), contentVariantSupplier);
+    public DatabaseAdapter build(StoreWorker<?, ?, ?> storeWorker) {
+      return create(getConfig(), getConnector(), storeWorker);
     }
   }
 }

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -37,8 +37,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
@@ -70,8 +70,8 @@ public class RocksDatabaseAdapter
   public RocksDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       RocksDbInstance dbInstance,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    super(config, storeWorker);
 
     this.keyPrefix = ByteString.copyFromUtf8(config.getRepositoryId() + ':');
     this.globalPointerKey = ByteString.copyFromUtf8(config.getRepositoryId()).toByteArray();

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapterFactory.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.persist.rocks;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterFactory;
@@ -34,7 +34,7 @@ public class RocksDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       RocksDbInstance rocksDbInstance,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new RocksDatabaseAdapter(config, rocksDbInstance, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    return new RocksDatabaseAdapter(config, rocksDbInstance, storeWorker);
   }
 }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/DatabaseAdapterExtension.java
@@ -56,7 +56,6 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
 import org.projectnessie.versioned.persist.adapter.spi.TracingDatabaseAdapter;
-import org.projectnessie.versioned.persist.store.GenericContentVariantSupplier;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
 import org.projectnessie.versioned.persist.tests.SystemPropertiesConfigurer;
 
@@ -330,7 +329,7 @@ public class DatabaseAdapterExtension
         .configure(applyCustomConfig)
         .withConnector(getConnectionProvider(context));
 
-    return builder.build(new GenericContentVariantSupplier<>(storeWorker));
+    return builder.build(storeWorker);
   }
 
   private static Function<AdjustableDatabaseAdapterConfig, DatabaseAdapterConfig>

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -71,6 +71,7 @@ import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.ReferenceRetryFailureException;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.VersionStoreException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
@@ -78,7 +79,6 @@ import org.projectnessie.versioned.persist.adapter.CommitParams;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
 import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
@@ -114,8 +114,8 @@ public abstract class TxDatabaseAdapter
   public TxDatabaseAdapter(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<?> db,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    super(config, storeWorker);
 
     // get the externally configured TxConnectionProvider
     Objects.requireNonNull(

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.persist.tx;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
@@ -25,9 +25,7 @@ public abstract class TxDatabaseAdapterFactory<CONNECTOR extends DatabaseConnect
         TxDatabaseAdapterConfig, AdjustableTxDatabaseAdapterConfig, CONNECTOR> {
 
   protected abstract DatabaseAdapter create(
-      TxDatabaseAdapterConfig config,
-      CONNECTOR connector,
-      ContentVariantSupplier contentVariantSupplier);
+      TxDatabaseAdapterConfig config, CONNECTOR connector, StoreWorker<?, ?, ?> storeWorker);
 
   @Override
   public Builder<TxDatabaseAdapterConfig, AdjustableTxDatabaseAdapterConfig, CONNECTOR>
@@ -48,8 +46,8 @@ public abstract class TxDatabaseAdapterFactory<CONNECTOR extends DatabaseConnect
     }
 
     @Override
-    public DatabaseAdapter build(ContentVariantSupplier contentVariantSupplier) {
-      return create(getConfig(), getConnector(), contentVariantSupplier);
+    public DatabaseAdapter build(StoreWorker<?, ?, ?> storeWorker) {
+      return create(getConfig(), getConnector(), storeWorker);
     }
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
@@ -17,7 +17,7 @@ package org.projectnessie.versioned.persist.tx.h2;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
@@ -27,8 +27,8 @@ public class H2DatabaseAdapter extends TxDatabaseAdapter {
   public H2DatabaseAdapter(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<?> db,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, db, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    super(config, db, storeWorker);
   }
 
   @Override

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.persist.tx.h2;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxConnectionConfig;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
@@ -36,7 +36,7 @@ public class H2DatabaseAdapterFactory
   protected DatabaseAdapter create(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<TxConnectionConfig> connectionProvider,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new H2DatabaseAdapter(config, connectionProvider, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    return new H2DatabaseAdapter(config, connectionProvider, storeWorker);
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
@@ -17,7 +17,7 @@ package org.projectnessie.versioned.persist.tx.postgres;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
@@ -27,8 +27,8 @@ public class PostgresDatabaseAdapter extends TxDatabaseAdapter {
   public PostgresDatabaseAdapter(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<?> db,
-      ContentVariantSupplier contentVariantSupplier) {
-    super(config, db, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    super(config, db, storeWorker);
   }
 
   @Override

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.persist.tx.postgres;
 
-import org.projectnessie.versioned.persist.adapter.ContentVariantSupplier;
+import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxConnectionConfig;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
@@ -36,7 +36,7 @@ public class PostgresDatabaseAdapterFactory
   protected DatabaseAdapter create(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<TxConnectionConfig> connectionProvider,
-      ContentVariantSupplier contentVariantSupplier) {
-    return new PostgresDatabaseAdapter(config, connectionProvider, contentVariantSupplier);
+      StoreWorker<?, ?, ?> storeWorker) {
+    return new PostgresDatabaseAdapter(config, connectionProvider, storeWorker);
   }
 }


### PR DESCRIPTION
The only implementation of `ContentVariantSupplier` delegates to `StoreWorker` anyways,
so `ContentVariantSupplier` is an unnecessary indirection.
