### PR TITLE
Fix keycloak startup docs

### DIFF
--- a/docker/authn/docker-compose.yml
+++ b/docker/authn/docker-compose.yml
@@ -35,3 +35,4 @@ services:
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: admin
+    command: start-dev

--- a/servers/quarkus-server/README.md
+++ b/servers/quarkus-server/README.md
@@ -6,7 +6,7 @@ It is meant to be used for testing purposes only.
 
 1. Start a local Keycloak server
   ```shell
-  docker run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin --name keycloak quay.io/keycloak/keycloak:latest
+  docker run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin --name keycloak quay.io/keycloak/keycloak:latest start-dev
   ```
 2. Log into Keycloak Admin Console at http://localhost:8080/auth/
 3. Create user `nessie` with password `nessie` (under the `master` realm)

--- a/site/docs/guides/keycloak.md
+++ b/site/docs/guides/keycloak.md
@@ -12,7 +12,7 @@ First, start a Keycloak container using its latest Docker image.
 
 ```shell
 docker run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin \
-  --name keycloak quay.io/keycloak/keycloak:latest
+  --name keycloak quay.io/keycloak/keycloak:latest start-dev
 ```
 
 Note the `admin` username and password. Those values will be required to log into the Keycloak Administration Console


### PR DESCRIPTION
Seems the image was changed so that it is now required to provide the
actual start command for keycloak.