### PR TITLE
Nessie REST (HTTP) client: verify JSON response

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpRequest.java
@@ -94,7 +94,7 @@ public class HttpRequest {
         ((HttpsURLConnection) con).setSSLSocketFactory(config.getSslContext().getSocketFactory());
       }
       RequestContext context = new RequestContext(headers, uri, method, body);
-      ResponseContext responseContext = new ResponseContextImpl(con);
+      ResponseContext responseContext = new ResponseContextImpl(con, uri);
       try {
         headers.put(HEADER_ACCEPT, accept);
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import java.io.InputStream;
-import org.projectnessie.client.rest.NessieServiceException;
+import org.projectnessie.client.rest.NessieBadResponseException;
 import org.projectnessie.error.ImmutableNessieError;
 
 /** Simple holder for http response object. */
@@ -59,7 +59,7 @@ public class HttpResponse {
 
   private void nonJsonResponse() throws IOException {
     Status status = responseContext.getResponseCode();
-    throw new NessieServiceException(
+    throw new NessieBadResponseException(
         ImmutableNessieError.builder()
             .status(status.getCode())
             .message(status.getReason())
@@ -68,8 +68,8 @@ public class HttpResponse {
                     "Expected the server to return a JSON compatible response, "
                         + "but the server returned with Content-Type '%s' from '%s'. "
                         + "Check the Nessie REST API base URI. "
-                        + "Nessie REST API base URI usually end in '/api/v1', unless you were "
-                        + "given a specific URI from your service provider.",
+                        + "Nessie REST API base URI usually end in '/api/v1', but your service "
+                        + "provider may have a different URL pattern.",
                     responseContext.getContentType(), responseContext.getRequestedUri()))
             .build());
   }

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import java.io.InputStream;
+import org.projectnessie.client.rest.NessieServiceException;
+import org.projectnessie.error.ImmutableNessieError;
 
 /** Simple holder for http response object. */
 public class HttpResponse {
@@ -44,11 +46,32 @@ public class HttpResponse {
         return null;
       }
       try (InputStream is = responseContext.getInputStream()) {
+        if (!responseContext.isJsonCompatibleResponse()) {
+          nonJsonResponse();
+        }
+
         return reader.readValue(is);
       }
     } catch (IOException e) {
       throw new HttpClientException("Cannot parse request.", e);
     }
+  }
+
+  private void nonJsonResponse() throws IOException {
+    Status status = responseContext.getResponseCode();
+    throw new NessieServiceException(
+        ImmutableNessieError.builder()
+            .status(status.getCode())
+            .message(status.getReason())
+            .reason(
+                String.format(
+                    "Expected the server to return a JSON compatible response, "
+                        + "but the server returned with Content-Type '%s' from '%s'. "
+                        + "Check the Nessie REST API base URI. "
+                        + "Nessie REST API base URI usually end in '/api/v1', unless you were "
+                        + "given a specific URI from your service provider.",
+                    responseContext.getContentType(), responseContext.getRequestedUri()))
+            .build());
   }
 
   public <V> V readEntity(Class<V> clazz) {

--- a/clients/client/src/main/java/org/projectnessie/client/http/ResponseContext.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/ResponseContext.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.http;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 
 /** Interface for the important parts of a response. This is created after executing the request. */
 public interface ResponseContext {
@@ -26,4 +27,10 @@ public interface ResponseContext {
   InputStream getInputStream() throws IOException;
 
   InputStream getErrorStream() throws IOException;
+
+  boolean isJsonCompatibleResponse();
+
+  String getContentType();
+
+  URI getRequestedUri();
 }

--- a/clients/client/src/main/java/org/projectnessie/client/rest/NessieBadResponseException.java
+++ b/clients/client/src/main/java/org/projectnessie/client/rest/NessieBadResponseException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.rest;
+
+import org.projectnessie.error.NessieError;
+
+/**
+ * Represents an unexpected response from the remote side, trying to access a Nessie endpoint. For
+ * example, non-JSON responses cause this unchecked exception to be thrown. Note: this exception is
+ * <em>not</em> thrown for an HTTP/400 (Bad Request).
+ */
+public class NessieBadResponseException extends NessieServiceException {
+
+  public NessieBadResponseException(NessieError serverError) {
+    super(serverError);
+  }
+}

--- a/clients/client/src/test/java/org/projectnessie/client/TestNessieHttpClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/TestNessieHttpClient.java
@@ -32,9 +32,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
+import org.projectnessie.client.rest.NessieBadResponseException;
 import org.projectnessie.client.rest.NessieInternalServerException;
 import org.projectnessie.client.rest.NessieNotAuthorizedException;
-import org.projectnessie.client.rest.NessieServiceException;
 import org.projectnessie.client.util.JaegerTestTracer;
 import org.projectnessie.client.util.TestHttpUtil;
 import org.projectnessie.client.util.TestServer;
@@ -60,7 +60,7 @@ class TestNessieHttpClient {
               .withTracing(true)
               .build(NessieApiV1.class);
       assertThatThrownBy(api::getDefaultBranch)
-          .isInstanceOf(NessieServiceException.class)
+          .isInstanceOf(NessieBadResponseException.class)
           .hasMessageStartingWith(
               "Expected the server to return a JSON compatible response, but the server returned with Content-Type 'text/html' from ");
     }

--- a/clients/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/clients/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -109,6 +110,21 @@ public class TestResponseFilter {
                       public InputStream getErrorStream() {
                         return new StringInputStream("this will fail");
                       }
+
+                      @Override
+                      public boolean isJsonCompatibleResponse() {
+                        return true;
+                      }
+
+                      @Override
+                      public String getContentType() {
+                        return null;
+                      }
+
+                      @Override
+                      public URI getRequestedUri() {
+                        return null;
+                      }
                     },
                     MAPPER))
         .isInstanceOf(NessieNotAuthorizedException.class)
@@ -139,6 +155,21 @@ public class TestResponseFilter {
                         // Quarkus may sometimes produce JSON error responses like this
                         return new StringInputStream(
                             "{\"details\":\"Error id ee7f7293-67ad-42bd-8973-179801e7120e-1\",\"stack\":\"\"}");
+                      }
+
+                      @Override
+                      public boolean isJsonCompatibleResponse() {
+                        return true;
+                      }
+
+                      @Override
+                      public String getContentType() {
+                        return null;
+                      }
+
+                      @Override
+                      public URI getRequestedUri() {
+                        return null;
                       }
                     },
                     MAPPER))
