### PR TITLE
Fix potential `ui/` build issue with diasbled terser-plugin

### DIFF
--- a/ui/config/webpack.config.js
+++ b/ui/config/webpack.config.js
@@ -206,6 +206,55 @@ module.exports = function (webpackEnv) {
     return loaders;
   };
 
+  const getMinimizers = () => {
+    const minimizers = [];
+    if (!disableTerserPlugin) {
+      // This is only used in production mode
+      minimizers.push(new TerserPlugin({
+        terserOptions: {
+          parse: {
+            // We want terser to parse ecma 8 code. However, we don't want it
+            // to apply any minification steps that turns valid ecma 5 code
+            // into invalid ecma 5 code. This is why the 'compress' and 'output'
+            // sections only apply transformations that are ecma 5 safe
+            // https://github.com/facebook/create-react-app/pull/4234
+            ecma: 8,
+          },
+          compress: {
+            ecma: 5,
+            warnings: false,
+            // Disabled because of an issue with Uglify breaking seemingly valid code:
+            // https://github.com/facebook/create-react-app/issues/2376
+            // Pending further investigation:
+            // https://github.com/mishoo/UglifyJS2/issues/2011
+            comparisons: false,
+            // Disabled because of an issue with Terser breaking valid code:
+            // https://github.com/facebook/create-react-app/issues/5250
+            // Pending further investigation:
+            // https://github.com/terser-js/terser/issues/120
+            inline: 2,
+          },
+          mangle: {
+            safari10: true,
+          },
+          // Added for profiling in devtools
+          keep_classnames: isEnvProductionProfile,
+          keep_fnames: isEnvProductionProfile,
+          output: {
+            ecma: 5,
+            comments: false,
+            // Turned on because emoji and regex is not minified properly using default
+            // https://github.com/facebook/create-react-app/issues/2488
+            ascii_only: true,
+          },
+        },
+      }));
+    }
+    // This is only used in production mode
+    minimizers.push(new CssMinimizerPlugin());
+    return minimizers;
+  };
+
   const config = {
     target: ["browserslist"],
     mode: isEnvProduction ? "production" : isEnvDevelopment && "development",
@@ -253,50 +302,7 @@ module.exports = function (webpackEnv) {
     },
     optimization: {
       minimize: isEnvProduction,
-      minimizer: [
-        // This is only used in production mode
-        !disableTerserPlugin && new TerserPlugin({
-          terserOptions: {
-            parse: {
-              // We want terser to parse ecma 8 code. However, we don't want it
-              // to apply any minification steps that turns valid ecma 5 code
-              // into invalid ecma 5 code. This is why the 'compress' and 'output'
-              // sections only apply transformations that are ecma 5 safe
-              // https://github.com/facebook/create-react-app/pull/4234
-              ecma: 8,
-            },
-            compress: {
-              ecma: 5,
-              warnings: false,
-              // Disabled because of an issue with Uglify breaking seemingly valid code:
-              // https://github.com/facebook/create-react-app/issues/2376
-              // Pending further investigation:
-              // https://github.com/mishoo/UglifyJS2/issues/2011
-              comparisons: false,
-              // Disabled because of an issue with Terser breaking valid code:
-              // https://github.com/facebook/create-react-app/issues/5250
-              // Pending further investigation:
-              // https://github.com/terser-js/terser/issues/120
-              inline: 2,
-            },
-            mangle: {
-              safari10: true,
-            },
-            // Added for profiling in devtools
-            keep_classnames: isEnvProductionProfile,
-            keep_fnames: isEnvProductionProfile,
-            output: {
-              ecma: 5,
-              comments: false,
-              // Turned on because emoji and regex is not minified properly using default
-              // https://github.com/facebook/create-react-app/issues/2488
-              ascii_only: true,
-            },
-          },
-        }),
-        // This is only used in production mode
-        new CssMinimizerPlugin(),
-      ],
+      minimizer: getMinimizers(),
     },
     resolve: {
       // This allows you to set a fallback for where webpack should look for modules.


### PR DESCRIPTION
Potential issue:
```
[INFO] --- frontend-maven-plugin:1.12.1:npm (build minimized webpack bundle) @ nessie-ui ---
[INFO] Running 'npm run build' in /home/snazy/devel/projectnessie/nessie/nessie/ui
[INFO]
[INFO] > nessie-ui@0.25.1-snapshot build
[INFO] > node scripts/build.js
[INFO]
[INFO] Creating an optimized production build...
[INFO] Failed to compile.
[INFO]
[INFO] Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
[INFO]  - configuration.optimization.minimizer[0] should be one of these:
[INFO]    "..." | object { apply, … } | function
[INFO]    -> Plugin of type object or instanceof Function.
[INFO]    Details:
[INFO]     * configuration.optimization.minimizer[0] should be "...".
[INFO]     * configuration.optimization.minimizer[0] should be an object:
[INFO]       object { apply, … }
[INFO]       -> Plugin instance.
[INFO]     * configuration.optimization.minimizer[0] should be an instance of function.
[INFO]       -> Function acting as plugin.
```