### PR TITLE
Align Java parameter names in Http classes with RestAPI parameter names

### DIFF
--- a/model/src/main/java/org/projectnessie/api/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/TreeApi.java
@@ -137,7 +137,7 @@ public interface TreeApi {
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String referenceName,
       @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
-          String oldHash,
+          String expectedHash,
       @Valid @NotNull Reference assignTo)
       throws NessieNotFoundException, NessieConflictException;
 
@@ -149,7 +149,7 @@ public interface TreeApi {
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String referenceName,
       @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
-          String hash)
+          String expectedHash)
       throws NessieConflictException, NessieNotFoundException;
 
   /** cherry pick a set of commits into a branch. */
@@ -159,7 +159,7 @@ public interface TreeApi {
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String branchName,
       @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
-          String hash,
+          String expectedHash,
       @Valid String message,
       @Valid Transplant transplant)
       throws NessieNotFoundException, NessieConflictException;
@@ -171,7 +171,7 @@ public interface TreeApi {
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String branchName,
       @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
-          String hash,
+          String expectedHash,
       @Valid @NotNull Merge merge)
       throws NessieNotFoundException, NessieConflictException;
 
@@ -181,7 +181,7 @@ public interface TreeApi {
    * that contains the operations of the invocation.
    *
    * @param branchName Branch to change, defaults to default branch.
-   * @param hash Expected hash of branch.
+   * @param expectedHash Expected hash of branch.
    * @param operations {@link Operations} to apply
    * @return updated {@link Branch} objects with the hash of the new HEAD
    * @throws NessieNotFoundException if {@code branchName} could not be found
@@ -194,7 +194,7 @@ public interface TreeApi {
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String branchName,
       @Valid @NotNull @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
-          String hash,
+          String expectedHash,
       @Valid @NotNull Operations operations)
       throws NessieNotFoundException, NessieConflictException;
 }

--- a/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/http/HttpTreeApi.java
@@ -302,7 +302,7 @@ public interface HttpTreeApi extends TreeApi {
               description = "Expected previous hash of reference",
               examples = {@ExampleObject(ref = "hash")})
           @QueryParam("expectedHash")
-          String oldHash,
+          String expectedHash,
       @RequestBody(
               description =
                   "Reference hash to which 'referenceName' shall be assigned to. This must be either a "
@@ -341,7 +341,7 @@ public interface HttpTreeApi extends TreeApi {
               description = "Expected hash of tag",
               examples = {@ExampleObject(ref = "hash")})
           @QueryParam("expectedHash")
-          String hash)
+          String expectedHash)
       throws NessieConflictException, NessieNotFoundException;
 
   @Override
@@ -379,7 +379,7 @@ public interface HttpTreeApi extends TreeApi {
               description = "Expected hash of tag.",
               examples = {@ExampleObject(ref = "hash")})
           @QueryParam("expectedHash")
-          String hash,
+          String expectedHash,
       @Parameter(
               description = "commit message",
               examples = {@ExampleObject(ref = "commitMessage")})
@@ -431,7 +431,7 @@ public interface HttpTreeApi extends TreeApi {
               description = "Expected current HEAD of 'branchName'",
               examples = {@ExampleObject(ref = "hash")})
           @QueryParam("expectedHash")
-          String hash,
+          String expectedHash,
       @RequestBody(
               description =
                   "Merge operation that defines the source reference name and an optional hash. "
@@ -481,7 +481,7 @@ public interface HttpTreeApi extends TreeApi {
               description = "Expected hash of branch.",
               examples = {@ExampleObject(ref = "hash")})
           @QueryParam("expectedHash")
-          String hash,
+          String expectedHash,
       @RequestBody(
               description = "Operations",
               content =

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestInvalidWithHttp.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestInvalidWithHttp.java
@@ -226,7 +226,7 @@ public abstract class AbstractRestInvalidWithHttp extends AbstractRestInvalidRef
                             .commit())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".hash: " + HASH_MESSAGE)
