### PR TITLE
build/ui: premature add java dir to `PATH`

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -210,6 +210,16 @@ tasks.withType<NpmTask>().configureEach {
   outputs.cacheIf { true }
   environment.put("CI", "true")
   environment.put("BUILD_PATH", npmBuildDir.path)
+  val javaDir =
+    javaToolchains
+      .launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) }
+      .get()
+      .metadata
+      .installationPath
+  environment.put(
+    "PATH",
+    "${System.getenv("PATH")}${System.getProperty("path.separator")}$javaDir/bin"
+  )
 }
 
 tasks.named<Jar>("jar") { dependsOn(npmBuild) }


### PR DESCRIPTION
When running Gradle tasks via IDEA, the `PATH` environment will not
contain the Java installation directory. This can break certain
node/npm tasks that "blindly" invoke `java` w/o repsecting
`JAVA_HOME`.

This change adds the Java 11 directory to the `PATH` environment for
npm/node tasks.