### PR TITLE
Use isort instead of flake8-import-order

### DIFF
--- a/python/pynessie/auth/config.py
+++ b/python/pynessie/auth/config.py
@@ -19,8 +19,7 @@
 from typing import Optional
 
 from confuse import Configuration
-from requests.auth import AuthBase
-from requests.auth import HTTPBasicAuth
+from requests.auth import AuthBase, HTTPBasicAuth
 
 from .aws import setup_aws_auth
 from .bearer import TokenAuth as BearerTokenAuth

--- a/python/pynessie/cli.py
+++ b/python/pynessie/cli.py
@@ -24,16 +24,18 @@ import confuse
 from . import __version__
 from .cli_common_context import ContextObject
 from .client import NessieClient
-from .commands import branch_
-from .commands import cherry_pick
-from .commands import config
-from .commands import content
-from .commands import diff
-from .commands import log
-from .commands import merge
-from .commands import reflog
-from .commands import remote
-from .commands import tag
+from .commands import (
+    branch_,
+    cherry_pick,
+    config,
+    content,
+    diff,
+    log,
+    merge,
+    reflog,
+    remote,
+    tag,
+)
 from .conf import build_config
 
 

--- a/python/pynessie/cli_common_context.py
+++ b/python/pynessie/cli_common_context.py
@@ -16,16 +16,11 @@
 #
 
 """Cli Common context functions that can be used by CLI commands/groups."""
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Mapping
-from typing import Tuple
+from typing import Any, Dict, List, Mapping, Tuple
 
 import attr
 import click
-from click import Option
-from click import UsageError
+from click import Option, UsageError
 
 from .client import NessieClient
 

--- a/python/pynessie/client/_endpoints.py
+++ b/python/pynessie/client/_endpoints.py
@@ -17,10 +17,7 @@
 
 """Direct API operations on Nessie with requests."""
 
-from typing import Any
-from typing import cast
-from typing import Optional
-from typing import Union
+from typing import Any, Optional, Union, cast
 
 import requests
 import simplejson as jsonlib

--- a/python/pynessie/client/nessie_client.py
+++ b/python/pynessie/client/nessie_client.py
@@ -16,60 +16,61 @@
 #
 """Main module."""
 
-from typing import Any
-from typing import cast
-from typing import Generator
-from typing import Optional
+from typing import Any, Generator, Optional, cast
 
 import confuse
 
-from ._endpoints import all_references
-from ._endpoints import assign_branch
-from ._endpoints import assign_tag
-from ._endpoints import cherry_pick
-from ._endpoints import commit
-from ._endpoints import create_reference
-from ._endpoints import delete_branch
-from ._endpoints import delete_tag
-from ._endpoints import get_content
-from ._endpoints import get_default_branch
-from ._endpoints import get_diff
-from ._endpoints import get_reference
-from ._endpoints import list_logs
-from ._endpoints import list_reflog
-from ._endpoints import list_tables
-from ._endpoints import merge
 from ..auth import setup_auth
-from ..model import Branch
-from ..model import CommitMeta
-from ..model import Content
-from ..model import ContentKey
-from ..model import ContentSchema
-from ..model import Detached
-from ..model import DETACHED_REFERENCE_NAME
-from ..model import DiffResponse
-from ..model import DiffResponseSchema
-from ..model import Entries
-from ..model import EntriesSchema
-from ..model import LogEntry
-from ..model import LogResponse
-from ..model import LogResponseSchema
-from ..model import Merge
-from ..model import MergeSchema
-from ..model import MultiContents
-from ..model import MultiContentSchema
-from ..model import Operation
-from ..model import Reference
-from ..model import ReferenceSchema
-from ..model import ReferencesResponse
-from ..model import ReferencesResponseSchema
-from ..model import ReflogEntry
-from ..model import ReflogResponse
-from ..model import ReflogResponseSchema
-from ..model import split_into_reference_and_hash
-from ..model import Tag
-from ..model import Transplant
-from ..model import TransplantSchema
+from ..model import (
+    DETACHED_REFERENCE_NAME,
+    Branch,
+    CommitMeta,
+    Content,
+    ContentKey,
+    ContentSchema,
+    Detached,
+    DiffResponse,
+    DiffResponseSchema,
+    Entries,
+    EntriesSchema,
+    LogEntry,
+    LogResponse,
+    LogResponseSchema,
+    Merge,
+    MergeSchema,
+    MultiContents,
+    MultiContentSchema,
+    Operation,
+    Reference,
+    ReferenceSchema,
+    ReferencesResponse,
+    ReferencesResponseSchema,
+    ReflogEntry,
+    ReflogResponse,
+    ReflogResponseSchema,
+    Tag,
+    Transplant,
+    TransplantSchema,
+    split_into_reference_and_hash,
+)
+from ._endpoints import (
+    all_references,
+    assign_branch,
+    assign_tag,
+    cherry_pick,
+    commit,
+    create_reference,
+    delete_branch,
+    delete_tag,
+    get_content,
+    get_default_branch,
+    get_diff,
+    get_reference,
+    list_logs,
+    list_reflog,
+    list_tables,
+    merge,
+)
 
 
 class NessieClient:

