### PR TITLE
Add commit-ID to KeyListEntry when writing new key-lists

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -517,8 +517,8 @@ public abstract class AbstractDatabaseAdapter<
    *     retrieved
    * @param defaultBranchHead prerequisite, the hash of the default branch's HEAD commit (depending
    *     on the database-adapter implementation). If {@code null}, {@link
-   *     #namedRefsWithDefaultBranchRelatedInfo(Object, GetNamedRefsParams, Stream, Hash)} will not
-   *     add additional default-branch related information (common ancestor and commits
+   *     #namedRefsWithDefaultBranchRelatedInfo(AutoCloseable, GetNamedRefsParams, Stream, Hash)}
+   *     will not add additional default-branch related information (common ancestor and commits
    *     behind/ahead).
    * @param refs current {@link Stream} of {@link ReferenceInfo} to be enhanced.
    * @return filtered/enhanced stream based on {@code refs}.
@@ -661,8 +661,8 @@ public abstract class AbstractDatabaseAdapter<
   }
 
   /**
-   * Convenience for {@link #hashOnRef(Object, Hash, NamedRef, Optional, Consumer) hashOnRef(ctx,
-   * knownHead, ref.getReference(), ref.getHashOnReference(), null)}.
+   * Convenience for {@link #hashOnRef(AutoCloseable, Hash, NamedRef, Optional, Consumer)
+   * hashOnRef(ctx, knownHead, ref.getReference(), ref.getHashOnReference(), null)}.
    */
   protected Hash hashOnRef(
       OP_CONTEXT ctx, NamedRef reference, Optional<Hash> hashOnRef, Hash knownHead)
@@ -836,7 +836,7 @@ public abstract class AbstractDatabaseAdapter<
   }
 
   /**
-   * Like {@link #readCommitLogStream(Object, Hash)}, but only returns the {@link Hash
+   * Like {@link #readCommitLogStream(AutoCloseable, Hash)}, but only returns the {@link Hash
    * commit-log-entry hashes}, which can be taken from {@link CommitLogEntry#getParents()}, thus no
    * need to perform a read-operation against every hash.
    */
@@ -861,8 +861,8 @@ public abstract class AbstractDatabaseAdapter<
 
   /**
    * Constructs a {@link Stream} of entries for either the global-state-log or a commit-log or a
-   * reflog entry. Use {@link #readCommitLogStream(Object, Hash)} or the similar implementation for
-   * the global-log or reflog entry for non-transactional adapters.
+   * reflog entry. Use {@link #readCommitLogStream(AutoCloseable, Hash)} or the similar
+   * implementation for the global-log or reflog entry for non-transactional adapters.
    */
   protected <T> Spliterator<T> logFetcher(
       OP_CONTEXT ctx,
@@ -985,7 +985,7 @@ public abstract class AbstractDatabaseAdapter<
     return Hash.of(UnsafeByteOperations.unsafeWrap(hasher.hash().asBytes()));
   }
 
