### PR TITLE
Support adding/updating/removing Namespace properties

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/NessieApiV1.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/NessieApiV1.java
@@ -135,4 +135,7 @@ public interface NessieApiV1 extends NessieApi {
 
   /** Delete a single {@link org.projectnessie.model.Namespace}. */
   DeleteNamespaceBuilder deleteNamespace();
+
+  /** Updates properties of a {@link org.projectnessie.model.Namespace}. */
+  UpdateNamespacePropertiesBuilder updateProperties();
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/UpdateNamespacePropertiesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/UpdateNamespacePropertiesBuilder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.api;
+
+import java.util.List;
+import java.util.Map;
+import org.projectnessie.error.NessieNamespaceNotFoundException;
+import org.projectnessie.error.NessieReferenceNotFoundException;
+import org.projectnessie.model.Namespace;
+
+/**
+ * Request builder for updating properties of a {@link Namespace}.
+ *
+ * @since {@link NessieApiV1}
+ */
+public interface UpdateNamespacePropertiesBuilder
+    extends OnNamespaceBuilder<UpdateNamespacePropertiesBuilder> {
+
+  UpdateNamespacePropertiesBuilder propertyRemovals(List<String> propertyRemovals);
+
+  UpdateNamespacePropertiesBuilder propertyUpdates(Map<String, String> propertyUpdates);
+
+  void update() throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException;
+}

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpNamespaceClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpNamespaceClient.java
@@ -19,6 +19,7 @@ import javax.validation.constraints.NotNull;
 import org.projectnessie.api.http.HttpNamespaceApi;
 import org.projectnessie.api.params.MultipleNamespacesParams;
 import org.projectnessie.api.params.NamespaceParams;
+import org.projectnessie.api.params.NamespacePropertyUpdate;
 import org.projectnessie.error.NessieNamespaceAlreadyExistsException;
 import org.projectnessie.error.NessieNamespaceNotEmptyException;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
@@ -84,5 +85,18 @@ class HttpNamespaceClient implements HttpNamespaceApi {
         .queryParam("hashOnRef", params.getHashOnRef())
         .get()
         .readEntity(GetNamespacesResponse.class);
+  }
+
+  @Override
+  public void updateProperties(
+      NamespaceParams params, NamespacePropertyUpdate namespacePropertyUpdate)
+      throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException {
+    client
+        .newRequest()
+        .path("namespaces/namespace/{ref}/{name}/properties")
+        .resolveTemplate("ref", params.getRefName())
+        .resolveTemplate("name", params.getNamespace().toPathString())
+        .queryParam("hashOnRef", params.getHashOnRef())
+        .post(namespacePropertyUpdate);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
@@ -35,6 +35,7 @@ import org.projectnessie.client.api.GetReferenceBuilder;
 import org.projectnessie.client.api.MergeReferenceBuilder;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.api.TransplantCommitsBuilder;
+import org.projectnessie.client.api.UpdateNamespacePropertiesBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -156,5 +157,10 @@ public final class HttpApiV1 implements NessieApiV1 {
   @Override
   public DeleteNamespaceBuilder deleteNamespace() {
     return new HttpDeleteNamespace(client);
+  }
+
+  @Override
+  public UpdateNamespacePropertiesBuilder updateProperties() {
+    return new HttpUpdateNamespaceProperties(client);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpUpdateNamespaceProperties.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpUpdateNamespaceProperties.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v1api;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.projectnessie.api.params.ImmutableNamespacePropertyUpdate;
+import org.projectnessie.api.params.NamespaceParams;
+import org.projectnessie.api.params.NamespaceParamsBuilder;
+import org.projectnessie.client.api.UpdateNamespacePropertiesBuilder;
+import org.projectnessie.client.http.NessieApiClient;
+import org.projectnessie.error.NessieNamespaceNotFoundException;
+import org.projectnessie.error.NessieReferenceNotFoundException;
+import org.projectnessie.model.Namespace;
+
+final class HttpUpdateNamespaceProperties extends BaseHttpRequest
+    implements UpdateNamespacePropertiesBuilder {
+
+  private final NamespaceParamsBuilder builder = NamespaceParams.builder();
+  private final ImmutableNamespacePropertyUpdate.Builder updateBuilder =
+      ImmutableNamespacePropertyUpdate.builder();
+
+  HttpUpdateNamespaceProperties(NessieApiClient client) {
+    super(client);
+  }
+
+  @Override
+  public UpdateNamespacePropertiesBuilder namespace(Namespace namespace) {
+    builder.namespace(namespace);
+    return this;
+  }
+
+  @Override
+  public UpdateNamespacePropertiesBuilder refName(String refName) {
+    builder.refName(refName);
+    return this;
+  }
+
+  @Override
+  public UpdateNamespacePropertiesBuilder hashOnRef(@Nullable String hashOnRef) {
+    builder.hashOnRef(hashOnRef);
+    return this;
+  }
+
+  @Override
+  public UpdateNamespacePropertiesBuilder propertyRemovals(List<String> propertyRemovals) {
+    updateBuilder.propertyRemovals(propertyRemovals);
+    return this;
+  }
+
+  @Override
+  public UpdateNamespacePropertiesBuilder propertyUpdates(Map<String, String> propertyUpdates) {
+    updateBuilder.propertyUpdates(propertyUpdates);
+    return this;
+  }
+
+  @Override
+  public void update() throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException {
+    client.getNamespaceApi().updateProperties(builder.build(), updateBuilder.build());
+  }
+}

--- a/model/src/main/java/org/projectnessie/api/NamespaceApi.java
+++ b/model/src/main/java/org/projectnessie/api/NamespaceApi.java
@@ -18,6 +18,7 @@ package org.projectnessie.api;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.api.params.MultipleNamespacesParams;
 import org.projectnessie.api.params.NamespaceParams;
+import org.projectnessie.api.params.NamespacePropertyUpdate;
 import org.projectnessie.error.NessieNamespaceAlreadyExistsException;
 import org.projectnessie.error.NessieNamespaceNotEmptyException;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
@@ -72,4 +73,8 @@ public interface NamespaceApi {
    */
   GetNamespacesResponse getNamespaces(@NotNull MultipleNamespacesParams params)
       throws NessieReferenceNotFoundException;
+
+  void updateProperties(
+      @NotNull NamespaceParams params, @NotNull NamespacePropertyUpdate namespacePropertyUpdate)
+      throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException;
 }

--- a/model/src/main/java/org/projectnessie/api/http/HttpNamespaceApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpNamespaceApi.java
@@ -20,6 +20,7 @@ import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -28,11 +29,13 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.projectnessie.api.NamespaceApi;
 import org.projectnessie.api.params.MultipleNamespacesParams;
 import org.projectnessie.api.params.NamespaceParams;
+import org.projectnessie.api.params.NamespacePropertyUpdate;
 import org.projectnessie.error.NessieNamespaceAlreadyExistsException;
 import org.projectnessie.error.NessieNamespaceNotEmptyException;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
@@ -128,4 +131,29 @@ public interface HttpNamespaceApi extends NamespaceApi {
   })
   GetNamespacesResponse getNamespaces(@BeanParam @NotNull MultipleNamespacesParams params)
       throws NessieReferenceNotFoundException;
+
+  @Override
+  @POST
+  @Path("/namespace/{ref}/{name}/properties")
+  @Produces(MediaType.APPLICATION_JSON)
+  @APIResponses({
+    @APIResponse(
+        responseCode = "200",
+        description = "Updates namespace properties for the given namespace."),
+    @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
+    @APIResponse(responseCode = "403", description = "Not allowed to update namespace properties"),
+    @APIResponse(responseCode = "404", description = "Reference or Namespace not found"),
+  })
+  void updateProperties(
+      @BeanParam @NotNull NamespaceParams params,
+      @RequestBody(
+              description = "Namespace properties to update/delete.",
+              content = {
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    examples = {@ExampleObject(ref = "namespacePropertyUpdate")})
+              })
+          @NotNull
+          NamespacePropertyUpdate namespacePropertyUpdate)
+      throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException;
 }

--- a/model/src/main/java/org/projectnessie/api/params/NamespacePropertyUpdate.java
+++ b/model/src/main/java/org/projectnessie/api/params/NamespacePropertyUpdate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.params;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableNamespacePropertyUpdate.class)
+@JsonDeserialize(as = ImmutableNamespacePropertyUpdate.class)
+public abstract class NamespacePropertyUpdate {
+
+  @Nullable
+  public abstract List<String> getPropertyRemovals();
+
+  @Nullable
+  public abstract Map<String, String> getPropertyUpdates();
+}

