### PR TITLE
Add content-variant using attachments

### DIFF
--- a/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/CheckContent.java
+++ b/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/CheckContent.java
@@ -210,7 +210,9 @@ public class CheckContent extends BaseCommand {
           try {
             Object value =
                 worker.valueFromStore(
-                    contentAndState.getRefState(), contentAndState::getGlobalState);
+                    contentAndState.getRefState(),
+                    contentAndState::getGlobalState,
+                    databaseAdapter::mapToAttachment);
             report(generator, k, null, value);
           } catch (Exception e) {
             report(generator, k, e, null);

--- a/servers/quarkus-cli/src/test/java/org/projectnessie/quarkus/cli/ITCheckContent.java
+++ b/servers/quarkus-cli/src/test/java/org/projectnessie/quarkus/cli/ITCheckContent.java
@@ -139,7 +139,11 @@ class ITCheckContent {
 
   private void commit(IcebergTable table, DatabaseAdapter adapter) throws Exception {
     TableCommitMetaStoreWorker worker = new TableCommitMetaStoreWorker();
-    commit(table.getId(), worker.getPayload(table), worker.toStoreOnReferenceState(table), adapter);
+    commit(
+        table.getId(),
+        worker.getPayload(table),
+        worker.toStoreOnReferenceState(table, att -> {}),
+        adapter);
   }
 
   private void commit(String testId, byte payload, ByteString value, DatabaseAdapter adapter)

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -334,29 +334,6 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
     }
   }
 
