### PR TITLE
Increase severity of some errorprone checks

### DIFF
--- a/codestyle/errorprone-rules.properties
+++ b/codestyle/errorprone-rules.properties
@@ -549,8 +549,7 @@ UnicodeInCode=OFF
 #AmbiguousMethodReference=WARN
 # Method reference is ambiguous
 
-# TODO to ERROR
-#AnnotateFormatMethod=WARN
+AnnotateFormatMethod=ERROR
 # This method passes a pair of parameters through to String.format, but the enclosing method wasn't annotated @FormatMethod. Doing so gives compile-time rather than run-time protection against malformed format strings.
 
 #ArgumentSelectionDefectChecker=WARN
@@ -559,13 +558,13 @@ UnicodeInCode=OFF
 ArrayAsKeyOfSetOrMap=ERROR
 # Arrays do not override equals() or hashCode, so comparisons will be done on reference equality only. If neither deduplication nor lookup are needed, consider using a List instead. Otherwise, use IdentityHashMap/Set, a Map from a library that handles object arrays, or an Iterable/List of pairs.
 
-#AssertEqualsArgumentOrderChecker=WARN
+AssertEqualsArgumentOrderChecker=ERROR
 # Arguments are swapped in assertEquals-like call
 
-#AssertThrowsMultipleStatements=WARN
+AssertThrowsMultipleStatements=ERROR
 # The lambda passed to assertThrows should contain exactly one statement
 
-#AssertionFailureIgnored=WARN
+AssertionFailureIgnored=ERROR
 # This assertion throws an AssertionError if it fails, which will be caught by an enclosing try block.
 
 #AssistedInjectAndInjectOnSameConstructor=WARN
@@ -658,8 +657,7 @@ ClassNewInstance=ERROR
 DateFormatConstant=ERROR
 # DateFormat is not thread-safe, and should not be used as a constant field.
 
-# TODO to ERROR
-#DefaultCharset=WARN
+DefaultCharset=ERROR
 # Implicit use of the platform default charset, which can result in differing behaviour between JVM executions or incorrect behavior if the encoding of the data source doesn't match expectations.
 
 #DefaultPackage=WARN
@@ -692,11 +690,10 @@ DoubleCheckedLocking=ERROR
 #EmptySetMultibindingContributions=WARN
 # @Multibinds is a more efficient and declarative mechanism for ensuring that a set multibinding is present in the graph.
 
-# TODO to ERROR
-#EqualsGetClass=WARN
+EqualsGetClass=ERROR
 # Prefer instanceof to getClass when implementing Object#equals.
 
-#EqualsIncompatibleType=WARN
+EqualsIncompatibleType=ERROR
 # An equality test between objects with incompatible types always returns false
 
 EqualsUnsafeCast=ERROR
@@ -705,8 +702,7 @@ EqualsUnsafeCast=ERROR
 EqualsUsingHashCode=ERROR
 # Implementing #equals by just comparing hashCodes is fragile. Hashes collide frequently, and this will lead to false positives in #equals.
 
-# TODO to ERROR
-#ErroneousBitwiseExpression=WARN
+ErroneousBitwiseExpression=ERROR
 # This expression evaluates to 0. If this isn't an error, consider expressing it as a literal 0.
 
 ErroneousThreadPoolConstructorChecker=ERROR
@@ -937,7 +933,7 @@ LongFloatConversion=ERROR
 #MissingImplementsComparable=WARN
 # Classes implementing valid compareTo function should implement Comparable interface
 
-#MissingOverride=WARN
+MissingOverride=ERROR
 # method overrides method in supertype; expected @Override
 
 #MissingSummary=WARN
@@ -1009,7 +1005,7 @@ ObjectEqualsForPrimitives=ERROR
 #ObjectsHashCodePrimitive=WARN
 # Objects.hashCode(Object o) should not be passed a primitive value
 
-#OperatorPrecedence=WARN
+OperatorPrecedence=ERROR
 # Use grouping parenthesis to make the operator precedence explicit
 
 #OptionalMapToOptional=WARN
@@ -1192,7 +1188,7 @@ URLEqualsHashCode=ERROR
 #UnsynchronizedOverridesSynchronized=WARN
 # Unsynchronized method overrides a synchronized method.
 
-#UnusedMethod=WARN
+UnusedMethod=ERROR
 # Unused.
 
 #UnusedNestedClass=WARN
@@ -1204,7 +1200,7 @@ URLEqualsHashCode=ERROR
 #UseBinds=WARN
 # @Binds is a more efficient and declarative mechanism for delegating a binding.
 
-#UseCorrectAssertInTests=WARN
+UseCorrectAssertInTests=ERROR
 # Java assert is used in test. For testing purposes Assert.* matchers should be used.
 
 #VariableNameSameAsType=WARN
@@ -1388,10 +1384,10 @@ PrimitiveArrayPassedToVarargsMethod=WARN
 #QualifierWithTypeUse=WARN
 # Injection frameworks currently don't understand Qualifiers in TYPE_PARAMETER or TYPE_USE contexts.
 
-RedundantOverride=WARN
+RedundantOverride=ERROR
 # This overriding method is redundant, and can be removed.
 
-RedundantThrows=WARN
+RedundantThrows=ERROR
 # Thrown exception is a subtype of another
 
 StronglyTypeByteString=WARN
@@ -1585,7 +1581,7 @@ TryFailRefactoring=WARN
 UnnecessaryBoxedAssignment=WARN
 # This expression can be implicitly boxed.
 
-UnnecessaryBoxedVariable=WARN
+UnnecessaryBoxedVariable=ERROR
 # It is unnecessary for this variable to be boxed. Use the primitive instead.
 
 #UnnecessarySetDefault=WARN
@@ -1608,12 +1604,12 @@ UseEnumSwitch=WARN
 # See https://github.com/KengoTODA/errorprone-slf4j
 ####################################################################################################
 
-#Slf4jPlaceholderMismatch=ERROR
-#Slf4jFormatShouldBeConst=ERROR
-#Slf4jLoggerShouldBePrivate=ERROR
-#Slf4jLoggerShouldBeFinal=ERROR
+Slf4jPlaceholderMismatch=ERROR
+Slf4jFormatShouldBeConst=ERROR
+Slf4jLoggerShouldBePrivate=ERROR
+Slf4jLoggerShouldBeFinal=ERROR
 Slf4jLoggerShouldBeNonStatic=OFF
-#Slf4jIllegalPassedClass=ERROR
+Slf4jIllegalPassedClass=ERROR
 #Slf4jSignOnlyFormat=OFF
 #Slf4jDoNotLogMessageOfExceptionExplicitly=ERROR
 


### PR DESCRIPTION
Follow-up to https://github.com/projectnessie/nessie/pull/4476 where we fixed the following violations:
```
rg --no-line-number -o "warning: \[[^\]]*" errorpronemaster.txt | sort | uniq -c
      2 warning: [EqualsGetClass
      2 warning: [InlineMeInliner
      5 warning: [MissingOverride
      2 warning: [OperatorPrecedence
      4 warning: [RedundantOverride
      1 warning: [RedundantThrows
      1 warning: [Slf4jIllegalPassedClass
      1 warning: [UnnecessaryBoxedVariable
      1 warning: [UnnecessaryLambda
      3 warning: [UnusedMethod
      6 warning: [UnusedVariable
```
the other checks had no violations and we just tighten the rules for the future (and get rid of some `TODOs`)