### PR TITLE
Python-requirements: move Sphinx to separate requirements.txt

### DIFF
--- a/python/requirements_basedev.txt
+++ b/python/requirements_basedev.txt
@@ -14,7 +14,20 @@
 # limitations under the License.
 #
 
-# Common dev dependencies, compatible with Python 3.8+
--r requirements_basedev.txt
-Sphinx==4.5.0
-sphinx-autodoc-typehints==1.18.0
+# Base dev dependencies, compatible with Python 3.7+
+-r requirements.txt
+assertpy==1.1
+bump2version==1.0.1
+codecov==2.1.12
+coverage==6.3.2
+flake8==4.0.1
+pip==22.0.4
+pytest==7.1.1
+pytest-cov==3.0.0
+pytest-mock==3.7.0
+pytest-mypy==0.9.1
+pytest-recording==0.12.0
+tox==3.25.0
+twine==4.0.0
+watchdog==2.1.7
+wheel==0.37.1

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -67,6 +67,6 @@ setenv =
     PYTHONPATH = {toxinidir}
 passenv = TOXENV CI CODECOV_*
 deps =
-    -r{toxinidir}/requirements_dev.txt
+    -r{toxinidir}/requirements_basedev.txt
 commands =
     pytest --cov=pynessie --basetemp={envtmpdir} --block-network --cov-report=xml


### PR DESCRIPTION
See #3932

Includes #3739 & #3927