### PR TITLE
Fix POM transitive dependency issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ val versionImmutables = "2.9.0"
 val versionJackson = "2.13.3"
 val versionJacksonSpark3 = "2.13.3"
 val versionJacoco = "0.8.8"
+val versionJakartaAnnotationApi = "1.3.5"
 val versionJakartaEnterpriseCdiApi = "2.0.2"
 val versionJakartaValidationApi = "2.0.2"
 val versionJandex = "2.4.3.Final"
@@ -174,6 +175,7 @@ dependencies {
     api("io.quarkus:quarkus-bom:$versionQuarkus")
     api("io.quarkiverse.loggingsentry:quarkus-logging-sentry:$versionQuarkusLoggingSentry")
     api("io.rest-assured:rest-assured:$versionRestAssured")
+    api("jakarta.validation:jakarta.annotation-api:$versionJakartaAnnotationApi")
     api("jakarta.enterprise:jakarta.enterprise.cdi-api:$versionJakartaEnterpriseCdiApi")
     api("jakarta.validation:jakarta.validation-api:$versionJakartaValidationApi")
     api("javax.servlet:javax.servlet-api:$versionJavaxServlet")


### PR DESCRIPTION
Following _warning_ is emitted by the `buildToolIntegrationMaven` task
```
[WARNING] The POM for org.projectnessie:nessie-rest-services:jar:0.30.1-SNAPSHOT is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
```
which is caused by a missing dependency version for `jakarta.validation:jakarta.annotation-api` in the main nessie-pom