### PR TITLE
Add PR workflow for Nessie-Query-Engine-Integration-Tests

### DIFF
--- a/.github/actions/patch-git/action.yml
+++ b/.github/actions/patch-git/action.yml
@@ -1,0 +1,86 @@
+# Merge a "patch branch"
+name: 'Patch Git'
+description: 'Checkout the main and optional patch repositories and apply necessary patches'
+inputs:
+  name:
+    description: 'Human readable name of the project/product being checked out and patched'
+    required: true
+  local-dir:
+    description: 'Local workspace directory'
+    required: true
+  main-repository:
+    description: 'Main github repository in the form owner/repo'
+    required: true
+  main-branch:
+    description: 'Name of the main/master branch, leave empty to use the Git reference of the workflow run'
+    required: false
+  patch-repository:
+    description: 'Patch github repository in the form owner/repo'
+    required: false
+  patch-branch:
+    description: 'Name of the branch in patch-repository that has the patch commits'
+    required: false
+  work-branch:
+    description: 'Local work directory for the project/product'
+    required: true
+runs:
+  using: "composite"
+  steps:
+
+    - name: Checkout ${{ inputs.name }} repo
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.main-repository }}
+        ref: ${{ inputs.main-branch }}
+        path: ${{ inputs.local-dir }}
+        # Need the full history for the merge below
+        fetch-depth: 0
+
+    - name: Apply ${{ inputs.name }} changes
+      shell: bash
+      env:
+        MAIN_REPOSITORY: ${{ inputs.main-repository }}
+        PATCH_REPOSITORY: ${{ inputs.patch-repository }}
+        PATCH_BRANCH: ${{ inputs.patch-branch }}
+        # Taken from a 'git fetch' from actions/checkout
+        GIT_FETCH: -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules
+        WORK_BRANCH: ${{ inputs.work-branch }}
+      working-directory: ${{ inputs.local-dir }}
+      run: |
+        REFERENCE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        REFERENCE_COMMIT=$(git rev-parse HEAD)
+
+        if [[ -n ${PATCH_REPOSITORY} ]]; then
+          PATCH_REMOTE_NAME="$(echo ${PATCH_REPOSITORY} | cut -d/ -f1)"
+
+          if [[ ${MAIN_REPOSITORY} != ${PATCH_REPOSITORY} ]] ; then
+            echo "::group::Add remote ${PATCH_REPOSITORY} as ${PATCH_REMOTE_NAME}"
+            git remote add ${PATCH_REMOTE_NAME} https://github.com/${PATCH_REPOSITORY}.git
+            echo "::endgroup::"
+          fi
+  
+          echo "::group::Fetch ${PATCH_BRANCH} from ${PATCH_REPOSITORY}"
+          git ${GIT_FETCH} ${PATCH_REMOTE_NAME} +refs/heads/${PATCH_BRANCH}*:refs/remotes/${PATCH_REMOTE_NAME}/${PATCH_BRANCH}* +refs/tags/${PATCH_BRANCH}*:refs/tags/${PATCH_BRANCH}*
+          echo "::endgroup::"
+  
+          echo "::group::Checkout branch ${PATCH_BRANCH} from ${PATCH_REPOSITORY}"
+          git checkout --progress --force -B ${PATCH_BRANCH} refs/remotes/${PATCH_REMOTE_NAME}/${PATCH_BRANCH}
+          PATCH_COMMIT=$(git rev-parse ${PATCH_BRANCH})
+          echo "::endgroup::"
+  
+          echo "::group::Create new work branch ${WORK_BRANCH} from ${REFERENCE_BRANCH} at ${REFERENCE_COMMIT}"
+          git checkout -b ${WORK_BRANCH} ${REFERENCE_COMMIT}
+          echo "::endgroup::"
+  
+          echo "::group::Merge ${PATCH_BRANCH} into ${WORK_BRANCH}"
+          git merge --no-edit ${PATCH_BRANCH}
+          echo "::endgroup::"
+        fi
+
+        echo "## ${{ inputs.name }} changes" >> $GITHUB_STEP_SUMMARY
+        echo "| Remote | Branch | Commit |" >> $GITHUB_STEP_SUMMARY
+        echo "|--|--|--|" >> $GITHUB_STEP_SUMMARY
+        echo "| ${MAIN_REPOSITORY} | ${REFERENCE_BRANCH} | ${REFERENCE_COMMIT} |" >> $GITHUB_STEP_SUMMARY
+        if [[ -n ${PATCH_REPOSITORY} ]]; then
+          echo "| ${PATCH_REPOSITORY} | ${PATCH_BRANCH} | ${PATCH_COMMIT} |" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/.github/workflows/pull-request-integ.yml
+++ b/.github/workflows/pull-request-integ.yml
@@ -28,6 +28,102 @@ jobs:
     name: Integrations Tests
     runs-on: ubuntu-20.04
     if: contains(github.event.pull_request.labels.*.name, 'pr-integrations')
