### PR TITLE
Restore backwards compatibility

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetCommitLogBuilder.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.api;
 import javax.annotation.Nullable;
 import javax.validation.constraints.Pattern;
 import org.projectnessie.api.params.FetchOption;
+import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Validation;
 
@@ -42,4 +43,7 @@ public interface GetCommitLogBuilder
   GetCommitLogBuilder untilHash(
       @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String untilHash);
+
+  @Override // kept for byte-code compatibility
+  LogResponse get() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client.api;
 
+import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.EntriesResponse;
 
 /**
@@ -28,4 +29,7 @@ public interface GetEntriesBuilder
         OnReferenceBuilder<GetEntriesBuilder> {
 
   GetEntriesBuilder namespaceDepth(Integer namespaceDepth);
+
+  @Override // kept for byte-code compatibility
+  EntriesResponse get() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.api;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.Pattern;
+import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.model.Validation;
 
@@ -46,4 +47,7 @@ public interface GetRefLogBuilder
   GetRefLogBuilder fromHash(
       @Nullable @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
           String fromHash);
+
+  @Override // kept for byte-code compatibility
+  RefLogResponse get() throws NessieNotFoundException;
 }


### PR DESCRIPTION
Prevents the following error(s) when using older, already compiled tools:
```
java.lang.NoSuchMethodError: 'org.projectnessie.model.EntriesResponse org.projectnessie.client.api.GetEntriesBuilder.get()'
```