-  @Override
-  public boolean requiresPerContentState(Content content) {
-    if (content instanceof IcebergTable) {
-      IcebergTable table = (IcebergTable) content;
-      return table.getMetadata() != null;
-    }
-    if (content instanceof IcebergView) {
-      IcebergView view = (IcebergView) content;
-      return view.getMetadata() != null;
-    }
-    return false;
-  }
-
-  @Override
-  public boolean requiresPerContentState(ByteString content) {
-    return false;
-  }
-
-  @Override
-  public boolean requiresPerContentState(Enum<Content.Type> type) {
-    return type == Content.Type.ICEBERG_TABLE || type == Content.Type.ICEBERG_VIEW;
-  }
-
   private static ObjectTypes.Content parse(ByteString value) {
     try {
       return ObjectTypes.Content.parseFrom(value);

--- a/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/TableCommitMetaStoreWorker.java
@@ -22,7 +22,10 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.DeltaLakeTable;
@@ -35,6 +38,8 @@ import org.projectnessie.model.ImmutableIcebergView;
 import org.projectnessie.model.ImmutableNamespace;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.server.store.proto.ObjectTypes;
+import org.projectnessie.versioned.ContentAttachment;
+import org.projectnessie.versioned.ContentAttachmentKey;
 import org.projectnessie.versioned.Serializer;
 import org.projectnessie.versioned.StoreWorker;
 
@@ -44,51 +49,67 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
   private final Serializer<CommitMeta> metaSerializer = new MetadataSerializer();
 
   @Override
-  public ByteString toStoreOnReferenceState(Content content) {
+  public ByteString toStoreOnReferenceState(
+      Content content, Consumer<ContentAttachment> attachmentConsumer) {
     ObjectTypes.Content.Builder builder = ObjectTypes.Content.newBuilder().setId(content.getId());
     if (content instanceof IcebergTable) {
-      IcebergTable table = (IcebergTable) content;
-      ObjectTypes.IcebergRefState.Builder stateBuilder =
-          ObjectTypes.IcebergRefState.newBuilder()
-              .setSnapshotId(table.getSnapshotId())
-              .setSchemaId(table.getSchemaId())
-              .setSpecId(table.getSpecId())
-              .setSortOrderId(table.getSortOrderId())
-              .setMetadataLocation(table.getMetadataLocation());
-      builder.setIcebergRefState(stateBuilder);
+      toStoreIcebergTable((IcebergTable) content, builder);
     } else if (content instanceof IcebergView) {
-      IcebergView view = (IcebergView) content;
-      builder.setIcebergViewState(
-          ObjectTypes.IcebergViewState.newBuilder()
-              .setVersionId(view.getVersionId())
-              .setSchemaId(view.getSchemaId())
-              .setDialect(view.getDialect())
-              .setSqlText(view.getSqlText())
-              .setMetadataLocation(view.getMetadataLocation()));
+      toStoreIcebergView((IcebergView) content, builder);
     } else if (content instanceof DeltaLakeTable) {
-      ObjectTypes.DeltaLakeTable.Builder table =
-          ObjectTypes.DeltaLakeTable.newBuilder()
-              .addAllMetadataLocationHistory(
-                  ((DeltaLakeTable) content).getMetadataLocationHistory())
-              .addAllCheckpointLocationHistory(
-                  ((DeltaLakeTable) content).getCheckpointLocationHistory());
-      String lastCheckpoint = ((DeltaLakeTable) content).getLastCheckpoint();
-      if (lastCheckpoint != null) {
-        table.setLastCheckpoint(lastCheckpoint);
-      }
-      builder.setDeltaLakeTable(table);
+      toStoreDeltaLakeTable((DeltaLakeTable) content, builder);
     } else if (content instanceof Namespace) {
-      Namespace ns = (Namespace) content;
-      builder.setNamespace(
-          ObjectTypes.Namespace.newBuilder()
-              .addAllElements(ns.getElements())
-              .putAllProperties(ns.getProperties())
-              .build());
+      toStoreNamespace((Namespace) content, builder);
     } else {
       throw new IllegalArgumentException("Unknown type " + content);
     }
 
     return builder.build().toByteString();
+  }
+
+  private static void toStoreDeltaLakeTable(
+      DeltaLakeTable content, ObjectTypes.Content.Builder builder) {
+    ObjectTypes.DeltaLakeTable.Builder table =
+        ObjectTypes.DeltaLakeTable.newBuilder()
+            .addAllMetadataLocationHistory(content.getMetadataLocationHistory())
+            .addAllCheckpointLocationHistory(content.getCheckpointLocationHistory());
+    String lastCheckpoint = content.getLastCheckpoint();
+    if (lastCheckpoint != null) {
+      table.setLastCheckpoint(lastCheckpoint);
+    }
+    builder.setDeltaLakeTable(table);
+  }
+
+  private static void toStoreNamespace(Namespace content, ObjectTypes.Content.Builder builder) {
+    builder.setNamespace(
+        ObjectTypes.Namespace.newBuilder()
+            .addAllElements(content.getElements())
+            .putAllProperties(content.getProperties())
+            .build());
+  }
+
+  private static void toStoreIcebergView(IcebergView view, ObjectTypes.Content.Builder builder) {
+    ObjectTypes.IcebergViewState.Builder stateBuilder =
+        ObjectTypes.IcebergViewState.newBuilder()
+            .setVersionId(view.getVersionId())
+            .setSchemaId(view.getSchemaId())
+            .setDialect(view.getDialect())
+            .setSqlText(view.getSqlText())
+            .setMetadataLocation(view.getMetadataLocation());
+
+    builder.setIcebergViewState(stateBuilder);
+  }
+
+  private static void toStoreIcebergTable(IcebergTable table, ObjectTypes.Content.Builder builder) {
+    ObjectTypes.IcebergRefState.Builder stateBuilder =
+        ObjectTypes.IcebergRefState.newBuilder()
+            .setSnapshotId(table.getSnapshotId())
+            .setSchemaId(table.getSchemaId())
+            .setSpecId(table.getSpecId())
+            .setSortOrderId(table.getSortOrderId())
+            .setMetadataLocation(table.getMetadataLocation());
+
+    builder.setIcebergRefState(stateBuilder);
   }
 
   @Override
@@ -114,61 +135,35 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
   }
 
   @Override
-  public Content valueFromStore(ByteString onReferenceValue, Supplier<ByteString> globalState) {
+  public Content valueFromStore(
+      ByteString onReferenceValue,
+      Supplier<ByteString> globalState,
+      Function<Stream<ContentAttachmentKey>, Stream<ContentAttachment>> attachmentsRetriever) {
     ObjectTypes.Content content = parse(onReferenceValue);
+    Supplier<String> metadataPointerSupplier =
+        () -> {
+          ByteString global = globalState.get();
+          if (global == null) {
+            throw noIcebergMetadataPointer();
+          }
+          ObjectTypes.Content globalContent = parse(global);
+          if (!globalContent.hasIcebergMetadataPointer()) {
+            throw noIcebergMetadataPointer();
+          }
+          return globalContent.getIcebergMetadataPointer().getMetadataLocation();
+        };
     switch (content.getObjectTypeCase()) {
       case DELTA_LAKE_TABLE:
-        ObjectTypes.DeltaLakeTable deltaLakeTable = content.getDeltaLakeTable();
-        ImmutableDeltaLakeTable.Builder builder =
-            ImmutableDeltaLakeTable.builder()
-                .id(content.getId())
-                .addAllMetadataLocationHistory(deltaLakeTable.getMetadataLocationHistoryList())
-                .addAllCheckpointLocationHistory(deltaLakeTable.getCheckpointLocationHistoryList());
-        if (deltaLakeTable.hasLastCheckpoint()) {
-          builder.lastCheckpoint(content.getDeltaLakeTable().getLastCheckpoint());
-        }
-        return builder.build();
+        return valueFromStoreDeltaLakeTable(content);
 
       case ICEBERG_REF_STATE:
-        ObjectTypes.IcebergRefState table = content.getIcebergRefState();
-        String metadataLocation;
-        if (table.hasMetadataLocation()) {
-          metadataLocation = table.getMetadataLocation();
-        } else {
-          metadataLocation = metadataLocationFromGlobal(globalState);
-        }
-        return ImmutableIcebergTable.builder()
-            .metadataLocation(metadataLocation)
-            .snapshotId(table.getSnapshotId())
-            .schemaId(table.getSchemaId())
-            .specId(table.getSpecId())
-            .sortOrderId(table.getSortOrderId())
-            .id(content.getId())
-            .build();
+        return valueFromStoreIcebergTable(content, metadataPointerSupplier);
 
       case ICEBERG_VIEW_STATE:
-        ObjectTypes.IcebergViewState view = content.getIcebergViewState();
-        if (view.hasMetadataLocation()) {
-          metadataLocation = view.getMetadataLocation();
-        } else {
-          metadataLocation = metadataLocationFromGlobal(globalState);
-        }
-        return ImmutableIcebergView.builder()
-            .metadataLocation(metadataLocation)
-            .versionId(view.getVersionId())
-            .schemaId(view.getSchemaId())
-            .dialect(view.getDialect())
-            .sqlText(view.getSqlText())
-            .id(content.getId())
-            .build();
+        return valueFromStoreIcebergView(content, metadataPointerSupplier);
 
       case NAMESPACE:
-        ObjectTypes.Namespace namespace = content.getNamespace();
-        return ImmutableNamespace.builder()
-            .id(content.getId())
-            .elements(namespace.getElementsList())
-            .putAllProperties(namespace.getPropertiesMap())
-            .build();
+        return valueFromStoreNamespace(content);
 
       case OBJECTTYPE_NOT_SET:
       default:
@@ -176,16 +171,61 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
     }
   }
 
-  private static String metadataLocationFromGlobal(Supplier<ByteString> globalContent) {
-    ByteString globalBytes = globalContent.get();
-    if (globalBytes == null) {
-      throw noIcebergMetadataPointer();
+  private static ImmutableDeltaLakeTable valueFromStoreDeltaLakeTable(ObjectTypes.Content content) {
+    ObjectTypes.DeltaLakeTable deltaLakeTable = content.getDeltaLakeTable();
+    ImmutableDeltaLakeTable.Builder builder =
+        ImmutableDeltaLakeTable.builder()
+            .id(content.getId())
+            .addAllMetadataLocationHistory(deltaLakeTable.getMetadataLocationHistoryList())
+            .addAllCheckpointLocationHistory(deltaLakeTable.getCheckpointLocationHistoryList());
+    if (deltaLakeTable.hasLastCheckpoint()) {
+      builder.lastCheckpoint(content.getDeltaLakeTable().getLastCheckpoint());
     }
-    ObjectTypes.Content global = parse(globalBytes);
-    if (!global.hasIcebergMetadataPointer()) {
-      throw noIcebergMetadataPointer();
-    }
-    return global.getIcebergMetadataPointer().getMetadataLocation();
+    return builder.build();
+  }
+
+  private static ImmutableNamespace valueFromStoreNamespace(ObjectTypes.Content content) {
+    ObjectTypes.Namespace namespace = content.getNamespace();
+    return ImmutableNamespace.builder()
+        .id(content.getId())
+        .elements(namespace.getElementsList())
+        .putAllProperties(namespace.getPropertiesMap())
+        .build();
+  }
+
+  private static ImmutableIcebergTable valueFromStoreIcebergTable(
+      ObjectTypes.Content content, Supplier<String> metadataPointerSupplier) {
+    ObjectTypes.IcebergRefState table = content.getIcebergRefState();
+    String metadataLocation =
+        table.hasMetadataLocation() ? table.getMetadataLocation() : metadataPointerSupplier.get();
+
+    return IcebergTable.builder()
+        .metadataLocation(metadataLocation)
+        .snapshotId(table.getSnapshotId())
+        .schemaId(table.getSchemaId())
+        .specId(table.getSpecId())
+        .sortOrderId(table.getSortOrderId())
+        .id(content.getId())
+        .build();
+  }
+
+  private static ImmutableIcebergView valueFromStoreIcebergView(
+      ObjectTypes.Content content, Supplier<String> metadataPointerSupplier) {
+    String metadataLocation;
+    ObjectTypes.IcebergViewState view = content.getIcebergViewState();
+    // If the (protobuf) view has the metadataLocation attribute set, use that one, otherwise
+    // it's an old representation using global state.
+    metadataLocation =
+        view.hasMetadataLocation() ? view.getMetadataLocation() : metadataPointerSupplier.get();
+
+    return IcebergView.builder()
+        .metadataLocation(metadataLocation)
+        .versionId(view.getVersionId())
+        .schemaId(view.getSchemaId())
+        .dialect(view.getDialect())
+        .sqlText(view.getSqlText())
+        .id(content.getId())
+        .build();
   }
 
   private static IllegalArgumentException noIcebergMetadataPointer() {
@@ -292,6 +332,29 @@ public class TableCommitMetaStoreWorker implements StoreWorker<Content, CommitMe
       default:
         return false;
     }
+  }
+
+  @Override
+  public boolean requiresPerContentState(Content content) {
+    if (content instanceof IcebergTable) {
+      IcebergTable table = (IcebergTable) content;
+      return table.getMetadata() != null;
+    }
+    if (content instanceof IcebergView) {
+      IcebergView view = (IcebergView) content;
+      return view.getMetadata() != null;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean requiresPerContentState(ByteString content) {
+    return false;
+  }
+
+  @Override
+  public boolean requiresPerContentState(Enum<Content.Type> type) {
+    return type == Content.Type.ICEBERG_TABLE || type == Content.Type.ICEBERG_VIEW;
   }
 
   private static ObjectTypes.Content parse(ByteString value) {

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -17,6 +17,7 @@ package org.projectnessie.server.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,6 +28,7 @@ import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
@@ -45,6 +47,7 @@ import org.projectnessie.server.store.proto.ObjectTypes;
 import org.projectnessie.server.store.proto.ObjectTypes.IcebergMetadataPointer;
 import org.projectnessie.server.store.proto.ObjectTypes.IcebergRefState;
 import org.projectnessie.server.store.proto.ObjectTypes.IcebergViewState;
+import org.projectnessie.versioned.ContentAttachment;
 
 class TestStoreWorker {
 
@@ -52,6 +55,10 @@ class TestStoreWorker {
   private static final String ID = "x";
   public static final String CID = "cid";
   private final TableCommitMetaStoreWorker worker = new TableCommitMetaStoreWorker();
+
+  @SuppressWarnings("UnnecessaryLambda")
+  private static final Consumer<ContentAttachment> ALWAYS_THROWING_ATTACHMENT_CONSUMER =
+      attachment -> fail("Unexpected use of Consumer<ContentAttachment>");
 
   @Test
   void tableMetadataLocationGlobalNotAvailable() {
@@ -68,7 +75,8 @@ class TestStoreWorker {
                                 .setSortOrderId(45))
                         .build()
                         .toByteString(),
-                    () -> null))
+                    () -> null,
+                    contentAttachmentKeyStream -> Stream.empty()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Iceberg content from reference must have global state, but has none");
   }
@@ -94,7 +102,8 @@ class TestStoreWorker {
                         IcebergMetadataPointer.newBuilder()
                             .setMetadataLocation("metadata-location"))
                     .build()
-                    .toByteString());
+                    .toByteString(),
+            contentAttachmentKeyStream -> Stream.empty());
     assertThat(value)
         .isInstanceOf(IcebergTable.class)
         .asInstanceOf(InstanceOfAssertFactories.type(IcebergTable.class))
@@ -122,7 +131,8 @@ class TestStoreWorker {
                         .setMetadataLocation("metadata-location"))
                 .build()
                 .toByteString(),
-            () -> null);
+            () -> null,
+            contentAttachmentKeyStream -> Stream.empty());
     assertThat(value)
         .isInstanceOf(IcebergTable.class)
         .asInstanceOf(InstanceOfAssertFactories.type(IcebergTable.class))
@@ -146,7 +156,8 @@ class TestStoreWorker {
                             ObjectTypes.IcebergViewState.newBuilder().setVersionId(42))
                         .build()
                         .toByteString(),
-                    () -> null))
+                    () -> null,
+                    contentAttachmentKeyStream -> Stream.empty()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Iceberg content from reference must have global state, but has none");
   }
