### PR TITLE
Allow anonymous health checks

### DIFF
--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
@@ -19,6 +19,7 @@ import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
+import java.util.Set;
 
 /** Configuration for Nessie authentication settings. */
 @StaticInitSafe
@@ -29,4 +30,8 @@ public interface QuarkusNessieAuthenticationConfig {
   @WithName("enabled")
   @WithDefault("false")
   boolean enabled();
+
+  /** Returns the set of HTTP URL paths that are permitted to be serviced without authentication. */
+  @WithName("anonymous-paths")
+  Set<String> anonymousPaths();
 }

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -116,6 +116,7 @@ quarkus.resteasy.gzip.enabled=true
 #quarkus.oidc.credentials.secret=
 #quarkus.oidc.client-id=
 nessie.server.authentication.enabled=false
+nessie.server.authentication.anonymous-paths=/q/health/live,/q/health/live/,/q/health/ready,/q/health/ready/
 # to be overwritten by end user when enabling OpenID validation
 quarkus.oidc.auth-server-url=http://127.255.0.0:0/auth/realms/unset/
 # fixed at buildtime

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestHealthCheckAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestHealthCheckAuthentication.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@QuarkusTest
+@TestProfile(value = TestBasicAuthentication.Profile.class)
+public class TestHealthCheckAuthentication {
+
+  private static RequestSpecification request() {
+    return given().when().baseUri(RestAssured.baseURI);
+  }
+
+  public static Stream<Arguments> paths() {
+    return Stream.of("/q/health/live", "/q/health/live/", "/q/health/ready", "/q/health/ready/")
+        .map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("paths")
+  void testValidCredentials(String path) {
+    assertThat(request().basePath(path).auth().basic("test_user", "test_user").get().statusCode())
+        .isEqualTo(200);
+  }
+
+  @ParameterizedTest
+  @MethodSource("paths")
+  void testNoCredentials(String path) {
+    assertThat(request().basePath(path).get().statusCode()).isEqualTo(200);
+  }
+}


### PR DESCRIPTION
* Add a config option for NessieHttpAuthenticator to list URL paths that
  should be allowed under the anonymous identity even when authentication
  is enabled.

* Allow anonymous access `/q/health/live` and `/q/health/ready` by default.

Fixes #4317