### PR TITLE
Rename internal packages, avoid package name shared across artifacts

### DIFF
--- a/servers/store-proto/src/main/proto/table.proto
+++ b/servers/store-proto/src/main/proto/table.proto
@@ -16,7 +16,7 @@
 syntax = "proto3";
 package nessie.store;
 
-option java_package = "org.projectnessie.store";
+option java_package = "org.projectnessie.server.store.proto";
 option java_outer_classname = "ObjectTypes";
 option java_generate_equals_and_hash = true;
 

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -34,7 +34,7 @@ import org.projectnessie.model.ImmutableIcebergTable;
 import org.projectnessie.model.ImmutableIcebergView;
 import org.projectnessie.model.ImmutableNamespace;
 import org.projectnessie.model.Namespace;
-import org.projectnessie.store.ObjectTypes;
+import org.projectnessie.server.store.proto.ObjectTypes;
 import org.projectnessie.versioned.Serializer;
 import org.projectnessie.versioned.StoreWorker;
 

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -36,10 +36,10 @@ import org.projectnessie.model.IcebergView;
 import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.ImmutableDeltaLakeTable;
 import org.projectnessie.model.Namespace;
-import org.projectnessie.store.ObjectTypes;
-import org.projectnessie.store.ObjectTypes.IcebergMetadataPointer;
-import org.projectnessie.store.ObjectTypes.IcebergRefState;
-import org.projectnessie.store.ObjectTypes.IcebergViewState;
+import org.projectnessie.server.store.proto.ObjectTypes;
+import org.projectnessie.server.store.proto.ObjectTypes.IcebergMetadataPointer;
+import org.projectnessie.server.store.proto.ObjectTypes.IcebergRefState;
+import org.projectnessie.server.store.proto.ObjectTypes.IcebergViewState;
 
 class TestStoreWorker {
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.dynamodb;
 
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.toProto;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.KEY_NAME;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_COMMIT_LOG;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_GLOBAL_LOG;
@@ -23,7 +24,6 @@ import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_KEY_LIST
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_REF_LOG;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.TABLE_REPO_DESC;
 import static org.projectnessie.versioned.persist.dynamodb.Tables.VALUE_NAME;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.toProto;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -50,14 +50,14 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
+import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.Parser;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalOperationContext;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
-import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
-import org.projectnessie.versioned.persist.serialize.ProtoSerialization.Parser;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -15,10 +15,10 @@
  */
 package org.projectnessie.versioned.persist.inmem;
 
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToCommitLogEntry;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToKeyList;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.toProto;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.hashCollisionDetected;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToCommitLogEntry;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToKeyList;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.toProto;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -37,13 +37,13 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalOperationContext;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
-import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
 
 public class InmemoryDatabaseAdapter
     extends NonTransactionalDatabaseAdapter<NonTransactionalDatabaseAdapterConfig> {

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -15,8 +15,8 @@
  */
 package org.projectnessie.versioned.persist.mongodb;
 
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToKeyList;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.toProto;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToKeyList;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.toProto;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.mongodb.ErrorCategory;
@@ -50,6 +50,8 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
+import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.Parser;
 import org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
@@ -58,8 +60,6 @@ import org.projectnessie.versioned.persist.serialize.AdapterTypes;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RepoProps;
-import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
-import org.projectnessie.versioned.persist.serialize.ProtoSerialization.Parser;
 
 public class MongoDatabaseAdapter
     extends NonTransactionalDatabaseAdapter<NonTransactionalDatabaseAdapterConfig> {

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -82,6 +82,7 @@ import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.adapter.RepoMaintenanceParams;
 import org.projectnessie.versioned.persist.adapter.TransplantParams;
+import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
 import org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.spi.Traced;
 import org.projectnessie.versioned.persist.adapter.spi.TryLoopState;
@@ -96,7 +97,6 @@ import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.Op
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.RefType;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer.Type;
-import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
 
 /**
  * Non-transactional database-adapter implementation suitable for no-sql databases.

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -15,12 +15,12 @@
  */
 package org.projectnessie.versioned.persist.rocks;
 
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToCommitLogEntry;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToKeyList;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToRefLog;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToRepoDescription;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.toProto;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.hashCollisionDetected;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToCommitLogEntry;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToKeyList;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToRefLog;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToRepoDescription;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.toProto;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -43,13 +43,13 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalOperationContext;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
-import org.projectnessie.versioned.persist.serialize.ProtoSerialization;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.Holder;
 import org.rocksdb.RocksDBException;

--- a/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
+++ b/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.serialize;
+package org.projectnessie.versioned.persist.adapter.serialize;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -32,11 +32,14 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RepoProps;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RepoProps.Builder;
 
 public class ProtoSerialization {
 
-  public static AdapterTypes.RepoProps toProto(RepoDescription repoDescription) {
-    AdapterTypes.RepoProps.Builder proto =
+  public static RepoProps toProto(RepoDescription repoDescription) {
+    Builder proto =
         AdapterTypes.RepoProps.newBuilder().setRepoVersion(repoDescription.getRepoVersion());
     // Must be sorted
     new TreeMap<>(repoDescription.getProperties())

--- a/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/adapter/serialize/TestSerialization.java
+++ b/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/adapter/serialize/TestSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.serialize;
+package org.projectnessie.versioned.persist.adapter.serialize;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.toProto;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.toProto;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -49,11 +49,13 @@ import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.NamedReference;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RepoProps;
 
 /** (Re-)serialization tests using random data for relevant types. */
 class TestSerialization {
@@ -204,7 +206,7 @@ class TestSerialization {
     params.add(
         new TypeSerialization<>(
             RepoDescription.class,
-            AdapterTypes.RepoProps.class,
+            RepoProps.class,
             TestSerialization::createRepoDescription,
             ProtoSerialization::toProto,
             v -> {

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -15,6 +15,11 @@
  */
 package org.projectnessie.versioned.persist.tx;
 
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToCommitLogEntry;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToKeyList;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToRefLog;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.protoToRepoDescription;
+import static org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.toProto;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.assignConflictMessage;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.commitConflictMessage;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.createConflictMessage;
@@ -29,11 +34,6 @@ import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUti
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.verifyExpectedHash;
 import static org.projectnessie.versioned.persist.adapter.spi.Traced.trace;
 import static org.projectnessie.versioned.persist.adapter.spi.TryLoopState.newTryLoopState;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToCommitLogEntry;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToKeyList;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToRefLog;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.protoToRepoDescription;
-import static org.projectnessie.versioned.persist.serialize.ProtoSerialization.toProto;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
Just package renames - no functional changes.

(Re)using the same package name in different artifacts is not just only
bad practice, it can likely cause issues later down the road, e.g. with
JPMS, but also Quarkus warns about that.