@@ -167,7 +178,8 @@ class TestStoreWorker {
                         IcebergMetadataPointer.newBuilder()
                             .setMetadataLocation("metadata-location"))
                     .build()
-                    .toByteString());
+                    .toByteString(),
+            contentAttachmentKeyStream -> Stream.empty());
     assertThat(value)
         .isInstanceOf(IcebergView.class)
         .asInstanceOf(InstanceOfAssertFactories.type(IcebergView.class))
@@ -295,7 +307,10 @@ class TestStoreWorker {
         .asInstanceOf(InstanceOfAssertFactories.type(ByteString.class))
         .extracting(worker::requiresGlobalState, worker::getType)
         .containsExactly(storeGlobal, type);
-    assertThat(worker.valueFromStore(onRef, () -> global)).isEqualTo(content);
+    assertThat(
+            worker.valueFromStore(
+                onRef, () -> global, contentAttachmentKeyStream -> Stream.empty()))
+        .isEqualTo(content);
 
     if (storeGlobal) {
       // Add "metadataLocation" to expected on-ref status, because toStoreOnReferenceState() always
@@ -322,7 +337,11 @@ class TestStoreWorker {
       }
     }
 
-    assertThat(content).extracting(worker::toStoreOnReferenceState).isEqualTo(onRef);
+    assertThat(content)
+        .extracting(
+            content1 ->
+                worker.toStoreOnReferenceState(content1, ALWAYS_THROWING_ATTACHMENT_CONSUMER))
+        .isEqualTo(onRef);
     if (storeGlobal) {
       assertThat(content).extracting(worker::toStoreGlobalState).isEqualTo(global);
     }
@@ -340,7 +359,8 @@ class TestStoreWorker {
                         .setMetadataLocation("metadata-location"))
                 .build()
                 .toByteString(),
-            () -> null);
+            () -> null,
+            contentAttachmentKeyStream -> Stream.empty());
     assertThat(value)
         .isInstanceOf(IcebergView.class)
         .asInstanceOf(InstanceOfAssertFactories.type(IcebergView.class))
