### PR TITLE
errorprone: ignores

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
@@ -31,6 +31,7 @@ public class HttpResponse {
     this.mapper = mapper;
   }
 
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   private <V> V readEntity(ObjectReader reader) {
     try {
       if (responseContext.getResponseCode().getCode() == Status.NO_CONTENT.getCode()) {

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
@@ -33,6 +33,7 @@ import java.security.KeyStore.TrustedCertificateEntry;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import javax.net.ssl.KeyManagerFactory;
@@ -188,7 +189,7 @@ class TestHttpsClient {
     final KeyStore trustStore = KeyStore.getInstance(storeType);
     keyStore.load(null, null);
     trustStore.load(null, null);
-    ZonedDateTime now = ZonedDateTime.now();
+    ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
     final SecureRandom random = new SecureRandom();
 
     KeyPair keyPair = generateKeyPair(random);

--- a/model/src/main/java/org/projectnessie/error/ErrorCode.java
+++ b/model/src/main/java/org/projectnessie/error/ErrorCode.java
@@ -40,6 +40,8 @@ public enum ErrorCode {
   ;
 
   private final int httpStatus;
+
+  @SuppressWarnings("ImmutableEnumChecker")
   private final Function<NessieError, ? extends Exception> exceptionBuilder;
 
   <T extends Exception & ErrorCodeAware> ErrorCode(

--- a/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -252,7 +252,10 @@ public class TestModelObjectsSerialization {
 
   static class Json { // Helps in building json strings, which can be used for verification.
 
+    @SuppressWarnings("InlineFormatString")
     private static final String STR_KV_FORMAT = "%s,\"%s\":\"%s\"";
+
+    @SuppressWarnings("InlineFormatString")
     private static final String NO_QUOTES_KV_FORMAT = "%s,\"%s\":%s";
 
     String currentContent;

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/AbstractContentGeneratorTest.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/AbstractContentGeneratorTest.java
@@ -84,10 +84,6 @@ public class AbstractContentGeneratorTest {
       return exitCode;
     }
 
-    private String getStdOut() {
-      return stdOut;
-    }
-
     List<String> getStdOutLines() {
       return Arrays.asList(stdOut.split("\n"));
     }


### PR DESCRIPTION
ErrorCode: [ImmutableEnumChecker] enums should be immutable: 'ErrorCode' has field 'exceptionBuilder' of type 'java.util.function.Function<org.projectnessie.error.NessieError,? extends java.lang.Exception>', the declaration of type 'java.util.function.Function<org.projectnessie.error.NessieError,? extends java.lang.Exception>' is not annotated with @com.google.errorprone.annotations.Immutable

TestModelObjectsSerialization: [InlineFormatString] Prefer to create format strings inline, instead of extracting them to a single-use constant

HttpResponse: [TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts at invocations of the method, and it interacts badly with method overload resolution.

TestHttpsClient: [JavaTimeDefaultTimeZone] ZonedDateTime.now() is not allowed because it silently uses the system default time-zone. You must pass an explicit time-zone (e.g., ZoneId.of("America/Los_Angeles")) to this method.

AbstractContentGeneratorTest: [UnusedMethod] Method 'getStdOut' is never used.