+    env:
+      NESSIE_DIR: included-builds/nessie
+      NESSIE_PATCH_REPOSITORY: ''
+      NESSIE_PATCH_BRANCH: ''
+      ICEBERG_DIR: included-builds/iceberg
+      ICEBERG_MAIN_REPOSITORY: apache/iceberg
+      ICEBERG_MAIN_BRANCH: master
+      ICEBERG_PATCH_REPOSITORY: ''
+      ICEBERG_PATCH_BRANCH: ''
+      SPARK_LOCAL_IP: localhost
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Prepare Git
+        run: |
+          git config --global user.email "integrations-testing@projectnessie.org"
+          git config --global user.name "Integrations Testing [Bot]"
+
+      - name: Checkout nqeit repo
+        uses: actions/checkout@v3
+        with:
+          repository: projectnessie/query-engine-integration-tests
+          ref: main
+
+      - name: Checkout and patch Nessie PR
+        uses: ./.github/actions/patch-git
+        with:
+          name: Nessie
+          local-dir: ${{env.NESSIE_DIR}}
+          main-repository: ${{ env.GITHUB_REPOSITORY }}
+          patch-repository: ${{env.NESSIE_PATCH_REPOSITORY}}
+          patch-branch: ${{env.NESSIE_PATCH_BRANCH}}
+          work-branch: nessie-integration-patched
+
+      - name: Checkout and patch Iceberg
+        uses: ./.github/actions/patch-git
+        with:
+          name: Nessie
+          local-dir: ${{env.ICEBERG_DIR}}
+          main-repository: ${{env.ICEBERG_MAIN_REPOSITORY}}
+          main-branch: ${{env.ICEBERG_MAIN_BRANCH}}
+          patch-repository: ${{env.ICEBERG_PATCH_REPOSITORY}}
+          patch-branch: ${{env.ICEBERG_PATCH_BRANCH}}
+          work-branch: iceberg-integration-patched
+
+      # Setup Gradle properties, heap requirements are for the "Integration test w/ Nessie".
+      - name: Setup gradle.properties
+        run: |
+          mkdir -p ~/.gradle
+          echo "org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" >> ~/.gradle/gradle.properties
+          echo "org.gradle.vfs.watch=false" >> ~/.gradle/gradle.properties
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Iceberg Nessie test
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :iceberg:iceberg-nessie:test
+
+      - name: Nessie Spark 3.1 Extensions test
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.1_2.12:test :nessie-iceberg:nessie-spark-extensions-3.1_2.12:intTest
+
+      - name: Nessie Spark 3.2 / 2.12 Extensions test
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest
+
+      - name: Nessie Spark 3.3 / 2.12 Extensions test
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest
+
+      - name: Publish Nessie + Iceberg to local Maven repo
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishLocal
+
+      - name: Gather locally published versions
+        run: |
+          NESSIE_VERSION="$(cat included-builds/nessie/version.txt)"
+          ICEBERG_VERSION="$(cat included-builds/iceberg/build/iceberg-build.properties | grep '^git.build.version=' | cut -d= -f2)"
+          echo "NESSIE_VERSION=${NESSIE_VERSION}" >> ${GITHUB_ENV}
+          echo "ICEBERG_VERSION=${ICEBERG_VERSION}" >> ${GITHUB_ENV}
+          cat <<! >> $GITHUB_STEP_SUMMARY
+          ## Published versions
+          | Published Nessie version | Published Iceberg version |
+          | ------------------------ | ------------------------- |
+          | ${NESSIE_VERSION}        | ${ICEBERG_VERSION}        |
+          !
+
+      - name: Tools & Integrations tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: intTest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Project Nessie
 
 [![Build Status](https://github.com/projectnessie/nessie/workflows/Main%20CI/badge.svg)](https://github.com/projectnessie/nessie/actions/workflows/main.yml)
+[![Query Engine Integrations](https://github.com/projectnessie/query-engine-integration-tests/actions/workflows/main.yml/badge.svg)](https://github.com/projectnessie/query-engine-integration-tests/actions/workflows/main.yml)
 [![Java 17+18](https://github.com/projectnessie/nessie/actions/workflows/newer-java.yml/badge.svg)](https://github.com/projectnessie/nessie/actions/workflows/newer-java.yml)
 [![codecov](https://codecov.io/gh/projectnessie/nessie/branch/main/graph/badge.svg?token=W9J9ZUYO1Y)](https://codecov.io/gh/projectnessie/nessie)
 [![Maven Central](https://img.shields.io/maven-central/v/org.projectnessie/nessie)](https://search.maven.org/artifact/org.projectnessie/nessie)


### PR DESCRIPTION
**NOTE: This PR, actually the integrations-testing stuff it uses, is very much work-in-progress**

It relies on the state in https://github.com/snazy/nessie-integration-tests/ - and that piece is changing rapidly. It is at least the foundation of Nessie-Query-Engine-Integration-Tests - i.e. to allow testing various query engines using Nessie against various environments.

See #4737 

To merge this PR:
* [x] the `nessie-integration-tests` repo needs to be in `projectnessie`

Following two bullet points not necessary at the moment:
* X need a branch in `projectnessie/nessie` that contains the patches for Nessie to make it work against "latest Iceberg"
* X need a (temporary) fork of `apache/iceberg` - but only apply the Iceberg PRs https://github.com/apache/iceberg/pull/5051 and https://github.com/apache/iceberg/pull/5193 - however, maybe we need a "permanent patch branch"