@@ -351,28 +371,32 @@ class TestStoreWorker {
   @ParameterizedTest
   @MethodSource("provideDeserialization")
   void testDeserialization(Map.Entry<ByteString, Content> entry) {
-    Content actual = worker.valueFromStore(entry.getKey(), () -> null);
+    Content actual = worker.valueFromStore(entry.getKey(), () -> null, x -> Stream.empty());
     assertThat(actual).isEqualTo(entry.getValue());
   }
 
   @ParameterizedTest
   @MethodSource("provideDeserialization")
   void testSerialization(Map.Entry<ByteString, Content> entry) {
-    ByteString actual = worker.toStoreOnReferenceState(entry.getValue());
+    ByteString actual =
+        worker.toStoreOnReferenceState(entry.getValue(), ALWAYS_THROWING_ATTACHMENT_CONSUMER);
     assertThat(actual).isEqualTo(entry.getKey());
   }
 
   @ParameterizedTest
   @MethodSource("provideDeserialization")
   void testSerde(Map.Entry<ByteString, Content> entry) {
-    ByteString actualBytes = worker.toStoreOnReferenceState(entry.getValue());
-    assertThat(worker.valueFromStore(actualBytes, () -> null)).isEqualTo(entry.getValue());
-    Content actualContent = worker.valueFromStore(entry.getKey(), () -> null);
-    assertThat(worker.toStoreOnReferenceState(actualContent)).isEqualTo(entry.getKey());
+    ByteString actualBytes =
+        worker.toStoreOnReferenceState(entry.getValue(), ALWAYS_THROWING_ATTACHMENT_CONSUMER);
+    assertThat(worker.valueFromStore(actualBytes, () -> null, x -> Stream.empty()))
+        .isEqualTo(entry.getValue());
+    Content actualContent = worker.valueFromStore(entry.getKey(), () -> null, x -> Stream.empty());
+    assertThat(worker.toStoreOnReferenceState(actualContent, ALWAYS_THROWING_ATTACHMENT_CONSUMER))
+        .isEqualTo(entry.getKey());
   }
 
   @Test
-  void testSerdeIceberg() {
+  void testSerdeIcebergTableNoMetadata() {
     String path = "foo/bar";
     IcebergTable table = IcebergTable.of(path, 42, 43, 44, 45, ID);
 
@@ -395,17 +419,19 @@ class TestStoreWorker {
             .build();
 
     ByteString tableGlobalBytes = worker.toStoreGlobalState(table);
-    ByteString snapshotBytes = worker.toStoreOnReferenceState(table);
+    ByteString snapshotBytes =
+        worker.toStoreOnReferenceState(table, ALWAYS_THROWING_ATTACHMENT_CONSUMER);
 
     assertThat(tableGlobalBytes).isEqualTo(protoTableGlobal.toByteString());
     assertThat(snapshotBytes).isEqualTo(protoOnRef.toByteString());
 
-    Content deserialized = worker.valueFromStore(snapshotBytes, () -> tableGlobalBytes);
+    Content deserialized =
+        worker.valueFromStore(snapshotBytes, () -> tableGlobalBytes, x -> Stream.empty());
     assertThat(deserialized).isEqualTo(table);
   }
 
   @Test
-  void testSerdeIcebergView() {
+  void testSerdeIcebergViewNoMetadata() {
     String path = "foo/view";
     String dialect = "Dremio";
     String sqlText = "select * from world";
@@ -430,12 +456,14 @@ class TestStoreWorker {
             .build();
 
     ByteString tableGlobalBytes = worker.toStoreGlobalState(view);
-    ByteString snapshotBytes = worker.toStoreOnReferenceState(view);
+    ByteString snapshotBytes =
+        worker.toStoreOnReferenceState(view, ALWAYS_THROWING_ATTACHMENT_CONSUMER);
 
     assertThat(tableGlobalBytes).isEqualTo(protoTableGlobal.toByteString());
     assertThat(snapshotBytes).isEqualTo(protoOnRef.toByteString());
 
-    Content deserialized = worker.valueFromStore(snapshotBytes, () -> tableGlobalBytes);
+    Content deserialized =
+        worker.valueFromStore(snapshotBytes, () -> tableGlobalBytes, x -> Stream.empty());
     assertThat(deserialized).isEqualTo(view);
   }
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitParams.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
+import org.projectnessie.versioned.ContentAttachment;
 import org.projectnessie.versioned.Key;
 
 /** API helper method to encapsulate parameters for {@link DatabaseAdapter#commit(CommitParams)}. */
@@ -39,6 +40,9 @@ public interface CommitParams extends ToBranchParams {
    * Content}.
    */
   List<KeyWithBytes> getPuts();
+
+  /** The content attachments for the put operations. */
+  List<ContentAttachment> getAttachments();
 
   /** List of "unchanged" keys, from {@code Unchanged} commit operations. */
   List<Key> getUnchanged();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
@@ -36,11 +36,13 @@ public interface ContentAndState<CONTENT> {
 
   @Nonnull
   static <CONTENT> ContentAndState<CONTENT> of(
-      @Nonnull CONTENT refState, @Nonnull CONTENT globalState) {
-    return ImmutableContentAndState.<CONTENT>builder()
-        .refState(refState)
-        .globalState(globalState)
-        .build();
+      @Nonnull CONTENT refState, @Nullable CONTENT globalState) {
+    ImmutableContentAndState.Builder<CONTENT> b =
+        ImmutableContentAndState.<CONTENT>builder().refState(refState);
+    if (globalState != null) {
+      b.globalState(globalState);
+    }
+    return b.build();
   }
 
   @Nonnull

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
@@ -37,12 +37,10 @@ public interface ContentAndState<CONTENT> {
   @Nonnull
   static <CONTENT> ContentAndState<CONTENT> of(
       @Nonnull CONTENT refState, @Nullable CONTENT globalState) {
-    ImmutableContentAndState.Builder<CONTENT> b =
-        ImmutableContentAndState.<CONTENT>builder().refState(refState);
-    if (globalState != null) {
-      b.globalState(globalState);
-    }
-    return b.build();
+    return ImmutableContentAndState.<CONTENT>builder()
+        .refState(refState)
+        .globalState(globalState)
+        .build();
   }
 
   @Nonnull

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -262,6 +262,9 @@ public abstract class AbstractDatabaseAdapter<
             currentCommit,
             emptyList());
     writeIndividualCommit(ctx, newBranchCommit);
+
+    persistAttachments(ctx, commitParams.getAttachments().stream());
+
     return newBranchCommit;
   }
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitLogScan.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitLogScan.java
@@ -212,7 +212,10 @@ public abstract class AbstractCommitLogScan {
                               + numCommits))
                   .addPuts(
                       KeyWithBytes.of(
-                          key, cid, payload, SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)))
+                          key,
+                          cid,
+                          payload,
+                          SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c, att -> {})))
                   .build());
       committed.accept(head);
     }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
