### PR TITLE
Eliminiate global-pointer contention (non-tx database adapters)

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
@@ -112,4 +112,14 @@ public interface QuarkusVersionStoreAdvancedConfig
   @WithDefault("")
   @WithConverter(RepoIdConverter.class)
   String getJdbcSchema();
+
+  @WithName("references.segment.size")
+  @WithDefault("" + DEFAULT_REFERENCES_SEGMENT_SIZE)
+  @Override
+  int getReferencesSegmentSize();
+
+  @WithName("ref-log.stripes")
+  @WithDefault("" + DEFAULT_REF_LOG_STRIPES)
+  @Override
+  int getRefLogStripes();
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
@@ -123,6 +123,11 @@ public interface QuarkusVersionStoreAdvancedConfig
   @Override
   int getReferencesSegmentPrefetch();
 
+  @WithName("reference-names.batch.size")
+  @WithDefault("" + DEFAULT_REFERENCE_NAMES_BATCH_SIZE)
+  @Override
+  int getReferenceNamesBatchSize();
+
   @WithName("ref-log.stripes")
   @WithDefault("" + DEFAULT_REF_LOG_STRIPES)
   @Override

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
@@ -118,6 +118,11 @@ public interface QuarkusVersionStoreAdvancedConfig
   @Override
   int getReferencesSegmentSize();
 
+  @WithName("references.segment.prefetch")
+  @WithDefault("" + DEFAULT_REFERENCES_SEGMENT_PREFETCH)
+  @Override
+  int getReferencesSegmentPrefetch();
+
   @WithName("ref-log.stripes")
   @WithDefault("" + DEFAULT_REF_LOG_STRIPES)
   @Override

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -88,6 +88,8 @@ The following configurations are advanced configurations to configure how Nessie
 | `nessie.version.store.advanced.tx.batch-size`                   | `20`                | `int`    | Sets the DML batch size, used when writing multiple commits to a branch during a transplant or merge operation or when writing "overflow full key-lists".                                                               |
 | `nessie.version.store.advanced.tx.jdbc.catalog`                 |                     | `String` | Sets the catalog name to use via JDBC.                                                                                                                                                                                  |
 | `nessie.version.store.advanced.tx.jdbc.schema`                  |                     | `String` | Sets the schema name to use via JDBC.                                                                                                                                                                                   |
+| `nessie.version.store.advanced.references.segment.prefetch`     | `1`                 | `int`    | Sets the number of reference name segments to prefetch.                                                                                                                                                                 |
+| `nessie.version.store.advanced.references.segment.size`         | `250_000`           | `int`    | Sets the size of a reference name segments.                                                                                                                                                                             |
 
 ### Authentication settings
 

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -90,6 +90,7 @@ The following configurations are advanced configurations to configure how Nessie
 | `nessie.version.store.advanced.tx.jdbc.schema`                  |                     | `String` | Sets the schema name to use via JDBC.                                                                                                                                                                                   |
 | `nessie.version.store.advanced.references.segment.prefetch`     | `1`                 | `int`    | Sets the number of reference name segments to prefetch.                                                                                                                                                                 |
 | `nessie.version.store.advanced.references.segment.size`         | `250_000`           | `int`    | Sets the size of a reference name segments.                                                                                                                                                                             |
+| `nessie.version.store.advanced.reference.names.batch.size`      | `25`                | `int`    | Sets the number of references to resolve at once when fetching all references.                                                                                                                                          |
 
 ### Authentication settings
 

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -91,6 +91,7 @@ The following configurations are advanced configurations to configure how Nessie
 | `nessie.version.store.advanced.references.segment.prefetch`     | `1`                 | `int`    | Sets the number of reference name segments to prefetch.                                                                                                                                                                 |
 | `nessie.version.store.advanced.references.segment.size`         | `250_000`           | `int`    | Sets the size of a reference name segments.                                                                                                                                                                             |
 | `nessie.version.store.advanced.reference.names.batch.size`      | `25`                | `int`    | Sets the number of references to resolve at once when fetching all references.                                                                                                                                          |
+| `nessie.version.store.advanced.ref-log.stripes`                 | `8`                 | `int`    | Sets the number of stripes for the ref-log.                                                                                                                                          |
 
 ### Authentication settings
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1999,17 +1999,8 @@ public abstract class AbstractDatabaseAdapter<
     return StreamSupport.stream(split, false);
   }
 
