### PR TITLE
Make NessieContentGenerator extensible

### DIFF
--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/AbstractCommand.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/AbstractCommand.java
@@ -15,26 +15,15 @@
  */
 package org.projectnessie.tools.contentgenerator.cli;
 
-import java.net.URI;
 import java.util.concurrent.Callable;
-import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.api.NessieApiV1;
-import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.BaseNessieClientServerException;
+import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
 public abstract class AbstractCommand implements Callable<Integer> {
 
-  @Option(
-      names = {"-u", "--uri"},
-      description = "Nessie API endpoint URI, defaults to http://localhost:19120/api/v1.")
-  private URI uri = URI.create("http://localhost:19120/api/v1");
-
-  @Option(
-      names = {"-B", "--custom-nessie-client-builder"},
-      hidden = true,
-      description = "Custom implementation of org.projectnessie.client.NessieClientBuilder.")
-  private Class<?> customBuilder;
+  @CommandLine.ParentCommand private ContentGenerator<NessieApiV1> parent;
 
   @Option(
       names = {"-v", "--verbose"},
@@ -46,22 +35,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
   }
 
   public NessieApiV1 createNessieApiInstance() {
-    NessieClientBuilder<?> clientBuilder;
-    if (customBuilder != null) {
-      try {
-        clientBuilder =
-            (NessieClientBuilder<?>) customBuilder.getDeclaredMethod("builder").invoke(null);
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to use custom NessieClientBuilder", e);
-      }
-    } else {
-      clientBuilder = HttpClientBuilder.builder();
-    }
-    clientBuilder.fromSystemProperties();
-    if (uri != null) {
-      clientBuilder.withUri(uri);
-    }
-    return clientBuilder.build(NessieApiV1.class);
+    return parent.createNessieApiInstance();
   }
 
   /** Convenience method declaration that allows to "just throw" Nessie API exceptions. */

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ContentGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ContentGenerator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import org.projectnessie.client.api.NessieApiV1;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "nessie-content-generator",
+    mixinStandardHelpOptions = true,
+    versionProvider = NessieVersionProvider.class,
+    subcommands = {
+      GenerateContent.class,
+      ReadCommits.class,
+      ReadReferences.class,
+      ReadContent.class,
+      CommandLine.HelpCommand.class
+    })
+public abstract class ContentGenerator<API extends NessieApiV1> {
+
+  public abstract API createNessieApiInstance();
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/NessieContentGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/NessieContentGenerator.java
@@ -17,27 +17,34 @@ package org.projectnessie.tools.contentgenerator.cli;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.PrintWriter;
+import java.net.URI;
+import org.projectnessie.client.NessieClientBuilder;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.error.BaseNessieClientServerException;
 import picocli.CommandLine;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.HelpCommand;
 
-@Command(
-    name = "nessie-content-generator",
-    mixinStandardHelpOptions = true,
-    versionProvider = NessieVersionProvider.class,
-    subcommands = {
-      GenerateContent.class,
-      ReadCommits.class,
-      ReadReferences.class,
-      ReadContent.class,
-      HelpCommand.class
-    })
-public class NessieContentGenerator {
+public class NessieContentGenerator extends ContentGenerator<NessieApiV1> {
+
+  @CommandLine.Option(
+      names = {"-u", "--uri"},
+      scope = CommandLine.ScopeType.INHERIT,
+      description = "Nessie API endpoint URI, defaults to http://localhost:19120/api/v1.")
+  private URI uri = URI.create("http://localhost:19120/api/v1");
 
   public static void main(String[] arguments) {
     System.exit(runMain(arguments));
+  }
+
+  @Override
+  public NessieApiV1 createNessieApiInstance() {
+    NessieClientBuilder<?> clientBuilder = HttpClientBuilder.builder();
+    clientBuilder.fromSystemProperties();
+    if (uri != null) {
+      clientBuilder.withUri(uri);
+    }
+    return clientBuilder.build(NessieApiV1.class);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
* Add abstract base class to hold CLI annotations

* Delegate client construction to the concrete main class

* Move the --uri option to the parent command.

These changes allow downstream projects to reuse Nessie commands
while adding extra commands and overriding the client init code.