### PR TITLE
Fix codecov upload in CI

### DIFF
--- a/.github/actions/ci-results/action.yml
+++ b/.github/actions/ci-results/action.yml
@@ -9,12 +9,14 @@ runs:
         path: perftest/simulations/target/gatling/*/simulation.log
     - uses: codecov/codecov-action@v2
       with:
+        fail_ci_if_error: true
         flags: java
         files: |
           code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
           tools/apprunner-gradle-plugin/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
     - uses: codecov/codecov-action@v2
       with:
+        fail_ci_if_error: true
         flags: javascript
         files: |
           ui/coverage/clover.xml

--- a/.github/actions/ci-results/action.yml
+++ b/.github/actions/ci-results/action.yml
@@ -12,13 +12,10 @@ runs:
         verbose: true
         fail_ci_if_error: true
         flags: java
-        files: |
-          ./code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
+        files: code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
     - uses: codecov/codecov-action@v2
       with:
         verbose: true
         fail_ci_if_error: true
         flags: javascript
-        files: |
-          ./ui/coverage/clover.xml
-          ./ui/coverage/lcov.info
+        files: ui/coverage/clover.xml,ui/coverage/lcov.info

--- a/.github/actions/ci-results/action.yml
+++ b/.github/actions/ci-results/action.yml
@@ -9,15 +9,16 @@ runs:
         path: perftest/simulations/target/gatling/*/simulation.log
     - uses: codecov/codecov-action@v2
       with:
+        verbose: true
         fail_ci_if_error: true
         flags: java
         files: |
-          code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
-          tools/apprunner-gradle-plugin/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+          ./code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
     - uses: codecov/codecov-action@v2
       with:
+        verbose: true
         fail_ci_if_error: true
         flags: javascript
         files: |
-          ui/coverage/clover.xml
-          ui/coverage/lcov.info
+          ./ui/coverage/clover.xml
+          ./ui/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,5 +144,6 @@ jobs:
       working-directory: ${{env.working-directory}}
     - uses: codecov/codecov-action@v2
       with:
+        verbose: true
         fail_ci_if_error: true
         flags: python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,4 +144,5 @@ jobs:
       working-directory: ${{env.working-directory}}
     - uses: codecov/codecov-action@v2
       with:
+        fail_ci_if_error: true
         flags: python

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -83,6 +83,7 @@ jobs:
       working-directory: ${{env.working-directory}}
     - uses: codecov/codecov-action@v2
       with:
+        verbose: true
         fail_ci_if_error: true
         flags: python
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -83,6 +83,7 @@ jobs:
       working-directory: ${{env.working-directory}}
     - uses: codecov/codecov-action@v2
       with:
+        fail_ci_if_error: true
         flags: python
 
   site:


### PR DESCRIPTION
We accidentally broke the codecov upload/report generation in https://github.com/projectnessie/nessie/pull/3691 without anyone noticing for almost a month :sweat_smile: 

Turns out that `files` argument must be comma separated:
https://github.com/codecov/codecov-action#arguments

Somehow this was not mentioned in the migration guide at https://github.com/codecov/codecov-action#migration-from-v1-to-v2
but possibly using multiple lines was never really supported and just happened to work with the old bash uploader

before:
```
2022-04-25T11:26:59.5741715Z [2022-04-25T11:26:59.573Z] ['error'] None of the following appear to exist as files: code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
2022-04-25T11:26:59.5742703Z tools/apprunner-gradle-plugin/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
2022-04-25T11:26:59.5743680Z [2022-04-25T11:26:59.573Z] ['error'] There was an error running the uploader: Error while cleaning paths. No paths matched existing files!
2022-04-25T11:26:59.6035267Z ##[group]Run codecov/codecov-action@v2
(...)
2022-04-25T11:27:00.5740195Z [2022-04-25T11:27:00.573Z] ['info'] Searching for coverage files...
2022-04-25T11:27:00.8127885Z [2022-04-25T11:27:00.812Z] ['error'] None of the following appear to exist as files: ui/coverage/clover.xml
2022-04-25T11:27:00.8128884Z ui/coverage/lcov.info
2022-04-25T11:27:00.8129775Z [2022-04-25T11:27:00.812Z] ['error'] There was an error running the uploader: Error while cleaning paths. No paths matched existing files!
```

after:
```
2022-04-26T09:53:48.4411909Z [2022-04-26T09:53:48.440Z] ['verbose'] Searching for files in /home/runner/work/nessie/nessie
2022-04-26T09:53:48.4514996Z [2022-04-26T09:53:48.451Z] ['verbose'] Skipping coveragepy conversion: Error: coveragepy is not installed
2022-04-26T09:53:48.4515642Z [2022-04-26T09:53:48.451Z] ['info'] Searching for coverage files...
2022-04-26T09:53:48.7255261Z [2022-04-26T09:53:48.724Z] ['verbose'] Preparing to clean the following coverage paths: code-coverage/target/site/jacoco-aggregate-all/jacoco.xml,code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
2022-04-26T09:53:48.7256246Z [2022-04-26T09:53:48.725Z] ['info'] => Found 1 possible coverage files:
2022-04-26T09:53:48.7256859Z   code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
2022-04-26T09:53:48.7257455Z [2022-04-26T09:53:48.725Z] ['verbose'] End of network processing
2022-04-26T09:53:48.7258226Z [2022-04-26T09:53:48.725Z] ['info'] Processing /home/runner/work/nessie/nessie/code-coverage/target/site/jacoco-aggregate-all/jacoco.xml...
2022-04-26T09:53:48.7711043Z [2022-04-26T09:53:48.770Z] ['info'] Detected GitHub Actions as the CI provider.
(...)
2022-04-26T09:53:50.5127034Z [2022-04-26T09:53:50.512Z] ['info'] => Project root located at: /home/runner/work/nessie/nessie
2022-04-26T09:53:50.5161544Z [2022-04-26T09:53:50.515Z] ['info'] -> No token specified or token is empty
2022-04-26T09:53:50.5162277Z [2022-04-26T09:53:50.515Z] ['verbose'] Start of network processing...
2022-04-26T09:53:50.5163075Z [2022-04-26T09:53:50.515Z] ['verbose'] Searching for files in /home/runner/work/nessie/nessie
2022-04-26T09:53:50.5251301Z [2022-04-26T09:53:50.524Z] ['verbose'] Skipping coveragepy conversion: Error: coveragepy is not installed
2022-04-26T09:53:50.5252061Z [2022-04-26T09:53:50.524Z] ['info'] Searching for coverage files...
2022-04-26T09:53:50.7812148Z [2022-04-26T09:53:50.780Z] ['verbose'] Preparing to clean the following coverage paths: ui/coverage/clover.xml,ui/coverage/lcov.info,ui/coverage/clover.xml,ui/coverage/lcov.info
2022-04-26T09:53:50.7815321Z [2022-04-26T09:53:50.781Z] ['info'] => Found 2 possible coverage files:
2022-04-26T09:53:50.7816004Z   ui/coverage/clover.xml
2022-04-26T09:53:50.7816717Z   ui/coverage/lcov.info
```