### PR TITLE
GH WF: Prevent duplicate WF runs

### DIFF
--- a/.github/workflows/newer-java.yml
+++ b/.github/workflows/newer-java.yml
@@ -3,7 +3,7 @@ name: Newer Java versions
 on:
   schedule:
     # Run daily on week days
-    - cron:  '* 4 * * 1-5'
+    - cron:  '0 4 * * 1-5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The `Newer Java versions` shall run once every 24h on weekdays.
However, GH triggers the WF twice. This seems to be an issue in GH WFs,
but the simple workaround is to tweak the cron-expression.