### PR TITLE
Helm: Fix k8s version detection in ingress template

### DIFF
--- a/helm/nessie/templates/ingress.yaml
+++ b/helm/nessie/templates/ingress.yaml
@@ -1,9 +1,10 @@
+{{- $kubeVersion := .Capabilities.KubeVersion.Version -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "nessie.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.22-0" $kubeVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" $kubeVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -35,8 +36,9 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
-              {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
+              {{- if semverCompare ">=1.22-0" $kubeVersion }}
               service:
                 name: {{ $fullName }}
                 port:


### PR DESCRIPTION
Fixes #4202.

Inside a loop the root "." object gets shadowed and "Capabilities" isn't available anymore.

Also, added `pathType` to path parameters which wasn't required in older k8s versions and default to `ImplementationSpecific` but became a required parameter in newer versions.

Tested using `helm template . --validate` with k8s 1.18 and 1.22 clusters using values:
```
ingress:
  enabled: true
  annotations: {}
  hosts:
    - host: chart-example.local
      paths:
        - "/"
  tls: []
```