### PR TITLE
Let StoreWorker pull global-state

### DIFF
--- a/servers/store-proto/src/main/proto/table.proto
+++ b/servers/store-proto/src/main/proto/table.proto
@@ -50,7 +50,7 @@ message IcebergViewState {
 }
 
 message DeltaLakeTable {
-  string last_checkpoint = 1;
+  optional string last_checkpoint = 1;
   repeated string checkpoint_location_history = 2;
   repeated string metadata_location_history = 3;
 }

--- a/servers/store/pom.xml
+++ b/servers/store/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.server.store;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
@@ -23,9 +25,7 @@ import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,24 +49,24 @@ class TestStoreWorker {
   @ParameterizedTest
   @MethodSource("provideDeserialization")
   void testDeserialization(Map.Entry<ByteString, Content> entry) {
-    Content actual = worker.valueFromStore(entry.getKey(), Optional.empty());
-    Assertions.assertEquals(entry.getValue(), actual);
+    Content actual = worker.valueFromStore(entry.getKey(), () -> null);
+    assertThat(actual).isEqualTo(entry.getValue());
   }
 
   @ParameterizedTest
   @MethodSource("provideDeserialization")
   void testSerialization(Map.Entry<ByteString, Content> entry) {
     ByteString actual = worker.toStoreOnReferenceState(entry.getValue());
-    Assertions.assertEquals(entry.getKey(), actual);
+    assertThat(actual).isEqualTo(entry.getKey());
   }
 
   @ParameterizedTest
   @MethodSource("provideDeserialization")
   void testSerde(Map.Entry<ByteString, Content> entry) {
     ByteString actualBytes = worker.toStoreOnReferenceState(entry.getValue());
-    Assertions.assertEquals(entry.getValue(), worker.valueFromStore(actualBytes, Optional.empty()));
-    Content actualContent = worker.valueFromStore(entry.getKey(), Optional.empty());
-    Assertions.assertEquals(entry.getKey(), worker.toStoreOnReferenceState(actualContent));
+    assertThat(worker.valueFromStore(actualBytes, () -> null)).isEqualTo(entry.getValue());
+    Content actualContent = worker.valueFromStore(entry.getKey(), () -> null);
+    assertThat(worker.toStoreOnReferenceState(actualContent)).isEqualTo(entry.getKey());
   }
 
   @Test
@@ -94,11 +94,11 @@ class TestStoreWorker {
     ByteString tableGlobalBytes = worker.toStoreGlobalState(table);
     ByteString snapshotBytes = worker.toStoreOnReferenceState(table);
 
-    Assertions.assertEquals(protoTableGlobal.toByteString(), tableGlobalBytes);
-    Assertions.assertEquals(protoOnRef.toByteString(), snapshotBytes);
+    assertThat(tableGlobalBytes).isEqualTo(protoTableGlobal.toByteString());
+    assertThat(snapshotBytes).isEqualTo(protoOnRef.toByteString());
 
-    Content deserialized = worker.valueFromStore(snapshotBytes, Optional.of(tableGlobalBytes));
-    Assertions.assertEquals(table, deserialized);
+    Content deserialized = worker.valueFromStore(snapshotBytes, () -> tableGlobalBytes);
+    assertThat(deserialized).isEqualTo(table);
   }
 
   @Test
@@ -128,11 +128,11 @@ class TestStoreWorker {
     ByteString tableGlobalBytes = worker.toStoreGlobalState(view);
     ByteString snapshotBytes = worker.toStoreOnReferenceState(view);
 
-    Assertions.assertEquals(protoTableGlobal.toByteString(), tableGlobalBytes);
-    Assertions.assertEquals(protoOnRef.toByteString(), snapshotBytes);
+    assertThat(tableGlobalBytes).isEqualTo(protoTableGlobal.toByteString());
+    assertThat(snapshotBytes).isEqualTo(protoOnRef.toByteString());
 
-    Content deserialized = worker.valueFromStore(snapshotBytes, Optional.of(tableGlobalBytes));
-    Assertions.assertEquals(view, deserialized);
+    Content deserialized = worker.valueFromStore(snapshotBytes, () -> tableGlobalBytes);
+    assertThat(deserialized).isEqualTo(view);
   }
 
   @Test
@@ -149,13 +149,13 @@ class TestStoreWorker {
 
     ByteString expectedBytes = ByteString.copyFrom(MAPPER.writeValueAsBytes(expectedCommit));
     CommitMeta actualCommit = worker.getMetadataSerializer().fromBytes(expectedBytes);
-    Assertions.assertEquals(expectedCommit, actualCommit);
+    assertThat(actualCommit).isEqualTo(expectedCommit);
     ByteString actualBytes = worker.getMetadataSerializer().toBytes(expectedCommit);
-    Assertions.assertEquals(expectedBytes, actualBytes);
+    assertThat(actualBytes).isEqualTo(expectedBytes);
     actualBytes = worker.getMetadataSerializer().toBytes(expectedCommit);
-    Assertions.assertEquals(expectedCommit, worker.getMetadataSerializer().fromBytes(actualBytes));
+    assertThat(worker.getMetadataSerializer().fromBytes(actualBytes)).isEqualTo(expectedCommit);
     actualCommit = worker.getMetadataSerializer().fromBytes(expectedBytes);
-    Assertions.assertEquals(expectedBytes, worker.getMetadataSerializer().toBytes(actualCommit));
+    assertThat(worker.getMetadataSerializer().toBytes(actualCommit)).isEqualTo(expectedBytes);
   }
 
   private static Stream<Map.Entry<ByteString, Content>> provideDeserialization() {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
@@ -16,7 +16,7 @@
 package org.projectnessie.versioned;
 
 import com.google.protobuf.ByteString;
-import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * A set of helpers that users of a VersionStore must implement.
@@ -31,21 +31,15 @@ public interface StoreWorker<CONTENT, COMMIT_METADATA, CONTENT_TYPE extends Enum
 
   ByteString toStoreGlobalState(CONTENT content);
 
-  CONTENT valueFromStore(ByteString onReferenceValue, Optional<ByteString> globalState);
+  CONTENT valueFromStore(ByteString onReferenceValue, Supplier<ByteString> globalState);
 
   String getId(CONTENT content);
 
   Byte getPayload(CONTENT content);
 
-  default boolean requiresGlobalState(ByteString content) {
-    return requiresGlobalState(getType(content));
-  }
+  boolean requiresGlobalState(ByteString content);
 
-  default boolean requiresGlobalState(CONTENT content) {
-    return requiresGlobalState(getType(content));
-  }
-
-  boolean requiresGlobalState(Enum<CONTENT_TYPE> contentType);
+  boolean requiresGlobalState(CONTENT content);
 
   CONTENT_TYPE getType(ByteString onRefContent);
 


### PR DESCRIPTION
`StoreWorker` implementations previously got an `Optional` containing the
value of a content's global state. This change changes the behavior to
pull the global state value.

Also marks an attribute for delta-lake-tables as optional to properly handle
the case coded in `TableCommitMetaStoreWorker`.

`PersistVersionStore` checks the content-IDs of the new and expected values
in a `Put` operation.

Migrates to AssertJ for tests in `servers/store`.

Prerequisite for #3866