### PR TITLE
Rename ITDynamoDatabaseAdapter to ITDatabaseAdapterDynamo

### DIFF
--- a/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDatabaseAdapterDynamo.java
+++ b/versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDatabaseAdapterDynamo.java
@@ -40,7 +40,7 @@ import org.projectnessie.versioned.persist.tests.LongerCommitTimeouts;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
 @NessieExternalDatabase(LocalDynamoTestConnectionProviderSource.class)
-public class ITDynamoDatabaseAdapter extends AbstractNonTxDatabaseAdapterTest
+public class ITDatabaseAdapterDynamo extends AbstractNonTxDatabaseAdapterTest
     implements LongerCommitTimeouts {
 
   protected DynamoDatabaseAdapter implDatabaseAdapter() {


### PR DESCRIPTION
```
This follows the naming convention of all other tests
```

currently on main:
```
~/code/nessie$ find . -name '*.java' | rg 'DatabaseAdapter' | rg 'IT|Test'
./versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterVersionStoreTest.java
./versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
./versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITDatabaseAdapterCockroach.java
./versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/postgres/ITDatabaseAdapterPostgres.java
./versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/h2/TestDatabaseAdapterH2.java
./versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/TestDatabaseAdapterInmemory.java
./versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestDatabaseAdapterUtil.java
./versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/ITDatabaseAdapterMongo.java
./versioned/persist/rocks/src/test/java/org/projectnessie/versioned/persist/rocks/ITDatabaseAdapterRocks.java
./versioned/persist/nontx/src/test/java/org/projectnessie/versioned/persist/nontx/AbstractNonTxDatabaseAdapterTest.java
./versioned/persist/dynamodb/src/test/java/org/projectnessie/versioned/persist/dynamodb/ITDynamoDatabaseAdapter.java
```