### PR TITLE
Generate content ID on the server side & namespace content-IDs

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Content.java
+++ b/model/src/main/java/org/projectnessie/model/Content.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
+import javax.annotation.Nullable;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -61,10 +61,8 @@ public abstract class Content {
    * <p>This id is unique for the entire lifetime of this Content object and persists across
    * renames. Two content objects with the same key will have different id.
    */
-  @Value.Default
-  public String getId() {
-    return UUID.randomUUID().toString();
-  }
+  @Nullable
+  public abstract String getId();
 
   /**
    * Returns the {@link Type} enum constant for this content object.

--- a/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -64,14 +64,6 @@ public abstract class Namespace extends Content {
     return toPathString();
   }
 
-  @Override
-  @NotNull
-  @Derived
-  @JsonIgnore
-  public String getId() {
-    return name();
-  }
-
   @JsonIgnore
   @Value.Redacted
   public boolean isEmpty() {

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
@@ -94,7 +94,9 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
     Branch base = createBranch("base");
     Branch branch = createBranch("branch");
 
+    ContentKey key1 = ContentKey.of("key1");
     IcebergTable table1 = IcebergTable.of("table1", 42, 42, 42, 42);
+    ContentKey key2 = ContentKey.of("key2");
     IcebergTable table2 = IcebergTable.of("table2", 43, 43, 43, 43);
 
     Branch committed1 =
@@ -103,9 +105,19 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
             .branchName(branch.getName())
             .hash(branch.getHash())
             .commitMeta(CommitMeta.fromMessage("test-branch1"))
-            .operation(Put.of(ContentKey.of("key1"), table1))
+            .operation(Put.of(key1, table1))
             .commit();
     assertThat(committed1.getHash()).isNotNull();
+
+    table1 =
+        getApi()
+            .getContent()
+            .reference(committed1)
+            .key(key1)
+            .get()
+            .get(key1)
+            .unwrap(IcebergTable.class)
+            .get();
 
     Branch committed2 =
         getApi()
@@ -113,7 +125,7 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
             .branchName(branch.getName())
             .hash(committed1.getHash())
             .commitMeta(CommitMeta.fromMessage("test-branch2"))
-            .operation(Put.of(ContentKey.of("key1"), table1, table1))
+            .operation(Put.of(key1, table1, table1))
             .commit();
     assertThat(committed2.getHash()).isNotNull();
 
@@ -132,7 +144,7 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
         .branchName(base.getName())
         .hash(base.getHash())
         .commitMeta(CommitMeta.fromMessage("test-main"))
-        .operation(Put.of(ContentKey.of("key2"), table2))
+        .operation(Put.of(key2, table2))
         .commit();
 
     actor.accept(Tuple.tuple(base, branch, committed1, committed2));
@@ -198,6 +210,16 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWit
             .operation(Put.of(key1, table1))
             .commit();
     assertThat(committed1.getHash()).isNotNull();
+
+    table1 =
+        getApi()
+            .getContent()
+            .reference(committed1)
+            .key(key1)
+            .get()
+            .get(key1)
+            .unwrap(IcebergTable.class)
+            .get();
 
     Branch committed2 =
         getApi()

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -39,6 +39,7 @@ import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.IcebergView;
 import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.ImmutableDeltaLakeTable;
+import org.projectnessie.model.ImmutableNamespace;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.server.store.proto.ObjectTypes;
 import org.projectnessie.server.store.proto.ObjectTypes.IcebergMetadataPointer;
@@ -46,8 +47,10 @@ import org.projectnessie.server.store.proto.ObjectTypes.IcebergRefState;
 import org.projectnessie.server.store.proto.ObjectTypes.IcebergViewState;
 
 class TestStoreWorker {
+
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String ID = "x";
+  public static final String CID = "cid";
   private final TableCommitMetaStoreWorker worker = new TableCommitMetaStoreWorker();
 
   @Test
@@ -56,7 +59,7 @@ class TestStoreWorker {
             () ->
                 worker.valueFromStore(
                     ObjectTypes.Content.newBuilder()
-                        .setId("cid")
+                        .setId(CID)
                         .setIcebergRefState(
                             ObjectTypes.IcebergRefState.newBuilder()
                                 .setSnapshotId(42)
@@ -75,7 +78,7 @@ class TestStoreWorker {
     Content value =
         worker.valueFromStore(
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergRefState(
                     IcebergRefState.newBuilder()
                         .setSnapshotId(42)
@@ -86,7 +89,7 @@ class TestStoreWorker {
                 .toByteString(),
             () ->
                 ObjectTypes.Content.newBuilder()
-                    .setId("cid")
+                    .setId(CID)
                     .setIcebergMetadataPointer(
                         IcebergMetadataPointer.newBuilder()
                             .setMetadataLocation("metadata-location"))
@@ -109,7 +112,7 @@ class TestStoreWorker {
     Content value =
         worker.valueFromStore(
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergRefState(
                     IcebergRefState.newBuilder()
                         .setSnapshotId(42)
@@ -138,7 +141,7 @@ class TestStoreWorker {
             () ->
                 worker.valueFromStore(
                     ObjectTypes.Content.newBuilder()
-                        .setId("cid")
+                        .setId(CID)
                         .setIcebergViewState(
                             ObjectTypes.IcebergViewState.newBuilder().setVersionId(42))
                         .build()
@@ -153,13 +156,13 @@ class TestStoreWorker {
     Content value =
         worker.valueFromStore(
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergViewState(ObjectTypes.IcebergViewState.newBuilder().setVersionId(42))
                 .build()
                 .toByteString(),
             () ->
                 ObjectTypes.Content.newBuilder()
-                    .setId("cid")
+                    .setId(CID)
                     .setIcebergMetadataPointer(
                         IcebergMetadataPointer.newBuilder()
                             .setMetadataLocation("metadata-location"))
@@ -175,20 +178,20 @@ class TestStoreWorker {
   static Stream<Arguments> requiresGlobalStateModelType() {
     return Stream.of(
         Arguments.of(
-            Namespace.of("foo"),
+            withId(Namespace.of("foo")),
             false,
             ObjectTypes.Content.newBuilder()
-                .setId("foo")
+                .setId(CID)
                 .setNamespace(ObjectTypes.Namespace.newBuilder().addElements("foo")),
             null,
             false,
             Content.Type.NAMESPACE),
         //
         Arguments.of(
-            IcebergTable.of("metadata", 42, 43, 44, 45, "cid"),
+            IcebergTable.of("metadata", 42, 43, 44, 45, CID),
             false,
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergRefState(
                     ObjectTypes.IcebergRefState.newBuilder()
                         .setSnapshotId(42)
@@ -196,7 +199,7 @@ class TestStoreWorker {
                         .setSpecId(44)
                         .setSortOrderId(45)),
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergMetadataPointer(
                     ObjectTypes.IcebergMetadataPointer.newBuilder()
                         .setMetadataLocation("metadata")),
@@ -204,10 +207,10 @@ class TestStoreWorker {
             Content.Type.ICEBERG_TABLE),
         //
         Arguments.of(
-            IcebergTable.of("metadata", 42, 43, 44, 45, "cid"),
+            IcebergTable.of("metadata", 42, 43, 44, 45, CID),
             false,
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergRefState(
                     ObjectTypes.IcebergRefState.newBuilder()
                         .setSnapshotId(42)
@@ -220,10 +223,10 @@ class TestStoreWorker {
             Content.Type.ICEBERG_TABLE),
         //
         Arguments.of(
-            IcebergView.of("cid", "metadata", 42, 43, "dialect", "sqlText"),
+            IcebergView.of(CID, "metadata", 42, 43, "dialect", "sqlText"),
             false,
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergViewState(
                     ObjectTypes.IcebergViewState.newBuilder()
                         .setVersionId(42)
@@ -231,7 +234,7 @@ class TestStoreWorker {
                         .setDialect("dialect")
                         .setSqlText("sqlText")),
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergMetadataPointer(
                     ObjectTypes.IcebergMetadataPointer.newBuilder()
                         .setMetadataLocation("metadata")),
@@ -239,10 +242,10 @@ class TestStoreWorker {
             Content.Type.ICEBERG_VIEW),
         //
         Arguments.of(
-            IcebergView.of("cid", "metadata", 42, 43, "dialect", "sqlText"),
+            IcebergView.of(CID, "metadata", 42, 43, "dialect", "sqlText"),
             false,
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergViewState(
                     ObjectTypes.IcebergViewState.newBuilder()
                         .setVersionId(42)
@@ -256,13 +259,13 @@ class TestStoreWorker {
         //
         Arguments.of(
             ImmutableDeltaLakeTable.builder()
-                .id("cid")
+                .id(CID)
                 .addCheckpointLocationHistory("check")
                 .addMetadataLocationHistory("meta")
                 .build(),
             false,
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setDeltaLakeTable(
                     ObjectTypes.DeltaLakeTable.newBuilder()
                         .addCheckpointLocationHistory("check")
@@ -330,7 +333,7 @@ class TestStoreWorker {
     Content value =
         worker.valueFromStore(
             ObjectTypes.Content.newBuilder()
-                .setId("cid")
+                .setId(CID)
                 .setIcebergViewState(
                     ObjectTypes.IcebergViewState.newBuilder()
                         .setVersionId(42)
@@ -495,7 +498,7 @@ class TestStoreWorker {
 
   private static Map.Entry<ByteString, Content> getNamespace() {
     List<String> elements = Arrays.asList("a", "b.c", "d");
-    Namespace namespace = Namespace.of(elements);
+    Namespace namespace = withId(Namespace.of(elements));
     ByteString bytes =
         ObjectTypes.Content.newBuilder()
             .setId(namespace.getId())
@@ -508,7 +511,7 @@ class TestStoreWorker {
   private static Map.Entry<ByteString, Content> getNamespaceWithProperties() {
     List<String> elements = Arrays.asList("a", "b.c", "d");
     Map<String, String> properties = ImmutableMap.of("key1", "val1");
-    Namespace namespace = Namespace.of(elements, properties);
+    Namespace namespace = withId(Namespace.of(elements, properties));
     ByteString bytes =
         ObjectTypes.Content.newBuilder()
             .setId(namespace.getId())
@@ -520,5 +523,9 @@ class TestStoreWorker {
             .build()
             .toByteString();
     return new AbstractMap.SimpleImmutableEntry<>(bytes, namespace);
+  }
+
+  private static Namespace withId(Namespace namespace) {
+    return ImmutableNamespace.builder().from(namespace).id(CID).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
@@ -33,6 +33,8 @@ public interface StoreWorker<CONTENT, COMMIT_METADATA, CONTENT_TYPE extends Enum
 
   CONTENT valueFromStore(ByteString onReferenceValue, Supplier<ByteString> globalState);
 
+  CONTENT applyId(CONTENT content, String id);
+
   String getId(CONTENT content);
 
   Byte getPayload(CONTENT content);

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/SimpleStoreWorker.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/SimpleStoreWorker.java
@@ -22,6 +22,7 @@ import static org.projectnessie.versioned.testworker.OnRefOnly.onRef;
 import static org.projectnessie.versioned.testworker.WithGlobalStateContent.withGlobal;
 
 import com.google.protobuf.ByteString;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.projectnessie.versioned.Serializer;
 import org.projectnessie.versioned.StoreWorker;
@@ -98,6 +99,21 @@ public final class SimpleStoreWorker
       default:
         throw new IllegalArgumentException("" + onReferenceValue);
     }
+  }
+
+  @Override
+  public BaseContent applyId(BaseContent baseContent, String id) {
+    Objects.requireNonNull(baseContent, "baseContent must not be null");
+    Objects.requireNonNull(id, "id must not be null");
+    if (baseContent instanceof OnRefOnly) {
+      OnRefOnly onRef = (OnRefOnly) baseContent;
+      return OnRefOnly.onRef(onRef.getOnRef(), id);
+    }
+    if (baseContent instanceof WithGlobalStateContent) {
+      WithGlobalStateContent withGlobal = (WithGlobalStateContent) baseContent;
+      return WithGlobalStateContent.withGlobal(withGlobal.getGlobal(), withGlobal.getOnRef(), id);
+    }
+    throw new IllegalArgumentException("Unknown type " + baseContent);
   }
 
   @Override


### PR DESCRIPTION
This change is driven by the demand to have "unique" content-IDs for
namespaces. Technically there are two kinds of namespaces:
* explicitly created namespaces (via `NamespaceApi.createNamespace`)
  and
* implicitly "created" namespaces, which are returned by
  `NamespaceApi.getNamespaces`, if no explicitly created namespace
  exists.

The previous approach had a deterministic content ID, because
content ID == namespace-path. "Unique" (aka `UUID.randomUUID()`)
are not deterministic.

To be able to distinguish between implicitly and explicitly created
namespaces (think: retrieving an implicitly created one, adding
properties and persisting it vs. the same with an explicitly created
namespace), the content ID must be `null` for implicitly created
namespaces and non-`null` for explicitly created ones.

This mandates the change to make `Content.getId()` `@Nullable` and
remove the "implicit" creation of a content ID, if not present.

Also implicitly changes the technical behavior that content-IDs are
now _only_ created on the server side. Previously, the content-ID
was generated for clients using the Java `:nessie-model` classes.

A content object to be created must have no (== `null`) content ID
and the expected-content object must be `null` as well.
A content object to be updated must have a non-`null` content ID,
and the expected-content object must be non-`null` as well, with
the same content-ID.

Fixes #3731
Fixes #4017