### PR TITLE
Helm: Add ingress support for Kubernetes >=1.22

### DIFF
--- a/helm/nessie/templates/ingress.yaml
+++ b/helm/nessie/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "nessie.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -34,8 +36,15 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             backend:
+              {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Update the ingress Helm template to support newer Kubernetes versions.

networking.k8s.io/v1beta1 was removed in Kubernetes 1.22 and networking.k8s.io/v1 is available since 1.19.

Source: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122