+                .hasMessageContaining(".expectedHash: " + HASH_MESSAGE)
                 .hasMessageContaining(opsCountMsg),
         () ->
             assertThatThrownBy(
@@ -238,7 +238,7 @@ public abstract class AbstractRestInvalidWithHttp extends AbstractRestInvalidRef
                             .delete())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".hash: " + HASH_MESSAGE),
+                .hasMessageContaining(".expectedHash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->
@@ -250,7 +250,7 @@ public abstract class AbstractRestInvalidWithHttp extends AbstractRestInvalidRef
                             .assign())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".oldHash: " + HASH_MESSAGE),
+                .hasMessageContaining(".expectedHash: " + HASH_MESSAGE),
         () -> {
           if (null != getHttpClient()) {
             assertThatThrownBy(
@@ -264,7 +264,7 @@ public abstract class AbstractRestInvalidWithHttp extends AbstractRestInvalidRef
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
                 .hasMessageContaining("mergeRefIntoBranch.merge: must not be null")
-                .hasMessageContaining(".hash: " + HASH_MESSAGE);
+                .hasMessageContaining(".expectedHash: " + HASH_MESSAGE);
           }
         },
         () ->
@@ -278,13 +278,13 @@ public abstract class AbstractRestInvalidWithHttp extends AbstractRestInvalidRef
                             .merge())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".hash: " + HASH_MESSAGE),
