### PR TITLE
CI: Also test with Java 17 + 18

### DIFF
--- a/.github/workflows/newer-java.yml
+++ b/.github/workflows/newer-java.yml
@@ -1,0 +1,90 @@
+name: Newer Java versions
+
+on:
+  schedule:
+    # Run daily on week days
+    - cron:  '* 4 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  java:
+    name: Exercise Java version
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        include:
+          - java-version: 17
+          - java-version: 18
+    env:
+      SPARK_LOCAL_IP: localhost
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup runner
+      uses: ./.github/actions/setup-runner
+    - name: Setup Java, Gradle
+      uses: ./.github/actions/dev-tool-java
+      with:
+        java-version: ${{ matrix.java-version }}
+
+    - name: Gradle / spotless
+      uses: gradle/gradle-build-action@v2
+      with:
+        cache-read-only: true
+        # 'spotlessCheck' separate: workaround until https://github.com/diffplug/spotless/issues/1215 is fixed
+        arguments: spotlessCheck
+
+    - name: Gradle / compile
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: checkstyleMain checkstyleTest jar testClasses testJar
+
+    - name: Gradle / unit test
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: test
+
+    - name: Gradle / check incl. integ-test
+      uses: gradle/gradle-build-action@v2
+      with:
+        # '-x spotlessCheck': workaround until https://github.com/diffplug/spotless/issues/1215 is fixed
+        arguments: check -x spotlessCheck
+
+    - name: Gradle / Gatling simulations
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: gatlingRun
+
+    - name: Gradle / assemble + publish local
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          assemble
+          codeCoverageReport -x test -x intTest
+          publishToMavenLocal
+          -Puber-jar
+
+    - name: Gradle / build tools integration tests
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: buildToolsIntegrationTest
+
+    - name: Gradle / integration test native
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          --no-daemon
+          :nessie-quarkus:quarkusBuild
+          :nessie-quarkus:intTest
+          -Pnative
+          -Pdocker
+
+    - name: Capture Test Reports
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: test-results-native
+        path: |
+          **/build/reports/*
+          **/build/test-results/*


### PR DESCRIPTION
Currently all CI jobs run with Java 11. To ensure that Nessie works
fine with Java versions 17 and newer as well (excluding Spark
related code + tests), this GH workflow is being introduced, which
runs daily against the main branch.

This new workflow can also be triggered manually, even in a fork,
choosing the branch to run against.