### PR TITLE
Fix task output dependency issues for jacoco

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,7 +30,7 @@ pluginManagement {
   versions["versionQuarkus"] = versionQuarkus
   val versionErrorPronePlugin = "2.0.2"
   versions["versionErrorPronePlugin"] = versionErrorPronePlugin
-  val versionNessieBuildPlugins = "0.1.4"
+  val versionNessieBuildPlugins = "0.1.5"
   versions["versionNessieBuildPlugins"] = versionNessieBuildPlugins
   val versionIdeaExtPlugin = "1.1.4"
   versions["versionIdeaExtPlugin"] = versionIdeaExtPlugin


### PR DESCRIPTION
Example:
```
> Task :code-coverage:codeCoverageReport
Execution optimizations have been disabled for task ':code-coverage:codeCoverageReport' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/snazy/devel/projectnessie/nessie/nessie/servers/lambda/build/classes/java/quarkus-generated-sources/avdl'. Reason: Task ':code-coverage:codeCoverageReport' uses this output of task ':servers:lambda:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/snazy/devel/projectnessie/nessie/nessie/servers/lambda/build/classes/java/quarkus-generated-sources/avpr'. Reason: Task ':code-coverage:codeCoverageReport' uses this output of task ':servers:lambda:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/snazy/devel/projectnessie/nessie/nessie/servers/lambda/build/classes/java/quarkus-generated-sources/avsc'. Reason: Task ':code-coverage:codeCoverageReport' uses this output of task ':servers:lambda:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/snazy/devel/projectnessie/nessie/nessie/servers/lambda/build/classes/java/quarkus-generated-sources/grpc'. Reason: Task ':code-coverage:codeCoverageReport' uses this output of task ':servers:lambda:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```