### PR TITLE
Don't throw exception in requiresGlobalState

### DIFF
--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -257,9 +257,8 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
         // yes, Iceberg Views used global state before, but no longer do so
       case DELTA_LAKE_TABLE:
       case NAMESPACE:
-        return false;
       default:
-        throw new IllegalArgumentException("Unknown onRefContent " + content);
+        return false;
     }
   }
 
@@ -271,11 +270,8 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
         return !parsed.getIcebergRefState().hasMetadataLocation();
       case ICEBERG_VIEW_STATE:
         return !parsed.getIcebergViewState().hasMetadataLocation();
-      case DELTA_LAKE_TABLE:
-      case NAMESPACE:
-        return false;
       default:
-        throw new IllegalArgumentException("Unsupported on-ref content " + parsed);
+        return false;
     }
   }
 


### PR DESCRIPTION
It's possible that an old storage format hits this code and fails to
upgrade if it uses and old storage format type, thus it's better to
return false rather than throwing an exception