### PR TITLE
Add namespace api metric patterns

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -196,5 +196,6 @@ quarkus.micrometer.binder.http-server.match-patterns=\
   /api/v1/trees/tree/.*/log+=/api/v1/trees/tree/{ref}/log, \
   /api/v1/trees/tree/.*+=/api/v1/trees/tree/{ref}, \
   /api/v1/trees/.*/.*+=/api/v1/trees/{referenceType}/{ref}, \
+  /api/v1/namespaces/namespace/.*/.*+=/api/v1/namespaces/namespace/{ref}/{name}, \
+  /api/v1/namespaces/.*+=/api/v1/namespaces/{ref}, \
   /contents/.*+=/contents/{key}
-

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractRestWithMetrics.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractRestWithMetrics.java
@@ -49,6 +49,8 @@ public abstract class AbstractRestWithMetrics extends AbstractTestRest {
     assertThat(body).contains("/api/v1/trees/{referenceType}/{ref}");
     assertThat(body).contains("/api/v1/trees/branch/{ref}");
     assertThat(body).contains("/api/v1/trees/tree/{ref}/entries");
+    assertThat(body).contains("/api/v1/namespaces/{ref}");
+    assertThat(body).contains("/api/v1/namespaces/namespace/{ref}/{name}");
     assertThat(body).contains("http_server_connections_seconds_max");
     assertThat(body).contains("http_server_connections_seconds_active_count");
   }


### PR DESCRIPTION
seems like in https://github.com/projectnessie/nessie/pull/3572 we forgot to apply the workaround from https://github.com/projectnessie/nessie/pull/3511 for the new api endpoints