### PR TITLE
Hashed key-lists using open-addrressing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -190,6 +190,7 @@ dependencies {
     api("org.graalvm.nativeimage:svm:$versionGraalSvm")
     api("org.immutables:builder:$versionImmutables")
     api("org.immutables:value-annotations:$versionImmutables")
+    api("org.immutables:value-fixture:$versionImmutables")
     api("org.immutables:value-processor:$versionImmutables")
     api("org.jacoco:jacoco-maven-plugin:$versionJacoco")
     api("org.jboss:jandex:$versionJandex")

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
@@ -68,6 +68,11 @@ public interface QuarkusVersionStoreAdvancedConfig
   @Override
   int getMaxKeyListEntitySize();
 
+  @WithName("key-list-hash-load-factor")
+  @WithDefault("" + DEFAULT_KEY_LIST_HASH_LOAD_FACTOR)
+  @Override
+  float getKeyListHashLoadFactor();
+
   @WithName("commit-timeout")
   @WithDefault("" + DEFAULT_COMMIT_TIMEOUT)
   @Override

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
@@ -73,6 +73,11 @@ public interface QuarkusVersionStoreAdvancedConfig
   @Override
   float getKeyListHashLoadFactor();
 
+  @WithName("key-list-entity-prefetch")
+  @WithDefault("" + DEFAULT_KEY_LIST_ENTITY_PREFETCH)
+  @Override
+  int getKeyListEntityPrefetch();
+
   @WithName("commit-timeout")
   @WithDefault("" + DEFAULT_COMMIT_TIMEOUT)
   @Override

--- a/versioned/persist/adapter/build.gradle.kts
+++ b/versioned/persist/adapter/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
   implementation(projects.versioned.spi)
   compileOnly("org.immutables:value-annotations")
+  compileOnly("org.immutables:value-fixture")
   annotationProcessor("org.immutables:value-processor")
   implementation("com.google.protobuf:protobuf-java")
   implementation("com.google.code.findbugs:jsr305")

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
@@ -77,7 +77,7 @@ public interface CommitLogEntry {
   Float getKeyListLoadFactor();
 
   @Nullable
-  Integer getKeyListBucketCount();
+  Integer getKeyListSegmentCount();
 
   /** Number of commits since the last complete key-list. */
   int getKeyListDistance();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
@@ -80,6 +80,10 @@ public interface CommitLogEntry {
     return KeyListVariant.EMBEDDED_AND_EXTERNAL_MRU;
   }
 
+  default boolean hasKeySummary() {
+    return getKeyListVariant() != KeyListVariant.EMBEDDED_AND_EXTERNAL_MRU || getKeyList() != null;
+  }
+
   static CommitLogEntry of(
       long createdTime,
       Hash hash,
@@ -135,6 +139,6 @@ public interface CommitLogEntry {
      * represents a hash bucket. All {@link KeyListEntry}s in each bucket are sorted by {@link
      * KeyListEntry#getKey() content key}.
      */
-    SORTED_AND_HASHED
+    HASHED_AND_SORTED
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
@@ -37,6 +37,7 @@ public interface DatabaseAdapterConfig {
   int DEFAULT_MAX_ENTITY_SIZE = 250_000;
   int DEFAULT_MAX_KEY_LIST_ENTITY_SIZE = 1_000_000;
   float DEFAULT_KEY_LIST_HASH_LOAD_FACTOR = 0.65f;
+  int DEFAULT_KEY_LIST_ENTITY_PREFETCH = 0;
   int DEFAULT_COMMIT_TIMEOUT = 500;
   int DEFAULT_COMMIT_RETRIES = Integer.MAX_VALUE;
   int DEFAULT_PARENTS_PER_REFLOG_ENTRY = 20;
@@ -134,6 +135,18 @@ public interface DatabaseAdapterConfig {
   @Value.Default
   default float getKeyListHashLoadFactor() {
     return DEFAULT_KEY_LIST_HASH_LOAD_FACTOR;
+  }
+
+  /**
+   * The number of adjacent key-list-entities to fetch, defaults to {@value
+   * #DEFAULT_KEY_LIST_ENTITY_PREFETCH}.
+   *
+   * <p>Applied to key-lists written by Nessie since 0.31.0 using the {@link
+   * CommitLogEntry.KeyListVariant#OPEN_ADDRESSING} format.
+   */
+  @Value.Default
+  default int getKeyListEntityPrefetch() {
+    return DEFAULT_KEY_LIST_ENTITY_PREFETCH;
   }
 
   /**

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
@@ -36,6 +36,7 @@ public interface DatabaseAdapterConfig {
   int DEFAULT_KEY_LIST_DISTANCE = 20;
   int DEFAULT_MAX_ENTITY_SIZE = 250_000;
   int DEFAULT_MAX_KEY_LIST_ENTITY_SIZE = 1_000_000;
+  float DEFAULT_KEY_LIST_HASH_LOAD_FACTOR = 0.65f;
   int DEFAULT_COMMIT_TIMEOUT = 500;
   int DEFAULT_COMMIT_RETRIES = Integer.MAX_VALUE;
   int DEFAULT_PARENTS_PER_REFLOG_ENTRY = 20;
@@ -116,6 +117,23 @@ public interface DatabaseAdapterConfig {
   @Value.Default
   default int getMaxKeyListEntitySize() {
     return DEFAULT_MAX_KEY_LIST_ENTITY_SIZE;
+  }
+
+  /**
+   * Configures key-list hash-table load-factor for the open-addressing hash map used for key-lists.
+   *
+   * <p>Small segments and load factors above 0.65 are bad, as those would lead to many database
+   * fetches. Good configurations, that usually lead to only one additional key-list segment fetch
+   * are these:
+   *
+   * <ul>
+   *   <li>segment size of 128kB or more with a load factor of 0.65
+   *   <li>segment sizes of 64kB or more with a load factor of 0.45
+   * </ul>
+   */
+  @Value.Default
+  default float getKeyListHashLoadFactor() {
+    return DEFAULT_KEY_LIST_HASH_LOAD_FACTOR;
   }
 
   /**

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
@@ -24,6 +24,9 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 public interface KeyList {
+
+  KeyList EMPTY = ImmutableKeyList.builder().build();
+
   List<KeyListEntry> getKeys();
 
   static KeyList of(List<KeyListEntry> keys) {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.persist.adapter;
 
 import java.util.List;
+import org.immutables.fixture.modifiable.AllowNulls;
 import org.immutables.value.Value;
 
 /**
@@ -23,10 +24,12 @@ import org.immutables.value.Value;
  * org.projectnessie.versioned.persist.adapter.CommitLogEntry}.
  */
 @Value.Immutable
+@Value.Style(jdkOnly = true) // to allow null in collections
 public interface KeyList {
 
   KeyList EMPTY = ImmutableKeyList.builder().build();
 
+  @AllowNulls
   List<KeyListEntry> getKeys();
 
   static KeyList of(List<KeyListEntry> keys) {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -96,6 +96,7 @@ import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry.KeyListVariant;
 import org.projectnessie.versioned.persist.adapter.CommitParams;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
@@ -1153,7 +1154,10 @@ public abstract class AbstractDatabaseAdapter<
 
     // Return the new commit-log-entry with the complete-key-list
     ImmutableCommitLogEntry.Builder newCommitEntry =
-        ImmutableCommitLogEntry.builder().from(unwrittenEntry).keyListDistance(0);
+        ImmutableCommitLogEntry.builder()
+            .from(unwrittenEntry)
+            .keyListDistance(0)
+            .keyListVariant(KeyListVariant.SORTED_AND_HASHED);
 
     KeyListBuildState buildState =
         new KeyListBuildState(
@@ -1198,9 +1202,7 @@ public abstract class AbstractDatabaseAdapter<
       }
     }
 
-    buildState.finish();
-
-    List<KeyListEntity> newKeyListEntities = buildState.buildNewKeyListEntities();
+    List<KeyListEntity> newKeyListEntities = buildState.finish();
 
     // Inform the (CAS)-op-loop about the IDs of the KeyListEntities being optimistically written.
     newKeyListEntities.stream().map(KeyListEntity::getId).forEach(newKeyLists);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1440,20 +1440,15 @@ public abstract class AbstractDatabaseAdapter<
                   commitLogEntries.forEach(commitLogEntryHandler);
                 }
 
-                if (keyListEntries.stream()
-                    .map(KeyListEntry::getCommitId)
-                    .anyMatch(Objects::isNull)) {
-                  // Older Nessie versions before 0.22.0 did not record the commit-ID for a key
-                  // so that we have to continue scanning the commit log for the remaining keys.
-                  remainingKeys.retainAll(
-                      keyListEntries.stream()
-                          .map(KeyListEntry::getKey)
-                          .collect(Collectors.toSet()));
-                } else {
-                  // Newer Nessie versions since 0.22.0 do record the commit-ID, so we can safely
-                  // assume that remainingKeys do not exist.
-                  remainingKeys.clear();
-                }
+                // Older Nessie versions before 0.22.0 did not record the commit-ID for a key
+                // so that we have to continue scanning the commit log for the remaining keys.
+                // Newer Nessie versions since 0.22.0 do record the commit-ID, so we can safely
+                // assume that remainingKeys do not exist.
+                remainingKeys.retainAll(
+                    keyListEntries.stream()
+                        .filter(e -> e.getCommitId() == null)
+                        .map(KeyListEntry::getKey)
+                        .collect(Collectors.toSet()));
               }
             }
           });

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.spi;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import org.agrona.collections.Hashing;
+import org.agrona.collections.Object2IntHashMap;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.KeyListEntity;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
+
+final class FetchValuesUsingOpenAddressing {
+
+  final int[] keyListSegmentOffsets;
+  final int keyListCount;
+  final KeyListEntry[][] keyListsArray;
+  final Object2IntHashMap<Hash> entityIdToSegment;
+  final int hashMask;
+  final List<Hash> keyListIds;
+
+  FetchValuesUsingOpenAddressing(CommitLogEntry entry) {
+    List<Integer> keyListSegmentOffsetsList = entry.getKeyListEntityOffsets();
+    keyListSegmentOffsets =
+        keyListSegmentOffsetsList != null
+            ? keyListSegmentOffsetsList.stream().mapToInt(Integer::intValue).toArray()
+            : new int[0];
+    keyListCount = 1 + keyListSegmentOffsets.length;
+
+    keyListsArray = new KeyListEntry[keyListCount][];
+    keyListsArray[0] = entry.getKeyList().getKeys().toArray(new KeyListEntry[0]);
+
+    entityIdToSegment = new Object2IntHashMap<>(keyListCount, Hashing.DEFAULT_LOAD_FACTOR, -1);
+
+    hashMask = entry.getKeyListBucketCount() - 1;
+
+    keyListIds = entry.getKeyListsIds();
+  }
+
+  /** Calculates the open-addressing bucket for a key. */
+  int bucketForKey(Key key) {
+    return key.hashCode() & hashMask;
+  }
+
+  /**
+   * Identifies the segment for a bucket. Segment 0 is the embedded key list, segment 1 is the first
+   * key-list-entity.
+   */
+  int segmentForKey(int bucket, int round) {
+    int binIdx = Arrays.binarySearch(keyListSegmentOffsets, bucket);
+    int segment = binIdx >= 0 ? binIdx + 1 : -binIdx - 1;
+    return (segment + round) & hashMask;
+  }
+
+  /**
+   * Identify the {@link KeyListEntity}s that need to be fetched to get the {@link KeyListEntry}s
+   * for {@code remainingKeys}.
+   */
+  List<Hash> entityIdsToFetch(int round, int prefetchEntities, Collection<Key> remainingKeys) {
+    // Identify the key-list segments to fetch
+    List<Hash> entitiesToFetch = new ArrayList<>();
+    for (Key key : remainingKeys) {
+      int keyBucket = bucketForKey(key);
+      int segment = segmentForKey(keyBucket, round);
+
+      for (int prefetch = 0; ; prefetch++) {
+        if (segment > 0) {
+          int entitySegment = segment - 1;
+          Hash entityId = keyListIds.get(entitySegment);
+          if (entityIdToSegment.put(entityId, segment) == -1) {
+            entitiesToFetch.add(entityId);
+          }
+        }
+        if (prefetch >= prefetchEntities) {
+          break;
+        }
+        segment++;
+        if (segment == keyListCount) {
+          segment = 0;
+        }
+      }
+    }
+    return entitiesToFetch;
+  }
+
+  /**
+   * Callback to memoize a loaded {@link KeyListEntity} so it can be used in {@link
+   * #checkForKeys(int, Collection, Consumer)}.
+   */
+  void entityLoaded(KeyListEntity keyListEntity) {
+    Integer index = entityIdToSegment.get(keyListEntity.getId());
+    keyListsArray[index] = keyListEntity.getKeys().getKeys().toArray(new KeyListEntry[0]);
+  }
+
+  /**
+   * Find the {@link KeyListEntry}s for the {@code remainingKeys}, return the {@link Key}s that
+   * could not be found yet, but are likely in the next segment.
+   */
+  Collection<Key> checkForKeys(
+      int round, Collection<Key> remainingKeys, Consumer<KeyListEntry> resultConsumer) {
+    List<Key> keysForNextRound = new ArrayList<>();
+    for (Key key : remainingKeys) {
+      int keyBucket = bucketForKey(key);
+      int segment = segmentForKey(keyBucket, round);
+      int offsetInSegment = 0;
+      if (round == 0) {
+        offsetInSegment = keyBucket;
+        if (segment > 0) {
+          offsetInSegment -= keyListSegmentOffsets[segment - 1];
+        }
+      }
+
+      KeyListEntry[] keys = keyListsArray[segment];
+      for (int i = offsetInSegment; ; i++) {
+        KeyListEntry keyListEntry = keys[i];
+        if (keyListEntry == null) {
+          // key _not_ found
+          break;
+        } else if (keyListEntry.getKey().equals(key)) {
+          resultConsumer.accept(keyListEntry);
+          break;
+        } else if (i == keys.length - 1) {
+          keysForNextRound.add(key);
+          break;
+        }
+      }
+    }
+    return keysForNextRound;
+  }
+}

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.adapter.spi;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.randomHash;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
@@ -44,16 +45,13 @@ class KeyListBuildState {
   private final int maxEmbeddedKeyListSize;
   private final int maxKeyListEntitySize;
   private final ToIntFunction<KeyListEntry> serializedEntrySize;
-  private final int currentSize;
   private final List<KeyListEntry> entries = new ArrayList<>();
 
   KeyListBuildState(
-      int initialSize,
       ImmutableCommitLogEntry.Builder newCommitEntry,
       int maxEmbeddedKeyListSize,
       int maxKeyListEntitySize,
       ToIntFunction<KeyListEntry> serializedEntrySize) {
-    this.currentSize = initialSize;
     this.newCommitEntry = newCommitEntry;
     this.maxEmbeddedKeyListSize = maxEmbeddedKeyListSize;
     this.maxKeyListEntitySize = maxKeyListEntitySize;
@@ -68,17 +66,39 @@ class KeyListBuildState {
     return Math.abs(entry.getKey().hashCode() % bucketCount);
   }
 
+  int calcBucketCount(int totalSize, int maxBucketSize) {
+    int bucketCount = totalSize / maxBucketSize;
+    if (totalSize % maxBucketSize != 0) {
+      bucketCount++;
+    }
+    // Distribution of the "final" bucket size is rather non-uniform, especially for very similar
+    // keys. For example, adding 500 keys, each with one element representing the string
+    // representation of the int range 0..500 results in a poor distribution: from buckets with 0
+    // entries up to buckets with nearly 20 buckets, where the "ideal" number of entries is 8.
+    //
+    // In theory, using the next-power-of-2 _should_ mitigate the above problem, but sadly it does
+    // not. And we might up persisting way more entities as necessary.
+    return bucketCount;
+  }
+
   List<KeyListEntity> finish() {
     int totalSize = entries.stream().mapToInt(serializedEntrySize).sum();
-    int remainingEmbedded = maxEmbeddedKeyListSize - currentSize;
-    int maxBucketSize =
-        Math.max(MINIMUM_BUCKET_SIZE, Math.min(remainingEmbedded, maxKeyListEntitySize));
 
-    int bucketCount = totalSize / maxBucketSize + 1;
+    if (totalSize <= maxEmbeddedKeyListSize) {
+      ImmutableKeyList.Builder embeddedBuilder = ImmutableKeyList.builder();
+      sortBucket(entries);
+      embeddedBuilder.addAllKeys(entries);
+      newCommitEntry.keyList(embeddedBuilder.build());
+      return Collections.emptyList();
+    }
+
+    int maxBucketSize = Math.max(MINIMUM_BUCKET_SIZE, maxKeyListEntitySize);
+    int bucketCount = calcBucketCount(totalSize, maxBucketSize);
     List<List<KeyListEntry>> buckets = new ArrayList<>(bucketCount);
     for (int i = 0; i < bucketCount; i++) {
       buckets.add(new ArrayList<>());
     }
+
     for (KeyListEntry entry : entries) {
       int bucket = bucket(entry, bucketCount);
       buckets.get(bucket).add(entry);
@@ -91,13 +111,9 @@ class KeyListBuildState {
           return bucket;
         };
 
-    ImmutableKeyList.Builder embeddedBuilder = ImmutableKeyList.builder();
-    embeddedBuilder.addAllKeys(sortedBucket.apply(0));
-    newCommitEntry.keyList(embeddedBuilder.build());
+    List<KeyListEntity> newKeyListEntities = new ArrayList<>(bucketCount);
 
-    List<KeyListEntity> newKeyListEntities = new ArrayList<>(bucketCount - 1);
-
-    for (int b = 1; b < buckets.size(); b++) {
+    for (int b = 0; b < buckets.size(); b++) {
       KeyList keyList = ImmutableKeyList.builder().addAllKeys(sortedBucket.apply(b)).build();
       Hash id = randomHash();
       newKeyListEntities.add(KeyListEntity.of(id, keyList));
@@ -105,5 +121,9 @@ class KeyListBuildState {
     }
 
     return newKeyListEntities;
+  }
+
+  private static void sortBucket(List<KeyListEntry> bucket) {
+    bucket.sort(Comparator.comparing(KeyListEntry::getKey));
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
@@ -15,18 +15,18 @@
  */
 package org.projectnessie.versioned.persist.adapter.spi;
 
+import static java.lang.Integer.numberOfLeadingZeros;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.randomHash;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.IntFunction;
 import java.util.function.ToIntFunction;
-import org.projectnessie.versioned.Hash;
+import java.util.stream.Collectors;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ImmutableKeyList;
 import org.projectnessie.versioned.persist.adapter.KeyList;
@@ -34,8 +34,23 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntity;
 import org.projectnessie.versioned.persist.adapter.KeyListEntry;
 
 /**
- * Helper object for {@link AbstractDatabaseAdapter#buildKeyList(AutoCloseable, CommitLogEntry,
- * Consumer, Function)}.
+ * Compute the {@link CommitLogEntry#getKeyList() embedded key-list} and {@link KeyListEntity}s,
+ * accessible via {@link CommitLogEntry#getKeyListsIds()}.
+ *
+ * <p>Commits with {@link CommitLogEntry.KeyListVariant#OPEN_ADDRESSING} are represented as an
+ * open-addressing hash map with {@link org.projectnessie.versioned.Key} as the map key.
+ *
+ * <p>That open-addressing hash map is split into multiple segments, if necessary.
+ *
+ * <p>The first segment is represented by the {@link CommitLogEntry#getKeyList() embedded key-list}
+ * with a serialized size goal up to {@link DatabaseAdapterConfig#getMaxKeyListSize()}. All
+ * following segments have a serialized size up to {@link
+ * DatabaseAdapterConfig#getMaxKeyListEntitySize()} as the goal.
+ *
+ * <p>Maximum size constraints are fulfilled using a best-effort approach.
+ *
+ * <p>Used by {@link AbstractDatabaseAdapter#buildKeyList(AutoCloseable, CommitLogEntry, Consumer,
+ * Function)}.
  */
 class KeyListBuildState {
 
@@ -44,6 +59,7 @@ class KeyListBuildState {
 
   private final int maxEmbeddedKeyListSize;
   private final int maxKeyListEntitySize;
+  private final float loadFactor;
   private final ToIntFunction<KeyListEntry> serializedEntrySize;
   private final List<KeyListEntry> entries = new ArrayList<>();
 
@@ -51,10 +67,12 @@ class KeyListBuildState {
       ImmutableCommitLogEntry.Builder newCommitEntry,
       int maxEmbeddedKeyListSize,
       int maxKeyListEntitySize,
+      float loadFactor,
       ToIntFunction<KeyListEntry> serializedEntrySize) {
     this.newCommitEntry = newCommitEntry;
     this.maxEmbeddedKeyListSize = maxEmbeddedKeyListSize;
     this.maxKeyListEntitySize = maxKeyListEntitySize;
+    this.loadFactor = loadFactor;
     this.serializedEntrySize = serializedEntrySize;
   }
 
@@ -62,68 +80,91 @@ class KeyListBuildState {
     entries.add(entry);
   }
 
-  int bucket(KeyListEntry entry, int bucketCount) {
-    return Math.abs(entry.getKey().hashCode() % bucketCount);
-  }
-
-  int calcBucketCount(int totalSize, int maxBucketSize) {
-    int bucketCount = totalSize / maxBucketSize;
-    if (totalSize % maxBucketSize != 0) {
-      bucketCount++;
-    }
-    // Distribution of the "final" bucket size is rather non-uniform, especially for very similar
-    // keys. For example, adding 500 keys, each with one element representing the string
-    // representation of the int range 0..500 results in a poor distribution: from buckets with 0
-    // entries up to buckets with nearly 20 buckets, where the "ideal" number of entries is 8.
-    //
-    // In theory, using the next-power-of-2 _should_ mitigate the above problem, but sadly it does
-    // not. And we might up persisting way more entities as necessary.
-    return bucketCount;
+  static int nextPowerOfTwo(final int v) {
+    return 1 << (32 - numberOfLeadingZeros(v - 1));
   }
 
   List<KeyListEntity> finish() {
-    int totalSize = entries.stream().mapToInt(serializedEntrySize).sum();
-
-    if (totalSize <= maxEmbeddedKeyListSize) {
-      ImmutableKeyList.Builder embeddedBuilder = ImmutableKeyList.builder();
-      sortBucket(entries);
-      embeddedBuilder.addAllKeys(entries);
-      newCommitEntry.keyList(embeddedBuilder.build());
-      return Collections.emptyList();
-    }
-
-    int maxBucketSize = Math.max(MINIMUM_BUCKET_SIZE, maxKeyListEntitySize);
-    int bucketCount = calcBucketCount(totalSize, maxBucketSize);
-    List<List<KeyListEntry>> buckets = new ArrayList<>(bucketCount);
-    for (int i = 0; i < bucketCount; i++) {
-      buckets.add(new ArrayList<>());
-    }
-
+    // Build open-addressing map
+    int openAddressingEntries = openAddressingBuckets();
+    int openAddressingMask = openAddressingEntries - 1;
+    KeyListEntry[] openAddressingHashMap = new KeyListEntry[openAddressingEntries];
     for (KeyListEntry entry : entries) {
-      int bucket = bucket(entry, bucketCount);
-      buckets.get(bucket).add(entry);
+      int hash = entry.getKey().hashCode();
+      int bucket = hash & openAddressingMask;
+
+      // add to map
+      for (int i = bucket; ; ) {
+        if (openAddressingHashMap[i] == null) {
+          openAddressingHashMap[i] = entry;
+          break;
+        }
+
+        i++;
+        if (i == openAddressingEntries) {
+          i = 0;
+        }
+      }
     }
 
-    IntFunction<List<KeyListEntry>> sortedBucket =
-        idx -> {
-          List<KeyListEntry> bucket = buckets.get(idx);
-          bucket.sort(Comparator.comparing(KeyListEntry::getKey));
-          return bucket;
-        };
+    // Generate all KeyList objects. The first one for the embedded key-list and all other ones
+    // for key-list-entities. Offsets are kept for key-list-entities, because the embedded
+    // key-list's is always the first one.
 
-    List<KeyListEntity> newKeyListEntities = new ArrayList<>(bucketCount);
+    List<Integer> offsets = new ArrayList<>();
+    List<KeyList> keyLists = new ArrayList<>();
 
-    for (int b = 0; b < buckets.size(); b++) {
-      KeyList keyList = ImmutableKeyList.builder().addAllKeys(sortedBucket.apply(b)).build();
-      Hash id = randomHash();
-      newKeyListEntities.add(KeyListEntity.of(id, keyList));
-      newCommitEntry.addKeyListsIds(id);
+    int bucketSize = 0;
+    int maxBucketSize = maxEmbeddedKeyListSize;
+    ImmutableKeyList.Builder keyListBuilder = ImmutableKeyList.builder();
+    for (int i = 0; i < openAddressingHashMap.length; i++) {
+      KeyListEntry entry = openAddressingHashMap[i];
+
+      if (entry != null) {
+        int entrySize = serializedEntrySize.applyAsInt(entry);
+
+        if (bucketSize + entrySize > maxBucketSize) {
+          maxBucketSize = maxKeyListEntitySize;
+          offsets.add(i);
+          keyLists.add(keyListBuilder.build());
+          keyListBuilder = ImmutableKeyList.builder();
+          bucketSize = 0;
+        }
+
+        bucketSize += entrySize;
+      }
+      keyListBuilder.addKeys(entry);
+    }
+    if (bucketSize > 0) {
+      // Only add the last key-list-entity if it actually contains entries (not all null)
+      keyLists.add(keyListBuilder.build());
     }
 
-    return newKeyListEntities;
+    // Very rare, but it's possible that there are no keys at all.
+    if (!keyLists.isEmpty()) {
+      newCommitEntry.keyList(keyLists.get(0));
+    } else {
+      newCommitEntry.keyList(KeyList.EMPTY);
+    }
+    newCommitEntry.keyListLoadFactor(loadFactor);
+    newCommitEntry.keyListBucketCount(openAddressingEntries);
+
+    List<KeyListEntity> builtEntities =
+        keyLists.stream()
+            .skip(1)
+            .map(keyList -> KeyListEntity.of(randomHash(), keyList))
+            .collect(Collectors.toList());
+
+    if (!builtEntities.isEmpty()) {
+      builtEntities.stream().map(KeyListEntity::getId).forEach(newCommitEntry::addKeyListsIds);
+      newCommitEntry.addAllKeyListEntityOffsets(offsets);
+    }
+
+    return builtEntities;
   }
 
-  private static void sortBucket(List<KeyListEntry> bucket) {
-    bucket.sort(Comparator.comparing(KeyListEntry::getKey));
+  @VisibleForTesting
+  int openAddressingBuckets() {
+    return nextPowerOfTwo((int) (entries.size() / loadFactor));
   }
 }

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestKeyListBuildState.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestKeyListBuildState.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.adapter.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.randomHash;
+
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.persist.adapter.ContentId;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.KeyList;
+import org.projectnessie.versioned.persist.adapter.KeyListEntity;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
+
+public class TestKeyListBuildState {
+  @Test
+  void noKeysAtAll() {
+    ImmutableCommitLogEntry.Builder commit = newCommit();
+    KeyListBuildState keyListBuilder =
+        new KeyListBuildState(0, commit, 0, 0, e -> e.getKey().toString().length());
+
+    List<KeyListEntity> entities = keyListBuilder.finish();
+
+    assertThat(entities).isEmpty();
+    assertThat(commit.build().getKeyList()).extracting(KeyList::getKeys).asList().isEmpty();
+  }
+
+  @Test
+  void oneKey() {
+    ImmutableCommitLogEntry.Builder commit = newCommit();
+    KeyListBuildState keyListBuilder =
+        new KeyListBuildState(0, commit, 0, 0, e -> e.getKey().toString().length());
+
+    KeyListEntry entry = entry("meep");
+    keyListBuilder.add(entry);
+
+    List<KeyListEntity> entities = keyListBuilder.finish();
+
+    assertThat(entities).isEmpty();
+    assertThat(commit.build().getKeyList())
+        .extracting(KeyList::getKeys)
+        .asList()
+        .containsExactly(entry);
+  }
+
+  @Test
+  void embeddedNoEntities() {
+    ImmutableCommitLogEntry.Builder commit = newCommit();
+    KeyListBuildState keyListBuilder =
+        new KeyListBuildState(0, commit, 0, 0, e -> KeyListBuildState.MINIMUM_BUCKET_SIZE / 10);
+
+    List<KeyListEntry> entries =
+        IntStream.range(0, 9).mapToObj(i -> entry("meep-" + i)).collect(Collectors.toList());
+
+    entries.forEach(keyListBuilder::add);
+
+    List<KeyListEntity> entities = keyListBuilder.finish();
+
+    assertThat(entities).isEmpty();
+    assertThat(commit.build().getKeyList())
+        .extracting(KeyList::getKeys)
+        .asInstanceOf(list(KeyListEntry.class))
+        .satisfies(this::assertSortedList)
+        .containsExactlyElementsOf(entries);
+  }
+
+  @Test
+  void twoBuckets() {
+    ImmutableCommitLogEntry.Builder commit = newCommit();
+    KeyListBuildState keyListBuilder =
+        new KeyListBuildState(0, commit, 0, 0, e -> KeyListBuildState.MINIMUM_BUCKET_SIZE >> 3);
+
+    List<KeyListEntry> entries =
+        IntStream.range(0, 8).mapToObj(i -> entry("meep-" + i)).collect(Collectors.toList());
+
+    entries.forEach(keyListBuilder::add);
+
+    List<KeyListEntity> entities = keyListBuilder.finish();
+
+    assertThat(entities)
+        .hasSize(1)
+        .allSatisfy(this::assertSortedEntity)
+        .flatMap(entity -> entity.getKeys().getKeys())
+        .isEqualTo(
+            entries.stream()
+                .filter(e -> keyListBuilder.bucket(e, 2) == 1)
+                .collect(Collectors.toList()));
+
+    assertThat(commit.build().getKeyList())
+        .extracting(KeyList::getKeys)
+        .asInstanceOf(list(KeyListEntry.class))
+        .satisfies(this::assertSortedList)
+        .containsExactlyElementsOf(
+            entries.stream()
+                .filter(e -> keyListBuilder.bucket(e, 2) == 0)
+                .collect(Collectors.toList()));
+  }
+
+  @RepeatedTest(20)
+  void manyBuckets() {
+    ImmutableCommitLogEntry.Builder commit = newCommit();
+    KeyListBuildState keyListBuilder =
+        new KeyListBuildState(0, commit, 0, 0, e -> KeyListBuildState.MINIMUM_BUCKET_SIZE >> 3);
+
+    int entryCount = 500;
+    int bucketCount = entryCount / 8 + 1;
+
+    List<KeyListEntry> entries = new ArrayList<>();
+    IntStream.range(0, entryCount).mapToObj(i -> entry("meep-" + i)).forEach(entries::add);
+
+    // randomize the order of the keys
+    Collections.shuffle(entries);
+
+    entries.forEach(keyListBuilder::add);
+
+    List<List<KeyListEntry>> expectedEntities = new ArrayList<>();
+    for (int i = 1; i < bucketCount; i++) {
+      int b = i;
+      expectedEntities.add(
+          entries.stream()
+              .filter(e -> keyListBuilder.bucket(e, bucketCount) == b)
+              .sorted(Comparator.comparing(KeyListEntry::getKey))
+              .collect(Collectors.toList()));
+    }
+    List<KeyListEntry> expectedEmbedded =
+        entries.stream()
+            .filter(e -> keyListBuilder.bucket(e, bucketCount) == 0)
+            .sorted(Comparator.comparing(KeyListEntry::getKey))
+            .collect(Collectors.toList());
+
+    List<KeyListEntity> entities = keyListBuilder.finish();
+
+    assertThat(entities)
+        .hasSize(bucketCount - 1)
+        .allSatisfy(this::assertSortedEntity)
+        .map(entity -> entity.getKeys().getKeys())
+        .containsExactlyElementsOf(expectedEntities);
+
+    assertThat(commit.build().getKeyList())
+        .extracting(KeyList::getKeys)
+        .asInstanceOf(list(KeyListEntry.class))
+        .satisfies(this::assertSortedList)
+        .containsExactlyElementsOf(expectedEmbedded);
+  }
+
+  private void assertSortedEntity(KeyListEntity entries) {
+    assertSortedList(entries.getKeys().getKeys());
+  }
+
+  private void assertSortedList(List<? extends KeyListEntry> entries) {
+    ArrayList<KeyListEntry> validate = new ArrayList<>(entries);
+    validate.sort(Comparator.comparing(KeyListEntry::getKey));
+    assertThat(entries).isEqualTo(validate);
+  }
+
+  private static KeyListEntry entry(String key) {
+    return KeyListEntry.of(Key.of(key), ContentId.of(key), (byte) 0, randomHash());
+  }
+
+  private ImmutableCommitLogEntry.Builder newCommit() {
+    return ImmutableCommitLogEntry.builder()
+        .createdTime(1L)
+        .hash(randomHash())
+        .commitSeq(123L)
+        .metadata(ByteString.EMPTY)
+        .keyListDistance(42);
+  }
+}

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestKeyListBuildState.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestKeyListBuildState.java
@@ -131,7 +131,7 @@ public class TestKeyListBuildState {
 
     assertThat(entities).hasSize(expectedBuckets);
 
-    int totalBuckets = keyListBuilder.openAddressingBuckets();
+    int totalBuckets = keyListBuilder.openAddressingSegments();
     int hashMask = totalBuckets - 1;
     assertThat(entries)
         .allSatisfy(

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -91,6 +91,11 @@ public class DynamoDatabaseAdapter
   // DynamoDB limit
   private static final int DYNAMO_BATCH_WRITE_MAX_REQUESTS = 25;
   private static final int DYNAMO_MAX_ITEM_SIZE = 375 * 1024;
+  /**
+   * Have to restrict the "target" size for key-list-entities, because hash-bucketing can
+   * "overshoot" by a lot.
+   */
+  private static final int DYNAMO_MAX_KEY_LIST_ENTITY_SIZE = 100 * 1024;
 
   private static final char PREFIX_SEPARATOR = ':';
   private final DynamoDatabaseClient client;
@@ -619,6 +624,11 @@ public class DynamoDatabaseAdapter
   @Override
   protected int maxEntitySize(int value) {
     return Math.min(value, DYNAMO_MAX_ITEM_SIZE);
+  }
+
+  @Override
+  protected int maxKeyListEntitySize() {
+    return Math.min(config.getMaxKeyListEntitySize(), DYNAMO_MAX_KEY_LIST_ENTITY_SIZE);
   }
 
   @Override

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -91,11 +91,6 @@ public class DynamoDatabaseAdapter
   // DynamoDB limit
   private static final int DYNAMO_BATCH_WRITE_MAX_REQUESTS = 25;
   private static final int DYNAMO_MAX_ITEM_SIZE = 375 * 1024;
-  /**
-   * Have to restrict the "target" size for key-list-entities, because hash-bucketing can
-   * "overshoot" by a lot.
-   */
-  private static final int DYNAMO_MAX_KEY_LIST_ENTITY_SIZE = 100 * 1024;
 
   private static final char PREFIX_SEPARATOR = ':';
   private final DynamoDatabaseClient client;
@@ -624,11 +619,6 @@ public class DynamoDatabaseAdapter
   @Override
   protected int maxEntitySize(int value) {
     return Math.min(value, DYNAMO_MAX_ITEM_SIZE);
-  }
-
-  @Override
-  protected int maxKeyListEntitySize() {
-    return Math.min(config.getMaxKeyListEntitySize(), DYNAMO_MAX_KEY_LIST_ENTITY_SIZE);
   }
 
   @Override

--- a/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDatabaseAdapterDynamo.java
+++ b/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDatabaseAdapterDynamo.java
@@ -84,6 +84,7 @@ public class ITDatabaseAdapterDynamo extends AbstractNonTxDatabaseAdapterTest
               0,
               KeyList.of(Collections.emptyList()),
               Collections.emptyList(),
+              Collections.emptyList(),
               Collections.emptyList());
       implDatabaseAdapter().doWriteIndividualCommit(ctx, commit);
       branchCommits.add(commitId);

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -43,7 +43,7 @@ message CommitLogEntry {
 // See CommitLogEntry.KeyListVariant
 enum KeyListVariant {
   EMBEDDED_AND_EXTERNAL_MRU = 0;
-  SORTED_AND_HASHED = 1;
+  HASHED_AND_SORTED = 1;
 }
 
 message Key {

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -43,7 +43,7 @@ message CommitLogEntry {
   // Open-addressing bucket offsets. Same number of elements as key_list_ids.
   repeated int32 key_list_entity_offsets = 13;
   optional float key_list_load_factor = 14;
-  optional int32 key_list_bucket_count = 15;
+  optional int32 key_list_segment_count = 15;
 }
 
 // See CommitLogEntry.KeyListVariant

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -37,13 +37,19 @@ message CommitLogEntry {
   // additional parents, yet - but implementing this as a list for N-way
   // merges in the future.
   repeated bytes additional_parents = 11;
+  // Since Nessie 0.31.0 - the way in which key-lists are persisted, both
+  // embedded (in key_list) and externally (via key_list_ids).
   optional KeyListVariant key_list_variant = 12;
+  // Open-addressing bucket offsets. Same number of elements as key_list_ids.
+  repeated int32 key_list_entity_offsets = 13;
+  optional float key_list_load_factor = 14;
+  optional int32 key_list_bucket_count = 15;
 }
 
 // See CommitLogEntry.KeyListVariant
 enum KeyListVariant {
   EMBEDDED_AND_EXTERNAL_MRU = 0;
-  HASHED_AND_SORTED = 1;
+  OPEN_ADDRESSING = 1;
 }
 
 message Key {

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -37,6 +37,13 @@ message CommitLogEntry {
   // additional parents, yet - but implementing this as a list for N-way
   // merges in the future.
   repeated bytes additional_parents = 11;
+  optional KeyListVariant key_list_variant = 12;
+}
+
+// See CommitLogEntry.KeyListVariant
+enum KeyListVariant {
+  EMBEDDED_AND_EXTERNAL_MRU = 0;
+  SORTED_AND_HASHED = 1;
 }
 
 message Key {

--- a/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
+++ b/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
@@ -105,7 +105,7 @@ public final class ProtoSerialization {
     }
     if (entry.getKeyListLoadFactor() != null) {
       proto.setKeyListLoadFactor(entry.getKeyListLoadFactor());
-      proto.setKeyListBucketCount(entry.getKeyListBucketCount());
+      proto.setKeyListSegmentCount(entry.getKeyListSegmentCount());
     }
     entry.getAdditionalParents().forEach(p -> proto.addAdditionalParents(p.asBytes()));
 
@@ -172,7 +172,7 @@ public final class ProtoSerialization {
     proto.getAdditionalParentsList().forEach(p -> entry.addAdditionalParents(Hash.of(p)));
     if (proto.hasKeyListLoadFactor()) {
       entry.keyListLoadFactor(proto.getKeyListLoadFactor());
-      entry.keyListBucketCount(proto.getKeyListBucketCount());
+      entry.keyListSegmentCount(proto.getKeyListSegmentCount());
     }
 
     return entry.build();

--- a/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
+++ b/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
@@ -100,6 +100,13 @@ public final class ProtoSerialization {
       entry.getKeyList().getKeys().forEach(k -> proto.addKeyList(toProto(k)));
     }
     entry.getKeyListsIds().forEach(k -> proto.addKeyListIds(k.asBytes()));
+    if (entry.getKeyListEntityOffsets() != null) {
+      proto.addAllKeyListEntityOffsets(entry.getKeyListEntityOffsets());
+    }
+    if (entry.getKeyListLoadFactor() != null) {
+      proto.setKeyListLoadFactor(entry.getKeyListLoadFactor());
+      proto.setKeyListBucketCount(entry.getKeyListBucketCount());
+    }
     entry.getAdditionalParents().forEach(p -> proto.addAdditionalParents(p.asBytes()));
 
     return proto.build();
@@ -161,7 +168,12 @@ public final class ProtoSerialization {
       entry.keyList(KeyList.EMPTY);
     }
     proto.getKeyListIdsList().forEach(p -> entry.addKeyListsIds(Hash.of(p)));
+    entry.addAllKeyListEntityOffsets(proto.getKeyListEntityOffsetsList());
     proto.getAdditionalParentsList().forEach(p -> entry.addAdditionalParents(Hash.of(p)));
+    if (proto.hasKeyListLoadFactor()) {
+      entry.keyListLoadFactor(proto.getKeyListLoadFactor());
+      entry.keyListBucketCount(proto.getKeyListBucketCount());
+    }
 
     return entry.build();
   }
@@ -240,6 +252,9 @@ public final class ProtoSerialization {
   }
 
   public static AdapterTypes.KeyListEntry toProto(KeyListEntry x) {
+    if (x == null) {
+      return AdapterTypes.KeyListEntry.getDefaultInstance();
+    }
     AdapterTypes.KeyListEntry.Builder builder =
         AdapterTypes.KeyListEntry.newBuilder()
             .setKey(keyToProto(x.getKey()))
@@ -252,6 +267,9 @@ public final class ProtoSerialization {
   }
 
   public static KeyListEntry protoToKeyListEntry(AdapterTypes.KeyListEntry proto) {
+    if (!proto.hasKey()) {
+      return null;
+    }
     return KeyListEntry.of(
         protoToKey(proto.getKey()),
         ContentId.of(proto.getContentId().getId()),

--- a/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/adapter/serialize/TestSerialization.java
+++ b/versioned/persist/serialize/src/test/java/org/projectnessie/versioned/persist/adapter/serialize/TestSerialization.java
@@ -448,6 +448,9 @@ class TestSerialization {
         IntStream.range(0, ThreadLocalRandom.current().nextInt(20))
             .mapToObj(i -> randomHash())
             .collect(Collectors.toList()),
+        IntStream.range(0, ThreadLocalRandom.current().nextInt(20))
+            .mapToObj(i -> (int) randomLong())
+            .collect(Collectors.toList()),
         IntStream.range(0, ThreadLocalRandom.current().nextInt(3))
             .mapToObj(i -> randomHash())
             .collect(Collectors.toList()));

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -222,6 +223,7 @@ public abstract class AbstractManyKeys {
                             e.getId(),
                             KeyList.of(
                                 e.getKeys().getKeys().stream()
+                                    .filter(Objects::nonNull)
                                     .map(
                                         k ->
                                             KeyListEntry.of(
@@ -273,6 +275,7 @@ public abstract class AbstractManyKeys {
             .allSatisfy(
                 kl ->
                     assertThat(kl.getKeys().getKeys())
+                        .filteredOn(Objects::nonNull)
                         .allSatisfy(
                             e ->
                                 assertThat(e)


### PR DESCRIPTION
Refactors key-lists handling in `CommitLogEntry`.

The `KeyListEntry`s in the key-list(s) in `CommitLogEntry` are currently organized by "least recently updated keys first", which degrades read performance with many keys per reference.

This PR re-organizes the keys using an open-addressing hash-map, with the content's `Key` as the open-addressing hash-map's key. The whole open-addressing hash-map is split into multiple segments: the first segment is the "embedded" key-list inside `CommitLogEntry`, with additional segments as `KeyListEntity`s. This allows effective point-queries, both to only fetch the required `KeyListEntry` and within the `KeyListEntry`.