### PR TITLE
Do not write empty global-log-entries

### DIFF
--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -285,14 +286,14 @@ public class DynamoDatabaseAdapter
   @Override
   protected void doCleanUpCommitCas(
       NonTransactionalOperationContext ctx,
-      Hash globalId,
+      Optional<Hash> globalHead,
       Set<Hash> branchCommits,
       Set<Hash> newKeyLists,
       Hash refLogId) {
     try (BatchDelete batchDelete = new BatchDelete()) {
       branchCommits.forEach(h -> batchDelete.add(TABLE_COMMIT_LOG, h));
       newKeyLists.forEach(h -> batchDelete.add(TABLE_KEY_LISTS, h));
-      batchDelete.add(TABLE_GLOBAL_LOG, globalId);
+      globalHead.ifPresent(h -> batchDelete.add(TABLE_GLOBAL_LOG, h));
       batchDelete.add(TABLE_REF_LOG, refLogId);
     }
   }

--- a/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDynamoDatabaseAdapter.java
@@ -23,6 +23,7 @@ import com.google.protobuf.ByteString;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -115,7 +116,8 @@ public class ITDynamoDatabaseAdapter extends AbstractDatabaseAdapterTest
         .extracting(l -> l.get(0))
         .allMatch(Objects::nonNull);
 
-    implDatabaseAdapter().doCleanUpCommitCas(ctx, globalId, branchCommits, newKeyLists, refLogId);
+    implDatabaseAdapter()
+        .doCleanUpCommitCas(ctx, Optional.of(globalId), branchCommits, newKeyLists, refLogId);
 
     assertThat(implDatabaseAdapter().doFetchFromGlobalLog(ctx, globalId)).isNull();
     assertThat(implDatabaseAdapter().doFetchFromRefLog(ctx, refLogId)).isNull();

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -25,6 +25,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -131,11 +132,11 @@ public class InmemoryDatabaseAdapter
   @Override
   protected void doCleanUpCommitCas(
       NonTransactionalOperationContext ctx,
-      Hash globalId,
+      Optional<Hash> globalHead,
       Set<Hash> branchCommits,
       Set<Hash> newKeyLists,
       Hash refLogId) {
-    store.globalStateLog.remove(dbKey(globalId));
+    globalHead.ifPresent(h -> store.globalStateLog.remove(dbKey(h)));
     branchCommits.forEach(h -> store.commitLog.remove(dbKey(h)));
     newKeyLists.forEach(h -> store.keyLists.remove(dbKey(h)));
     store.refLog.remove(dbKey(refLogId));

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -438,11 +439,11 @@ public class MongoDatabaseAdapter
   @Override
   protected void doCleanUpCommitCas(
       NonTransactionalOperationContext ctx,
-      Hash globalId,
+      Optional<Hash> globalHead,
       Set<Hash> branchCommits,
       Set<Hash> newKeyLists,
       Hash refLogId) {
-    client.getGlobalLog().deleteOne(Filters.eq(toId(globalId)));
+    globalHead.ifPresent(h -> client.getGlobalLog().deleteOne(Filters.eq(toId(h))));
 
     delete(client.getCommitLog(), branchCommits);
     delete(client.getKeyLists(), newKeyLists);

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Function;
@@ -229,7 +230,7 @@ public class RocksDatabaseAdapter
   @Override
   protected void doCleanUpCommitCas(
       NonTransactionalOperationContext ctx,
-      Hash globalId,
+      Optional<Hash> globalHead,
       Set<Hash> branchCommits,
       Set<Hash> newKeyLists,
       Hash refLogId) {
@@ -237,7 +238,9 @@ public class RocksDatabaseAdapter
     lock.lock();
     try {
       WriteBatch batch = new WriteBatch();
-      batch.delete(dbInstance.getCfGlobalLog(), dbKey(globalId));
+      if (globalHead.isPresent()) {
+        batch.delete(dbInstance.getCfGlobalLog(), dbKey(globalHead.get()));
+      }
       for (Hash h : branchCommits) {
         batch.delete(dbInstance.getCfCommitLog(), dbKey(h));
       }

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -103,12 +103,17 @@ message RefLogEntry {
 
 // Used by non-transactional database-adapters
 message GlobalStatePointer {
+  // Random ID, used for CAS.
   bytes global_id = 1;
   // most recently updated named reference appears first
   repeated NamedReference named_references = 2;
   bytes ref_log_id = 3;
   repeated bytes global_parents_incl_head = 4;
   repeated bytes ref_log_parents_incl_head = 5;
+  // If present, contains the ID of the head of the global-log.
+  // If not present, probably from an older Nessie version, global_id
+  // represents the head of the global-log.
+  optional bytes global_log_head = 6;
 }
 
 // Used by transactional database-adapters

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCompactGlobalLog.java
@@ -146,8 +146,8 @@ public abstract class AbstractCompactGlobalLog {
         .containsEntry("compacted", "true")
         .containsEntry("entries.puts", Long.toString(commits))
         .containsEntry("entries.uniquePuts", Long.toString(contentIdEmitter.size()))
-        .containsEntry("entries.read", Long.toString(commits + 2))
-        .containsEntry("entries.read.total", Long.toString(commits + 2));
+        .containsEntry("entries.read", Long.toString(commits + 1))
+        .containsEntry("entries.read.total", Long.toString(commits + 1));
 
     // Verify again
     verify.run();

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
@@ -59,7 +59,6 @@ public abstract class AbstractTracing extends AbstractNestedVersionStore {
     12 (39000µs)          DatabaseAdapter.create {nessie.database-adapter.operation=create, nessie.database-adapter.hash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d, nessie.database-adapter.ref=traceCreateBranch}
     13 (36000µs)              DatabaseAdapter.try-loop.createRef {nessie.database-adapter.operation=try-loop.createRef, nessie.database-adapter.try-loop.attempt=0, nessie.database-adapter.try-loop.retries=0}
     14 (    0µs)                  DatabaseAdapter.fetchGlobalPointer {nessie.database-adapter.operation=fetchGlobalPointer}
-    16 (    0µs)                  DatabaseAdapter.writeGlobalCommit {nessie.database-adapter.operation=writeGlobalCommit}
     18 (    0µs)                  DatabaseAdapter.writeRefLog {nessie.database-adapter.operation=writeRefLog}
     19 (    0µs)                  DatabaseAdapter.globalPointerCas {nessie.database-adapter.operation=globalPointerCas}
     */
@@ -81,7 +80,6 @@ public abstract class AbstractTracing extends AbstractNestedVersionStore {
                                                 tryLoop ->
                                                     tryLoop
                                                         .add("DatabaseAdapter.fetchGlobalPointer")
-                                                        .add("DatabaseAdapter.writeGlobalCommit")
                                                         .add("DatabaseAdapter.writeRefLog")
                                                         .add(
                                                             "DatabaseAdapter.globalPointerCas"))))),


### PR DESCRIPTION
The current non-transactional database-adapters write empty global-log entries
for changes that do not affect global state.

Since it is not great to write empty global-log-entries, this change
optimizes the non-transactional database-adapter implementation to no longer
write "empty" global-log entries. The change there is to split the global-id,
which was used to both point to the head of the global-log and to serve as the
reference value for the global-pointer CAS operation. The head of the global
log is now maintained as a separate field in global-pointer so that the global-id
can still be used as the reference value for the CAS operation.

Prerequisite for #3866