### PR TITLE
Avoid converting 415 Unsupported Media Type into 500 ISE (#4436)

### DIFF
--- a/clients/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/clients/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -42,6 +42,7 @@ import org.projectnessie.error.NessieContentNotFoundException;
 import org.projectnessie.error.NessieError;
 import org.projectnessie.error.NessieForbiddenException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
+import org.projectnessie.error.NessieUnsupportedMediaTypeException;
 import software.amazon.awssdk.utils.StringInputStream;
 
 @Execution(ExecutionMode.CONCURRENT)
@@ -188,6 +189,10 @@ public class TestResponseFilter {
         Arguments.of(Status.NOT_FOUND, ErrorCode.UNKNOWN, RuntimeException.class),
         Arguments.of(Status.CONFLICT, ErrorCode.REFERENCE_CONFLICT, NessieConflictException.class),
         Arguments.of(Status.CONFLICT, ErrorCode.UNKNOWN, RuntimeException.class),
+        Arguments.of(
+            Status.UNSUPPORTED_MEDIA_TYPE,
+            ErrorCode.UNSUPPORTED_MEDIA_TYPE,
+            NessieUnsupportedMediaTypeException.class),
         Arguments.of(
             Status.INTERNAL_SERVER_ERROR, ErrorCode.UNKNOWN, NessieInternalServerException.class));
   }

--- a/model/src/main/java/org/projectnessie/error/ErrorCode.java
+++ b/model/src/main/java/org/projectnessie/error/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
   NAMESPACE_NOT_FOUND(404, NessieNamespaceNotFoundException::new),
   NAMESPACE_ALREADY_EXISTS(409, NessieNamespaceAlreadyExistsException::new),
   NAMESPACE_NOT_EMPTY(409, NessieNamespaceNotEmptyException::new),
+  UNSUPPORTED_MEDIA_TYPE(415, NessieUnsupportedMediaTypeException::new),
   ;
 
   private final int httpStatus;

--- a/model/src/main/java/org/projectnessie/error/NessieUnsupportedMediaTypeException.java
+++ b/model/src/main/java/org/projectnessie/error/NessieUnsupportedMediaTypeException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.error;
+
+/** This exception is thrown when the request's media type is not accepted at the specified path. */
+public class NessieUnsupportedMediaTypeException extends NessieConflictException {
+
+  public NessieUnsupportedMediaTypeException(NessieError error) {
+    super(error);
+  }
+
+  @Override
+  public ErrorCode getErrorCode() {
+    return ErrorCode.UNSUPPORTED_MEDIA_TYPE;
+  }
+}

--- a/model/src/main/java/org/projectnessie/error/NessieUnsupportedMediaTypeException.java
+++ b/model/src/main/java/org/projectnessie/error/NessieUnsupportedMediaTypeException.java
@@ -15,8 +15,8 @@
  */
 package org.projectnessie.error;
 
-/** This exception is thrown when the request's media type is not accepted at the specified path. */
-public class NessieUnsupportedMediaTypeException extends NessieConflictException {
+/** This exception is thrown when the request's media type is not accepted at its specified path. */
+public class NessieUnsupportedMediaTypeException extends NessieRuntimeException {
 
   public NessieUnsupportedMediaTypeException(NessieError error) {
     super(error);

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ErrorTestService.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ErrorTestService.java
@@ -77,6 +77,13 @@ public class ErrorTestService {
     return "oh oh";
   }
 
+  @Path("unsupportedMediaTypePut")
+  @PUT
+  @Consumes(MediaType.TEXT_PLAIN)
+  public String unsupportedMediaTypePut(@NotNull String txt) {
+    return "oh oh";
+  }
+
   @Path("nessieNotFound")
   @GET
   public String nessieNotFound() throws NessieNotFoundException {

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -144,7 +144,8 @@ class TestNessieError {
                         unwrap(
                             () -> client.newRequest().path("unsupportedMediaTypePut").put("foo")))
                 .isInstanceOf(NessieUnsupportedMediaTypeException.class)
-                .hasMessage("RESTEASY003065: Cannot consume content type"));
+                .hasMessage(
+                    "Unsupported Media Type (HTTP/415): RESTEASY003065: Cannot consume content type"));
   }
 
   @Test

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -38,6 +38,7 @@ import org.projectnessie.error.NessieBackendThrottledException;
 import org.projectnessie.error.NessieBadRequestException;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.error.NessieUnsupportedMediaTypeException;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 
 /**
@@ -132,6 +133,18 @@ class TestNessieError {
                 .isInstanceOf(NessieBadRequestException.class)
                 .hasMessage(
                     "Bad Request (HTTP/400): blankParameterQueryGet.hash: must not be blank"));
+  }
+
+  @Test
+  void unsupportedMediaTypePut() {
+    assertAll(
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        unwrap(
+                            () -> client.newRequest().path("unsupportedMediaTypePut").put("foo")))
+                .isInstanceOf(NessieUnsupportedMediaTypeException.class)
+                .hasMessage("RESTEASY003065: Cannot consume content type"));
   }
 
   @Test

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/NessieExceptionMapper.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/NessieExceptionMapper.java
@@ -21,6 +21,7 @@ import com.google.common.base.Throwables;
 import java.security.AccessControlException;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 import org.projectnessie.error.BaseNessieClientServerException;
@@ -75,6 +76,9 @@ public class NessieExceptionMapper extends BaseExceptionMapper<Exception> {
       message = "Backend store refused to process the request: " + exception;
     } else if (exception instanceof AccessControlException) {
       errorCode = ErrorCode.FORBIDDEN;
+      message = exception.getMessage();
+    } else if (exception instanceof NotSupportedException) {
+      errorCode = ErrorCode.UNSUPPORTED_MEDIA_TYPE;
       message = exception.getMessage();
     } else {
       LOGGER.warn("Unhandled exception returned as HTTP/500 to client", exception);


### PR DESCRIPTION
This is an attempt to address #4436, with context from my contemporaneous comment there.

Some notes on this PR:

- I've run `./gradlew test` and `gradlew intTest check` locally from the repo root, and I've run the newly introduced tests by themselves quite a bit during iteration; but maybe the github checks will reveal other problems, so it might be worth punting on review until the checks complete/fail.
- Is the exception message compatible with Nessie's style?  Resteasy generates the message "RESTEASY003065: Cannot consume content type" in the case touched by this commit, and NEM passes that message through to the client.  I noticed other response message strings prefixed by their status code for redundancy, and this one isn't prefixed that way.
- I think the newly-added `NessieUnsupportedMediaTypeException` fits the mold in `ErrorCode`, but maybe there's an argument for removing or renaming it.

_(the remainder of this descrption is just the message of the PR's sole commit)_

In cases where a client request specified a Content-Type that a Nessie-Quarkus method wouldn't accept, NessieExceptionMapper would convert the resulting 415 exception into a generic 500 exception.  The reason string still provided a useful hint ("Cannot consume content type"), but the code was more general than necessary.

This commit adds a case to JAX-WS NotSupportedException case to NessieExceptionMapper, preventing it from falling through to the catch-all 500 ISE case.  It also adds a couple of tests covering the change.