### PR TITLE
Let Nessie Spark-SQL extensions test against in-tree Nessie server version

### DIFF
--- a/clients/spark-3.2-extensions/build.gradle.kts
+++ b/clients/spark-3.2-extensions/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-  nessieQuarkusServer("org.projectnessie:nessie-quarkus:$clientNessieVersion:runner")
+  nessieQuarkusServer(project(":nessie-quarkus", "quarkusRunner"))
 }
 
 nessieQuarkusApp {

--- a/clients/spark-extensions-base/build.gradle.kts
+++ b/clients/spark-extensions-base/build.gradle.kts
@@ -49,4 +49,5 @@ dependencies {
   testImplementation("org.assertj:assertj-core")
   testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/clients/spark-extensions-base/build.gradle.kts
+++ b/clients/spark-extensions-base/build.gradle.kts
@@ -39,8 +39,12 @@ dependencies {
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
   testImplementation(platform(rootProject))
+  testAnnotationProcessor(platform(rootProject))
   testImplementation("org.apache.spark:spark-sql_2.12") { forSpark(sparkVersion) }
   testImplementation("org.eclipse.microprofile.openapi:microprofile-openapi-api")
+
+  testCompileOnly("org.immutables:value-annotations")
+  testAnnotationProcessor("org.immutables:value-processor")
 
   testImplementation("org.assertj:assertj-core")
   testImplementation(platform("org.junit:junit-bom"))

--- a/clients/spark-extensions-base/src/test/java/org/projectnessie/spark/extensions/SparkCommitLogEntry.java
+++ b/clients/spark-extensions-base/src/test/java/org/projectnessie/spark/extensions/SparkCommitLogEntry.java
@@ -84,25 +84,25 @@ abstract class SparkCommitLogEntry {
   SparkCommitLogEntry relevantFromMerge() {
     return ImmutableSparkCommitLogEntry.builder()
         .hash(getHash())
-        .putAllProperties(removeInternalProperties(getProperties()))
+        .putAllProperties(withoutInternalProperties(getProperties()))
         .build();
   }
 
-  SparkCommitLogEntry mergedCommits(SparkCommitLogEntry b) {
+  SparkCommitLogEntry mergedCommits(SparkCommitLogEntry other) {
     Map<String, String> mergedCommitProperties = new HashMap<>();
     mergedCommitProperties.putAll(this.getProperties());
-    mergedCommitProperties.putAll(b.getProperties());
+    mergedCommitProperties.putAll(other.getProperties());
     return ImmutableSparkCommitLogEntry.builder()
-        .from(b)
+        .from(other)
         .message(
-            b.getMessage()
+            other.getMessage()
                 + "\n---------------------------------------------\n"
                 + this.getMessage())
         .properties(mergedCommitProperties)
         .build();
   }
 
-  private static Map<String, String> removeInternalProperties(Map<String, String> properties) {
+  private static Map<String, String> withoutInternalProperties(Map<String, String> properties) {
     return properties.entrySet().stream()
         .filter(e -> !e.getKey().startsWith("_"))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/clients/spark-extensions-base/src/test/java/org/projectnessie/spark/extensions/SparkCommitLogEntry.java
+++ b/clients/spark-extensions-base/src/test/java/org/projectnessie/spark/extensions/SparkCommitLogEntry.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.spark.extensions;
+
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+import org.projectnessie.model.CommitMeta;
+
+/** Somewhat simplified Nessie commit log entry used by Spark-SQL extensions tests. */
+@Value.Immutable
+abstract class SparkCommitLogEntry {
+
+  @Value.Default
+  String getAuthor() {
+    return "";
+  }
+
+  @Value.Default
+  String getCommitter() {
+    return "";
+  }
+
+  @Nullable
+  abstract String getHash();
+
+  @Nullable
+  abstract String getMessage();
+
+  @Value.Default
+  String getSignedOffBy() {
+    return "";
+  }
+
+  @Nullable
+  abstract Timestamp getAuthorTime();
+
+  @Nullable
+  abstract Timestamp getCommitTime();
+
+  abstract Map<String, String> getProperties();
+
+  @SuppressWarnings("unchecked")
+  static SparkCommitLogEntry fromShowLog(Object[] row) {
+    return ImmutableSparkCommitLogEntry.builder()
+        .author((String) row[0])
+        .committer((String) row[1])
+        .hash((String) row[2])
+        .message((String) row[3])
+        .signedOffBy((String) row[4])
+        .authorTime((Timestamp) row[5])
+        // commit-time omitted
+        .properties((Map<String, String>) row[7])
+        .build();
+  }
+
+  static SparkCommitLogEntry fromCommitMeta(CommitMeta cm, String hash) {
+    return ImmutableSparkCommitLogEntry.builder()
+        .author(cm.getAuthor())
+        .hash(hash)
+        .message(cm.getMessage())
+        .authorTime(cm.getAuthorTime() == null ? null : Timestamp.from(cm.getAuthorTime()))
+        .commitTime(cm.getCommitTime() == null ? null : Timestamp.from(cm.getCommitTime()))
+        .properties(cm.getProperties())
+        .build();
+  }
+
+  SparkCommitLogEntry relevantFromMerge() {
+    return ImmutableSparkCommitLogEntry.builder()
+        .hash(getHash())
+        .putAllProperties(removeInternalProperties(getProperties()))
+        .build();
+  }
+
+  SparkCommitLogEntry mergedCommits(SparkCommitLogEntry b) {
+    Map<String, String> mergedCommitProperties = new HashMap<>();
+    mergedCommitProperties.putAll(this.getProperties());
+    mergedCommitProperties.putAll(b.getProperties());
+    return ImmutableSparkCommitLogEntry.builder()
+        .from(b)
+        .message(
+            b.getMessage()
+                + "\n---------------------------------------------\n"
+                + this.getMessage())
+        .properties(mergedCommitProperties)
+        .build();
+  }
+
+  private static Map<String, String> removeInternalProperties(Map<String, String> properties) {
+    return properties.entrySet().stream()
+        .filter(e -> !e.getKey().startsWith("_"))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  SparkCommitLogEntry withoutHashAndTime() {
+    return ImmutableSparkCommitLogEntry.builder()
+        .from(this)
+        .hash(null)
+        .commitTime(null)
+        .authorTime(null)
+        .build();
+  }
+}

--- a/clients/spark-extensions/build.gradle.kts
+++ b/clients/spark-extensions/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-  nessieQuarkusServer("org.projectnessie:nessie-quarkus:$clientNessieVersion:runner")
+  nessieQuarkusServer(project(":nessie-quarkus", "quarkusRunner"))
 }
 
 nessieQuarkusApp {


### PR DESCRIPTION
Test changes:
* adopt to "squash-merge" behavior
* reset default branch after each test