### PR TITLE
Fix `unknown enum constant SchemaType.OBJECT` compilation warnings

### DIFF
--- a/clients/deltalake/pom.xml
+++ b/clients/deltalake/pom.xml
@@ -74,6 +74,11 @@
       <version>${deltalake.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-spark-3.2-extensions</artifactId>
       <version>${project.version}</version>

--- a/clients/iceberg-views/pom.xml
+++ b/clients/iceberg-views/pom.xml
@@ -76,6 +76,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-persist-tests</artifactId>
       <version>${project.version}</version>

--- a/clients/spark-extensions-base/pom.xml
+++ b/clients/spark-extensions-base/pom.xml
@@ -37,6 +37,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-spark-extensions-grammar</artifactId>
       <version>${project.version}</version>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -78,6 +78,11 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/compatibility/compatibility-tests/pom.xml
+++ b/compatibility/compatibility-tests/pom.xml
@@ -49,6 +49,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-versioned-persist-in-memory</artifactId>
       <version>${project.version}</version>

--- a/compatibility/jersey/pom.xml
+++ b/compatibility/jersey/pom.xml
@@ -125,5 +125,10 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/gc/gc-base/pom.xml
+++ b/gc/gc-base/pom.xml
@@ -42,6 +42,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/perftest/simulations/pom.xml
+++ b/perftest/simulations/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>nessie-perftest-gatling</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/servers/jax-rs-testextension/pom.xml
+++ b/servers/jax-rs-testextension/pom.xml
@@ -40,5 +40,10 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/servers/jax-rs-tests/pom.xml
+++ b/servers/jax-rs-tests/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
       <scope>test</scope>

--- a/servers/jax-rs/pom.xml
+++ b/servers/jax-rs/pom.xml
@@ -194,5 +194,10 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/servers/quarkus-common/pom.xml
+++ b/servers/quarkus-common/pom.xml
@@ -118,5 +118,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-mongodb-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/servers/rest-services/pom.xml
+++ b/servers/rest-services/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/servers/services/pom.xml
+++ b/servers/services/pom.xml
@@ -58,6 +58,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/servers/store/pom.xml
+++ b/servers/store/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/tools/content-generator/pom.xml
+++ b/tools/content-generator/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
       <optional>true</optional>

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
@@ -48,16 +48,10 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
 
     final String name;
     String msg;
-    ThrowingFunction setup;
     ThrowingFunction function;
 
     ReferenceNotFoundFunction(String name) {
       this.name = name;
-    }
-
-    ReferenceNotFoundFunction setup(ThrowingFunction setup) {
-      this.setup = setup;
-      return this;
     }
 
     ReferenceNotFoundFunction function(ThrowingFunction function) {
@@ -270,10 +264,7 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
 
   @ParameterizedTest
   @MethodSource("referenceNotFoundFunctions")
-  void referenceNotFound(ReferenceNotFoundFunction f) throws Exception {
-    if (f.setup != null) {
-      f.setup.run(store());
-    }
+  void referenceNotFound(ReferenceNotFoundFunction f) {
     assertThatThrownBy(() -> f.function.run(store()))
         .isInstanceOf(ReferenceNotFoundException.class)
         .hasMessage(f.msg);


### PR DESCRIPTION
```
[WARN] unknown enum constant SchemaType.OBJECT
[WARN]   reason: class file for org.eclipse.microprofile.openapi.annotations.enums.SchemaType not found
```