-  /** Helper object for {@link #buildKeyList(Object, CommitLogEntry, Consumer, Function)}. */
+  /** Helper object for {@link #buildKeyList(AutoCloseable, CommitLogEntry, Consumer, Function)}. */
   private static class KeyListBuildState {
     final ImmutableCommitLogEntry.Builder newCommitEntry;
     /** Builder for {@link CommitLogEntry#getKeyList()}. */

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -122,6 +122,11 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   @Override
+  public NonTransactionalOperationContext borrowConnection() {
+    return NON_TRANSACTIONAL_OPERATION_CONTEXT;
+  }
+
+  @Override
   public Hash hashOnReference(NamedRef namedReference, Optional<Hash> hashOnReference)
       throws ReferenceNotFoundException {
     return hashOnRef(NON_TRANSACTIONAL_OPERATION_CONTEXT, namedReference, hashOnReference);
@@ -718,9 +723,9 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   /**
-   * Convenience method for {@link AbstractDatabaseAdapter#hashOnRef(Object, NamedRef, Optional,
-   * Hash) hashOnRef(ctx, reference.getReference(), branchHead(fetchGlobalPointer(ctx), reference),
-   * reference.getHashOnReference())}.
+   * Convenience method for {@link AbstractDatabaseAdapter#hashOnRef(AutoCloseable, NamedRef,
+   * Optional, Hash) hashOnRef(ctx, reference.getReference(), branchHead(fetchGlobalPointer(ctx),
+   * reference), reference.getHashOnReference())}.
    */
   protected Hash hashOnRef(
       NonTransactionalOperationContext ctx, NamedRef reference, Optional<Hash> hashOnRef)
@@ -729,8 +734,8 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   /**
-   * Convenience method for {@link AbstractDatabaseAdapter#hashOnRef(Object, NamedRef, Optional,
-   * Hash) hashOnRef(ctx, reference.getReference(), branchHead(pointer, reference),
+   * Convenience method for {@link AbstractDatabaseAdapter#hashOnRef(AutoCloseable, NamedRef,
+   * Optional, Hash) hashOnRef(ctx, reference.getReference(), branchHead(pointer, reference),
    * reference.getHashOnReference())}.
    */
   protected Hash hashOnRef(

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalOperationContext.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalOperationContext.java
@@ -15,11 +15,14 @@
  */
 package org.projectnessie.versioned.persist.nontx;
 
-public class NonTransactionalOperationContext {
+public class NonTransactionalOperationContext implements AutoCloseable {
 
   @SuppressWarnings("InstantiationOfUtilityClass")
   public static final NonTransactionalOperationContext NON_TRANSACTIONAL_OPERATION_CONTEXT =
       new NonTransactionalOperationContext();
 
   private NonTransactionalOperationContext() {}
+
+  @Override
+  public void close() {}
 }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -17,10 +17,15 @@ package org.projectnessie.versioned.persist.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.spy;
 
 import com.google.protobuf.ByteString;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -44,10 +49,15 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.Difference;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
+import org.projectnessie.versioned.persist.adapter.KeyList;
+import org.projectnessie.versioned.persist.adapter.KeyListEntity;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+import org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter;
 import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterConfigItem;
+import org.projectnessie.versioned.testworker.OnRefOnly;
 import org.projectnessie.versioned.testworker.SimpleStoreWorker;
 import org.projectnessie.versioned.testworker.WithGlobalStateContent;
 
@@ -541,6 +551,143 @@ public abstract class AbstractDatabaseAdapterTest {
       assertThat(log.collect(Collectors.toList()))
           .extracting(CommitLogEntry::getMetadata)
           .containsExactlyInAnyOrder(barCommitMeta);
+    }
+  }
+
+  /**
+   * Nessie versions before 0.22.0 write key-lists without the ID of the commit that last updated
+   * the key. This test ensures that the commit-ID is added for newly written key-lists.
+   */
+  @Test
+  void enhanceKeyListWithCommitId(
+      @NessieDbAdapter
+          @NessieDbAdapterConfigItem(name = "key.list.distance", value = "5")
+          @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "100")
+          @NessieDbAdapterConfigItem(name = "max.key.list.entity.size", value = "100")
+          DatabaseAdapter da)
+      throws Exception {
+
+    // All other database adapter implementation don't work, because they use "INSERT"-ish (no
+    // "upsert"), so the code to "break" the key-lists below, which is essential for the test to
+    // work, will fail.
+    assumeThat(da)
+        .extracting(Object::getClass)
+        .extracting(Class::getSimpleName)
+        .isIn("InmemoryDatabaseAdapter", "RocksDatabaseAdapter");
+
+    // Because we cannot write "old" KeyListEntry's, write a series of keys + commits here and then
+    // "break" the last written key-list-entities by removing the commitID. Then write a new
+    // key-list
+    // and verify that the key-list-entries have the (right) commit IDs.
+
+    @SuppressWarnings("unchecked")
+    AbstractDatabaseAdapter<AutoCloseable, ?> ada = (AbstractDatabaseAdapter<AutoCloseable, ?>) da;
+
+    int keyListDistance = ada.getConfig().getKeyListDistance();
+
+    String longString =
+        "keykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykey"
+            + "keykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykey";
+
+    BranchName branch = BranchName.of("main");
+    ByteString meta = ByteString.copyFromUtf8("msg");
+
+    Map<Key, Hash> keyToCommit = new HashMap<>();
+    for (int i = 0; i < 10 * keyListDistance; i++) {
+      Key key = Key.of("k" + i, longString);
+      Hash hash =
+          da.commit(
+              ImmutableCommitParams.builder()
+                  .toBranch(branch)
+                  .commitMetaSerialized(meta)
+                  .addPuts(
+                      KeyWithBytes.of(
+                          key,
+                          ContentId.of("c" + i),
+                          (byte) 0,
+                          SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                              OnRefOnly.onRef("r" + i, "c" + i))))
+                  .build());
+      keyToCommit.put(key, hash);
+    }
+
+    Hash head = da.namedRef(branch.getName(), GetNamedRefsParams.DEFAULT).getHash();
+
+    try (AutoCloseable ctx = ada.borrowConnection()) {
+      // Sanity: fetchKeyLists called exactly once
+      AbstractDatabaseAdapter<AutoCloseable, ?> adaSpy = spy(ada);
+      adaSpy.values(head, keyToCommit.keySet(), KeyFilterPredicate.ALLOW_ALL);
+
+      CommitLogEntry commit = ada.fetchFromCommitLog(ctx, head);
+      assertThat(commit).isNotNull();
+      try (Stream<KeyListEntity> keyListEntityStream =
+          ada.fetchKeyLists(ctx, commit.getKeyListsIds())) {
+
+        List<KeyListEntity> noCommitIds =
+            keyListEntityStream
+                .map(
+                    e ->
+                        KeyListEntity.of(
+                            e.getId(),
+                            KeyList.of(
+                                e.getKeys().getKeys().stream()
+                                    .map(
+                                        k ->
+                                            KeyListEntry.of(
+                                                k.getKey(), k.getContentId(), k.getType(), null))
+                                    .collect(Collectors.toList()))))
+                .collect(Collectors.toList());
+        ada.writeKeyListEntities(ctx, noCommitIds);
+      }
+
+      // Cross-check that commitIDs in all KeyListEntry is null.
+      try (Stream<KeyListEntity> keyListEntityStream =
+          ada.fetchKeyLists(ctx, commit.getKeyListsIds())) {
+        assertThat(keyListEntityStream)
+            .allSatisfy(
+                kl ->
+                    assertThat(kl.getKeys().getKeys())
+                        .allSatisfy(e -> assertThat(e.getCommitId()).isNull()));
+      }
+    }
+
+    for (int i = 0; i < keyListDistance; i++) {
+      Key key = Key.of("pre-fix-" + i);
+      Hash hash =
+          da.commit(
+              ImmutableCommitParams.builder()
+                  .toBranch(branch)
+                  .commitMetaSerialized(meta)
+                  .addPuts(
+                      KeyWithBytes.of(
+                          key,
+                          ContentId.of("c" + i),
+                          (byte) 0,
+                          SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                              OnRefOnly.onRef("pf" + i, "cpf" + i))))
+                  .build());
+      keyToCommit.put(key, hash);
+    }
+
+    Hash fixedHead = da.namedRef(branch.getName(), GetNamedRefsParams.DEFAULT).getHash();
+
+    try (AutoCloseable ctx = ada.borrowConnection()) {
+      CommitLogEntry commit = ada.fetchFromCommitLog(ctx, fixedHead);
+      assertThat(commit).isNotNull();
+
+      // Check that commitIDs in all KeyListEntry is NOT null and points to the expected commitId.
+      try (Stream<KeyListEntity> keyListEntityStream =
+          ada.fetchKeyLists(ctx, commit.getKeyListsIds())) {
+        assertThat(keyListEntityStream)
+            .allSatisfy(
+                kl ->
+                    assertThat(kl.getKeys().getKeys())
+                        .allSatisfy(
+                            e ->
+                                assertThat(e)
+                                    .extracting(KeyListEntry::getCommitId, KeyListEntry::getKey)
+                                    .containsExactly(keyToCommit.get(e.getKey()), e.getKey())));
+      }
     }
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -678,8 +678,8 @@ public abstract class TxDatabaseAdapter
   // /////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Convenience for {@link AbstractDatabaseAdapter#hashOnRef(Object, NamedRef, Optional, Hash)
-   * hashOnRef(conn, ref, fetchNamedRefHead(conn, ref.getReference()))}.
+   * Convenience for {@link AbstractDatabaseAdapter#hashOnRef(AutoCloseable, NamedRef, Optional,
+   * Hash) hashOnRef(conn, ref, fetchNamedRefHead(conn, ref.getReference()))}.
    */
   protected Hash hashOnRef(ConnectionWrapper conn, NamedRef reference, Optional<Hash> hashOnRef)
       throws ReferenceNotFoundException {
@@ -696,7 +696,8 @@ public abstract class TxDatabaseAdapter
     return toProto(entry).getSerializedSize();
   }
 
-  protected ConnectionWrapper borrowConnection() {
+  @Override
+  public ConnectionWrapper borrowConnection() {
     return ConnectionWrapper.borrow(this::newConnection);
   }
 


### PR DESCRIPTION
`KeyListEntry` written before Nessie 0.22.0 do not have the commit-ID field set,
which means the remaining commit-log needs to be searched for the commit that
added the key.

This change adds the missing commit-ID when writing a new key-list.