### PR TITLE
Add `metadata` to `IcebergTable` + `IcebergView`

### DIFF
--- a/model/src/main/java/org/projectnessie/model/GenericMetadata.java
+++ b/model/src/main/java/org/projectnessie/model/GenericMetadata.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGenericMetadata.class)
+@JsonDeserialize(as = ImmutableGenericMetadata.class)
+public interface GenericMetadata {
+
+  @NotEmpty
+  String getVariant();
+
+  @Schema(type = SchemaType.OBJECT)
+  JsonNode getMetadata();
+
+  static GenericMetadata of(@NotNull String variant, @NotNull JsonNode metadata) {
+    return ImmutableGenericMetadata.builder().variant(variant).metadata(metadata).build();
+  }
+}

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -15,9 +15,12 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -60,12 +63,16 @@ public abstract class IcebergTable extends Content {
   @NotBlank
   public abstract String getMetadataLocation();
 
+  /** Corresponds to Iceberg's {@code currentSnapshotId}. */
   public abstract long getSnapshotId();
 
+  /** Corresponds to Iceberg's {@code currentSchemaId}. */
   public abstract int getSchemaId();
 
+  /** Corresponds to Iceberg's {@code defaultSpecId}. */
   public abstract int getSpecId();
 
+  /** Corresponds to Iceberg's {@code defaultSortOrderId}. */
   public abstract int getSortOrderId();
 
   @Override
@@ -73,9 +80,17 @@ public abstract class IcebergTable extends Content {
     return Type.ICEBERG_TABLE;
   }
 
+  @Nullable
+  @JsonInclude(Include.NON_NULL)
+  public abstract GenericMetadata getMetadata();
+
+  public static ImmutableIcebergTable.Builder builder() {
+    return ImmutableIcebergTable.builder();
+  }
+
   public static IcebergTable of(
       String metadataLocation, long snapshotId, int schemaId, int specId, int sortOrderId) {
-    return ImmutableIcebergTable.builder()
+    return builder()
         .metadataLocation(metadataLocation)
         .snapshotId(snapshotId)
         .schemaId(schemaId)
@@ -91,7 +106,7 @@ public abstract class IcebergTable extends Content {
       int specId,
       int sortOrderId,
       String contentId) {
-    return ImmutableIcebergTable.builder()
+    return builder()
         .metadataLocation(metadataLocation)
         .snapshotId(snapshotId)
         .schemaId(schemaId)

--- a/model/src/main/java/org/projectnessie/model/IcebergView.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergView.java
@@ -15,9 +15,12 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
@@ -36,6 +39,7 @@ public abstract class IcebergView extends Content {
   @NotBlank
   public abstract String getMetadataLocation();
 
+  /** Corresponds to Iceberg's {@code currentVersionId}. */
   public abstract int getVersionId();
 
   public abstract int getSchemaId();
@@ -44,8 +48,7 @@ public abstract class IcebergView extends Content {
   @NotNull
   public abstract String getSqlText();
 
-  @NotNull
-  @NotBlank
+  @Nullable // TODO this is currently undefined in Iceberg
   public abstract String getDialect();
 
   @Override
@@ -53,9 +56,17 @@ public abstract class IcebergView extends Content {
     return Type.ICEBERG_VIEW;
   }
 
+  @Nullable
+  @JsonInclude(Include.NON_NULL)
+  public abstract GenericMetadata getMetadata();
+
+  public static ImmutableIcebergView.Builder builder() {
+    return ImmutableIcebergView.builder();
+  }
+
   public static IcebergView of(
       String metadataLocation, int versionId, int schemaId, String dialect, String sqlText) {
-    return ImmutableIcebergView.builder()
+    return builder()
         .metadataLocation(metadataLocation)
         .versionId(versionId)
         .schemaId(schemaId)
@@ -71,7 +82,7 @@ public abstract class IcebergView extends Content {
       int schemaId,
       String dialect,
       String sqlText) {
-    return ImmutableIcebergView.builder()
+    return builder()
         .id(id)
         .metadataLocation(metadataLocation)
         .versionId(versionId)


### PR DESCRIPTION
This change only adds the fields to the model objects to include the Iceberg
metadata. No functionality added or changed.

The new field defaults to `null` and is not serialized if it is `null`.