### PR TITLE
NessieApi - automatic paging stream

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/ResultStreamPaginator.java
+++ b/clients/client/src/main/java/org/projectnessie/client/ResultStreamPaginator.java
@@ -54,6 +54,16 @@ final class ResultStreamPaginator<R extends PaginatedResponse, E> {
     this.fetcher = fetcher;
   }
 
+  Stream<E> limitedStream(OptionalInt maxRecords) throws NessieNotFoundException {
+    return limitedStream(maxRecords, OptionalInt.empty());
+  }
+
+  Stream<E> limitedStream(OptionalInt maxRecords, OptionalInt pageSizeHint)
+      throws NessieNotFoundException {
+    Stream<E> stream = generateStream(pageSizeHint);
+    return (maxRecords.isPresent()) ? stream.limit(maxRecords.getAsInt()) : stream;
+  }
+
   /**
    * Constructs the stream that uses paging under the covers.
    *

--- a/clients/client/src/main/java/org/projectnessie/client/ResultStreamPaginator.java
+++ b/clients/client/src/main/java/org/projectnessie/client/ResultStreamPaginator.java
@@ -55,10 +55,10 @@ final class ResultStreamPaginator<R extends PaginatedResponse, E> {
   }
 
   Stream<E> limitedStream(OptionalInt maxRecords) throws NessieNotFoundException {
-    return limitedStream(maxRecords, OptionalInt.empty());
+    return limitedStream(OptionalInt.empty(), maxRecords);
   }
 
-  Stream<E> limitedStream(OptionalInt maxRecords, OptionalInt pageSizeHint)
+  Stream<E> limitedStream(OptionalInt pageSizeHint, OptionalInt maxRecords)
       throws NessieNotFoundException {
     Stream<E> stream = generateStream(pageSizeHint);
     return (maxRecords.isPresent()) ? stream.limit(maxRecords.getAsInt()) : stream;

--- a/clients/client/src/main/java/org/projectnessie/client/ResultStreamPaginator.java
+++ b/clients/client/src/main/java/org/projectnessie/client/ResultStreamPaginator.java
@@ -54,16 +54,6 @@ final class ResultStreamPaginator<R extends PaginatedResponse, E> {
     this.fetcher = fetcher;
   }
 
-  Stream<E> limitedStream(OptionalInt maxRecords) throws NessieNotFoundException {
-    return limitedStream(maxRecords, OptionalInt.empty());
-  }
-
-  Stream<E> limitedStream(OptionalInt maxRecords, OptionalInt pageSizeHint)
-      throws NessieNotFoundException {
-    Stream<E> stream = generateStream(pageSizeHint);
-    return (maxRecords.isPresent()) ? stream.limit(maxRecords.getAsInt()) : stream;
-  }
-
   /**
    * Constructs the stream that uses paging under the covers.
    *

--- a/clients/client/src/main/java/org/projectnessie/client/ResultStreamPaginator.java
+++ b/clients/client/src/main/java/org/projectnessie/client/ResultStreamPaginator.java
@@ -55,10 +55,10 @@ final class ResultStreamPaginator<R extends PaginatedResponse, E> {
   }
 
   Stream<E> limitedStream(OptionalInt maxRecords) throws NessieNotFoundException {
-    return limitedStream(OptionalInt.empty(), maxRecords);
+    return limitedStream(maxRecords, OptionalInt.empty());
   }
 
-  Stream<E> limitedStream(OptionalInt pageSizeHint, OptionalInt maxRecords)
+  Stream<E> limitedStream(OptionalInt maxRecords, OptionalInt pageSizeHint)
       throws NessieNotFoundException {
     Stream<E> stream = generateStream(pageSizeHint);
     return (maxRecords.isPresent()) ? stream.limit(maxRecords.getAsInt()) : stream;

--- a/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
+++ b/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
@@ -55,8 +55,8 @@ public final class StreamingUtil {
    * @param builderCustomizer a Function that takes and returns {@link GetAllReferencesBuilder} that
    *     is passed to the caller of this method. It allows the caller to customize the
    *     GetAllReferencesBuilder with additional parameters (e.g.: filter).
-   * @param maxRecords - a maximum number of records in the stream. If it is {@code
-   *     Optional.empty()} the stream will be unbounded.
+   * @param pageSizeHint - the page size hint passed to the Nessie server. Undefined, if {@code
+   *     Optional.empty()}.
    * @return stream of {@link Reference} objects
    * @deprecated Use {@link GetAllReferencesBuilder#stream(OptionalInt)}
    */
@@ -64,7 +64,7 @@ public final class StreamingUtil {
   public static Stream<Reference> getAllReferencesStream(
       @NotNull NessieApiV1 api,
       @NotNull Function<GetAllReferencesBuilder, GetAllReferencesBuilder> builderCustomizer,
-      @NotNull OptionalInt maxRecords)
+      @NotNull OptionalInt pageSizeHint)
       throws NessieNotFoundException {
 
     return new ResultStreamPaginator<>(
@@ -73,7 +73,7 @@ public final class StreamingUtil {
               GetAllReferencesBuilder builder = builderCustomizer.apply(api.getAllReferences());
               return builderWithPaging(builder, pageSize, token).get();
             })
-        .limitedStream(maxRecords);
+        .limitedStream(pageSizeHint);
   }
 
   /**
@@ -87,8 +87,8 @@ public final class StreamingUtil {
    * @param builderCustomizer a Function that takes and returns {@link GetEntriesBuilder} that is
    *     passed to the caller of this method. It allows the caller to customize the
    *     GetEntriesBuilder with additional parameters (e.g.: hashOnRef, filter).
-   * @param maxRecords - a maximum number of records in the stream. If it is {@code
-   *     Optional.empty()} the stream will be unbounded.
+   * @param pageSizeHint - the page size hint passed to the Nessie server. Undefined, if {@code
+   *     Optional.empty()}.
    * @return stream of {@link Entry} objects
    * @deprecated Use {@link GetEntriesBuilder#stream(OptionalInt)}
    */
@@ -96,7 +96,7 @@ public final class StreamingUtil {
   public static Stream<Entry> getEntriesStream(
       @NotNull NessieApiV1 api,
       @NotNull Function<GetEntriesBuilder, GetEntriesBuilder> builderCustomizer,
-      @NotNull OptionalInt maxRecords)
+      @NotNull OptionalInt pageSizeHint)
       throws NessieNotFoundException {
 
     return new ResultStreamPaginator<>(
@@ -105,7 +105,7 @@ public final class StreamingUtil {
               GetEntriesBuilder builder = builderCustomizer.apply(api.getEntries());
               return builderWithPaging(builder, pageSize, token).get();
             })
-        .limitedStream(maxRecords);
+        .limitedStream(pageSizeHint);
   }
 
   /**
@@ -120,8 +120,8 @@ public final class StreamingUtil {
    *     passed to the caller of this method. It allows the caller to customize the
    *     GetCommitLogBuilder with additional parameters (e.g.: hashOnRef, untilHash, filter,
    *     fetchOption).
-   * @param maxRecords - a maximum number of records in the stream. If it is {@code
-   *     Optional.empty()} the stream will be unbounded.
+   * @param pageSizeHint - the page size hint passed to the Nessie server. Undefined, if {@code
+   *     Optional.empty()}.
    * @return stream of {@link CommitMeta} objects
    * @deprecated Use {@link GetCommitLogBuilder#stream(OptionalInt)}
    */
@@ -129,7 +129,7 @@ public final class StreamingUtil {
   public static Stream<LogEntry> getCommitLogStream(
       @NotNull NessieApiV1 api,
       @NotNull Function<GetCommitLogBuilder, GetCommitLogBuilder> builderCustomizer,
-      @NotNull OptionalInt maxRecords)
+      @NotNull OptionalInt pageSizeHint)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
             LogResponse::getLogEntries,
@@ -137,7 +137,7 @@ public final class StreamingUtil {
               GetCommitLogBuilder builder = builderCustomizer.apply(api.getCommitLog());
               return builderWithPaging(builder, pageSize, token).get();
             })
-        .generateStream(maxRecords);
+        .generateStream(pageSizeHint);
   }
 
   /**
@@ -151,8 +151,8 @@ public final class StreamingUtil {
    * @param builderCustomizer a Function that takes and returns {@link GetRefLogBuilder} that is
    *     passed to the caller of this method. It allows the caller to customize the GetRefLogBuilder
    *     with additional parameters (e.g.: fromHash, untilHash, filter).
-   * @param maxRecords - a maximum number of records in the stream. If it is {@code
-   *     Optional.empty()} the stream will be unbounded.
+   * @param pageSizeHint - the page size hint passed to the Nessie server. Undefined, if {@code
+   *     Optional.empty()}.
    * @return stream of {@link RefLogResponse.RefLogResponseEntry} objects
    * @deprecated Use {@link GetRefLogBuilder#stream(OptionalInt)}
    */
@@ -160,7 +160,7 @@ public final class StreamingUtil {
   public static Stream<RefLogResponse.RefLogResponseEntry> getReflogStream(
       @NotNull NessieApiV1 api,
       @NotNull Function<GetRefLogBuilder, GetRefLogBuilder> builderCustomizer,
-      @NotNull OptionalInt maxRecords)
+      @NotNull OptionalInt pageSizeHint)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
             RefLogResponse::getLogEntries,
@@ -168,47 +168,55 @@ public final class StreamingUtil {
               GetRefLogBuilder builder = builderCustomizer.apply(api.getRefLog());
               return builderWithPaging(builder, pageSize, token).get();
             })
-        .limitedStream(maxRecords);
+        .limitedStream(pageSizeHint);
   }
 
   @SuppressWarnings("deprecation")
   public static Stream<LogEntry> getCommitLogStream(
-      @NotNull GetCommitLogBuilder builder, @NotNull OptionalInt maxRecords)
+      @NotNull GetCommitLogBuilder builder,
+      @NotNull OptionalInt pageSizeHint,
+      @NotNull OptionalInt maxRecords)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
             LogResponse::getLogEntries,
             (pageSize, token) -> builderWithPaging(builder, pageSize, token).get())
-        .limitedStream(maxRecords);
+        .limitedStream(pageSizeHint, maxRecords);
   }
 
   @SuppressWarnings("deprecation")
   public static Stream<Reference> getAllReferencesStream(
-      @NotNull GetAllReferencesBuilder builder, @NotNull OptionalInt maxRecords)
+      @NotNull GetAllReferencesBuilder builder,
+      @NotNull OptionalInt pageSizeHint,
+      @NotNull OptionalInt maxRecords)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
             ReferencesResponse::getReferences,
             (pageSize, token) -> builderWithPaging(builder, pageSize, token).get())
-        .limitedStream(maxRecords);
+        .limitedStream(pageSizeHint, maxRecords);
   }
 
   @SuppressWarnings("deprecation")
   public static Stream<Entry> getEntriesStream(
-      @NotNull GetEntriesBuilder builder, @NotNull OptionalInt maxRecords)
+      @NotNull GetEntriesBuilder builder,
+      @NotNull OptionalInt pageSizeHint,
+      @NotNull OptionalInt maxRecords)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
             EntriesResponse::getEntries,
             (pageSize, token) -> builderWithPaging(builder, pageSize, token).get())
-        .limitedStream(maxRecords);
+        .limitedStream(pageSizeHint, maxRecords);
   }
 
   @SuppressWarnings("deprecation")
   public static Stream<RefLogResponse.RefLogResponseEntry> getReflogStream(
-      @NotNull GetRefLogBuilder builder, @NotNull OptionalInt maxRecords)
+      @NotNull GetRefLogBuilder builder,
+      @NotNull OptionalInt pageSizeHint,
+      @NotNull OptionalInt maxRecords)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
             RefLogResponse::getLogEntries,
             (pageSize, token) -> builderWithPaging(builder, pageSize, token).get())
