### PR TITLE
Flatten `Hash`

### DIFF
--- a/versioned/spi/pom.xml
+++ b/versioned/spi/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>micrometer-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Hash.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Hash.java
@@ -18,51 +18,42 @@ package org.projectnessie.versioned;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.io.BaseEncoding;
-import com.google.common.io.BaseEncoding.DecodingException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.Objects;
+import com.google.protobuf.UnsafeByteOperations;
+import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 /**
  * Describes a specific point in time/history. Internally is a binary value but a string
  * representation is available.
  */
-public final class Hash implements Ref {
+public abstract class Hash implements Ref {
 
-  private static final BaseEncoding ENCODING = BaseEncoding.base16().lowerCase();
-  private final ByteString bytes;
-
-  private Hash(ByteString bytes) {
-    this.bytes = requireNonNull(bytes);
-  }
+  private static final char[] HEX = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+  };
 
   /** Generates a string representation of the hash suitable to be used with {@link #of(String)}. */
-  public String asString() {
-    final int maxSize = 2 * bytes.size();
-    try (final StringWriter sw = new StringWriter(maxSize);
-        final OutputStream os = ENCODING.encodingStream(sw)) {
-      bytes.writeTo(os);
-      return sw.toString();
-    } catch (IOException e) {
-      // Should not happen as all operations are in memory
-      throw new AssertionError(e);
-    }
-  }
+  public abstract String asString();
 
   /**
    * Gets the bytes representation of the hash.
    *
    * @return the hash's bytes
    */
-  public ByteString asBytes() {
-    return bytes;
-  }
+  public abstract ByteString asBytes();
+
+  /**
+   * Retrieve the nibble (4 bit part) at the given index.
+   *
+   * <p>This retrieves the 4-bit value of the hex character from {@link #asString()} at the same
+   * index..
+   */
+  public abstract int nibbleAt(int nibbleIndex);
+
+  /** Return the size of the hash in bytes. */
+  public abstract int size();
 
   /**
    * Creates a hash instance from its string representation.
@@ -74,19 +65,15 @@ public final class Hash implements Ref {
    */
   public static Hash of(@Nonnull String hash) {
     requireNonNull(hash);
+    int len = hash.length();
     checkArgument(
-        hash.length() % 2 == 0, "hash length needs to be a multiple of two, was %s", hash.length());
+        len % 2 == 0 && len > 0, "hash length needs to be a multiple of two, was %s", len);
 
-    final int maxSize = hash.length() / 2;
-    try (final StringReader sr = new StringReader(hash);
-        final InputStream is = ENCODING.decodingStream(sr)) {
-      ByteString bytes = ByteString.readFrom(is, maxSize);
-      return Hash.of(bytes);
-    } catch (DecodingException e) {
-      throw new IllegalArgumentException(e);
-    } catch (IOException e) {
-      // Should not happen as all operations are in memory
-      throw new AssertionError(e);
+    switch (len >> 1) {
+      case 32:
+        return new Hash256(hash);
+      default:
+        return new GenericHash(hash);
     }
   }
 
@@ -98,25 +85,257 @@ public final class Hash implements Ref {
    * @throws NullPointerException if {@code hash} is {@code null}
    */
   public static Hash of(@Nonnull ByteString bytes) {
-    return new Hash(bytes);
-  }
-
-  @Override
-  public int hashCode() {
-    return bytes.hashCode();
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof Hash)) {
-      return false;
+    switch (bytes.size()) {
+      case 32:
+        return new Hash256(bytes);
+      default:
+        return new GenericHash(bytes);
     }
-    Hash that = (Hash) obj;
-    return Objects.equals(this.bytes, that.bytes);
   }
 
   @Override
   public String toString() {
     return "Hash " + asString();
+  }
+
+  @VisibleForTesting
+  static byte nibble(char c) {
+    if (c >= '0' && c <= '9') {
+      return (byte) (c - '0');
+    }
+    if (c >= 'a' && c <= 'f') {
+      return (byte) (c - 'a' + 10);
+    }
+    if (c >= 'A' && c <= 'F') {
+      return (byte) (c - 'A' + 10);
+    }
+    throw new IllegalArgumentException("Illegal hex character '" + c + "'");
+  }
+
+  @VisibleForTesting
+  static long bytesToLong(ByteString bytes, int off) {
+    long l = (bytes.byteAt(off++) & 0xffL) << 56L;
+    l |= (bytes.byteAt(off++) & 0xffL) << 48L;
+    l |= (bytes.byteAt(off++) & 0xffL) << 40L;
+    l |= (bytes.byteAt(off++) & 0xffL) << 32L;
+    l |= (bytes.byteAt(off++) & 0xffL) << 24L;
+    l |= (bytes.byteAt(off++) & 0xffL) << 16L;
+    l |= (bytes.byteAt(off++) & 0xffL) << 8L;
+    l |= bytes.byteAt(off) & 0xffL;
+    return l;
+  }
+
+  @VisibleForTesting
+  static void longToBytes(byte[] arr, int off, long v) {
+    arr[off++] = (byte) (v >> 56L);
+    arr[off++] = (byte) (v >> 48L);
+    arr[off++] = (byte) (v >> 40L);
+    arr[off++] = (byte) (v >> 32L);
+    arr[off++] = (byte) (v >> 24L);
+    arr[off++] = (byte) (v >> 16L);
+    arr[off++] = (byte) (v >> 8L);
+    arr[off] = (byte) v;
+  }
+
+  @VisibleForTesting
+  static long stringToLong(String s, int off) {
+    long l = ((long) nibble(s.charAt(off++))) << 60L;
+    l |= ((long) nibble(s.charAt(off++))) << 56L;
+    l |= ((long) nibble(s.charAt(off++))) << 52L;
+    l |= ((long) nibble(s.charAt(off++))) << 48L;
+    l |= ((long) nibble(s.charAt(off++))) << 44L;
+    l |= ((long) nibble(s.charAt(off++))) << 40L;
+    l |= ((long) nibble(s.charAt(off++))) << 36L;
+    l |= ((long) nibble(s.charAt(off++))) << 32L;
+    l |= ((long) nibble(s.charAt(off++))) << 28L;
+    l |= ((long) nibble(s.charAt(off++))) << 24L;
+    l |= ((long) nibble(s.charAt(off++))) << 20L;
+    l |= ((long) nibble(s.charAt(off++))) << 16L;
+    l |= ((long) nibble(s.charAt(off++))) << 12L;
+    l |= ((long) nibble(s.charAt(off++))) << 8L;
+    l |= ((long) nibble(s.charAt(off++))) << 4L;
+    l |= nibble(s.charAt(off));
+    return l;
+  }
+
+  @VisibleForTesting
+  static int nibbleFromLong(long v, int index) {
+    return (int) (v >> (60 - index * 4L)) & 0xf;
+  }
+
+  @VisibleForTesting
+  static final class Hash256 extends Hash {
+    private final long l0;
+    private final long l1;
+    private final long l2;
+    private final long l3;
+
+    private Hash256(String hash) {
+      l0 = stringToLong(hash, 0);
+      l1 = stringToLong(hash, 16);
+      l2 = stringToLong(hash, 32);
+      l3 = stringToLong(hash, 48);
+    }
+
+    private Hash256(ByteString bytes) {
+      l0 = bytesToLong(bytes, 0);
+      l1 = bytesToLong(bytes, 8);
+      l2 = bytesToLong(bytes, 16);
+      l3 = bytesToLong(bytes, 24);
+    }
+
+    @Override
+    public int nibbleAt(int nibbleIndex) {
+      if (nibbleIndex >= 0) {
+        if (nibbleIndex < 16) {
+          return nibbleFromLong(l0, nibbleIndex);
+        }
+        if (nibbleIndex < 32) {
+          return nibbleFromLong(l1, nibbleIndex - 16);
+        }
+        if (nibbleIndex < 48) {
+          return nibbleFromLong(l2, nibbleIndex - 32);
+        }
+        if (nibbleIndex < 64) {
+          return nibbleFromLong(l3, nibbleIndex - 48);
+        }
+      }
+      throw new IllegalArgumentException("Invalid nibble index " + nibbleIndex);
+    }
+
+    @Override
+    public int size() {
+      return 32;
+    }
+
+    @Override
+    public String asString() {
+      StringBuilder sb = new StringBuilder(64);
+      longToString(sb, l0);
+      longToString(sb, l1);
+      longToString(sb, l2);
+      longToString(sb, l3);
+      return sb.toString();
+    }
+
+    private static void longToString(StringBuilder sb, long v) {
+      sb.append(HEX[(int) (v >> 60) & 0xf]);
+      sb.append(HEX[(int) (v >> 56) & 0xf]);
+      sb.append(HEX[(int) (v >> 52) & 0xf]);
+      sb.append(HEX[(int) (v >> 48) & 0xf]);
+      sb.append(HEX[(int) (v >> 44) & 0xf]);
+      sb.append(HEX[(int) (v >> 40) & 0xf]);
+      sb.append(HEX[(int) (v >> 36) & 0xf]);
+      sb.append(HEX[(int) (v >> 32) & 0xf]);
+      sb.append(HEX[(int) (v >> 28) & 0xf]);
+      sb.append(HEX[(int) (v >> 24) & 0xf]);
+      sb.append(HEX[(int) (v >> 20) & 0xf]);
+      sb.append(HEX[(int) (v >> 16) & 0xf]);
+      sb.append(HEX[(int) (v >> 12) & 0xf]);
+      sb.append(HEX[(int) (v >> 8) & 0xf]);
+      sb.append(HEX[(int) (v >> 4) & 0xf]);
+      sb.append(HEX[(int) v & 0xf]);
+    }
+
+    @Override
+    public ByteString asBytes() {
+      byte[] bytes = new byte[32];
+      longToBytes(bytes, 0, l0);
+      longToBytes(bytes, 8, l1);
+      longToBytes(bytes, 16, l2);
+      longToBytes(bytes, 24, l3);
+      return UnsafeByteOperations.unsafeWrap(bytes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Hash256)) {
+        return false;
+      }
+      Hash256 hash256 = (Hash256) o;
+      return l0 == hash256.l0 && l1 == hash256.l1 && l2 == hash256.l2 && l3 == hash256.l3;
+    }
+
+    @Override
+    public int hashCode() {
+      return (int) (l0 >> 32L);
+    }
+  }
+
+  @VisibleForTesting
+  static final class GenericHash extends Hash {
+    private final byte[] bytes;
+
+    private GenericHash(String hash) {
+      int len = hash.length();
+      byte[] bytes = new byte[len >> 1];
+      for (int i = 0, c = 0; c < len; i++) {
+        byte value = (byte) (nibble(hash.charAt(c++)) << 4);
+        value |= nibble(hash.charAt(c++));
+        bytes[i] = value;
+      }
+      this.bytes = bytes;
+    }
+
+    private GenericHash(ByteString bytes) {
+      this.bytes = bytes.toByteArray();
+    }
+
+    @Override
+    public int nibbleAt(int nibbleIndex) {
+      byte b = bytes[nibbleIndex >> 1];
+      if ((nibbleIndex & 1) == 0) {
+        b >>= 4;
+      }
+      return b & 0xf;
+    }
+
+    @Override
+    public int size() {
+      return bytes.length;
+    }
+
+    @Override
+    public String asString() {
+      StringBuilder sb = new StringBuilder(2 * bytes.length);
+      for (byte b : bytes) {
+        sb.append(HEX[(b >> 4) & 0xf]);
+        sb.append(HEX[b & 0xf]);
+      }
+      return sb.toString();
+    }
+
+    @Override
+    public ByteString asBytes() {
+      return UnsafeByteOperations.unsafeWrap(bytes);
+    }
+
+    @Override
+    public int hashCode() {
+      byte[] b = bytes;
+      int h = (bytes[0] & 0xff) << 24;
+      if (b.length > 1) {
+        h |= ((bytes[1] & 0xff) << 16);
+      }
+      if (b.length > 2) {
+        h |= ((bytes[2] & 0xff) << 8);
+      }
+      if (b.length > 3) {
+        h |= (bytes[3] & 0xff);
+      }
+      return h;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof GenericHash)) {
+        return false;
+      }
+      GenericHash that = (GenericHash) obj;
+      return Arrays.equals(this.bytes, that.bytes);
+    }
   }
 }

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestHash.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestHash.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.google.protobuf.ByteString;
+import java.util.Locale;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.versioned.Hash.GenericHash;
+import org.projectnessie.versioned.Hash.Hash256;
+
+public class TestHash {
+  @SuppressWarnings("ConstantConditions")
+  @Test
+  void nullCheck() {
+    assertThatThrownBy(() -> Hash.of((String) null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> Hash.of((ByteString) null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "1", "123"})
+  void illegalLengths(String s) {
+    assertThatThrownBy(() -> Hash.of(s))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("length needs to be a multiple of two");
+  }
+
+  @Test
+  void illegalChars() {
+    assertThatThrownBy(() -> Hash.of("deadex"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Illegal hex character");
+  }
+
+  static Stream<Arguments> hashOfString() {
+    return Stream.of(
+        arguments("01", GenericHash.class),
+        arguments("23", GenericHash.class),
+        arguments("45", GenericHash.class),
+        arguments("67", GenericHash.class),
+        arguments("89", GenericHash.class),
+        arguments("ab", GenericHash.class),
+        arguments("cd", GenericHash.class),
+        arguments("ef", GenericHash.class),
+        arguments("AB", GenericHash.class),
+        arguments("CD", GenericHash.class),
+        arguments("EF", GenericHash.class),
+        arguments("0123456789abcdef", GenericHash.class),
+        arguments("0123456789abcdef", GenericHash.class),
+        arguments(
+            "0011223344556677" + "1213141516171819" + "2123242526272829" + "3132343536373839",
+            Hash256.class),
+        arguments(
+            "ffddbbaa88665544" + "9192939495969798" + "80776699deadbeef" + "cafebabe12345688",
+            Hash256.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("hashOfString")
+  void hashOfString(String s, Class<? extends Hash> type) {
+    assertThat(Hash.of(s))
+        .isInstanceOf(type)
+        .satisfies(
+            h -> assertThat(h.size()).isEqualTo(s.length() / 2),
+            h -> assertThat(h.asBytes()).isEqualTo(ByteString.fromHex(s)),
+            h -> assertThat(h.toString()).isEqualTo("Hash " + s.toLowerCase(Locale.US)),
+            h -> assertThat(h).isEqualTo(Hash.of(ByteString.fromHex(s))));
+  }
+
+  static Stream<Arguments> hashCodes() {
+    return Stream.of(
+        arguments("01", 0x01000000),
+        arguments("23", 0x23000000),
+        arguments("45", 0x45000000),
+        arguments("67", 0x67000000),
+        arguments("89", 0x89000000),
+        arguments("ab", 0xab000000),
+        arguments("cd", 0xcd000000),
+        arguments("ef", 0xef000000),
+        arguments("AB", 0xab000000),
+        arguments("CD", 0xcd000000),
+        arguments("EF", 0xef000000),
+        arguments("0123456789abcdef", 0x01234567),
+        arguments(
+            "0011223344556677" + "1213141516171819" + "2123242526272829" + "3132343536373839",
+            0x00112233),
+        arguments(
+            "ffddbbaa88665544" + "9192939495969798" + "80776699deadbeef" + "cafebabe12345688",
+            0xffddbbaa));
+  }
+
+  @ParameterizedTest
+  @MethodSource("hashCodes")
+  void hashCodes(String s, int expected) {
+    assertThat(Hash.of(s)).extracting(Hash::hashCode).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "01",
+        "23",
+        "cd",
+        "ef",
+        "0123456789abcdef",
+        "0011223344556677" + "1213141516171819" + "2123242526272829" + "3132343536373839",
+        "ffddbbaa88665544" + "9192939495969798" + "80776699deadbeef" + "cafebabe12345688"
+      })
+  void nibbles(String s) {
+    ByteString bytes = ByteString.fromHex(s);
+    Hash h = Hash.of(s);
+
+    assertThatThrownBy(() -> h.nibbleAt(-1)).isInstanceOf(RuntimeException.class);
+    assertThatThrownBy(() -> h.nibbleAt(bytes.size() * 2)).isInstanceOf(RuntimeException.class);
+
+    for (int i = 0; i < bytes.size(); i++) {
+      int nib = i * 2;
+      assertThat(h.nibbleAt(nib))
+          .describedAs("nibble %s", nib)
+          .isEqualTo((bytes.byteAt(i) >> 4) & 15);
+      assertThat(h.nibbleAt(nib + 1))
+          .describedAs("nibble %s", nib + 1)
+          .isEqualTo(bytes.byteAt(i) & 15);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("bytesToLong")
+  void bytesToLong(ByteString bytes, int off, long expected) {
+    assertThat(Hash.bytesToLong(bytes, off)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("stringToLong")
+  void stringToLong(String s, int off, long expected) {
+    assertThat(Hash.stringToLong(s, off)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("longToBytes")
+  void longToBytes(long v, int off, byte[] expected) {
+    byte[] arr = new byte[off + 8];
+    Hash.longToBytes(arr, off, v);
+    assertThat(arr).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> longToBytes() {
+    return Stream.of(
+        arguments(0xcafebabe12345688L, 0, ByteString.fromHex("cafebabe12345688").toByteArray()),
+        arguments(
+            0xcafebabe12345688L,
+            8,
+            ByteString.fromHex("0000000000000000" + "cafebabe12345688").toByteArray()),
+        arguments(
+            0xcafebabe12345688L,
+            16,
+            ByteString.fromHex("0000000000000000" + "0000000000000000" + "cafebabe12345688")
+                .toByteArray()),
+        arguments(
+            0xcafebabe12345688L,
+            24,
+            ByteString.fromHex(
+                    "0000000000000000"
+                        + "0000000000000000"
+                        + "0000000000000000"
+                        + "cafebabe12345688")
+                .toByteArray()));
+  }
+
+  static Stream<Arguments> bytesToLong() {
+    return stringToLong()
+        .map(Arguments::get)
+        .map(
+            args ->
+                Arguments.of(
+                    ByteString.fromHex((String) args[0]), ((Integer) args[1]) / 2, args[2]));
+  }
+
+  static Stream<Arguments> stringToLong() {
+    return Stream.of(
+        arguments(
+            "0011223344556677" + "1213141516171819" + "2123242526272829" + "3132343536373839",
+            0,
+            0x0011223344556677L),
+        arguments(
+            "0011223344556677" + "1213141516171819" + "2123242526272829" + "3132343536373839",
+            16,
+            0x1213141516171819L),
+        arguments(
+            "0011223344556677" + "1213141516171819" + "2123242526272829" + "3132343536373839",
+            32,
+            0x2123242526272829L),
+        arguments(
+            "0011223344556677" + "1213141516171819" + "2123242526272829" + "3132343536373839",
+            48,
+            0x3132343536373839L),
+        //
+        arguments(
+            "ffddbbaa88665544" + "9192939495969798" + "80776699deadbeef" + "cafebabe12345688",
+            0,
+            0xffddbbaa88665544L),
+        arguments(
+            "ffddbbaa88665544" + "9192939495969798" + "80776699deadbeef" + "cafebabe12345688",
+            16,
+            0x9192939495969798L),
+        arguments(
+            "ffddbbaa88665544" + "9192939495969798" + "80776699deadbeef" + "cafebabe12345688",
+            32,
+            0x80776699deadbeefL),
+        arguments(
+            "ffddbbaa88665544" + "9192939495969798" + "80776699deadbeef" + "cafebabe12345688",
+            48,
+            0xcafebabe12345688L));
+  }
+}


### PR DESCRIPTION
* Specialized implementation for 256 bit hashes (4 `long` fields)
* Generic implementation for all other sizes (1 `byte[]` field)
* Both eliminate the use of `ByteString` as an intermediate representation