### PR TITLE
Unify identical enums in `persist.proto`

### DIFF
--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -93,8 +93,8 @@ import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePoi
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.NamedReference;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.Operation;
-import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.RefType;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefType;
 
 /**
  * Non-transactional database-adapter implementation suitable for no-sql databases.
@@ -224,7 +224,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                     ctx,
                     pointer,
                     mergeParams.getToBranch().getName(),
-                    RefLogEntry.RefType.Branch,
+                    RefType.Branch,
                     newHead,
                     RefLogEntry.Operation.MERGE,
                     timeInMicros,
@@ -270,7 +270,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                     ctx,
                     pointer,
                     transplantParams.getToBranch().getName(),
-                    RefLogEntry.RefType.Branch,
+                    RefType.Branch,
                     newHead,
                     RefLogEntry.Operation.TRANSPLANT,
                     timeInMicros,
@@ -321,7 +321,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                     ctx,
                     pointer,
                     commitParams.getToBranch().getName(),
-                    RefLogEntry.RefType.Branch,
+                    RefType.Branch,
                     newBranchCommit.getHash(),
                     RefLogEntry.Operation.COMMIT,
                     timeInMicros,
@@ -366,8 +366,7 @@ public abstract class NonTransactionalDatabaseAdapter<
 
             validateHashExists(ctx, hash);
 
-            RefLogEntry.RefType refType =
-                ref instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
+            RefType refType = ref instanceof TagName ? RefType.Tag : RefType.Branch;
             RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
@@ -401,8 +400,7 @@ public abstract class NonTransactionalDatabaseAdapter<
             Hash branchHead = branchHead(pointer, reference);
             verifyExpectedHash(branchHead, reference, expectedHead);
 
-            RefLogEntry.RefType refType =
-                reference instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
+            RefType refType = reference instanceof TagName ? RefType.Tag : RefType.Branch;
             RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
@@ -438,8 +436,7 @@ public abstract class NonTransactionalDatabaseAdapter<
 
             validateHashExists(ctx, assignTo);
 
-            RefLogEntry.RefType refType =
-                assignee instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
+            RefType refType = assignee instanceof TagName ? RefType.Tag : RefType.Branch;
             RefLogEntry newRefLog =
                 writeRefLogEntry(
                     ctx,
@@ -490,7 +487,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                 ctx,
                 dummyPointer,
                 defaultBranchName,
-                RefLogEntry.RefType.Branch,
+                RefType.Branch,
                 NO_ANCESTOR,
                 RefLogEntry.Operation.CREATE_REFERENCE,
                 commitTimeInMicros(),
@@ -509,7 +506,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                       .setName(defaultBranchName)
                       .setRef(
                           RefPointer.newBuilder()
-                              .setType(RefPointer.Type.Branch)
+                              .setType(RefType.Branch)
                               .setHash(NO_ANCESTOR.asBytes())))
               .setRefLogId(newRefLog.getRefLogId())
               .addRefLogParentsInclHead(newRefLog.getRefLogId())
@@ -693,12 +690,12 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   /** Get the protobuf-enum-value for a named-reference. */
-  protected static RefPointer.Type protoTypeForRef(NamedRef target) {
-    RefPointer.Type type;
+  protected static RefType protoTypeForRef(NamedRef target) {
+    RefType type;
     if (target instanceof BranchName) {
-      type = RefPointer.Type.Branch;
+      type = RefType.Branch;
     } else if (target instanceof TagName) {
-      type = RefPointer.Type.Tag;
+      type = RefType.Tag;
     } else {
       throw new IllegalArgumentException(target.getClass().getSimpleName());
     }
@@ -709,7 +706,7 @@ public abstract class NonTransactionalDatabaseAdapter<
    * Transform the protobuf-enum-value for the named-reference-type plus the reference name into a
    * {@link NamedRef}.
    */
-  protected static NamedRef toNamedRef(RefPointer.Type type, String name) {
+  protected static NamedRef toNamedRef(RefType type, String name) {
     switch (type) {
       case Branch:
         return BranchName.of(name);

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -78,13 +78,14 @@ message GlobalStateLogEntry {
   repeated ContentIdWithBytes puts = 4;
 }
 
+enum RefType {
+  Branch = 0;
+  Tag = 1;
+}
+
 message RefLogEntry {
   bytes ref_log_id = 1;
   bytes ref_name = 2;
-  enum RefType {
-    Branch = 0;
-    Tag = 1;
-  }
   RefType ref_type = 3;
   bytes commit_hash = 4;
   repeated bytes parents = 5;
@@ -128,11 +129,7 @@ message NamedReference {
 
 // Used by non-transactional database-adapters
 message RefPointer {
-  enum Type {
-    Branch = 0;
-    Tag = 1;
-  }
-  Type type = 1;
+  RefType type = 1;
   bytes hash = 2;
 }
 

--- a/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/adapter/serialize/TestSerialization.java
+++ b/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/adapter/serialize/TestSerialization.java
@@ -54,6 +54,7 @@ import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePoi
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.NamedReference;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefType;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RepoProps;
 
 /** (Re-)serialization tests using random data for relevant types. */
@@ -415,10 +416,7 @@ class TestSerialization {
       state.addNamedReferences(
           NamedReference.newBuilder()
               .setName(randomString(32))
-              .setRef(
-                  RefPointer.newBuilder()
-                      .setType(RefPointer.Type.Branch)
-                      .setHash(randomBytes(32))));
+              .setRef(RefPointer.newBuilder().setType(RefType.Branch).setHash(randomBytes(32))));
     }
     return state.build();
   }
@@ -510,7 +508,7 @@ class TestSerialization {
     }
     entry.setRefLogId(randomHash().asBytes());
     entry.setRefName(ByteString.copyFromUtf8("temp"));
-    entry.setRefType(RefLogEntry.RefType.Branch);
+    entry.setRefType(RefType.Branch);
     entry.setCommitHash(randomHash().asBytes());
     entry.setOperation(RefLogEntry.Operation.MERGE);
     return entry.build();

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -95,6 +95,7 @@ import org.projectnessie.versioned.persist.adapter.spi.TryLoopState;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry.Operation;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogParents;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefType;
 
 /**
  * Transactional/relational {@link AbstractDatabaseAdapter} implementation using JDBC primitives.
@@ -1713,8 +1714,7 @@ public abstract class TxDatabaseAdapter
 
       newParents = refLogHead.getRefLogParentsInclHead().stream().map(Hash::asBytes);
     }
-    RefLogEntry.RefType refType =
-        ref instanceof TagName ? RefLogEntry.RefType.Tag : RefLogEntry.RefType.Branch;
+    RefType refType = ref instanceof TagName ? RefType.Tag : RefType.Branch;
 
     RefLogEntry.Builder entry =
         RefLogEntry.newBuilder()


### PR DESCRIPTION
The enums `RefPointer.Type` and `RefLogEntry.RefType` are identical and can be unified.