@@ -17,11 +17,13 @@ package org.projectnessie.versioned.persist.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
 
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
@@ -150,7 +152,8 @@ public abstract class AbstractCommitScenarios {
                     oldKey,
                     contentId,
                     payload,
-                    SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(initialContent)));
+                    SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                        initialContent, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
     Hash hashInitial = databaseAdapter.commit(commit.build());
 
     List<Hash> beforeRename =
@@ -168,7 +171,8 @@ public abstract class AbstractCommitScenarios {
                     newKey,
                     contentId,
                     payload,
-                    SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(renamContent)));
+                    SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                        renamContent, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
     Hash hashRename = databaseAdapter.commit(commit.build());
 
     List<Hash> beforeDelete =
@@ -269,7 +273,8 @@ public abstract class AbstractCommitScenarios {
               key,
               ContentId.of(cid),
               SimpleStoreWorker.INSTANCE.getPayload(c),
-              SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)));
+              SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                  c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
     }
     Hash head = databaseAdapter.commit(commit.build());
 
@@ -288,7 +293,8 @@ public abstract class AbstractCommitScenarios {
                 keys.get(i),
                 ContentId.of(cid),
                 SimpleStoreWorker.INSTANCE.getPayload(newContent),
-                SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(newContent)));
+                SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                    newContent, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
       }
 
       Hash newHead = databaseAdapter.commit(commit.build());
