### PR TITLE
Repository changed events from `AbstractDatabaseAdapter`

### DIFF
--- a/clients/iceberg-views/pom.xml
+++ b/clients/iceberg-views/pom.xml
@@ -144,6 +144,10 @@
           <groupId>org.slf4j</groupId>
         </exclusion>
         <exclusion>
+          <artifactId>slf4j-reload4j</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>mockito-all</artifactId>
           <groupId>org.mockito</groupId>
         </exclusion>

--- a/versioned/persist/adapter/pom.xml
+++ b/versioned/persist/adapter/pom.xml
@@ -36,6 +36,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterFactory.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterFactory.java
@@ -20,6 +20,7 @@ import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.projectnessie.versioned.StoreWorker;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 
 /**
  * Each {@link org.projectnessie.versioned.persist.adapter.DatabaseAdapter} is configured and
@@ -46,6 +47,7 @@ public interface DatabaseAdapterFactory<
   abstract class Builder<Config, AdjustableConfig, Connector> {
     private Config config;
     private Connector connector;
+    private AdapterEventConsumer eventConsumer;
 
     public Builder<Config, AdjustableConfig, Connector> withConfig(Config config) {
       this.config = config;
@@ -54,6 +56,13 @@ public interface DatabaseAdapterFactory<
 
     public Builder<Config, AdjustableConfig, Connector> withConnector(Connector connector) {
       this.connector = connector;
+      return this;
+    }
+
+    /** Register the {@link AdapterEventConsumer} to receive events from the database adapter. */
+    public Builder<Config, AdjustableConfig, Connector> withEventConsumer(
+        AdapterEventConsumer eventConsumer) {
+      this.eventConsumer = eventConsumer;
       return this;
     }
 
@@ -70,6 +79,10 @@ public interface DatabaseAdapterFactory<
 
     public Connector getConnector() {
       return connector;
+    }
+
+    public AdapterEventConsumer getEventConsumer() {
+      return eventConsumer;
     }
 
     public abstract DatabaseAdapter build(StoreWorker<?, ?, ?> storeWorker);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/AdapterEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/AdapterEvent.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.persist.adapter.events;
 
 import com.google.common.annotations.Beta;
-import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 
 /**
  * Base class for all events emitted by {@link
@@ -30,7 +29,8 @@ public interface AdapterEvent {
   OperationType getOperationType();
 
   /**
-   * Time when the event was created, source is {@link DatabaseAdapterConfig#getClock()} ({@link
+   * Time when the event was created, source is {@link
+   * org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig#getClock()} ({@link
    * java.time.Clock#systemUTC()} in production) using {@link java.time.Instant#getEpochSecond} plus
    * {@link java.time.Instant#getNano()}.
    */

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/AdapterEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/AdapterEvent.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.versioned.persist.adapter.events;
 
+import com.google.common.annotations.Beta;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
+
 /**
  * Base class for all events emitted by {@link
  * org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter} implementations.
@@ -22,15 +25,21 @@ package org.projectnessie.versioned.persist.adapter.events;
  * <p>Database adapter events and infrastructure are "Nessie internal" and may change, even
  * fundamentally, w/o prior notice.
  */
