### PR TITLE
Spark SQL: Configure ref.hash for NessieCatalog only when explicitly requested

### DIFF
--- a/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseUseReferenceExec.scala
+++ b/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseUseReferenceExec.scala
@@ -34,7 +34,12 @@ abstract class BaseUseReferenceExec(
   ): Seq[InternalRow] = {
 
     val ref = NessieUtils.calculateRef(branch, timestampOrHash, api)
-    NessieUtils.setCurrentRefForSpark(currentCatalog, catalog, ref)
+    NessieUtils.setCurrentRefForSpark(
+      currentCatalog,
+      catalog,
+      ref,
+      timestampOrHash.isDefined
+    )
 
     Seq(
       InternalRow(


### PR DESCRIPTION
This makes sure that we only configure the `ref.hash` parameter for the
`NessieCatalog` only when the Spark SQL cmd actually specifies a hash.
Specifying a hash means that generally a user wants to read data at a
particular hash. It is however not possible to update data at a
particular hash, thus the following sequence of operations will lead to
an unexpected exception:
* USE REFERENCE branchName IN nessie
* CREATE TABLE ....

This will lead to the error shown in
https://github.com/apache/iceberg/blob/b5f367bdedc26e0f676d88462912b57ff7bae167/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java#L76
because once the `NessieCatalog` is set to a particular hash, it is
never updated (which makes sense).

Note that this issue only happens with the fix described in
https://github.com/apache/iceberg/pull/4330, hence the current tests
that we have are all passing.