### PR TITLE
Compare Namespaces based on their canonical elements

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -151,6 +151,29 @@ public abstract class Namespace extends Content {
   }
 
   /**
+   * Checks whether the current {@link Namespace} is the same as or a sub-element of the given
+   * {@link Namespace} instance by comparing each canonical element.
+   *
+   * @param parent {@link Namespace} instance to compare with.
+   * @return <code>true</code> if the current {@link Namespace} is the same as or a sub-element of
+   *     the given {@link Namespace} instance by comparing each canonical element, <code>false
+   *     </code> otherwise.
+   */
+  public boolean isSameOrSubElementOf(Namespace parent) {
+    Objects.requireNonNull(parent, "namespace must be non-null");
+    if (getElements().size() < parent.getElements().size()) {
+      return false;
+    }
+    for (int i = 0; i < parent.getElements().size(); i++) {
+      // elements must match exactly
+      if (!getElements().get(i).equals(parent.getElements().get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Convert from path encoded string to normal string.
    *
    * @param encoded Path encoded string

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestNamespace.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestNamespace.java
@@ -162,7 +162,7 @@ public abstract class AbstractRestNamespace extends AbstractRestRefLog {
             getApi()
                 .getMultipleNamespaces()
                 .refName(branch.getName())
-                .namespace("on")
+                .namespace("one")
                 .get()
                 .getNamespaces())
         .containsExactly(four);
@@ -361,7 +361,7 @@ public abstract class AbstractRestNamespace extends AbstractRestRefLog {
                 .refName(branch.getName())
                 .get()
                 .getNamespaces())
-        .containsExactlyInAnyOrderElementsOf(namespaces);
+        .containsExactly(second);
 
     assertThat(
             getApi()

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -115,8 +115,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceApi {
               if (keys.anyMatch(
                   k ->
                       Namespace.of(k.getKey().getElements())
-                              .name()
-                              .startsWith(params.getNamespace().name())
+                              .isSameOrSubElementOf(params.getNamespace())
                           && k.getType() != Type.NAMESPACE)) {
                 throw namespaceNotEmptyException(params);
               }
@@ -227,7 +226,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceApi {
     return getStore()
         .getKeys(branch)
         .filter(earlyFilterPredicate)
-        .filter(k -> null == namespace || namespaceFromType(k).name().startsWith(namespace.name()));
+        .filter(k -> null == namespace || namespaceFromType(k).isSameOrSubElementOf(namespace));
   }
 
   /**


### PR DESCRIPTION
Previously the `NamespaceApi` would only compare two namespaces using
their string representation. With the introduction of the group
separator character we need to actually check each canonical namespace
element individually.

For example, one would expect both of these checks
to produce the same result (because we treat \u001D and \u0000 equally):

```
assertThat(namespace.name()).startsWith("a.b\u001Dc");
assertThat(namespace.name()).startsWith("a.b\u0000c");
```

Thus we're introducing a `Namespace.isSameOrSubElementOf(Namespace)` method that
allows such a comparison.