### PR TITLE
Prevent codecov upload on forks

### DIFF
--- a/.github/actions/ci-results/action.yml
+++ b/.github/actions/ci-results/action.yml
@@ -8,12 +8,14 @@ runs:
         name: gatling-logs
         path: perftest/simulations/target/gatling/*/simulation.log
     - uses: codecov/codecov-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         verbose: true
         fail_ci_if_error: true
         flags: java
         files: code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
     - uses: codecov/codecov-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         verbose: true
         fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,7 @@ jobs:
       run: tox
       working-directory: ${{env.working-directory}}
     - uses: codecov/codecov-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         verbose: true
         fail_ci_if_error: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -82,6 +82,7 @@ jobs:
       run: tox
       working-directory: ${{env.working-directory}}
     - uses: codecov/codecov-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         verbose: true
         fail_ci_if_error: true


### PR DESCRIPTION
alternative suggestion to https://github.com/projectnessie/nessie/pull/4094

will prevent errors on forks like:
```
[2022-04-26T11:35:07.490Z] ['verbose'] The error stack is: Error: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - Not Found - {'detail': ErrorDetail(string='Could not find a repository, try using repo upload token', code='not_found')}
    at main (/snapshot/repo/dist/src/index.js)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```