### PR TITLE
Remove `fail_ci_if_error: true` for codecov

### DIFF
--- a/.github/actions/ci-results/action.yml
+++ b/.github/actions/ci-results/action.yml
@@ -10,12 +10,10 @@ runs:
     - uses: codecov/codecov-action@v2
       with:
         verbose: true
-        fail_ci_if_error: true
         flags: java
         files: code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
     - uses: codecov/codecov-action@v2
       with:
         verbose: true
-        fail_ci_if_error: true
         flags: javascript
         files: ui/coverage/clover.xml,ui/coverage/lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,5 +145,4 @@ jobs:
     - uses: codecov/codecov-action@v2
       with:
         verbose: true
-        fail_ci_if_error: true
         flags: python

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,7 +84,6 @@ jobs:
     - uses: codecov/codecov-action@v2
       with:
         verbose: true
-        fail_ci_if_error: true
         flags: python
 
   site:


### PR DESCRIPTION
... because that let's GH Workflows fail on Nessie forks.