@@ -345,7 +351,9 @@ public abstract class AbstractCommitScenarios {
                     key,
                     ContentId.of(cid),
                     SimpleStoreWorker.INSTANCE.getPayload(c),
-                    SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)))
+                    SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                        c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)))
+            .putExpectedStates(ContentId.of(cid), Optional.empty())
             .validator(validator);
     databaseAdapter.commit(commit.build());
   }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.tests;
 
 import static io.micrometer.core.instrument.Metrics.globalRegistry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
 
 import com.google.protobuf.ByteString;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -154,7 +155,8 @@ public abstract class AbstractConcurrency {
                             keys.get(ki),
                             contentId,
                             SimpleStoreWorker.INSTANCE.getPayload(c),
-                            SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)));
+                            SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                                c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
                   }
 
                   try {
@@ -198,7 +200,8 @@ public abstract class AbstractConcurrency {
                   k,
                   contentId,
                   SimpleStoreWorker.INSTANCE.getPayload(c),
-                  SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)));
+                  SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                      c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
         }
         commitAndRecord(onRefStates, branch, commitAttempt);
       }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDiff.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDiff.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.persist.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
 
 import com.google.protobuf.ByteString;
 import java.util.Optional;
@@ -65,7 +66,8 @@ public abstract class AbstractDiff {
                 Key.of("key", Integer.toString(k)),
                 ContentId.of("C" + k),
                 SimpleStoreWorker.INSTANCE.getPayload(c),
-                SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)));
+                SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                    c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
       }
       commits[i] = databaseAdapter.commit(commit.build());
     }
@@ -97,7 +99,8 @@ public abstract class AbstractDiff {
                               Optional.empty(),
                               Optional.empty(),
                               Optional.of(
-                                  SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(content)));
+                                  SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                                      content, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
                         })
                     .collect(Collectors.toList()));
       }
@@ -121,7 +124,8 @@ public abstract class AbstractDiff {
                               Key.of("key", Integer.toString(k)),
                               Optional.empty(),
                               Optional.of(
-                                  SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(content)),
+                                  SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                                      content, ALWAYS_THROWING_ATTACHMENT_CONSUMER)),
                               Optional.empty());
                         })
                     .collect(Collectors.toList()));
@@ -148,8 +152,12 @@ public abstract class AbstractDiff {
                           return Difference.of(
                               Key.of("key", Integer.toString(k)),
                               Optional.empty(),
-                              Optional.of(SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(from)),
-                              Optional.of(SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(to)));
+                              Optional.of(
+                                  SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                                      from, ALWAYS_THROWING_ATTACHMENT_CONSUMER)),
+                              Optional.of(
+                                  SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                                      to, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
                         })
                     .collect(Collectors.toList()));
       }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractEvents.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractEvents.java
@@ -167,7 +167,7 @@ public abstract class AbstractEvents {
             ContentId.of("cid-events-assign"),
             (byte) 0,
             SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
-                OnRefOnly.onRef("foo", "cid-events-assign")));
+                OnRefOnly.onRef("foo", "cid-events-assign"), att -> {}));
 
     ByteString meta = ByteString.copyFromUtf8("foo bar baz");
 
@@ -214,7 +214,7 @@ public abstract class AbstractEvents {
             ContentId.of("cid-events-commit"),
             (byte) 0,
             SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
-                OnRefOnly.onRef("foo", "cid-events-commit")));
+                OnRefOnly.onRef("foo", "cid-events-commit"), att -> {}));
 
     ByteString meta = ByteString.copyFromUtf8("foo bar baz");
 
@@ -267,7 +267,7 @@ public abstract class AbstractEvents {
             ContentId.of("cid-events-merge"),
             (byte) 0,
             SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
-                OnRefOnly.onRef("foo", "cid-events-merge")));
+                OnRefOnly.onRef("foo", "cid-events-merge"), att -> {}));
 
     ByteString meta = ByteString.copyFromUtf8("merge me");
 
