### PR TITLE
UI: Fix relevant ui module tasks not run

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -205,6 +205,7 @@ val npmLint =
 tasks.withType<NpmTask>().configureEach {
   inputs.property("node.version", node.version)
   inputs.property("npm.version", node.npmVersion)
+  inputs.files("package.json", "package-lock.json").withPathSensitivity(PathSensitivity.RELATIVE)
   outputs.cacheIf { true }
   environment.put("CI", "true")
   environment.put("BUILD_PATH", npmBuildDir.path)


### PR DESCRIPTION
Relevant tasks (like `test`) are not always run. Reason is that the `NpmTask`s do not depend on the `package.json` + `package-lock.json` files.