@@ -220,6 +251,21 @@ public class TestResponseFilter {
       }
       String value = MAPPER.writeValueAsString(error);
       return new StringInputStream(value);
+    }
+
+    @Override
+    public boolean isJsonCompatibleResponse() {
+      return true;
+    }
+
+    @Override
+    public String getContentType() {
+      return null;
+    }
+
+    @Override
+    public URI getRequestedUri() {
+      return null;
     }
   }
 }

--- a/clients/client/src/test/java/org/projectnessie/client/util/TestHttpUtil.java
+++ b/clients/client/src/test/java/org/projectnessie/client/util/TestHttpUtil.java
@@ -25,6 +25,12 @@ public class TestHttpUtil {
   private TestHttpUtil() {}
 
   public static void writeResponseBody(HttpExchange http, String response) throws IOException {
+    writeResponseBody(http, response, "application/json");
+  }
+
+  public static void writeResponseBody(HttpExchange http, String response, String contentType)
+      throws IOException {
+    http.getResponseHeaders().add("Content-Type", contentType);
     byte[] body = response.getBytes(StandardCharsets.UTF_8);
     http.sendResponseHeaders(200, body.length);
     try (OutputStream os = http.getResponseBody()) {


### PR DESCRIPTION
When users configure the REST base URI incorrectly, e.g. by setting
it to `http://127.0.0.1:19120/` against a locally running
Nessie-Quarkus-Server, they just get some "cannot parse response
entity" error message, which isn't helpful.

This change verifies the the `Content-Type` returned by the server
is a valid JSON one, one that ends in either `/json` or `+json`.
If the response is not a JSON response, the thrown exceptions gives
a better hint to what _could_ be wrong.