### PR TITLE
SQL extensions: Small cleanup

### DIFF
--- a/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseMergeBranchExec.scala
+++ b/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseMergeBranchExec.scala
@@ -35,7 +35,7 @@ abstract class BaseMergeBranchExec(
     val from = api.getReference
       .refName(
         branch.getOrElse(
-          NessieUtils.getCurrentRef(currentCatalog, catalog).getName
+          NessieUtils.getCurrentRef(api, currentCatalog, catalog).getName
         )
       )
     api

--- a/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseShowLogExec.scala
+++ b/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseShowLogExec.scala
@@ -20,8 +20,8 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, MapData}
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.unsafe.types.UTF8String
-import org.projectnessie.client.api.NessieApiV1
 import org.projectnessie.client.StreamingUtil
+import org.projectnessie.client.api.NessieApiV1
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -39,7 +39,7 @@ abstract class BaseShowLogExec(
       api: NessieApiV1
   ): Seq[InternalRow] = {
     val refName = branch.getOrElse(
-      NessieUtils.getCurrentRef(currentCatalog, catalog).getName
+      NessieUtils.getCurrentRef(api, currentCatalog, catalog).getName
     )
     val stream = StreamingUtil.getCommitLogStream(
       api,

--- a/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseShowReferenceExec.scala
+++ b/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BaseShowReferenceExec.scala
@@ -30,7 +30,7 @@ abstract class BaseShowReferenceExec(
       api: NessieApiV1
   ): Seq[InternalRow] = {
 
-    val ref = NessieUtils.getCurrentRef(currentCatalog, catalog)
+    val ref = NessieUtils.getCurrentRef(api, currentCatalog, catalog)
     // todo have to figure out if this is delta or iceberg and extract the ref accordingly
     singleRowForRef(ref)
   }


### PR DESCRIPTION
No need to create a `NessieApi` instance, because all call sites have an instance available.