### PR TITLE
Show error prone warnings during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1305,6 +1305,7 @@ limitations under the License.
                 <!-- Turning off Unicode check as it gives invalid errors in ErrorProne 2.11.0 -->
                 <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -XepExcludedPaths:.*/target/generated-*sources/.*</arg>
               </compilerArgs>
+              <showWarnings>true</showWarnings>
               <annotationProcessorPaths combine.children="append">
                 <path>
                   <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
The `error-prone` profile, although practically enabled by default, is
currently kinda useless, because warnings aren't printed yet.

This change enables the output of compiler warnings, and therefore
the error-prone warnings as well.