@@ -339,7 +339,7 @@ public abstract class AbstractEvents {
             ContentId.of("cid-events-transplant"),
             (byte) 0,
             SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
-                OnRefOnly.onRef("foo", "cid-events-transplant")));
+                OnRefOnly.onRef("foo", "cid-events-transplant"), att -> {}));
 
     ByteString meta = ByteString.copyFromUtf8("transplant me");
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.persist.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
 
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
@@ -79,7 +80,11 @@ public abstract class AbstractManyCommits {
               .commitMetaSerialized(ByteString.copyFromUtf8("commit #" + i + " of " + numCommits))
               .addPuts(
                   KeyWithBytes.of(
-                      key, fixed, payload, SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(c)));
+                      key,
+                      fixed,
+                      payload,
+                      SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                          c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
       Hash hash = databaseAdapter.commit(commit.build());
       commits[i] = hash;
     }
@@ -125,7 +130,9 @@ public abstract class AbstractManyCommits {
       OnRefOnly expected =
           OnRefOnly.onRef("value for #" + i + " of " + numCommits, contentId.getId());
 
-      ByteString expectValue = SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(expected);
+      ByteString expectValue =
+          SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+              expected, ALWAYS_THROWING_ATTACHMENT_CONSUMER);
       ContentAndState<ByteString> expect = ContentAndState.of(expectValue);
       assertThat(values).containsExactly(Maps.immutableEntry(key, expect));
     } catch (ReferenceNotFoundException e) {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.spy;
+import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
 
 import com.google.protobuf.ByteString;
 import java.util.Arrays;
@@ -201,7 +202,8 @@ public abstract class AbstractManyKeys {
                           ContentId.of("c" + i),
                           (byte) 0,
                           SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
-                              OnRefOnly.onRef("r" + i, "c" + i))))
+                              OnRefOnly.onRef("r" + i, "c" + i),
+                              ALWAYS_THROWING_ATTACHMENT_CONSUMER)))
                   .build());
       keyToCommit.put(key, hash);
     }
@@ -260,7 +262,8 @@ public abstract class AbstractManyKeys {
                           ContentId.of("c" + i),
                           (byte) 0,
                           SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
-                              OnRefOnly.onRef("pf" + i, "cpf" + i))))
+                              OnRefOnly.onRef("pf" + i, "cpf" + i),
+                              ALWAYS_THROWING_ATTACHMENT_CONSUMER)))
                   .build());
       keyToCommit.put(key, hash);
     }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig.DEFAULT_KEY_LIST_DISTANCE;
+import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
 
 import com.google.protobuf.ByteString;
 import java.util.Arrays;
@@ -264,7 +265,9 @@ public abstract class AbstractMergeTransplant {
       for (int k = 0; k < 3; k++) {
         Key key = Key.of("key", Integer.toString(k));
         OnRefOnly value = OnRefOnly.newOnRef("value " + i + " for " + k);
-        ByteString onRef = SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(value);
+        ByteString onRef =
+            SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                value, ALWAYS_THROWING_ATTACHMENT_CONSUMER);
         keysAndValue.put(key, ContentAndState.of(onRef));
         commit.addPuts(
             KeyWithBytes.of(
@@ -381,7 +384,8 @@ public abstract class AbstractMergeTransplant {
               Key.of("key", Integer.toString(k)),
               ContentId.of("C" + k),
               SimpleStoreWorker.INSTANCE.getPayload(conflictValue),
-              SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(conflictValue)));
+              SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                  conflictValue, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
     }
     Hash conflictHead = databaseAdapter.commit(commit.build());
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractReferences.java
@@ -324,7 +324,7 @@ public abstract class AbstractReferences {
                               ContentId.of("c" + commit),
                               (byte) 0,
                               SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
-                                  OnRefOnly.newOnRef("c" + commit))))
+                                  OnRefOnly.newOnRef("c" + commit), att -> {})))
                       .build());
           refLogOpsPerRef
               .computeIfAbsent(ref, x -> new ArrayList<>())

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/DatabaseAdapterTestUtils.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/DatabaseAdapterTestUtils.java
@@ -13,20 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.testworker;
+package org.projectnessie.versioned.persist.tests;
 