+@Beta
 public interface AdapterEvent {
   OperationType getOperationType();
 
-  long getEventTimeInMicros();
+  /**
+   * Time when the event was created, source is {@link DatabaseAdapterConfig#getClock()} ({@link
+   * java.time.Clock#systemUTC()} in production) using {@link java.time.Instant#getEpochSecond} plus
+   * {@link java.time.Instant#getNano()}.
+   */
+  long getEventTimeMicros();
 
   interface Builder<B extends Builder<B, E>, E extends AdapterEvent> {
     B operationType(OperationType operationType);
 
-    B eventTimeInMicros(long eventTimeInMicros);
+    B eventTimeMicros(long eventTimeMicros);
 
     E build();
   }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/AdapterEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/AdapterEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+/**
+ * Base class for all events emitted by {@link
+ * org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter} implementations.
+ *
+ * <p>Database adapter events and infrastructure are "Nessie internal" and may change, even
+ * fundamentally, w/o prior notice.
+ */
+public interface AdapterEvent {
+  OperationType getOperationType();
+
+  long getEventTimeInMicros();
+
+  interface Builder<B extends Builder<B, E>, E extends AdapterEvent> {
+    B operationType(OperationType operationType);
+
+    B eventTimeInMicros(long eventTimeInMicros);
+
+    E build();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/AdapterEventConsumer.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/AdapterEventConsumer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import java.util.function.Consumer;
+
+/**
+ * Consumer interface for {@link AdapterEvent}s.
+ *
+ * <p>Database adapter events and infrastructure are "Nessie internal" and may change, even *
+ * fundamentally, w/o prior notice.
+ */
+@FunctionalInterface
+public interface AdapterEventConsumer extends Consumer<AdapterEvent> {
+
+  @Override
+  void accept(AdapterEvent adapterEvent);
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/CommitEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/CommitEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface CommitEvent extends CommittingEvent {
+
+  @Override
+  @Value.Default
+  default OperationType getOperationType() {
+    return OperationType.COMMIT;
+  }
+
+  interface Builder extends CommittingEvent.Builder<Builder, CommitEvent> {}
+
+  static CommitEvent.Builder builder() {
+    return ImmutableCommitEvent.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/CommittingEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/CommittingEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import java.util.List;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+
+public interface CommittingEvent extends AdapterEvent {
+
+  BranchName getBranch();
+
+  Hash getPreviousHash();
+
+  Hash getHash();
+
+  List<CommitLogEntry> getCommits();
+
+  interface Builder<B extends Builder<B, E>, E extends CommittingEvent>
+      extends AdapterEvent.Builder<B, E> {
+    B branch(BranchName branch);
+
+    B hash(Hash hash);
+
+    B previousHash(Hash previousHash);
+
+    B addCommits(CommitLogEntry commitLogEntry);
+
+    B commits(Iterable<? extends CommitLogEntry> elements);
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/MergeEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/MergeEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface MergeEvent extends CommittingEvent {
+
+  @Override
+  @Value.Default
+  default OperationType getOperationType() {
+    return OperationType.MERGE;
+  }
+
+  interface Builder extends CommittingEvent.Builder<Builder, MergeEvent> {}
+
+  static MergeEvent.Builder builder() {
+    return ImmutableMergeEvent.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/OperationType.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/OperationType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+public enum OperationType {
+  COMMIT,
+  TRANSPLANT,
+  MERGE,
+  CRETE_REF,
+  DELETE_REF,
+  ASSIGN_REF,
+  REPOSITORY_INITIALIZED,
+  REPOSITORY_ERASED,
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/OperationType.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/OperationType.java
@@ -16,12 +16,30 @@
 package org.projectnessie.versioned.persist.adapter.events;
 
 public enum OperationType {
-  COMMIT,
-  TRANSPLANT,
-  MERGE,
-  CRETE_REF,
-  DELETE_REF,
-  ASSIGN_REF,
-  REPOSITORY_INITIALIZED,
-  REPOSITORY_ERASED,
+  COMMIT(true, false),
+  TRANSPLANT(true, false),
+  MERGE(true, false),
+  CRETE_REF(false, true),
+  DELETE_REF(false, true),
+  ASSIGN_REF(false, true),
+  REPOSITORY_INITIALIZED(false, false),
+  REPOSITORY_ERASED(false, false);
+
+  private final boolean committingEvent;
+  private final boolean reference;
+
+  OperationType(boolean committing, boolean reference) {
+    this.committingEvent = committing;
+    this.reference = reference;
+  }
+
+  /** Whether the event / operation-type is one that wrote (at least) one commit. */
+  public boolean isCommitting() {
+    return committingEvent;
+  }
+
+  /** Whether the event / operation-type is one that modified a named reference. */
+  public boolean isReference() {
+    return reference;
+  }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceAssignedEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceAssignedEvent.java
@@ -21,6 +21,7 @@ import org.projectnessie.versioned.Hash;
 @Value.Immutable
 public interface ReferenceAssignedEvent extends ReferenceEvent {
 
+  /** The reference's current commit-ID before it was assigned. */
   Hash getPreviousHash();
 
   @Override

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceAssignedEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceAssignedEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.immutables.value.Value;
+import org.projectnessie.versioned.Hash;
+
+@Value.Immutable
+public interface ReferenceAssignedEvent extends ReferenceEvent {
+
+  Hash getPreviousHash();
+
+  @Override
+  @Value.Default
+  default OperationType getOperationType() {
+    return OperationType.ASSIGN_REF;
+  }
+
+  interface Builder extends ReferenceEvent.Builder<Builder, ReferenceAssignedEvent> {
+    Builder previousHash(Hash previousHash);
+  }
+
+  static ReferenceAssignedEvent.Builder builder() {
+    return ImmutableReferenceAssignedEvent.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceCreatedEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceCreatedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ReferenceCreatedEvent extends ReferenceEvent {
+
+  @Override
+  @Value.Default
+  default OperationType getOperationType() {
+    return OperationType.CRETE_REF;
+  }
+
+  interface Builder extends ReferenceEvent.Builder<Builder, ReferenceCreatedEvent> {}
+
+  static ReferenceCreatedEvent.Builder builder() {
+    return ImmutableReferenceCreatedEvent.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceDeletedEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceDeletedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ReferenceDeletedEvent extends ReferenceEvent {
+
+  @Override
+  @Value.Default
+  default OperationType getOperationType() {
+    return OperationType.DELETE_REF;
+  }
+
+  interface Builder extends ReferenceEvent.Builder<Builder, ReferenceDeletedEvent> {}
+
+  static ReferenceDeletedEvent.Builder builder() {
+    return ImmutableReferenceDeletedEvent.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.NamedRef;
+
+public interface ReferenceEvent extends AdapterEvent {
+  NamedRef getRef();
+
+  Hash getHash();
+
+  interface Builder<B extends Builder<B, E>, E extends ReferenceEvent>
+      extends AdapterEvent.Builder<B, E> {
+    B ref(NamedRef ref);
+
+    B hash(Hash hash);
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/ReferenceEvent.java
@@ -21,12 +21,23 @@ import org.projectnessie.versioned.NamedRef;
 public interface ReferenceEvent extends AdapterEvent {
   NamedRef getRef();
 
-  Hash getHash();
+  /**
+   * Hash of the reference, specific meaning for each event type.
+   *
+   * <ul>
+   *   <li>For {@link ReferenceCreatedEvent}: the current/initial commit ID of the reference when it
+   *       was created
+   *   <li>For {@link ReferenceDeletedEvent}: the current commit ID of the reference when it was
+   *       deleted
+   *   <li>For {@link ReferenceAssignedEvent}): the <em>new</em> commit ID of the named reference
+   * </ul>
+   */
+  Hash getCurrentHash();
 
   interface Builder<B extends Builder<B, E>, E extends ReferenceEvent>
       extends AdapterEvent.Builder<B, E> {
     B ref(NamedRef ref);
 
-    B hash(Hash hash);
+    B currentHash(Hash currentHash);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/RepositoryErasedEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/RepositoryErasedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface RepositoryErasedEvent extends AdapterEvent {
+
+  @Override
+  @Value.Default
+  default OperationType getOperationType() {
+    return OperationType.REPOSITORY_ERASED;
+  }
+
+  interface Builder extends AdapterEvent.Builder<Builder, RepositoryErasedEvent> {}
+
+  static RepositoryErasedEvent.Builder builder() {
+    return ImmutableRepositoryErasedEvent.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/RepositoryInitializedEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/RepositoryInitializedEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface RepositoryInitializedEvent extends AdapterEvent {
+
+  String getDefaultBranch();
+
+  @Override
+  @Value.Default
+  default OperationType getOperationType() {
+    return OperationType.REPOSITORY_INITIALIZED;
+  }
+
+  interface Builder extends AdapterEvent.Builder<Builder, RepositoryInitializedEvent> {
+    Builder defaultBranch(String defaultBranch);
+  }
+
+  static RepositoryInitializedEvent.Builder builder() {
+    return ImmutableRepositoryInitializedEvent.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/TransplantEvent.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/events/TransplantEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.events;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface TransplantEvent extends CommittingEvent {
+
+  @Override
+  @Value.Default
+  default OperationType getOperationType() {
+    return OperationType.TRANSPLANT;
+  }
+
+  interface Builder extends CommittingEvent.Builder<Builder, TransplantEvent> {}
+
+  static TransplantEvent.Builder builder() {
+    return ImmutableTransplantEvent.builder();
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -60,6 +60,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -106,6 +107,8 @@ import org.projectnessie.versioned.persist.adapter.MergeParams;
 import org.projectnessie.versioned.persist.adapter.MetadataRewriteParams;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.TransplantParams;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEvent;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 
 /**
  * Contains all the database-independent logic for a Database-adapter.
@@ -135,6 +138,7 @@ public abstract class AbstractDatabaseAdapter<
   protected static final String TAG_COUNT = "count";
   protected final CONFIG config;
   protected final StoreWorker<?, ?, ?> storeWorker;
+  private final AdapterEventConsumer eventConsumer;
 
   @SuppressWarnings("UnstableApiUsage")
   public static final Hash NO_ANCESTOR =
@@ -144,15 +148,22 @@ public abstract class AbstractDatabaseAdapter<
 
   protected static long COMMIT_LOG_HASH_SEED = 946928273206945677L;
 
-  protected AbstractDatabaseAdapter(CONFIG config, StoreWorker<?, ?, ?> storeWorker) {
+  protected AbstractDatabaseAdapter(
+      CONFIG config, StoreWorker<?, ?, ?> storeWorker, AdapterEventConsumer eventConsumer) {
     Objects.requireNonNull(config, "config parameter must not be null");
     this.config = config;
     this.storeWorker = storeWorker;
+    this.eventConsumer = eventConsumer;
   }
 
   @VisibleForTesting
   public CONFIG getConfig() {
     return config;
+  }
+
+  @VisibleForTesting
+  public AdapterEventConsumer getEventConsumer() {
+    return eventConsumer;
   }
 
   @VisibleForTesting
@@ -287,6 +298,7 @@ public abstract class AbstractDatabaseAdapter<
       Hash toHead,
       Consumer<Hash> branchCommits,
       Consumer<Hash> newKeyLists,
+      Consumer<CommitLogEntry> writtenCommits,
       MergeParams mergeParams,
       ImmutableMergeResult.Builder<CommitLogEntry> mergeResult)
       throws ReferenceNotFoundException, ReferenceConflictException {
@@ -340,7 +352,8 @@ public abstract class AbstractDatabaseAdapter<
         commitsToMergeChronological,
         toEntriesReverseChronological,
         mergeParams,
-        mergeResult);
+        mergeResult,
+        writtenCommits);
   }
 
   /**
@@ -358,6 +371,7 @@ public abstract class AbstractDatabaseAdapter<
       Hash targetHead,
       Consumer<Hash> branchCommits,
       Consumer<Hash> newKeyLists,
+      Consumer<CommitLogEntry> writtenCommits,
       TransplantParams transplantParams,
       ImmutableMergeResult.Builder<CommitLogEntry> mergeResult)
       throws ReferenceNotFoundException, ReferenceConflictException {
@@ -422,7 +436,8 @@ public abstract class AbstractDatabaseAdapter<
         commitsToTransplantChronological,
         targetEntriesReverseChronological,
         transplantParams,
-        mergeResult);
+        mergeResult,
+        writtenCommits);
   }
 
   protected Hash mergeTransplantCommon(
@@ -434,7 +449,8 @@ public abstract class AbstractDatabaseAdapter<
       List<CommitLogEntry> commitsToMergeChronological,
       List<CommitLogEntry> toEntriesReverseChronological,
       MetadataRewriteParams params,
-      ImmutableMergeResult.Builder<CommitLogEntry> mergeResult)
+      ImmutableMergeResult.Builder<CommitLogEntry> mergeResult,
+      Consumer<CommitLogEntry> writtenCommits)
       throws ReferenceConflictException, ReferenceNotFoundException {
 
     // Collect modified keys.
@@ -522,10 +538,13 @@ public abstract class AbstractDatabaseAdapter<
 
       // Write commits
 
-      commitsToMergeChronological.stream().map(CommitLogEntry::getHash).forEach(branchCommits);
       writeMultipleCommits(ctx, commitsToMergeChronological);
+      commitsToMergeChronological.stream()
+          .peek(writtenCommits)
+          .map(CommitLogEntry::getHash)
+          .forEach(branchCommits);
     } else {
-      toHead =
+      CommitLogEntry squashed =
           squashCommits(
               ctx,
               timeInMicros,
@@ -534,6 +553,11 @@ public abstract class AbstractDatabaseAdapter<
               newKeyLists,
               params.getUpdateCommitMetadata(),
               mergePredicate);
+
+      if (squashed != null) {
+        writtenCommits.accept(squashed);
+        toHead = squashed.getHash();
+      }
     }
     return toHead;
   }
@@ -1769,7 +1793,7 @@ public abstract class AbstractDatabaseAdapter<
    * For merge/transplant, applies one squashed commit derived from the given commits onto the
    * target-hash.
    */
-  protected Hash squashCommits(
+  protected CommitLogEntry squashCommits(
       OP_CONTEXT ctx,
       long timeInMicros,
       Hash toHead,
@@ -1802,7 +1826,7 @@ public abstract class AbstractDatabaseAdapter<
 
     if (puts.isEmpty() && deletes.isEmpty()) {
       // Copied commit will not contain any operation, skip.
-      return toHead;
+      return null;
     }
 
     ByteString newCommitMeta = rewriteMetadata.squash(commitMeta);
@@ -1839,7 +1863,7 @@ public abstract class AbstractDatabaseAdapter<
 
     writeIndividualCommit(ctx, squashedCommit);
 
-    return squashedCommit.getHash();
+    return squashedCommit;
   }
 
   /** For merge/transplant, applies the given commits onto the target-hash. */
@@ -2005,5 +2029,11 @@ public abstract class AbstractDatabaseAdapter<
   protected void tryLoopStateCompletion(@Nonnull Boolean success, TryLoopState state) {
     tryLoopFinished(
         success ? "success" : "fail", state.getRetries(), state.getDuration(NANOSECONDS));
+  }
+
+  protected void repositoryEvent(Supplier<? extends AdapterEvent.Builder<?, ?>> eventBuilder) {
+    if (eventConsumer != null && eventBuilder != null) {
+      eventConsumer.accept(eventBuilder.get().eventTimeInMicros(commitTimeInMicros()).build());
+    }
   }
 }

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -55,6 +55,7 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
 import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.Parser;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
@@ -97,8 +98,9 @@ public class DynamoDatabaseAdapter
   public DynamoDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       DynamoDatabaseClient c,
-      StoreWorker<?, ?, ?> storeWorker) {
-    super(config, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    super(config, storeWorker, eventConsumer);
 
     Objects.requireNonNull(
         c, "Requires a non-null DynamoDatabaseClient from DynamoDatabaseAdapterConfig");
@@ -134,7 +136,7 @@ public class DynamoDatabaseAdapter
   }
 
   @Override
-  public void eraseRepo() {
+  protected void doEraseRepo() {
     client.client.deleteItem(b -> b.tableName(TABLE_GLOBAL_POINTER).key(globalPointerKeyMap));
 
     try (BatchDelete batchDelete = new BatchDelete()) {

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapterFactory.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapterFactory.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.dynamodb;
 
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterFactory;
 
@@ -34,7 +35,8 @@ public class DynamoDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       DynamoDatabaseClient dynamoDatabaseClient,
-      StoreWorker<?, ?, ?> storeWorker) {
-    return new DynamoDatabaseAdapter(config, dynamoDatabaseClient, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    return new DynamoDatabaseAdapter(config, dynamoDatabaseClient, storeWorker, eventConsumer);
   }
 }

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -40,6 +40,7 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
@@ -61,8 +62,9 @@ public class InmemoryDatabaseAdapter
   public InmemoryDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       InmemoryStore store,
-      StoreWorker<?, ?, ?> storeWorker) {
-    super(config, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    super(config, storeWorker, eventConsumer);
 
     this.keyPrefix = ByteString.copyFromUtf8(config.getRepositoryId() + ':');
 
@@ -89,7 +91,7 @@ public class InmemoryDatabaseAdapter
   }
 
   @Override
-  public void eraseRepo() {
+  protected void doEraseRepo() {
     store.reinitializeRepo(keyPrefix);
   }
 

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapterFactory.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapterFactory.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.inmem;
 
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterFactory;
 
@@ -34,7 +35,8 @@ public class InmemoryDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       InmemoryStore inmemoryStore,
-      StoreWorker<?, ?, ?> storeWorker) {
-    return new InmemoryDatabaseAdapter(config, inmemoryStore, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    return new InmemoryDatabaseAdapter(config, inmemoryStore, storeWorker, eventConsumer);
   }
 }

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -57,6 +57,7 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
 import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization.Parser;
 import org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil;
@@ -93,8 +94,9 @@ public class MongoDatabaseAdapter
   protected MongoDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       MongoDatabaseClient client,
-      StoreWorker<?, ?, ?> storeWorker) {
-    super(config, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    super(config, storeWorker, eventConsumer);
 
     Objects.requireNonNull(client, "MongoDatabaseClient cannot be null");
     this.client = client;
@@ -106,7 +108,7 @@ public class MongoDatabaseAdapter
   }
 
   @Override
-  public void eraseRepo() {
+  protected void doEraseRepo() {
     client.getGlobalPointers().deleteMany(Filters.eq(globalPointerKey));
     Bson idPrefixFilter = Filters.eq(ID_REPO_PATH, repositoryId);
     client.allExceptGlobalPointer().forEach(coll -> coll.deleteMany(idPrefixFilter));

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapterFactory.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapterFactory.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.mongodb;
 
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterFactory;
 
@@ -34,7 +35,8 @@ public class MongoDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       MongoDatabaseClient client,
-      StoreWorker<?, ?, ?> storeWorker) {
-    return new MongoDatabaseAdapter(config, client, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    return new MongoDatabaseAdapter(config, client, storeWorker, eventConsumer);
   }
 }

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -431,7 +431,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                         .setCommitHash(newHead.asBytes())
                         .setOperationTime(commitTimeInMicros())
                         .setOperation(RefLogEntry.Operation.CREATE_REFERENCE),
-                () -> ReferenceCreatedEvent.builder().hash(newHead).ref(ref));
+                () -> ReferenceCreatedEvent.builder().currentHash(newHead).ref(ref));
           },
           () -> createConflictMessage("Retry-Failure", ref, target));
     } catch (ReferenceAlreadyExistsException | ReferenceNotFoundException | RuntimeException e) {
@@ -463,7 +463,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                         .setCommitHash(currentHead.asBytes())
                         .setOperationTime(commitTimeInMicros())
                         .setOperation(RefLogEntry.Operation.DELETE_REFERENCE),
-                () -> ReferenceDeletedEvent.builder().hash(currentHead).ref(reference));
+                () -> ReferenceDeletedEvent.builder().currentHash(currentHead).ref(reference));
           },
           () -> deleteConflictMessage("Retry-Failure", reference, expectedHead));
     } catch (ReferenceNotFoundException | ReferenceConflictException | RuntimeException e) {
@@ -500,7 +500,7 @@ public abstract class NonTransactionalDatabaseAdapter<
                         .addSourceHashes(beforeAssign.asBytes()),
                 () ->
                     ReferenceAssignedEvent.builder()
-                        .hash(assignTo)
+                        .currentHash(assignTo)
                         .ref(assignee)
                         .previousHash(beforeAssign));
           },
@@ -570,7 +570,8 @@ public abstract class NonTransactionalDatabaseAdapter<
       Preconditions.checkState(
           createNamedReference(ctx, defaultBranch, NO_ANCESTOR), "Could not create default branch");
 
-      repositoryEvent(() -> ReferenceCreatedEvent.builder().ref(defaultBranch).hash(NO_ANCESTOR));
+      repositoryEvent(
+          () -> ReferenceCreatedEvent.builder().ref(defaultBranch).currentHash(NO_ANCESTOR));
     }
   }
 

--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterFactory.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapterFactory.java
@@ -19,6 +19,7 @@ import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 
 public abstract class NonTransactionalDatabaseAdapterFactory<
         CONNECTOR extends DatabaseConnectionProvider<?>>
@@ -30,7 +31,8 @@ public abstract class NonTransactionalDatabaseAdapterFactory<
   protected abstract DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       CONNECTOR connector,
-      StoreWorker<?, ?, ?> storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer);
 
   @Override
   public Builder<
@@ -61,7 +63,7 @@ public abstract class NonTransactionalDatabaseAdapterFactory<
 
     @Override
     public DatabaseAdapter build(StoreWorker<?, ?, ?> storeWorker) {
-      return create(getConfig(), getConnector(), storeWorker);
+      return create(getConfig(), getConnector(), storeWorker, getEventConsumer());
     }
   }
 }

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -43,6 +43,7 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 import org.projectnessie.versioned.persist.adapter.RefLog;
 import org.projectnessie.versioned.persist.adapter.RepoDescription;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.adapter.serialize.ProtoSerialization;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
@@ -74,8 +75,9 @@ public class RocksDatabaseAdapter
   public RocksDatabaseAdapter(
       NonTransactionalDatabaseAdapterConfig config,
       RocksDbInstance dbInstance,
-      StoreWorker<?, ?, ?> storeWorker) {
-    super(config, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    super(config, storeWorker, eventConsumer);
 
     this.keyPrefix = ByteString.copyFromUtf8(config.getRepositoryId() + ':');
     this.globalPointerKey = ByteString.copyFromUtf8(config.getRepositoryId()).toByteArray();
@@ -109,7 +111,7 @@ public class RocksDatabaseAdapter
   }
 
   @Override
-  public void eraseRepo() {
+  protected void doEraseRepo() {
     try {
       db.delete(dbInstance.getCfGlobalPointer(), globalPointerKey());
       dbInstance

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapterFactory.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapterFactory.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.rocks;
 
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapterFactory;
 
@@ -34,7 +35,8 @@ public class RocksDatabaseAdapterFactory
   protected DatabaseAdapter create(
       NonTransactionalDatabaseAdapterConfig config,
       RocksDbInstance rocksDbInstance,
-      StoreWorker<?, ?, ?> storeWorker) {
-    return new RocksDatabaseAdapter(config, rocksDbInstance, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    return new RocksDatabaseAdapter(config, rocksDbInstance, storeWorker, eventConsumer);
   }
 }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -35,6 +35,14 @@ public abstract class AbstractDatabaseAdapterTest {
 
   @Nested
   @SuppressWarnings("ClassCanBeStatic")
+  public class Events extends AbstractEvents {
+    Events() {
+      super(databaseAdapter);
+    }
+  }
+
+  @Nested
+  @SuppressWarnings("ClassCanBeStatic")
   public class Repositories extends AbstractRepositories {
     Repositories() {
       super(databaseAdapter);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractEvents.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractEvents.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.MergeResult;
+import org.projectnessie.versioned.MetadataRewriter;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.ContentId;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
+import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+import org.projectnessie.versioned.persist.adapter.MergeParams;
+import org.projectnessie.versioned.persist.adapter.TransplantParams;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEvent;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
+import org.projectnessie.versioned.persist.adapter.events.CommitEvent;
+import org.projectnessie.versioned.persist.adapter.events.MergeEvent;
+import org.projectnessie.versioned.persist.adapter.events.OperationType;
+import org.projectnessie.versioned.persist.adapter.events.ReferenceAssignedEvent;
+import org.projectnessie.versioned.persist.adapter.events.ReferenceCreatedEvent;
+import org.projectnessie.versioned.persist.adapter.events.ReferenceDeletedEvent;
+import org.projectnessie.versioned.persist.adapter.events.RepositoryErasedEvent;
+import org.projectnessie.versioned.persist.adapter.events.RepositoryInitializedEvent;
+import org.projectnessie.versioned.persist.adapter.events.TransplantEvent;
+import org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
+import org.projectnessie.versioned.testworker.OnRefOnly;
+import org.projectnessie.versioned.testworker.SimpleStoreWorker;
+
+/** Verifies handling of repo-description in the database-adapters. */
+public abstract class AbstractEvents {
+
+  private final DatabaseAdapter databaseAdapter;
+
+  protected AbstractEvents(DatabaseAdapter databaseAdapter) {
+    this.databaseAdapter = databaseAdapter;
+  }
+
+  @Test
+  public void eventRepoInit(
+      @NessieDbAdapter(initializeRepo = false, eventConsumer = EventCollector.class)
+          AbstractDatabaseAdapter<?, ?> adapter) {
+
+    EventCollector events = (EventCollector) adapter.getEventConsumer();
+
+    adapter.initializeRepo("main");
+    assertThat(events.events).isEmpty();
+
+    adapter.eraseRepo();
+
+    assertThat(events.events)
+        .hasSize(1)
+        .last()
+        .asInstanceOf(type(RepositoryErasedEvent.class))
+        .extracting(RepositoryErasedEvent::getOperationType)
+        .isEqualTo(OperationType.REPOSITORY_ERASED);
+    events.events.clear();
+
+    adapter.initializeRepo("main");
+
+    assertThat(events.events)
+        .asInstanceOf(list(AdapterEvent.class))
+        .satisfiesExactly(
+            repoInit ->
+                assertThat(repoInit)
+                    .asInstanceOf(type(RepositoryInitializedEvent.class))
+                    .extracting(
+                        RepositoryInitializedEvent::getOperationType,
+                        RepositoryInitializedEvent::getDefaultBranch)
+                    .containsExactly(OperationType.REPOSITORY_INITIALIZED, "main"),
+            createRef ->
+                assertThat(createRef)
+                    .asInstanceOf(type(ReferenceCreatedEvent.class))
+                    .extracting(
+                        ReferenceCreatedEvent::getOperationType,
+                        ReferenceCreatedEvent::getHash,
+                        ReferenceCreatedEvent::getRef)
+                    .containsExactly(
+                        OperationType.CRETE_REF, adapter.noAncestorHash(), BranchName.of("main")));
+  }
+
+  @Test
+  public void eventCreateRef(
+      @NessieDbAdapter(initializeRepo = false, eventConsumer = EventCollector.class)
+          AbstractDatabaseAdapter<?, ?> adapter)
+      throws Exception {
+
+    EventCollector events = (EventCollector) adapter.getEventConsumer();
+
+    BranchName branch = BranchName.of("events-create");
+
+    adapter.create(branch, adapter.noAncestorHash());
+    assertThat(events.events)
+        .hasSize(1)
+        .last()
+        .asInstanceOf(type(ReferenceCreatedEvent.class))
+        .extracting(
+            ReferenceCreatedEvent::getOperationType,
+            ReferenceCreatedEvent::getHash,
+            ReferenceCreatedEvent::getRef)
+        .containsExactly(OperationType.CRETE_REF, adapter.noAncestorHash(), branch);
+  }
+
+  @Test
+  public void eventDeleteRef(
+      @NessieDbAdapter(initializeRepo = false, eventConsumer = EventCollector.class)
+          AbstractDatabaseAdapter<?, ?> adapter)
+      throws Exception {
+
+    EventCollector events = (EventCollector) adapter.getEventConsumer();
+
+    BranchName branch = BranchName.of("events-delete");
+
+    adapter.create(branch, adapter.noAncestorHash());
+
+    events.events.clear();
+
+    adapter.delete(branch, Optional.empty());
+
+    assertThat(events.events)
+        .hasSize(1)
+        .last()
+        .asInstanceOf(type(ReferenceDeletedEvent.class))
+        .extracting(
+            ReferenceDeletedEvent::getOperationType,
+            ReferenceDeletedEvent::getHash,
+            ReferenceDeletedEvent::getRef)
+        .containsExactly(OperationType.DELETE_REF, adapter.noAncestorHash(), branch);
+  }
+
+  @Test
+  public void eventAssignRef(
+      @NessieDbAdapter(initializeRepo = false, eventConsumer = EventCollector.class)
+          AbstractDatabaseAdapter<?, ?> adapter)
+      throws Exception {
+
+    EventCollector events = (EventCollector) adapter.getEventConsumer();
+
+    BranchName branch = BranchName.of("events-assign");
+
+    adapter.create(branch, adapter.noAncestorHash());
+
+    KeyWithBytes put =
+        KeyWithBytes.of(
+            Key.of("one", "two"),
+            ContentId.of("cid-events-assign"),
+            (byte) 0,
+            SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                OnRefOnly.onRef("foo", "cid-events-assign")));
+
+    ByteString meta = ByteString.copyFromUtf8("foo bar baz");
+
+    Hash committed =
+        adapter.commit(
+            ImmutableCommitParams.builder()
+                .toBranch(branch)
+                .commitMetaSerialized(meta)
+                .addPuts(put)
+                .build());
+
+    events.events.clear();
+
+    adapter.assign(branch, Optional.empty(), adapter.noAncestorHash());
+
+    assertThat(events.events)
+        .hasSize(1)
+        .last()
+        .asInstanceOf(type(ReferenceAssignedEvent.class))
+        .extracting(
+            ReferenceAssignedEvent::getOperationType,
+            ReferenceAssignedEvent::getHash,
+            ReferenceAssignedEvent::getPreviousHash,
+            ReferenceAssignedEvent::getRef)
+        .containsExactly(OperationType.ASSIGN_REF, adapter.noAncestorHash(), committed, branch);
+  }
+
+  @Test
+  public void eventCommit(
+      @NessieDbAdapter(initializeRepo = false, eventConsumer = EventCollector.class)
+          AbstractDatabaseAdapter<?, ?> adapter)
+      throws Exception {
+
+    EventCollector events = (EventCollector) adapter.getEventConsumer();
+
+    BranchName branch = BranchName.of("events-commit");
+    adapter.create(branch, adapter.noAncestorHash());
+
+    events.events.clear();
+
+    KeyWithBytes put =
+        KeyWithBytes.of(
+            Key.of("one", "two"),
+            ContentId.of("cid-events-commit"),
+            (byte) 0,
+            SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                OnRefOnly.onRef("foo", "cid-events-commit")));
+
+    ByteString meta = ByteString.copyFromUtf8("foo bar baz");
+
+    Hash committed =
+        adapter.commit(
+            ImmutableCommitParams.builder()
+                .toBranch(branch)
+                .commitMetaSerialized(meta)
+                .addPuts(put)
+                .build());
+
+    assertThat(events.events)
+        .hasSize(1)
+        .last()
+        .asInstanceOf(type(CommitEvent.class))
+        .satisfies(
+            commit ->
+                assertThat(commit)
+                    .extracting(
+                        CommitEvent::getOperationType,
+                        CommitEvent::getHash,
+                        CommitEvent::getPreviousHash,
+                        CommitEvent::getBranch)
+                    .containsExactly(
+                        OperationType.COMMIT, committed, adapter.noAncestorHash(), branch),
+            commit ->
+                assertThat(commit.getCommits())
+                    .hasSize(1)
+                    .last()
+                    .extracting(
+                        CommitLogEntry::getHash,
+                        CommitLogEntry::getPuts,
+                        CommitLogEntry::getMetadata)
+                    .containsExactly(committed, singletonList(put), meta));
+  }
+
+  @Test
+  public void eventMerge(
+      @NessieDbAdapter(initializeRepo = false, eventConsumer = EventCollector.class)
+          AbstractDatabaseAdapter<?, ?> adapter)
+      throws Exception {
+
+    EventCollector events = (EventCollector) adapter.getEventConsumer();
+
+    BranchName main = BranchName.of("main");
+
+    KeyWithBytes put =
+        KeyWithBytes.of(
+            Key.of("one", "two"),
+            ContentId.of("cid-events-merge"),
+            (byte) 0,
+            SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                OnRefOnly.onRef("foo", "cid-events-merge")));
+
+    ByteString meta = ByteString.copyFromUtf8("merge me");
+
+    BranchName source = BranchName.of("events-merge");
+    adapter.create(source, adapter.noAncestorHash());
+    Hash committed =
+        adapter.commit(
+            ImmutableCommitParams.builder()
+                .toBranch(source)
+                .commitMetaSerialized(meta)
+                .addPuts(put)
+                .build());
+
+    events.events.clear();
+
+    MetadataRewriter<ByteString> updater = createMetadataUpdater();
+    MergeResult<CommitLogEntry> mergeResult =
+        adapter.merge(
+            MergeParams.builder()
+                .mergeFromHash(committed)
+                .toBranch(main)
+                .updateCommitMetadata(updater)
+                .build());
+
+    assertThat(events.events)
+        .hasSize(1)
+        .last()
+        .asInstanceOf(type(MergeEvent.class))
+        .satisfies(
+            merge ->
+                assertThat(merge)
+                    .extracting(
+                        MergeEvent::getOperationType,
+                        MergeEvent::getHash,
+                        MergeEvent::getPreviousHash,
+                        MergeEvent::getBranch)
+                    .containsExactly(
+                        OperationType.MERGE,
+                        mergeResult.getResultantTargetHash(),
+                        adapter.noAncestorHash(),
+                        main),
+            merge ->
+                assertThat(merge.getCommits())
+                    .hasSize(1)
+                    .last()
+                    .extracting(
+                        CommitLogEntry::getHash,
+                        CommitLogEntry::getPuts,
+                        CommitLogEntry::getMetadata)
+                    .containsExactly(
+                        mergeResult.getResultantTargetHash(),
+                        singletonList(put),
+                        updater.rewriteSingle(meta)));
+  }
+
+  @Test
+  public void eventTransplant(
+      @NessieDbAdapter(initializeRepo = false, eventConsumer = EventCollector.class)
+          AbstractDatabaseAdapter<?, ?> adapter)
+      throws Exception {
+
+    EventCollector events = (EventCollector) adapter.getEventConsumer();
+
+    BranchName main = BranchName.of("main");
+
+    KeyWithBytes put =
+        KeyWithBytes.of(
+            Key.of("one", "two"),
+            ContentId.of("cid-events-transplant"),
+            (byte) 0,
+            SimpleStoreWorker.INSTANCE.toStoreOnReferenceState(
+                OnRefOnly.onRef("foo", "cid-events-transplant")));
+
+    ByteString meta = ByteString.copyFromUtf8("transplant me");
+
+    BranchName source = BranchName.of("events-transplant");
+    adapter.create(source, adapter.noAncestorHash());
+    Hash committed =
+        adapter.commit(
+            ImmutableCommitParams.builder()
+                .toBranch(source)
+                .commitMetaSerialized(meta)
+                .addPuts(put)
+                .build());
+
+    events.events.clear();
+
+    MetadataRewriter<ByteString> updater = createMetadataUpdater();
+    MergeResult<CommitLogEntry> mergeResult =
+        adapter.transplant(
+            TransplantParams.builder()
+                .addSequenceToTransplant(committed)
+                .updateCommitMetadata(updater)
+                .toBranch(main)
+                .build());
+
+    assertThat(events.events)
+        .hasSize(1)
+        .last()
+        .asInstanceOf(type(TransplantEvent.class))
+        .satisfies(
+            transplant ->
+                assertThat(transplant)
+                    .extracting(
+                        TransplantEvent::getOperationType,
+                        TransplantEvent::getHash,
+                        TransplantEvent::getPreviousHash,
+                        TransplantEvent::getBranch)
+                    .containsExactly(
+                        OperationType.TRANSPLANT,
+                        mergeResult.getResultantTargetHash(),
+                        adapter.noAncestorHash(),
+                        main),
+            tranplant ->
+                assertThat(tranplant.getCommits())
+                    .hasSize(1)
+                    .last()
+                    .extracting(
+                        CommitLogEntry::getHash,
+                        CommitLogEntry::getPuts,
+                        CommitLogEntry::getMetadata)
+                    .containsExactly(
+                        mergeResult.getResultantTargetHash(),
+                        singletonList(put),
+                        updater.rewriteSingle(meta)));
+  }
+
+  static class EventCollector implements AdapterEventConsumer {
+
+    final List<AdapterEvent> events = new ArrayList<>();
+
+    @Override
+    public void accept(AdapterEvent event) {
+      events.add(event);
+    }
+  }
+
+  private static MetadataRewriter<ByteString> createMetadataUpdater() {
+    return new MetadataRewriter<ByteString>() {
+      @Override
+      public ByteString rewriteSingle(ByteString metadata) {
+        return ByteString.copyFromUtf8(metadata.toStringUtf8() + " updated");
+      }
+
+      @Override
+      public ByteString squash(List<ByteString> metadata) {
+        return rewriteSingle(metadata.get(0));
+      }
+    };
+  }
+}

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractEvents.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractEvents.java
@@ -99,7 +99,7 @@ public abstract class AbstractEvents {
                     .asInstanceOf(type(ReferenceCreatedEvent.class))
                     .extracting(
                         ReferenceCreatedEvent::getOperationType,
-                        ReferenceCreatedEvent::getHash,
+                        ReferenceCreatedEvent::getCurrentHash,
                         ReferenceCreatedEvent::getRef)
                     .containsExactly(
                         OperationType.CRETE_REF, adapter.noAncestorHash(), BranchName.of("main")));
@@ -122,7 +122,7 @@ public abstract class AbstractEvents {
         .asInstanceOf(type(ReferenceCreatedEvent.class))
         .extracting(
             ReferenceCreatedEvent::getOperationType,
-            ReferenceCreatedEvent::getHash,
+            ReferenceCreatedEvent::getCurrentHash,
             ReferenceCreatedEvent::getRef)
         .containsExactly(OperationType.CRETE_REF, adapter.noAncestorHash(), branch);
   }
@@ -149,7 +149,7 @@ public abstract class AbstractEvents {
         .asInstanceOf(type(ReferenceDeletedEvent.class))
         .extracting(
             ReferenceDeletedEvent::getOperationType,
-            ReferenceDeletedEvent::getHash,
+            ReferenceDeletedEvent::getCurrentHash,
             ReferenceDeletedEvent::getRef)
         .containsExactly(OperationType.DELETE_REF, adapter.noAncestorHash(), branch);
   }
@@ -194,7 +194,7 @@ public abstract class AbstractEvents {
         .asInstanceOf(type(ReferenceAssignedEvent.class))
         .extracting(
             ReferenceAssignedEvent::getOperationType,
-            ReferenceAssignedEvent::getHash,
+            ReferenceAssignedEvent::getCurrentHash,
             ReferenceAssignedEvent::getPreviousHash,
             ReferenceAssignedEvent::getRef)
         .containsExactly(OperationType.ASSIGN_REF, adapter.noAncestorHash(), committed, branch);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbAdapter.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/extension/NessieDbAdapter.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.projectnessie.versioned.StoreWorker;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.testworker.SimpleStoreWorker;
 
 @Target({ElementType.FIELD, ElementType.PARAMETER})
@@ -62,4 +63,6 @@ public @interface NessieDbAdapter {
   boolean withTracing() default false;
 
   Class<? extends StoreWorker<?, ?, ?>> storeWorker() default SimpleStoreWorker.class;
+
+  Class<? extends AdapterEventConsumer> eventConsumer() default AdapterEventConsumer.class;
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -469,7 +469,7 @@ public abstract class TxDatabaseAdapter
                 RefLogEntry.Operation.CREATE_REFERENCE,
                 emptyList());
 
-            return opResult(hash, () -> ReferenceCreatedEvent.builder().hash(hash).ref(ref));
+            return opResult(hash, () -> ReferenceCreatedEvent.builder().currentHash(hash).ref(ref));
           },
           () -> createConflictMessage("Conflict", ref, target),
           () -> createConflictMessage("Retry-Failure", ref, target));
@@ -512,7 +512,8 @@ public abstract class TxDatabaseAdapter
                 emptyList());
 
             return opResult(
-                pointer, () -> ReferenceDeletedEvent.builder().hash(commitHash).ref(reference));
+                pointer,
+                () -> ReferenceDeletedEvent.builder().currentHash(commitHash).ref(reference));
           },
           () -> deleteConflictMessage("Conflict", reference, expectedHead),
           () -> deleteConflictMessage("Retry-Failure", reference, expectedHead));
@@ -552,7 +553,7 @@ public abstract class TxDatabaseAdapter
                 resultHash,
                 () ->
                     ReferenceAssignedEvent.builder()
-                        .hash(assignTo)
+                        .currentHash(assignTo)
                         .ref(assignee)
                         .previousHash(assigneeHead));
           },
@@ -608,7 +609,8 @@ public abstract class TxDatabaseAdapter
 
         repositoryEvent(
             () -> RepositoryInitializedEvent.builder().defaultBranch(defaultBranchName));
-        repositoryEvent(() -> ReferenceCreatedEvent.builder().ref(defaultBranch).hash(NO_ANCESTOR));
+        repositoryEvent(
+            () -> ReferenceCreatedEvent.builder().ref(defaultBranch).currentHash(NO_ANCESTOR));
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapterFactory.java
@@ -19,13 +19,17 @@ import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionProvider;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 
 public abstract class TxDatabaseAdapterFactory<CONNECTOR extends DatabaseConnectionProvider<?>>
     implements DatabaseAdapterFactory<
         TxDatabaseAdapterConfig, AdjustableTxDatabaseAdapterConfig, CONNECTOR> {
 
   protected abstract DatabaseAdapter create(
-      TxDatabaseAdapterConfig config, CONNECTOR connector, StoreWorker<?, ?, ?> storeWorker);
+      TxDatabaseAdapterConfig config,
+      CONNECTOR connector,
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer);
 
   @Override
   public Builder<TxDatabaseAdapterConfig, AdjustableTxDatabaseAdapterConfig, CONNECTOR>
@@ -47,7 +51,7 @@ public abstract class TxDatabaseAdapterFactory<CONNECTOR extends DatabaseConnect
 
     @Override
     public DatabaseAdapter build(StoreWorker<?, ?, ?> storeWorker) {
-      return create(getConfig(), getConnector(), storeWorker);
+      return create(getConfig(), getConnector(), storeWorker, getEventConsumer());
     }
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapter.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.tx.h2;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.projectnessie.versioned.StoreWorker;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
@@ -27,8 +28,9 @@ public class H2DatabaseAdapter extends TxDatabaseAdapter {
   public H2DatabaseAdapter(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<?> db,
-      StoreWorker<?, ?, ?> storeWorker) {
-    super(config, db, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    super(config, db, storeWorker, eventConsumer);
   }
 
   @Override

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/h2/H2DatabaseAdapterFactory.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.tx.h2;
 
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.tx.TxConnectionConfig;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
@@ -36,7 +37,8 @@ public class H2DatabaseAdapterFactory
   protected DatabaseAdapter create(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<TxConnectionConfig> connectionProvider,
-      StoreWorker<?, ?, ?> storeWorker) {
-    return new H2DatabaseAdapter(config, connectionProvider, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    return new H2DatabaseAdapter(config, connectionProvider, storeWorker, eventConsumer);
   }
 }

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapter.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.tx.postgres;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.projectnessie.versioned.StoreWorker;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
@@ -27,8 +28,9 @@ public class PostgresDatabaseAdapter extends TxDatabaseAdapter {
   public PostgresDatabaseAdapter(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<?> db,
-      StoreWorker<?, ?, ?> storeWorker) {
-    super(config, db, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    super(config, db, storeWorker, eventConsumer);
   }
 
   @Override

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresDatabaseAdapterFactory.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.tx.postgres;
 
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.events.AdapterEventConsumer;
 import org.projectnessie.versioned.persist.tx.TxConnectionConfig;
 import org.projectnessie.versioned.persist.tx.TxConnectionProvider;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
@@ -36,7 +37,8 @@ public class PostgresDatabaseAdapterFactory
   protected DatabaseAdapter create(
       TxDatabaseAdapterConfig config,
       TxConnectionProvider<TxConnectionConfig> connectionProvider,
-      StoreWorker<?, ?, ?> storeWorker) {
-    return new PostgresDatabaseAdapter(config, connectionProvider, storeWorker);
+      StoreWorker<?, ?, ?> storeWorker,
+      AdapterEventConsumer eventConsumer) {
+    return new PostgresDatabaseAdapter(config, connectionProvider, storeWorker, eventConsumer);
   }
 }


### PR DESCRIPTION
Allows to configure a `AdapterEventConsumer` for a `DatabaseAdapter`,
which receives `AdapterEvents` (repo init/erase, ref create/delete/assign,
commit/merge/transplant).

This adds a "Nessie internal API", that is not publicly exposed and can
change at any time w/o prior notice.