### PR TITLE
Fix build of the Nessie Docker image

### DIFF
--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -141,6 +141,7 @@ val quarkusBuild =
       System.setProperty("quarkus.native.builder-image", dependencyVersion("quarkus.builder-image"))
       if (useDocker) {
         System.setProperty("quarkus.native.container-build", "true")
+        System.setProperty("quarkus.container-image.build", "true")
       }
     }
   }


### PR DESCRIPTION
Quarkus didn't create the Docker image, that's now enabled with the `quarkus.container-image.build` property.