### PR TITLE
Do not create `spark-warehouse` in project directory

### DIFF
--- a/clients/spark-extensions-base/src/test/java/org/projectnessie/spark/extensions/AbstractSparkSqlTest.java
+++ b/clients/spark-extensions-base/src/test/java/org/projectnessie/spark/extensions/AbstractSparkSqlTest.java
@@ -87,6 +87,7 @@ public abstract class AbstractSparkSqlTest {
 
     conf.set(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
         .set("spark.testing", "true")
+        .set("spark.sql.warehouse.dir", tempFile.toURI().toString())
         .set("spark.sql.shuffle.partitions", "4")
         .set("spark.sql.catalog.nessie.catalog-impl", "org.apache.iceberg.nessie.NessieCatalog")
         .set("spark.sql.catalog.nessie", "org.apache.iceberg.spark.SparkCatalog");


### PR DESCRIPTION
Prevents creation of `spark-warehouse` directly underneath `spark-extensions` + `spark-3.2-extensions`.