### PR TITLE
Bump node from 16.2.0 to 16.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -799,7 +799,7 @@
           <version>1.12.1</version>
           <configuration>
             <installDirectory>${project.build.directory}</installDirectory>
-            <nodeVersion>v16.2.0</nodeVersion>
+            <nodeVersion>v16.14.2</nodeVersion>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Fixes errors for various packages like this
```
[INFO] npm WARN EBADENGINE Unsupported engine {
[INFO] npm WARN EBADENGINE   package: 'jest-util@28.0.0',
[INFO] npm WARN EBADENGINE   required: { node: '^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0' },
[INFO] npm WARN EBADENGINE   current: { node: 'v16.2.0', npm: '7.13.0' }
[INFO] npm WARN EBADENGINE }
```

Fixes #4016