### PR TITLE
Handle times in SQL extensions better

### DIFF
--- a/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/NessieUtils.scala
+++ b/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/NessieUtils.scala
@@ -32,7 +32,7 @@ import org.projectnessie.model.{
 }
 
 import java.time.format.DateTimeParseException
-import java.time.{Instant, LocalDateTime, ZoneOffset}
+import java.time.{Instant, LocalDateTime, ZoneOffset, ZonedDateTime}
 import java.util.OptionalInt
 import scala.collection.JavaConverters._
 
@@ -61,11 +61,14 @@ object NessieUtils {
       .map(x => x.replaceAll("`", ""))
       .map(x => {
         try {
-          LocalDateTime.parse(x).atZone(ZoneOffset.UTC).toInstant
+          ZonedDateTime.parse(x).toInstant
         } catch {
           case e: DateTimeParseException =>
             throw new NessieNotFoundException(
-              "Invalid timestamp provided: " + e.getMessage
+              String.format(
+                "Invalid timestamp provided: %s. You need to provide it with a zone info. For more info, see: https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html",
+                e.getMessage
+              )
             )
         }
       })


### PR DESCRIPTION
We start accepting dateTime with time zone only. If the user passes the dateTime without zone:
"2022-06-29T09:26:07.974992" we should throw an exception denoting that the user needs to pass the zone explicitly. The new dataTime format should be: 2022-06-29T11:26:07.976777+02:00. It means that we are breaking the compatibility of the current API, but we concluded that having an exception with a meaningful message would be enough in that case. Also, Nessie is not 1.x version yet, so the API changes can be justified.