### PR TITLE
Lint & Test Nessie Helm chart

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -106,12 +106,40 @@ jobs:
         run: mkdocs build
         working-directory: ./site
 
-  lint-helm:
-    name: Lint Helm chart
+  helm-testing:
+    name: Lint & Test Helm chart
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Lint Helm
-        uses: WyriHaximus/github-action-helm3@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          exec: helm lint ./helm/nessie/
+          fetch-depth: 0
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@main
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --debug --charts ./helm/nessie
+
+      - name: Set up & Start Minikube
+        uses: medyagh/setup-minikube@master
+
+      - name: Show pods
+        run: kubectl get pods -A
+
+      - name: Run chart-testing (install)
+        run: ct install --debug --charts ./helm/nessie

--- a/helm/nessie/Chart.yaml
+++ b/helm/nessie/Chart.yaml
@@ -14,3 +14,7 @@ keywords:
   - data lake
   - transactional catalog
   - git-like semantics
+maintainers:
+  - name: nastra
+  - name: snazy
+  - name: dimas-b

--- a/helm/nessie/README.md
+++ b/helm/nessie/README.md
@@ -90,26 +90,22 @@ This is broadly following the example from https://kubernetes.io/docs/tasks/acce
 * Start Minikube cluster: `minikube start`
 * Enable NGINX Ingress controller: `minikube addons enable ingress`
 * Verify Ingress controller is running: `kubectl get pods -n ingress-nginx`
-* Configure Nessie with the following ingress settings
-  ```
-  ingress:
-    enabled: true
-    annotations: {}
-    hosts:
-      - host: chart-example.local
-        paths:
-          - "/"
-    tls: []
-  ```
 * Create K8s Namespace: `kubectl create namespace nessie-ns`
-* Install Nessie Helm chart: `helm install nessie -n nessie-ns helm/nessie`
-* Verify that the IP address is set:
+* Install Nessie Helm chart with Ingress enabled: 
+  ```bash
+  helm install nessie -n nessie-ns helm/nessie \
+    --set ingress.enabled=true \
+    --set ingress.hosts[0].host='chart-example.local' \
+    --set ingress.hosts[0].paths[0]='/'
   ```
-  $ kubectl get ingress
+
+* Verify that the IP address is set:
+  ```bash
+  kubectl get ingress -n nessie-ns
   NAME     CLASS   HOSTS   ADDRESS        PORTS   AGE
   nessie   nginx   *       192.168.49.2   80      4m35s
   ```
-* Add `192.168.49.2 chart-example.local` to `/etc/hosts`
+* Use the IP from the above output and add it to `/etc/hosts` via `echo "192.168.49.2 chart-example.local" | sudo tee /etc/hosts`
 * Verify that `curl chart-example.local` works
 
 ### Stop/Uninstall everything in Dev

--- a/helm/nessie/ci/ingress-values.yaml
+++ b/helm/nessie/ci/ingress-values.yaml
@@ -1,0 +1,7 @@
+---
+ingress:
+  enabled: true
+  hosts:
+    - host: chart-example.local
+      paths:
+        - "/"

--- a/helm/nessie/ci/inmemory-values.yaml
+++ b/helm/nessie/ci/inmemory-values.yaml
@@ -1,0 +1,4 @@
+---
+versionStoreType: INMEMORY
+jaegerTracing:
+  enabled: true

--- a/helm/nessie/ci/rocksdb-values.yaml
+++ b/helm/nessie/ci/rocksdb-values.yaml
@@ -1,0 +1,2 @@
+---
+versionStoreType: ROCKS

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -41,7 +41,7 @@ authentication:
 authorization:
   enabled: false
   # the authorization rules when authorization.enabled=true. Example rules can be found at https://projectnessie.org/features/metadata_authorization/#authorization-rules
-  #rules:
+  # rules:
   #  allowViewingBranch: op=='VIEW_REFERENCE' && role.startsWith('test_user') && ref.startsWith('allowedBranch')
   #  allowCommits: op=='COMMIT_CHANGE_AGAINST_REFERENCE' && role.startsWith('test_user') && ref.startsWith('allowedBranch')
 


### PR DESCRIPTION
This uses https://github.com/helm/chart-testing-action (which in turn is
based on https://github.com/helm/chart-testing) to lint and test Helm
charts.

The chart testing itself actually looks into `helm/nessie/ci` and
installs the different `*-values.yaml` charts in alphabetical order
(note that only files ending with `values.yaml` are considered for
testing)

Additionally, this commit addresses some issues that were reporting when
running `ct lint`, such as the missing maintainers field.