### PR TITLE
Remove `Hasher` usage from `randomHash`

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
@@ -47,14 +47,11 @@ public final class DatabaseAdapterUtil {
     return Hashing.sha256().newHasher();
   }
 
-  @SuppressWarnings("UnstableApiUsage")
   public static Hash randomHash() {
     ThreadLocalRandom rand = ThreadLocalRandom.current();
-    Hasher hasher = newHasher();
-    for (int i = 0; i < 20; i++) {
-      hasher.putInt(rand.nextInt());
-    }
-    return Hash.of(UnsafeByteOperations.unsafeWrap(hasher.hash().asBytes()));
+    byte[] bytes = new byte[32];
+    rand.nextBytes(bytes);
+    return Hash.of(UnsafeByteOperations.unsafeWrap(bytes));
   }
 
   @SuppressWarnings("UnstableApiUsage")

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestDatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestDatabaseAdapterUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.projectnessie.versioned.Hash;
+
+public class TestDatabaseAdapterUtil {
+  @SuppressWarnings("UnstableApiUsage")
+  @Test
+  void randomHashHasCorrectSize() {
+    Hash randomHash = DatabaseAdapterUtil.randomHash();
+    byte[] hashed = DatabaseAdapterUtil.newHasher().hash().asBytes();
+    assertThat(randomHash.size()).isEqualTo(hashed.length);
+  }
+}


### PR DESCRIPTION
It's not necessary to hash random values for a random hash.