### PR TITLE
Bump versions of Postgres + Cockroach used in tests

### DIFF
--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/PostgresTestResourceLifecycleManager.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/PostgresTestResourceLifecycleManager.java
@@ -38,7 +38,7 @@ public class PostgresTestResourceLifecycleManager
 
   @Override
   public Map<String, String> start() {
-    String version = System.getProperty("it.nessie.container.postgres.tag", "9.6.22");
+    String version = System.getProperty("it.nessie.container.postgres.tag", "14");
 
     container = new PostgreSQLContainer<>("postgres:" + version).withLogConsumer(outputFrame -> {});
     containerNetworkId.ifPresent(container::withNetworkMode);

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/CockroachTestConnectionProviderSource.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/CockroachTestConnectionProviderSource.java
@@ -33,7 +33,7 @@ public class CockroachTestConnectionProviderSource extends ContainerTestConnecti
 
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {
-    String version = System.getProperty("it.nessie.container.cockroach.tag", "v21.1.6");
+    String version = System.getProperty("it.nessie.container.cockroach.tag", "latest-v21.2");
     return new CockroachContainer("cockroachdb/cockroach:" + version);
   }
 }

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/PostgresTestConnectionProviderSource.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/PostgresTestConnectionProviderSource.java
@@ -33,7 +33,7 @@ public class PostgresTestConnectionProviderSource extends ContainerTestConnectio
 
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {
-    String version = System.getProperty("it.nessie.container.postgres.tag", "9.6.22");
+    String version = System.getProperty("it.nessie.container.postgres.tag", "14");
     return new PostgreSQLContainer<>("postgres:" + version);
   }
 }


### PR DESCRIPTION
Postgres from 9.6.22 to 14-latest
Cockroach from 21.1.6 to 21.2-latest