### PR TITLE
Simplify compatibilty tests versions

### DIFF
--- a/compatibility/compatibility-tests/src/test/resources/META-INF/nessie-compatibility.properties
+++ b/compatibility/compatibility-tests/src/test/resources/META-INF/nessie-compatibility.properties
@@ -14,4 +14,14 @@
 # limitations under the License.
 #
 
-nessie.versions=0.15.0,0.18.0,0.19.0,0.20.1,0.21.2,current
+# 0.18.0:
+#   - ref-log
+# 0.19.0:
+#   - "detached" commits
+#   - Iceberg views
+# 0.23.1:
+#   - namespaces (without properties)
+# 0.26.0:
+#   - Change 'marker' character to indicate `.` in namespace/table identifiers from ASCII 0 to \u001D
+#   - Squash merged and transplanted commits by default (with opt-out)
+nessie.versions=0.15.0,0.18.0,0.26.0,current


### PR DESCRIPTION
From 0.15.0,0.18.0,0.19.0,0.20.1,0.21.2,current
to   0.15.0,0.18.0,0.26.0,current

replace 0.19.0 + 0.20.1 + 0.21.2 with 0.26.0 (save two steps)