### PR TITLE
Add Rolling-Upgrade test suite

### DIFF
--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -118,6 +118,13 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-mongodb</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/NessieAPI.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/NessieAPI.java
@@ -35,4 +35,17 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface NessieAPI {
   String builderClassName() default "org.projectnessie.client.http.HttpClientBuilder";
+
+  /**
+   * Defines the target Nessie version instance in case multiple Nessie versions are running, for
+   * rolling-upgrade tests.
+   *
+   * <ul>
+   *   <li>{@link TargetVersion#TESTED} defines that the annotated element shall be provided for the
+   *       currently tested and released Nessie version instance - aka rolling-upgrade-from version.
+   *   <li>{@link TargetVersion#CURRENT} defines that the annotated element shall be provided for
+   *       the in-tree Nessie version instance - aka rolling-upgrade-to version.
+   * </ul>
+   */
+  TargetVersion targetVersion() default TargetVersion.TESTED;
 }

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/TargetVersion.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/TargetVersion.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.compatibility.api;
+
+public enum TargetVersion {
+  /** The tested Nessie version. */
+  TESTED,
+  /** The current in-tree Nessie. */
+  CURRENT
+}

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/AbstractMultiVersionExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/AbstractMultiVersionExtension.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.projectnessie.tools.compatibility.api.Version.parseVersion;
 import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateAnnotatedFields;
+import static org.projectnessie.tools.compatibility.internal.MultiNessieVersionsTestEngine.NESSIE_VERSION_SEGMENT_TYPE;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.Arrays;
@@ -125,7 +126,7 @@ abstract class AbstractMultiVersionExtension
     }
     Version version = nessieVersion.get();
 
-    populateAnnotatedFields(context, instance, NessieVersion.class, f -> version);
+    populateAnnotatedFields(context, instance, NessieVersion.class, a -> true, f -> version);
 
     return version;
   }
