### PR TITLE
Detailed merge/transplant results (database adapters)

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -26,6 +26,7 @@ import org.projectnessie.versioned.Diff;
 import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
@@ -147,7 +148,7 @@ public interface DatabaseAdapter {
    *     branch due to a conflicting change or if the expected hash of {@code toBranch} is not its
    *     expected hEAD
    */
-  Hash transplant(TransplantParams transplantParams)
+  MergeResult<CommitLogEntry> transplant(TransplantParams transplantParams)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
@@ -165,7 +166,8 @@ public interface DatabaseAdapter {
    *     branch due to a conflicting change or if the expected hash of {@code toBranch} is not its
    *     expected hEAD
    */
-  Hash merge(MergeParams mergeParams) throws ReferenceNotFoundException, ReferenceConflictException;
+  MergeResult<CommitLogEntry> merge(MergeParams mergeParams)
+      throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
    * Resolve the current HEAD of the given named-reference and optionally additional information.

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
@@ -25,6 +25,13 @@ public interface MergeParams extends MetadataRewriteParams {
   /** Commit-hash to start reading commits from. */
   Hash getMergeFromHash();
 
+  @SuppressWarnings("override")
+  interface Builder extends MetadataRewriteParams.Builder<ImmutableMergeParams.Builder> {
+    ImmutableMergeParams.Builder mergeFromHash(Hash mergeFromHash);
+
+    MergeParams build();
+  }
+
   static ImmutableMergeParams.Builder builder() {
     return ImmutableMergeParams.builder();
   }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
@@ -26,7 +26,7 @@ public interface MergeParams extends MetadataRewriteParams {
   Hash getMergeFromHash();
 
   @SuppressWarnings("override")
-  interface Builder extends MetadataRewriteParams.Builder<ImmutableMergeParams.Builder> {
+  interface Builder extends MetadataRewriteParams.Builder<Builder> {
     Builder mergeFromHash(Hash mergeFromHash);
 
     MergeParams build();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MergeParams.java
@@ -27,12 +27,12 @@ public interface MergeParams extends MetadataRewriteParams {
 
   @SuppressWarnings("override")
   interface Builder extends MetadataRewriteParams.Builder<ImmutableMergeParams.Builder> {
-    ImmutableMergeParams.Builder mergeFromHash(Hash mergeFromHash);
+    Builder mergeFromHash(Hash mergeFromHash);
 
     MergeParams build();
   }
 
-  static ImmutableMergeParams.Builder builder() {
+  static Builder builder() {
     return ImmutableMergeParams.builder();
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MetadataRewriteParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MetadataRewriteParams.java
@@ -53,6 +53,8 @@ public interface MetadataRewriteParams extends ToBranchParams {
 
     B putMergeTypes(Key key, MergeType value);
 
+    B mergeTypes(Map<? extends Key, ? extends MergeType> entries);
+
     B isDryRun(boolean dryRun);
 
     B updateCommitMetadata(MetadataRewriter<ByteString> updateCommitMetadata);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MetadataRewriteParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/MetadataRewriteParams.java
@@ -33,10 +33,28 @@ public interface MetadataRewriteParams extends ToBranchParams {
   Map<Key, MergeType> getMergeTypes();
 
   @Value.Default
+  default boolean isDryRun() {
+    return false;
+  }
+
+  @Value.Default
   default MergeType getDefaultMergeType() {
     return MergeType.NORMAL;
   }
 
   /** Function to rewrite the commit-metadata. */
   MetadataRewriter<ByteString> getUpdateCommitMetadata();
+
+  @SuppressWarnings({"override", "UnusedReturnValue"})
+  interface Builder<B> extends ToBranchParams.Builder<B> {
+    B keepIndividualCommits(boolean keepIndividualCommits);
+
+    B defaultMergeType(MergeType defaultMergeType);
+
+    B putMergeTypes(Key key, MergeType value);
+
+    B isDryRun(boolean dryRun);
+
+    B updateCommitMetadata(MetadataRewriter<ByteString> updateCommitMetadata);
+  }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ToBranchParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ToBranchParams.java
@@ -34,4 +34,11 @@ public interface ToBranchParams {
   default Optional<Hash> getExpectedHead() {
     return Optional.empty();
   }
+
+  @SuppressWarnings({"override", "UnusedReturnValue"})
+  interface Builder<B> {
+    B toBranch(BranchName toBranch);
+
+    B expectedHead(Optional<Hash> expectedHead);
+  }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.adapter;
 import java.util.List;
 import org.immutables.value.Value;
 import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.persist.adapter.ImmutableTransplantParams.Builder;
 
 /**
  * API helper method to encapsulate parameters for {@link
@@ -30,8 +31,10 @@ public interface TransplantParams extends MetadataRewriteParams {
   List<Hash> getSequenceToTransplant();
 
   @SuppressWarnings("override")
-  interface Builder extends MetadataRewriteParams.Builder<ImmutableTransplantParams.Builder> {
+  interface Builder extends MetadataRewriteParams.Builder<Builder> {
     Builder sequenceToTransplant(Iterable<? extends Hash> elements);
+
+    Builder addSequenceToTransplant(Hash... elements);
 
     TransplantParams build();
   }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
@@ -18,7 +18,6 @@ package org.projectnessie.versioned.persist.adapter;
 import java.util.List;
 import org.immutables.value.Value;
 import org.projectnessie.versioned.Hash;
-import org.projectnessie.versioned.persist.adapter.ImmutableTransplantParams.Builder;
 
 /**
  * API helper method to encapsulate parameters for {@link

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
@@ -31,12 +31,12 @@ public interface TransplantParams extends MetadataRewriteParams {
 
   @SuppressWarnings("override")
   interface Builder extends MetadataRewriteParams.Builder<ImmutableTransplantParams.Builder> {
-    ImmutableTransplantParams.Builder sequenceToTransplant(Iterable<? extends Hash> elements);
+    Builder sequenceToTransplant(Iterable<? extends Hash> elements);
 
     TransplantParams build();
   }
 
-  static ImmutableTransplantParams.Builder builder() {
+  static Builder builder() {
     return ImmutableTransplantParams.builder();
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/TransplantParams.java
@@ -29,6 +29,13 @@ public interface TransplantParams extends MetadataRewriteParams {
   /** Commits to cherry-pick onto {@link #getToBranch()}. */
   List<Hash> getSequenceToTransplant();
 
+  @SuppressWarnings("override")
+  interface Builder extends MetadataRewriteParams.Builder<ImmutableTransplantParams.Builder> {
+    ImmutableTransplantParams.Builder sequenceToTransplant(Iterable<? extends Hash> elements);
+
+    TransplantParams build();
+  }
+
   static ImmutableTransplantParams.Builder builder() {
     return ImmutableTransplantParams.builder();
   }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -490,7 +490,7 @@ public abstract class AbstractDatabaseAdapter<
         hasKeyCollisions(ctx, toHead, keysTouchedOnTarget, commitsToMergeChronological, keyDetails);
     keyDetailsMap.forEach((key, details) -> mergeResult.putDetails(key, details.build()));
 
-    mergeResult.isSuccessful(!hasCollisions);
+    mergeResult.wasSuccessful(!hasCollisions);
 
     if (hasCollisions && !params.isDryRun()) {
       MergeResult<CommitLogEntry> result = mergeResult.resultantTargetHash(toHead).build();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
@@ -122,7 +123,7 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   }
 
   @Override
-  public Hash transplant(TransplantParams transplantParams)
+  public MergeResult<CommitLogEntry> transplant(TransplantParams transplantParams)
       throws ReferenceNotFoundException, ReferenceConflictException {
     try (Traced ignore =
         trace("transplant").tag(TAG_REF, transplantParams.getToBranch().getName())) {
@@ -131,7 +132,7 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   }
 
   @Override
-  public Hash merge(MergeParams mergeParams)
+  public MergeResult<CommitLogEntry> merge(MergeParams mergeParams)
       throws ReferenceNotFoundException, ReferenceConflictException {
     try (Traced ignore =
         trace("merge")

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -39,10 +39,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -53,7 +55,9 @@ import javax.annotation.Nullable;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
@@ -188,7 +192,7 @@ public abstract class NonTransactionalDatabaseAdapter<
   }
 
   @Override
-  public Hash merge(MergeParams mergeParams)
+  public MergeResult<CommitLogEntry> merge(MergeParams mergeParams)
       throws ReferenceNotFoundException, ReferenceConflictException {
     // The spec for 'VersionStore.merge' mentions "(...) until we arrive at a common ancestor",
     // but old implementations allowed a merge even if the "merge-from" and "merge-to" have no
@@ -200,39 +204,61 @@ public abstract class NonTransactionalDatabaseAdapter<
     // Note: "beginning-of-time" (aka creating a branch without specifying a "create-from")
     // creates a new commit-tree that is decoupled from other commit-trees.
     try {
-      return casOpLoop(
-          "merge",
-          mergeParams.getToBranch(),
-          CasOpVariant.COMMIT,
-          (ctx, pointer, branchCommits, newKeyLists) -> {
-            Hash currentHead = branchHead(pointer, mergeParams.getToBranch());
+      AtomicReference<ImmutableMergeResult.Builder<CommitLogEntry>> mergeResultHolder =
+          new AtomicReference<>();
 
-            long timeInMicros = commitTimeInMicros();
+      Hash result =
+          casOpLoop(
+              "merge",
+              mergeParams.getToBranch(),
+              CasOpVariant.COMMIT,
+              (ctx, pointer, branchCommits, newKeyLists) -> {
+                ImmutableMergeResult.Builder<CommitLogEntry> mergeResult = MergeResult.builder();
+                mergeResultHolder.set(mergeResult);
 
-            Hash newHead =
-                mergeAttempt(
-                    ctx, timeInMicros, currentHead, branchCommits, newKeyLists, mergeParams);
+                Hash currentHead = branchHead(pointer, mergeParams.getToBranch());
 
-            if (newHead.equals(currentHead)) {
-              // nothing done
-              return pointer;
-            }
+                long timeInMicros = commitTimeInMicros();
 
-            RefLogEntry newRefLog =
-                writeRefLogEntry(
-                    ctx,
-                    pointer,
-                    mergeParams.getToBranch().getName(),
-                    RefType.Branch,
-                    newHead,
-                    RefLogEntry.Operation.MERGE,
-                    timeInMicros,
-                    Collections.singletonList(mergeParams.getMergeFromHash()));
+                Hash newHead =
+                    mergeAttempt(
+                        ctx,
+                        timeInMicros,
+                        currentHead,
+                        branchCommits,
+                        newKeyLists,
+                        mergeParams,
+                        mergeResult);
 
-            // Return hash of last commit (toHead) added to 'targetBranch' (via the casOpLoop)
-            return updateGlobalStatePointer(mergeParams.getToBranch(), pointer, newHead, newRefLog);
-          },
-          () -> mergeConflictMessage("Retry-failure", mergeParams));
+                if (newHead.equals(currentHead)) {
+                  // nothing done
+                  return pointer;
+                }
+
+                RefLogEntry newRefLog =
+                    writeRefLogEntry(
+                        ctx,
+                        pointer,
+                        mergeParams.getToBranch().getName(),
+                        RefType.Branch,
+                        newHead,
+                        RefLogEntry.Operation.MERGE,
+                        timeInMicros,
+                        Collections.singletonList(mergeParams.getMergeFromHash()));
+
+                // Return hash of last commit (toHead) added to 'targetBranch' (via the casOpLoop)
+                return updateGlobalStatePointer(
+                    mergeParams.getToBranch(), pointer, newHead, newRefLog);
+              },
+              () -> mergeConflictMessage("Retry-failure", mergeParams));
+
+      ImmutableMergeResult.Builder<CommitLogEntry> mergeResult =
+          Objects.requireNonNull(
+              mergeResultHolder.get(), "Internal error, merge-result builder not set.");
+      if (!mergeParams.isDryRun()) {
+        mergeResult.isApplied(true);
+      }
+      return mergeResult.currentTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
@@ -242,44 +268,65 @@ public abstract class NonTransactionalDatabaseAdapter<
 
   @SuppressWarnings("RedundantThrows")
   @Override
-  public Hash transplant(TransplantParams transplantParams)
+  public MergeResult<CommitLogEntry> transplant(TransplantParams transplantParams)
       throws ReferenceNotFoundException, ReferenceConflictException {
     try {
-      return casOpLoop(
-          "transplant",
-          transplantParams.getToBranch(),
-          CasOpVariant.COMMIT,
-          (ctx, pointer, branchCommits, newKeyLists) -> {
-            Hash currentHead = branchHead(pointer, transplantParams.getToBranch());
+      AtomicReference<ImmutableMergeResult.Builder<CommitLogEntry>> mergeResultHolder =
+          new AtomicReference<>();
 
-            long timeInMicros = commitTimeInMicros();
+      Hash result =
+          casOpLoop(
+              "transplant",
+              transplantParams.getToBranch(),
+              CasOpVariant.COMMIT,
+              (ctx, pointer, branchCommits, newKeyLists) -> {
+                ImmutableMergeResult.Builder<CommitLogEntry> mergeResult = MergeResult.builder();
+                mergeResultHolder.set(mergeResult);
 
-            Hash newHead =
-                transplantAttempt(
-                    ctx, timeInMicros, currentHead, branchCommits, newKeyLists, transplantParams);
+                Hash currentHead = branchHead(pointer, transplantParams.getToBranch());
 
-            if (newHead.equals(currentHead)) {
-              // nothing done
-              return pointer;
-            }
+                long timeInMicros = commitTimeInMicros();
 
-            RefLogEntry newRefLog =
-                writeRefLogEntry(
-                    ctx,
-                    pointer,
-                    transplantParams.getToBranch().getName(),
-                    RefType.Branch,
-                    newHead,
-                    RefLogEntry.Operation.TRANSPLANT,
-                    timeInMicros,
-                    transplantParams.getSequenceToTransplant());
+                Hash newHead =
+                    transplantAttempt(
+                        ctx,
+                        timeInMicros,
+                        currentHead,
+                        branchCommits,
+                        newKeyLists,
+                        transplantParams,
+                        mergeResult);
 
-            // Return hash of last commit (targetHead) added to 'targetBranch' (via the casOpLoop)
-            return updateGlobalStatePointer(
-                transplantParams.getToBranch(), pointer, newHead, newRefLog);
-          },
-          () -> transplantConflictMessage("Retry-failure", transplantParams));
+                if (newHead.equals(currentHead)) {
+                  // nothing done
+                  return pointer;
+                }
 
+                RefLogEntry newRefLog =
+                    writeRefLogEntry(
+                        ctx,
+                        pointer,
+                        transplantParams.getToBranch().getName(),
+                        RefType.Branch,
+                        newHead,
+                        RefLogEntry.Operation.TRANSPLANT,
+                        timeInMicros,
+                        transplantParams.getSequenceToTransplant());
+
+                // Return hash of last commit (targetHead) added to 'targetBranch' (via the
+                // casOpLoop)
+                return updateGlobalStatePointer(
+                    transplantParams.getToBranch(), pointer, newHead, newRefLog);
+              },
+              () -> transplantConflictMessage("Retry-failure", transplantParams));
+
+      ImmutableMergeResult.Builder<CommitLogEntry> mergeResult =
+          Objects.requireNonNull(
+              mergeResultHolder.get(), "Internal error, merge-result builder not set.");
+      if (!transplantParams.isDryRun()) {
+        mergeResult.isApplied(true);
+      }
+      return mergeResult.currentTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
     } catch (Exception e) {

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -256,7 +256,7 @@ public abstract class NonTransactionalDatabaseAdapter<
           Objects.requireNonNull(
               mergeResultHolder.get(), "Internal error, merge-result builder not set.");
       if (!mergeParams.isDryRun()) {
-        mergeResult.isApplied(true);
+        mergeResult.wasApplied(true);
       }
       return mergeResult.resultantTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
@@ -324,7 +324,7 @@ public abstract class NonTransactionalDatabaseAdapter<
           Objects.requireNonNull(
               mergeResultHolder.get(), "Internal error, merge-result builder not set.");
       if (!transplantParams.isDryRun()) {
-        mergeResult.isApplied(true);
+        mergeResult.wasApplied(true);
       }
       return mergeResult.resultantTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -258,7 +258,7 @@ public abstract class NonTransactionalDatabaseAdapter<
       if (!mergeParams.isDryRun()) {
         mergeResult.isApplied(true);
       }
-      return mergeResult.currentTargetHash(result).build();
+      return mergeResult.resultantTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
@@ -326,7 +326,7 @@ public abstract class NonTransactionalDatabaseAdapter<
       if (!transplantParams.isDryRun()) {
         mergeResult.isApplied(true);
       }
-      return mergeResult.currentTargetHash(result).build();
+      return mergeResult.resultantTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
     } catch (Exception e) {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
@@ -344,7 +344,7 @@ public abstract class AbstractMergeTransplant {
       targetHead = databaseAdapter.hashOnReference(target, Optional.empty());
 
       assertThat(mergeResult)
-          .isEqualTo(expectedMergeResult.resultantTargetHash(targetHead).isApplied(true).build());
+          .isEqualTo(expectedMergeResult.resultantTargetHash(targetHead).wasApplied(true).build());
 
       // Briefly check commit log
 
@@ -470,7 +470,7 @@ public abstract class AbstractMergeTransplant {
       List<CommitLogEntry> expectedSourceCommits) {
     ImmutableMergeResult.Builder<CommitLogEntry> expectedMergeResult =
         MergeResult.<CommitLogEntry>builder()
-            .isSuccessful(true)
+            .wasSuccessful(true)
             .targetBranch(targetBranch)
             .effectiveTargetHash(mainHead)
             .expectedHash(null)

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
@@ -168,7 +168,7 @@ public abstract class AbstractMergeTransplant {
                     .updateCommitMetadata(metadataUpdater)
                     .keepIndividualCommits(keepIndividualCommits)
                     .build())
-            .getCurrentTargetHash();
+            .getResultantTargetHash();
     int offset = unifier.get();
 
     checkTransplantedCommits(keepIndividualCommits, commits, transplanted, offset);
@@ -183,7 +183,7 @@ public abstract class AbstractMergeTransplant {
                     .updateCommitMetadata(metadataUpdater)
                     .keepIndividualCommits(keepIndividualCommits)
                     .build())
-            .getCurrentTargetHash();
+            .getResultantTargetHash();
     offset = unifier.get();
 
     checkTransplantedCommits(keepIndividualCommits, commits, transplanted, offset);
@@ -333,7 +333,7 @@ public abstract class AbstractMergeTransplant {
                   .expectedHead(Optional.empty())
                   .isDryRun(true));
 
-      assertThat(mergeResult).isEqualTo(expectedMergeResult.currentTargetHash(mainHead).build());
+      assertThat(mergeResult).isEqualTo(expectedMergeResult.resultantTargetHash(mainHead).build());
 
       // Merge/transplant
 
@@ -344,7 +344,7 @@ public abstract class AbstractMergeTransplant {
       targetHead = databaseAdapter.hashOnReference(target, Optional.empty());
 
       assertThat(mergeResult)
-          .isEqualTo(expectedMergeResult.currentTargetHash(targetHead).isApplied(true).build());
+          .isEqualTo(expectedMergeResult.resultantTargetHash(targetHead).isApplied(true).build());
 
       // Briefly check commit log
 
@@ -434,9 +434,9 @@ public abstract class AbstractMergeTransplant {
 
     ImmutableMergeResult.Builder<CommitLogEntry> expectedMergeResult =
         MergeResult.<CommitLogEntry>builder()
-            .currentTargetHash(conflictHead)
+            .resultantTargetHash(conflictHead)
             .targetBranch(conflict)
-            .targetHash(conflictHead)
+            .effectiveTargetHash(conflictHead)
             .expectedHash(conflictBase)
             .commonAncestor(merge ? conflictBase : null)
             .addAllSourceCommits(expectedSourceCommits)
@@ -472,7 +472,7 @@ public abstract class AbstractMergeTransplant {
         MergeResult.<CommitLogEntry>builder()
             .isSuccessful(true)
             .targetBranch(targetBranch)
-            .targetHash(mainHead)
+            .effectiveTargetHash(mainHead)
             .expectedHash(null)
             .commonAncestor(merge ? mainHead : null)
             .addAllSourceCommits(expectedSourceCommits);

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -285,7 +285,7 @@ public abstract class TxDatabaseAdapter
           Objects.requireNonNull(
               mergeResultHolder.get(), "Internal error, merge-result builder not set.");
       if (!mergeParams.isDryRun()) {
-        mergeResult.isApplied(true);
+        mergeResult.wasApplied(true);
       }
       return mergeResult.resultantTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
@@ -345,7 +345,7 @@ public abstract class TxDatabaseAdapter
           Objects.requireNonNull(
               mergeResultHolder.get(), "Internal error, merge-result builder not set.");
       if (!transplantParams.isDryRun()) {
-        mergeResult.isApplied(true);
+        mergeResult.wasApplied(true);
       }
       return mergeResult.resultantTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -287,7 +287,7 @@ public abstract class TxDatabaseAdapter
       if (!mergeParams.isDryRun()) {
         mergeResult.isApplied(true);
       }
-      return mergeResult.currentTargetHash(result).build();
+      return mergeResult.resultantTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
@@ -347,7 +347,7 @@ public abstract class TxDatabaseAdapter
       if (!transplantParams.isDryRun()) {
         mergeResult.isApplied(true);
       }
-      return mergeResult.currentTargetHash(result).build();
+      return mergeResult.resultantTargetHash(result).build();
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
       throw e;
     } catch (Exception e) {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeConflictException.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeConflictException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+/**
+ * Special case of a {@link ReferenceConflictException} indicating that a non-dry-run merge or
+ * transplant operation could not be completed due to conflicts.
+ */
+public class MergeConflictException extends ReferenceConflictException {
+
+  private final MergeResult<?> mergeResult;
+
+  public MergeConflictException(String message, MergeResult<?> mergeResult) {
+    super(message);
+    this.mergeResult = mergeResult;
+  }
+
+  public MergeResult<?> getMergeResult() {
+    return mergeResult;
+  }
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
@@ -28,18 +28,16 @@ public interface MergeResult<COMMIT> {
   default boolean isApplied() {
     return false;
   }
-  ;
 
   /** Indicates whether the merge or transplant operation was successful without any conflicts. */
   @Value.Default
   default boolean isSuccessful() {
     return false;
   }
-  ;
 
-  /** Current commit-ID of the target branch. */
+  /** Commit-ID of the target branch after the merge/transplant operation. */
   @Nullable
-  Hash getCurrentTargetHash();
+  Hash getResultantTargetHash();
 
   /** Commit-ID of the identified common ancestor, only returned for a merge operation. */
   @Nullable
@@ -49,7 +47,7 @@ public interface MergeResult<COMMIT> {
   BranchName getTargetBranch();
 
   /** Head commit-ID of the target branch identified by the merge or transplant operation. */
-  Hash getTargetHash();
+  Hash getEffectiveTargetHash();
 
   /** The expected commit-ID of the target branch, as specified by the caller. */
   @Nullable
@@ -59,8 +57,8 @@ public interface MergeResult<COMMIT> {
   List<COMMIT> getSourceCommits();
 
   /**
-   * List of commit-IDs between {@link #getExpectedHash()} and {@link #getTargetHash()}, if the
-   * expected hash was provided.
+   * List of commit-IDs between {@link #getExpectedHash()} and {@link #getEffectiveTargetHash()}, if
+   * the expected hash was provided.
    */
   @Nullable
   List<COMMIT> getTargetCommits();

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
@@ -25,13 +25,13 @@ public interface MergeResult<COMMIT> {
 
   /** Indicates whether the merge or transplant operation has been applied. */
   @Value.Default
-  default boolean isApplied() {
+  default boolean wasApplied() {
     return false;
   }
 
   /** Indicates whether the merge or transplant operation was successful without any conflicts. */
   @Value.Default
-  default boolean isSuccessful() {
+  default boolean wasSuccessful() {
     return false;
   }
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface MergeResult<COMMIT> {
+
+  /** Indicates whether the merge or transplant operation has been applied. */
+  @Value.Default
+  default boolean isApplied() {
+    return false;
+  }
+  ;
+
+  /** Indicates whether the merge or transplant operation was successful without any conflicts. */
+  @Value.Default
+  default boolean isSuccessful() {
+    return false;
+  }
+  ;
+
+  /** Current commit-ID of the target branch. */
+  @Nullable
+  Hash getCurrentTargetHash();
+
+  /** Commit-ID of the identified common ancestor, only returned for a merge operation. */
+  @Nullable
+  Hash getCommonAncestor();
+
+  /** Name of the target branch. */
+  BranchName getTargetBranch();
+
+  /** Head commit-ID of the target branch identified by the merge or transplant operation. */
+  Hash getTargetHash();
+
+  /** The expected commit-ID of the target branch, as specified by the caller. */
+  @Nullable
+  Hash getExpectedHash();
+
+  /** List of commit-IDs to be merged or transplanted. */
+  List<COMMIT> getSourceCommits();
+
+  /**
+   * List of commit-IDs between {@link #getExpectedHash()} and {@link #getTargetHash()}, if the
+   * expected hash was provided.
+   */
+  @Nullable
+  List<COMMIT> getTargetCommits();
+
+  /** Details of all keys encountered during the merge or transplant operation. */
+  Map<Key, KeyDetails> getDetails();
+
+  @Value.Immutable
+  interface KeyDetails {
+    MergeType getMergeType();
+
+    @Value.Default
+    default ConflictType getConflictType() {
+      return ConflictType.NONE;
+    }
+
+    List<Hash> getSourceCommits();
+
+    List<Hash> getTargetCommits();
+
+    static ImmutableKeyDetails.Builder builder() {
+      return ImmutableKeyDetails.builder();
+    }
+  }
+
+  enum ConflictType {
+    NONE,
+    UNRESOLVABLE
+  }
+
+  static <COMMIT> ImmutableMergeResult.Builder<COMMIT> builder() {
+    return ImmutableMergeResult.builder();
+  }
+}


### PR DESCRIPTION
Expose detailed merge/transplant results via `MergeResult`, containing
the outcome (success + applied), per-key details, commit IDs (source,
target, per key for source + target).

Also introduces a "dry run" functionality.

Also introduces a new `MergeConflictException` extending
`ReferenceConflictException` holding a `MergeResult`.

This change does not expose the `MergeResult` or detailed new exception
via the API, which will be part of a follow-up PR.