-        .limitedStream(maxRecords);
+        .limitedStream(pageSizeHint, maxRecords);
   }
 
   private static <B extends PagingBuilder<B, ?, ?>> B builderWithPaging(

--- a/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
+++ b/clients/client/src/main/java/org/projectnessie/client/StreamingUtil.java
@@ -55,8 +55,8 @@ public final class StreamingUtil {
    * @param builderCustomizer a Function that takes and returns {@link GetAllReferencesBuilder} that
    *     is passed to the caller of this method. It allows the caller to customize the
    *     GetAllReferencesBuilder with additional parameters (e.g.: filter).
-   * @param pageSizeHint - the page size hint passed to the Nessie server. Undefined, if {@code
-   *     Optional.empty()}.
+   * @param maxRecords - a maximum number of records in the stream. If it is {@code
+   *     Optional.empty()} the stream will be unbounded.
    * @return stream of {@link Reference} objects
    * @deprecated Use {@link GetAllReferencesBuilder#stream(OptionalInt)}
    */
@@ -64,7 +64,7 @@ public final class StreamingUtil {
   public static Stream<Reference> getAllReferencesStream(
       @NotNull NessieApiV1 api,
       @NotNull Function<GetAllReferencesBuilder, GetAllReferencesBuilder> builderCustomizer,
-      @NotNull OptionalInt pageSizeHint)
+      @NotNull OptionalInt maxRecords)
       throws NessieNotFoundException {
 
     return new ResultStreamPaginator<>(
@@ -73,7 +73,7 @@ public final class StreamingUtil {
               GetAllReferencesBuilder builder = builderCustomizer.apply(api.getAllReferences());
               return builderWithPaging(builder, pageSize, token).get();
             })
-        .limitedStream(pageSizeHint);
+        .limitedStream(maxRecords);
   }
 
   /**
@@ -87,8 +87,8 @@ public final class StreamingUtil {
    * @param builderCustomizer a Function that takes and returns {@link GetEntriesBuilder} that is
    *     passed to the caller of this method. It allows the caller to customize the
    *     GetEntriesBuilder with additional parameters (e.g.: hashOnRef, filter).
-   * @param pageSizeHint - the page size hint passed to the Nessie server. Undefined, if {@code
-   *     Optional.empty()}.
+   * @param maxRecords - a maximum number of records in the stream. If it is {@code
+   *     Optional.empty()} the stream will be unbounded.
    * @return stream of {@link Entry} objects
    * @deprecated Use {@link GetEntriesBuilder#stream(OptionalInt)}
    */
@@ -96,7 +96,7 @@ public final class StreamingUtil {
   public static Stream<Entry> getEntriesStream(
       @NotNull NessieApiV1 api,
       @NotNull Function<GetEntriesBuilder, GetEntriesBuilder> builderCustomizer,
-      @NotNull OptionalInt pageSizeHint)
+      @NotNull OptionalInt maxRecords)
       throws NessieNotFoundException {
 
     return new ResultStreamPaginator<>(
@@ -105,7 +105,7 @@ public final class StreamingUtil {
               GetEntriesBuilder builder = builderCustomizer.apply(api.getEntries());
               return builderWithPaging(builder, pageSize, token).get();
             })
-        .limitedStream(pageSizeHint);
+        .limitedStream(maxRecords);
   }
 
   /**
@@ -120,8 +120,8 @@ public final class StreamingUtil {
    *     passed to the caller of this method. It allows the caller to customize the
    *     GetCommitLogBuilder with additional parameters (e.g.: hashOnRef, untilHash, filter,
    *     fetchOption).
-   * @param pageSizeHint - the page size hint passed to the Nessie server. Undefined, if {@code
-   *     Optional.empty()}.
+   * @param maxRecords - a maximum number of records in the stream. If it is {@code
+   *     Optional.empty()} the stream will be unbounded.
    * @return stream of {@link CommitMeta} objects
    * @deprecated Use {@link GetCommitLogBuilder#stream(OptionalInt)}
    */
@@ -129,7 +129,7 @@ public final class StreamingUtil {
   public static Stream<LogEntry> getCommitLogStream(
       @NotNull NessieApiV1 api,
       @NotNull Function<GetCommitLogBuilder, GetCommitLogBuilder> builderCustomizer,
-      @NotNull OptionalInt pageSizeHint)
+      @NotNull OptionalInt maxRecords)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
             LogResponse::getLogEntries,
@@ -137,7 +137,7 @@ public final class StreamingUtil {
               GetCommitLogBuilder builder = builderCustomizer.apply(api.getCommitLog());
               return builderWithPaging(builder, pageSize, token).get();
             })
-        .generateStream(pageSizeHint);
+        .generateStream(maxRecords);
   }
 
   /**
@@ -151,8 +151,8 @@ public final class StreamingUtil {
    * @param builderCustomizer a Function that takes and returns {@link GetRefLogBuilder} that is
    *     passed to the caller of this method. It allows the caller to customize the GetRefLogBuilder
    *     with additional parameters (e.g.: fromHash, untilHash, filter).
-   * @param pageSizeHint - the page size hint passed to the Nessie server. Undefined, if {@code
-   *     Optional.empty()}.
+   * @param maxRecords - a maximum number of records in the stream. If it is {@code
+   *     Optional.empty()} the stream will be unbounded.
    * @return stream of {@link RefLogResponse.RefLogResponseEntry} objects
    * @deprecated Use {@link GetRefLogBuilder#stream(OptionalInt)}
    */
@@ -160,7 +160,7 @@ public final class StreamingUtil {
   public static Stream<RefLogResponse.RefLogResponseEntry> getReflogStream(
       @NotNull NessieApiV1 api,
       @NotNull Function<GetRefLogBuilder, GetRefLogBuilder> builderCustomizer,
-      @NotNull OptionalInt pageSizeHint)
+      @NotNull OptionalInt maxRecords)
       throws NessieNotFoundException {
     return new ResultStreamPaginator<>(
             RefLogResponse::getLogEntries,
@@ -168,10 +168,9 @@ public final class StreamingUtil {
               GetRefLogBuilder builder = builderCustomizer.apply(api.getRefLog());
               return builderWithPaging(builder, pageSize, token).get();
             })
-        .limitedStream(pageSizeHint);
+        .limitedStream(maxRecords);
   }
 
-  @SuppressWarnings("deprecation")
   public static Stream<LogEntry> getCommitLogStream(
       @NotNull GetCommitLogBuilder builder,
       @NotNull OptionalInt pageSizeHint,
@@ -180,10 +179,9 @@ public final class StreamingUtil {
     return new ResultStreamPaginator<>(
             LogResponse::getLogEntries,
             (pageSize, token) -> builderWithPaging(builder, pageSize, token).get())
-        .limitedStream(pageSizeHint, maxRecords);
+        .limitedStream(maxRecords, pageSizeHint);
   }
 
-  @SuppressWarnings("deprecation")
   public static Stream<Reference> getAllReferencesStream(
       @NotNull GetAllReferencesBuilder builder,
       @NotNull OptionalInt pageSizeHint,
@@ -192,10 +190,9 @@ public final class StreamingUtil {
     return new ResultStreamPaginator<>(
             ReferencesResponse::getReferences,
             (pageSize, token) -> builderWithPaging(builder, pageSize, token).get())
-        .limitedStream(pageSizeHint, maxRecords);
+        .limitedStream(maxRecords, pageSizeHint);
   }
 
-  @SuppressWarnings("deprecation")
   public static Stream<Entry> getEntriesStream(
       @NotNull GetEntriesBuilder builder,
       @NotNull OptionalInt pageSizeHint,
@@ -204,10 +201,9 @@ public final class StreamingUtil {
     return new ResultStreamPaginator<>(
             EntriesResponse::getEntries,
             (pageSize, token) -> builderWithPaging(builder, pageSize, token).get())
-        .limitedStream(pageSizeHint, maxRecords);
+        .limitedStream(maxRecords, pageSizeHint);
   }
 
-  @SuppressWarnings("deprecation")
   public static Stream<RefLogResponse.RefLogResponseEntry> getReflogStream(
       @NotNull GetRefLogBuilder builder,
       @NotNull OptionalInt pageSizeHint,
@@ -216,7 +212,7 @@ public final class StreamingUtil {
     return new ResultStreamPaginator<>(
             RefLogResponse::getLogEntries,
             (pageSize, token) -> builderWithPaging(builder, pageSize, token).get())
-        .limitedStream(pageSizeHint, maxRecords);
+        .limitedStream(maxRecords, pageSizeHint);
   }
 
   private static <B extends PagingBuilder<B, ?, ?>> B builderWithPaging(

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -42,9 +42,12 @@ public interface GetAllReferencesBuilder
    */
   GetAllReferencesBuilder fetch(FetchOption fetchOption);
 
+  // Mandatory override (must maintain function signature w/ previous versions)
   @Override
-  default Stream<Reference> stream(OptionalInt maxTotalRecords, OptionalInt pageSizeHint)
-      throws NessieNotFoundException {
-    return StreamingUtil.getAllReferencesStream(this, pageSizeHint, maxTotalRecords);
+  ReferencesResponse get();
+
+  @Override
+  default Stream<Reference> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException {
+    return StreamingUtil.getAllReferencesStream(this, OptionalInt.empty(), maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -15,7 +15,12 @@
  */
 package org.projectnessie.client.api;
 
+import java.util.OptionalInt;
+import java.util.stream.Stream;
 import org.projectnessie.api.params.FetchOption;
+import org.projectnessie.client.StreamingUtil;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferencesResponse;
 
 /**
@@ -24,7 +29,8 @@ import org.projectnessie.model.ReferencesResponse;
  * @since {@link NessieApiV1}
  */
 public interface GetAllReferencesBuilder
-    extends QueryBuilder<GetAllReferencesBuilder>, PagingBuilder<GetAllReferencesBuilder> {
+    extends QueryBuilder<GetAllReferencesBuilder>,
+        PagingBuilder<GetAllReferencesBuilder, ReferencesResponse, Reference> {
 
   /**
    * Will fetch additional metadata about {@link org.projectnessie.model.Branch} / {@link
@@ -36,10 +42,15 @@ public interface GetAllReferencesBuilder
    */
   GetAllReferencesBuilder fetch(FetchOption fetchOption);
 
-  /**
-   * Fetches all references and returns them in a {@link ReferencesResponse} instance.
-   *
-   * @return Fetches all references and returns them in a {@link ReferencesResponse} instance.
-   */
+  @Override
   ReferencesResponse get();
+
+  @Override
+  default Stream<Reference> stream(OptionalInt maxTotalRecords) {
+    try {
+      return StreamingUtil.getAllReferencesStream(this, maxTotalRecords);
+    } catch (NessieNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -43,9 +43,6 @@ public interface GetAllReferencesBuilder
   GetAllReferencesBuilder fetch(FetchOption fetchOption);
 
   @Override
-  ReferencesResponse get();
-
-  @Override
   default Stream<Reference> stream(OptionalInt pageSizeHint, OptionalInt maxTotalRecords)
       throws NessieNotFoundException {
     return StreamingUtil.getAllReferencesStream(this, pageSizeHint, maxTotalRecords);

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -46,7 +46,8 @@ public interface GetAllReferencesBuilder
   ReferencesResponse get();
 
   @Override
-  default Stream<Reference> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException {
-    return StreamingUtil.getAllReferencesStream(this, maxTotalRecords);
+  default Stream<Reference> stream(OptionalInt pageSizeHint, OptionalInt maxTotalRecords)
+      throws NessieNotFoundException {
+    return StreamingUtil.getAllReferencesStream(this, pageSizeHint, maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -15,11 +15,7 @@
  */
 package org.projectnessie.client.api;
 
-import java.util.OptionalInt;
-import java.util.stream.Stream;
 import org.projectnessie.api.params.FetchOption;
-import org.projectnessie.client.StreamingUtil;
-import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferencesResponse;
 
@@ -45,9 +41,4 @@ public interface GetAllReferencesBuilder
   // Mandatory override (must maintain function signature w/ previous versions)
   @Override
   ReferencesResponse get();
-
-  @Override
-  default Stream<Reference> stream() throws NessieNotFoundException {
-    return StreamingUtil.getAllReferencesStream(this, OptionalInt.empty());
-  }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -46,11 +46,7 @@ public interface GetAllReferencesBuilder
   ReferencesResponse get();
 
   @Override
-  default Stream<Reference> stream(OptionalInt maxTotalRecords) {
-    try {
-      return StreamingUtil.getAllReferencesStream(this, maxTotalRecords);
-    } catch (NessieNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+  default Stream<Reference> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException {
+    return StreamingUtil.getAllReferencesStream(this, maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -47,7 +47,7 @@ public interface GetAllReferencesBuilder
   ReferencesResponse get();
 
   @Override
-  default Stream<Reference> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException {
-    return StreamingUtil.getAllReferencesStream(this, OptionalInt.empty(), maxTotalRecords);
+  default Stream<Reference> stream() throws NessieNotFoundException {
+    return StreamingUtil.getAllReferencesStream(this, OptionalInt.empty());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetAllReferencesBuilder.java
@@ -43,7 +43,7 @@ public interface GetAllReferencesBuilder
   GetAllReferencesBuilder fetch(FetchOption fetchOption);
 
   @Override
-  default Stream<Reference> stream(OptionalInt pageSizeHint, OptionalInt maxTotalRecords)
+  default Stream<Reference> stream(OptionalInt maxTotalRecords, OptionalInt pageSizeHint)
       throws NessieNotFoundException {
     return StreamingUtil.getAllReferencesStream(this, pageSizeHint, maxTotalRecords);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
@@ -15,9 +15,12 @@
  */
 package org.projectnessie.client.api;
 
+import java.util.OptionalInt;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.validation.constraints.Pattern;
 import org.projectnessie.api.params.FetchOption;
+import org.projectnessie.client.StreamingUtil;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Validation;
@@ -29,7 +32,7 @@ import org.projectnessie.model.Validation;
  */
 public interface GetCommitLogBuilder
     extends QueryBuilder<GetCommitLogBuilder>,
-        PagingBuilder<GetCommitLogBuilder>,
+        PagingBuilder<GetCommitLogBuilder, LogResponse, LogResponse.LogEntry>,
         OnReferenceBuilder<GetCommitLogBuilder> {
 
   /**
@@ -44,5 +47,9 @@ public interface GetCommitLogBuilder
       @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String untilHash);
 
-  LogResponse get() throws NessieNotFoundException;
+  @Override
+  default Stream<LogResponse.LogEntry> stream(OptionalInt maxTotalRecords)
+      throws NessieNotFoundException {
+    return StreamingUtil.getCommitLogStream(this, maxTotalRecords);
+  }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
@@ -48,8 +48,8 @@ public interface GetCommitLogBuilder
           String untilHash);
 
   @Override
-  default Stream<LogResponse.LogEntry> stream(OptionalInt maxTotalRecords)
+  default Stream<LogResponse.LogEntry> stream(OptionalInt pageSizeHint, OptionalInt maxTotalRecords)
       throws NessieNotFoundException {
-    return StreamingUtil.getCommitLogStream(this, maxTotalRecords);
+    return StreamingUtil.getCommitLogStream(this, pageSizeHint, maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
@@ -48,8 +48,7 @@ public interface GetCommitLogBuilder
           String untilHash);
 
   @Override
-  default Stream<LogResponse.LogEntry> stream(OptionalInt maxTotalRecords)
-      throws NessieNotFoundException {
-    return StreamingUtil.getCommitLogStream(this, OptionalInt.empty(), maxTotalRecords);
+  default Stream<LogResponse.LogEntry> stream() throws NessieNotFoundException {
+    return StreamingUtil.getCommitLogStream(this, OptionalInt.empty());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
@@ -15,13 +15,9 @@
  */
 package org.projectnessie.client.api;
 
-import java.util.OptionalInt;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.validation.constraints.Pattern;
 import org.projectnessie.api.params.FetchOption;
-import org.projectnessie.client.StreamingUtil;
-import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Validation;
 
@@ -46,9 +42,4 @@ public interface GetCommitLogBuilder
   GetCommitLogBuilder untilHash(
       @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String untilHash);
-
-  @Override
-  default Stream<LogResponse.LogEntry> stream() throws NessieNotFoundException {
-    return StreamingUtil.getCommitLogStream(this, OptionalInt.empty());
-  }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
@@ -48,7 +48,7 @@ public interface GetCommitLogBuilder
           String untilHash);
 
   @Override
-  default Stream<LogResponse.LogEntry> stream(OptionalInt pageSizeHint, OptionalInt maxTotalRecords)
+  default Stream<LogResponse.LogEntry> stream(OptionalInt maxTotalRecords, OptionalInt pageSizeHint)
       throws NessieNotFoundException {
     return StreamingUtil.getCommitLogStream(this, pageSizeHint, maxTotalRecords);
   }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
@@ -48,8 +48,8 @@ public interface GetCommitLogBuilder
           String untilHash);
 
   @Override
-  default Stream<LogResponse.LogEntry> stream(OptionalInt maxTotalRecords, OptionalInt pageSizeHint)
+  default Stream<LogResponse.LogEntry> stream(OptionalInt maxTotalRecords)
       throws NessieNotFoundException {
-    return StreamingUtil.getCommitLogStream(this, pageSizeHint, maxTotalRecords);
+    return StreamingUtil.getCommitLogStream(this, OptionalInt.empty(), maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -35,7 +35,7 @@ public interface GetEntriesBuilder
 
   @Override
   default Stream<EntriesResponse.Entry> stream(
-      OptionalInt pageSizeHint, OptionalInt maxTotalRecords) throws NessieNotFoundException {
+      OptionalInt maxTotalRecords, OptionalInt pageSizeHint) throws NessieNotFoundException {
     return StreamingUtil.getEntriesStream(this, pageSizeHint, maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -34,8 +34,8 @@ public interface GetEntriesBuilder
   GetEntriesBuilder namespaceDepth(Integer namespaceDepth);
 
   @Override
-  default Stream<EntriesResponse.Entry> stream(
-      OptionalInt maxTotalRecords, OptionalInt pageSizeHint) throws NessieNotFoundException {
-    return StreamingUtil.getEntriesStream(this, pageSizeHint, maxTotalRecords);
+  default Stream<EntriesResponse.Entry> stream(OptionalInt maxTotalRecords)
+      throws NessieNotFoundException {
+    return StreamingUtil.getEntriesStream(this, OptionalInt.empty(), maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -15,10 +15,6 @@
  */
 package org.projectnessie.client.api;
 
-import java.util.OptionalInt;
-import java.util.stream.Stream;
-import org.projectnessie.client.StreamingUtil;
-import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.EntriesResponse;
 
 /**
@@ -32,9 +28,4 @@ public interface GetEntriesBuilder
         OnReferenceBuilder<GetEntriesBuilder> {
 
   GetEntriesBuilder namespaceDepth(Integer namespaceDepth);
-
-  @Override
-  default Stream<EntriesResponse.Entry> stream() throws NessieNotFoundException {
-    return StreamingUtil.getEntriesStream(this, OptionalInt.empty());
-  }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.client.api;
 
+import java.util.OptionalInt;
+import java.util.stream.Stream;
+import org.projectnessie.client.StreamingUtil;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.EntriesResponse;
 
@@ -25,10 +28,14 @@ import org.projectnessie.model.EntriesResponse;
  */
 public interface GetEntriesBuilder
     extends QueryBuilder<GetEntriesBuilder>,
-        PagingBuilder<GetEntriesBuilder>,
+        PagingBuilder<GetEntriesBuilder, EntriesResponse, EntriesResponse.Entry>,
         OnReferenceBuilder<GetEntriesBuilder> {
 
   GetEntriesBuilder namespaceDepth(Integer namespaceDepth);
 
-  EntriesResponse get() throws NessieNotFoundException;
+  @Override
+  default Stream<EntriesResponse.Entry> stream(OptionalInt maxTotalRecords)
+      throws NessieNotFoundException {
+    return StreamingUtil.getEntriesStream(this, maxTotalRecords);
+  }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -34,8 +34,7 @@ public interface GetEntriesBuilder
   GetEntriesBuilder namespaceDepth(Integer namespaceDepth);
 
   @Override
-  default Stream<EntriesResponse.Entry> stream(OptionalInt maxTotalRecords)
-      throws NessieNotFoundException {
-    return StreamingUtil.getEntriesStream(this, OptionalInt.empty(), maxTotalRecords);
+  default Stream<EntriesResponse.Entry> stream() throws NessieNotFoundException {
+    return StreamingUtil.getEntriesStream(this, OptionalInt.empty());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -34,8 +34,8 @@ public interface GetEntriesBuilder
   GetEntriesBuilder namespaceDepth(Integer namespaceDepth);
 
   @Override
-  default Stream<EntriesResponse.Entry> stream(OptionalInt maxTotalRecords)
-      throws NessieNotFoundException {
-    return StreamingUtil.getEntriesStream(this, maxTotalRecords);
+  default Stream<EntriesResponse.Entry> stream(
+      OptionalInt pageSizeHint, OptionalInt maxTotalRecords) throws NessieNotFoundException {
+    return StreamingUtil.getEntriesStream(this, pageSizeHint, maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -52,8 +52,7 @@ public interface GetRefLogBuilder
           String fromHash);
 
   @Override
-  default Stream<RefLogResponse.RefLogResponseEntry> stream(OptionalInt maxTotalRecords)
-      throws NessieNotFoundException {
-    return StreamingUtil.getReflogStream(this, OptionalInt.empty(), maxTotalRecords);
+  default Stream<RefLogResponse.RefLogResponseEntry> stream() throws NessieNotFoundException {
+    return StreamingUtil.getReflogStream(this, OptionalInt.empty());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -52,8 +52,8 @@ public interface GetRefLogBuilder
           String fromHash);
 
   @Override
-  default Stream<RefLogResponse.RefLogResponseEntry> stream(
-      OptionalInt maxTotalRecords, OptionalInt pageSizeHint) throws NessieNotFoundException {
-    return StreamingUtil.getReflogStream(this, pageSizeHint, maxTotalRecords);
+  default Stream<RefLogResponse.RefLogResponseEntry> stream(OptionalInt maxTotalRecords)
+      throws NessieNotFoundException {
+    return StreamingUtil.getReflogStream(this, OptionalInt.empty(), maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -15,12 +15,8 @@
  */
 package org.projectnessie.client.api;
 
-import java.util.OptionalInt;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.validation.constraints.Pattern;
-import org.projectnessie.client.StreamingUtil;
-import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.model.Validation;
 
@@ -50,9 +46,4 @@ public interface GetRefLogBuilder
   GetRefLogBuilder fromHash(
       @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String fromHash);
-
-  @Override
-  default Stream<RefLogResponse.RefLogResponseEntry> stream() throws NessieNotFoundException {
-    return StreamingUtil.getReflogStream(this, OptionalInt.empty());
-  }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -15,8 +15,11 @@
  */
 package org.projectnessie.client.api;
 
+import java.util.OptionalInt;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.validation.constraints.Pattern;
+import org.projectnessie.client.StreamingUtil;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.model.Validation;
@@ -29,7 +32,8 @@ import org.projectnessie.model.Validation;
  * @since {@link NessieApiV1}
  */
 public interface GetRefLogBuilder
-    extends PagingBuilder<GetRefLogBuilder>, QueryBuilder<GetRefLogBuilder> {
+    extends PagingBuilder<GetRefLogBuilder, RefLogResponse, RefLogResponse.RefLogResponseEntry>,
+        QueryBuilder<GetRefLogBuilder> {
 
   /**
    * Hash of the reflog (inclusive) to start from (in chronological sense), the 'far' end of the
@@ -47,5 +51,9 @@ public interface GetRefLogBuilder
       @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String fromHash);
 
-  RefLogResponse get() throws NessieNotFoundException;
+  @Override
+  default Stream<RefLogResponse.RefLogResponseEntry> stream(OptionalInt maxTotalRecords)
+      throws NessieNotFoundException {
+    return StreamingUtil.getReflogStream(this, maxTotalRecords);
+  }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -53,7 +53,7 @@ public interface GetRefLogBuilder
 
   @Override
   default Stream<RefLogResponse.RefLogResponseEntry> stream(
-      OptionalInt pageSizeHint, OptionalInt maxTotalRecords) throws NessieNotFoundException {
+      OptionalInt maxTotalRecords, OptionalInt pageSizeHint) throws NessieNotFoundException {
     return StreamingUtil.getReflogStream(this, pageSizeHint, maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -52,8 +52,8 @@ public interface GetRefLogBuilder
           String fromHash);
 
   @Override
-  default Stream<RefLogResponse.RefLogResponseEntry> stream(OptionalInt maxTotalRecords)
-      throws NessieNotFoundException {
-    return StreamingUtil.getReflogStream(this, maxTotalRecords);
+  default Stream<RefLogResponse.RefLogResponseEntry> stream(
+      OptionalInt pageSizeHint, OptionalInt maxTotalRecords) throws NessieNotFoundException {
+    return StreamingUtil.getReflogStream(this, pageSizeHint, maxTotalRecords);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -41,28 +41,17 @@ public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, EN
   RESP get() throws NessieNotFoundException;
 
   /**
-   * This is a convenience function that is equivalent to {@link #stream(OptionalInt, OptionalInt)}
-   * with default page-size-hint and no limit on the number of returned entries.
+   * This is a convenience function that is equivalent to {@link #stream(OptionalInt)} with default
+   * page-size-hint and no limit on the number of returned entries.
    */
   default Stream<ENTRY> stream() throws NessieNotFoundException {
     return stream(OptionalInt.empty());
   }
 
   /**
-   * This is a convenience function that is equivalent to {@link #stream(OptionalInt, OptionalInt)}
-   * with the specified page-size-hint and no limit on the number of returned entries.
-   */
-  default Stream<ENTRY> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException {
-    return stream(maxTotalRecords, OptionalInt.empty());
-  }
-
-  /**
    * Retrieve entries/results as a Java {@link Stream}, uses automatic paging.
    *
    * @param maxTotalRecords {@link OptionalInt#empty()} for unlimited amount of results or a limit
-   * @param pageSizeHint {@link OptionalInt#empty()} to let the Nessie server choose the page size,
-   *     or provide a <em>proposal</em> to the Nessie server
    */
-  Stream<ENTRY> stream(OptionalInt maxTotalRecords, OptionalInt pageSizeHint)
-      throws NessieNotFoundException;
+  Stream<ENTRY> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -40,17 +40,28 @@ public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, EN
   RESP get() throws NessieNotFoundException;
 
   /**
-   * Retrieve entries/results as a Java {@link Stream} without limiting the total amount of results,
-   * uses automatic paging.
+   * This is a convenience function that is equivalent to {@link #stream(OptionalInt, OptionalInt)}
+   * with default page-size-hint and no limit on the number of returned entries.
    */
   default Stream<ENTRY> stream() throws NessieNotFoundException {
-    return stream(OptionalInt.empty());
+    return stream(OptionalInt.empty(), OptionalInt.empty());
+  }
+
+  /**
+   * This is a convenience function that is equivalent to {@link #stream(OptionalInt, OptionalInt)}
+   * with the specified page-size-hint and no limit on the number of returned entries.
+   */
+  default Stream<ENTRY> stream(OptionalInt pageSizeHint) throws NessieNotFoundException {
+    return stream(pageSizeHint, OptionalInt.empty());
   }
 
   /**
    * Retrieve entries/results as a Java {@link Stream}, uses automatic paging.
    *
+   * @param pageSizeHint {@link OptionalInt#empty()} to let the Nessie server choose the page size,
+   *     or provide a <em>proposal</em> to the Nessie server
    * @param maxTotalRecords {@link OptionalInt#empty()} for unlimited amount of results or a limit
    */
-  Stream<ENTRY> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException;
+  Stream<ENTRY> stream(OptionalInt pageSizeHint, OptionalInt maxTotalRecords)
+      throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -15,16 +15,36 @@
  */
 package org.projectnessie.client.api;
 
-import org.projectnessie.model.EntriesResponse;
+import java.util.OptionalInt;
+import java.util.stream.Stream;
+import org.projectnessie.error.NessieNotFoundException;
 
-public interface PagingBuilder<R extends PagingBuilder<R>> {
+public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, ENTRY> {
 
-  /** Recommended: specify the maximum number of records to return. */
+  /**
+   * When using the manual paging, it is recommended to set this parameter, this parameter is
+   * configured when necessary via {@link #stream(OptionalInt)}.
+   */
   R maxRecords(int maxRecords);
 
   /**
-   * For paged requests: pass the {@link EntriesResponse#getToken()} from the previous request,
-   * otherwise don't call this method.
+   * When using the manual paging, pass the {@code token} from the previous request, otherwise don't
+   * call this method.
    */
   R pageToken(String pageToken);
+
+  /**
+   * Fetches responses.
+   *
+   * @deprecated Use {@link #stream(OptionalInt)} instead.
+   */
+  @Deprecated
+  RESP get() throws NessieNotFoundException;
+
+  /**
+   * Retrieve entries/results as a Java {@link Stream}.
+   *
+   * @param maxTotalRecords {@link OptionalInt#empty()} for unlimited amount of results or a limit
+   */
+  Stream<ENTRY> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -34,15 +34,21 @@ public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, EN
   R pageToken(String pageToken);
 
   /**
-   * Fetches responses.
-   *
-   * @deprecated Use {@link #stream(OptionalInt)} instead.
+   * Fetches responses, but callers must implement paging on their own, if necessary. If in doubt,
+   * use {@link #stream()} instead.
    */
-  @Deprecated
   RESP get() throws NessieNotFoundException;
 
   /**
-   * Retrieve entries/results as a Java {@link Stream}.
+   * Retrieve entries/results as a Java {@link Stream} without limiting the total amount of results,
+   * uses automatic paging.
+   */
+  default Stream<ENTRY> stream() throws NessieNotFoundException {
+    return stream(OptionalInt.empty());
+  }
+
+  /**
+   * Retrieve entries/results as a Java {@link Stream}, uses automatic paging.
    *
    * @param maxTotalRecords {@link OptionalInt#empty()} for unlimited amount of results or a limit
    */

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -45,24 +45,24 @@ public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, EN
    * with default page-size-hint and no limit on the number of returned entries.
    */
   default Stream<ENTRY> stream() throws NessieNotFoundException {
-    return stream(OptionalInt.empty(), OptionalInt.empty());
+    return stream(OptionalInt.empty());
   }
 
   /**
    * This is a convenience function that is equivalent to {@link #stream(OptionalInt, OptionalInt)}
    * with the specified page-size-hint and no limit on the number of returned entries.
    */
-  default Stream<ENTRY> stream(OptionalInt pageSizeHint) throws NessieNotFoundException {
-    return stream(pageSizeHint, OptionalInt.empty());
+  default Stream<ENTRY> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException {
+    return stream(maxTotalRecords, OptionalInt.empty());
   }
 
   /**
    * Retrieve entries/results as a Java {@link Stream}, uses automatic paging.
    *
+   * @param maxTotalRecords {@link OptionalInt#empty()} for unlimited amount of results or a limit
    * @param pageSizeHint {@link OptionalInt#empty()} to let the Nessie server choose the page size,
    *     or provide a <em>proposal</em> to the Nessie server
-   * @param maxTotalRecords {@link OptionalInt#empty()} for unlimited amount of results or a limit
    */
-  Stream<ENTRY> stream(OptionalInt pageSizeHint, OptionalInt maxTotalRecords)
+  Stream<ENTRY> stream(OptionalInt maxTotalRecords, OptionalInt pageSizeHint)
       throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -22,11 +22,8 @@ import org.projectnessie.error.NessieNotFoundException;
 public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, ENTRY> {
 
   /**
-   * Sets the maximum number of records to be returned in a <em>ingle</em>s response object from the
-   * {@link #get()} method. When using stream() methods this parameter must not be set.
-   *
-   * <p>Only for manual paging via {@link #get()} - do <em>not</em> call when using any of the
-   * {@link #stream()} functions.
+   * Sets the maximum number of records to be returned in a <em>single</em> response object from the
+   * {@link #get()} method.
    *
    * <p>This setter reflects the OpenAPI parameter {@code maxRecords} in a paged request, for
    * example {@link org.projectnessie.api.params.CommitLogParams} for {@link
@@ -54,10 +51,6 @@ public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, EN
    */
   RESP get() throws NessieNotFoundException;
 
-  /**
-   * Retrieve entries/results as a Java {@link Stream}, uses automatic paging.
-   *
-   * <p>Callers must neither use {@link #maxRecords(int)} nor {@link #pageToken(String)}.
-   */
+  /** Retrieve entries/results as a Java {@link Stream}, uses automatic paging. */
   Stream<ENTRY> stream() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -15,49 +15,49 @@
  */
 package org.projectnessie.client.api;
 
-import java.util.OptionalInt;
 import java.util.stream.Stream;
+import org.projectnessie.api.params.CommitLogParams;
 import org.projectnessie.error.NessieNotFoundException;
 
 public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, ENTRY> {
 
   /**
-   * When using the manual paging, it is recommended to set this parameter, this parameter is
-   * configured when necessary via {@link #stream(OptionalInt)}.
+   * Sets the maximum number of records to be returned in a <em>ingle</em>s response object from the
+   * {@link #get()} method. When using stream() methods this parameter must not be set.
    *
    * <p>Only for manual paging via {@link #get()} - do <em>not</em> call when using any of the
    * {@link #stream()} functions.
+   *
+   * <p>This setter reflects the OpenAPI parameter {@code maxRecords} in a paged request, for
+   * example {@link org.projectnessie.api.params.CommitLogParams} for {@link
+   * org.projectnessie.api.TreeApi#getCommitLog(String, CommitLogParams)}.
    */
   R maxRecords(int maxRecords);
 
   /**
-   * When using the manual paging, pass the {@code token} from the previous request, otherwise don't
-   * call this method.
+   * Sets the page token from the previous' {@link #get()} method invocation. When using {@link
+   * #stream()} methods this parameter must not be set.
    *
    * <p>Only for manual paging via {@link #get()} - do <em>not</em> call when using any of the
    * {@link #stream()} functions.
+   *
+   * <p>This setter reflects the OpenAPI parameter {@code pageToken} in a paged request, for example
+   * {@link org.projectnessie.api.params.CommitLogParams} for {@link
+   * org.projectnessie.api.TreeApi#getCommitLog(String, CommitLogParams)}.
    */
   R pageToken(String pageToken);
 
   /**
-   * Fetches a response chunk (might be one page or complete response depending on use case and
-   * parameters), but callers must implement paging on their own, if necessary. If in doubt, use
-   * {@link #stream()} instead.
+   * Advanced usage, for <em>manual</em> paging: fetches a response chunk (might be one page or
+   * complete response depending on use case and parameters), but callers must implement paging on
+   * their own, if necessary. If in doubt, use {@link #stream()} instead.
    */
   RESP get() throws NessieNotFoundException;
 
   /**
-   * This is a convenience function that is equivalent to {@link #stream(OptionalInt)} with default
-   * page-size-hint and no limit on the number of returned entries.
-   */
-  default Stream<ENTRY> stream() throws NessieNotFoundException {
-    return stream(OptionalInt.empty());
-  }
-
-  /**
    * Retrieve entries/results as a Java {@link Stream}, uses automatic paging.
    *
-   * @param maxTotalRecords {@link OptionalInt#empty()} for unlimited amount of results or a limit
+   * <p>Callers must neither use {@link #maxRecords(int)} nor {@link #pageToken(String)}.
    */
-  Stream<ENTRY> stream(OptionalInt maxTotalRecords) throws NessieNotFoundException;
+  Stream<ENTRY> stream() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -24,12 +24,18 @@ public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, EN
   /**
    * When using the manual paging, it is recommended to set this parameter, this parameter is
    * configured when necessary via {@link #stream(OptionalInt)}.
+   *
+   * <p>Only for manual paging via {@link #get()} - do <em>not</em> call when using any of the
+   * {@link #stream()} functions.
    */
   R maxRecords(int maxRecords);
 
   /**
    * When using the manual paging, pass the {@code token} from the previous request, otherwise don't
    * call this method.
+   *
+   * <p>Only for manual paging via {@link #get()} - do <em>not</em> call when using any of the
+   * {@link #stream()} functions.
    */
   R pageToken(String pageToken);
 

--- a/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/PagingBuilder.java
@@ -34,8 +34,9 @@ public interface PagingBuilder<R extends PagingBuilder<R, RESP, ENTRY>, RESP, EN
   R pageToken(String pageToken);
 
   /**
-   * Fetches responses, but callers must implement paging on their own, if necessary. If in doubt,
-   * use {@link #stream()} instead.
+   * Fetches a response chunk (might be one page or complete response depending on use case and
+   * parameters), but callers must implement paging on their own, if necessary. If in doubt, use
+   * {@link #stream()} instead.
    */
   RESP get() throws NessieNotFoundException;
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
@@ -79,6 +79,7 @@ final class HttpGetAllReferences extends BaseHttpRequest implements GetAllRefere
   @Override
   public Stream<Reference> stream() throws NessieNotFoundException {
     ReferencesParams p = params();
-    return StreamingUtil.getAllReferencesStream(pageToken -> get(p.forNextPage(pageToken)));
+    return StreamingUtil.generateStream(
+        ReferencesResponse::getReferences, pageToken -> get(p.forNextPage(pageToken)));
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetAllReferences.java
@@ -15,19 +15,28 @@
  */
 package org.projectnessie.client.http.v1api;
 
+import java.util.stream.Stream;
 import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.api.params.ReferencesParams;
 import org.projectnessie.api.params.ReferencesParamsBuilder;
+import org.projectnessie.client.StreamingUtil;
 import org.projectnessie.client.api.GetAllReferencesBuilder;
 import org.projectnessie.client.http.NessieApiClient;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferencesResponse;
 
 final class HttpGetAllReferences extends BaseHttpRequest implements GetAllReferencesBuilder {
 
-  private final ReferencesParamsBuilder params = ReferencesParams.builder();
+  private final ReferencesParamsBuilder params;
 
   HttpGetAllReferences(NessieApiClient client) {
+    this(client, ReferencesParams.builder());
+  }
+
+  HttpGetAllReferences(NessieApiClient client, ReferencesParamsBuilder params) {
     super(client);
+    this.params = params;
   }
 
   @Override
@@ -54,8 +63,22 @@ final class HttpGetAllReferences extends BaseHttpRequest implements GetAllRefere
     return this;
   }
 
+  private ReferencesParams params() {
+    return params.build();
+  }
+
   @Override
   public ReferencesResponse get() {
-    return client.getTreeApi().getAllReferences(params.build());
+    return get(params());
+  }
+
+  private ReferencesResponse get(ReferencesParams p) {
+    return client.getTreeApi().getAllReferences(p);
+  }
+
+  @Override
+  public Stream<Reference> stream() throws NessieNotFoundException {
+    ReferencesParams p = params();
+    return StreamingUtil.getAllReferencesStream(pageToken -> get(p.forNextPage(pageToken)));
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetCommitLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetCommitLog.java
@@ -82,6 +82,7 @@ final class HttpGetCommitLog extends BaseHttpOnReferenceRequest<GetCommitLogBuil
   @Override
   public Stream<LogEntry> stream() throws NessieNotFoundException {
     CommitLogParams p = params();
-    return StreamingUtil.getCommitLogStream(pageToken -> get(p.forNextPage(pageToken)));
+    return StreamingUtil.generateStream(
+        LogResponse::getLogEntries, pageToken -> get(p.forNextPage(pageToken)));
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
@@ -75,6 +75,7 @@ final class HttpGetEntries extends BaseHttpOnReferenceRequest<GetEntriesBuilder>
   @Override
   public Stream<Entry> stream() throws NessieNotFoundException {
     EntriesParams p = params();
-    return StreamingUtil.getEntriesStream(pageToken -> get(p.forNextPage(pageToken)));
+    return StreamingUtil.generateStream(
+        EntriesResponse::getEntries, pageToken -> get(p.forNextPage(pageToken)));
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
@@ -15,12 +15,15 @@
  */
 package org.projectnessie.client.http.v1api;
 
+import java.util.stream.Stream;
 import org.projectnessie.api.params.RefLogParams;
 import org.projectnessie.api.params.RefLogParamsBuilder;
+import org.projectnessie.client.StreamingUtil;
 import org.projectnessie.client.api.GetRefLogBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
+import org.projectnessie.model.RefLogResponse.RefLogResponseEntry;
 
 final class HttpGetRefLog extends BaseHttpRequest implements GetRefLogBuilder {
 
@@ -60,8 +63,22 @@ final class HttpGetRefLog extends BaseHttpRequest implements GetRefLogBuilder {
     return this;
   }
 
+  private RefLogParams params() {
+    return params.build();
+  }
+
   @Override
   public RefLogResponse get() throws NessieNotFoundException {
-    return client.getRefLogApi().getRefLog(params.build());
+    return get(params());
+  }
+
+  private RefLogResponse get(RefLogParams p) throws NessieNotFoundException {
+    return client.getRefLogApi().getRefLog(p);
+  }
+
+  @Override
+  public Stream<RefLogResponseEntry> stream() throws NessieNotFoundException {
+    RefLogParams p = params();
+    return StreamingUtil.getReflogStream(pageToken -> get(p.forNextPage(pageToken)));
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
@@ -79,6 +79,7 @@ final class HttpGetRefLog extends BaseHttpRequest implements GetRefLogBuilder {
   @Override
   public Stream<RefLogResponseEntry> stream() throws NessieNotFoundException {
     RefLogParams p = params();
-    return StreamingUtil.getReflogStream(pageToken -> get(p.forNextPage(pageToken)));
+    return StreamingUtil.generateStream(
+        RefLogResponse::getLogEntries, pageToken -> get(p.forNextPage(pageToken)));
   }
 }

--- a/clients/client/src/test/java/org/projectnessie/client/TestResultStreamPaginator.java
+++ b/clients/client/src/test/java/org/projectnessie/client/TestResultStreamPaginator.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
@@ -40,10 +39,10 @@ class TestResultStreamPaginator {
     ResultStreamPaginator<MockPaginatedResponse, String> paginator =
         new ResultStreamPaginator<>(
             MockPaginatedResponse::getElements,
-            (pageSize, token) -> {
+            token -> {
               throw new NessieReferenceNotFoundException("Ref not found");
             });
-    assertThatThrownBy(() -> paginator.generateStream(OptionalInt.empty()))
+    assertThatThrownBy(paginator::generateStream)
         .isInstanceOf(NessieReferenceNotFoundException.class)
         .hasMessage("Ref not found");
   }
@@ -53,12 +52,11 @@ class TestResultStreamPaginator {
     ResultStreamPaginator<MockPaginatedResponse, String> paginator =
         new ResultStreamPaginator<>(
             MockPaginatedResponse::getElements,
-            (pageSize, token) -> {
-              assertNull(pageSize);
+            token -> {
               assertNull(token);
               return new MockPaginatedResponse(false, null, Arrays.asList("1", "2", "3"));
             });
-    assertThat(paginator.generateStream(OptionalInt.empty())).containsExactly("1", "2", "3");
+    assertThat(paginator.generateStream()).containsExactly("1", "2", "3");
   }
 
   @Test
@@ -73,13 +71,11 @@ class TestResultStreamPaginator {
     ResultStreamPaginator<MockPaginatedResponse, String> paginator =
         new ResultStreamPaginator<>(
             MockPaginatedResponse::getElements,
-            (pageSize, token) -> {
-              assertNull(pageSize);
+            token -> {
               assertEquals(expectedTokens.next(), token);
               return responses.next();
             });
-    assertThat(paginator.generateStream(OptionalInt.empty()))
-        .containsExactly("1", "2", "3", "4", "5", "6");
+    assertThat(paginator.generateStream()).containsExactly("1", "2", "3", "4", "5", "6");
   }
 
   @Test
@@ -87,12 +83,11 @@ class TestResultStreamPaginator {
     ResultStreamPaginator<MockPaginatedResponse, String> paginator =
         new ResultStreamPaginator<>(
             MockPaginatedResponse::getElements,
-            (pageSize, token) -> {
-              assertEquals(5, pageSize);
+            token -> {
               assertNull(token);
               return new MockPaginatedResponse(false, null, Arrays.asList("1", "2", "3"));
             });
-    assertThat(paginator.generateStream(OptionalInt.of(5))).containsExactly("1", "2", "3");
+    assertThat(paginator.generateStream()).containsExactly("1", "2", "3");
   }
 
   @Test
@@ -107,13 +102,11 @@ class TestResultStreamPaginator {
     ResultStreamPaginator<MockPaginatedResponse, String> paginator =
         new ResultStreamPaginator<>(
             MockPaginatedResponse::getElements,
-            (pageSize, token) -> {
-              assertEquals(5, pageSize);
+            token -> {
               assertEquals(expectedTokens.next(), token);
               return responses.next();
             });
-    assertThat(paginator.generateStream(OptionalInt.of(5)))
-        .containsExactly("1", "2", "3", "4", "5", "6");
+    assertThat(paginator.generateStream()).containsExactly("1", "2", "3", "4", "5", "6");
   }
 
   @Test
@@ -121,8 +114,8 @@ class TestResultStreamPaginator {
     ResultStreamPaginator<MockPaginatedResponse, String> paginator =
         new ResultStreamPaginator<>(
             MockPaginatedResponse::getElements,
-            (pageSize, token) -> new MockPaginatedResponse(false, null, Collections.emptyList()));
-    assertThat(paginator.generateStream(OptionalInt.of(5))).isEmpty();
+            token -> new MockPaginatedResponse(false, null, Collections.emptyList()));
+    assertThat(paginator.generateStream()).isEmpty();
   }
 
   @Test
@@ -137,12 +130,11 @@ class TestResultStreamPaginator {
     ResultStreamPaginator<MockPaginatedResponse, String> paginator =
         new ResultStreamPaginator<>(
             MockPaginatedResponse::getElements,
-            (pageSize, token) -> {
-              assertEquals(5, pageSize);
+            token -> {
               assertEquals(expectedTokens.next(), token);
               return responses.next();
             });
-    assertThat(paginator.generateStream(OptionalInt.of(5))).containsExactly("1", "2", "3");
+    assertThat(paginator.generateStream()).containsExactly("1", "2", "3");
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -158,13 +150,11 @@ class TestResultStreamPaginator {
     ResultStreamPaginator<MockPaginatedResponse, String> paginator =
         new ResultStreamPaginator<>(
             MockPaginatedResponse::getElements,
-            (pageSize, token) -> {
-              assertEquals(5, pageSize);
+            token -> {
               assertEquals(expectedTokens.next(), token);
               return responses.next();
             });
-    assertThatThrownBy(
-            () -> paginator.generateStream(OptionalInt.of(5)).collect(Collectors.toList()))
+    assertThatThrownBy(() -> paginator.generateStream().collect(Collectors.toList()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Backend returned empty page, but indicates there are more results");
   }

--- a/clients/deltalake/src/test/java/org/projectnessie/deltalake/AbstractDeltaTest.java
+++ b/clients/deltalake/src/test/java/org/projectnessie/deltalake/AbstractDeltaTest.java
@@ -23,7 +23,6 @@ import io.delta.sql.DeltaSparkSessionExtension;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.spark.SparkConf;
@@ -91,7 +90,7 @@ public class AbstractDeltaTest {
   @AfterEach
   void removeBranches() throws NessieConflictException, NessieNotFoundException {
     Branch defaultBranch = api.getDefaultBranch();
-    api.getAllReferences().stream(OptionalInt.empty())
+    api.getAllReferences().stream()
         .forEach(
             ref -> {
               try {

--- a/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
+++ b/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.OptionalInt;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
@@ -44,7 +45,6 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.jaxrs.ext.NessieUri;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
 import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
@@ -79,14 +79,20 @@ public class BaseIcebergTest {
   }
 
   private void resetData() throws NessieConflictException, NessieNotFoundException {
-    for (Reference r : api.getAllReferences().get().getReferences()) {
-      // remove only 'branch' that is used by the test.
-      if (r instanceof Branch && !r.getName().equals("main")) {
-        api.deleteBranch().branch((Branch) r).delete();
-      } else if (r instanceof Tag) {
-        api.deleteTag().tag((Tag) r).delete();
-      }
-    }
+    Branch defaultBranch = api.getDefaultBranch();
+    api.getAllReferences().stream(OptionalInt.empty())
+        .forEach(
+            ref -> {
+              try {
+                if (ref instanceof Branch && !ref.getName().equals(defaultBranch.getName())) {
+                  api.deleteBranch().branch((Branch) ref).delete();
+                } else if (ref instanceof Tag) {
+                  api.deleteTag().tag((Tag) ref).delete();
+                }
+              } catch (NessieConflictException | NessieNotFoundException e) {
+                throw new RuntimeException(e);
+              }
+            });
     api.createReference().reference(Branch.of(branch, null)).create();
   }
 

--- a/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
+++ b/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.OptionalInt;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
@@ -80,7 +79,7 @@ public class BaseIcebergTest {
 
   private void resetData() throws NessieConflictException, NessieNotFoundException {
     Branch defaultBranch = api.getDefaultBranch();
-    api.getAllReferences().stream(OptionalInt.empty())
+    api.getAllReferences().stream()
         .forEach(
             ref -> {
               try {

--- a/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergViews.java
+++ b/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergViews.java
@@ -30,7 +30,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -116,7 +118,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
     assertThat(metadataFilesForViews(viewIdentifier.name())).isNotNull().hasSize(1);
 
     verifyCommitMetadata();
-    assertThat(api.getCommitLog().refName(BRANCH).get().getLogEntries()).hasSize(3);
+    assertThat(api.getCommitLog().refName(BRANCH).stream(OptionalInt.empty())).hasSize(3);
 
     verifyViewInNessie(viewIdentifier, icebergView, BRANCH);
   }
@@ -176,7 +178,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
     assertThat(metadataFilesForViews(VIEW_IDENTIFIER.name())).isNotNull().hasSize(4);
 
     verifyCommitMetadata();
-    assertThat(api.getCommitLog().refName(BRANCH).get().getLogEntries()).hasSize(6);
+    assertThat(api.getCommitLog().refName(BRANCH).stream(OptionalInt.empty())).hasSize(6);
     verifyViewInNessie(VIEW_IDENTIFIER, icebergView, BRANCH);
   }
 
@@ -204,7 +206,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
     assertThat(metadataFilesForViews(VIEW_IDENTIFIER.name())).isNotNull().hasSize(2);
 
     verifyCommitMetadata();
-    assertThat(api.getCommitLog().refName(BRANCH).get().getLogEntries()).hasSize(3);
+    assertThat(api.getCommitLog().refName(BRANCH).stream(OptionalInt.empty())).hasSize(3);
     verifyViewInNessie(VIEW_IDENTIFIER, icebergView, BRANCH);
   }
 
@@ -287,7 +289,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
 
   private void verifyCommitMetadata() throws NessieNotFoundException {
     // check that the author is properly set
-    List<LogEntry> log = api.getCommitLog().refName(BRANCH).get().getLogEntries();
+    Stream<LogEntry> log = api.getCommitLog().refName(BRANCH).stream(OptionalInt.empty());
     assertThat(log)
         .isNotNull()
         .isNotEmpty()

--- a/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergViews.java
+++ b/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergViews.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.Path;
@@ -118,7 +117,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
     assertThat(metadataFilesForViews(viewIdentifier.name())).isNotNull().hasSize(1);
 
     verifyCommitMetadata();
-    assertThat(api.getCommitLog().refName(BRANCH).stream(OptionalInt.empty())).hasSize(3);
+    assertThat(api.getCommitLog().refName(BRANCH).stream()).hasSize(3);
 
     verifyViewInNessie(viewIdentifier, icebergView, BRANCH);
   }
@@ -178,7 +177,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
     assertThat(metadataFilesForViews(VIEW_IDENTIFIER.name())).isNotNull().hasSize(4);
 
     verifyCommitMetadata();
-    assertThat(api.getCommitLog().refName(BRANCH).stream(OptionalInt.empty())).hasSize(6);
+    assertThat(api.getCommitLog().refName(BRANCH).stream()).hasSize(6);
     verifyViewInNessie(VIEW_IDENTIFIER, icebergView, BRANCH);
   }
 
@@ -206,7 +205,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
     assertThat(metadataFilesForViews(VIEW_IDENTIFIER.name())).isNotNull().hasSize(2);
 
     verifyCommitMetadata();
-    assertThat(api.getCommitLog().refName(BRANCH).stream(OptionalInt.empty())).hasSize(3);
+    assertThat(api.getCommitLog().refName(BRANCH).stream()).hasSize(3);
     verifyViewInNessie(VIEW_IDENTIFIER, icebergView, BRANCH);
   }
 
@@ -289,7 +288,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
 
   private void verifyCommitMetadata() throws NessieNotFoundException {
     // check that the author is properly set
-    Stream<LogEntry> log = api.getCommitLog().refName(BRANCH).stream(OptionalInt.empty());
+    Stream<LogEntry> log = api.getCommitLog().refName(BRANCH).stream();
     assertThat(log)
         .isNotNull()
         .isNotEmpty()

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -51,6 +51,7 @@ import org.projectnessie.tools.compatibility.api.VersionCondition;
 @VersionCondition(maxVersion = Version.NOT_CURRENT_STRING)
 public abstract class AbstractCompatibilityTests {
 
+  public static final String NESSIE_0_30_0 = "0.30.0";
   @NessieAPI protected NessieApiV1 api;
   @NessieVersion Version version;
 
@@ -58,8 +59,8 @@ public abstract class AbstractCompatibilityTests {
 
   @SuppressWarnings("deprecation")
   Stream<Reference> allReferences() throws NessieNotFoundException {
-    if (getClientVersion().isGreaterThan(Version.parseVersion("0.30.0"))) {
-      return api.getAllReferences().stream(OptionalInt.empty());
+    if (getClientVersion().isGreaterThan(Version.parseVersion(NESSIE_0_30_0))) {
+      return api.getAllReferences().stream();
     } else {
       return StreamingUtil.getAllReferencesStream(api, Function.identity(), OptionalInt.empty());
     }
@@ -69,8 +70,8 @@ public abstract class AbstractCompatibilityTests {
   Stream<LogResponse.LogEntry> commitLog(
       Function<GetCommitLogBuilder, GetCommitLogBuilder> configurer)
       throws NessieNotFoundException {
-    if (getClientVersion().isGreaterThan(Version.parseVersion("0.30.0"))) {
-      return configurer.apply(api.getCommitLog()).stream(OptionalInt.empty());
+    if (getClientVersion().isGreaterThan(Version.parseVersion(NESSIE_0_30_0))) {
+      return configurer.apply(api.getCommitLog()).stream();
     } else {
       return StreamingUtil.getCommitLogStream(api, configurer, OptionalInt.empty());
     }
@@ -252,6 +253,6 @@ public abstract class AbstractCompatibilityTests {
   }
 
   boolean nessieWithMergeResponse() {
-    return version.isGreaterThan(Version.parseVersion("0.30.0"));
+    return version.isGreaterThan(Version.parseVersion(NESSIE_0_30_0));
   }
 }

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -22,7 +22,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.Map;
+import java.util.OptionalInt;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.client.StreamingUtil;
+import org.projectnessie.client.api.GetCommitLogBuilder;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
@@ -38,7 +43,6 @@ import org.projectnessie.model.Namespace;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Reference;
-import org.projectnessie.model.ReferencesResponse;
 import org.projectnessie.tools.compatibility.api.NessieAPI;
 import org.projectnessie.tools.compatibility.api.NessieVersion;
 import org.projectnessie.tools.compatibility.api.Version;
@@ -50,13 +54,34 @@ public abstract class AbstractCompatibilityTests {
   @NessieAPI protected NessieApiV1 api;
   @NessieVersion Version version;
 
+  abstract Version getClientVersion();
+
+  @SuppressWarnings("deprecation")
+  Stream<Reference> allReferences() throws NessieNotFoundException {
+    if (getClientVersion().isGreaterThan(Version.parseVersion("0.30.0"))) {
+      return api.getAllReferences().stream(OptionalInt.empty());
+    } else {
+      return StreamingUtil.getAllReferencesStream(api, Function.identity(), OptionalInt.empty());
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  Stream<LogResponse.LogEntry> commitLog(
+      Function<GetCommitLogBuilder, GetCommitLogBuilder> configurer)
+      throws NessieNotFoundException {
+    if (getClientVersion().isGreaterThan(Version.parseVersion("0.30.0"))) {
+      return configurer.apply(api.getCommitLog()).stream(OptionalInt.empty());
+    } else {
+      return StreamingUtil.getCommitLogStream(api, configurer, OptionalInt.empty());
+    }
+  }
+
   @Test
   void getDefaultBranch() throws Exception {
     Branch defaultBranch = api.getDefaultBranch();
     assertThat(defaultBranch).extracting(Branch::getName).isEqualTo("main");
 
-    ReferencesResponse allRefs = api.getAllReferences().get();
-    assertThat(allRefs.getReferences()).contains(defaultBranch);
+    assertThat(allReferences()).contains(defaultBranch);
   }
 
   @Test
@@ -88,8 +113,8 @@ public abstract class AbstractCompatibilityTests {
         .extracting(Branch::getName)
         .isEqualTo(branch.getName());
 
-    LogResponse commitLog = api.getCommitLog().refName(branch.getName()).get();
-    assertThat(commitLog.getLogEntries())
+    Stream<LogEntry> commitLog = commitLog(b -> b.refName(branch.getName()));
+    assertThat(commitLog)
         .hasSize(1)
         .map(LogEntry::getCommitMeta)
         .map(CommitMeta::getMessage)

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITOlderClients.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITOlderClients.java
@@ -16,7 +16,13 @@
 package org.projectnessie.tools.compatibility.tests;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.internal.OlderNessieClientsExtension;
 
 @ExtendWith(OlderNessieClientsExtension.class)
-public class ITOlderClients extends AbstractCompatibilityTests {}
+public class ITOlderClients extends AbstractCompatibilityTests {
+  @Override
+  Version getClientVersion() {
+    return version;
+  }
+}

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
@@ -16,7 +16,14 @@
 package org.projectnessie.tools.compatibility.tests;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.internal.OlderNessieServersExtension;
 
 @ExtendWith(OlderNessieServersExtension.class)
-public class ITOlderServers extends AbstractCompatibilityTests {}
+public class ITOlderServers extends AbstractCompatibilityTests {
+
+  @Override
+  Version getClientVersion() {
+    return Version.CURRENT;
+  }
+}

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
@@ -104,7 +104,7 @@ public class ITUpgradePath {
   @SuppressWarnings("deprecation")
   Stream<Reference> allReferences() throws NessieNotFoundException {
     if (version.isGreaterThan(Version.parseVersion("0.30.0"))) {
-      return api.getAllReferences().stream(OptionalInt.empty());
+      return api.getAllReferences().stream();
     } else {
       return StreamingUtil.getAllReferencesStream(api, Function.identity(), OptionalInt.empty());
     }
@@ -114,7 +114,7 @@ public class ITUpgradePath {
   Stream<EntriesResponse.Entry> entries(Function<GetEntriesBuilder, GetEntriesBuilder> configurer)
       throws NessieNotFoundException {
     if (version.isGreaterThan(Version.parseVersion("0.30.0"))) {
-      return configurer.apply(api.getEntries()).stream(OptionalInt.empty());
+      return configurer.apply(api.getEntries()).stream();
     } else {
       return StreamingUtil.getEntriesStream(api, configurer, OptionalInt.empty());
     }
@@ -125,7 +125,7 @@ public class ITUpgradePath {
       Function<GetCommitLogBuilder, GetCommitLogBuilder> configurer)
       throws NessieNotFoundException {
     if (version.isGreaterThan(Version.parseVersion("0.30.0"))) {
-      return configurer.apply(api.getCommitLog()).stream(OptionalInt.empty());
+      return configurer.apply(api.getCommitLog()).stream();
     } else {
       return StreamingUtil.getCommitLogStream(api, configurer, OptionalInt.empty());
     }
@@ -135,7 +135,7 @@ public class ITUpgradePath {
   Stream<RefLogResponse.RefLogResponseEntry> refLog(
       Function<GetRefLogBuilder, GetRefLogBuilder> configurer) throws NessieNotFoundException {
     if (version.isGreaterThan(Version.parseVersion("0.30.0"))) {
-      return configurer.apply(api.getRefLog()).stream(OptionalInt.empty());
+      return configurer.apply(api.getRefLog()).stream();
     } else {
       return StreamingUtil.getReflogStream(api, configurer, OptionalInt.empty());
     }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
@@ -101,13 +101,12 @@ public class GCImpl {
     Map<String, ContentBloomFilter> liveContentsBloomFilterMap;
     try (NessieApiV1 api = GCUtil.getApi(gcParams.getNessieClientConfigs())) {
       distributedIdentifyContents = new DistributedIdentifyContents(session, gcParams);
-      List<Reference> liveReferences = api.getAllReferences().get().getReferences();
+      Stream<Reference> liveReferences = api.getAllReferences().stream(OptionalInt.empty());
       Map<String, Instant> droppedReferenceTimeMap = collectDeadReferences(api);
       // As this list of references is passed from Spark driver to executor,
       // using available Immutables JSON serialization instead of adding java serialization to the
       // classes.
-      allRefs =
-          liveReferences.stream().map(GCUtil::serializeReference).collect(Collectors.toList());
+      allRefs = liveReferences.map(GCUtil::serializeReference).collect(Collectors.toList());
       if (droppedReferenceTimeMap.size() > 0) {
         allRefs.addAll(droppedReferenceTimeMap.keySet());
       }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/GCImpl.java
@@ -95,13 +95,13 @@ public class GCImpl {
    * @param session spark session for distributed computation
    * @return current run id of the completed gc task
    */
-  public String identifyExpiredContents(SparkSession session) {
+  public String identifyExpiredContents(SparkSession session) throws NessieNotFoundException {
     DistributedIdentifyContents distributedIdentifyContents;
     List<String> allRefs;
     Map<String, ContentBloomFilter> liveContentsBloomFilterMap;
     try (NessieApiV1 api = GCUtil.getApi(gcParams.getNessieClientConfigs())) {
       distributedIdentifyContents = new DistributedIdentifyContents(session, gcParams);
-      Stream<Reference> liveReferences = api.getAllReferences().stream(OptionalInt.empty());
+      Stream<Reference> liveReferences = api.getAllReferences().stream();
       Map<String, Instant> droppedReferenceTimeMap = collectDeadReferences(api);
       // As this list of references is passed from Spark driver to executor,
       // using available Immutables JSON serialization instead of adding java serialization to the

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifyContentsPerExecutor.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifyContentsPerExecutor.java
@@ -163,8 +163,7 @@ public class IdentifyContentsPerExecutor implements Serializable {
               .getEntries()
               .refName(Detached.REF_NAME)
               .hashOnRef(logEntry.getCommitMeta().getHash())
-              .get()
-              .getEntries()
+              .stream(OptionalInt.empty())
               .forEach(entries -> liveContentKeys.add(entries.getName()));
 
           if (liveContentKeys.isEmpty()) {

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifyContentsPerExecutor.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/base/IdentifyContentsPerExecutor.java
@@ -163,7 +163,7 @@ public class IdentifyContentsPerExecutor implements Serializable {
               .getEntries()
               .refName(Detached.REF_NAME)
               .hashOnRef(logEntry.getCommitMeta().getHash())
-              .stream(OptionalInt.empty())
+              .stream()
               .forEach(entries -> liveContentKeys.add(entries.getName()));
 
           if (liveContentKeys.isEmpty()) {

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
@@ -61,9 +63,8 @@ public abstract class AbstractRestGC extends AbstractRest {
         .refName(branch.getName())
         .hashOnRef(branch.getHash())
         .fetch(FetchOption.ALL)
-        .maxRecords(numCommits)
-        .get()
-        .getLogEntries();
+        .stream(OptionalInt.of(numCommits))
+        .collect(Collectors.toList());
   }
 
   void fillExpectedContents(Branch branch, int numCommits, List<Row> expected)

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
@@ -97,7 +97,8 @@ public abstract class AbstractRestGC extends AbstractRest {
       Map<String, Instant> cutOffTimeStampPerRef,
       List<Row> expectedDataSet,
       boolean disableCommitProtection,
-      Instant deadReferenceCutoffTime) {
+      Instant deadReferenceCutoffTime)
+      throws NessieNotFoundException {
 
     try (SparkSession sparkSession = getSparkSession()) {
       ImmutableGCParams.Builder builder = ImmutableGCParams.builder();

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/base/AbstractRestGC.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 import org.apache.spark.SparkConf;
@@ -63,7 +62,8 @@ public abstract class AbstractRestGC extends AbstractRest {
         .refName(branch.getName())
         .hashOnRef(branch.getHash())
         .fetch(FetchOption.ALL)
-        .stream(OptionalInt.of(numCommits))
+        .stream()
+        .limit(numCommits)
         .collect(Collectors.toList());
   }
 

--- a/model/src/main/java/org/projectnessie/api/params/AbstractParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/AbstractParams.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 import javax.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 
-public abstract class AbstractParams {
+public abstract class AbstractParams<IMPL extends AbstractParams<IMPL>> {
 
   @Parameter(description = "maximum number of entries to return, just a hint for the server")
   @QueryParam("maxRecords")
@@ -50,6 +50,8 @@ public abstract class AbstractParams {
   public String pageToken() {
     return pageToken;
   }
+
+  public abstract IMPL forNextPage(String pageToken);
 
   public abstract static class Builder<T extends Builder<T>> {
 

--- a/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/CommitLogParams.java
@@ -31,7 +31,7 @@ import org.projectnessie.model.Validation;
  * <p>For easier usage of this class, there is {@link CommitLogParams#builder()}, which allows
  * configuring/setting the different parameters.
  */
-public class CommitLogParams extends AbstractParams {
+public class CommitLogParams extends AbstractParams<CommitLogParams> {
 
   @Nullable
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
@@ -120,6 +120,11 @@ public class CommitLogParams extends AbstractParams {
 
   public static CommitLogParams empty() {
     return builder().build();
+  }
+
+  @Override
+  public CommitLogParams forNextPage(String pageToken) {
+    return new CommitLogParams(startHash, endHash, maxRecords(), pageToken, filter, fetchOption);
   }
 
   @Override

--- a/model/src/main/java/org/projectnessie/api/params/EntriesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/EntriesParams.java
@@ -31,7 +31,7 @@ import org.projectnessie.model.Validation;
  * <p>For easier usage of this class, there is {@link EntriesParams#builder()}, which allows
  * configuring/setting the different parameters.
  */
-public class EntriesParams extends AbstractParams {
+public class EntriesParams extends AbstractParams<EntriesParams> {
 
   @Nullable
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
@@ -98,6 +98,11 @@ public class EntriesParams extends AbstractParams {
   @Nullable
   public Integer namespaceDepth() {
     return namespaceDepth;
+  }
+
+  @Override
+  public EntriesParams forNextPage(String pageToken) {
+    return new EntriesParams(hashOnRef, maxRecords(), pageToken, namespaceDepth, filter);
   }
 
   @Override

--- a/model/src/main/java/org/projectnessie/api/params/RefLogParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/RefLogParams.java
@@ -30,7 +30,7 @@ import org.projectnessie.model.Validation;
  * <p>For easier usage of this class, there is {@link RefLogParams#builder()}, which allows
  * configuring/setting the different parameters.
  */
-public class RefLogParams extends AbstractParams {
+public class RefLogParams extends AbstractParams<RefLogParams> {
 
   @Nullable
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
@@ -101,6 +101,11 @@ public class RefLogParams extends AbstractParams {
 
   public static RefLogParams empty() {
     return builder().build();
+  }
+
+  @Override
+  public RefLogParams forNextPage(String pageToken) {
+    return new RefLogParams(startHash, endHash, maxRecords(), pageToken, filter);
   }
 
   @Override

--- a/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
+++ b/model/src/main/java/org/projectnessie/api/params/ReferencesParams.java
@@ -30,7 +30,7 @@ import org.projectnessie.api.http.HttpTreeApi;
  * <p>For easier usage of this class, there is {@link ReferencesParams#builder()}, which allows
  * configuring/setting the different parameters.
  */
-public class ReferencesParams extends AbstractParams {
+public class ReferencesParams extends AbstractParams<ReferencesParams> {
 
   @Parameter(
       description =
@@ -94,6 +94,11 @@ public class ReferencesParams extends AbstractParams {
 
   public static ReferencesParams empty() {
     return builder().build();
+  }
+
+  @Override
+  public ReferencesParams forNextPage(String pageToken) {
+    return new ReferencesParams(maxRecords(), pageToken, fetchOption, filter);
   }
 
   @Override

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.util.Locale;
-import java.util.OptionalInt;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,7 +84,7 @@ public abstract class AbstractRest {
   @AfterEach
   public void tearDown() throws Exception {
     Branch defaultBranch = api.getDefaultBranch();
-    api.getAllReferences().stream(OptionalInt.empty())
+    api.getAllReferences().stream()
         .forEach(
             ref -> {
               try {

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestAssign.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestAssign.java
@@ -17,11 +17,11 @@ package org.projectnessie.jaxrs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.OptionalInt;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
 
@@ -35,8 +35,8 @@ public abstract class AbstractRestAssign extends AbstractRest {
       throws BaseNessieClientServerException {
     Reference main = getApi().getReference().refName("main").get();
     // make sure main doesn't have any commits
-    LogResponse log = getApi().getCommitLog().refName(main.getName()).get();
-    assertThat(log.getLogEntries()).isEmpty();
+    assertThat(getApi().getCommitLog().refName(main.getName()).stream(OptionalInt.empty()))
+        .isEmpty();
 
     Branch testBranch = createBranch("testBranch");
     getApi().assignBranch().branch(testBranch).assignTo(main).assign();

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestAssign.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestAssign.java
@@ -17,7 +17,6 @@ package org.projectnessie.jaxrs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.OptionalInt;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.projectnessie.error.BaseNessieClientServerException;
@@ -35,8 +34,7 @@ public abstract class AbstractRestAssign extends AbstractRest {
       throws BaseNessieClientServerException {
     Reference main = getApi().getReference().refName("main").get();
     // make sure main doesn't have any commits
-    assertThat(getApi().getCommitLog().refName(main.getName()).stream(OptionalInt.empty()))
-        .isEmpty();
+    assertThat(getApi().getCommitLog().refName(main.getName()).stream()).isEmpty();
 
     Branch testBranch = createBranch("testBranch");
     getApi().assignBranch().branch(testBranch).assignTo(main).assign();

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestCommitLog.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestCommitLog.java
@@ -83,8 +83,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.type == 'PUT')")
-                .get()
-                .getLogEntries())
+                .stream(OptionalInt.empty()))
         .hasSize(1);
     assertThat(
             getApi()
@@ -92,8 +91,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.key.startsWith('hello.world.'))")
-                .get()
-                .getLogEntries())
+                .stream(OptionalInt.empty()))
         .hasSize(1);
     assertThat(
             getApi()
@@ -101,8 +99,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.key.startsWith('not.there.'))")
-                .get()
-                .getLogEntries())
+                .stream(OptionalInt.empty()))
         .isEmpty();
     assertThat(
             getApi()
@@ -110,8 +107,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.name == 'BaseTable')")
-                .get()
-                .getLogEntries())
+                .stream(OptionalInt.empty()))
         .hasSize(1);
     assertThat(
             getApi()
@@ -119,8 +115,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.name == 'ThereIsNoSuchTable')")
-                .get()
-                .getLogEntries())
+                .stream(OptionalInt.empty()))
         .isEmpty();
   }
 
@@ -133,82 +128,78 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
 
     String currentHash = branch.getHash();
     createCommits(branch, numAuthors, commitsPerAuthor, currentHash);
-    LogResponse log = getApi().getCommitLog().refName(branch.getName()).get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(numAuthors * commitsPerAuthor);
+    List<LogResponse.LogEntry> log =
+        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(numAuthors * commitsPerAuthor);
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author == 'author-3'")
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(commitsPerAuthor);
-    log.getLogEntries()
-        .forEach(commit -> assertThat(commit.getCommitMeta().getAuthor()).isEqualTo("author-3"));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(commitsPerAuthor);
+    log.forEach(commit -> assertThat(commit.getCommitMeta().getAuthor()).isEqualTo("author-3"));
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author == 'author-3' && commit.committer == 'random-committer'")
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).isEmpty();
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).isEmpty();
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author == 'author-3'")
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(commitsPerAuthor);
-    log.getLogEntries()
-        .forEach(commit -> assertThat(commit.getCommitMeta().getAuthor()).isEqualTo("author-3"));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(commitsPerAuthor);
+    log.forEach(commit -> assertThat(commit.getCommitMeta().getAuthor()).isEqualTo("author-3"));
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author in ['author-1', 'author-3', 'author-4']")
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(commitsPerAuthor * 3);
-    log.getLogEntries()
-        .forEach(
-            commit ->
-                assertThat(ImmutableList.of("author-1", "author-3", "author-4"))
-                    .contains(commit.getCommitMeta().getAuthor()));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(commitsPerAuthor * 3);
+    log.forEach(
+        commit ->
+            assertThat(ImmutableList.of("author-1", "author-3", "author-4"))
+                .contains(commit.getCommitMeta().getAuthor()));
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter("!(commit.author in ['author-1', 'author-0'])")
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(commitsPerAuthor * 3);
-    log.getLogEntries()
-        .forEach(
-            commit ->
-                assertThat(ImmutableList.of("author-2", "author-3", "author-4"))
-                    .contains(commit.getCommitMeta().getAuthor()));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(commitsPerAuthor * 3);
+    log.forEach(
+        commit ->
+            assertThat(ImmutableList.of("author-2", "author-3", "author-4"))
+                .contains(commit.getCommitMeta().getAuthor()));
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author.matches('au.*-(2|4)')")
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(commitsPerAuthor * 2);
-    log.getLogEntries()
-        .forEach(
-            commit ->
-                assertThat(ImmutableList.of("author-2", "author-4"))
-                    .contains(commit.getCommitMeta().getAuthor()));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(commitsPerAuthor * 2);
+    log.forEach(
+        commit ->
+            assertThat(ImmutableList.of("author-2", "author-4"))
+                .contains(commit.getCommitMeta().getAuthor()));
   }
 
   @Test
@@ -221,14 +212,14 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
 
     String currentHash = branch.getHash();
     createCommits(branch, numAuthors, commitsPerAuthor, currentHash);
-    LogResponse log = getApi().getCommitLog().refName(branch.getName()).get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(expectedTotalSize);
+    List<LogResponse.LogEntry> log =
+        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(expectedTotalSize);
 
-    Instant initialCommitTime =
-        log.getLogEntries().get(log.getLogEntries().size() - 1).getCommitMeta().getCommitTime();
+    Instant initialCommitTime = log.get(log.size() - 1).getCommitMeta().getCommitTime();
     assertThat(initialCommitTime).isNotNull();
-    Instant lastCommitTime = log.getLogEntries().get(0).getCommitMeta().getCommitTime();
+    Instant lastCommitTime = log.get(0).getCommitMeta().getCommitTime();
     assertThat(lastCommitTime).isNotNull();
     Instant fiveMinLater = initialCommitTime.plus(5, ChronoUnit.MINUTES);
 
@@ -238,25 +229,22 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .refName(branch.getName())
             .filter(
                 String.format("timestamp(commit.commitTime) > timestamp('%s')", initialCommitTime))
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(expectedTotalSize - 1);
-    log.getLogEntries()
-        .forEach(
-            commit ->
-                assertThat(commit.getCommitMeta().getCommitTime()).isAfter(initialCommitTime));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(expectedTotalSize - 1);
+    log.forEach(
+        commit -> assertThat(commit.getCommitMeta().getCommitTime()).isAfter(initialCommitTime));
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter(String.format("timestamp(commit.commitTime) < timestamp('%s')", fiveMinLater))
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(expectedTotalSize);
-    log.getLogEntries()
-        .forEach(
-            commit -> assertThat(commit.getCommitMeta().getCommitTime()).isBefore(fiveMinLater));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(expectedTotalSize);
+    log.forEach(
+        commit -> assertThat(commit.getCommitMeta().getCommitTime()).isBefore(fiveMinLater));
 
     log =
         getApi()
@@ -266,24 +254,23 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 String.format(
                     "timestamp(commit.commitTime) > timestamp('%s') && timestamp(commit.commitTime) < timestamp('%s')",
                     initialCommitTime, lastCommitTime))
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(expectedTotalSize - 2);
-    log.getLogEntries()
-        .forEach(
-            commit ->
-                assertThat(commit.getCommitMeta().getCommitTime())
-                    .isAfter(initialCommitTime)
-                    .isBefore(lastCommitTime));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(expectedTotalSize - 2);
+    log.forEach(
+        commit ->
+            assertThat(commit.getCommitMeta().getCommitTime())
+                .isAfter(initialCommitTime)
+                .isBefore(lastCommitTime));
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter(String.format("timestamp(commit.commitTime) > timestamp('%s')", fiveMinLater))
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).isEmpty();
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).isEmpty();
   }
 
   @Test
@@ -295,31 +282,31 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
 
     String currentHash = branch.getHash();
     createCommits(branch, numAuthors, commitsPerAuthor, currentHash);
-    LogResponse log = getApi().getCommitLog().refName(branch.getName()).get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(numAuthors * commitsPerAuthor);
+    List<LogResponse.LogEntry> log =
+        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(numAuthors * commitsPerAuthor);
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.properties['prop1'] == 'val1'")
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(numAuthors * commitsPerAuthor);
-    log.getLogEntries()
-        .forEach(
-            commit ->
-                assertThat(commit.getCommitMeta().getProperties().get("prop1")).isEqualTo("val1"));
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(numAuthors * commitsPerAuthor);
+    log.forEach(
+        commit ->
+            assertThat(commit.getCommitMeta().getProperties().get("prop1")).isEqualTo("val1"));
 
     log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.properties['prop1'] == 'val3'")
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).isEmpty();
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).isEmpty();
   }
 
   @Test
@@ -330,37 +317,37 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
 
     String currentHash = branch.getHash();
     createCommits(branch, 1, numCommits, currentHash);
-    LogResponse entireLog = getApi().getCommitLog().refName(branch.getName()).get();
-    assertThat(entireLog).isNotNull();
-    assertThat(entireLog.getLogEntries()).hasSize(numCommits);
+    List<LogResponse.LogEntry> entireLog =
+        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(entireLog).hasSize(numCommits);
 
     // if startHash > endHash, then we return all commits starting from startHash
-    String startHash = entireLog.getLogEntries().get(numCommits / 2).getCommitMeta().getHash();
-    String endHash = entireLog.getLogEntries().get(0).getCommitMeta().getHash();
-    LogResponse log =
+    String startHash = entireLog.get(numCommits / 2).getCommitMeta().getHash();
+    String endHash = entireLog.get(0).getCommitMeta().getHash();
+    List<LogResponse.LogEntry> log =
         getApi()
             .getCommitLog()
             .refName(branch.getName())
             .hashOnRef(endHash)
             .untilHash(startHash)
-            .get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(numCommits / 2 + 1);
+            .stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(numCommits / 2 + 1);
 
     for (int i = 0, j = numCommits - 1; i < j; i++, j--) {
-      startHash = entireLog.getLogEntries().get(j).getCommitMeta().getHash();
-      endHash = entireLog.getLogEntries().get(i).getCommitMeta().getHash();
+      startHash = entireLog.get(j).getCommitMeta().getHash();
+      endHash = entireLog.get(i).getCommitMeta().getHash();
       log =
           getApi()
               .getCommitLog()
               .refName(branch.getName())
               .hashOnRef(endHash)
               .untilHash(startHash)
-              .get();
-      assertThat(log).isNotNull();
-      assertThat(log.getLogEntries()).hasSize(numCommits - (i * 2));
-      assertThat(ImmutableList.copyOf(entireLog.getLogEntries()).subList(i, j + 1))
-          .containsExactlyElementsOf(log.getLogEntries());
+              .stream(OptionalInt.empty())
+              .collect(Collectors.toList());
+      assertThat(log).hasSize(numCommits - (i * 2));
+      assertThat(ImmutableList.copyOf(entireLog).subList(i, j + 1)).containsExactlyElementsOf(log);
     }
   }
 
@@ -374,13 +361,14 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
     int expectedTotalSize = numAuthors * commits;
 
     createCommits(branch, numAuthors, commits, branch.getHash());
-    LogResponse log = getApi().getCommitLog().refName(branch.getName()).get();
-    assertThat(log).isNotNull();
-    assertThat(log.getLogEntries()).hasSize(expectedTotalSize);
+    List<LogResponse.LogEntry> log =
+        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
+            .collect(Collectors.toList());
+    assertThat(log).hasSize(expectedTotalSize);
 
     String author = "author-1";
     List<String> messagesOfAuthorOne =
-        log.getLogEntries().stream()
+        log.stream()
             .map(LogEntry::getCommitMeta)
             .filter(c -> author.equals(c.getAuthor()))
             .map(CommitMeta::getMessage)
@@ -388,7 +376,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
     verifyPaging(branch.getName(), commits, pageSizeHint, messagesOfAuthorOne, author);
 
     List<String> allMessages =
-        log.getLogEntries().stream()
+        log.stream()
             .map(LogEntry::getCommitMeta)
             .map(CommitMeta::getMessage)
             .collect(Collectors.toList());
@@ -501,8 +489,8 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                     .getCommitLog()
                     .untilHash(firstParent)
                     .reference(refMode.transform(branchRef))
-                    .get()
-                    .getLogEntries()))
+                    .stream(OptionalInt.empty())
+                    .collect(Collectors.toList())))
         .allSatisfy(
             c -> {
               assertThat(c.getOperations()).isNull();
@@ -520,8 +508,8 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .fetch(FetchOption.ALL)
                 .reference(refMode.transform(branchRef))
                 .untilHash(firstParent)
-                .get()
-                .getLogEntries());
+                .stream(OptionalInt.empty())
+                .collect(Collectors.toList()));
     assertThat(IntStream.rangeClosed(1, numCommits))
         .allSatisfy(
             i -> {
@@ -566,7 +554,8 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
         .commit();
 
     List<LogEntry> logEntries =
-        getApi().getCommitLog().fetch(FetchOption.ALL).refName(branch).get().getLogEntries();
+        getApi().getCommitLog().fetch(FetchOption.ALL).refName(branch).stream(OptionalInt.empty())
+            .collect(Collectors.toList());
     assertThat(logEntries.size()).isEqualTo(1);
     assertThat(logEntries.get(0).getCommitMeta().getMessage()).contains("Commit #1");
     assertThat(logEntries.get(0).getOperations()).isNull();
@@ -585,6 +574,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
       if (null != filterByAuthor) {
         filter = String.format("commit.author=='%s'", filterByAuthor);
       }
+      @SuppressWarnings("deprecation")
       LogResponse response =
           getApi()
               .getCommitLog()

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestCommitLog.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestCommitLog.java
@@ -83,7 +83,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.type == 'PUT')")
-                .stream(OptionalInt.empty()))
+                .stream())
         .hasSize(1);
     assertThat(
             getApi()
@@ -91,7 +91,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.key.startsWith('hello.world.'))")
-                .stream(OptionalInt.empty()))
+                .stream())
         .hasSize(1);
     assertThat(
             getApi()
@@ -99,7 +99,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.key.startsWith('not.there.'))")
-                .stream(OptionalInt.empty()))
+                .stream())
         .isEmpty();
     assertThat(
             getApi()
@@ -107,7 +107,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.name == 'BaseTable')")
-                .stream(OptionalInt.empty()))
+                .stream())
         .hasSize(1);
     assertThat(
             getApi()
@@ -115,7 +115,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .refName(branch.getName())
                 .fetch(FetchOption.ALL)
                 .filter("operations.exists(op, op.name == 'ThereIsNoSuchTable')")
-                .stream(OptionalInt.empty()))
+                .stream())
         .isEmpty();
   }
 
@@ -129,8 +129,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
     String currentHash = branch.getHash();
     createCommits(branch, numAuthors, commitsPerAuthor, currentHash);
     List<LogResponse.LogEntry> log =
-        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
-            .collect(Collectors.toList());
+        getApi().getCommitLog().refName(branch.getName()).stream().collect(Collectors.toList());
     assertThat(log).hasSize(numAuthors * commitsPerAuthor);
 
     log =
@@ -138,7 +137,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author == 'author-3'")
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(commitsPerAuthor);
     log.forEach(commit -> assertThat(commit.getCommitMeta().getAuthor()).isEqualTo("author-3"));
@@ -148,7 +147,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author == 'author-3' && commit.committer == 'random-committer'")
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).isEmpty();
 
@@ -157,7 +156,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author == 'author-3'")
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(commitsPerAuthor);
     log.forEach(commit -> assertThat(commit.getCommitMeta().getAuthor()).isEqualTo("author-3"));
@@ -167,7 +166,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author in ['author-1', 'author-3', 'author-4']")
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(commitsPerAuthor * 3);
     log.forEach(
@@ -180,7 +179,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter("!(commit.author in ['author-1', 'author-0'])")
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(commitsPerAuthor * 3);
     log.forEach(
@@ -193,7 +192,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.author.matches('au.*-(2|4)')")
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(commitsPerAuthor * 2);
     log.forEach(
@@ -213,8 +212,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
     String currentHash = branch.getHash();
     createCommits(branch, numAuthors, commitsPerAuthor, currentHash);
     List<LogResponse.LogEntry> log =
-        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
-            .collect(Collectors.toList());
+        getApi().getCommitLog().refName(branch.getName()).stream().collect(Collectors.toList());
     assertThat(log).hasSize(expectedTotalSize);
 
     Instant initialCommitTime = log.get(log.size() - 1).getCommitMeta().getCommitTime();
@@ -229,7 +227,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .refName(branch.getName())
             .filter(
                 String.format("timestamp(commit.commitTime) > timestamp('%s')", initialCommitTime))
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(expectedTotalSize - 1);
     log.forEach(
@@ -240,7 +238,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter(String.format("timestamp(commit.commitTime) < timestamp('%s')", fiveMinLater))
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(expectedTotalSize);
     log.forEach(
@@ -254,7 +252,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 String.format(
                     "timestamp(commit.commitTime) > timestamp('%s') && timestamp(commit.commitTime) < timestamp('%s')",
                     initialCommitTime, lastCommitTime))
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(expectedTotalSize - 2);
     log.forEach(
@@ -268,7 +266,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter(String.format("timestamp(commit.commitTime) > timestamp('%s')", fiveMinLater))
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).isEmpty();
   }
@@ -283,8 +281,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
     String currentHash = branch.getHash();
     createCommits(branch, numAuthors, commitsPerAuthor, currentHash);
     List<LogResponse.LogEntry> log =
-        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
-            .collect(Collectors.toList());
+        getApi().getCommitLog().refName(branch.getName()).stream().collect(Collectors.toList());
     assertThat(log).hasSize(numAuthors * commitsPerAuthor);
 
     log =
@@ -292,7 +289,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.properties['prop1'] == 'val1'")
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(numAuthors * commitsPerAuthor);
     log.forEach(
@@ -304,7 +301,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .getCommitLog()
             .refName(branch.getName())
             .filter("commit.properties['prop1'] == 'val3'")
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).isEmpty();
   }
@@ -318,8 +315,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
     String currentHash = branch.getHash();
     createCommits(branch, 1, numCommits, currentHash);
     List<LogResponse.LogEntry> entireLog =
-        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
-            .collect(Collectors.toList());
+        getApi().getCommitLog().refName(branch.getName()).stream().collect(Collectors.toList());
     assertThat(entireLog).hasSize(numCommits);
 
     // if startHash > endHash, then we return all commits starting from startHash
@@ -331,7 +327,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
             .refName(branch.getName())
             .hashOnRef(endHash)
             .untilHash(startHash)
-            .stream(OptionalInt.empty())
+            .stream()
             .collect(Collectors.toList());
     assertThat(log).hasSize(numCommits / 2 + 1);
 
@@ -344,7 +340,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
               .refName(branch.getName())
               .hashOnRef(endHash)
               .untilHash(startHash)
-              .stream(OptionalInt.empty())
+              .stream()
               .collect(Collectors.toList());
       assertThat(log).hasSize(numCommits - (i * 2));
       assertThat(ImmutableList.copyOf(entireLog).subList(i, j + 1)).containsExactlyElementsOf(log);
@@ -362,8 +358,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
 
     createCommits(branch, numAuthors, commits, branch.getHash());
     List<LogResponse.LogEntry> log =
-        getApi().getCommitLog().refName(branch.getName()).stream(OptionalInt.empty())
-            .collect(Collectors.toList());
+        getApi().getCommitLog().refName(branch.getName()).stream().collect(Collectors.toList());
     assertThat(log).hasSize(expectedTotalSize);
 
     String author = "author-1";
@@ -489,7 +484,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                     .getCommitLog()
                     .untilHash(firstParent)
                     .reference(refMode.transform(branchRef))
-                    .stream(OptionalInt.empty())
+                    .stream()
                     .collect(Collectors.toList())))
         .allSatisfy(
             c -> {
@@ -508,7 +503,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
                 .fetch(FetchOption.ALL)
                 .reference(refMode.transform(branchRef))
                 .untilHash(firstParent)
-                .stream(OptionalInt.empty())
+                .stream()
                 .collect(Collectors.toList()));
     assertThat(IntStream.rangeClosed(1, numCommits))
         .allSatisfy(
@@ -554,7 +549,7 @@ public abstract class AbstractRestCommitLog extends AbstractRestAssign {
         .commit();
 
     List<LogEntry> logEntries =
-        getApi().getCommitLog().fetch(FetchOption.ALL).refName(branch).stream(OptionalInt.empty())
+        getApi().getCommitLog().fetch(FetchOption.ALL).refName(branch).stream()
             .collect(Collectors.toList());
     assertThat(logEntries.size()).isEqualTo(1);
     assertThat(logEntries.get(0).getCommitMeta().getMessage()).contains("Commit #1");

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestContents.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestContents.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -140,7 +141,9 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
 
     assertAll(
         () -> {
-          List<Entry> entries = getApi().getEntries().refName(branch.getName()).get().getEntries();
+          List<Entry> entries =
+              getApi().getEntries().refName(branch.getName()).stream(OptionalInt.empty())
+                  .collect(Collectors.toList());
           List<Entry> expect =
               contentAndOps.stream()
                   .filter(c -> c.operation instanceof Put)
@@ -183,12 +186,8 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
         () ->
             // Verify that the operations on the HEAD commit contains the committed operations
             assertThat(
-                    getApi()
-                        .getCommitLog()
-                        .reference(committed)
-                        .fetch(FetchOption.ALL)
-                        .get()
-                        .getLogEntries())
+                    getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream(
+                        OptionalInt.empty()))
                 .element(0)
                 .extracting(LogEntry::getOperations)
                 .extracting(this::clearIdOnOperations, list(Operation.class))
@@ -223,7 +222,8 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
       assertAll(
           () -> {
             List<Entry> entries =
-                getApi().getEntries().refName(branch.getName()).get().getEntries();
+                getApi().getEntries().refName(branch.getName()).stream(OptionalInt.empty())
+                    .collect(Collectors.toList());
             assertThat(entries)
                 .containsExactly(
                     Entry.builder()
@@ -250,10 +250,11 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
           },
           () -> {
             // Compare operation on HEAD commit with the committed operation
-            LogResponse log =
-                getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).get();
+            List<LogResponse.LogEntry> log =
+                getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream(
+                        OptionalInt.empty())
+                    .collect(Collectors.toList());
             assertThat(log)
-                .extracting(LogResponse::getLogEntries, list(LogEntry.class))
                 .element(0)
                 .extracting(LogEntry::getOperations, list(Operation.class))
                 .element(0)
@@ -266,7 +267,8 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
       assertAll(
           () -> {
             List<Entry> entries =
-                getApi().getEntries().refName(branch.getName()).get().getEntries();
+                getApi().getEntries().refName(branch.getName()).stream(OptionalInt.empty())
+                    .collect(Collectors.toList());
             assertThat(entries).isEmpty();
           },
           () -> {
@@ -284,10 +286,11 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
           },
           () -> {
             // Compare operation on HEAD commit with the committed operation
-            LogResponse log =
-                getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).get();
+            List<LogResponse.LogEntry> log =
+                getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream(
+                        OptionalInt.empty())
+                    .collect(Collectors.toList());
             assertThat(log)
-                .extracting(LogResponse::getLogEntries, list(LogEntry.class))
                 .element(0)
                 .extracting(LogEntry::getOperations)
                 .satisfies(

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestContents.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestContents.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -184,9 +183,7 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
         },
         () ->
             // Verify that the operations on the HEAD commit contains the committed operations
-            assertThat(
-                    getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream(
-                        OptionalInt.empty()))
+            assertThat(getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream())
                 .element(0)
                 .extracting(LogEntry::getOperations)
                 .extracting(this::clearIdOnOperations, list(Operation.class))
@@ -250,8 +247,7 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
           () -> {
             // Compare operation on HEAD commit with the committed operation
             List<LogResponse.LogEntry> log =
-                getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream(
-                        OptionalInt.empty())
+                getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream()
                     .collect(Collectors.toList());
             assertThat(log)
                 .element(0)
@@ -286,8 +282,7 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
           () -> {
             // Compare operation on HEAD commit with the committed operation
             List<LogResponse.LogEntry> log =
-                getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream(
-                        OptionalInt.empty())
+                getApi().getCommitLog().reference(committed).fetch(FetchOption.ALL).stream()
                     .collect(Collectors.toList());
             assertThat(log)
                 .element(0)

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestContents.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestContents.java
@@ -142,8 +142,7 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
     assertAll(
         () -> {
           List<Entry> entries =
-              getApi().getEntries().refName(branch.getName()).stream(OptionalInt.empty())
-                  .collect(Collectors.toList());
+              getApi().getEntries().refName(branch.getName()).stream().collect(Collectors.toList());
           List<Entry> expect =
               contentAndOps.stream()
                   .filter(c -> c.operation instanceof Put)
@@ -222,7 +221,7 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
       assertAll(
           () -> {
             List<Entry> entries =
-                getApi().getEntries().refName(branch.getName()).stream(OptionalInt.empty())
+                getApi().getEntries().refName(branch.getName()).stream()
                     .collect(Collectors.toList());
             assertThat(entries)
                 .containsExactly(
@@ -267,7 +266,7 @@ public abstract class AbstractRestContents extends AbstractRestCommitLog {
       assertAll(
           () -> {
             List<Entry> entries =
-                getApi().getEntries().refName(branch.getName()).stream(OptionalInt.empty())
+                getApi().getEntries().refName(branch.getName()).stream()
                     .collect(Collectors.toList());
             assertThat(entries).isEmpty();
           },

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractOpenIdAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractOpenIdAuthentication.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.smallrye.jwt.build.Jwt;
 import java.util.Map;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.auth.BearerAuthenticationProvider;
 import org.projectnessie.client.rest.NessieNotAuthorizedException;
@@ -44,14 +45,14 @@ public abstract class AbstractOpenIdAuthentication extends BaseClientAuthTest {
   void testValidJwt() {
     withClientCustomizer(
         b -> b.withAuthentication(BearerAuthenticationProvider.create(getJwtToken())));
-    assertThat(api().getAllReferences().get().getReferences()).isNotEmpty();
+    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
   }
 
   @Test
   void testExpiredToken() {
     withClientCustomizer(
         b -> b.withAuthentication(BearerAuthenticationProvider.create(getExpiredJwtToken())));
-    assertThatThrownBy(() -> api().getAllReferences().get())
+    assertThatThrownBy(() -> api().getAllReferences().stream(OptionalInt.empty()))
         .isInstanceOfSatisfying(
             NessieNotAuthorizedException.class,
             e -> assertThat(e.getError().getStatus()).isEqualTo(401));
@@ -59,7 +60,7 @@ public abstract class AbstractOpenIdAuthentication extends BaseClientAuthTest {
 
   @Test
   void testAbsentToken() {
-    assertThatThrownBy(() -> api().getAllReferences().get())
+    assertThatThrownBy(() -> api().getAllReferences().stream(OptionalInt.empty()))
         .isInstanceOfSatisfying(
             NessieNotAuthorizedException.class,
             e -> assertThat(e.getError().getStatus()).isEqualTo(401));

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractOpenIdAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractOpenIdAuthentication.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.smallrye.jwt.build.Jwt;
 import java.util.Map;
-import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.auth.BearerAuthenticationProvider;
 import org.projectnessie.client.rest.NessieNotAuthorizedException;
@@ -42,17 +41,17 @@ public abstract class AbstractOpenIdAuthentication extends BaseClientAuthTest {
   }
 
   @Test
-  void testValidJwt() {
+  void testValidJwt() throws Exception {
     withClientCustomizer(
         b -> b.withAuthentication(BearerAuthenticationProvider.create(getJwtToken())));
-    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
+    assertThat(api().getAllReferences().stream()).isNotEmpty();
   }
 
   @Test
   void testExpiredToken() {
     withClientCustomizer(
         b -> b.withAuthentication(BearerAuthenticationProvider.create(getExpiredJwtToken())));
-    assertThatThrownBy(() -> api().getAllReferences().stream(OptionalInt.empty()))
+    assertThatThrownBy(() -> api().getAllReferences().stream())
         .isInstanceOfSatisfying(
             NessieNotAuthorizedException.class,
             e -> assertThat(e.getError().getStatus()).isEqualTo(401));
@@ -60,7 +59,7 @@ public abstract class AbstractOpenIdAuthentication extends BaseClientAuthTest {
 
   @Test
   void testAbsentToken() {
-    assertThatThrownBy(() -> api().getAllReferences().stream(OptionalInt.empty()))
+    assertThatThrownBy(() -> api().getAllReferences().stream())
         .isInstanceOfSatisfying(
             NessieNotAuthorizedException.class,
             e -> assertThat(e.getError().getStatus()).isEqualTo(401));

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
@@ -18,7 +18,8 @@ package org.projectnessie.server;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.security.TestSecurity;
-import java.util.List;
+import java.util.OptionalInt;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -67,8 +68,8 @@ abstract class AbstractTestBasicOperations {
   void testAdmin() throws BaseNessieClientServerException {
     getCatalog("testx");
     Branch branch = (Branch) api.getReference().refName("testx").get();
-    List<Entry> tables = api.getEntries().refName("testx").get().getEntries();
-    Assertions.assertTrue(tables.isEmpty());
+    Stream<Entry> tables = api.getEntries().refName("testx").stream(OptionalInt.empty());
+    assertThat(tables).isEmpty();
     ContentKey key = ContentKey.of("x", "x");
     tryEndpointPass(
         () ->

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
@@ -18,7 +18,6 @@ package org.projectnessie.server;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.security.TestSecurity;
-import java.util.OptionalInt;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -68,7 +67,7 @@ abstract class AbstractTestBasicOperations {
   void testAdmin() throws BaseNessieClientServerException {
     getCatalog("testx");
     Branch branch = (Branch) api.getReference().refName("testx").get();
-    Stream<Entry> tables = api.getEntries().refName("testx").stream(OptionalInt.empty());
+    Stream<Entry> tables = api.getEntries().refName("testx").stream();
     assertThat(tables).isEmpty();
     ContentKey key = ContentKey.of("x", "x");
     tryEndpointPass(

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -22,7 +22,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.security.TestSecurity;
 import java.util.Arrays;
-import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -198,8 +197,7 @@ class TestAuthorizationRules extends BaseClientAuthTest {
 
     targetBranch = retrieveBranch(targetBranch.getName(), role, false);
 
-    assertThat(api().getCommitLog().reference(targetBranch).stream(OptionalInt.empty()))
-        .isNotEmpty();
+    assertThat(api().getCommitLog().reference(targetBranch).stream()).isNotEmpty();
   }
 
   @Test
@@ -227,7 +225,7 @@ class TestAuthorizationRules extends BaseClientAuthTest {
         .transplantCommitsIntoBranch()
         .fromRefName(branch.getName())
         .hashesToTransplant(
-            api().getCommitLog().reference(branch).stream(OptionalInt.empty())
+            api().getCommitLog().reference(branch).stream()
                 .map(e -> e.getCommitMeta().getHash())
                 .collect(Collectors.toList()))
         .branch(targetBranch)
@@ -235,8 +233,7 @@ class TestAuthorizationRules extends BaseClientAuthTest {
 
     targetBranch = retrieveBranch(targetBranch.getName(), role, false);
 
-    assertThat(api().getCommitLog().reference(targetBranch).stream(OptionalInt.empty()))
-        .isNotEmpty();
+    assertThat(api().getCommitLog().reference(targetBranch).stream()).isNotEmpty();
   }
 
   @Test
@@ -288,13 +285,14 @@ class TestAuthorizationRules extends BaseClientAuthTest {
     deleteBranch(branch, role, false);
   }
 
-  private void listAllReferences(String branchName, boolean filteredOut) {
+  private void listAllReferences(String branchName, boolean filteredOut)
+      throws NessieNotFoundException {
     if (filteredOut) {
-      assertThat(api().getAllReferences().stream(OptionalInt.empty()))
+      assertThat(api().getAllReferences().stream())
           .extracting(Reference::getName)
           .doesNotContain(branchName);
     } else {
-      assertThat(api().getAllReferences().stream(OptionalInt.empty()))
+      assertThat(api().getAllReferences().stream())
           .extracting(Reference::getName)
           .contains(branchName);
     }
@@ -380,12 +378,12 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   private void getEntriesFor(String branchName, String role, boolean shouldFail)
       throws NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> api().getEntries().refName(branchName).stream(OptionalInt.empty()))
+      assertThatThrownBy(() -> api().getEntries().refName(branchName).stream())
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(
               String.format("'READ_ENTRIES' is not allowed for role '%s' on reference", role));
     } else {
-      Stream<Entry> tables = api().getEntries().refName(branchName).stream(OptionalInt.empty());
+      Stream<Entry> tables = api().getEntries().refName(branchName).stream();
       assertThat(tables).isNotEmpty();
     }
   }
@@ -393,24 +391,23 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   private void getCommitLog(String branchName, String role, boolean shouldFail)
       throws NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> api().getCommitLog().refName(branchName).stream(OptionalInt.empty()))
+      assertThatThrownBy(() -> api().getCommitLog().refName(branchName).stream())
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(
               String.format("'LIST_COMMIT_LOG' is not allowed for role '%s' on reference", role));
     } else {
-      Stream<LogEntry> commits =
-          api().getCommitLog().refName(branchName).stream(OptionalInt.empty());
+      Stream<LogEntry> commits = api().getCommitLog().refName(branchName).stream();
       assertThat(commits).isNotEmpty();
     }
   }
 
   private void getRefLog(String role, boolean shouldFail) throws NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> api().getRefLog().stream(OptionalInt.empty()))
+      assertThatThrownBy(() -> api().getRefLog().stream())
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(String.format("'VIEW_REFLOG' is not allowed for role '%s'", role));
     } else {
-      Stream<RefLogResponseEntry> entries = api().getRefLog().stream(OptionalInt.empty());
+      Stream<RefLogResponseEntry> entries = api().getRefLog().stream();
       assertThat(entries).isNotEmpty();
     }
   }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -22,9 +22,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.security.TestSecurity;
 import java.util.Arrays;
-import java.util.List;
+import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -40,7 +41,7 @@ import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Operation.Delete;
 import org.projectnessie.model.Operation.Put;
-import org.projectnessie.model.RefLogResponse;
+import org.projectnessie.model.RefLogResponse.RefLogResponseEntry;
 import org.projectnessie.model.Reference;
 import org.projectnessie.server.authz.NessieAuthorizationTestProfile;
 
@@ -197,7 +198,8 @@ class TestAuthorizationRules extends BaseClientAuthTest {
 
     targetBranch = retrieveBranch(targetBranch.getName(), role, false);
 
-    assertThat(api().getCommitLog().reference(targetBranch).get().getLogEntries()).isNotEmpty();
+    assertThat(api().getCommitLog().reference(targetBranch).stream(OptionalInt.empty()))
+        .isNotEmpty();
   }
 
   @Test
@@ -225,7 +227,7 @@ class TestAuthorizationRules extends BaseClientAuthTest {
         .transplantCommitsIntoBranch()
         .fromRefName(branch.getName())
         .hashesToTransplant(
-            api().getCommitLog().reference(branch).get().getLogEntries().stream()
+            api().getCommitLog().reference(branch).stream(OptionalInt.empty())
                 .map(e -> e.getCommitMeta().getHash())
                 .collect(Collectors.toList()))
         .branch(targetBranch)
@@ -233,7 +235,8 @@ class TestAuthorizationRules extends BaseClientAuthTest {
 
     targetBranch = retrieveBranch(targetBranch.getName(), role, false);
 
-    assertThat(api().getCommitLog().reference(targetBranch).get().getLogEntries()).isNotEmpty();
+    assertThat(api().getCommitLog().reference(targetBranch).stream(OptionalInt.empty()))
+        .isNotEmpty();
   }
 
   @Test
@@ -287,11 +290,11 @@ class TestAuthorizationRules extends BaseClientAuthTest {
 
   private void listAllReferences(String branchName, boolean filteredOut) {
     if (filteredOut) {
-      assertThat(api().getAllReferences().get().getReferences())
+      assertThat(api().getAllReferences().stream(OptionalInt.empty()))
           .extracting(Reference::getName)
           .doesNotContain(branchName);
     } else {
-      assertThat(api().getAllReferences().get().getReferences())
+      assertThat(api().getAllReferences().stream(OptionalInt.empty()))
           .extracting(Reference::getName)
           .contains(branchName);
     }
@@ -377,12 +380,12 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   private void getEntriesFor(String branchName, String role, boolean shouldFail)
       throws NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> api().getEntries().refName(branchName).get().getEntries())
+      assertThatThrownBy(() -> api().getEntries().refName(branchName).stream(OptionalInt.empty()))
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(
               String.format("'READ_ENTRIES' is not allowed for role '%s' on reference", role));
     } else {
-      List<Entry> tables = api().getEntries().refName(branchName).get().getEntries();
+      Stream<Entry> tables = api().getEntries().refName(branchName).stream(OptionalInt.empty());
       assertThat(tables).isNotEmpty();
     }
   }
@@ -390,23 +393,24 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   private void getCommitLog(String branchName, String role, boolean shouldFail)
       throws NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> api().getCommitLog().refName(branchName).get().getLogEntries())
+      assertThatThrownBy(() -> api().getCommitLog().refName(branchName).stream(OptionalInt.empty()))
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(
               String.format("'LIST_COMMIT_LOG' is not allowed for role '%s' on reference", role));
     } else {
-      List<LogEntry> commits = api().getCommitLog().refName(branchName).get().getLogEntries();
+      Stream<LogEntry> commits =
+          api().getCommitLog().refName(branchName).stream(OptionalInt.empty());
       assertThat(commits).isNotEmpty();
     }
   }
 
   private void getRefLog(String role, boolean shouldFail) throws NessieNotFoundException {
     if (shouldFail) {
-      assertThatThrownBy(() -> api().getRefLog().get().getLogEntries())
+      assertThatThrownBy(() -> api().getRefLog().stream(OptionalInt.empty()))
           .isInstanceOf(NessieForbiddenException.class)
           .hasMessageContaining(String.format("'VIEW_REFLOG' is not allowed for role '%s'", role));
     } else {
-      List<RefLogResponse.RefLogResponseEntry> entries = api().getRefLog().get().getLogEntries();
+      Stream<RefLogResponseEntry> entries = api().getRefLog().stream(OptionalInt.empty());
       assertThat(entries).isNotEmpty();
     }
   }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicAuthentication.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import java.util.Map;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.auth.BasicAuthenticationProvider;
 import org.projectnessie.client.rest.NessieNotAuthorizedException;
@@ -35,21 +36,21 @@ class TestBasicAuthentication extends BaseClientAuthTest {
   void testValidCredentials() {
     withClientCustomizer(
         c -> c.withAuthentication(BasicAuthenticationProvider.create("test_user", "test_user")));
-    assertThat(api().getAllReferences().get().getReferences()).isNotEmpty();
+    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
   }
 
   @Test
   void testValidAdminCredentials() {
     withClientCustomizer(
         c -> c.withAuthentication(BasicAuthenticationProvider.create("admin_user", "test123")));
-    assertThat(api().getAllReferences().get().getReferences()).isNotEmpty();
+    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
   }
 
   @Test
   void testInvalidCredentials() {
     withClientCustomizer(
         c -> c.withAuthentication(BasicAuthenticationProvider.create("test_user", "bad_password")));
-    assertThatThrownBy(() -> api().getAllReferences().get())
+    assertThatThrownBy(() -> api().getAllReferences().stream(OptionalInt.empty()))
         .isInstanceOfSatisfying(
             NessieNotAuthorizedException.class,
             e -> assertThat(e.getError().getStatus()).isEqualTo(401));

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicAuthentication.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import java.util.Map;
-import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.auth.BasicAuthenticationProvider;
 import org.projectnessie.client.rest.NessieNotAuthorizedException;
@@ -33,24 +32,24 @@ import org.projectnessie.server.authn.AuthenticationEnabledProfile;
 class TestBasicAuthentication extends BaseClientAuthTest {
 
   @Test
-  void testValidCredentials() {
+  void testValidCredentials() throws Exception {
     withClientCustomizer(
         c -> c.withAuthentication(BasicAuthenticationProvider.create("test_user", "test_user")));
-    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
+    assertThat(api().getAllReferences().stream()).isNotEmpty();
   }
 
   @Test
-  void testValidAdminCredentials() {
+  void testValidAdminCredentials() throws Exception {
     withClientCustomizer(
         c -> c.withAuthentication(BasicAuthenticationProvider.create("admin_user", "test123")));
-    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
+    assertThat(api().getAllReferences().stream()).isNotEmpty();
   }
 
   @Test
   void testInvalidCredentials() {
     withClientCustomizer(
         c -> c.withAuthentication(BasicAuthenticationProvider.create("test_user", "bad_password")));
-    assertThatThrownBy(() -> api().getAllReferences().stream(OptionalInt.empty()))
+    assertThatThrownBy(() -> api().getAllReferences().stream())
         .isInstanceOfSatisfying(
             NessieNotAuthorizedException.class,
             e -> assertThat(e.getError().getStatus()).isEqualTo(401));

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestDisabledAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestDisabledAuthentication.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.auth.BasicAuthenticationProvider;
 import org.projectnessie.client.auth.BearerAuthenticationProvider;
@@ -35,21 +34,21 @@ import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 public class TestDisabledAuthentication extends BaseClientAuthTest {
 
   @Test
-  void testBasic() {
+  void testBasic() throws Exception {
     withClientCustomizer(
         c -> c.withAuthentication(BasicAuthenticationProvider.create("any_user", "any_password")));
-    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
+    assertThat(api().getAllReferences().stream()).isNotEmpty();
   }
 
   @Test
-  void testBearer() {
+  void testBearer() throws Exception {
     withClientCustomizer(
         c -> c.withAuthentication(BearerAuthenticationProvider.create("any_token")));
-    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
+    assertThat(api().getAllReferences().stream()).isNotEmpty();
   }
 
   @Test
-  void testNone() {
-    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
+  void testNone() throws Exception {
+    assertThat(api().getAllReferences().stream()).isNotEmpty();
   }
 }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestDisabledAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestDisabledAuthentication.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.auth.BasicAuthenticationProvider;
 import org.projectnessie.client.auth.BearerAuthenticationProvider;
@@ -37,18 +38,18 @@ public class TestDisabledAuthentication extends BaseClientAuthTest {
   void testBasic() {
     withClientCustomizer(
         c -> c.withAuthentication(BasicAuthenticationProvider.create("any_user", "any_password")));
-    assertThat(api().getAllReferences().get().getReferences()).isNotEmpty();
+    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
   }
 
   @Test
   void testBearer() {
     withClientCustomizer(
         c -> c.withAuthentication(BearerAuthenticationProvider.create("any_token")));
-    assertThat(api().getAllReferences().get().getReferences()).isNotEmpty();
+    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
   }
 
   @Test
   void testNone() {
-    assertThat(api().getAllReferences().get().getReferences()).isNotEmpty();
+    assertThat(api().getAllReferences().stream(OptionalInt.empty())).isNotEmpty();
   }
 }

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
@@ -17,7 +17,6 @@ package org.projectnessie.tools.contentgenerator.cli;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.OptionalInt;
 import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.error.NessieNotFoundException;
@@ -44,7 +43,7 @@ public class ReadCommits extends AbstractCommand {
     try (NessieApiV1 api = createNessieApiInstance()) {
       spec.commandLine().getOut().printf("Reading commits for ref '%s'\n\n", ref);
       FetchOption fetchOption = isVerbose() ? FetchOption.ALL : FetchOption.MINIMAL;
-      api.getCommitLog().refName(ref).fetch(fetchOption).stream(OptionalInt.empty())
+      api.getCommitLog().refName(ref).fetch(fetchOption).stream()
           .forEach(
               logEntry -> {
                 CommitMeta commitMeta = logEntry.getCommitMeta();

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadReferences.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadReferences.java
@@ -15,7 +15,8 @@
  */
 package org.projectnessie.tools.contentgenerator.cli;
 
-import java.util.List;
+import java.util.OptionalInt;
+import java.util.stream.Stream;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.model.Reference;
 import picocli.CommandLine.Command;
@@ -32,7 +33,7 @@ public class ReadReferences extends AbstractCommand {
   public void execute() {
     try (NessieApiV1 api = createNessieApiInstance()) {
       spec.commandLine().getOut().printf("Reading all references\n\n");
-      List<Reference> references = api.getAllReferences().get().getReferences();
+      Stream<Reference> references = api.getAllReferences().stream(OptionalInt.empty());
       references.forEach(reference -> spec.commandLine().getOut().println(reference));
       spec.commandLine().getOut().printf("\nDone reading all references\n\n");
     }

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadReferences.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadReferences.java
@@ -15,9 +15,9 @@
  */
 package org.projectnessie.tools.contentgenerator.cli;
 
-import java.util.OptionalInt;
 import java.util.stream.Stream;
 import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
@@ -30,10 +30,10 @@ public class ReadReferences extends AbstractCommand {
   @Spec private CommandSpec spec;
 
   @Override
-  public void execute() {
+  public void execute() throws NessieNotFoundException {
     try (NessieApiV1 api = createNessieApiInstance()) {
       spec.commandLine().getOut().printf("Reading all references\n\n");
-      Stream<Reference> references = api.getAllReferences().stream(OptionalInt.empty());
+      Stream<Reference> references = api.getAllReferences().stream();
       references.forEach(reference -> spec.commandLine().getOut().println(reference));
       spec.commandLine().getOut().printf("\nDone reading all references\n\n");
     }

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
@@ -17,6 +17,7 @@ package org.projectnessie.tools.contentgenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.OptionalInt;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -49,7 +50,7 @@ class ITGenerateContent extends AbstractContentGeneratorTest {
               "--type=" + contentType.name());
 
       assertThat(proc.getExitCode()).isEqualTo(0);
-      assertThat(api.getCommitLog().refName(testCaseBranch).get().getLogEntries())
+      assertThat(api.getCommitLog().refName(testCaseBranch).stream(OptionalInt.empty()))
           .hasSize(numCommits);
     }
   }

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITGenerateContent.java
@@ -17,7 +17,6 @@ package org.projectnessie.tools.contentgenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.OptionalInt;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -50,8 +49,7 @@ class ITGenerateContent extends AbstractContentGeneratorTest {
               "--type=" + contentType.name());
 
       assertThat(proc.getExitCode()).isEqualTo(0);
-      assertThat(api.getCommitLog().refName(testCaseBranch).stream(OptionalInt.empty()))
-          .hasSize(numCommits);
+      assertThat(api.getCommitLog().refName(testCaseBranch).stream()).hasSize(numCommits);
     }
   }
 }

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
@@ -18,7 +18,9 @@ package org.projectnessie.tools.contentgenerator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.api.params.FetchOption;
@@ -52,7 +54,8 @@ class ITReadCommits extends AbstractContentGeneratorTest {
     assertThat(output).noneSatisfy(s -> assertThat(s).contains(CONTENT_KEY.toString()));
 
     try (NessieApiV1 api = buildNessieApi()) {
-      assertThat(api.getCommitLog().refName(branch.getName()).get().getLogEntries()).hasSize(1);
+      assertThat(api.getCommitLog().refName(branch.getName()).stream(OptionalInt.empty()))
+          .hasSize(1);
     }
   }
 
@@ -74,7 +77,9 @@ class ITReadCommits extends AbstractContentGeneratorTest {
 
     try (NessieApiV1 api = buildNessieApi()) {
       List<LogEntry> logEntries =
-          api.getCommitLog().refName(branch.getName()).fetch(FetchOption.ALL).get().getLogEntries();
+          api.getCommitLog().refName(branch.getName()).fetch(FetchOption.ALL).stream(
+                  OptionalInt.empty())
+              .collect(Collectors.toList());
       assertThat(logEntries).hasSize(1);
       assertThat(logEntries.get(0).getOperations()).isNotEmpty();
       assertThat(logEntries.get(0).getParentCommitHash()).isNotNull();

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
@@ -18,7 +18,6 @@ package org.projectnessie.tools.contentgenerator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,8 +75,7 @@ class ITReadCommits extends AbstractContentGeneratorTest {
 
     try (NessieApiV1 api = buildNessieApi()) {
       List<LogEntry> logEntries =
-          api.getCommitLog().refName(branch.getName()).fetch(FetchOption.ALL).stream(
-                  OptionalInt.empty())
+          api.getCommitLog().refName(branch.getName()).fetch(FetchOption.ALL).stream()
               .collect(Collectors.toList());
       assertThat(logEntries).hasSize(1);
       assertThat(logEntries.get(0).getOperations()).isNotEmpty();

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
@@ -54,8 +54,7 @@ class ITReadCommits extends AbstractContentGeneratorTest {
     assertThat(output).noneSatisfy(s -> assertThat(s).contains(CONTENT_KEY.toString()));
 
     try (NessieApiV1 api = buildNessieApi()) {
-      assertThat(api.getCommitLog().refName(branch.getName()).stream(OptionalInt.empty()))
-          .hasSize(1);
+      assertThat(api.getCommitLog().refName(branch.getName()).stream()).hasSize(1);
     }
   }
 


### PR DESCRIPTION
Deprecate the `.get()` functions in NessieApi builder classes that
extend `PagingBuilder` and implement `.stream()` functions that
automatically perform paging. Using the `StreamingUtil` class
directly is also deprecated, because it is no longer needed.

This change "pushes" clients to use the "right" functionality.

Fixes #4291
Obsoletes #3766 