### PR TITLE
Move antlr-runtime dependency back into Nessie

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     api(rootProject)
     api(project(":nessie-clients"))
     api(project(":nessie-client"))
+    api(project(":nessie-spark-antlr-runtime"))
     api(project(":nessie-compatibility"))
     api(project(":nessie-compatibility-common"))
     api(project(":nessie-compatibility-tests"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,7 +139,15 @@ extra["versionSpark32"] = versionSpark32
 
 extra["quarkus.builder-image"] = "quay.io/quarkus/ubi-quarkus-native-image:22.1-java17"
 
+// Dummy configuration to allow dependabot to manage dependencies here, but not include those
+// dependencies in the constraints. Those "managedOnly" dependencies do not "leak" to other
+// projects.
+configurations.create("managedOnly")
+
 dependencies {
+  add("managedOnly", "org.antlr:antlr4:$versionAntlr")
+  add("managedOnly", "org.antlr:antlr4-runtime:$versionAntlr")
+
   constraints {
     api("ch.qos.logback:logback-access:$versionLogback")
     api("ch.qos.logback:logback-classic:$versionLogback")
@@ -208,7 +216,6 @@ dependencies {
     api("org.openjdk.jmh:jmh-generator-annprocess:$versionJmh")
     api("org.postgresql:postgresql:$versionPostgres")
     api("org.mockito:mockito-core:$versionMockito")
-    api("org.projectnessie:nessie-antlr-runtime:$versionAntlr")
     api("org.projectnessie.cel:cel-bom:$versionCel")
     api("org.rocksdb:rocksdbjni:$versionRocksDb")
     api("org.slf4j:jcl-over-slf4j:$versionSlf4j")

--- a/clients/antlr-runtime/build.gradle.kts
+++ b/clients/antlr-runtime/build.gradle.kts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+plugins {
+  `java-library`
+  jacoco
+  `maven-publish`
+  id("com.github.johnrengelman.shadow")
+  `nessie-conventions`
+}
+
+extra["maven.name"] = "Nessie - Antlr Runtime"
+
+dependencies {
+  implementation(platform(rootProject))
+
+  implementation("org.antlr:antlr4-runtime:${dependencyVersion("versionAntlr")}")
+}
+
+tasks.named<ShadowJar>("shadowJar") {
+  dependencies { include(dependency("org.antlr:antlr4-runtime")) }
+  relocate("org.antlr.v4.runtime", "org.projectnessie.shaded.org.antlr.v4.runtime")
+}

--- a/clients/spark-antlr-grammar/build.gradle.kts
+++ b/clients/spark-antlr-grammar/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   antlr("org.antlr:antlr4:${dependencyVersion("versionAntlr")}")
 
   implementation(platform(nessieRootProject()))
-  api("org.projectnessie:nessie-antlr-runtime")
+  api(project(":nessie-spark-antlr-runtime", "shadow"))
 }
 
 sourceSets { main { antlr { setSrcDirs(listOf(project.projectDir.resolve("src/main/antlr4"))) } } }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -121,6 +121,8 @@ nessieProject("nessie-bom", "bom")
 
 nessieProject("nessie-clients", "clients")
 
+nessieProject("nessie-spark-antlr-runtime", "clients/antlr-runtime")
+
 nessieProject("nessie-client", "clients/client")
 
 nessieProject("nessie-compatibility", "compatibility")


### PR DESCRIPTION
Back in the (Maven) days, we had to move the shaded antlr-runtime to
a separate build, because otherwise the non-shaded and shaded
antlr4-runtime classes conflicted and the build became quite tricky.

Now with Gradle it's possible to get rid of the "artificial"
nessie-antlr-runtime dependency using the same group-id but a
different version schema.

Adding back the relocated antlr4 runtime as a nessie project.

This eliminates the need for https://github.com/projectnessie/nessie-antlr-runtime/