### PR TITLE
Limit key length and number of key elements

### DIFF
--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Key.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Key.java
@@ -15,11 +15,18 @@
  */
 package org.projectnessie.versioned;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
-@Immutable
+@Value.Immutable
 public abstract class Key implements Comparable<Key> {
+
+  /** Maximum number of characters in a key. Note: characters can take up to 3 bytes via UTF-8. */
+  public static final int MAX_LENGTH = 500;
+
+  /** Maximum number of elemengts. */
+  public static final int MAX_ELEMENTS = 20;
 
   public abstract List<String> getElements();
 
@@ -70,6 +77,18 @@ public abstract class Key implements Comparable<Key> {
 
   public static Key of(List<String> elements) {
     return ImmutableKey.builder().addAllElements(elements).build();
+  }
+
+  @Value.Check
+  protected void check() {
+    Preconditions.checkState(
+        getElements().stream().mapToInt(String::length).sum() <= MAX_LENGTH,
+        "Key too long, max allowed length: %s",
+        MAX_LENGTH);
+    Preconditions.checkState(
+        getElements().size() <= MAX_ELEMENTS,
+        "Key too long, max allowed number of elements: %s",
+        MAX_ELEMENTS);
   }
 
   @Override

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestKey.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestKey.java
@@ -15,16 +15,82 @@
  */
 package org.projectnessie.versioned;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestKey {
+
+  static final String STRING_100 =
+      "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+
+  @ParameterizedTest
+  @MethodSource("keyLengthGood")
+  void keyLengthGood(List<String> elements) {
+    Key.of(elements);
+  }
+
+  static Stream<Arguments> keyLengthGood() {
+    return Stream.of(
+        arguments(emptyList()),
+        arguments(singletonList("")),
+        arguments(singletonList(STRING_100)),
+        arguments(singletonList(STRING_100 + STRING_100 + STRING_100 + STRING_100 + STRING_100)),
+        arguments(asList(STRING_100, STRING_100)),
+        arguments(asList(STRING_100, STRING_100, STRING_100)),
+        arguments(asList(STRING_100, STRING_100, STRING_100, STRING_100)),
+        arguments(asList(STRING_100, STRING_100, STRING_100, STRING_100, STRING_100)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("keyTooLong")
+  void keyTooLong(List<String> elements) {
+    assertThatThrownBy(() -> Key.of(elements))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Key too long, max allowed length: " + Key.MAX_LENGTH);
+  }
+
+  static Stream<Arguments> keyTooLong() {
+    return Stream.of(
+        arguments(
+            singletonList(STRING_100 + STRING_100 + STRING_100 + STRING_100 + STRING_100 + "x")),
+        arguments(
+            singletonList(
+                STRING_100 + STRING_100 + STRING_100 + STRING_100 + STRING_100 + STRING_100)),
+        arguments(asList(STRING_100, STRING_100, STRING_100, STRING_100, STRING_100, "x")),
+        arguments(asList("x", STRING_100, STRING_100, STRING_100, STRING_100, STRING_100)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 2, 5, 15, 19, 20})
+  void keyElementsGood(int elements) {
+    Key.of(IntStream.range(0, elements).mapToObj(i -> "foo").collect(Collectors.toList()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {21, 55, 100})
+  void keyTooManyElements(int elements) {
+    assertThatThrownBy(
+            () ->
+                Key.of(
+                    IntStream.range(0, elements).mapToObj(i -> "foo").collect(Collectors.toList())))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Key too long, max allowed number of elements: " + Key.MAX_ELEMENTS);
+  }
+
   @ParameterizedTest
   @MethodSource("compare")
   void compare(Key a, Key b, int expectedCompare) {


### PR DESCRIPTION
Key length limit: max 500 characters
Key element limit: max 20 elements

Fixes #4550