+                .hasMessageContaining(".expectedHash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () -> getApi().deleteTag().tagName(validBranchName).hash(invalidHash).delete())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".hash: " + HASH_MESSAGE),
+                .hasMessageContaining(".expectedHash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(
                     () ->
@@ -299,7 +299,7 @@ public abstract class AbstractRestInvalidWithHttp extends AbstractRestInvalidRef
                             .transplant())
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessageContaining("Bad Request (HTTP/400):")
-                .hasMessageContaining(".hash: " + HASH_MESSAGE),
+                .hasMessageContaining(".expectedHash: " + HASH_MESSAGE),
         () ->
             assertThatThrownBy(() -> getApi().getContent().refName(invalidHash).get())
                 .isInstanceOf(NessieBadRequestException.class)

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNessieError.java
@@ -56,7 +56,7 @@ public class ITNessieError {
     ContentKey k = ContentKey.of("a");
     IcebergTable t = IcebergTable.of("path1", 42, 42, 42, 42);
     assertEquals(
-        "Bad Request (HTTP/400): commitMultipleOperations.hash: must not be null",
+        "Bad Request (HTTP/400): commitMultipleOperations.expectedHash: must not be null",
         assertThrows(
                 NessieBadRequestException.class,
                 () ->

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -117,35 +117,36 @@ public class RestTreeResource implements HttpTreeApi {
   public void assignReference(
       Reference.ReferenceType referenceType,
       String referenceName,
-      String oldHash,
+      String expectedHash,
       Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
-    resource().assignReference(referenceType, referenceName, oldHash, assignTo);
+    resource().assignReference(referenceType, referenceName, expectedHash, assignTo);
   }
 
   @Override
   public void deleteReference(
-      Reference.ReferenceType referenceType, String referenceName, String hash)
+      Reference.ReferenceType referenceType, String referenceName, String expectedHash)
       throws NessieConflictException, NessieNotFoundException {
-    resource().deleteReference(referenceType, referenceName, hash);
+    resource().deleteReference(referenceType, referenceName, expectedHash);
   }
 
   @Override
   public MergeResponse transplantCommitsIntoBranch(
-      String branchName, String hash, String message, Transplant transplant)
+      String branchName, String expectedHash, String message, Transplant transplant)
       throws NessieNotFoundException, NessieConflictException {
-    return resource().transplantCommitsIntoBranch(branchName, hash, message, transplant);
+    return resource().transplantCommitsIntoBranch(branchName, expectedHash, message, transplant);
   }
 
   @Override
-  public MergeResponse mergeRefIntoBranch(String branchName, String hash, Merge merge)
+  public MergeResponse mergeRefIntoBranch(String branchName, String expectedHash, Merge merge)
       throws NessieNotFoundException, NessieConflictException {
-    return resource().mergeRefIntoBranch(branchName, hash, merge);
+    return resource().mergeRefIntoBranch(branchName, expectedHash, merge);
   }
 
   @Override
-  public Branch commitMultipleOperations(String branchName, String hash, Operations operations)
+  public Branch commitMultipleOperations(
+      String branchName, String expectedHash, Operations operations)
       throws NessieNotFoundException, NessieConflictException {
-    return resource().commitMultipleOperations(branchName, hash, operations);
+    return resource().commitMultipleOperations(branchName, expectedHash, operations);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
@@ -118,18 +118,18 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
   }
 
   @Override
-  protected void assignReference(NamedRef ref, String oldHash, Reference assignTo)
+  protected void assignReference(NamedRef ref, String expectedHash, Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
     startAccessCheck()
         .canViewReference(
             namedRefWithHashOrThrow(assignTo.getName(), assignTo.getHash()).getValue())
         .canAssignRefToHash(ref)
         .checkAndThrow();
-    super.assignReference(ref, oldHash, assignTo);
+    super.assignReference(ref, expectedHash, assignTo);
   }
 
   @Override
-  protected void deleteReference(NamedRef ref, String hash)
+  protected void deleteReference(NamedRef ref, String expectedHash)
       throws NessieConflictException, NessieNotFoundException {
     BatchAccessChecker check = startAccessCheck();
     if (ref instanceof BranchName && getConfig().getDefaultBranch().equals(ref.getName())) {
@@ -138,7 +138,7 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
       check.canDeleteReference(ref);
     }
     check.checkAndThrow();
-    super.deleteReference(ref, hash);
+    super.deleteReference(ref, expectedHash);
   }
 
   @Override
@@ -230,7 +230,7 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
 
   @Override
   public MergeResponse transplantCommitsIntoBranch(
-      String branchName, String hash, String message, Transplant transplant)
+      String branchName, String expectedHash, String message, Transplant transplant)
       throws NessieNotFoundException, NessieConflictException {
     if (transplant.getHashesToTransplant().isEmpty()) {
       throw new IllegalArgumentException("No hashes given to transplant.");
@@ -246,22 +246,22 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
                 .getValue())
         .canCommitChangeAgainstReference(BranchName.of(branchName))
         .checkAndThrow();
-    return super.transplantCommitsIntoBranch(branchName, hash, message, transplant);
+    return super.transplantCommitsIntoBranch(branchName, expectedHash, message, transplant);
   }
 
   @Override
-  public MergeResponse mergeRefIntoBranch(String branchName, String hash, Merge merge)
+  public MergeResponse mergeRefIntoBranch(String branchName, String expectedHash, Merge merge)
       throws NessieNotFoundException, NessieConflictException {
     startAccessCheck()
         .canViewReference(
             namedRefWithHashOrThrow(merge.getFromRefName(), merge.getFromHash()).getValue())
         .canCommitChangeAgainstReference(BranchName.of(branchName))
         .checkAndThrow();
-    return super.mergeRefIntoBranch(branchName, hash, merge);
+    return super.mergeRefIntoBranch(branchName, expectedHash, merge);
   }
 
   @Override
-  public Branch commitMultipleOperations(String branch, String hash, Operations operations)
+  public Branch commitMultipleOperations(String branch, String expectedHash, Operations operations)
       throws NessieNotFoundException, NessieConflictException {
     BranchName branchName = BranchName.of(branch);
     BatchAccessChecker check = startAccessCheck().canCommitChangeAgainstReference(branchName);
@@ -281,6 +281,6 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
               }
             });
     check.checkAndThrow();
-    return super.commitMultipleOperations(branch, hash, operations);
+    return super.commitMultipleOperations(branch, expectedHash, operations);
   }
 }


### PR DESCRIPTION
If parameter validation fails, then hibernate-validator will use the
actual parameter name from the Java method to indicate where things went
wrong. This renames the `hash` parameter to `expectedHash` to have a clearer error message when parameter validation fails.

I also checked all the other parameter names and those are already
aligned.

fixes #4311