### PR TITLE
versioned/spi: remove `Collator` in `Key` 

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -520,7 +520,9 @@ public abstract class AbstractDatabaseAdapter<
               "The following keys have been changed in conflict: %s",
               result.getDetails().entrySet().stream()
                   .filter(e -> e.getValue().getConflictType() != ConflictType.NONE)
-                  .map(e -> String.format("'%s'", e.getKey()))
+                  .map(Map.Entry::getKey)
+                  .sorted()
+                  .map(key -> String.format("'%s'", key))
                   .collect(Collectors.joining(", "))),
           result);
     }

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestKey.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestKey.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestKey {
+  @ParameterizedTest
+  @MethodSource("compare")
+  void compare(Key a, Key b, int expectedCompare) {
+    AbstractIntegerAssert<?> ass =
+        assertThat(a)
+            .describedAs("Compare of %s to %s expect %d", a, b, expectedCompare)
+            .extracting(k -> k.compareTo(b))
+            .asInstanceOf(INTEGER);
+    if (expectedCompare < 0) {
+      ass.isNegative();
+    } else if (expectedCompare > 0) {
+      ass.isPositive();
+    } else {
+      ass.isZero();
+    }
+  }
+
+  static Stream<Arguments> compare() {
+    return Stream.of(
+        arguments(Key.of(), Key.of(), 0),
+        arguments(Key.of(), Key.of(""), -1),
+        arguments(Key.of(""), Key.of(), 1),
+        arguments(Key.of(), Key.of("abcdef"), -1),
+        arguments(Key.of("abcdef"), Key.of(), 1),
+        arguments(Key.of("abcdef"), Key.of("0123", "123", "123"), 1),
+        arguments(Key.of("abcdef", "abc", "abc"), Key.of("0123"), 1),
+        arguments(Key.of(), Key.of("0123", "123", "123"), -1),
+        arguments(Key.of("abcdef", "abc", "abc"), Key.of(), 1),
+        arguments(Key.of("key.0"), Key.of("key.1"), -1),
+        arguments(Key.of("key.1"), Key.of("key.0"), 1),
+        arguments(Key.of("key.42"), Key.of("key.42"), 0),
+        arguments(Key.of("key", "0"), Key.of("key", "1"), -1),
+        arguments(Key.of("key", "1"), Key.of("key", "0"), 1),
+        arguments(Key.of("key", "42"), Key.of("key", "42"), 0));
+  }
+}

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestKey.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestKey.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.stream.Stream;
-import org.assertj.core.api.AbstractIntegerAssert;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,18 +28,11 @@ public class TestKey {
   @ParameterizedTest
   @MethodSource("compare")
   void compare(Key a, Key b, int expectedCompare) {
-    AbstractIntegerAssert<?> ass =
-        assertThat(a)
-            .describedAs("Compare of %s to %s expect %d", a, b, expectedCompare)
-            .extracting(k -> k.compareTo(b))
-            .asInstanceOf(INTEGER);
-    if (expectedCompare < 0) {
-      ass.isNegative();
-    } else if (expectedCompare > 0) {
-      ass.isPositive();
-    } else {
-      ass.isZero();
-    }
+    assertThat(a)
+        .describedAs("Compare of %s to %s expect %d", a, b, expectedCompare)
+        .extracting(k -> Integer.signum(k.compareTo(b)))
+        .asInstanceOf(INTEGER)
+        .isEqualTo(expectedCompare);
   }
 
   static Stream<Arguments> compare() {


### PR DESCRIPTION
`java.text.Collator` is nice when working with real text, but content
keys are not "real text" (with for example german umlauts, french
accents, etc).

`Collator` is used in `org.projectnessie.versioned.Key` for all kinds
of preformance critical operations like `equals()`, `hashCode()` and
`compareTo()`.

Expecially #4536 suffered due to the use of `Collator`, which became
obvious in the test case `TestKeyListBuildState#manyBuckets`, because
it was super slow and a flame graph immediately pointed to the use
of `Collator`. A single iteration of that test takes ~2ms locally
in IntelliJ without `Collator`, but 70ms with `Collator` for 500 `Key`s.

(The change in AbstractDatabaseAdapter is rather a nice-to-have and
a unit test fix.)