--- a/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -25,10 +25,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Derived;
 
 /**
@@ -78,6 +81,11 @@ public abstract class Namespace extends Content {
   @NotNull
   public abstract List<String> getElements();
 
+  @Default
+  public Map<String, String> getProperties() {
+    return Collections.unmodifiableMap(new HashMap<>());
+  }
+
   /**
    * Builds a {@link Namespace} instance for the given elements.
    *
@@ -86,6 +94,18 @@ public abstract class Namespace extends Content {
    *     Namespace#name()} will be an empty string.
    */
   public static Namespace of(String... elements) {
+    return Namespace.of(new HashMap<>(), elements);
+  }
+
+  /**
+   * Builds a {@link Namespace} instance for the given elements and the given properties.
+   *
+   * @param elements The elements to build the namespace from.
+   * @param properties The namespace properties.
+   * @return The constructed {@link Namespace} instance. If <b>elements</b> is empty, then {@link
+   *     Namespace#name()} will be an empty string.
+   */
+  public static Namespace of(Map<String, String> properties, String... elements) {
     Objects.requireNonNull(elements, "elements must be non-null");
     if (elements.length == 0 || (elements.length == 1 && "".equals(elements[0]))) {
       return EMPTY;
@@ -115,7 +135,10 @@ public abstract class Namespace extends Content {
           String.format(ERROR_MSG_TEMPLATE, Arrays.toString(elements)));
     }
 
-    return ImmutableNamespace.builder().elements(Arrays.asList(elements)).build();
+    return ImmutableNamespace.builder()
+        .elements(Arrays.asList(elements))
+        .properties(properties)
+        .build();
   }
 
   /**
@@ -128,6 +151,19 @@ public abstract class Namespace extends Content {
   public static Namespace of(List<String> elements) {
     Objects.requireNonNull(elements, "elements must be non-null");
     return Namespace.of(elements.toArray(new String[0]));
+  }
+
+  /**
+   * Builds a {@link Namespace} instance for the given elements and the given properties.
+   *
+   * @param elements The elements to build the namespace from.
+   * @param properties The properties of the namespace.
+   * @return The constructed {@link Namespace} instance. If <b>elements</b> is empty, then {@link
+   *     Namespace#name()} will be an empty string.
+   */
+  public static Namespace of(List<String> elements, Map<String, String> properties) {
+    Objects.requireNonNull(elements, "elements must be non-null");
+    return Namespace.of(properties, elements.toArray(new String[0]));
   }
 
   /**

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -95,6 +95,15 @@ components:
               - b
               - d
 
+    namespacePropertyUpdate:
+      value:
+        propertyUpdates:
+          - key1: value1
+          - key2: value2
+        propertyRemovals:
+          - key3
+          - key4
+
     iceberg:
       value:
         type: ICEBERG_TABLE

--- a/model/src/test/java/org/projectnessie/model/TestNamespace.java
+++ b/model/src/test/java/org/projectnessie/model/TestNamespace.java
@@ -22,7 +22,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -144,6 +146,15 @@ public class TestNamespace {
     // even though we treat the zero byte + the group separator equally, we can't do comparisons
     // based on strings only
     assertThat(Namespace.of(asList("a", "b.c", "namespace")).name()).doesNotStartWith("a.b\u0000c");
+  }
+
+  @Test
+  public void testNamespaceWithProperties() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("location", "/tmp");
+    properties.put("x", "y");
+    Namespace namespace = Namespace.of(properties, "a", "b.c", "d");
+    assertThat(namespace.getProperties()).isEqualTo(properties);
   }
 
   @ParameterizedTest

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestNamespace.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestNamespace.java
@@ -18,8 +18,10 @@ package org.projectnessie.jaxrs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -56,7 +58,7 @@ public abstract class AbstractRestNamespace extends AbstractRestRefLog {
     assertThat(getApi().getNamespace().refName(branch.getName()).namespace(ns).get())
         .isEqualTo(namespace);
 
-    // the namespace in the error message will contain the reprensentation with u001D
+    // the namespace in the error message will contain the representation with u001D
     String namespaceInErrorMsg = namespaceName.replace("\u0000", "\u001D");
 
     assertThatThrownBy(
@@ -458,5 +460,46 @@ public abstract class AbstractRestNamespace extends AbstractRestRefLog {
                 .get()
                 .getNamespaces())
         .isEmpty();
+  }
+
+  @Test
+  public void testNamespaceWithProperties() throws BaseNessieClientServerException {
+    Branch branch = createBranch("namespaceWithProperties");
+    Map<String, String> properties = ImmutableMap.of("key1", "val1", "key2", "val2");
+    Namespace namespace = Namespace.of("a", "b", "c");
+
+    Namespace ns = getApi().createNamespace().namespace(namespace).reference(branch).create();
+    assertThat(ns.getProperties()).isEmpty();
+
+    assertThatThrownBy(
+            () ->
+                getApi()
+                    .updateProperties()
+                    .reference(branch)
+                    .namespace("non-existing")
+                    .propertyUpdates(properties)
+                    .update())
+        .isInstanceOf(NessieNamespaceNotFoundException.class)
+        .hasMessage("Namespace 'non-existing' does not exist");
+
+    getApi()
+        .updateProperties()
+        .reference(branch)
+        .namespace(namespace)
+        .propertyUpdates(properties)
+        .update();
+
+    ns = getApi().getNamespace().reference(branch).namespace(namespace).get();
+    assertThat(ns.getProperties()).isEqualTo(properties);
+
+    getApi()
+        .updateProperties()
+        .reference(branch)
+        .namespace(namespace)
+        .propertyUpdates(ImmutableMap.of("key3", "val3", "key1", "xyz"))
+        .propertyRemovals(Arrays.asList("key2", "key5"))
+        .update();
+    ns = getApi().getNamespace().reference(branch).namespace(namespace).get();
+    assertThat(ns.getProperties()).isEqualTo(ImmutableMap.of("key1", "xyz", "key3", "val3"));
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
@@ -24,6 +24,7 @@ import org.projectnessie.api.NamespaceApi;
 import org.projectnessie.api.http.HttpNamespaceApi;
 import org.projectnessie.api.params.MultipleNamespacesParams;
 import org.projectnessie.api.params.NamespaceParams;
+import org.projectnessie.api.params.NamespacePropertyUpdate;
 import org.projectnessie.error.NessieNamespaceAlreadyExistsException;
 import org.projectnessie.error.NessieNamespaceNotEmptyException;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
@@ -96,5 +97,12 @@ public class RestNamespaceResource implements HttpNamespaceApi {
   public GetNamespacesResponse getNamespaces(@NotNull MultipleNamespacesParams params)
       throws NessieReferenceNotFoundException {
     return resource().getNamespaces(params);
+  }
+
+  @Override
+  public void updateProperties(
+      NamespaceParams params, NamespacePropertyUpdate namespacePropertyUpdate)
+      throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException {
+    resource().updateProperties(params, namespacePropertyUpdate);
   }
 }

--- a/servers/store-proto/src/main/proto/table.proto
+++ b/servers/store-proto/src/main/proto/table.proto
@@ -67,4 +67,5 @@ message DeltaLakeTable {
 
 message Namespace {
   repeated string elements = 1;
+  map<string, string> properties = 2;
 }

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -79,7 +79,11 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
       builder.setDeltaLakeTable(table);
     } else if (content instanceof Namespace) {
       Namespace ns = (Namespace) content;
-      builder.setNamespace(ObjectTypes.Namespace.newBuilder().addAllElements(ns.getElements()));
+      builder.setNamespace(
+          ObjectTypes.Namespace.newBuilder()
+              .addAllElements(ns.getElements())
+              .putAllProperties(ns.getProperties())
+              .build());
     } else {
       throw new IllegalArgumentException("Unknown type " + content);
     }
@@ -160,7 +164,10 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
 
       case NAMESPACE:
         ObjectTypes.Namespace namespace = content.getNamespace();
-        return ImmutableNamespace.builder().elements(namespace.getElementsList()).build();
+        return ImmutableNamespace.builder()
+            .elements(namespace.getElementsList())
+            .putAllProperties(namespace.getPropertiesMap())
+            .build();
 
       case OBJECTTYPE_NOT_SET:
       default:

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import java.time.Instant;
 import java.util.AbstractMap;
@@ -459,7 +460,7 @@ class TestStoreWorker {
   }
 
   private static Stream<Map.Entry<ByteString, Content>> provideDeserialization() {
-    return Stream.of(getDelta(), getNamespace());
+    return Stream.of(getDelta(), getNamespace(), getNamespaceWithProperties());
   }
 
   private static Map.Entry<ByteString, Content> getDelta() {
@@ -499,6 +500,23 @@ class TestStoreWorker {
         ObjectTypes.Content.newBuilder()
             .setId(namespace.getId())
             .setNamespace(ObjectTypes.Namespace.newBuilder().addAllElements(elements).build())
+            .build()
+            .toByteString();
+    return new AbstractMap.SimpleImmutableEntry<>(bytes, namespace);
+  }
+
+  private static Map.Entry<ByteString, Content> getNamespaceWithProperties() {
+    List<String> elements = Arrays.asList("a", "b.c", "d");
+    Map<String, String> properties = ImmutableMap.of("key1", "val1");
+    Namespace namespace = Namespace.of(elements, properties);
+    ByteString bytes =
+        ObjectTypes.Content.newBuilder()
+            .setId(namespace.getId())
+            .setNamespace(
+                ObjectTypes.Namespace.newBuilder()
+                    .addAllElements(elements)
+                    .putAllProperties(properties)
+                    .build())
             .build()
             .toByteString();
     return new AbstractMap.SimpleImmutableEntry<>(bytes, namespace);


### PR DESCRIPTION
This adds a new API endpoint to the existing `NamespaceApi` that
supports adding/updating/removing Namespace properties.