### PR TITLE
Fix `BadImport` error-prone warnings

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
@@ -40,7 +40,6 @@ import org.projectnessie.api.http.HttpDiffApi;
 import org.projectnessie.api.http.HttpNamespaceApi;
 import org.projectnessie.api.http.HttpRefLogApi;
 import org.projectnessie.api.http.HttpTreeApi;
-import org.projectnessie.client.http.HttpClient.Builder;
 import org.projectnessie.client.rest.NessieHttpResponseFilter;
 import org.projectnessie.error.BaseNessieClientServerException;
 
@@ -67,7 +66,7 @@ public class NessieHttpClient extends NessieApiClient {
   }
 
   private static HttpClient buildClient(
-      HttpAuthentication authentication, boolean enableTracing, Builder clientBuilder) {
+      HttpAuthentication authentication, boolean enableTracing, HttpClient.Builder clientBuilder) {
     clientBuilder.setObjectMapper(MAPPER);
     if (enableTracing) {
       addTracing(clientBuilder);

--- a/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/DatabaseAdapters.java
+++ b/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/DatabaseAdapters.java
@@ -24,7 +24,6 @@ import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory.Builder;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
 import org.projectnessie.versioned.persist.tests.SystemPropertiesConfigurer;
@@ -124,20 +123,26 @@ public class DatabaseAdapters {
   }
 
   private static DatabaseAdapter buildPre019(
-      Builder<DatabaseAdapterConfig, DatabaseAdapterConfig, DatabaseConnectionProvider<?>> builder,
+      DatabaseAdapterFactory.Builder<
+              DatabaseAdapterConfig, DatabaseAdapterConfig, DatabaseConnectionProvider<?>>
+          builder,
       Method build) {
     return doBuild(builder, build);
   }
 
   private static DatabaseAdapter buildWithStoreWorker(
-      Builder<DatabaseAdapterConfig, DatabaseAdapterConfig, DatabaseConnectionProvider<?>> builder)
+      DatabaseAdapterFactory.Builder<
+              DatabaseAdapterConfig, DatabaseAdapterConfig, DatabaseConnectionProvider<?>>
+          builder)
       throws NoSuchMethodException, ClassNotFoundException {
     Method build = DatabaseAdapterFactory.Builder.class.getMethod("build", StoreWorker.class);
     return doBuild(builder, build, new TableCommitMetaStoreWorker());
   }
 
   private static DatabaseAdapter buildWithContentVariantSupplier(
-      Builder<DatabaseAdapterConfig, DatabaseAdapterConfig, DatabaseConnectionProvider<?>> builder)
+      DatabaseAdapterFactory.Builder<
+              DatabaseAdapterConfig, DatabaseAdapterConfig, DatabaseConnectionProvider<?>>
+          builder)
       throws NoSuchMethodException, ClassNotFoundException, InvocationTargetException,
           InstantiationException, IllegalAccessException {
     Method build =
@@ -152,7 +157,9 @@ public class DatabaseAdapters {
   }
 
   private static DatabaseAdapter doBuild(
-      Builder<DatabaseAdapterConfig, DatabaseAdapterConfig, DatabaseConnectionProvider<?>> builder,
+      DatabaseAdapterFactory.Builder<
+              DatabaseAdapterConfig, DatabaseAdapterConfig, DatabaseConnectionProvider<?>>
+          builder,
       Method build,
       Object... args) {
     try {

--- a/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/PersistVersionStoreExtension.java
+++ b/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/PersistVersionStoreExtension.java
@@ -25,7 +25,6 @@ import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.util.TypeLiteral;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
@@ -46,7 +45,7 @@ public class PersistVersionStoreExtension implements Extension {
     TableCommitMetaStoreWorker storeWorker = new TableCommitMetaStoreWorker();
 
     abd.addBean()
-        .addType(new TypeLiteral<VersionStore<Content, CommitMeta, Type>>() {})
+        .addType(new TypeLiteral<VersionStore<Content, CommitMeta, Content.Type>>() {})
         .addQualifier(Default.Literal.INSTANCE)
         .scope(ApplicationScoped.class)
         .produceWith(i -> new PersistVersionStore<>(databaseAdapter.get(), storeWorker));

--- a/model/src/main/java/org/projectnessie/model/Content.java
+++ b/model/src/main/java/org/projectnessie/model/Content.java
@@ -17,7 +17,6 @@ package org.projectnessie.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Objects;
 import java.util.Optional;
@@ -40,12 +39,12 @@ import org.immutables.value.Value;
     },
     discriminatorProperty = "type")
 @JsonSubTypes({
-  @Type(IcebergTable.class),
-  @Type(DeltaLakeTable.class),
-  @Type(IcebergView.class),
-  @Type(Namespace.class)
+  @JsonSubTypes.Type(IcebergTable.class),
+  @JsonSubTypes.Type(DeltaLakeTable.class),
+  @JsonSubTypes.Type(IcebergView.class),
+  @JsonSubTypes.Type(Namespace.class)
 })
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public abstract class Content {
 
   public enum Type {

--- a/model/src/main/java/org/projectnessie/model/ContentKey.java
+++ b/model/src/main/java/org/projectnessie/model/ContentKey.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import org.immutables.value.Value;
-import org.projectnessie.model.ImmutableContentKey.Builder;
 
 /**
  * Key for the content of an object.
@@ -66,7 +65,7 @@ public abstract class ContentKey {
   }
 
   public static ContentKey of(Namespace namespace, String name) {
-    Builder b = ImmutableContentKey.builder();
+    ImmutableContentKey.Builder b = ImmutableContentKey.builder();
     if (namespace != null && !namespace.isEmpty()) {
       b.elements(namespace.getElements());
     }

--- a/model/src/main/java/org/projectnessie/model/Operation.java
+++ b/model/src/main/java/org/projectnessie/model/Operation.java
@@ -16,7 +16,6 @@
 package org.projectnessie.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -39,9 +38,9 @@ import org.immutables.value.Value;
     },
     discriminatorProperty = "type")
 @JsonSubTypes({
-  @Type(Operation.Put.class),
-  @Type(Operation.Delete.class),
-  @Type(Operation.Unchanged.class)
+  @JsonSubTypes.Type(Operation.Put.class),
+  @JsonSubTypes.Type(Operation.Delete.class),
+  @JsonSubTypes.Type(Operation.Unchanged.class)
 })
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public interface Operation {

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
@@ -48,8 +47,12 @@ import org.immutables.value.Value;
       @SchemaProperty(name = "hash", pattern = Validation.HASH_REGEX),
       @SchemaProperty(name = "metadata", nullable = true)
     })
-@JsonSubTypes({@Type(Branch.class), @Type(Tag.class), @Type(Detached.class)})
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(Branch.class),
+  @JsonSubTypes.Type(Tag.class),
+  @JsonSubTypes.Type(Detached.class)
+})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public interface Reference extends Base {
   /** Human-readable reference name. */
   @NotBlank

--- a/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.model.BaseMergeTransplant.MergeBehavior;
 import org.projectnessie.model.BaseMergeTransplant.MergeKeyBehavior;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.LogResponse.LogEntry;
 
 /**
@@ -99,7 +98,7 @@ public class TestModelObjectsSerialization {
             EntriesResponse.builder()
                 .addEntries(
                     ImmutableEntry.builder()
-                        .type(Type.ICEBERG_TABLE)
+                        .type(Content.Type.ICEBERG_TABLE)
                         .name(ContentKey.fromPathString("/tmp/testpath"))
                         .build())
                 .token(HASH)

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestContents.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestContents.java
@@ -31,7 +31,6 @@ import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.EntriesResponse.Entry;
 import org.projectnessie.model.IcebergTable;
@@ -46,15 +45,16 @@ import org.projectnessie.model.Operation.Unchanged;
 public abstract class AbstractRestContents extends AbstractRestCommitLog {
 
   public static final class ContentAndOperationType {
-    final Type type;
+    final Content.Type type;
     final Operation operation;
     final Operation globalOperation;
 
-    public ContentAndOperationType(Type type, Operation operation) {
+    public ContentAndOperationType(Content.Type type, Operation operation) {
       this(type, operation, null);
     }
 
-    public ContentAndOperationType(Type type, Operation operation, Operation globalOperation) {
+    public ContentAndOperationType(
+        Content.Type type, Operation operation, Operation globalOperation) {
       this.type = type;
       this.operation = operation;
       this.globalOperation = globalOperation;
@@ -81,26 +81,26 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
   public static Stream<ContentAndOperationType> contentAndOperationTypes() {
     return Stream.of(
         new ContentAndOperationType(
-            Type.ICEBERG_TABLE,
+            Content.Type.ICEBERG_TABLE,
             Put.of(
                 ContentKey.of("a", "iceberg"), IcebergTable.of("/iceberg/table", 42, 42, 42, 42))),
         new ContentAndOperationType(
-            Type.ICEBERG_VIEW,
+            Content.Type.ICEBERG_VIEW,
             Put.of(
                 ContentKey.of("a", "view_dremio"),
                 IcebergView.of("/iceberg/view", 1, 1, "Dremio", "SELECT foo FROM dremio"))),
         new ContentAndOperationType(
-            Type.ICEBERG_VIEW,
+            Content.Type.ICEBERG_VIEW,
             Put.of(
                 ContentKey.of("a", "view_presto"),
                 IcebergView.of("/iceberg/view", 1, 1, "Presto", "SELECT foo FROM presto"))),
         new ContentAndOperationType(
-            Type.ICEBERG_VIEW,
+            Content.Type.ICEBERG_VIEW,
             Put.of(
                 ContentKey.of("b", "view_spark"),
                 IcebergView.of("/iceberg/view2", 1, 1, "Spark", "SELECT foo FROM spark"))),
         new ContentAndOperationType(
-            Type.DELTA_LAKE_TABLE,
+            Content.Type.DELTA_LAKE_TABLE,
             Put.of(
                 ContentKey.of("c", "delta"),
                 ImmutableDeltaLakeTable.builder()
@@ -108,21 +108,21 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
                     .addMetadataLocationHistory("metadata")
                     .build())),
         new ContentAndOperationType(
-            Type.ICEBERG_TABLE, Delete.of(ContentKey.of("a", "iceberg_delete"))),
+            Content.Type.ICEBERG_TABLE, Delete.of(ContentKey.of("a", "iceberg_delete"))),
         new ContentAndOperationType(
-            Type.ICEBERG_TABLE, Unchanged.of(ContentKey.of("a", "iceberg_unchanged"))),
+            Content.Type.ICEBERG_TABLE, Unchanged.of(ContentKey.of("a", "iceberg_unchanged"))),
         new ContentAndOperationType(
-            Type.ICEBERG_VIEW, Delete.of(ContentKey.of("a", "view_dremio_delete"))),
+            Content.Type.ICEBERG_VIEW, Delete.of(ContentKey.of("a", "view_dremio_delete"))),
         new ContentAndOperationType(
-            Type.ICEBERG_VIEW, Unchanged.of(ContentKey.of("a", "view_dremio_unchanged"))),
+            Content.Type.ICEBERG_VIEW, Unchanged.of(ContentKey.of("a", "view_dremio_unchanged"))),
         new ContentAndOperationType(
-            Type.ICEBERG_VIEW, Delete.of(ContentKey.of("a", "view_spark_delete"))),
+            Content.Type.ICEBERG_VIEW, Delete.of(ContentKey.of("a", "view_spark_delete"))),
         new ContentAndOperationType(
-            Type.ICEBERG_VIEW, Unchanged.of(ContentKey.of("a", "view_spark_unchanged"))),
+            Content.Type.ICEBERG_VIEW, Unchanged.of(ContentKey.of("a", "view_spark_unchanged"))),
         new ContentAndOperationType(
-            Type.DELTA_LAKE_TABLE, Delete.of(ContentKey.of("a", "delta_delete"))),
+            Content.Type.DELTA_LAKE_TABLE, Delete.of(ContentKey.of("a", "delta_delete"))),
         new ContentAndOperationType(
-            Type.DELTA_LAKE_TABLE, Unchanged.of(ContentKey.of("a", "delta_unchanged"))));
+            Content.Type.DELTA_LAKE_TABLE, Unchanged.of(ContentKey.of("a", "delta_unchanged"))));
   }
 
   @Test

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestEntries.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestEntries.java
@@ -34,7 +34,7 @@ import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
-import org.projectnessie.model.Content.Type;
+import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.EntriesResponse.Entry;
 import org.projectnessie.model.IcebergTable;
@@ -71,8 +71,8 @@ public abstract class AbstractRestEntries extends AbstractRestDiff {
         getApi().getEntries().reference(refMode.transform(branch)).get().getEntries();
     List<Entry> expected =
         asList(
-            Entry.builder().name(a).type(Type.ICEBERG_TABLE).build(),
-            Entry.builder().name(b).type(Type.ICEBERG_VIEW).build());
+            Entry.builder().name(a).type(Content.Type.ICEBERG_TABLE).build(),
+            Entry.builder().name(b).type(Content.Type.ICEBERG_VIEW).build());
     assertThat(entries).containsExactlyInAnyOrderElementsOf(expected);
 
     entries =
@@ -237,7 +237,7 @@ public abstract class AbstractRestEntries extends AbstractRestDiff {
             .getEntries();
     assertThat(entries).hasSize(1);
     assertThat(entries.get(0))
-        .matches(e -> e.getType().equals(Type.NAMESPACE))
+        .matches(e -> e.getType().equals(Content.Type.NAMESPACE))
         .matches(e -> e.getName().equals(ContentKey.of("a")));
 
     entries =
@@ -250,13 +250,13 @@ public abstract class AbstractRestEntries extends AbstractRestDiff {
             .getEntries();
     assertThat(entries).hasSize(3);
     assertThat(entries.get(2))
-        .matches(e -> e.getType().equals(Type.ICEBERG_TABLE))
+        .matches(e -> e.getType().equals(Content.Type.ICEBERG_TABLE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "thirdTable")));
     assertThat(entries.get(1))
-        .matches(e -> e.getType().equals(Type.NAMESPACE))
+        .matches(e -> e.getType().equals(Content.Type.NAMESPACE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "b")));
     assertThat(entries.get(0))
-        .matches(e -> e.getType().equals(Type.NAMESPACE))
+        .matches(e -> e.getType().equals(Content.Type.NAMESPACE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "boo")));
 
     entries =
@@ -269,10 +269,10 @@ public abstract class AbstractRestEntries extends AbstractRestDiff {
             .getEntries();
     assertThat(entries).hasSize(2);
     assertThat(entries.get(1))
-        .matches(e -> e.getType().equals(Type.NAMESPACE))
+        .matches(e -> e.getType().equals(Content.Type.NAMESPACE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "b", "c")));
     assertThat(entries.get(0))
-        .matches(e -> e.getType().equals(Type.ICEBERG_TABLE))
+        .matches(e -> e.getType().equals(Content.Type.ICEBERG_TABLE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "b", "fourthTable")));
 
     entries =
@@ -285,10 +285,10 @@ public abstract class AbstractRestEntries extends AbstractRestDiff {
             .getEntries();
     assertThat(entries).hasSize(2);
     assertThat(entries.get(1))
-        .matches(e -> e.getType().equals(Type.ICEBERG_TABLE))
+        .matches(e -> e.getType().equals(Content.Type.ICEBERG_TABLE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "b", "c", "firstTable")));
     assertThat(entries.get(0))
-        .matches(e -> e.getType().equals(Type.ICEBERG_TABLE))
+        .matches(e -> e.getType().equals(Content.Type.ICEBERG_TABLE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "b", "c", "secondTable")));
 
     entries =
@@ -311,13 +311,13 @@ public abstract class AbstractRestEntries extends AbstractRestDiff {
             .getEntries();
     assertThat(entries).hasSize(3);
     assertThat(entries.get(2))
-        .matches(e -> e.getType().equals(Type.NAMESPACE))
+        .matches(e -> e.getType().equals(Content.Type.NAMESPACE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "b", "c")));
     assertThat(entries.get(1))
-        .matches(e -> e.getType().equals(Type.ICEBERG_TABLE))
+        .matches(e -> e.getType().equals(Content.Type.ICEBERG_TABLE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "b", "fourthTable")));
     assertThat(entries.get(0))
-        .matches(e -> e.getType().equals(Type.ICEBERG_TABLE))
+        .matches(e -> e.getType().equals(Content.Type.ICEBERG_TABLE))
         .matches(e -> e.getName().equals(ContentKey.of("a", "boo", "fifthTable")));
 
     if (ReferenceMode.DETACHED != refMode) {

--- a/servers/jax-rs/src/main/java/org/projectnessie/versioned/PersistVersionStoreExtension.java
+++ b/servers/jax-rs/src/main/java/org/projectnessie/versioned/PersistVersionStoreExtension.java
@@ -25,7 +25,6 @@ import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.util.TypeLiteral;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.store.PersistVersionStore;
@@ -46,7 +45,7 @@ public class PersistVersionStoreExtension implements Extension {
     TableCommitMetaStoreWorker storeWorker = new TableCommitMetaStoreWorker();
 
     abd.addBean()
-        .addType(new TypeLiteral<VersionStore<Content, CommitMeta, Type>>() {})
+        .addType(new TypeLiteral<VersionStore<Content, CommitMeta, Content.Type>>() {})
         .addQualifier(Default.Literal.INSTANCE)
         .scope(ApplicationScoped.class)
         .produceWith(i -> new PersistVersionStore<>(databaseAdapter.get(), storeWorker));

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
@@ -24,7 +24,6 @@ import org.projectnessie.api.http.HttpContentApi;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.GetMultipleContentsRequest;
 import org.projectnessie.model.GetMultipleContentsResponse;
@@ -42,7 +41,7 @@ public class RestContentResource implements HttpContentApi {
   // empty resources (no REST methods defined) and potentially other.
 
   private final ServerConfig config;
-  private final VersionStore<Content, CommitMeta, Type> store;
+  private final VersionStore<Content, CommitMeta, Content.Type> store;
   private final Authorizer authorizer;
 
   @Context SecurityContext securityContext;
@@ -54,7 +53,9 @@ public class RestContentResource implements HttpContentApi {
 
   @Inject
   public RestContentResource(
-      ServerConfig config, VersionStore<Content, CommitMeta, Type> store, Authorizer authorizer) {
+      ServerConfig config,
+      VersionStore<Content, CommitMeta, Content.Type> store,
+      Authorizer authorizer) {
     this.config = config;
     this.store = store;
     this.authorizer = authorizer;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
@@ -25,7 +25,6 @@ import org.projectnessie.api.params.DiffParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.DiffResponse;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
@@ -41,7 +40,7 @@ public class RestDiffResource implements HttpDiffApi {
   // empty resources (no REST methods defined) and potentially other.
 
   private final ServerConfig config;
-  private final VersionStore<Content, CommitMeta, Type> store;
+  private final VersionStore<Content, CommitMeta, Content.Type> store;
   private final Authorizer authorizer;
 
   @Context SecurityContext securityContext;
@@ -53,7 +52,9 @@ public class RestDiffResource implements HttpDiffApi {
 
   @Inject
   public RestDiffResource(
-      ServerConfig config, VersionStore<Content, CommitMeta, Type> store, Authorizer authorizer) {
+      ServerConfig config,
+      VersionStore<Content, CommitMeta, Content.Type> store,
+      Authorizer authorizer) {
     this.config = config;
     this.store = store;
     this.authorizer = authorizer;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
@@ -31,7 +31,6 @@ import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.GetNamespacesResponse;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.services.authz.Authorizer;
@@ -48,7 +47,7 @@ public class RestNamespaceResource implements HttpNamespaceApi {
   // NamespaceApi, empty resources (no REST methods defined) and potentially other.
 
   private final ServerConfig config;
-  private final VersionStore<Content, CommitMeta, Type> store;
+  private final VersionStore<Content, CommitMeta, Content.Type> store;
   private final Authorizer authorizer;
 
   @Context SecurityContext securityContext;
@@ -60,7 +59,9 @@ public class RestNamespaceResource implements HttpNamespaceApi {
 
   @Inject
   public RestNamespaceResource(
-      ServerConfig config, VersionStore<Content, CommitMeta, Type> store, Authorizer authorizer) {
+      ServerConfig config,
+      VersionStore<Content, CommitMeta, Content.Type> store,
+      Authorizer authorizer) {
     this.config = config;
     this.store = store;
     this.authorizer = authorizer;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogResource.java
@@ -25,7 +25,6 @@ import org.projectnessie.api.params.RefLogParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
@@ -37,7 +36,7 @@ import org.projectnessie.versioned.VersionStore;
 public class RestRefLogResource implements HttpRefLogApi {
 
   private final ServerConfig config;
-  private final VersionStore<Content, CommitMeta, Type> store;
+  private final VersionStore<Content, CommitMeta, Content.Type> store;
   private final Authorizer authorizer;
 
   @Context SecurityContext securityContext;
@@ -49,7 +48,9 @@ public class RestRefLogResource implements HttpRefLogApi {
 
   @Inject
   public RestRefLogResource(
-      ServerConfig config, VersionStore<Content, CommitMeta, Type> store, Authorizer authorizer) {
+      ServerConfig config,
+      VersionStore<Content, CommitMeta, Content.Type> store,
+      Authorizer authorizer) {
     this.config = config;
     this.store = store;
     this.authorizer = authorizer;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -30,7 +30,6 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Merge;
@@ -52,7 +51,7 @@ public class RestTreeResource implements HttpTreeApi {
   // empty resources (no REST methods defined) and potentially other.
 
   private final ServerConfig config;
-  private final VersionStore<Content, CommitMeta, Type> store;
+  private final VersionStore<Content, CommitMeta, Content.Type> store;
   private final Authorizer authorizer;
 
   @Context SecurityContext securityContext;
@@ -64,7 +63,9 @@ public class RestTreeResource implements HttpTreeApi {
 
   @Inject
   public RestTreeResource(
-      ServerConfig config, VersionStore<Content, CommitMeta, Type> store, Authorizer authorizer) {
+      ServerConfig config,
+      VersionStore<Content, CommitMeta, Content.Type> store,
+      Authorizer authorizer) {
     this.config = config;
     this.store = store;
     this.authorizer = authorizer;

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImplWithAuthorization.java
@@ -19,7 +19,6 @@ import java.security.Principal;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.GetMultipleContentsRequest;
 import org.projectnessie.model.GetMultipleContentsResponse;
@@ -35,7 +34,7 @@ public class ContentApiImplWithAuthorization extends ContentApiImpl {
 
   public ContentApiImplWithAuthorization(
       ServerConfig config,
-      VersionStore<Content, CommitMeta, Type> store,
+      VersionStore<Content, CommitMeta, Content.Type> store,
       Authorizer authorizer,
       Principal principal) {
     super(config, store, authorizer, principal);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -27,7 +27,6 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.DiffResponse;
 import org.projectnessie.model.ImmutableDiffEntry;
 import org.projectnessie.model.ImmutableDiffResponse;
-import org.projectnessie.model.ImmutableDiffResponse.Builder;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.Diff;
@@ -56,7 +55,7 @@ public class DiffApiImpl extends BaseApiImpl implements DiffApi {
   }
 
   protected DiffResponse getDiff(Hash from, Hash to) throws NessieNotFoundException {
-    Builder builder = ImmutableDiffResponse.builder();
+    ImmutableDiffResponse.Builder builder = ImmutableDiffResponse.builder();
     try {
       try (Stream<Diff<Content>> diffs = getStore().getDiffs(from, to)) {
         diffs

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImplWithAuthorization.java
@@ -20,7 +20,6 @@ import org.projectnessie.api.params.DiffParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.DiffResponse;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
@@ -33,7 +32,7 @@ public class DiffApiImplWithAuthorization extends DiffApiImpl {
 
   public DiffApiImplWithAuthorization(
       ServerConfig config,
-      VersionStore<Content, CommitMeta, Type> store,
+      VersionStore<Content, CommitMeta, Content.Type> store,
       Authorizer authorizer,
       Principal principal) {
     super(config, store, authorizer, principal);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImplWithAuthorization.java
@@ -24,7 +24,6 @@ import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.GetNamespacesResponse;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.services.authz.Authorizer;
@@ -36,7 +35,7 @@ public class NamespaceApiImplWithAuthorization extends NamespaceApiImpl {
 
   public NamespaceApiImplWithAuthorization(
       ServerConfig config,
-      VersionStore<Content, CommitMeta, Type> store,
+      VersionStore<Content, CommitMeta, Content.Type> store,
       Authorizer authorizer,
       Principal principal) {
     super(config, store, authorizer, principal);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImpl.java
@@ -37,7 +37,6 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.error.NessieRefLogNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.ImmutableRefLogResponse;
 import org.projectnessie.model.ImmutableRefLogResponseEntry;
 import org.projectnessie.model.RefLogResponse;
@@ -54,7 +53,7 @@ public class RefLogApiImpl extends BaseApiImpl implements RefLogApi {
 
   public RefLogApiImpl(
       ServerConfig config,
-      VersionStore<Content, CommitMeta, Type> store,
+      VersionStore<Content, CommitMeta, Content.Type> store,
       Authorizer authorizer,
       Principal principal) {
     super(config, store, authorizer, principal);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImplWithAuthorization.java
@@ -20,7 +20,6 @@ import org.projectnessie.api.params.RefLogParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
@@ -31,7 +30,7 @@ public class RefLogApiImplWithAuthorization extends RefLogApiImpl {
 
   public RefLogApiImplWithAuthorization(
       ServerConfig config,
-      VersionStore<Content, CommitMeta, Type> store,
+      VersionStore<Content, CommitMeta, Content.Type> store,
       Authorizer authorizer,
       Principal principal) {
     super(config, store, authorizer, principal);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -63,7 +63,6 @@ import org.projectnessie.model.BaseMergeTransplant;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Detached;
 import org.projectnessie.model.EntriesResponse;
@@ -464,14 +463,14 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
     //  all existing VersionStore implementations have to read all keys anyways so we don't get much
     try {
       ImmutableEntriesResponse.Builder response = EntriesResponse.builder();
-      try (Stream<KeyEntry<Type>> entryStream = getStore().getKeys(refWithHash.getHash())) {
+      try (Stream<KeyEntry<Content.Type>> entryStream = getStore().getKeys(refWithHash.getHash())) {
         Stream<EntriesResponse.Entry> entriesStream =
             filterEntries(refWithHash, entryStream, params.filter())
                 .map(
                     key ->
                         EntriesResponse.Entry.builder()
                             .name(fromKey(key.getKey()))
-                            .type((Type) key.getType())
+                            .type((Content.Type) key.getType())
                             .build());
         if (params.namespaceDepth() != null && params.namespaceDepth() > 0) {
           entriesStream =
@@ -492,7 +491,8 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
     if (depth == null || depth < 1) {
       return entry;
     }
-    Type type = entry.getName().getElements().size() > depth ? Type.NAMESPACE : entry.getType();
+    Content.Type type =
+        entry.getName().getElements().size() > depth ? Content.Type.NAMESPACE : entry.getType();
     ContentKey key = ContentKey.of(entry.getName().getElements().subList(0, depth));
     return EntriesResponse.Entry.builder().type(type).name(key).build();
   }
@@ -504,8 +504,8 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
    * @param filter The filter to filter by
    * @return A potentially filtered {@link Stream} of entries based on the filter
    */
-  protected Stream<KeyEntry<Type>> filterEntries(
-      WithHash<NamedRef> refWithHash, Stream<KeyEntry<Type>> entries, String filter) {
+  protected Stream<KeyEntry<Content.Type>> filterEntries(
+      WithHash<NamedRef> refWithHash, Stream<KeyEntry<Content.Type>> entries, String filter) {
     if (Strings.isNullOrEmpty(filter)) {
       return entries;
     }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
@@ -34,7 +34,6 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.ImmutableLogEntry;
 import org.projectnessie.model.ImmutableLogResponse;
@@ -62,7 +61,7 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
 
   public TreeApiImplWithAuthorization(
       ServerConfig config,
-      VersionStore<Content, CommitMeta, Type> store,
+      VersionStore<Content, CommitMeta, Content.Type> store,
       Authorizer authorizer,
       Principal principal) {
     super(config, store, authorizer, principal);
@@ -142,8 +141,8 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
   }
 
   @Override
-  protected Stream<KeyEntry<Type>> filterEntries(
-      WithHash<NamedRef> refWithHash, Stream<KeyEntry<Type>> entries, String filter) {
+  protected Stream<KeyEntry<Content.Type>> filterEntries(
+      WithHash<NamedRef> refWithHash, Stream<KeyEntry<Content.Type>> entries, String filter) {
 
     startAccessCheck().canReadEntries(refWithHash.getValue()).checkAndThrow();
 
@@ -154,7 +153,7 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
 
     // First, collect the content-keys to which the user has no access to.
 
-    List<KeyEntry<Type>> entriesList =
+    List<KeyEntry<Content.Type>> entriesList =
         super.filterEntries(refWithHash, entries, filter).collect(Collectors.toList());
 
     BatchAccessChecker responseCheck = startAccessCheck();

--- a/servers/services/src/test/java/org/projectnessie/services/authz/BatchAccessCheckerTest.java
+++ b/servers/services/src/test/java/org/projectnessie/services/authz/BatchAccessCheckerTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.services.authz.Check.CheckType;
-import org.projectnessie.services.authz.ImmutableCheck.Builder;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.DetachedRef;
 import org.projectnessie.versioned.TagName;
@@ -182,7 +181,7 @@ public class BatchAccessCheckerTest {
     return Arrays.stream(CheckType.values())
         .map(
             t -> {
-              Builder b = Check.builder(t);
+              ImmutableCheck.Builder b = Check.builder(t);
               if (t.isRef()) {
                 b.ref(BranchName.of("some-branch"));
               }

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
@@ -22,14 +22,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.Content.Type;
 
 class ITGenerateContent extends AbstractContentGeneratorTest {
 
   @ParameterizedTest
   @EnumSource(Content.Type.class)
   void basicGenerateContentTest(Content.Type contentType) throws Exception {
-    Assumptions.assumeTrue(contentType != Content.Type.UNKNOWN && contentType != Type.NAMESPACE);
+    Assumptions.assumeTrue(
+        contentType != Content.Type.UNKNOWN && contentType != Content.Type.NAMESPACE);
 
     int numCommits = 20;
 

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -89,14 +89,12 @@ import org.projectnessie.versioned.persist.adapter.spi.TryLoopState;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.ContentIdWithBytes;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry;
-import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStateLogEntry.Builder;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.NamedReference;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.Operation;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.RefType;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
-import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer.Type;
 
 /**
  * Non-transactional database-adapter implementation suitable for no-sql databases.
@@ -511,7 +509,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                       .setName(defaultBranchName)
                       .setRef(
                           RefPointer.newBuilder()
-                              .setType(Type.Branch)
+                              .setType(RefPointer.Type.Branch)
                               .setHash(NO_ANCESTOR.asBytes())))
               .setRefLogId(newRefLog.getRefLogId())
               .addRefLogParentsInclHead(newRefLog.getRefLogId())
@@ -695,12 +693,12 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   /** Get the protobuf-enum-value for a named-reference. */
-  protected static Type protoTypeForRef(NamedRef target) {
-    Type type;
+  protected static RefPointer.Type protoTypeForRef(NamedRef target) {
+    RefPointer.Type type;
     if (target instanceof BranchName) {
-      type = Type.Branch;
+      type = RefPointer.Type.Branch;
     } else if (target instanceof TagName) {
-      type = Type.Tag;
+      type = RefPointer.Type.Tag;
     } else {
       throw new IllegalArgumentException(target.getClass().getSimpleName());
     }
@@ -711,7 +709,7 @@ public abstract class NonTransactionalDatabaseAdapter<
    * Transform the protobuf-enum-value for the named-reference-type plus the reference name into a
    * {@link NamedRef}.
    */
-  protected static NamedRef toNamedRef(Type type, String name) {
+  protected static NamedRef toNamedRef(RefPointer.Type type, String name) {
     switch (type) {
       case Branch:
         return BranchName.of(name);
@@ -1431,7 +1429,7 @@ public abstract class NonTransactionalDatabaseAdapter<
       NonTransactionalOperationContext ctx,
       CompactionStats stats,
       List<ByteString> globalParentsReverse,
-      Builder currentEntry,
+      GlobalStateLogEntry.Builder currentEntry,
       List<ByteString> newLogIds)
       throws ReferenceConflictException {
     writeGlobalCommit(ctx, currentEntry.build());

--- a/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
+++ b/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
@@ -34,12 +34,11 @@ import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RepoProps;
-import org.projectnessie.versioned.persist.serialize.AdapterTypes.RepoProps.Builder;
 
 public class ProtoSerialization {
 
   public static RepoProps toProto(RepoDescription repoDescription) {
-    Builder proto =
+    RepoProps.Builder proto =
         AdapterTypes.RepoProps.newBuilder().setRepoVersion(repoDescription.getRepoVersion());
     // Must be sorted
     new TreeMap<>(repoDescription.getProperties())

--- a/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/adapter/serialize/TestSerialization.java
+++ b/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/adapter/serialize/TestSerialization.java
@@ -44,7 +44,6 @@ import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.ContentIdAndBytes;
 import org.projectnessie.versioned.persist.adapter.ImmutableRepoDescription;
-import org.projectnessie.versioned.persist.adapter.ImmutableRepoDescription.Builder;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
@@ -425,7 +424,8 @@ class TestSerialization {
   }
 
   static RepoDescription createRepoDescription() {
-    Builder builder = RepoDescription.builder().repoVersion(ThreadLocalRandom.current().nextInt());
+    ImmutableRepoDescription.Builder builder =
+        RepoDescription.builder().repoVersion(ThreadLocalRandom.current().nextInt());
     IntStream.range(0, ThreadLocalRandom.current().nextInt(20))
         .forEach(i -> builder.putProperties("key" + i, randomString(20)));
     return builder.build();

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
@@ -53,7 +53,6 @@ import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
-import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams.Builder;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
 import org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterMetrics;
@@ -302,7 +301,7 @@ public abstract class AbstractConcurrency {
       Map<ContentId, ByteString> globalStates,
       Map<BranchName, Map<Key, ByteString>> onRefStates,
       BranchName branch,
-      Builder commitAttempt)
+      ImmutableCommitParams.Builder commitAttempt)
       throws ReferenceConflictException, ReferenceNotFoundException {
     CommitParams c = commitAttempt.build();
     databaseAdapter.commit(c);

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -35,8 +35,6 @@ import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.Meter.Id;
-import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
@@ -249,7 +247,7 @@ class TestMetricsVersionStore {
     VersionStore<String, String, DummyEnum> versionStore =
         new MetricsVersionStore<>(mockedVersionStore, registry, registry.clock);
 
-    Id timerId = timerId(opName, expectedThrow);
+    Meter.Id timerId = timerId(opName, expectedThrow);
 
     ThrowingConsumer<VersionStore<String, String, DummyEnum>> versionStoreExec =
         vs -> {
@@ -335,7 +333,7 @@ class TestMetricsVersionStore {
     DUMMY
   }
 
-  private static Id timerId(String opName, Exception expectedThrow) {
+  private static Meter.Id timerId(String opName, Exception expectedThrow) {
     // All exceptions except instances of VersionStoreException and IllegalArgumentExceptions
     // are server-errors.
     boolean isErrorException =
@@ -343,7 +341,7 @@ class TestMetricsVersionStore {
             && (!(expectedThrow instanceof VersionStoreException))
             && (!(expectedThrow instanceof IllegalArgumentException));
 
-    return new Id(
+    return new Meter.Id(
         "nessie.versionstore.request",
         Tags.of(
             "error",
@@ -354,7 +352,7 @@ class TestMetricsVersionStore {
             "Nessie"),
         "nanoseconds",
         null,
-        Type.TIMER);
+        Meter.Type.TIMER);
   }
 
   static class TestTimer extends AbstractTimer {
@@ -401,8 +399,8 @@ class TestMetricsVersionStore {
   static class TestMeterRegistry extends MeterRegistry {
     final TestClock clock;
 
-    final Map<Id, Gauge> gauges = new HashMap<>();
-    final Map<Id, TestTimer> timers = new HashMap<>();
+    final Map<Meter.Id, Gauge> gauges = new HashMap<>();
+    final Map<Meter.Id, TestTimer> timers = new HashMap<>();
 
     static TestMeterRegistry currentRegistry;
 
@@ -417,7 +415,7 @@ class TestMetricsVersionStore {
     }
 
     @Override
-    protected <T> Gauge newGauge(Id id, T obj, ToDoubleFunction<T> valueFunction) {
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
       Gauge gauge =
           new Gauge() {
             @Override
@@ -426,7 +424,7 @@ class TestMetricsVersionStore {
             }
 
             @Override
-            public Id getId() {
+            public Meter.Id getId() {
               return id;
             }
           };
@@ -435,13 +433,13 @@ class TestMetricsVersionStore {
     }
 
     @Override
-    protected Counter newCounter(Id id) {
+    protected Counter newCounter(Meter.Id id) {
       throw new UnsupportedOperationException();
     }
 
     @Override
     protected Timer newTimer(
-        Id id,
+        Meter.Id id,
         DistributionStatisticConfig distributionStatisticConfig,
         PauseDetector pauseDetector) {
       TestTimer timer =
@@ -453,18 +451,18 @@ class TestMetricsVersionStore {
 
     @Override
     protected DistributionSummary newDistributionSummary(
-        Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
+        Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    protected Meter newMeter(Id id, Type type, Iterable<Measurement> measurements) {
+    protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
       throw new UnsupportedOperationException();
     }
 
     @Override
     protected <T> FunctionTimer newFunctionTimer(
-        Id id,
+        Meter.Id id,
         T obj,
         ToLongFunction<T> countFunction,
         ToDoubleFunction<T> totalTimeFunction,
@@ -474,7 +472,7 @@ class TestMetricsVersionStore {
 
     @Override
     protected <T> FunctionCounter newFunctionCounter(
-        Id id, T obj, ToDoubleFunction<T> countFunction) {
+        Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
```
[BadImport] Importing nested classes/static methods/static fields with commonly-used names can make code harder to read, because it may not be clear from the context exactly which type is being referred to. Qualifying the name with that of the containing class can make the code clearer. Here we recommend using qualified class: RefPointer.
```