--- a/python/pynessie/commands/_branch_tag_handlers.py
+++ b/python/pynessie/commands/_branch_tag_handlers.py
@@ -23,7 +23,7 @@ import click
 
 from ..client import NessieClient
 from ..error import NessieConflictException
-from ..model import Branch, ReferenceSchema, split_into_reference_and_hash, Tag
+from ..model import Branch, ReferenceSchema, Tag, split_into_reference_and_hash
 
 
 def handle_branch_tag(

--- a/python/pynessie/commands/branch.py
+++ b/python/pynessie/commands/branch.py
@@ -19,9 +19,9 @@
 
 import click
 
-from ._branch_tag_handlers import handle_branch_tag
 from ..cli_common_context import ContextObject, MutuallyExclusiveOption
 from ..decorators import error_handler, pass_client
+from ._branch_tag_handlers import handle_branch_tag
 
 
 @click.command(name="branch")

--- a/python/pynessie/commands/content/__init__.py
+++ b/python/pynessie/commands/content/__init__.py
@@ -19,11 +19,11 @@
 
 import click
 
+from ...cli_common_context import ContextObject
+from ...decorators import pass_client
 from .commit import commit
 from .list_ import list_
 from .view import view
-from ...cli_common_context import ContextObject
-from ...decorators import pass_client
 
 
 @click.group(name="content")

--- a/python/pynessie/commands/content/view.py
+++ b/python/pynessie/commands/content/view.py
@@ -21,6 +21,7 @@ from typing import List
 import click
 
 from pynessie.types import CONTENT_KEY
+
 from ... import NessieClient
 from ...cli_common_context import ContextObject
 from ...decorators import error_handler, pass_client, validate_reference

--- a/python/pynessie/commands/log.py
+++ b/python/pynessie/commands/log.py
@@ -18,17 +18,19 @@
 """log CLI command."""
 
 import datetime
-from typing import Any
-from typing import List
-from typing import Optional
-from typing import Tuple
+from typing import Any, List, Optional, Tuple
 
 import click
 from dateutil.tz import tzlocal
 
 from ..cli_common_context import ContextObject, MutuallyExclusiveOption
 from ..decorators import error_handler, pass_client, validate_reference
-from ..model import CommitMetaSchema, LogEntry, LogEntrySchema, split_into_reference_and_hash
+from ..model import (
+    CommitMetaSchema,
+    LogEntry,
+    LogEntrySchema,
+    split_into_reference_and_hash,
+)
 from ..utils import build_filter_for_commit_log_flags
 
 

--- a/python/pynessie/commands/tag.py
+++ b/python/pynessie/commands/tag.py
@@ -19,9 +19,9 @@
 
 import click
 
-from ._branch_tag_handlers import handle_branch_tag
 from ..cli_common_context import ContextObject, MutuallyExclusiveOption
 from ..decorators import error_handler, pass_client
+from ._branch_tag_handlers import handle_branch_tag
 
 
 @click.command("tag")

--- a/python/pynessie/conf/config_command.py
+++ b/python/pynessie/conf/config_command.py
@@ -15,9 +15,7 @@
 # limitations under the License.
 #
 """Execute config command from cli."""
-from typing import cast
-from typing import Optional
-from typing import Union
+from typing import Optional, Union, cast
 
 import click
 import confuse

--- a/python/pynessie/decorators.py
+++ b/python/pynessie/decorators.py
@@ -26,7 +26,6 @@ from marshmallow import ValidationError
 from .cli_common_context import ContextObject
 from .error import NessieCliError, NessieException
 
-
 # Decorator to pass Nessie client down into Click sub-commands.
 pass_client = click.make_pass_decorator(ContextObject)
 

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -24,7 +24,6 @@ import desert
 from marshmallow import fields
 from marshmallow_oneofschema import OneOfSchema
 
-
 # regex taken from org.projectnessie.model.Validation
 __RE_REFERENCE_NAME_RAW = "[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9._-])"
 __RE_REFERENCE_NAME: re.Pattern = re.compile(f"^{__RE_REFERENCE_NAME_RAW}$")

--- a/python/pynessie/utils/__init__.py
+++ b/python/pynessie/utils/__init__.py
@@ -17,9 +17,11 @@
 
 """Top-level package for Utility module."""
 
-from .expression_util import build_filter_for_commit_log_flags
-from .expression_util import build_filter_for_contents_listing_flags
-from .expression_util import parse_to_iso8601
+from .expression_util import (
+    build_filter_for_commit_log_flags,
+    build_filter_for_contents_listing_flags,
+    parse_to_iso8601,
+)
 
 __all__ = [
     "build_filter_for_commit_log_flags",

--- a/python/requirements_lint.txt
+++ b/python/requirements_lint.txt
@@ -21,7 +21,8 @@ flake8-bandit==3.0.0
 flake8-black==0.3.3
 flake8-bugbear==22.7.1
 flake8-docstrings==1.6.0
-flake8-import-order==0.18.1
+flake8-isort==4.1.1
+isort==5.10.1
 pytest-mypy==0.9.1
 safety==2.0.0
 pylint==2.14.4

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -26,3 +26,6 @@ docstring-convention = google
 
 [aliases]
 test = pytest
+
+[isort]
+profile=black

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -19,15 +19,13 @@
 import os
 import shutil
 import tempfile
-from typing import Any, List
-from typing import Optional
+from typing import Any, List, Optional
 
 import attr
 import pytest
 import simplejson
 from assertpy import assert_that
-from click.testing import CliRunner
-from click.testing import Result
+from click.testing import CliRunner, Result
 from vcr.config import VCR
 from vcr.request import Request
 from vcr.serializers import yamlserializer

--- a/python/tests/test_expression_util.py
+++ b/python/tests/test_expression_util.py
@@ -16,9 +16,11 @@
 
 from assertpy import assert_that
 
-from pynessie.utils import build_filter_for_commit_log_flags
-from pynessie.utils import build_filter_for_contents_listing_flags
-from pynessie.utils import parse_to_iso8601
+from pynessie.utils import (
+    build_filter_for_commit_log_flags,
+    build_filter_for_contents_listing_flags,
+    parse_to_iso8601,
+)
 
 
 def test_building_empty_filter() -> None:

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -25,20 +25,28 @@ import simplejson
 from assertpy import assert_that
 
 from pynessie import __version__
-from pynessie.model import Branch
-from pynessie.model import CommitMeta
-from pynessie.model import CommitMetaSchema
-from pynessie.model import ContentKey
-from pynessie.model import ContentSchema
-from pynessie.model import DiffResponseSchema
-from pynessie.model import EntrySchema
-from pynessie.model import IcebergTable
-from pynessie.model import LogEntry
-from pynessie.model import LogEntrySchema
-from pynessie.model import ReferenceSchema
-from pynessie.model import ReflogEntry
-from pynessie.model import ReflogEntrySchema
-from .conftest import execute_cli_command, execute_cli_command_raw, make_commit, ref_hash
+from pynessie.model import (
+    Branch,
+    CommitMeta,
+    CommitMetaSchema,
+    ContentKey,
+    ContentSchema,
+    DiffResponseSchema,
+    EntrySchema,
+    IcebergTable,
+    LogEntry,
+    LogEntrySchema,
+    ReferenceSchema,
+    ReflogEntry,
+    ReflogEntrySchema,
+)
+
+from .conftest import (
+    execute_cli_command,
+    execute_cli_command_raw,
+    make_commit,
+    ref_hash,
+)
 
 
 @pytest.mark.vcr

--- a/python/tests/test_nessie_cli_content.py
+++ b/python/tests/test_nessie_cli_content.py
@@ -18,9 +18,16 @@ import pytest
 import simplejson
 from assertpy import assert_that
 
-from pynessie.model import ContentSchema, DeltaLakeTable, EntrySchema, IcebergTable, IcebergView, ReferenceSchema
-from .conftest import execute_cli_command, make_commit, ref_hash
+from pynessie.model import (
+    ContentSchema,
+    DeltaLakeTable,
+    EntrySchema,
+    IcebergTable,
+    IcebergView,
+    ReferenceSchema,
+)
 
+from .conftest import execute_cli_command, make_commit, ref_hash
 
 CONTENT_COMMAND = "content"
 

--- a/python/tests/test_nessie_cli_error.py
+++ b/python/tests/test_nessie_cli_error.py
@@ -18,7 +18,6 @@ import pytest
 
 from .conftest import execute_cli_command
 
-
 # Note: tests in this file use custom VCR files for error server responses.
 # Running these tests in recording mode will likely NOT produce the expected
 # server responses. The related VCR files need to be reviewed and corrected

--- a/python/tests/test_nessie_client.py
+++ b/python/tests/test_nessie_client.py
@@ -20,8 +20,7 @@ import pytest
 
 from pynessie import init
 from pynessie.error import NessieConflictException
-from pynessie.model import Branch
-from pynessie.model import Entries
+from pynessie.model import Branch, Entries
 
 
 @pytest.mark.vcr

--- a/python/tests/test_nessie_error.py
+++ b/python/tests/test_nessie_error.py
@@ -14,19 +14,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from pynessie.error import _create_exception
-from pynessie.error import NessieConflictException
-from pynessie.error import NessieContentNotFoundException
-from pynessie.error import NessieException
-from pynessie.error import NessieNotFoundException
-from pynessie.error import NessiePermissionException
-from pynessie.error import NessiePreconidtionFailedException
-from pynessie.error import NessieReferenceAlreadyExistsException
-from pynessie.error import NessieReferenceConflictException
-from pynessie.error import NessieReferenceNotFoundException
-from pynessie.error import NessieServerException
-from pynessie.error import NessieUnauthorizedException
-
+from pynessie.error import (
+    NessieConflictException,
+    NessieContentNotFoundException,
+    NessieException,
+    NessieNotFoundException,
+    NessiePermissionException,
+    NessiePreconidtionFailedException,
+    NessieReferenceAlreadyExistsException,
+    NessieReferenceConflictException,
+    NessieReferenceNotFoundException,
+    NessieServerException,
+    NessieUnauthorizedException,
+    _create_exception,
+)
 
 # Non-VCR tests for error response handling
 

--- a/python/tests/test_reference_expressions.py
+++ b/python/tests/test_reference_expressions.py
@@ -18,7 +18,12 @@
 
 from assertpy import assert_that
 
-from pynessie.model import DETACHED_REFERENCE_NAME, is_valid_hash, is_valid_reference_name, split_into_reference_and_hash
+from pynessie.model import (
+    DETACHED_REFERENCE_NAME,
+    is_valid_hash,
+    is_valid_reference_name,
+    split_into_reference_and_hash,
+)
 
 
 def test_is_valid_reference_name() -> None:

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -31,6 +31,7 @@ basepython = python
 deps =
     -r{toxinidir}/requirements_lint.txt
 commands =
+    isort pynessie tests tools
     black pynessie tests tools
 
 


### PR DESCRIPTION
[Isort](https://github.com/PyCQA/isort) has a nice way to sort Python imports, thus introducing this instead of flake8-import-order. Plus one big bonus with isort, it will auto sort the imports as of `tox -e format` command without needing to manually fix the imports the orders from `flake8-import-order`.