-  protected Spliterator<RefLog> readRefLog(OP_CONTEXT ctx, Hash initialHash)
-      throws RefLogNotFoundException {
-    if (NO_ANCESTOR.equals(initialHash)) {
-      return Spliterators.emptySpliterator();
-    }
-    RefLog initial = fetchFromRefLog(ctx, initialHash);
-    if (initial == null) {
-      throw RefLogNotFoundException.forRefLogId(initialHash.asString());
-    }
-    return logFetcher(ctx, initial, this::fetchPageFromRefLog, RefLog::getParents);
-  }
+  protected abstract Spliterator<RefLog> readRefLog(OP_CONTEXT ctx, Hash initialHash)
+      throws RefLogNotFoundException;
 
   protected void tryLoopStateCompletion(@Nonnull Boolean success, TryLoopState state) {
     tryLoopFinished(

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestTryLoopState.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestTryLoopState.java
@@ -93,6 +93,7 @@ class TestTryLoopState {
 
     // Similar for 'retryEndless'
 
+    tryLoopState.resetBounds();
     lower = initialLower;
     upper = initialUpper;
     for (int i = 0; i < 3; i++) {
@@ -112,6 +113,11 @@ class TestTryLoopState {
             }
           };
       inOrderClock.verify(clock, times(1)).sleepMillis(longThat(matcher));
+
+      if (upper * 2 <= maxSleep) {
+        lower *= 2;
+        upper *= 2;
+      }
     }
 
     verify(clock, times(1 + retries)).currentNanos();
@@ -244,6 +250,7 @@ class TestTryLoopState {
     lower = DatabaseAdapterConfig.DEFAULT_RETRY_INITIAL_SLEEP_MILLIS_LOWER;
     upper = DatabaseAdapterConfig.DEFAULT_RETRY_INITIAL_SLEEP_MILLIS_UPPER;
 
+    tryLoopState.resetBounds();
     for (int i = 0; i < 3; i++) {
       tryLoopState.retryEndless();
 
@@ -252,6 +259,9 @@ class TestTryLoopState {
 
       verify(clock).sleepMillis(longThat(v -> v >= l && v <= u));
       clearInvocations(clock);
+
+      lower *= 2;
+      upper *= 2;
     }
   }
 

--- a/versioned/persist/dynamodb/pom.xml
+++ b/versioned/persist/dynamodb/pom.xml
@@ -47,6 +47,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-non-transactional</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -390,21 +390,21 @@ public class DynamoDatabaseAdapter
   protected boolean doRefLogParentsCas(
       NonTransactionalOperationContext ctx,
       int stripe,
-      RefLogParents refLogParents,
-      RefLogParents refLogEntry) {
+      RefLogParents previousEntry,
+      RefLogParents newEntry) {
     Map<String, ExpectedAttributeValue> expected =
-        refLogParents != null
+        previousEntry != null
             ? singletonMap(
                 VALUE_NAME,
                 ExpectedAttributeValue.builder()
                     .value(
                         AttributeValue.builder()
-                            .b(SdkBytes.fromByteArray(refLogParents.toByteArray()))
+                            .b(SdkBytes.fromByteArray(previousEntry.toByteArray()))
                             .build())
                     .build())
             : singletonMap(KEY_NAME, ExpectedAttributeValue.builder().exists(false).build());
     AttributeValue newPointerBytes =
-        AttributeValue.builder().b(SdkBytes.fromByteArray(refLogEntry.toByteArray())).build();
+        AttributeValue.builder().b(SdkBytes.fromByteArray(newEntry.toByteArray())).build();
     try {
       client.client.updateItem(
           b ->

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/Tables.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/Tables.java
@@ -25,6 +25,9 @@ final class Tables {
   static final String TABLE_COMMIT_LOG = "commit_log";
   static final String TABLE_KEY_LISTS = "key_lists";
   static final String TABLE_REF_LOG = "ref_log";
+  static final String TABLE_REF_HEADS = "ref_heads";
+  static final String TABLE_REF_NAMES = "ref_names";
+  static final String TABLE_REF_LOG_HEADS = "ref_log_heads";
 
   static final String KEY_NAME = "key";
   static final String VALUE_NAME = "val";
@@ -37,6 +40,13 @@ final class Tables {
 
   static Stream<String> allExceptGlobalPointer() {
     return Stream.of(
-        TABLE_REPO_DESC, TABLE_GLOBAL_LOG, TABLE_COMMIT_LOG, TABLE_KEY_LISTS, TABLE_REF_LOG);
+        TABLE_REPO_DESC,
+        TABLE_GLOBAL_LOG,
+        TABLE_COMMIT_LOG,
+        TABLE_KEY_LISTS,
+        TABLE_REF_LOG,
+        TABLE_REF_HEADS,
+        TABLE_REF_NAMES,
+        TABLE_REF_LOG_HEADS);
   }
 }

--- a/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDynamoDatabaseAdapter.java
@@ -23,7 +23,6 @@ import com.google.protobuf.ByteString;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -110,8 +109,8 @@ public class ITDynamoDatabaseAdapter extends AbstractDatabaseAdapterTest
         .extracting(l -> l.get(0))
         .allMatch(Objects::nonNull);
 
-    implDatabaseAdapter()
-        .doCleanUpCommitCas(ctx, Optional.empty(), branchCommits, newKeyLists, refLogId);
+    implDatabaseAdapter().doCleanUpRefLogWrite(ctx, refLogId);
+    implDatabaseAdapter().doCleanUpCommitCas(ctx, branchCommits, newKeyLists);
 
     assertThat(implDatabaseAdapter().doFetchFromRefLog(ctx, refLogId)).isNull();
     assertThat(branchCommits)

--- a/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDynamoDatabaseAdapter.java
@@ -33,14 +33,14 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.KeyList;
 import org.projectnessie.versioned.persist.adapter.KeyListEntity;
+import org.projectnessie.versioned.persist.nontx.AbstractNonTxDatabaseAdapterTest;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalOperationContext;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefLogEntry;
-import org.projectnessie.versioned.persist.tests.AbstractDatabaseAdapterTest;
 import org.projectnessie.versioned.persist.tests.LongerCommitTimeouts;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
 @NessieExternalDatabase(LocalDynamoTestConnectionProviderSource.class)
-public class ITDynamoDatabaseAdapter extends AbstractDatabaseAdapterTest
+public class ITDynamoDatabaseAdapter extends AbstractNonTxDatabaseAdapterTest
     implements LongerCommitTimeouts {
 
   protected DynamoDatabaseAdapter implDatabaseAdapter() {
@@ -61,7 +61,7 @@ public class ITDynamoDatabaseAdapter extends AbstractDatabaseAdapterTest
 
   @ParameterizedTest
   @MethodSource("cleanUpCasBatch")
-  public void cleanUpCasBatch(int numCommits, int numKeyLists) throws Exception {
+  public void cleanUpCasBatch(int numCommits, int numKeyLists) {
     Set<Hash> branchCommits = new HashSet<>();
     Set<Hash> newKeyLists = new HashSet<>();
     Hash refLogId = randomHash();

--- a/versioned/persist/inmem/pom.xml
+++ b/versioned/persist/inmem/pom.xml
@@ -51,5 +51,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-non-transactional</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -117,11 +117,11 @@ public class InmemoryDatabaseAdapter
   protected boolean doRefLogParentsCas(
       NonTransactionalOperationContext ctx,
       int stripe,
-      RefLogParents refLogParents,
-      RefLogParents newRefLogParents) {
-    ByteString update = newRefLogParents.toByteString();
-    if (refLogParents != null) {
-      ByteString expected = refLogParents.toByteString();
+      RefLogParents previousEntry,
+      RefLogParents newEntry) {
+    ByteString update = newEntry.toByteString();
+    if (previousEntry != null) {
+      ByteString expected = previousEntry.toByteString();
       return store.refLogHeads.replace(dbKey(stripe), expected, update);
     } else {
       return store.refLogHeads.putIfAbsent(dbKey(stripe), update) == null;

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
@@ -34,6 +34,9 @@ public class InmemoryStore implements DatabaseConnectionProvider<InmemoryConfig>
   final ConcurrentMap<ByteString, ByteString> commitLog = new ConcurrentHashMap<>();
   final ConcurrentMap<ByteString, ByteString> keyLists = new ConcurrentHashMap<>();
   final ConcurrentMap<ByteString, ByteString> refLog = new ConcurrentHashMap<>();
+  final ConcurrentMap<ByteString, ByteString> refHeads = new ConcurrentHashMap<>();
+  final ConcurrentMap<ByteString, ByteString> refNames = new ConcurrentHashMap<>();
+  final ConcurrentMap<ByteString, ByteString> refLogHeads = new ConcurrentHashMap<>();
 
   public InmemoryStore() {}
 
@@ -47,7 +50,15 @@ public class InmemoryStore implements DatabaseConnectionProvider<InmemoryConfig>
   public void close() {}
 
   void reinitializeRepo(ByteString keyPrefix) {
-    Stream.of(repoDesc, globalStatePointer, globalStateLog, commitLog, keyLists, refLog)
+    Stream.of(
+            repoDesc,
+            globalStatePointer,
+            globalStateLog,
+            commitLog,
+            keyLists,
+            refLog,
+            refHeads,
+            refNames)
         .forEach(map -> map.keySet().removeIf(bytes -> bytes.startsWith(keyPrefix)));
   }
 }

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
@@ -58,7 +58,8 @@ public class InmemoryStore implements DatabaseConnectionProvider<InmemoryConfig>
             keyLists,
             refLog,
             refHeads,
-            refNames)
+            refNames,
+            refLogHeads)
         .forEach(map -> map.keySet().removeIf(bytes -> bytes.startsWith(keyPrefix)));
   }
 }

--- a/versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/TestDatabaseAdapterInmemory.java
+++ b/versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/TestDatabaseAdapterInmemory.java
@@ -15,8 +15,8 @@
  */
 package org.projectnessie.versioned.persist.inmem;
 
-import org.projectnessie.versioned.persist.tests.AbstractDatabaseAdapterTest;
+import org.projectnessie.versioned.persist.nontx.AbstractNonTxDatabaseAdapterTest;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
-class TestDatabaseAdapterInmemory extends AbstractDatabaseAdapterTest {}
+class TestDatabaseAdapterInmemory extends AbstractNonTxDatabaseAdapterTest {}

--- a/versioned/persist/mongodb/pom.xml
+++ b/versioned/persist/mongodb/pom.xml
@@ -47,6 +47,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-non-transactional</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -634,7 +634,9 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  protected void doCleanUpRefLogWrite(NonTransactionalOperationContext ctx, Hash refLogId) {}
+  protected void doCleanUpRefLogWrite(NonTransactionalOperationContext ctx, Hash refLogId) {
+    client.getRefLog().deleteOne(Filters.eq(toId(refLogId)));
+  }
 
   @Override
   protected List<ReferenceNames> doFetchReferenceNames(

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseClient.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseClient.java
@@ -34,6 +34,9 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
   private static final String COMMIT_LOG = "commit_log";
   private static final String KEY_LIST = "key_list";
   private static final String REF_LOG = "ref_log";
+  static final String TABLE_REF_HEADS = "ref_heads";
+  static final String TABLE_REF_NAMES = "ref_names";
+  static final String TABLE_REF_LOG_HEADS = "ref_log_heads";
 
   private MongoClientConfig config;
   private MongoClient managedClient;
@@ -43,6 +46,9 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
   private MongoCollection<Document> commitLog;
   private MongoCollection<Document> keyLists;
   private MongoCollection<Document> refLog;
+  private MongoCollection<Document> refHeads;
+  private MongoCollection<Document> refNames;
+  private MongoCollection<Document> refLogHeads;
 
   @Override
   public void configure(MongoClientConfig config) {
@@ -84,6 +90,9 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
     commitLog = database.getCollection(COMMIT_LOG);
     keyLists = database.getCollection(KEY_LIST);
     refLog = database.getCollection(REF_LOG);
+    refHeads = database.getCollection(TABLE_REF_HEADS);
+    refNames = database.getCollection(TABLE_REF_NAMES);
+    refLogHeads = database.getCollection(TABLE_REF_LOG_HEADS);
   }
 
   public MongoCollection<Document> getRepoDesc() {
@@ -110,7 +119,20 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
     return refLog;
   }
 
+  public MongoCollection<Document> getRefHeads() {
+    return refHeads;
+  }
+
+  public MongoCollection<Document> getRefNames() {
+    return refNames;
+  }
+
+  public MongoCollection<Document> getRefLogHeads() {
+    return refLogHeads;
+  }
+
   public Stream<MongoCollection<Document>> allExceptGlobalPointer() {
-    return Stream.of(repoDesc, globalLog, commitLog, keyLists, refLog);
+    return Stream.of(
+        repoDesc, globalLog, commitLog, keyLists, refLog, refHeads, refNames, refLogHeads);
   }
 }

--- a/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/ITDatabaseAdapterMongo.java
+++ b/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/ITDatabaseAdapterMongo.java
@@ -15,10 +15,10 @@
  */
 package org.projectnessie.versioned.persist.mongodb;
 
-import org.projectnessie.versioned.persist.tests.AbstractDatabaseAdapterTest;
+import org.projectnessie.versioned.persist.nontx.AbstractNonTxDatabaseAdapterTest;
 import org.projectnessie.versioned.persist.tests.LongerCommitTimeouts;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
 @NessieExternalDatabase(LocalMongoTestConnectionProviderSource.class)
-public class ITDatabaseAdapterMongo extends AbstractDatabaseAdapterTest
+public class ITDatabaseAdapterMongo extends AbstractNonTxDatabaseAdapterTest
     implements LongerCommitTimeouts {}

--- a/versioned/persist/nontx/pom.xml
+++ b/versioned/persist/nontx/pom.xml
@@ -51,5 +51,25 @@
       <artifactId>value</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/AdjustableNonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/AdjustableNonTransactionalDatabaseAdapterConfig.java
@@ -20,4 +20,13 @@ import org.projectnessie.versioned.persist.adapter.AdjustableDatabaseAdapterConf
 
 @Value.Immutable
 public interface AdjustableNonTransactionalDatabaseAdapterConfig
-    extends NonTransactionalDatabaseAdapterConfig, AdjustableDatabaseAdapterConfig {}
+    extends NonTransactionalDatabaseAdapterConfig, AdjustableDatabaseAdapterConfig {
+
+  AdjustableNonTransactionalDatabaseAdapterConfig withReferencesSegmentSize(int value);
+
+  AdjustableNonTransactionalDatabaseAdapterConfig withReferencesSegmentPrefetch(int value);
+
+  AdjustableNonTransactionalDatabaseAdapterConfig withReferenceNamesBatchSize(int value);
+
+  AdjustableNonTransactionalDatabaseAdapterConfig withRefLogStripes(int value);
+}

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/BatchSpliterator.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/BatchSpliterator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.nontx;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.Spliterators.AbstractSpliterator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class BatchSpliterator<SRC, DST> extends AbstractSpliterator<DST> {
+
+  private final Spliterator<SRC> source;
+  private final int batchSize;
+  private final List<SRC> batch;
+  private final Function<List<SRC>, Spliterator<DST>> batchMapper;
+
+  private SRC nextSource;
+  private boolean sourceEof;
+
+  private void setNextSource(SRC nextSource) {
+    this.nextSource = nextSource;
+  }
+
+  private DST nextMapped;
+  private boolean mappedEof;
+
+  private void setNextMapped(DST nextMapped) {
+    this.nextMapped = nextMapped;
+  }
+
+  private Spliterator<DST> mapped = Spliterators.emptySpliterator();
+
+  BatchSpliterator(
+      int batchSize, Spliterator<SRC> source, Function<List<SRC>, Spliterator<DST>> batchMapper) {
+    super(Long.MAX_VALUE, 0);
+    this.batchSize = batchSize;
+    this.batch = new ArrayList<>(batchSize);
+    this.source = source;
+    this.batchMapper = batchMapper;
+  }
+
+  @Override
+  public boolean tryAdvance(Consumer<? super DST> action) {
+
+    while (true) {
+      if (nextMapped != null) {
+        try {
+          action.accept(nextMapped);
+          return true;
+        } finally {
+          nextMapped = null;
+        }
+      }
+
+      if (!mappedEof && !mapped.tryAdvance(this::setNextMapped)) {
+        mappedEof = true;
+      }
+      if (nextMapped != null) {
+        continue;
+      }
+      if (sourceEof) {
+        return false;
+      }
+
+      while (true) {
+        if (!source.tryAdvance(this::setNextSource)) {
+          sourceEof = true;
+        }
+
+        if (nextSource != null) {
+          batch.add(nextSource);
+          nextSource = null;
+        }
+
+        if (batch.size() == batchSize || sourceEof) {
+          mappedEof = false;
+          try {
+            mapped = batch.isEmpty() ? Spliterators.emptySpliterator() : batchMapper.apply(batch);
+          } finally {
+            batch.clear();
+          }
+          break;
+        }
+      }
+    }
+  }
+}

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/BatchSpliterator.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/BatchSpliterator.java
@@ -47,8 +47,11 @@ final class BatchSpliterator<SRC, DST> extends AbstractSpliterator<DST> {
   private Spliterator<DST> mapped = Spliterators.emptySpliterator();
 
   BatchSpliterator(
-      int batchSize, Spliterator<SRC> source, Function<List<SRC>, Spliterator<DST>> batchMapper) {
-    super(Long.MAX_VALUE, 0);
+      int batchSize,
+      Spliterator<SRC> source,
+      Function<List<SRC>, Spliterator<DST>> batchMapper,
+      int characteristics) {
+    super(Long.MAX_VALUE, characteristics);
     this.batchSize = batchSize;
     this.batch = new ArrayList<>(batchSize);
     this.source = source;

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -56,6 +56,7 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.projectnessie.versioned.BranchName;
@@ -864,8 +865,11 @@ public abstract class NonTransactionalDatabaseAdapter<
       return Spliterators.emptySpliterator();
     }
 
-    return new RegLogSpliterator(
-        config.getRefLogStripes(), initialHash, stripe -> refLogStripeFetcher(ctx, stripe));
+    Stream<Spliterator<RefLog>> stripeFetchers =
+        IntStream.range(-1, config.getRefLogStripes())
+            .mapToObj(stripe -> refLogStripeFetcher(ctx, stripe));
+
+    return new RegLogSpliterator(initialHash, stripeFetchers);
   }
 
   protected abstract void unsafeWriteRefLogStripe(

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -888,7 +888,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                   ctx, initialPage, this::fetchPageFromRefLog, RefLog::getParents);
             });
 
-    return new RegLogSpliterator(initialHash, stripeFetchers);
+    return new RefLogSpliterator(initialHash, stripeFetchers);
   }
 
   protected abstract void unsafeWriteRefLogStripe(

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -806,6 +806,8 @@ public abstract class NonTransactionalDatabaseAdapter<
 
         // CAS against branch-heads succeeded, now try to write the ref-log-entry
 
+        // reset the retry-loop's sleep boundaries
+        tryState.resetBounds();
         int stripe = refLogStripeForName(ref.getName());
         while (true) {
           RefLogParents refLogParents = fetchRefLogParents(ctx, stripe);

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -867,6 +867,20 @@ public abstract class NonTransactionalDatabaseAdapter<
       return Spliterators.emptySpliterator();
     }
 
+    // Two possible optimizations here:
+    // 1. Paging - implement an "implementation aware token"
+    //    Instead of calling refLogStripeFetcher and then scanning the ref-log for the ref-log hash
+    //    from the page-token, add another parameter to this method that the ref-log-stripe fetchers
+    //    with their own initial ref-log-ids (so 1 hash per stripe in a paging token).
+    //    This requires this method to either return a wrapper around `RefLog` that also holds the
+    //    paging token for every returned `RefLog`, or to return a "PagingAwareSpliterator" that
+    //    allows retrieving the paging token. The latter is probably more efficient, but requires
+    //    a bit more "verbose" code.
+    // 2. Faster initial stripe fetching
+    //    Instead of retrieving all initial pages sequentially, perform a bulk-fetch for all initial
+    //    pages. Since ref-log queries are not performance critical and also rare operations, it is
+    //    not urgent to implement this optimization.
+
     Stream<Spliterator<RefLog>> stripeFetchers =
         IntStream.range(-1, config.getRefLogStripes())
             .mapToObj(stripe -> refLogStripeFetcher(ctx, stripe));

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -484,16 +484,6 @@ public abstract class NonTransactionalDatabaseAdapter<
     if (fetchGlobalPointer(ctx) == null) {
       RefLogEntry newRefLog;
       try {
-        for (int stripe = 0; stripe < config.getRefLogStripes(); stripe++) {
-          unsafeWriteRefLogStripe(
-              ctx,
-              stripe,
-              RefLogParents.newBuilder()
-                  .addRefLogParentsInclHead(NO_ANCESTOR.asBytes())
-                  .setVersion(randomHash().asBytes())
-                  .build());
-        }
-
         RefLogParents refLogParents =
             RefLogParents.newBuilder()
                 .addRefLogParentsInclHead(NO_ANCESTOR.asBytes())

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -1253,8 +1253,7 @@ public abstract class NonTransactionalDatabaseAdapter<
     if (ref == null) {
       return null;
     }
-    NamedReference namedReference =
-        fetchNamedReference(NON_TRANSACTIONAL_OPERATION_CONTEXT, ref.getName());
+    NamedReference namedReference = fetchNamedReference(ctx, ref.getName());
     if (namedReference == null || namedReference.getRef().getType() != protoTypeForRef(ref)) {
       throw referenceNotFound(ref.getName());
     }
@@ -1264,7 +1263,7 @@ public abstract class NonTransactionalDatabaseAdapter<
   protected ReferenceInfo<ByteString> referenceHead(
       NonTransactionalOperationContext ctx, String ref) throws ReferenceNotFoundException {
 
-    NamedReference namedReference = fetchNamedReference(NON_TRANSACTIONAL_OPERATION_CONTEXT, ref);
+    NamedReference namedReference = fetchNamedReference(ctx, ref);
     if (namedReference == null) {
       throw referenceNotFound(ref);
     }

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
@@ -15,6 +15,20 @@
  */
 package org.projectnessie.versioned.persist.nontx;
 
+import org.immutables.value.Value;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 
-public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterConfig {}
+public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterConfig {
+  int DEFAULT_REFERENCES_SEGMENT_SIZE = 250_000;
+  int DEFAULT_REF_LOG_STRIPES = 16;
+
+  @Value.Default
+  default int getReferencesSegmentSize() {
+    return DEFAULT_REFERENCES_SEGMENT_SIZE;
+  }
+
+  @Value.Default
+  default int getRefLogStripes() {
+    return DEFAULT_REF_LOG_STRIPES;
+  }
+}

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
@@ -22,6 +22,7 @@ public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterCo
   int DEFAULT_REFERENCES_SEGMENT_SIZE = 250_000;
   int DEFAULT_REF_LOG_STRIPES = 16;
   int DEFAULT_REFERENCES_SEGMENT_PREFETCH = 1;
+  int DEFAULT_REFERENCE_NAMES_BATCH_SIZE = 25;
 
   @Value.Default
   default int getReferencesSegmentSize() {
@@ -31,6 +32,11 @@ public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterCo
   @Value.Default
   default int getReferencesSegmentPrefetch() {
     return DEFAULT_REFERENCES_SEGMENT_PREFETCH;
+  }
+
+  @Value.Default
+  default int getReferenceNamesBatchSize() {
+    return DEFAULT_REFERENCE_NAMES_BATCH_SIZE;
   }
 
   @Value.Default

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
@@ -20,7 +20,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 
 public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterConfig {
   int DEFAULT_REFERENCES_SEGMENT_SIZE = 250_000;
-  int DEFAULT_REF_LOG_STRIPES = 16;
+  int DEFAULT_REF_LOG_STRIPES = 8;
   int DEFAULT_REFERENCES_SEGMENT_PREFETCH = 1;
   int DEFAULT_REFERENCE_NAMES_BATCH_SIZE = 25;
 

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterConfig.java
@@ -21,10 +21,16 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 public interface NonTransactionalDatabaseAdapterConfig extends DatabaseAdapterConfig {
   int DEFAULT_REFERENCES_SEGMENT_SIZE = 250_000;
   int DEFAULT_REF_LOG_STRIPES = 16;
+  int DEFAULT_REFERENCES_SEGMENT_PREFETCH = 1;
 
   @Value.Default
   default int getReferencesSegmentSize() {
     return DEFAULT_REFERENCES_SEGMENT_SIZE;
+  }
+
+  @Value.Default
+  default int getReferencesSegmentPrefetch() {
+    return DEFAULT_REFERENCES_SEGMENT_PREFETCH;
   }
 
   @Value.Default

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/RefLogSpliterator.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/RefLogSpliterator.java
@@ -108,7 +108,7 @@ final class RefLogSpliterator extends AbstractSpliterator<RefLog> {
       return true;
     }
 
-    return true;
+    return false;
   }
 
   private static final class RefLogSplit {

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/ReferenceNamesSpliterator.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/ReferenceNamesSpliterator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.nontx;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators.AbstractSpliterator;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.ReferenceNames;
+
+final class ReferenceNamesSpliterator extends AbstractSpliterator<ReferenceNames> {
+
+  private int segment;
+  private int offset;
+  private List<ReferenceNames> segments = Collections.emptyList();
+
+  private final IntFunction<List<ReferenceNames>> fetchReferenceNames;
+
+  ReferenceNamesSpliterator(IntFunction<List<ReferenceNames>> fetchReferenceNames) {
+    super(Long.MAX_VALUE, Spliterator.NONNULL);
+    this.fetchReferenceNames = fetchReferenceNames;
+  }
+
+  @Override
+  public boolean tryAdvance(Consumer<? super ReferenceNames> action) {
+    if (segment >= offset + segments.size()) {
+      offset = segment;
+      segments = fetchReferenceNames.apply(offset);
+    }
+
+    ReferenceNames referenceNames = segments.get(segment - offset);
+
+    if (referenceNames == null) {
+      return false;
+    }
+
+    segment++;
+
+    action.accept(referenceNames);
+    return true;
+  }
+}

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/ReferenceNamesSpliterator.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/ReferenceNamesSpliterator.java
@@ -23,6 +23,14 @@ import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import org.projectnessie.versioned.persist.serialize.AdapterTypes.ReferenceNames;
 
+/**
+ * {@link Spliterator} of {@link ReferenceNames} used to return all reference names.
+ *
+ * <p>Takes a function that takes the required segment number and returns a {@link List} of {@link
+ * ReferenceNames}, where the first element is the requested segment plus the prefetched segments,
+ * according to {@link NonTransactionalDatabaseAdapterConfig#getReferencesSegmentPrefetch()}. A
+ * {@link null} segment in the returned list indicates that there are no more segments.
+ */
 final class ReferenceNamesSpliterator extends AbstractSpliterator<ReferenceNames> {
 
   private int segment;

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/ReferenceNamesSpliterator.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/ReferenceNamesSpliterator.java
@@ -29,7 +29,7 @@ import org.projectnessie.versioned.persist.serialize.AdapterTypes.ReferenceNames
  * <p>Takes a function that takes the required segment number and returns a {@link List} of {@link
  * ReferenceNames}, where the first element is the requested segment plus the prefetched segments,
  * according to {@link NonTransactionalDatabaseAdapterConfig#getReferencesSegmentPrefetch()}. A
- * {@link null} segment in the returned list indicates that there are no more segments.
+ * {@code null} segment in the returned list indicates that there are no more segments.
  */
 final class ReferenceNamesSpliterator extends AbstractSpliterator<ReferenceNames> {
 
@@ -37,6 +37,12 @@ final class ReferenceNamesSpliterator extends AbstractSpliterator<ReferenceNames
   private int offset;
   private List<ReferenceNames> segments = Collections.emptyList();
 
+  /**
+   * Function that takes the segment number of the {@link ReferenceNames} segment to retrieve.
+   *
+   * <p>The function <em>must</em> return the requested segment in the returned list at index 0, but
+   * can return more {@link ReferenceNames} segments (prefetching).
+   */
   private final IntFunction<List<ReferenceNames>> fetchReferenceNames;
 
   ReferenceNamesSpliterator(IntFunction<List<ReferenceNames>> fetchReferenceNames) {

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/RegLogSpliterator.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/RegLogSpliterator.java
@@ -28,6 +28,14 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 
+/**
+ * {@link Spliterator} of {@link RefLog} entries using a variable number of ref-log stripes,
+ * according to {@link NonTransactionalDatabaseAdapterConfig#getRefLogStripes()} to read {@link
+ * RefLog}s from in parallel.
+ *
+ * <p>The next {@link RefLog} returned by this implementation is the next available from all stripes
+ * with the lowest {@link RefLog#getOperationTime()}.
+ */
 final class RegLogSpliterator extends AbstractSpliterator<RefLog> {
 
   private final List<RefLogSplit> splits;

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/RegLogSpliterator.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/RegLogSpliterator.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.nontx;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators.AbstractSpliterator;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.RefLogNotFoundException;
+import org.projectnessie.versioned.persist.adapter.RefLog;
+
+final class RegLogSpliterator extends AbstractSpliterator<RefLog> {
+
+  private final List<RefLogSplit> splits;
+
+  private final Hash initialHash;
+  private boolean initialHashSeen;
+  private RefLog initialRefLog;
+
+  RegLogSpliterator(
+      int stripes, Hash initialHash, IntFunction<Spliterator<RefLog>> refLogStripeFetcher)
+      throws RefLogNotFoundException {
+    super(Long.MAX_VALUE, 0);
+
+    this.initialHash = initialHash;
+    this.initialHashSeen = initialHash == null;
+
+    splits =
+        IntStream.range(-1, stripes)
+            .mapToObj(stripe -> new RefLogSplit(refLogStripeFetcher.apply(stripe)))
+            .collect(Collectors.toList());
+
+    // The API for DatabaseAdapter.refLog(Hash) requires to throw a RefLogNotFoundException,
+    // if no RefLog for the initial hash exists. This loop tries to find the initial RefLog entry
+    // and throw
+    AtomicReference<RefLog> initial = new AtomicReference<>();
+    while (!initialHashSeen) {
+      if (!tryAdvance(initial::set)) {
+        break;
+      }
+    }
+
+    // Throw RefLogNotFoundException, if RefLog with initial hash could not be found.
+    if (!initialHashSeen) {
+      throw RefLogNotFoundException.forRefLogId(initialHash.asString());
+    }
+    this.initialRefLog = initial.get();
+  }
+
+  @Override
+  public boolean tryAdvance(Consumer<? super RefLog> action) {
+    if (initialRefLog != null) {
+      // This returns the RefLog entry for the initial hash.
+      action.accept(initialRefLog);
+      initialRefLog = null;
+      return true;
+    }
+
+    Optional<RefLogSplit> oldest =
+        splits.stream()
+            .filter(RefLogSplit::hasMore)
+            .max(Comparator.comparing(RefLogSplit::operationTime));
+
+    if (!oldest.isPresent()) {
+      return false;
+    }
+
+    RefLog refLog = oldest.get().pull();
+    if (refLog == null) {
+      return false;
+    }
+
+    if (!initialHashSeen) {
+      initialHashSeen = refLog.getRefLogId().equals(initialHash);
+    }
+
+    if (initialHashSeen) {
+      action.accept(refLog);
+    }
+
+    return true;
+  }
+
+  private static final class RefLogSplit {
+
+    private final Spliterator<RefLog> source;
+
+    private boolean exhausted;
+
+    private RefLog current;
+
+    private RefLogSplit(Spliterator<RefLog> source) {
+      this.source = source;
+    }
+
+    private void advance() {
+      if (exhausted) {
+        return;
+      }
+
+      current = null;
+      if (!source.tryAdvance(refLog -> current = refLog)) {
+        exhausted = true;
+      }
+    }
+
+    private void maybeAdvance() {
+      if (current == null) {
+        advance();
+      }
+    }
+
+    RefLog pull() {
+      if (exhausted) {
+        return null;
+      }
+
+      maybeAdvance();
+
+      RefLog r = current;
+      if (r != null) {
+        current = null;
+      }
+      return r;
+    }
+
+    long operationTime() {
+      maybeAdvance();
+
+      return current != null ? current.getOperationTime() : 0L;
+    }
+
+    boolean hasMore() {
+      maybeAdvance();
+
+      return current != null;
+    }
+
+    @Override
+    public String toString() {
+      return "RefLogSplit{" + "exhausted=" + exhausted + ", current=" + current + '}';
+    }
+  }
+}

--- a/versioned/persist/nontx/src/test/java/org/projectnessie/versioned/persist/nontx/AbstractNonTxDatabaseAdapterTest.java
+++ b/versioned/persist/nontx/src/test/java/org/projectnessie/versioned/persist/nontx/AbstractNonTxDatabaseAdapterTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.nontx;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.randomHash;
+
+import com.google.common.base.Preconditions;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.GlobalStatePointer;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.NamedReference;
+import org.projectnessie.versioned.persist.serialize.AdapterTypes.RefPointer;
+import org.projectnessie.versioned.persist.tests.AbstractDatabaseAdapterTest;
+import org.projectnessie.versioned.persist.tests.LongerCommitTimeouts;
+
+public abstract class AbstractNonTxDatabaseAdapterTest extends AbstractDatabaseAdapterTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {10, 100, 200, 1000})
+  void migrateNamedReferencesFromGlobalPointer(int numNamedRefs) throws Exception {
+    assumeThat(numNamedRefs <= 200 || !(this instanceof LongerCommitTimeouts)).isTrue();
+
+    NonTransactionalDatabaseAdapter<?> nontx = (NonTransactionalDatabaseAdapter<?>) databaseAdapter;
+    int numThreads = 3;
+
+    Set<NamedReference> createdRefs = new HashSet<>();
+
+    // Prepare branches in GlobalPointer
+
+    try (NonTransactionalOperationContext ctx = nontx.borrowConnection()) {
+
+      GlobalStatePointer globalPointer = nontx.fetchGlobalPointer(ctx);
+
+      assertThat(globalPointer)
+          .extracting(GlobalStatePointer::getNamedReferencesCount)
+          .isEqualTo(0);
+
+      GlobalStatePointer.Builder newPointer =
+          globalPointer.toBuilder().setGlobalId(randomHash().asBytes());
+
+      RefPointer head = nontx.fetchNamedReference(ctx, "main").getRef();
+
+      IntFunction<String> refName = i -> "ref-" + i;
+
+      for (int i = 0; i < numNamedRefs; i++) {
+        NamedReference ref =
+            NamedReference.newBuilder()
+                .setName(refName.apply(i))
+                // set some random commit-ID
+                .setRef(head.toBuilder().setHash(randomHash().asBytes()))
+                .build();
+        newPointer.addNamedReferences(ref);
+        createdRefs.add(ref);
+      }
+
+      assertThat(nontx.globalPointerCas(ctx, globalPointer, newPointer.build())).isTrue();
+
+      // Let 'numThreads' concurrently try to migrate from global-pointer to
+      // one-row-per-named-reference.
+
+      ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+      try {
+        CountDownLatch readyLatch = new CountDownLatch(numThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numThreads);
+
+        List<Future<Object>> futures =
+            IntStream.range(0, numThreads)
+                .mapToObj(
+                    i ->
+                        executor.submit(
+                            () -> {
+                              readyLatch.countDown();
+                              Preconditions.checkState(startLatch.await(5, MINUTES));
+
+                              try {
+                                nontx.fetchNamedReferences(ctx);
+                              } finally {
+                                doneLatch.countDown();
+                              }
+                              return null;
+                            }))
+                .collect(Collectors.toList());
+
+        Preconditions.checkState(readyLatch.await(5, MINUTES));
+        startLatch.countDown();
+
+        Preconditions.checkState(doneLatch.await(20, MINUTES));
+
+        assertThat(futures)
+            .allSatisfy(f -> assertThatCode(() -> f.get(1, MINUTES)).doesNotThrowAnyException());
+      } finally {
+        executor.shutdown();
+      }
+
+      // verify that the list of named-refs is empty in global-pointer
+      assertThat(nontx.fetchGlobalPointer(ctx).getNamedReferencesList()).isEmpty();
+
+      // verify that fetchNamedReferences() returns all created references
+      try (Stream<NamedReference> namedRefs = nontx.fetchNamedReferences(ctx)) {
+        assertThat(namedRefs.filter(nr -> !"main".equals(nr.getName())))
+            .containsExactlyInAnyOrderElementsOf(createdRefs);
+      }
+
+      // verify that fetchNamedReference() return the expected value for all created references
+      assertThat(createdRefs)
+          .allSatisfy(
+              namedRef ->
+                  assertThat(nontx.fetchNamedReference(ctx, namedRef.getName()))
+                      .isEqualTo(namedRef));
+    }
+  }
+}

--- a/versioned/persist/nontx/src/test/java/org/projectnessie/versioned/persist/nontx/TestBatchSpliterator.java
+++ b/versioned/persist/nontx/src/test/java/org/projectnessie/versioned/persist/nontx/TestBatchSpliterator.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.persist.nontx;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ import org.junit.jupiter.api.Test;
 public class TestBatchSpliterator {
 
   static class IntMapper implements Function<List<Integer>, Spliterator<String>> {
-    final List<Integer> sizes = new ArrayList<>();
+    final List<List<Integer>> inputs = new ArrayList<>();
     final Set<Integer> results;
 
     IntMapper(Set<Integer> results) {
@@ -41,7 +42,7 @@ public class TestBatchSpliterator {
 
     @Override
     public Spliterator<String> apply(List<Integer> integers) {
-      sizes.add(integers.size());
+      inputs.add(new ArrayList<>(integers));
       return integers.stream()
           .filter(results::contains)
           .map(Objects::toString)
@@ -55,10 +56,14 @@ public class TestBatchSpliterator {
     IntMapper intMapper = new IntMapper(Collections.emptySet());
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(0, 0).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(0, 0).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false)).isEmpty();
-    assertThat(intMapper.sizes).isEmpty();
+    assertThat(intMapper.inputs).isEmpty();
   }
 
   @Test
@@ -66,10 +71,15 @@ public class TestBatchSpliterator {
     IntMapper intMapper = new IntMapper(Collections.emptySet());
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false)).isEmpty();
-    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+    assertThat(intMapper.inputs)
+        .containsExactly(asList(10, 11, 12), asList(13, 14, 15), asList(16, 17, 18), asList(19));
   }
 
   @Test
@@ -77,10 +87,15 @@ public class TestBatchSpliterator {
     IntMapper intMapper = new IntMapper(Collections.singleton(10));
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("10");
-    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+    assertThat(intMapper.inputs)
+        .containsExactly(asList(10, 11, 12), asList(13, 14, 15), asList(16, 17, 18), asList(19));
   }
 
   @Test
@@ -88,10 +103,15 @@ public class TestBatchSpliterator {
     IntMapper intMapper = new IntMapper(Collections.singleton(19));
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("19");
-    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+    assertThat(intMapper.inputs)
+        .containsExactly(asList(10, 11, 12), asList(13, 14, 15), asList(16, 17, 18), asList(19));
   }
 
   @Test
@@ -99,10 +119,15 @@ public class TestBatchSpliterator {
     IntMapper intMapper = new IntMapper(Collections.singleton(11));
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("11");
-    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+    assertThat(intMapper.inputs)
+        .containsExactly(asList(10, 11, 12), asList(13, 14, 15), asList(16, 17, 18), asList(19));
   }
 
   @Test
@@ -110,10 +135,15 @@ public class TestBatchSpliterator {
     IntMapper intMapper = new IntMapper(Collections.singleton(13));
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("13");
-    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+    assertThat(intMapper.inputs)
+        .containsExactly(asList(10, 11, 12), asList(13, 14, 15), asList(16, 17, 18), asList(19));
   }
 
   @Test
@@ -121,10 +151,15 @@ public class TestBatchSpliterator {
     IntMapper intMapper = new IntMapper(Collections.singleton(15));
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("15");
-    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+    assertThat(intMapper.inputs)
+        .containsExactly(asList(10, 11, 12), asList(13, 14, 15), asList(16, 17, 18), asList(19));
   }
 
   @Test
@@ -133,12 +168,17 @@ public class TestBatchSpliterator {
         new IntMapper(IntStream.range(10, 20).boxed().collect(Collectors.toSet()));
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false))
         .containsExactlyElementsOf(
             IntStream.range(10, 20).mapToObj(Integer::toString).collect(Collectors.toList()));
-    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+    assertThat(intMapper.inputs)
+        .containsExactly(asList(10, 11, 12), asList(13, 14, 15), asList(16, 17, 18), asList(19));
   }
 
   @Test
@@ -147,11 +187,52 @@ public class TestBatchSpliterator {
         new IntMapper(IntStream.range(13, 18).boxed().collect(Collectors.toSet()));
 
     BatchSpliterator<Integer, String> batchSpliterator =
-        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
     assertThat(StreamSupport.stream(batchSpliterator, false))
         .containsExactlyElementsOf(
             IntStream.range(13, 18).mapToObj(Integer::toString).collect(Collectors.toList()));
-    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+    assertThat(intMapper.inputs)
+        .containsExactly(asList(10, 11, 12), asList(13, 14, 15), asList(16, 17, 18), asList(19));
+  }
+
+  @Test
+  public void skipSome() {
+    IntMapper intMapper =
+        new IntMapper(IntStream.range(10, 20).boxed().collect(Collectors.toSet()));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().skip(4).spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false))
+        .containsExactlyElementsOf(
+            IntStream.range(14, 20).mapToObj(Integer::toString).collect(Collectors.toList()));
+    assertThat(intMapper.inputs).containsExactly(asList(14, 15, 16), asList(17, 18, 19));
+  }
+
+  @Test
+  public void skipSomeAndLimit() {
+    IntMapper intMapper =
+        new IntMapper(IntStream.range(10, 20).boxed().collect(Collectors.toSet()));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(
+            3,
+            IntStream.range(10, 20).boxed().skip(4).limit(5).spliterator(),
+            intMapper,
+            Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false))
+        .containsExactlyElementsOf(
+            IntStream.range(14, 19).mapToObj(Integer::toString).collect(Collectors.toList()));
+    assertThat(intMapper.inputs).containsExactly(asList(14, 15, 16), asList(17, 18));
   }
 }

--- a/versioned/persist/nontx/src/test/java/org/projectnessie/versioned/persist/nontx/TestBatchSpliterator.java
+++ b/versioned/persist/nontx/src/test/java/org/projectnessie/versioned/persist/nontx/TestBatchSpliterator.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.nontx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Test;
+
+public class TestBatchSpliterator {
+
+  static class IntMapper implements Function<List<Integer>, Spliterator<String>> {
+    final List<Integer> sizes = new ArrayList<>();
+    final Set<Integer> results;
+
+    IntMapper(Set<Integer> results) {
+      this.results = results;
+    }
+
+    @Override
+    public Spliterator<String> apply(List<Integer> integers) {
+      sizes.add(integers.size());
+      return integers.stream()
+          .filter(results::contains)
+          .map(Objects::toString)
+          .collect(Collectors.toList())
+          .spliterator();
+    }
+  }
+
+  @Test
+  public void emptyEmpty() {
+    IntMapper intMapper = new IntMapper(Collections.emptySet());
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(0, 0).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false)).isEmpty();
+    assertThat(intMapper.sizes).isEmpty();
+  }
+
+  @Test
+  public void absolutelyNoResults() {
+    IntMapper intMapper = new IntMapper(Collections.emptySet());
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false)).isEmpty();
+    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+  }
+
+  @Test
+  public void oneResultFirst() {
+    IntMapper intMapper = new IntMapper(Collections.singleton(10));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("10");
+    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+  }
+
+  @Test
+  public void oneResultLast() {
+    IntMapper intMapper = new IntMapper(Collections.singleton(19));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("19");
+    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+  }
+
+  @Test
+  public void oneResultMiddle() {
+    IntMapper intMapper = new IntMapper(Collections.singleton(11));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("11");
+    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+  }
+
+  @Test
+  public void oneResultSecondPageFirst() {
+    IntMapper intMapper = new IntMapper(Collections.singleton(13));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("13");
+    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+  }
+
+  @Test
+  public void oneResultSecondPageLast() {
+    IntMapper intMapper = new IntMapper(Collections.singleton(15));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false)).containsExactly("15");
+    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+  }
+
+  @Test
+  public void allResults() {
+    IntMapper intMapper =
+        new IntMapper(IntStream.range(10, 20).boxed().collect(Collectors.toSet()));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false))
+        .containsExactlyElementsOf(
+            IntStream.range(10, 20).mapToObj(Integer::toString).collect(Collectors.toList()));
+    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+  }
+
+  @Test
+  public void manyResults() {
+    IntMapper intMapper =
+        new IntMapper(IntStream.range(13, 18).boxed().collect(Collectors.toSet()));
+
+    BatchSpliterator<Integer, String> batchSpliterator =
+        new BatchSpliterator<>(3, IntStream.range(10, 20).boxed().spliterator(), intMapper);
+
+    assertThat(StreamSupport.stream(batchSpliterator, false))
+        .containsExactlyElementsOf(
+            IntStream.range(13, 18).mapToObj(Integer::toString).collect(Collectors.toList()));
+    assertThat(intMapper.sizes).containsExactly(3, 3, 3, 1);
+  }
+}

--- a/versioned/persist/rocks/pom.xml
+++ b/versioned/persist/rocks/pom.xml
@@ -51,6 +51,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-non-transactional</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -241,7 +241,17 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  protected void doCleanUpRefLogWrite(NonTransactionalOperationContext ctx, Hash refLogId) {}
+  protected void doCleanUpRefLogWrite(NonTransactionalOperationContext ctx, Hash refLogId) {
+    Lock lock = dbInstance.getLock().writeLock();
+    lock.lock();
+    try {
+      db.delete(dbInstance.getCfRefLog(), dbKey(refLogId));
+    } catch (RocksDBException e) {
+      throw new RuntimeException(e);
+    } finally {
+      lock.unlock();
+    }
+  }
 
   @Override
   protected GlobalStateLogEntry doFetchFromGlobalLog(

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -388,21 +388,21 @@ public class RocksDatabaseAdapter
   protected boolean doRefLogParentsCas(
       NonTransactionalOperationContext ctx,
       int stripe,
-      RefLogParents refLogParents,
-      RefLogParents refLogEntry) {
+      RefLogParents previousEntry,
+      RefLogParents newEntry) {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
     try {
       byte[] bytes = db.get(dbInstance.getCfRefLogHeads(), dbKey(stripe));
       RefLogParents parents = bytes != null ? RefLogParents.parseFrom(bytes) : null;
-      if (refLogParents != null) {
-        if (!refLogParents.equals(parents)) {
+      if (previousEntry != null) {
+        if (!previousEntry.equals(parents)) {
           return false;
         }
       } else if (parents != null) {
         return false;
       }
-      db.put(dbInstance.getCfRefLogHeads(), dbKey(stripe), refLogEntry.toByteArray());
+      db.put(dbInstance.getCfRefLogHeads(), dbKey(stripe), newEntry.toByteArray());
       return true;
     } catch (InvalidProtocolBufferException | RocksDBException e) {
       throw new RuntimeException(e);

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDbInstance.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDbInstance.java
@@ -53,10 +53,21 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
   public static final String CF_COMMIT_LOG = "commit_log";
   public static final String CF_KEY_LIST = "key_list";
   public static final String CF_REF_LOG = "ref_log";
+  static final String CF_REF_HEADS = "ref_heads";
+  static final String CF_REF_NAMES = "ref_names";
+  static final String CF_REF_LOG_HEADS = "ref_log_heads";
 
   private static final List<String> CF_ALL =
       Arrays.asList(
-          CF_REPO_PROPS, CF_GLOBAL_POINTER, CF_GLOBAL_LOG, CF_COMMIT_LOG, CF_KEY_LIST, CF_REF_LOG);
+          CF_REPO_PROPS,
+          CF_GLOBAL_POINTER,
+          CF_GLOBAL_LOG,
+          CF_COMMIT_LOG,
+          CF_KEY_LIST,
+          CF_REF_LOG,
+          CF_REF_HEADS,
+          CF_REF_NAMES,
+          CF_REF_LOG_HEADS);
 
   private ColumnFamilyHandle cfRepoProps;
   private ColumnFamilyHandle cfGlobalPointer;
@@ -64,6 +75,9 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
   private ColumnFamilyHandle cfCommitLog;
   private ColumnFamilyHandle cfKeyList;
   private ColumnFamilyHandle cfRefLog;
+  private ColumnFamilyHandle cfRefHeads;
+  private ColumnFamilyHandle cfRefNames;
+  private ColumnFamilyHandle cfRefLogHeads;
 
   private final ReadWriteLock lock = new StampedLock().asReadWriteLock();
 
@@ -130,6 +144,9 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
         cfCommitLog = columnFamilyHandleMap.get(CF_COMMIT_LOG);
         cfKeyList = columnFamilyHandleMap.get(CF_KEY_LIST);
         cfRefLog = columnFamilyHandleMap.get(CF_REF_LOG);
+        cfRefHeads = columnFamilyHandleMap.get(CF_REF_HEADS);
+        cfRefNames = columnFamilyHandleMap.get(CF_REF_NAMES);
+        cfRefLogHeads = columnFamilyHandleMap.get(CF_REF_LOG_HEADS);
       } catch (RocksDBException e) {
         throw new RuntimeException("RocksDB failed to start", e);
       }
@@ -160,6 +177,18 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
     return cfRefLog;
   }
 
+  public ColumnFamilyHandle getCfRefHeads() {
+    return cfRefHeads;
+  }
+
+  public ColumnFamilyHandle getCfRefNames() {
+    return cfRefNames;
+  }
+
+  public ColumnFamilyHandle getCfRefLogHeads() {
+    return cfRefLogHeads;
+  }
+
   public ReadWriteLock getLock() {
     return lock;
   }
@@ -169,6 +198,14 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
   }
 
   public Stream<ColumnFamilyHandle> allExceptGlobalPointer() {
-    return Stream.of(cfGlobalLog, cfCommitLog, cfRepoProps, cfKeyList, cfRefLog);
+    return Stream.of(
+        cfGlobalLog,
+        cfCommitLog,
+        cfRepoProps,
+        cfKeyList,
+        cfRefLog,
+        cfRefHeads,
+        cfRefNames,
+        cfRefLogHeads);
   }
 }

--- a/versioned/persist/rocks/src/test/java/org/projectnessie/versioned/persist/rocks/ITDatabaseAdapterRocks.java
+++ b/versioned/persist/rocks/src/test/java/org/projectnessie/versioned/persist/rocks/ITDatabaseAdapterRocks.java
@@ -15,8 +15,8 @@
  */
 package org.projectnessie.versioned.persist.rocks;
 
-import org.projectnessie.versioned.persist.tests.AbstractDatabaseAdapterTest;
+import org.projectnessie.versioned.persist.nontx.AbstractNonTxDatabaseAdapterTest;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
 @NessieExternalDatabase(RocksTestConnectionProviderSource.class)
-class ITDatabaseAdapterRocks extends AbstractDatabaseAdapterTest {}
+class ITDatabaseAdapterRocks extends AbstractNonTxDatabaseAdapterTest {}

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -119,7 +119,8 @@ message GlobalStatePointer {
 
 message RefLogParents {
   repeated bytes ref_log_parents_incl_head = 1;
-  optional bytes lock_id = 2;
+  // 'version' is used for optimistic locking / CAS, it's a random value
+  optional bytes version = 2;
 }
 
 message ReferenceNames {

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -117,9 +117,13 @@ message GlobalStatePointer {
   optional bytes global_log_head = 6;
 }
 
-// Used by transactional database-adapters
 message RefLogParents {
   repeated bytes ref_log_parents_incl_head = 1;
+  optional bytes lock_id = 2;
+}
+
+message ReferenceNames {
+  repeated string ref_names = 1;
 }
 
 message NamedReference {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -29,6 +29,7 @@ import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterConfig
 @ExtendWith(DatabaseAdapterExtension.class)
 @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "2048")
 @NessieDbAdapterConfigItem(name = "global.log.entry.size", value = "2048")
+@NessieDbAdapterConfigItem(name = "references.segment.size", value = "2048")
 public abstract class AbstractDatabaseAdapterTest {
   @NessieDbAdapter protected static DatabaseAdapter databaseAdapter;
 
@@ -76,6 +77,14 @@ public abstract class AbstractDatabaseAdapterTest {
   @SuppressWarnings("ClassCanBeStatic")
   public class Concurrency extends AbstractConcurrency {
     Concurrency() {
+      super(databaseAdapter);
+    }
+  }
+
+  @Nested
+  @SuppressWarnings("ClassCanBeStatic")
+  public class RefLog extends AbstractRefLog {
+    RefLog() {
       super(databaseAdapter);
     }
   }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRefLog.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRefLog.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.ByteString;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.RefLogNotFoundException;
+import org.projectnessie.versioned.ReferenceInfo;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.RefLog;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterConfigItem;
+
+/** Verifies handling of repo-description in the database-adapters. */
+public abstract class AbstractRefLog {
+
+  private final DatabaseAdapter databaseAdapter;
+
+  protected AbstractRefLog(DatabaseAdapter databaseAdapter) {
+    this.databaseAdapter = databaseAdapter;
+  }
+  /** Verify that increasing the number of ref-log stripes works. */
+  @Test
+  void increaseRefLogSplits(
+      @NessieDbAdapter(initializeRepo = false)
+          @NessieDbAdapterConfigItem(name = "ref.log.stripes", value = "50")
+          DatabaseAdapter moreRefLogStripes)
+      throws Exception {
+    IntFunction<BranchName> ref = i -> BranchName.of("branch-" + i);
+
+    for (int i = 0; i < 50; i++) {
+      databaseAdapter.create(ref.apply(i), databaseAdapter.noAncestorHash());
+    }
+
+    try (Stream<ReferenceInfo<ByteString>> refs =
+        databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT)) {
+      List<BranchName> all = IntStream.range(0, 50).mapToObj(ref).collect(Collectors.toList());
+      assertThat(refs.filter(r -> r.getNamedRef().getName().startsWith("branch-")))
+          .map(ReferenceInfo::getNamedRef)
+          .containsExactlyInAnyOrderElementsOf(all);
+    }
+
+    IntFunction<List<String>> branchNames =
+        num ->
+            IntStream.range(0, num)
+                .mapToObj(ref)
+                .map(NamedRef::getName)
+                .collect(Collectors.toList());
+    Function<Stream<RefLog>, Stream<RefLog>> filterCreateBranches =
+        refLog ->
+            refLog
+                .filter(l -> l.getOperation().equals("CREATE_REFERENCE"))
+                .filter(l -> l.getRefName().startsWith("branch-"));
+
+    try (Stream<RefLog> refLog = databaseAdapter.refLog(null)) {
+      List<String> all = branchNames.apply(50);
+      assertThat(filterCreateBranches.apply(refLog))
+          .map(RefLog::getRefName)
+          .containsExactlyInAnyOrderElementsOf(all);
+    }
+
+    try (Stream<RefLog> refLog = moreRefLogStripes.refLog(null)) {
+      List<String> all = branchNames.apply(50);
+      assertThat(filterCreateBranches.apply(refLog))
+          .map(RefLog::getRefName)
+          .containsExactlyInAnyOrderElementsOf(all);
+    }
+
+    // add 50 more branches
+
+    for (int i = 50; i < 100; i++) {
+      moreRefLogStripes.create(ref.apply(i), moreRefLogStripes.noAncestorHash());
+    }
+
+    try (Stream<ReferenceInfo<ByteString>> refs =
+        moreRefLogStripes.namedRefs(GetNamedRefsParams.DEFAULT)) {
+      List<BranchName> all = IntStream.range(0, 100).mapToObj(ref).collect(Collectors.toList());
+      assertThat(refs.filter(r -> r.getNamedRef().getName().startsWith("branch-")))
+          .map(ReferenceInfo::getNamedRef)
+          .containsExactlyInAnyOrderElementsOf(all);
+    }
+
+    try (Stream<RefLog> refLog = moreRefLogStripes.refLog(null)) {
+      List<String> all = branchNames.apply(100);
+      assertThat(filterCreateBranches.apply(refLog))
+          .map(RefLog::getRefName)
+          .containsExactlyInAnyOrderElementsOf(all);
+    }
+  }
+
+  @Test
+  void emptyRefLog() throws Exception {
+    try (Stream<RefLog> refLog = databaseAdapter.refLog(null)) {
+      assertThat(refLog)
+          .hasSize(1)
+          .first()
+          .extracting(
+              RefLog::getRefName, RefLog::getOperation, RefLog::getCommitHash, RefLog::getParents)
+          .containsExactly(
+              "main",
+              "CREATE_REFERENCE",
+              databaseAdapter.noAncestorHash(),
+              singletonList(databaseAdapter.noAncestorHash()));
+    }
+  }
+
+  @Test
+  void nonExitingRefLogEntry() {
+    assertThatThrownBy(() -> databaseAdapter.refLog(Hash.of("000000")))
+        .isInstanceOf(RefLogNotFoundException.class);
+  }
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
@@ -84,7 +84,11 @@ public abstract class AbstractTracing extends AbstractNestedVersionStore {
                                                             c ->
                                                                 c.add(
                                                                     "DatabaseAdapter.fetchGlobalPointer"))
-                                                        .add("DatabaseAdapter.createNamedReference")
+                                                        .child(
+                                                            "DatabaseAdapter.createNamedReference",
+                                                            c ->
+                                                                c.add(
+                                                                    "DatabaseAdapter.fetchReferenceNames"))
                                                         .add(
                                                             "DatabaseAdapter.fetchRefLogParentsForReference")
                                                         .add("DatabaseAdapter.writeRefLog")

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractTracing.java
@@ -79,10 +79,17 @@ public abstract class AbstractTracing extends AbstractNestedVersionStore {
                                                 "DatabaseAdapter.try-loop.createRef",
                                                 tryLoop ->
                                                     tryLoop
-                                                        .add("DatabaseAdapter.fetchGlobalPointer")
+                                                        .child(
+                                                            "DatabaseAdapter.fetchNamedReference",
+                                                            c ->
+                                                                c.add(
+                                                                    "DatabaseAdapter.fetchGlobalPointer"))
+                                                        .add("DatabaseAdapter.createNamedReference")
+                                                        .add(
+                                                            "DatabaseAdapter.fetchRefLogParentsForReference")
                                                         .add("DatabaseAdapter.writeRefLog")
                                                         .add(
-                                                            "DatabaseAdapter.globalPointerCas"))))),
+                                                            "DatabaseAdapter.refLogParentsCas"))))),
             // 2nd "satisfies()" - for transactional database adapters
             h ->
                 assertThat(h)


### PR DESCRIPTION
* Moves named-references from global-pointer to separate entities (one
  "row" per named reference), concurrent updates to the same named
  ref can content, but concurrent updates to the different named refs
  do not (minus ref-log, see below).
* Move ref-log HEAD from global-pointer to striped (mutliple) ref-log
  HEADs, using the name of the reference. This reduces the probability
  for contention to 1/16th (by default). Number of stripes can be
  increased (requires a restart of all nessie instances, no rolling
  upgrade).

Both changes are backwards compatible:
* Existing named references are migrated when Nessie finds existing
  named referenes in the global pointer.
* Existing ref-log does not need to be migrated, ref-log reads just
  "include" the ref-log HEAD in global-pointer as an additional
  stripe.

During a Nessie commit there is a (neglectible) chance that the
commit is written and the named-reference correctly updated, but the
corresponding ref-log-entry not written. This can happen when the
Nessie server crashes or is stopped right a successful CAS of the
named-reference HEAD but before the ref-log HEAD CAS. This is a
trade-off.

Upgrade procedure:
1. stop all existing Nessie instances
2. bump versions
3. restart.
