### PR TITLE
Efficiently identify referenced and unreferenced heads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
     <test.log.level>INFO</test.log.level>
 
     <!-- Version properties -->
+    <agrona.version>1.15.2</agrona.version>
     <antlr.version>4.10.1</antlr.version>
     <assertj.version>3.23.1</assertj.version>
     <awssdk.version>2.17.204</awssdk.version>
@@ -264,6 +265,11 @@
         <groupId>org.apache.iceberg</groupId>
         <artifactId>iceberg-spark-runtime-3.2_2.12</artifactId>
         <version>${iceberg.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.agrona</groupId>
+        <artifactId>agrona</artifactId>
+        <version>${agrona.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
@@ -137,4 +137,9 @@ public interface QuarkusVersionStoreAdvancedConfig
   @WithDefault("" + DEFAULT_COMMIT_LOG_SCAN_PREFETCH)
   @Override
   int getCommitLogScanPrefetch();
+
+  @WithName("assumed-wall-clock-drift-micros")
+  @WithDefault("" + DEFAULT_ASSUMED_WALL_CLOCK_DRIFT_MICROS)
+  @Override
+  long getAssumedWallClockDriftMicros();
 }

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -93,6 +93,7 @@ The following configurations are advanced configurations to configure how Nessie
 | `nessie.version.store.advanced.reference.names.batch.size`      | `25`                | `int`    | Sets the number of references to resolve at once when fetching all references.                                                                                                                                          |
 | `nessie.version.store.advanced.ref-log.stripes`                 | `8`                 | `int`    | Sets the number of stripes for the ref-log.                                                                                                                                                                             |
 | `nessie.version.store.advanced.commit-log-scan-prefetch`        | `25`                | `int`    | Sets the amount of commits to ask the database to pre-fetch during a full commits scan.                                                                                                                                 |
+| `nessie.version.store.advanced.assumed-wall-clock-drift-micros` | `5_000_000`         | `long`   | Sets the assumed wall-clock drift between multiple Nessie instances, in microseconds.                                                                                                                                   |
 
 ### Authentication settings
 

--- a/versioned/persist/adapter/pom.xml
+++ b/versioned/persist/adapter/pom.xml
@@ -45,6 +45,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
@@ -42,6 +42,7 @@ public interface DatabaseAdapterConfig {
   int DEFAULT_RETRY_INITIAL_SLEEP_MILLIS_LOWER = 5;
   int DEFAULT_RETRY_INITIAL_SLEEP_MILLIS_UPPER = 25;
   int DEFAULT_RETRY_MAX_SLEEP_MILLIS = 75;
+  long DEFAULT_ASSUMED_WALL_CLOCK_DRIFT_MICROS = 5_000_000L;
 
   /**
    * A free-form string that identifies a particular Nessie storage repository.
@@ -216,5 +217,11 @@ public interface DatabaseAdapterConfig {
   @Value.Default
   default int getParentsPerRefLogEntry() {
     return DEFAULT_PARENTS_PER_REFLOG_ENTRY;
+  }
+
+  /** The assumed wall-clock drift between multiple Nessie instances in microseconds. */
+  @Value.Default
+  default long getAssumedWallClockDriftMicros() {
+    return DEFAULT_ASSUMED_WALL_CLOCK_DRIFT_MICROS;
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/HeadsAndForkPoints.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/HeadsAndForkPoints.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import java.util.Set;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.Hash;
+
+@Value.Immutable
+public interface HeadsAndForkPoints {
+  @Value.Parameter
+  Set<Hash> getHeads();
+
+  @Value.Parameter
+  Set<Hash> getForkPoints();
+
+  @Value.Parameter
+  long getScanStartedAtInMicros();
+
+  static HeadsAndForkPoints of(Set<Hash> heads, Set<Hash> forkPoints, long scanStartedAtInMicros) {
+    return ImmutableHeadsAndForkPoints.of(heads, forkPoints, scanStartedAtInMicros);
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencedAndUnreferencedHeads.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencedAndUnreferencedHeads.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import java.util.Map;
+import java.util.Set;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.NamedRef;
+
+@Value.Immutable
+public interface ReferencedAndUnreferencedHeads {
+  @Value.Parameter
+  Map<Hash, Set<NamedRef>> getReferencedHeads();
+
+  @Value.Parameter
+  Set<Hash> getUnreferencedHeads();
+
+  static ReferencedAndUnreferencedHeads of(
+      Map<Hash, Set<NamedRef>> referencedHeads, Set<Hash> unreferencedHeads) {
+    return ImmutableReferencedAndUnreferencedHeads.of(referencedHeads, unreferencedHeads);
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencesUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencesUtil.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter;
+
+import com.google.common.annotations.Beta;
+import com.google.protobuf.ByteString;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.agrona.collections.Hashing;
+import org.agrona.collections.Object2ObjectHashMap;
+import org.agrona.collections.ObjectHashSet;
+import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.ReferenceInfo;
+import org.projectnessie.versioned.ReferenceNotFoundException;
+
+@Beta
+public final class ReferencesUtil {
+  private final DatabaseAdapter databaseAdapter;
+  private final DatabaseAdapterConfig config;
+
+  private ReferencesUtil(DatabaseAdapter databaseAdapter, DatabaseAdapterConfig config) {
+    this.databaseAdapter = databaseAdapter;
+    this.config = config;
+  }
+
+  public static ReferencesUtil forDatabaseAdapter(
+      DatabaseAdapter databaseAdapter, DatabaseAdapterConfig config) {
+    return new ReferencesUtil(databaseAdapter, config);
+  }
+
+  private static <K, V> Map<K, V> newOpenAddressingHashMap() {
+    return new Object2ObjectHashMap<>(16, Hashing.DEFAULT_LOAD_FACTOR, false);
+  }
+
+  private static <T> Set<T> newOpenAddressingHashSet(int initialCapacity) {
+    return new ObjectHashSet<>(initialCapacity, Hashing.DEFAULT_LOAD_FACTOR, false);
+  }
+
+  private static <T> Set<T> newOpenAddressingHashSet(Set<T> source) {
+    ObjectHashSet<T> copy = new ObjectHashSet<>(source.size(), Hashing.DEFAULT_LOAD_FACTOR, false);
+    if (source instanceof ObjectHashSet) {
+      copy.addAll((ObjectHashSet<T>) source);
+    } else {
+      copy.addAll(source);
+    }
+    return copy;
+  }
+
+  private static <T> Set<T> newOpenAddressingHashSet() {
+    return newOpenAddressingHashSet(ObjectHashSet.DEFAULT_INITIAL_CAPACITY);
+  }
+
+  /**
+   * Identifies all heads and fork-points.
+   *
+   * <ul>
+   *   <li>"Heads" are commits that are not referenced by other commits.
+   *   <li>"Fork points" are commits that are the parent of more than one other commit. Knowing
+   *       these commits can help to optimize the traversal of commit logs of multiple heads.
+   * </ul>
+   *
+   * @param expectedCommitCount it is recommended to tell the implementation the total number of
+   *     commits in the Nessie repository
+   */
+  public HeadsAndForkPoints identifyAllHeadsAndForkPoints(int expectedCommitCount) {
+    // Using open-addressing implementation here, because it's much more space-efficient than
+    // java.util.HashSet.
+    Set<Hash> parents = newOpenAddressingHashSet(expectedCommitCount);
+    Set<Hash> heads = newOpenAddressingHashSet();
+    Set<Hash> forkPoints = newOpenAddressingHashSet();
+
+    // Need to remember the time when the identification started, so that a follow-up
+    // identifyReferencedAndUnreferencedHeads() knows when it can stop scanning a named-reference's
+    // commit-log. identifyReferencedAndUnreferencedHeads() has to read up to the first commit
+    // _before_ this timestamp to not commit-IDs as "unreferenced".
+    //
+    // Note: keep in mind, that scanAllCommitLogEntries() returns all commits in a
+    // non-deterministic order. Example: if (at least) two commits are added to a branch while this
+    // function is running, the original HEAD of that branch could otherwise be returned as
+    // "unreferenced".
+    long scanStartedAtInMicros = config.currentTimeInMicros();
+
+    // scanAllCommitLogEntries() returns all commits in no specific order, parents may be scanned
+    // before or after their children.
+    try (Stream<CommitLogEntry> scan = databaseAdapter.scanAllCommitLogEntries()) {
+      scan.forEach(
+          entry -> {
+            Hash parent = entry.getParents().get(0);
+            if (!parents.add(parent)) {
+              // If "parent" has already been added to the set of parents, then it must be a
+              // fork point.
+              forkPoints.add(parent);
+            } else {
+              // Commits in "parents" that are also contained in "heads" cannot be HEADs.
+              // This can happen because the commits are scanned in "random order".
+              // Should do this here to prevent the "heads" set from becoming unnecessarily big.
+              heads.remove(parent);
+            }
+
+            Hash commitId = entry.getHash();
+            if (!parents.contains(commitId)) {
+              // If the commit-ID is not present in "parents", it must be a HEAD
+              heads.add(commitId);
+            }
+          });
+    }
+
+    // Commits in "parents" that are also contained in "heads" cannot be HEADs.
+    // This can happen because the commits are scanned in "random order".
+    // TODO this 'removeIf' should not actually remove anything, because it should already be
+    //  properly handled above.
+    heads.removeIf(parents::contains);
+
+    return HeadsAndForkPoints.of(heads, forkPoints, scanStartedAtInMicros);
+  }
+
+  /**
+   * Identifies unreferenced heads and heads that are part of a named reference.
+   *
+   * <p>Requires the output of {@link #identifyAllHeadsAndForkPoints(int)}.
+   */
+  public ReferencedAndUnreferencedHeads identifyReferencedAndUnreferencedHeads(
+      HeadsAndForkPoints headsAndForkPoints) throws ReferenceNotFoundException {
+    Map<Hash, Set<NamedRef>> referenced = newOpenAddressingHashMap();
+    Set<Hash> heads = headsAndForkPoints.getHeads();
+    Set<Hash> unreferenced = newOpenAddressingHashSet(heads);
+
+    long stopAtCommitTimeMicros =
+        headsAndForkPoints.getScanStartedAtInMicros() - config.getAssumedWallClockDriftMicros();
+
+    try (Stream<ReferenceInfo<ByteString>> namedRefs =
+        databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT)) {
+      namedRefs.forEach(
+          refInfo -> {
+            boolean canStop = false;
+            try (Stream<CommitLogEntry> logs = databaseAdapter.commitLog(refInfo.getHash())) {
+              if (!referenced.containsKey(refInfo.getHash())) {
+                // Only need to traverse the commit log from the same commit-ID once.
+
+                boolean identified = false;
+                for (Iterator<CommitLogEntry> logIter = logs.iterator(); logIter.hasNext(); ) {
+                  CommitLogEntry entry = logIter.next();
+
+                  Hash commitId = entry.getHash();
+
+                  if (referenced.containsKey(commitId)) {
+                    // Already saw this commit-ID, can break
+                    break;
+                  }
+
+                  if (heads.contains(commitId)) {
+                    unreferenced.remove(entry.getHash());
+                  }
+
+                  if (entry.getCreatedTime() < stopAtCommitTimeMicros) {
+                    // Must scan up to the commit created right before
+                    // identifyAllHeadsAndForkPoints() started to not accidentally return
+                    // commits in 'unreferencedHeads' that were the HEAD of a commit that happened
+                    // after identifyAllHeadsAndForkPoints() started.
+                    break;
+                  }
+                }
+              }
+
+              // Add the named reference to the reachable HEADs.
+              referenced
+                  .computeIfAbsent(refInfo.getHash(), x -> newOpenAddressingHashSet())
+                  .add(refInfo.getNamedRef());
+            } catch (ReferenceNotFoundException e) {
+              throw new RuntimeException(e);
+            }
+          });
+    }
+
+    return ReferencedAndUnreferencedHeads.of(referenced, unreferenced);
+  }
+}

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -149,17 +149,7 @@ public class DynamoDatabaseAdapter
               table ->
                   client
                       .client
-                      .scanPaginator(
-                          b ->
-                              b.tableName(table)
-                                  .scanFilter(
-                                      singletonMap(
-                                          KEY_NAME,
-                                          Condition.builder()
-                                              .comparisonOperator(ComparisonOperator.BEGINS_WITH)
-                                              .attributeValueList(
-                                                  AttributeValue.builder().s(keyPrefix).build())
-                                              .build())))
+                      .scanPaginator(b -> b.tableName(table).scanFilter(repositoryScanFilter()))
                       .forEach(
                           r ->
                               r.items().stream()
@@ -751,16 +741,7 @@ public class DynamoDatabaseAdapter
   protected Stream<CommitLogEntry> doScanAllCommitLogEntries(NonTransactionalOperationContext c) {
     return client
         .client
-        .scanPaginator(
-            b ->
-                b.tableName(TABLE_COMMIT_LOG)
-                    .scanFilter(
-                        singletonMap(
-                            KEY_NAME,
-                            Condition.builder()
-                                .comparisonOperator(ComparisonOperator.BEGINS_WITH)
-                                .attributeValueList(AttributeValue.builder().s(keyPrefix).build())
-                                .build())))
+        .scanPaginator(b -> b.tableName(TABLE_COMMIT_LOG).scanFilter(repositoryScanFilter()))
         .stream()
         .flatMap(
             scanResponse ->
@@ -769,5 +750,14 @@ public class DynamoDatabaseAdapter
                     .map(AttributeValue::b)
                     .map(BytesWrapper::asByteArray)
                     .map(ProtoSerialization::protoToCommitLogEntry));
+  }
+
+  private Map<String, Condition> repositoryScanFilter() {
+    return singletonMap(
+        KEY_NAME,
+        Condition.builder()
+            .comparisonOperator(ComparisonOperator.BEGINS_WITH)
+            .attributeValueList(AttributeValue.builder().s(keyPrefix).build())
+            .build());
   }
 }


### PR DESCRIPTION
Implement an efficient way to retrieve all unreferenced HEAD commits.

As a side effect (and up for discussion whether the information's useful), it also returns
* all fork-points (commits that are the parent of more than one other commits)
* map of commit-ID to named-refs

The implementation scans all commits and identifies all "heads" (aka commits that are not the parent of another commit) and all fork-points (commits that are the parent of more than one other commits).
In a next step all named-references and their commit-logs are scanned to identify the HEADs that are unreferenced and those that are the HEADs of named references.

"Efficient" means the only somewhat expensive part is the scan of all commits, but the computation/identification of all HEADs and fork-points (commit with more than one "child") plus the differentiation of unreferenced & referenced HEADs is not that expensive. Plus: it's a server-side implementation and interested clients (maintenance + GC) could just ask for this information.
