### PR TITLE
Fix snapshot-publish workflow

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SPARK_LOCAL_IP: localhost
-    if: ${{ env.MAVEN_USERNAME }}
+    if: github.repository_owner == 'projectnessie'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
`env` variables are not available when evaluating an `if` on a GH workflow job.
Switching to another condition.

Error:
```
The workflow is not valid. .github/workflows/snapshot-publish.yml (Line: 19, Col: 9): Unrecognized named-value: 'env'. Located at position 1 within expression: env.MAVEN_USERNAME
```