### PR TITLE
Suppress maven progress output in build-tools ITs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -255,7 +255,7 @@ val buildToolIntegrationMaven by
       "Checks whether the bom works fine with Maven, requires preceding publishToMavenLocal in a separate Gradle invocation"
 
     workingDir = file("build-tools-integration-tests")
-    commandLine("./mvnw", "clean", "test", "-Dnessie.version=${project.version}")
+    commandLine("./mvnw", "--batch-mode", "clean", "test", "-Dnessie.version=${project.version}")
   }
 
 val buildToolsIntegrationTest by


### PR DESCRIPTION
currently CI logs are spammed like this:
```
2022-06-24T07:19:46.1024068Z Downloaded from central: https://repo.maven.apache.org/maven2/org/objenesis/objenesis/3.2/objenesis-3.2.jar (49 kB at 127 kB/s)
2022-06-24T07:19:46.1024976Z Downloading from central: https://repo.maven.apache.org/maven2/org/agrona/agrona/1.15.2/agrona-1.15.2.jar
2022-06-24T07:19:46.1025361Z Progress (4): 2.8/3.0 MB | 1.7 MB | 638/663 kB | 0.7/3.8 MB
2022-06-24T07:19:46.1025730Z Progress (4): 2.8/3.0 MB | 1.7 MB | 643/663 kB | 0.7/3.8 MB
2022-06-24T07:19:46.1026075Z Progress (4): 2.8/3.0 MB | 1.7 MB | 647/663 kB | 0.7/3.8 MB
2022-06-24T07:19:46.1026429Z Progress (4): 2.8/3.0 MB | 1.7 MB | 651/663 kB | 0.7/3.8 MB
(...)
```