@@ -136,7 +137,7 @@ abstract class AbstractMultiVersionExtension
 
   static Optional<Version> nessieVersionFromContext(UniqueId uniqueId) {
     return uniqueId.getSegments().stream()
-        .filter(s -> "nessie-version".equals(s.getType()))
+        .filter(s -> NESSIE_VERSION_SEGMENT_TYPE.equals(s.getType()))
         .map(Segment::getValue)
         .map(Version::parseVersion)
         .findFirst();

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/AnnotatedFields.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/AnnotatedFields.java
@@ -16,32 +16,44 @@
 package org.projectnessie.tools.compatibility.internal;
 
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.projectnessie.tools.compatibility.api.NessieAPI;
+import org.projectnessie.tools.compatibility.api.TargetVersion;
 
 final class AnnotatedFields {
   private AnnotatedFields() {}
 
-  static void populateNessieAnnotatedFields(
-      ExtensionContext context, Object instance, Function<Field, Object> fieldValue) {
-    populateAnnotatedFields(context, instance, NessieAPI.class, fieldValue);
-  }
-
-  static void populateAnnotatedFields(
+  static void populateNessieApiFields(
       ExtensionContext context,
       Object instance,
-      Class<? extends Annotation> annotationType,
+      TargetVersion targetVersion,
+      Function<Field, Object> fieldValue) {
+    populateAnnotatedFields(
+        context, instance, NessieAPI.class, a -> a.targetVersion() == targetVersion, fieldValue);
+  }
+
+  static <A extends Annotation> void populateAnnotatedFields(
+      ExtensionContext context,
+      Object instance,
+      Class<A> annotationType,
+      Predicate<A> annotationFilter,
       Function<Field, Object> fieldValue) {
     Class<?> clazz = context.getRequiredTestClass();
     boolean isStatic = instance == null;
 
-    findAnnotatedFields(clazz, annotationType, m -> isStatic == isStatic(m))
+    Predicate<Field> staticPredicate = field -> isStatic == isStatic(field);
+    Predicate<Field> annotationPredicate =
+        field -> findAnnotation(field, annotationType).map(annotationFilter::test).orElse(true);
+
+    findAnnotatedFields(clazz, annotationType, staticPredicate.and(annotationPredicate))
         .forEach(f -> setField(f, instance, fieldValue.apply(f)));
   }
 

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/MultiNessieVersionsTestEngine.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/MultiNessieVersionsTestEngine.java
@@ -43,6 +43,8 @@ public class MultiNessieVersionsTestEngine implements TestEngine {
   public static final String ENGINE_ID = "nessie-versions";
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiNessieVersionsTestEngine.class);
 
+  static final String NESSIE_VERSION_SEGMENT_TYPE = "nessie-version";
+
   private final JupiterTestEngine delegate;
 
   public MultiNessieVersionsTestEngine() {
@@ -85,7 +87,7 @@ public class MultiNessieVersionsTestEngine implements TestEngine {
       }
 
       for (Version version : versionsToTest) {
-        UniqueId perVersionId = uniqueId.append("nessie-version", version.toString());
+        UniqueId perVersionId = uniqueId.append(NESSIE_VERSION_SEGMENT_TYPE, version.toString());
         NessieVersionTestDescriptor perVersionTestDescriptor =
             new NessieVersionTestDescriptor(perVersionId, version);
         engineDescriptor.addChild(perVersionTestDescriptor);

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
@@ -16,7 +16,7 @@
 package org.projectnessie.tools.compatibility.internal;
 
 import static org.projectnessie.tools.compatibility.internal.AbstractNessieApiHolder.apiInstanceForField;
-import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieAnnotatedFields;
+import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieApiFields;
 import static org.projectnessie.tools.compatibility.internal.GlobalForClass.globalForClass;
 import static org.projectnessie.tools.compatibility.internal.NessieServer.nessieServer;
 import static org.projectnessie.tools.compatibility.internal.NessieServer.nessieServerExisting;
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.projectnessie.tools.compatibility.api.TargetVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 
 /**
@@ -101,9 +102,10 @@ public class NessieUpgradesExtension extends AbstractMultiVersionExtension {
       Object instance,
       Version version,
       Function<ExtensionContext, NessieServer> nessieServerSupplier) {
-    populateNessieAnnotatedFields(
+    populateNessieApiFields(
         context,
         instance,
+        TargetVersion.TESTED,
         field -> apiInstanceForField(context, field, version, nessieServerSupplier));
   }
 }

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieClientsExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieClientsExtension.java
@@ -16,13 +16,14 @@
 package org.projectnessie.tools.compatibility.internal;
 
 import static org.projectnessie.tools.compatibility.internal.AbstractNessieApiHolder.apiInstanceForField;
-import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieAnnotatedFields;
+import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieApiFields;
 import static org.projectnessie.tools.compatibility.internal.NessieServer.nessieServer;
 import static org.projectnessie.tools.compatibility.internal.Util.classContext;
 
 import java.util.Collections;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.projectnessie.tools.compatibility.api.TargetVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 
 /**
@@ -51,14 +52,13 @@ public class OlderNessieClientsExtension extends AbstractMultiVersionExtension {
       return;
     }
 
-    populateNessieVersionAnnotatedFields(context, instance);
-
     ServerKey serverKey = new ServerKey(Version.CURRENT, "In-Memory", Collections.emptyMap());
     BooleanSupplier initializeRepository = () -> true;
 
-    populateNessieAnnotatedFields(
+    populateNessieApiFields(
         context,
         instance,
+        TargetVersion.TESTED,
         field ->
             apiInstanceForField(
                 classContext(context),

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieServersExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieServersExtension.java
@@ -16,7 +16,7 @@
 package org.projectnessie.tools.compatibility.internal;
 
 import static org.projectnessie.tools.compatibility.internal.AbstractNessieApiHolder.apiInstanceForField;
-import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieAnnotatedFields;
+import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieApiFields;
 import static org.projectnessie.tools.compatibility.internal.NessieServer.nessieServer;
 import static org.projectnessie.tools.compatibility.internal.Util.classContext;
 
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.projectnessie.tools.compatibility.api.TargetVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 
 /**
@@ -58,6 +59,6 @@ public class OlderNessieServersExtension extends AbstractMultiVersionExtension {
         field ->
             apiInstanceForField(classContext(context), field, Version.CURRENT, ctx -> nessieServer);
 
-    populateNessieAnnotatedFields(context, instance, fieldValue);
+    populateNessieApiFields(context, instance, TargetVersion.TESTED, fieldValue);
   }
 }

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/RollingUpgradesExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/RollingUpgradesExtension.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.compatibility.internal;
+
+import static org.projectnessie.tools.compatibility.internal.AbstractNessieApiHolder.apiInstanceForField;
+import static org.projectnessie.tools.compatibility.internal.GlobalForClass.globalForClass;
+import static org.projectnessie.tools.compatibility.internal.NessieServer.nessieServer;
+import static org.projectnessie.tools.compatibility.internal.NessieServer.nessieServerExisting;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.projectnessie.tools.compatibility.api.TargetVersion;
+import org.projectnessie.tools.compatibility.api.Version;
+import org.projectnessie.versioned.persist.mongodb.LocalMongo;
+
+/**
+ * Simulates a rolling-upgrade situation with one Nessie instance running an old version and another
+ * instance running the current (in-tree) version.
+ *
+ * <ul>
+ *   <li>{@link org.projectnessie.tools.compatibility.api.NessieVersion} annotated fields get the
+ *       old version injected.
+ *   <li>{@link org.projectnessie.tools.compatibility.api.NessieAPI} annotated fields with {@code
+ *       versionType} set to {@link TargetVersion#TESTED} get the API instance to the old version
+ *       injected.
+ *   <li>{@link org.projectnessie.tools.compatibility.api.NessieAPI} annotated fields with {@code
+ *       versionType} set to {@link TargetVersion#CURRENT} get the API instance to the current
+ *       (in-tree) version injected.
+ * </ul>
+ *
+ * <p>The repository is re-initialized for every Nessie version combination.
+ */
+public class RollingUpgradesExtension extends AbstractMultiVersionExtension {
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    Version version = populateNessieVersionAnnotatedFields(context, null);
+    if (version == null) {
+      return;
+    }
+
+    ServerKey serverKey = buildServerKey(version, context);
+    NessieServer nessieServer = nessieServer(context, serverKey, () -> true);
+    populateNessieApiFields(context, null, version, TargetVersion.TESTED, ctx -> nessieServer);
+
+    ServerKey serverKeyNext = buildServerKey(Version.CURRENT, context);
+    NessieServer nessieServerNext = nessieServer(context, serverKeyNext, () -> false);
+    populateNessieApiFields(
+        context, null, Version.CURRENT, TargetVersion.CURRENT, ctx -> nessieServerNext);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    Object testInstance = context.getRequiredTestInstance();
+    Version version = populateNessieVersionAnnotatedFields(context, testInstance);
+    if (version == null) {
+      return;
+    }
+
+    ServerKey serverKey = buildServerKey(version, context);
+    NessieServer nessieServer = nessieServerExisting(context, serverKey);
+    populateNessieApiFields(
+        context, testInstance, version, TargetVersion.TESTED, ctx -> nessieServer);
+
+    ServerKey serverKeyNext = buildServerKey(Version.CURRENT, context);
+    NessieServer nessieServerNext = nessieServerExisting(context, serverKeyNext);
+    populateNessieApiFields(
+        context, testInstance, Version.CURRENT, TargetVersion.CURRENT, ctx -> nessieServerNext);
+  }
+
+  private ServerKey buildServerKey(Version version, ExtensionContext context) {
+    Mongo mongo =
+        globalForClass(context).getOrCompute("local-mongo", x -> new Mongo(), Mongo.class);
+
+    // Eagerly create the Nessie server instance
+    String databaseAdapterName = "MongoDB";
+    Map<String, String> configuration =
+        ImmutableMap.of(
+            "nessie.store.connection.string",
+            mongo.getConnectionString(),
+            "nessie.store.database.name",
+            mongo.getDatabaseName());
+
+    return new ServerKey(version, databaseAdapterName, configuration);
+  }
+
+  private void populateNessieApiFields(
+      ExtensionContext context,
+      Object instance,
+      Version version,
+      TargetVersion targetVersion,
+      Function<ExtensionContext, NessieServer> nessieServerSupplier) {
+    AnnotatedFields.populateNessieApiFields(
+        context,
+        instance,
+        targetVersion,
+        field -> apiInstanceForField(context, field, version, nessieServerSupplier));
+  }
+
+  private static final class Mongo implements CloseableResource {
+
+    private LocalMongo localMongo;
+
+    private synchronized LocalMongo mongo() {
+      if (localMongo == null) {
+        localMongo = new LocalMongo();
+        localMongo.startMongo(Optional.empty(), true);
+      }
+      return localMongo;
+    }
+
+    String getConnectionString() {
+      return mongo().getConnectionString();
+    }
+
+    String getDatabaseName() {
+      return mongo().getDatabaseName();
+    }
+
+    @Override
+    public synchronized void close() {
+      if (localMongo == null) {
+        return;
+      }
+      try {
+        localMongo.stop();
+      } finally {
+        localMongo = null;
+      }
+    }
+  }
+}

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestAnnotatedFields.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestAnnotatedFields.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.projectnessie.tools.compatibility.api.NessieAPI;
 import org.projectnessie.tools.compatibility.api.NessieVersion;
+import org.projectnessie.tools.compatibility.api.TargetVersion;
 
 @SuppressWarnings({"unchecked", "rawtypes", "Convert2Lambda"})
 class TestAnnotatedFields {
@@ -51,7 +52,8 @@ class TestAnnotatedFields {
         };
     fieldToObject = spy(fieldToObject);
 
-    AnnotatedFields.populateNessieAnnotatedFields(extensionContext, null, fieldToObject);
+    AnnotatedFields.populateNessieApiFields(
+        extensionContext, null, TargetVersion.TESTED, fieldToObject);
 
     assertThat(AnnotatedFieldsTarget.nessieApiAnnotatedStatic).isEqualTo("hello");
     assertThat(AnnotatedFieldsTarget.nessieVersionAnnotatedStatic).isNull();
@@ -74,7 +76,7 @@ class TestAnnotatedFields {
     fieldToObject = spy(fieldToObject);
 
     AnnotatedFields.populateAnnotatedFields(
-        extensionContext, null, NessieVersion.class, fieldToObject);
+        extensionContext, null, NessieVersion.class, a -> true, fieldToObject);
 
     assertThat(AnnotatedFieldsTarget.nessieVersionAnnotatedStatic).isEqualTo("hello");
     assertThat(AnnotatedFieldsTarget.nessieApiAnnotatedStatic).isNull();
@@ -98,7 +100,8 @@ class TestAnnotatedFields {
 
     AnnotatedFieldsTarget instance = new AnnotatedFieldsTarget();
 
-    AnnotatedFields.populateNessieAnnotatedFields(extensionContext, instance, fieldToObject);
+    AnnotatedFields.populateNessieApiFields(
+        extensionContext, instance, TargetVersion.TESTED, fieldToObject);
 
     assertThat(instance.nessieApiAnnotatedInstance).isEqualTo("hello");
     assertThat(instance.nessieVersionAnnotatedInstance).isNull();
@@ -125,7 +128,7 @@ class TestAnnotatedFields {
     AnnotatedFieldsTarget instance = new AnnotatedFieldsTarget();
 
     AnnotatedFields.populateAnnotatedFields(
-        extensionContext, instance, NessieVersion.class, fieldToObject);
+        extensionContext, instance, NessieVersion.class, a -> true, fieldToObject);
 
     assertThat(instance.nessieApiAnnotatedInstance).isNull();
     assertThat(instance.nessieVersionAnnotatedInstance).isEqualTo("hello");

--- a/compatibility/compatibility-tests/pom.xml
+++ b/compatibility/compatibility-tests/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectnessie</groupId>
       <artifactId>nessie-compatibility-common</artifactId>
       <version>${project.version}</version>
@@ -77,6 +81,30 @@
       <artifactId>nessie-versioned-persist-rocks</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-mongodb</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectnessie</groupId>
+      <artifactId>nessie-versioned-persist-mongodb</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-sync</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mongodb</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgradeScenario.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgradeScenario.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.compatibility.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.google.common.collect.Maps;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Operation.Put;
+import org.projectnessie.tools.compatibility.api.NessieAPI;
+import org.projectnessie.tools.compatibility.api.NessieVersion;
+import org.projectnessie.tools.compatibility.api.TargetVersion;
+import org.projectnessie.tools.compatibility.api.Version;
+import org.projectnessie.tools.compatibility.api.VersionCondition;
+import org.projectnessie.tools.compatibility.internal.RollingUpgradesExtension;
+
+@ExtendWith(RollingUpgradesExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@VersionCondition(minVersion = "0.31.0")
+public class ITRollingUpgradeScenario {
+  public static final String NO_ANCESTOR =
+      "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d";
+
+  /** Nessie source version of the rolling upgrade. */
+  @NessieVersion Version version;
+
+  /** API of the "old" Nessie version instance. */
+  @NessieAPI(targetVersion = TargetVersion.TESTED)
+  NessieApiV1 apiOld;
+
+  /** API of the "current" (in-tree) Nessie version instance. */
+  @NessieAPI(targetVersion = TargetVersion.CURRENT)
+  NessieApiV1 apiCurrent;
+
+  static Map<ContentKey, IcebergTable> createdContent = new LinkedHashMap<>();
+
+  @BeforeAll
+  static void cleared() {
+    // The Nessie repository is reinitialized for every rolling-upgrade version combination.
+    createdContent.clear();
+  }
+
+  @Test
+  @Order(100)
+  void scenario() throws Exception {
+    Branch defaultBranch = apiOld.getDefaultBranch();
+    assertThat(defaultBranch).extracting(Branch::getName).isEqualTo("main");
+
+    Branch head = defaultBranch;
+
+    head = commit(apiOld, "old-one", head);
+
+    head = commit(apiCurrent, "new-one", head);
+
+    apiOld
+        .createReference()
+        .reference(Branch.of("branch-old-" + version, NO_ANCESTOR))
+        .sourceRefName("main")
+        .create();
+
+    head = commit(apiOld, "old-two", head);
+
+    commit(apiCurrent, "new-two", head);
+  }
+
+  Branch commit(NessieApiV1 api, String suffix, Branch head) throws Exception {
+    ThreadLocalRandom tlr = ThreadLocalRandom.current();
+
+    ContentKey key = ContentKey.of("key-" + suffix, "v" + version.toString());
+    IcebergTable table =
+        IcebergTable.of(
+            "metadata-" + version,
+            tlr.nextLong(),
+            tlr.nextInt(1234),
+            tlr.nextInt(1234),
+            tlr.nextInt(1234),
+            "cid-" + suffix + "-" + version);
+
+    head =
+        api.commitMultipleOperations()
+            .branch(head)
+            .operation(Put.of(key, table))
+            .commitMeta(CommitMeta.fromMessage("Commit " + suffix + " " + version))
+            .commit();
+
+    createdContent.put(key, table);
+
+    return head;
+  }
+
+  static Stream<Arguments> verifyContent() {
+    return createdContent.entrySet().stream().map(e -> arguments(e.getKey(), e.getValue()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("verifyContent")
+  @Order(109)
+  void verifyContentInOld(ContentKey key, IcebergTable table) throws Exception {
+    Map<ContentKey, Content> contents = apiOld.getContent().key(key).refName("main").get();
+
+    assertThat(contents).containsExactly(Maps.immutableEntry(key, table));
+  }
+
+  @ParameterizedTest
+  @MethodSource("verifyContent")
+  @Order(110)
+  void verifyContentInNew(ContentKey key, IcebergTable table) throws Exception {
+    Map<ContentKey, Content> contents = apiCurrent.getContent().key(key).refName("main").get();
+
+    assertThat(contents).containsExactly(Maps.immutableEntry(key, table));
+  }
+}

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgrades.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgrades.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.compatibility.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Operation.Put;
+import org.projectnessie.model.Reference;
+import org.projectnessie.tools.compatibility.api.NessieAPI;
+import org.projectnessie.tools.compatibility.api.NessieVersion;
+import org.projectnessie.tools.compatibility.api.TargetVersion;
+import org.projectnessie.tools.compatibility.api.Version;
+import org.projectnessie.tools.compatibility.api.VersionCondition;
+import org.projectnessie.tools.compatibility.internal.RollingUpgradesExtension;
+
+@ExtendWith(RollingUpgradesExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@VersionCondition(minVersion = "0.31.0")
+public class ITRollingUpgrades {
+
+  public static final String NO_ANCESTOR =
+      "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d";
+  /** Nessie source version of the rolling upgrade. */
+  @NessieVersion Version version;
+
+  /** API of the "old" Nessie version instance. */
+  @NessieAPI(targetVersion = TargetVersion.TESTED)
+  NessieApiV1 api;
+
+  /** API of the "current" (in-tree) Nessie version instance. */
+  @NessieAPI(targetVersion = TargetVersion.CURRENT)
+  NessieApiV1 apiCurrent;
+
+  static List<Reference> createdReferences = new ArrayList<>();
+  static Map<ContentKey, IcebergTable> createdContent = new LinkedHashMap<>();
+
+  @BeforeAll
+  static void cleared() {
+    // The Nessie repository is reinitialized for every rolling-upgrade version combination.
+    createdReferences.clear();
+    createdContent.clear();
+  }
+
+  @Test
+  @Order(100)
+  void defaultBranchInOld() throws Exception {
+    Branch defaultBranch = api.getDefaultBranch();
+    assertThat(defaultBranch).extracting(Branch::getName).isEqualTo("main");
+  }
+
+  @Test
+  @Order(101)
+  void defaultBranchInNew() throws Exception {
+    Branch defaultBranch = apiCurrent.getDefaultBranch();
+    assertThat(defaultBranch).extracting(Branch::getName).isEqualTo("main");
+  }
+
+  @Test
+  @Order(102)
+  void createBranchInOld() throws Exception {
+    Branch branch = Branch.of("branch-" + version, NO_ANCESTOR);
+    Reference created = api.createReference().sourceRefName("main").reference(branch).create();
+    createdReferences.add(created);
+
+    assertThat(created).isEqualTo(branch);
+  }
+
+  @Test
+  @Order(103)
+  void createBranchInNew() throws Exception {
+    Branch branch = Branch.of("branchCurrent-" + version, NO_ANCESTOR);
+    Reference created =
+        apiCurrent.createReference().sourceRefName("main").reference(branch).create();
+    createdReferences.add(created);
+
+    assertThat(created).isEqualTo(branch);
+  }
+
+  static List<Reference> checkCreatedReferences() {
+    return createdReferences;
+  }
+
+  @ParameterizedTest
+  @MethodSource("checkCreatedReferences")
+  @Order(105)
+  void checkCreatedReferencesInOld(Reference reference) throws Exception {
+    Reference ref = api.getReference().refName(reference.getName()).get();
+    assertThat(ref).isEqualTo(reference);
+  }
+
+  @ParameterizedTest
+  @MethodSource("checkCreatedReferences")
+  @Order(105)
+  void checkCreatedReferencesInNew(Reference reference) throws Exception {
+    Reference ref = apiCurrent.getReference().refName(reference.getName()).get();
+    assertThat(ref).isEqualTo(reference);
+  }
+
+  @Test
+  @Order(106)
+  void commitDataInOld() throws Exception {
+    ThreadLocalRandom tlr = ThreadLocalRandom.current();
+
+    ContentKey key = ContentKey.of("key", "v" + version.toString());
+    IcebergTable table =
+        IcebergTable.of(
+            "metadata-" + version,
+            tlr.nextLong(),
+            tlr.nextInt(1234),
+            tlr.nextInt(1234),
+            tlr.nextInt(1234),
+            "cid-" + version);
+
+    Branch branch = api.getDefaultBranch();
+
+    api.commitMultipleOperations()
+        .branch(branch)
+        .operation(Put.of(key, table))
+        .commitMeta(CommitMeta.fromMessage("Commit old " + version))
+        .commit();
+
+    createdContent.put(key, table);
+  }
+
+  @Test
+  @Order(107)
+  void commitDataInNew() throws Exception {
+    ThreadLocalRandom tlr = ThreadLocalRandom.current();
+
+    Branch branch = apiCurrent.getDefaultBranch();
+
+    ContentKey key = ContentKey.of("keyCurrent", "v" + version.toString());
+    IcebergTable table =
+        IcebergTable.of(
+            "metadataCurrent-" + version,
+            tlr.nextLong(),
+            tlr.nextInt(1234),
+            tlr.nextInt(1234),
+            tlr.nextInt(1234),
+            "cidCurrent-" + version);
+
+    apiCurrent
+        .commitMultipleOperations()
+        .branch(branch)
+        .operation(Put.of(key, table))
+        .commitMeta(CommitMeta.fromMessage("Commit new " + version))
+        .commit();
+
+    createdContent.put(key, table);
+  }
+
+  static Stream<Arguments> verifyContent() {
+    return createdContent.entrySet().stream().map(e -> arguments(e.getKey(), e.getValue()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("verifyContent")
+  @Order(109)
+  void verifyContentInOld(ContentKey key, IcebergTable table) throws Exception {
+    Map<ContentKey, Content> contents = api.getContent().key(key).refName("main").get();
+
+    assertThat(contents).containsExactly(Maps.immutableEntry(key, table));
+  }
+
+  @ParameterizedTest
+  @MethodSource("verifyContent")
+  @Order(110)
+  void verifyContentInNew(ContentKey key, IcebergTable table) throws Exception {
+    Map<ContentKey, Content> contents = apiCurrent.getContent().key(key).refName("main").get();
+
+    assertThat(contents).containsExactly(Maps.immutableEntry(key, table));
+  }
+}


### PR DESCRIPTION
Adds a new integration-tests for rolling upgrades including the
"machinery" to run rolling-upgrade tests.

That "machinery", implemented in `RollingUpgradesExtension` uses
MongoDB as the backend database. Using RocksDB doesn't work, because
rolling-upgrades requires that two server instances access the same
database - and RocksDB doesn't allow that.

Tests using `RollingUpgradesExtension` get two instances of
`NessieApiV1` - one configured against the "old" Nessie version and
the other against the "current" (in-tree) Nessie version.

`RollingUpgradesExtension` reinitializes the Nessie repository for
each combinations of Nessie versions.

The new `ITRollingUpgrades` tests a couple scenarios, against both
the old and new versions:
* get the default branch
* create new branch
* verify created branches
* commit a new table
* verify contents

`ITRollingUpgrades` is configured to require at least Nessie 0.31.0,
which is not yet released, because any rolling upgrade to current
in-tree will fail, because it is not safe for a rolling-upgrade
since #4234.

Fixes #4348