### PR TITLE
Prepare build files for integrations testing

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -28,18 +28,11 @@ dependencies {
     api(rootProject)
     api(project(":nessie-clients"))
     api(project(":nessie-client"))
-    api(project(":nessie-deltalake"))
-    api(project(":iceberg-views"))
-    api(project(":nessie-spark-extensions"))
-    api(project(":nessie-spark-3.2-extensions"))
-    api(project(":nessie-spark-extensions-grammar"))
-    api(project(":nessie-spark-extensions-base"))
     api(project(":nessie-compatibility"))
     api(project(":nessie-compatibility-common"))
     api(project(":nessie-compatibility-tests"))
     api(project(":nessie-compatibility-jersey"))
     api(project(":nessie-gc"))
-    api(project(":nessie-gc-base"))
     api(project(":nessie-model"))
     api(project(":nessie-perftest"))
     api(project(":nessie-server-parent"))
@@ -78,6 +71,15 @@ dependencies {
     api(project(":nessie-versioned-persist-transactional")) { testJarCapability() }
     api(project(":nessie-versioned-spi"))
     api(project(":nessie-versioned-tests"))
+    if (!isIntegrationsTestingEnabled()) {
+      api(project(":nessie-deltalake"))
+      api(project(":iceberg-views"))
+      api(project(":nessie-spark-extensions"))
+      api(project(":nessie-spark-3.2-extensions"))
+      api(project(":nessie-spark-extensions-grammar"))
+      api(project(":nessie-spark-extensions-base"))
+      api(project(":nessie-gc-base"))
+    }
   }
 }
 

