### PR TITLE
Fix pom validation to top-level pom

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -120,12 +120,12 @@ jobs:
       run: |
         if [[ -f build.gradle.kts ]] ; then
           echo "::group::Publish to Sonatype"
-          ./gradlew --no-watch-fs --no-daemon --info publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar
+          ./gradlew --no-watch-fs --no-daemon publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar
           echo "::endgroup::"
   
           # Build the native-image, it's not released to Maven Central
           echo "::group::Build native image"
-          ./gradlew --no-watch-fs --no-daemon --info :nessie-quarkus:quarkusBuild -Prelease -Pnative -Pdocker
+          ./gradlew --no-watch-fs --no-daemon :nessie-quarkus:quarkusBuild -Prelease -Pnative -Pdocker
           echo "::endgroup::"
   
           # Add version to the openapi file name

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ plugins {
 
 extra["maven.name"] = "Nessie"
 
+description = "Transactional Catalog for Data Lakes"
+
 /*
 Main dependency handling happens in this build script.
 Declare versions as variables and add dependency constraints.


### PR DESCRIPTION
Fixes Sonatype validation message:
```
Invalid POM: /org/projectnessie/nessie/0.40.0/nessie-0.40.0.pom: Project description missing
```

Also remove "--info" from release-publish WF, because the Actions log is unreadable otherwise (and way too big).