-/** Base content interface for {@link org.projectnessie.versioned.testworker.SimpleStoreWorker}. */
-public interface BaseContent {
+import static org.assertj.core.api.Assertions.fail;
 
-  enum Type {
-    /** Content type with on-reference state. */
-    ON_REF_ONLY,
-    /** Content type with on-reference state and mandatory global state. */
-    WITH_GLOBAL_STATE,
-    /** Content type with on-reference state and mandatory per-content-id state. */
-    WITH_PER_CONTENT_STATE
-  }
+import java.util.function.Consumer;
+import org.projectnessie.versioned.ContentAttachment;
 
-  /** Content-id. */
-  String getId();
+public class DatabaseAdapterTestUtils {
+  public static final Consumer<ContentAttachment> ALWAYS_THROWING_ATTACHMENT_CONSUMER =
+      attachment -> fail("Unexpected use of Consumer<ContentAttachment>");
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
@@ -50,16 +50,6 @@ public interface StoreWorker<CONTENT, COMMIT_METADATA, CONTENT_TYPE extends Enum
 
   boolean requiresGlobalState(CONTENT content);
 
-  default boolean requiresPerContentState(ByteString content) {
-    return requiresPerContentState(getType(content));
-  }
-
-  default boolean requiresPerContentState(CONTENT content) {
-    return requiresPerContentState(getType(content));
-  }
-
-  boolean requiresPerContentState(Enum<CONTENT_TYPE> contentType);
-
   CONTENT_TYPE getType(ByteString onRefContent);
 
   CONTENT_TYPE getType(Byte payload);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/StoreWorker.java
@@ -16,7 +16,10 @@
 package org.projectnessie.versioned;
 
 import com.google.protobuf.ByteString;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * A set of helpers that users of a VersionStore must implement.
@@ -27,11 +30,15 @@ import java.util.function.Supplier;
 public interface StoreWorker<CONTENT, COMMIT_METADATA, CONTENT_TYPE extends Enum<CONTENT_TYPE>> {
 
   /** Returns the serialized representation of the on-reference part of the given content-object. */
-  ByteString toStoreOnReferenceState(CONTENT content);
+  ByteString toStoreOnReferenceState(
+      CONTENT content, Consumer<ContentAttachment> attachmentConsumer);
 
   ByteString toStoreGlobalState(CONTENT content);
 
-  CONTENT valueFromStore(ByteString onReferenceValue, Supplier<ByteString> globalState);
+  CONTENT valueFromStore(
+      ByteString onReferenceValue,
+      Supplier<ByteString> globalState,
+      Function<Stream<ContentAttachmentKey>, Stream<ContentAttachment>> attachmentsRetriever);
 
   CONTENT applyId(CONTENT content, String id);
 
@@ -42,6 +49,16 @@ public interface StoreWorker<CONTENT, COMMIT_METADATA, CONTENT_TYPE extends Enum
   boolean requiresGlobalState(ByteString content);
 
   boolean requiresGlobalState(CONTENT content);
+
+  default boolean requiresPerContentState(ByteString content) {
+    return requiresPerContentState(getType(content));
+  }
+
+  default boolean requiresPerContentState(CONTENT content) {
+    return requiresPerContentState(getType(content));
+  }
+
+  boolean requiresPerContentState(Enum<CONTENT_TYPE> contentType);
 
   CONTENT_TYPE getType(ByteString onRefContent);
 

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/BaseContent.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/BaseContent.java
@@ -23,8 +23,8 @@ public interface BaseContent {
     ON_REF_ONLY,
     /** Content type with on-reference state and mandatory global state. */
     WITH_GLOBAL_STATE,
-    /** Content type with on-reference state and mandatory per-content-id state. */
-    WITH_PER_CONTENT_STATE
+    /** Content type with on-reference state and content attachments. */
+    WITH_ATTACHMENTS
   }
 
   /** Content-id. */

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/SimpleStoreWorker.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/SimpleStoreWorker.java
@@ -68,7 +68,7 @@ public final class SimpleStoreWorker
       case WITH_GLOBAL_STATE:
         value = ((WithGlobalStateContent) content).getOnRef();
         break;
-      case WITH_PER_CONTENT_STATE:
+      case WITH_ATTACHMENTS:
         value = ((WithAttachmentsContent) content).getOnRef();
         break;
       default:
@@ -115,7 +115,7 @@ public final class SimpleStoreWorker
       case WITH_GLOBAL_STATE:
         assertThat(global).isNotNull();
         return withGlobal(global.toStringUtf8(), onRef, contentId);
-      case WITH_PER_CONTENT_STATE:
+      case WITH_ATTACHMENTS:
         Stream<ContentAttachmentKey> keys = Stream.empty();
         try (Stream<ContentAttachment> attachments = attachmentsRetriever.apply(keys)) {
           assertThat(attachments).isNotEmpty();
@@ -176,7 +176,7 @@ public final class SimpleStoreWorker
       return BaseContent.Type.WITH_GLOBAL_STATE;
     }
     if (content instanceof WithAttachmentsContent) {
-      return BaseContent.Type.WITH_PER_CONTENT_STATE;
+      return BaseContent.Type.WITH_ATTACHMENTS;
     }
     throw new IllegalArgumentException("" + content);
   }
@@ -189,11 +189,6 @@ public final class SimpleStoreWorker
   @Override
   public boolean requiresGlobalState(BaseContent baseContent) {
     return baseContent instanceof WithGlobalStateContent;
-  }
-
-  @Override
-  public boolean requiresPerContentState(Enum<BaseContent.Type> type) {
-    return type == BaseContent.Type.WITH_PER_CONTENT_STATE;
   }
 
   @Override

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/WithAttachmentsContent.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/WithAttachmentsContent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.testworker;
+
+import java.util.List;
+import java.util.UUID;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.ContentAttachment;
+
+/** Content with on-reference state and mandatory global state. */
+@Value.Immutable
+public interface WithAttachmentsContent extends BaseContent {
+
+  static WithAttachmentsContent withAttachments(
+      List<ContentAttachment> perContent, String onRef, String contentId) {
+    return ImmutableWithAttachmentsContent.builder()
+        .onRef(onRef)
+        .perContent(perContent)
+        .id(contentId)
+        .build();
+  }
+
+  static WithAttachmentsContent newWithAttachments(
+      List<ContentAttachment> perContent, String onRef) {
+    return ImmutableWithAttachmentsContent.builder()
+        .onRef(onRef)
+        .perContent(perContent)
+        .id(UUID.randomUUID().toString())
+        .build();
+  }
+
+  String getOnRef();
+
+  List<ContentAttachment> getPerContent();
+}


### PR DESCRIPTION
Allow the `StoreWorker` to handle a third "content variant" in addition to "content on reference" and "content with global state". The third variant is actually an extension to "content on reference" and allows attachments. Each commit stores references to the required attachments, which are, in case of Iceberg, the "shallow metadata" and all child objects. Note: This technical change is not specific to Iceberg and a purely internal concern.

(See point 2 in #4138)