--- a/clients/deltalake/build.gradle.kts
+++ b/clients/deltalake/build.gradle.kts
@@ -33,16 +33,16 @@ dependencies {
   // picks the right dependencies for scala compilation
   forScala(scalaVersion)
 
-  implementation(platform(rootProject))
-  implementation(project(":nessie-model"))
-  implementation(project(":nessie-client"))
+  implementation(platform(nessieRootProject()))
+  implementation(nessieProject("nessie-model"))
+  implementation(nessieProject("nessie-client"))
   implementation("org.apache.spark:spark-core_2.12") { forSpark(sparkVersion) }
   implementation("org.apache.spark:spark-sql_2.12") { forSpark(sparkVersion) }
   implementation("io.delta:delta-core_2.12")
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  testImplementation(platform(rootProject))
-  testImplementation(project(":nessie-spark-3.2-extensions"))
+  testImplementation(platform(nessieRootProject()))
+  testImplementation(nessieProject("nessie-spark-3.2-extensions"))
   testImplementation("com.fasterxml.jackson.module:jackson-module-scala_2.12")
   testImplementation("com.fasterxml.jackson.core:jackson-databind")
   testImplementation("org.eclipse.microprofile.openapi:microprofile-openapi-api")
@@ -55,7 +55,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-  nessieQuarkusServer(project(":nessie-quarkus", "quarkusRunner"))
+  nessieQuarkusServer(nessieQuarkusServerRunner(this))
 }
 
 nessieQuarkusApp {

--- a/clients/spark-3.2-extensions/build.gradle.kts
+++ b/clients/spark-3.2-extensions/build.gradle.kts
@@ -29,21 +29,19 @@ val scalaVersion = dependencyVersion("versionScala2_12")
 
 val sparkVersion = dependencyVersion("versionSpark32")
 
-val clientNessieVersion = dependencyVersion("versionClientNessie")
-
 dependencies {
   // picks the right dependencies for scala compilation
   forScala(scalaVersion)
 
-  implementation(platform(rootProject))
+  implementation(platform(nessieRootProject()))
   implementation(project(":nessie-spark-extensions-grammar"))
   implementation(project(":nessie-spark-extensions-base"))
   compileOnly("org.apache.spark:spark-sql_2.12") { forSpark(sparkVersion) }
   compileOnly("org.apache.spark:spark-core_2.12") { forSpark(sparkVersion) }
   compileOnly("org.apache.spark:spark-hive_2.12") { forSpark(sparkVersion) }
-  implementation("org.projectnessie:nessie-client:$clientNessieVersion")
+  implementation(nessieClientForIceberg())
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(nessieRootProject()))
   testImplementation(project(":nessie-spark-extensions-base")) { testJarCapability() }
   testImplementation("org.apache.iceberg:iceberg-nessie")
   testImplementation("org.apache.iceberg:iceberg-spark-3.2_2.12")
@@ -60,7 +58,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-  nessieQuarkusServer(project(":nessie-quarkus", "quarkusRunner"))
+  nessieQuarkusServer(nessieQuarkusServerRunner(this))
 }
 
 nessieQuarkusApp {

--- a/clients/spark-antlr-grammar/build.gradle.kts
+++ b/clients/spark-antlr-grammar/build.gradle.kts
@@ -23,10 +23,10 @@ plugins {
 }
 
 dependencies {
-  antlr(platform(rootProject))
+  antlr(platform(nessieRootProject()))
   antlr("org.antlr:antlr4:${dependencyVersion("versionAntlr")}")
 
-  implementation(platform(rootProject))
+  implementation(platform(nessieRootProject()))
   api("org.projectnessie:nessie-antlr-runtime")
 }
 

--- a/clients/spark-extensions-base/build.gradle.kts
+++ b/clients/spark-extensions-base/build.gradle.kts
@@ -26,20 +26,18 @@ val scalaVersion = dependencyVersion("versionScala2_12")
 
 val sparkVersion = dependencyVersion("versionSpark31")
 
-val clientNessieVersion = dependencyVersion("versionClientNessie")
-
 dependencies {
   // picks the right dependencies for scala compilation
   forScala(scalaVersion)
 
-  implementation(platform(rootProject))
+  implementation(platform(nessieRootProject()))
   implementation(project(":nessie-spark-extensions-grammar"))
   compileOnly("org.apache.spark:spark-hive_2.12") { forSpark(sparkVersion) }
-  implementation("org.projectnessie:nessie-client:$clientNessieVersion")
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
+  implementation(nessieClientForIceberg())
 
-  testImplementation(platform(rootProject))
-  testAnnotationProcessor(platform(rootProject))
+  testImplementation(platform(nessieRootProject()))
+  testAnnotationProcessor(platform(nessieRootProject()))
   testImplementation("org.apache.spark:spark-sql_2.12") { forSpark(sparkVersion) }
   testImplementation("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 

--- a/clients/spark-extensions/build.gradle.kts
+++ b/clients/spark-extensions/build.gradle.kts
@@ -29,21 +29,19 @@ val scalaVersion = dependencyVersion("versionScala2_12")
 
 val sparkVersion = dependencyVersion("versionSpark31")
 
-val clientNessieVersion = dependencyVersion("versionClientNessie")
-
 dependencies {
   // picks the right dependencies for scala compilation
   forScala(scalaVersion)
 
-  implementation(platform(rootProject))
+  implementation(platform(nessieRootProject()))
   implementation(project(":nessie-spark-extensions-grammar"))
   implementation(project(":nessie-spark-extensions-base"))
   compileOnly("org.apache.spark:spark-sql_2.12") { forSpark(sparkVersion) }
   compileOnly("org.apache.spark:spark-core_2.12") { forSpark(sparkVersion) }
   compileOnly("org.apache.spark:spark-hive_2.12") { forSpark(sparkVersion) }
-  implementation("org.projectnessie:nessie-client:$clientNessieVersion")
+  implementation(nessieClientForIceberg())
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(nessieRootProject()))
   testImplementation(project(":nessie-spark-extensions-base")) { testJarCapability() }
   testImplementation("org.apache.iceberg:iceberg-nessie")
   testImplementation("org.apache.iceberg:iceberg-spark3")
@@ -60,7 +58,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-  nessieQuarkusServer(project(":nessie-quarkus", "quarkusRunner"))
+  nessieQuarkusServer(nessieQuarkusServerRunner(this))
 }
 
 nessieQuarkusApp {

--- a/gc/gc-base/build.gradle.kts
+++ b/gc/gc-base/build.gradle.kts
@@ -27,11 +27,9 @@ val scalaVersion = dependencyVersion("versionScala2_12")
 
 val sparkVersion = dependencyVersion("versionSpark31")
 
-val clientNessieVersion = dependencyVersion("versionClientNessie")
-
 dependencies {
-  implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  implementation(platform(nessieRootProject()))
+  annotationProcessor(platform(nessieRootProject()))
   implementation(platform("com.fasterxml.jackson:jackson-bom"))
 
   forScala(scalaVersion)
@@ -39,7 +37,7 @@ dependencies {
   compileOnly("org.immutables:value-annotations")
   annotationProcessor("org.immutables:value-processor")
 
-  compileOnly(project(":nessie-client"))
+  compileOnly(nessieProject("nessie-client"))
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
   compileOnly("jakarta.validation:jakarta.validation-api")
   implementation("com.fasterxml.jackson.core:jackson-annotations")
@@ -53,11 +51,11 @@ dependencies {
   compileOnly("org.apache.iceberg:iceberg-parquet")
   compileOnly("org.apache.parquet:parquet-column")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(nessieRootProject()))
 
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
-  testImplementation(project(":nessie-jaxrs-testextension"))
-  testImplementation(project(":nessie-jaxrs-tests"))
+  testImplementation(nessieProject("nessie-jaxrs-testextension"))
+  testImplementation(nessieProject("nessie-jaxrs-tests"))
   testImplementation("org.apache.spark:spark-sql_2.12") {
     forSpark(sparkVersion)
     exclude("com.sun.jersey", "jersey-servlet")

--- a/servers/lambda/build.gradle.kts
+++ b/servers/lambda/build.gradle.kts
@@ -63,8 +63,7 @@ java {
 }
 
 project.extra["quarkus.package.type"] =
-  if (project.hasProperty("uber-jar")) "uber-jar"
-  else if (project.hasProperty("native")) "native" else "fast-jar"
+  if (withUberJar()) "uber-jar" else if (project.hasProperty("native")) "native" else "fast-jar"
 
 // TODO remove the whole block
 quarkus { setFinalName("${project.name}-${project.version}") }
@@ -114,8 +113,7 @@ tasks.withType<Test>().configureEach {
 artifacts {
   add(
     quarkusRunner.name,
-    if (project.hasProperty("uber-jar")) quarkusBuild.runnerJar
-    else quarkusBuild.fastJar.resolve("quarkus-run.jar")
+    if (withUberJar()) quarkusBuild.runnerJar else quarkusBuild.fastJar.resolve("quarkus-run.jar")
   ) { builtBy(quarkusBuild) }
 }
 

--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -100,7 +100,7 @@ tasks.withType<Test>().configureEach {
 
 // nessie-quarkus-cli module needs to be adopted before we can generate a native runner
 project.extra["quarkus.package.type"] =
-  if (project.hasProperty("uber-jar") || project.hasProperty("native")) "uber-jar" else "fast-jar"
+  if (withUberJar() || project.hasProperty("native")) "uber-jar" else "fast-jar"
 
 // TODO remove the whole block
 quarkus { setFinalName("${project.name}-${project.version}") }
@@ -116,7 +116,7 @@ tasks.withType<QuarkusBuild>().configureEach {
   }
 }
 
-if (project.hasProperty("uber-jar")) {
+if (withUberJar()) {
   afterEvaluate {
     publishing {
       publications {

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -108,8 +108,7 @@ project.extra["quarkus.smallrye-openapi.store-schema-directory"] =
 project.extra["quarkus.smallrye-openapi.additional-docs-directory"] = "$openApiSpecDir"
 
 project.extra["quarkus.package.type"] =
-  if (project.hasProperty("uber-jar")) "uber-jar"
-  else if (project.hasProperty("native")) "native" else "fast-jar"
+  if (withUberJar()) "uber-jar" else if (project.hasProperty("native")) "native" else "fast-jar"
 
 // TODO remove the whole block
 quarkus { setFinalName("${project.name}-${project.version}") }
@@ -172,14 +171,14 @@ artifacts {
   add(
     quarkusRunner.name,
     provider {
-      if (project.hasProperty("uber-jar")) quarkusBuild.get().runnerJar
+      if (withUberJar()) quarkusBuild.get().runnerJar
       else quarkusBuild.get().fastJar.resolve("quarkus-run.jar")
     }
   ) { builtBy(quarkusBuild) }
 }
 
 // Add the uber-jar, if built, to the Maven publication
-if (project.hasProperty("uber-jar")) {
+if (withUberJar()) {
   afterEvaluate {
     publishing {
       publications {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -123,18 +123,6 @@ nessieProject("nessie-clients", "clients")
 
 nessieProject("nessie-client", "clients/client")
 
-nessieProject("nessie-deltalake", "clients/deltalake")
-
-nessieProject("iceberg-views", "clients/iceberg-views")
-
-nessieProject("nessie-spark-3.2-extensions", "clients/spark-3.2-extensions")
-
-nessieProject("nessie-spark-extensions-grammar", "clients/spark-antlr-grammar")
-
-nessieProject("nessie-spark-extensions", "clients/spark-extensions")
-
-nessieProject("nessie-spark-extensions-base", "clients/spark-extensions-base")
-
 nessieProject("nessie-compatibility", "compatibility")
 
 nessieProject("nessie-compatibility-common", "compatibility/common")
@@ -144,8 +132,6 @@ nessieProject("nessie-compatibility-tests", "compatibility/compatibility-tests")
 nessieProject("nessie-compatibility-jersey", "compatibility/jersey")
 
 nessieProject("nessie-gc", "gc")
-
-nessieProject("nessie-gc-base", "gc/gc-base")
 
 nessieProject("nessie-model", "model")
 
@@ -218,6 +204,24 @@ nessieProject("nessie-versioned-persist-transactional", "versioned/persist/tx")
 nessieProject("nessie-versioned-spi", "versioned/spi")
 
 nessieProject("nessie-versioned-tests", "versioned/tests")
+
+// Cannot use isIntegrationsTestingEnabled() in buildSrc/src/main/kotlin/Utilities.kt, because
+// settings.gradle is evaluated before buildSrc.
+if (!System.getProperty("nessie.integrationsTesting.enable").toBoolean()) {
+  nessieProject("nessie-deltalake", "clients/deltalake")
+
+  nessieProject("iceberg-views", "clients/iceberg-views")
+
+  nessieProject("nessie-spark-3.2-extensions", "clients/spark-3.2-extensions")
+
+  nessieProject("nessie-spark-extensions-grammar", "clients/spark-antlr-grammar")
+
+  nessieProject("nessie-spark-extensions", "clients/spark-extensions")
+
+  nessieProject("nessie-spark-extensions-base", "clients/spark-extensions-base")
+
+  nessieProject("nessie-gc-base", "gc/gc-base")
+}
 
 if (false) {
   include("gradle:dependabot")


### PR DESCRIPTION
This PR adds non-functional-changes to the build scripts as a
preparation for tools-integrations-testing.

Tools integrations testing will require a "surrounding" Gradle
build, which in turn includes three builds:
* Nessie build, but without all projects that depend on Apache
  Iceberg artifacts. For example: nessie-gc-base, spark-*
* Apache Iceberg build, which then uses the artifacts of the Nessie
  build.
* Nessie-Iceberg build containing the Gradle projects that are
  excluded in the first Nessie build, which can that way reference
  both the Nessie and Apache Iceberg artifacts. This includes the
  nessie-gc-base and nessie-spark-* projects.

Changes:

* Non-functional reorganization of the bom build script and
  settings.gradle.kts.
* Add utility method `withUberJar()`
* Add utility method to identify whether the Gradle build is run in
  context of tools-integrations-testing.
* Utility methods to resolve a Nessie artifact as a Gradle project
  in the current build (as it is done w/o tools-integrations-testing)
  or locate the referenced Nessie Gradle project, which is then part
  of _another_ included build.
* Utility method to resolve the artifact used by the Nessie Gradle
  plugin to resolve the Nessie-Quarkus-server, either in the
  "current" Gradle build or in _another_ included build.

NOT included is the change to enable tools-integration-testing, so
the README.md referenced in a comment isn't there yet.