### PR TITLE
Fix dependencies leaking into projects consuming Nessie

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,134 +104,157 @@ versionIceberg = System.getProperty("nessie.versionIceberg", versionIceberg)
 // Allow overriding the Nessie version used by integration tests that depend on Iceberg
 versionClientNessie = System.getProperty("nessie.versionClientNessie", versionClientNessie)
 
-extra["versionAntlr"] = versionAntlr
-
-extra["versionCheckstyle"] = versionCheckstyle
-
-extra["versionClientNessie"] = versionClientNessie
-
-extra["versionErrorProneAnnotations"] = versionErrorProneAnnotations
-
-extra["versionErrorProneCore"] = versionErrorProneCore
-
-extra["versionErrorProneSlf4j"] = versionErrorProneSlf4j
-
-extra["versionGatling"] = versionGatling
-
-extra["versionGoogleJavaFormat"] = versionGoogleJavaFormat
-
-extra["versionJacoco"] = versionJacoco
-
-extra["versionJandex"] = versionJandex
-
-extra["versionProtobuf"] = versionProtobuf
-
-extra["versionRocksDb"] = versionRocksDb
-
-extra["quarkus.builder-image"] = "quay.io/quarkus/ubi-quarkus-native-image:22.1-java17"
-
-for (e in loadProperties(file("clients/spark-scala.properties"))) {
-  extra[e.key.toString()] = e.value
-}
-
-// Dummy configuration to allow dependabot to manage dependencies here, but not include those
-// dependencies in the constraints. Those "managedOnly" dependencies do not "leak" to other
-// projects.
-configurations.create("managedOnly")
+mapOf(
+    "versionCheckstyle" to versionCheckstyle,
+    "versionClientNessie" to versionClientNessie,
+    "versionErrorProneAnnotations" to versionErrorProneAnnotations,
+    "versionErrorProneCore" to versionErrorProneCore,
+    "versionErrorProneSlf4j" to versionErrorProneSlf4j,
+    "versionGatling" to versionGatling,
+    "versionGoogleJavaFormat" to versionGoogleJavaFormat,
+    "versionJacoco" to versionJacoco,
+    "versionJandex" to versionJandex,
+    "versionProtobuf" to versionProtobuf,
+    "versionRocksDb" to versionRocksDb,
+    "quarkus.builder-image" to "quay.io/quarkus/ubi-quarkus-native-image:22.1-java17"
+  )
+  .plus(loadProperties(file("clients/spark-scala.properties")))
+  .forEach { (k, v) -> extra[k.toString()] = v }
 
 dependencies {
-  add("managedOnly", "org.antlr:antlr4:$versionAntlr")
-  add("managedOnly", "org.antlr:antlr4-runtime:$versionAntlr")
-
   constraints {
-    api("ch.qos.logback:logback-access:$versionLogback")
-    api("ch.qos.logback:logback-classic:$versionLogback")
-    api("ch.qos.logback:logback-core:$versionLogback")
     api("com.fasterxml.jackson:jackson-bom:$versionJackson")
     api("com.fasterxml.jackson.core:jackson-databind:$versionJacksonSpark3")
     api("com.fasterxml.jackson.module:jackson-module-scala_2.12:$versionJacksonSpark3")
-    api("com.github.docker-java:docker-java-api:$versionDockerjava")
     api("com.google.code.findbugs:jsr305:$versionJsr305")
-    api("com.google.errorprone:error_prone_annotations:$versionErrorProneAnnotations")
-    api("com.google.errorprone:error_prone_core:$versionErrorProneCore")
-    api("com.google.googlejavaformat:google-java-format:$versionGoogleJavaFormat")
     api("com.google.guava:guava:$versionGuava")
     api("com.google.protobuf:protobuf-java:$versionProtobuf")
-    api("com.h2database:h2:$versionH2")
-    api("com.puppycrawl.tools:checkstyle:$versionCheckstyle")
     api("info.picocli:picocli:$versionPicocli")
-    api("info.picocli:picocli-codegen:$versionPicocli")
-    api("io.agroal:agroal-pool:$versionAgroalPool")
-    api("io.delta:delta-core_2.12:$versionDeltalake")
-    api("io.gatling.highcharts:gatling-charts-highcharts:$versionGatling")
-    api("io.projectreactor:reactor-bom:$versionReactor")
-    api("io.quarkus.platform:quarkus-amazon-services-bom:$versionQuarkusAmazon")
-    api("io.quarkus:quarkus-bom:$versionQuarkus")
-    api("io.quarkiverse.loggingsentry:quarkus-logging-sentry:$versionQuarkusLoggingSentry")
-    api("io.rest-assured:rest-assured:$versionRestAssured")
+    api("io.quarkus:quarkus-smallrye-opentracing:$versionQuarkus")
     api("jakarta.validation:jakarta.annotation-api:$versionJakartaAnnotationApi")
     api("jakarta.enterprise:jakarta.enterprise.cdi-api:$versionJakartaEnterpriseCdiApi")
     api("jakarta.validation:jakarta.validation-api:$versionJakartaValidationApi")
     api("javax.servlet:javax.servlet-api:$versionJavaxServlet")
     api("javax.ws.rs:javax.ws.rs-api:$versionJavaxWsRs")
-    api("jp.skypencil.errorprone.slf4j:errorprone-slf4j:$versionErrorProneSlf4j")
-    api("org.agrona:agrona:$versionAgrona")
-    api("org.assertj:assertj-core:$versionAssertJ")
-    api("org.apache.hadoop:hadoop-client:$versionHadoop")
-    api("org.apache.iceberg:iceberg-api:$versionIceberg")
-    api("org.apache.iceberg:iceberg-bundled-guava:$versionIceberg")
-    api("org.apache.iceberg:iceberg-common:$versionIceberg")
-    api("org.apache.iceberg:iceberg-core:$versionIceberg")
-    api("org.apache.iceberg:iceberg-hive-metastore:$versionIceberg")
-    api("org.apache.iceberg:iceberg-nessie:$versionIceberg")
-    api("org.apache.iceberg:iceberg-parquet:$versionIceberg")
-    for (sparkVersion in project.extra["sparkVersions"].toString().split(",")) {
-      for (scalaVersion in
-        project.extra["sparkVersion-$sparkVersion-scalaVersions"].toString().split(",")) {
-        api("org.apache.iceberg:iceberg-spark-${sparkVersion}_$scalaVersion:$versionIceberg")
-        api(
-          "org.apache.iceberg:iceberg-spark-extensions-${sparkVersion}_$scalaVersion:$versionIceberg"
-        )
-      }
-    }
-    api("org.apache.maven:maven-resolver-provider:$versionMaven")
-    api("org.apache.maven.resolver:maven-resolver-connector-basic:$versionMavenResolver")
-    api("org.apache.maven.resolver:maven-resolver-transport-file:$versionMavenResolver")
-    api("org.apache.maven.resolver:maven-resolver-transport-http:$versionMavenResolver")
-    api("org.apache.parquet:parquet-column:$versionParquet")
-    api("org.bouncycastle:bcprov-jdk15on:$versionBouncyCastle")
-    api("org.bouncycastle:bcpkix-jdk15on:$versionBouncyCastle")
     api("org.eclipse.microprofile.openapi:microprofile-openapi-api:$versionOpenapi")
-    api("org.glassfish.jersey:jersey-bom:$versionJersey")
-    api("org.graalvm.nativeimage:svm:$versionGraalSvm")
-    api("org.immutables:builder:$versionImmutables")
-    api("org.immutables:value-annotations:$versionImmutables")
-    api("org.immutables:value-fixture:$versionImmutables")
-    api("org.immutables:value-processor:$versionImmutables")
-    api("org.jacoco:jacoco-maven-plugin:$versionJacoco")
-    api("org.jboss:jandex:$versionJandex")
-    api("org.jboss.weld.se:weld-se-core:$versionWeld")
     api("org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:$versionJaxrsApi21Spec")
-    api("org.junit:junit-bom:$versionJunit")
-    api("org.mongodb:mongodb-driver-sync:$versionMongodbDriverSync")
-    api("org.openjdk.jmh:jmh-core:$versionJmh")
-    api("org.openjdk.jmh:jmh-generator-annprocess:$versionJmh")
-    api("org.postgresql:postgresql:$versionPostgres")
-    api("org.mockito:mockito-core:$versionMockito")
     api("org.projectnessie.cel:cel-bom:$versionCel")
-    api("org.rocksdb:rocksdbjni:$versionRocksDb")
-    api("org.slf4j:jcl-over-slf4j:$versionSlf4j")
-    api("org.slf4j:log4j-over-slf4j:$versionSlf4j")
     api("org.slf4j:slf4j-api:$versionSlf4j")
-    api("org.testcontainers:cockroachdb:$versionTestcontainers")
-    api("org.testcontainers:mongodb:$versionTestcontainers")
-    api("org.testcontainers:postgresql:$versionTestcontainers")
-    api("org.testcontainers:testcontainers:$versionTestcontainers")
-    api("software.amazon.awssdk:bom:$versionAwssdk")
+    api("software.amazon.awssdk:auth:$versionAwssdk")
   }
 }
 
-javaPlatform { allowDependencies() }
+dependenciesProject("nessie-deps-antlr", "Antlr4 dependency management") {
+  api("org.antlr:antlr4:$versionAntlr")
+  api("org.antlr:antlr4-runtime:$versionAntlr")
+}
+
+dependenciesProject("nessie-deps-managed-only", "Only managed dependencies (for dependabot)") {
+  // This one is only here to get these dependencies, which are used outside of the usual
+  // configurations, managed by dependabot.
+  api("com.google.errorprone:error_prone_core:$versionErrorProneCore")
+  api("com.google.googlejavaformat:google-java-format:$versionGoogleJavaFormat")
+  api("jp.skypencil.errorprone.slf4j:errorprone-slf4j:$versionErrorProneSlf4j")
+  api("org.jacoco:jacoco-maven-plugin:$versionJacoco")
+  api("org.jboss:jandex:$versionJandex")
+}
+
+dependenciesProject("nessie-deps-persist", "Persistence/server dependency management") {
+  api("io.agroal:agroal-pool:$versionAgroalPool")
+  api("com.h2database:h2:$versionH2")
+  api("org.agrona:agrona:$versionAgrona")
+  api("org.mongodb:mongodb-driver-sync:$versionMongodbDriverSync")
+  api("org.postgresql:postgresql:$versionPostgres")
+  api("org.rocksdb:rocksdbjni:$versionRocksDb")
+}
+
+dependenciesProject("nessie-deps-quarkus", "Quarkus related dependency management") {
+  api("io.quarkus:quarkus-bom:$versionQuarkus")
+  api("io.quarkus.platform:quarkus-amazon-services-bom:$versionQuarkusAmazon")
+  api("software.amazon.awssdk:bom:$versionAwssdk")
+  api("io.quarkiverse.loggingsentry:quarkus-logging-sentry:$versionQuarkusLoggingSentry")
+}
+
+dependenciesProject("nessie-deps-build-only", "Build-only dependency management") {
+  api("com.google.errorprone:error_prone_annotations:$versionErrorProneAnnotations")
+  api("info.picocli:picocli-codegen:$versionPicocli")
+  api("org.graalvm.nativeimage:svm:$versionGraalSvm")
+  api("org.immutables:builder:$versionImmutables")
+  api("org.immutables:value-annotations:$versionImmutables")
+  api("org.immutables:value-fixture:$versionImmutables")
+  api("org.immutables:value-processor:$versionImmutables")
+  api("org.openjdk.jmh:jmh-generator-annprocess:$versionJmh")
+}
+
+dependenciesProject("nessie-deps-iceberg", "Iceberg, Spark and related dependency management") {
+  api("io.delta:delta-core_2.12:$versionDeltalake")
+  api("org.apache.hadoop:hadoop-client:$versionHadoop")
+  api("org.apache.iceberg:iceberg-api:$versionIceberg")
+  api("org.apache.iceberg:iceberg-bundled-guava:$versionIceberg")
+  api("org.apache.iceberg:iceberg-common:$versionIceberg")
+  api("org.apache.iceberg:iceberg-core:$versionIceberg")
+  api("org.apache.iceberg:iceberg-hive-metastore:$versionIceberg")
+  api("org.apache.iceberg:iceberg-nessie:$versionIceberg")
+  api("org.apache.iceberg:iceberg-parquet:$versionIceberg")
+  for (sparkVersion in rootProject.extra["sparkVersions"].toString().split(",")) {
+    for (scalaVersion in
+      rootProject.extra["sparkVersion-$sparkVersion-scalaVersions"].toString().split(",")) {
+      api("org.apache.iceberg:iceberg-spark-${sparkVersion}_$scalaVersion:$versionIceberg")
+      api(
+        "org.apache.iceberg:iceberg-spark-extensions-${sparkVersion}_$scalaVersion:$versionIceberg"
+      )
+    }
+  }
+  api("org.apache.parquet:parquet-column:$versionParquet")
+}
+
+dependenciesProject("nessie-deps-testing", "Testing dependency management") {
+  api("ch.qos.logback:logback-classic:$versionLogback")
+  api("com.github.docker-java:docker-java-api:$versionDockerjava")
+  api("com.puppycrawl.tools:checkstyle:$versionCheckstyle")
+  api("io.gatling.highcharts:gatling-charts-highcharts:$versionGatling")
+  api("io.rest-assured:rest-assured:$versionRestAssured")
+  api("org.assertj:assertj-core:$versionAssertJ")
+  api("org.apache.maven:maven-resolver-provider:$versionMaven")
+  api("org.apache.maven.resolver:maven-resolver-connector-basic:$versionMavenResolver")
+  api("org.apache.maven.resolver:maven-resolver-transport-file:$versionMavenResolver")
+  api("org.apache.maven.resolver:maven-resolver-transport-http:$versionMavenResolver")
+  api("org.bouncycastle:bcprov-jdk15on:$versionBouncyCastle")
+  api("org.bouncycastle:bcpkix-jdk15on:$versionBouncyCastle")
+  api("org.glassfish.jersey:jersey-bom:$versionJersey")
+  api("org.mockito:mockito-core:$versionMockito")
+  api("org.openjdk.jmh:jmh-core:$versionJmh")
+  api("org.jboss.weld.se:weld-se-core:$versionWeld")
+  api("org.junit:junit-bom:$versionJunit")
+  api("org.slf4j:jcl-over-slf4j:$versionSlf4j")
+  api("org.slf4j:log4j-over-slf4j:$versionSlf4j")
+  api("org.testcontainers:cockroachdb:$versionTestcontainers")
+  api("org.testcontainers:mongodb:$versionTestcontainers")
+  api("org.testcontainers:postgresql:$versionTestcontainers")
+  api("org.testcontainers:testcontainers:$versionTestcontainers")
+}
+
+fun dependenciesProject(
+  name: String,
+  description: String,
+  config: Action<DependencyConstraintHandlerScope>
+) {
+  project(":$name") {
+    this.buildDir = file(rootProject.buildDir.resolve(name))
+    this.group = rootProject.group
+    this.version = rootProject.version
+    this.description = description
+
+    apply {
+      plugin("java-platform")
+      plugin("maven-publish")
+      plugin("signing")
+      plugin("nessie-conventions")
+    }
+
+    dependencies { constraints { config.execute(this) } }
+  }
+}
 
 tasks.named<Wrapper>("wrapper") { distributionType = Wrapper.DistributionType.ALL }
 

--- a/buildSrc/src/main/kotlin/Utilities.kt
+++ b/buildSrc/src/main/kotlin/Utilities.kt
@@ -160,7 +160,7 @@ fun DependencyHandlerScope.nessieProject(
  * Ideally, it should be sufficient to use [nessieProject], but that does not work properly and
  * results in this Gradle error: `Incompatible because this component declares a platform and the
  * consumer needed a library`. Although it is correct that the component declares a platform, it is
- * wrong that the consumer needs a librara...
+ * wrong that the consumer needs a library...
  */
 fun DependencyHandlerScope.nessieProjectPlatform(artifactId: String, gradle: Gradle): Dependency {
   if (!isIntegrationsTestingEnabled()) {

--- a/buildSrc/src/main/kotlin/Utilities.kt
+++ b/buildSrc/src/main/kotlin/Utilities.kt
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint
+import org.gradle.api.invocation.Gradle
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.SourceSetContainer
@@ -150,6 +151,30 @@ fun DependencyHandlerScope.nessieProject(
     return project(if (artifactId == "nessie") ":" else ":$artifactId", configuration)
   } else {
     return module("org.projectnessie", artifactId, configuration = configuration)
+  }
+}
+
+/**
+ * Resolves a `platform()` dependency to a project in another Gradle build.
+ *
+ * Ideally, it should be sufficient to use [nessieProject], but that does not work properly and
+ * results in this Gradle error: `Incompatible because this component declares a platform and the
+ * consumer needed a library`. Although it is correct that the component declares a platform, it is
+ * wrong that the consumer needs a librara...
+ */
+fun DependencyHandlerScope.nessieProjectPlatform(artifactId: String, gradle: Gradle): Dependency {
+  if (!isIntegrationsTestingEnabled()) {
+    return platform(project(if (artifactId == "nessie") ":" else ":$artifactId"))
+  } else {
+    if (artifactId.startsWith("nessie-deps-")) {
+      val inclBuild = gradle.parent!!.includedBuild("nessie")
+      val inclBuildInternal = inclBuild as org.gradle.internal.composite.IncludedBuildInternal
+      val inclBuildTarget = inclBuildInternal.target
+      val nessiePrj = inclBuildTarget.projects.getProject(org.gradle.util.Path.path(":$artifactId"))
+      val model = nessiePrj.mutableModel
+      return platform(model.project)
+    }
+    return platform(module("org.projectnessie", artifactId))
   }
 }
 

--- a/clients/antlr-runtime/build.gradle.kts
+++ b/clients/antlr-runtime/build.gradle.kts
@@ -27,7 +27,10 @@ plugins {
 
 extra["maven.name"] = "Nessie - Antlr Runtime"
 
-dependencies { implementation("org.antlr:antlr4-runtime:${dependencyVersion("versionAntlr")}") }
+dependencies {
+  implementation(nessieProjectPlatform("nessie-deps-antlr", gradle))
+  implementation("org.antlr:antlr4-runtime")
+}
 
 tasks.named<ShadowJar>("shadowJar") {
   dependencies { include(dependency("org.antlr:antlr4-runtime")) }

--- a/clients/client/build.gradle.kts
+++ b/clients/client/build.gradle.kts
@@ -26,8 +26,8 @@ plugins {
 extra["maven.name"] = "Nessie - Client"
 
 dependencies {
-  compileOnly(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
   implementation(platform(rootProject))
 
   api(project(":nessie-model"))
@@ -65,25 +65,21 @@ dependencies {
   compileOnly("org.immutables:value-annotations")
   annotationProcessor("org.immutables:value-processor")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation("com.google.guava:guava")
   testImplementation("org.bouncycastle:bcprov-jdk15on")
   testImplementation("org.bouncycastle:bcpkix-jdk15on")
   testImplementation("org.mockito:mockito-core")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-  // Need a few things from Quarkus, but don't leak the dependencies
-  compileOnly(platform("io.quarkus:quarkus-bom"))
-  compileOnly(platform("software.amazon.awssdk:bom"))
   compileOnly("io.quarkus:quarkus-smallrye-opentracing")
   compileOnly("software.amazon.awssdk:auth")
-  testImplementation(platform("io.quarkus:quarkus-bom"))
-  testImplementation(platform("software.amazon.awssdk:bom"))
   testImplementation("io.quarkus:quarkus-smallrye-opentracing")
   testImplementation("software.amazon.awssdk:auth")
 }

--- a/clients/deltalake/build.gradle.kts
+++ b/clients/deltalake/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
   forScala(sparkScala.scalaVersion)
 
   implementation(platform(nessieRootProject()))
+  implementation(nessieProjectPlatform("nessie-deps-iceberg", gradle))
+
   implementation(nessieProject("nessie-model"))
   implementation(nessieProject("nessie-client"))
   implementation("org.apache.spark:spark-core_${sparkScala.scalaMajorVersion}") {
@@ -44,7 +46,9 @@ dependencies {
   implementation("io.delta:delta-core_${sparkScala.scalaMajorVersion}")
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  testImplementation(platform(nessieRootProject()))
+  testImplementation(nessieProjectPlatform("nessie-deps-testing", gradle))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(
     nessieProject(
       "nessie-spark-extensions-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}"
@@ -59,7 +63,6 @@ dependencies {
   testImplementation("org.slf4j:log4j-over-slf4j")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/clients/iceberg-views/build.gradle.kts
+++ b/clients/iceberg-views/build.gradle.kts
@@ -38,11 +38,13 @@ dependencies {
   )
   implementation("org.apache.iceberg:iceberg-nessie") { exclude("org.projectnessie", "*") }
   implementation("org.apache.hadoop:hadoop-client") {
+    exclude("javax.servlet.jsp", "jsp-api")
     exclude("javax.ws.rs", "javax.ws.rs-api")
     exclude("log4j", "log4j")
     exclude("org.slf4j", "slf4j-log4j12")
     exclude("org.slf4j", "slf4j-reload4j")
     exclude("com.sun.jersey", "jersey-servlet")
+    exclude("org.apache.hadoop", "hadoop-client")
   }
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 

--- a/clients/iceberg-views/build.gradle.kts
+++ b/clients/iceberg-views/build.gradle.kts
@@ -24,6 +24,8 @@ plugins {
 
 dependencies {
   implementation(platform(nessieRootProject()))
+  implementation(nessieProjectPlatform("nessie-deps-iceberg", gradle))
+
   implementation(nessieProject("nessie-client"))
   implementation(nessieProject("nessie-model"))
   implementation("org.apache.iceberg:iceberg-api")
@@ -44,7 +46,8 @@ dependencies {
   }
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  testImplementation(platform(nessieRootProject()))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(nessieProject("nessie-versioned-persist-tests"))
   testImplementation(nessieProject("nessie-versioned-persist-in-memory"))
   testImplementation(nessieProject("nessie-jaxrs-testextension"))
@@ -52,7 +55,6 @@ dependencies {
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/clients/spark-antlr-grammar/build.gradle.kts
+++ b/clients/spark-antlr-grammar/build.gradle.kts
@@ -24,8 +24,8 @@ plugins {
 }
 
 dependencies {
-  antlr(platform(nessieRootProject()))
-  antlr("org.antlr:antlr4:${dependencyVersion("versionAntlr")}")
+  antlr(nessieProjectPlatform("nessie-deps-antlr", gradle))
+  antlr("org.antlr:antlr4")
 
   api(platform(nessieRootProject()))
   api(project(":nessie-spark-antlr-runtime", "shadow"))

--- a/clients/spark-extensions-base/build.gradle.kts
+++ b/clients/spark-extensions-base/build.gradle.kts
@@ -37,8 +37,11 @@ dependencies {
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
   implementation(nessieClientForIceberg())
 
-  testImplementation(platform(nessieRootProject()))
-  testAnnotationProcessor(platform(nessieRootProject()))
+  testImplementation(nessieProjectPlatform("nessie-deps-testing", gradle))
+  testCompileOnly(nessieProjectPlatform("nessie-deps-build-only", gradle))
+  testAnnotationProcessor(nessieProjectPlatform("nessie-deps-build-only", gradle))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation("org.apache.spark:spark-sql_${sparkScala.scalaMajorVersion}") {
     forSpark(sparkScala.sparkVersion)
   }
@@ -48,7 +51,6 @@ dependencies {
   testAnnotationProcessor("org.immutables:value-processor")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/clients/spark-extensions/build.gradle.kts
+++ b/clients/spark-extensions/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
   forScala(sparkScala.scalaVersion)
 
   implementation(platform(nessieRootProject()))
+  compileOnly(nessieProjectPlatform("nessie-deps-iceberg", gradle))
+
   implementation(project(":nessie-spark-extensions-grammar"))
   implementation(project(":nessie-spark-extensions-base_${sparkScala.scalaMajorVersion}"))
   compileOnly("org.apache.spark:spark-sql_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }
@@ -40,7 +42,10 @@ dependencies {
   compileOnly("org.apache.spark:spark-hive_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }
   implementation(nessieClientForIceberg())
 
-  testImplementation(platform(nessieRootProject()))
+  testImplementation(nessieProjectPlatform("nessie-deps-testing", gradle))
+  testImplementation(nessieProjectPlatform("nessie-deps-iceberg", gradle))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-spark-extensions-base_${sparkScala.scalaMajorVersion}")) { testJarCapability() }
   testImplementation("org.apache.iceberg:iceberg-nessie")
   testImplementation("org.apache.iceberg:iceberg-spark-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}")
@@ -52,7 +57,6 @@ dependencies {
   testImplementation("org.apache.spark:spark-hive_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/compatibility/common/build.gradle.kts
+++ b/compatibility/common/build.gradle.kts
@@ -26,6 +26,9 @@ extra["maven.name"] = "Nessie - Backward Compatibility - Common"
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-testing")))
+  implementation(platform("com.fasterxml.jackson:jackson-bom"))
+  implementation(platform("org.junit:junit-bom"))
 
   api(project(":nessie-client"))
   api(project(":nessie-compatibility-jersey"))
@@ -42,15 +45,12 @@ dependencies {
   implementation("com.google.guava:guava")
   implementation("jakarta.enterprise:jakarta.enterprise.cdi-api")
   implementation("org.eclipse.microprofile.openapi:microprofile-openapi-api")
-  implementation(platform("com.fasterxml.jackson:jackson-bom"))
   implementation("com.fasterxml.jackson.core:jackson-annotations")
 
-  implementation(platform("org.junit:junit-bom"))
   api("org.junit.jupiter:junit-jupiter-api")
   implementation("org.junit.jupiter:junit-jupiter-engine")
   implementation("org.junit.platform:junit-platform-launcher")
 
-  testImplementation(platform(rootProject))
   testImplementation("org.mockito:mockito-core")
   testImplementation("com.google.guava:guava")
   testImplementation(project(":nessie-versioned-persist-in-memory"))
@@ -59,7 +59,6 @@ dependencies {
   testImplementation(project(":nessie-versioned-persist-rocks")) { testJarCapability() }
   compileOnly(project(":nessie-versioned-persist-mongodb")) { testJarCapability() }
 
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.platform:junit-platform-testkit")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
 }

--- a/compatibility/compatibility-tests/build.gradle.kts
+++ b/compatibility/compatibility-tests/build.gradle.kts
@@ -26,6 +26,9 @@ extra["maven.name"] = "Nessie - Backward Compatibility - Tests"
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform("com.fasterxml.jackson:jackson-bom"))
+  implementation(platform(project(":nessie-deps-testing")))
+  implementation(platform("org.junit:junit-bom"))
 
   implementation(platform("org.junit:junit-bom"))
   implementation(platform("com.fasterxml.jackson:jackson-bom"))
@@ -36,11 +39,9 @@ dependencies {
   implementation(project(":nessie-client"))
   implementation("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  implementation(platform("com.fasterxml.jackson:jackson-bom"))
   implementation("com.fasterxml.jackson.core:jackson-annotations")
 
   implementation("org.assertj:assertj-core")
-  implementation(platform("org.junit:junit-bom"))
   implementation("org.junit.jupiter:junit-jupiter-api")
 
   testImplementation("com.google.guava:guava")

--- a/compatibility/jersey/build.gradle.kts
+++ b/compatibility/jersey/build.gradle.kts
@@ -26,6 +26,12 @@ extra["maven.name"] = "Nessie - Backward Compatibility - Jersey"
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-testing")))
+  implementation(platform("org.glassfish.jersey:jersey-bom"))
+  implementation(platform("com.fasterxml.jackson:jackson-bom"))
+  implementation(
+    platform("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-bundle")
+  )
 
   implementation(project(":nessie-model"))
   implementation(project(":nessie-rest-services"))
@@ -35,8 +41,6 @@ dependencies {
   implementation(project(":nessie-versioned-persist-store"))
   implementation(project(":nessie-versioned-persist-tests"))
   implementation(project(":nessie-versioned-spi"))
-  implementation(platform("org.glassfish.jersey:jersey-bom"))
-  implementation(platform("com.fasterxml.jackson:jackson-bom"))
   implementation("org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec")
   implementation("jakarta.enterprise:jakarta.enterprise.cdi-api")
   implementation("jakarta.annotation:jakarta.annotation-api")
@@ -55,9 +59,6 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-annotations")
   implementation("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  implementation(
-    platform("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-bundle")
-  )
   implementation(
     "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2"
   )

--- a/gc/gc-base/build.gradle.kts
+++ b/gc/gc-base/build.gradle.kts
@@ -28,7 +28,9 @@ val sparkScala = useSparkScalaVersionsForProject("3.2")
 
 dependencies {
   implementation(platform(nessieRootProject()))
-  annotationProcessor(platform(nessieRootProject()))
+  annotationProcessor(nessieProjectPlatform("nessie-deps-build-only", gradle))
+  compileOnly(nessieProjectPlatform("nessie-deps-build-only", gradle))
+  compileOnly(nessieProjectPlatform("nessie-deps-iceberg", gradle))
   implementation(platform("com.fasterxml.jackson:jackson-bom"))
 
   forScala(sparkScala.scalaVersion)
@@ -54,7 +56,9 @@ dependencies {
   compileOnly("org.apache.iceberg:iceberg-parquet")
   compileOnly("org.apache.parquet:parquet-column")
 
-  testImplementation(platform(nessieRootProject()))
+  testImplementation(nessieProjectPlatform("nessie-deps-iceberg", gradle))
+  testCompileOnly(platform("com.fasterxml.jackson:jackson-bom"))
+  testImplementation(platform("org.junit:junit-bom"))
 
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
   testImplementation(nessieProject("nessie-jaxrs-testextension"))
@@ -66,7 +70,6 @@ dependencies {
   testImplementation("org.slf4j:log4j-over-slf4j")
   testImplementation("ch.qos.logback:logback-classic")
 
-  testCompileOnly(platform("com.fasterxml.jackson:jackson-bom"))
   testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
   testImplementation(project(":nessie-spark-extensions-base_${sparkScala.scalaMajorVersion}")) {
@@ -87,7 +90,6 @@ dependencies {
   testImplementation("org.apache.iceberg:iceberg-hive-metastore")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -27,8 +27,8 @@ plugins {
 }
 
 dependencies {
-  compileOnly(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
   implementation(platform(rootProject))
 
   implementation(platform("com.fasterxml.jackson:jackson-bom"))
@@ -44,11 +44,11 @@ dependencies {
   compileOnly("org.immutables:value-annotations")
   annotationProcessor("org.immutables:value-processor")
 
-  testImplementation(platform(rootProject))
-  testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
-
-  testImplementation("org.assertj:assertj-core")
+  testImplementation(platform(project(":nessie-deps-testing")))
   testImplementation(platform("org.junit:junit-bom"))
+
+  testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
+  testImplementation("org.assertj:assertj-core")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/nessie-iceberg/settings.gradle.kts
+++ b/nessie-iceberg/settings.gradle.kts
@@ -136,6 +136,8 @@ fun loadProjects(file: String) {
   }
 }
 
+val ideaSyncActive = System.getProperty("idea.sync.active").toBoolean()
+
 loadProjects("../gradle/projects.iceberg.properties")
 
 // Note: Unlike the "main" settings.gradle.kts this variant includes _all_ Spark _and_ Scala
@@ -153,6 +155,9 @@ for (sparkVersion in sparkVersions) {
     val artifactId = "nessie-spark-extensions-${sparkVersion}_$scalaVersion"
     nessieProject(artifactId, file("../clients/spark-extensions/v${sparkVersion}")).buildFileName =
       "../build.gradle.kts"
+    if (ideaSyncActive) {
+      break
+    }
   }
 }
 
@@ -161,14 +166,17 @@ for (scalaVersion in allScalaVersions) {
     "nessie-spark-extensions-base_$scalaVersion",
     file("../clients/spark-extensions-base")
   )
+  if (ideaSyncActive) {
+    break
+  }
 }
 
-nessieProject("nessie-spark-extensions", file("../clients/spark-extensions/v3.1")).buildFileName =
-  "../build.gradle.kts"
-
-nessieProject("nessie-spark-3.2-extensions", file("../clients/spark-extensions/v3.2"))
-  .buildFileName = "../build.gradle.kts"
-
-nessieProject("nessie-spark-extensions-base", file("../clients/spark-extensions-base"))
+if (!ideaSyncActive) {
+  nessieProject("nessie-spark-extensions", file("../clients/spark-extensions/v3.1")).buildFileName =
+    "../build.gradle.kts"
+  nessieProject("nessie-spark-3.2-extensions", file("../clients/spark-extensions/v3.2"))
+    .buildFileName = "../build.gradle.kts"
+  nessieProject("nessie-spark-extensions-base", file("../clients/spark-extensions-base"))
+}
 
 rootProject.name = "nessie-iceberg"

--- a/perftest/gatling/build.gradle.kts
+++ b/perftest/gatling/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
   forScala(scalaVersion)
 
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-testing")))
+
   implementation(project(":nessie-model"))
   implementation(project(":nessie-client"))
   implementation("io.gatling.highcharts:gatling-charts-highcharts") {

--- a/perftest/simulations/build.gradle.kts
+++ b/perftest/simulations/build.gradle.kts
@@ -29,6 +29,8 @@ extra["maven.name"] = "Nessie - Perf Test - Simulations"
 
 dependencies {
   gatling(platform(rootProject))
+  gatling(platform(project(":nessie-deps-testing")))
+
   gatling(project(":nessie-model"))
   gatling(project(":nessie-client"))
   gatling(project(":nessie-perftest-gatling"))

--- a/servers/jax-rs-testextension/build.gradle.kts
+++ b/servers/jax-rs-testextension/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
 
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  testImplementation(platform(rootProject))
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
   testImplementation("org.assertj:assertj-core")

--- a/servers/jax-rs-tests/build.gradle.kts
+++ b/servers/jax-rs-tests/build.gradle.kts
@@ -28,6 +28,10 @@ description = "Artifact for REST-API tests, includes Glassfish/Jersey/Weld imple
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-testing")))
+  implementation(platform("com.fasterxml.jackson:jackson-bom"))
+  api(platform("org.junit:junit-bom"))
+
   implementation(project(":nessie-client"))
   implementation("com.google.guava:guava")
   api("io.rest-assured:rest-assured")
@@ -35,17 +39,17 @@ dependencies {
   implementation(project(":nessie-servers-iceberg-fixtures"))
 
   api("org.assertj:assertj-core")
-  api(platform("org.junit:junit-bom"))
   api("org.junit.jupiter:junit-jupiter-api")
   api("org.junit.jupiter:junit-jupiter-params")
 
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
   compileOnly("jakarta.validation:jakarta.validation-api")
-  implementation(platform("com.fasterxml.jackson:jackson-bom"))
   implementation("com.fasterxml.jackson.core:jackson-databind")
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-persist")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-jaxrs-testextension"))
   testImplementation("org.slf4j:jcl-over-slf4j")
   testImplementation("io.agroal:agroal-pool")
@@ -57,7 +61,6 @@ dependencies {
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/servers/jax-rs/build.gradle.kts
+++ b/servers/jax-rs/build.gradle.kts
@@ -28,7 +28,12 @@ description = "Nessie on Glassfish/Jersey/Weld"
 
 dependencies {
   api(platform(rootProject))
-  implementation(platform(rootProject))
+  api(platform(project(":nessie-deps-testing")))
+  api(platform("org.glassfish.jersey:jersey-bom"))
+  api(
+    platform("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-bundle")
+  )
+
   api(project(":nessie-client"))
   api(project(":nessie-model"))
   api(project(":nessie-rest-services"))
@@ -52,7 +57,6 @@ dependencies {
   api(project(":nessie-versioned-persist-transactional")) { testJarCapability() }
   implementation("org.slf4j:slf4j-api")
   implementation("org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec")
-  api(platform("org.glassfish.jersey:jersey-bom"))
   api("jakarta.enterprise:jakarta.enterprise.cdi-api")
   api("jakarta.annotation:jakarta.annotation-api")
   api("jakarta.validation:jakarta.validation-api")
@@ -71,9 +75,6 @@ dependencies {
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
   compileOnly("jakarta.validation:jakarta.validation-api")
 
-  api(
-    platform("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-bundle")
-  )
   api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2")
   api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory")
   api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-external")

--- a/servers/lambda/build.gradle.kts
+++ b/servers/lambda/build.gradle.kts
@@ -33,6 +33,8 @@ val quarkusRunner by
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-persist")))
+  implementation(platform(project(":nessie-deps-quarkus")))
   implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
   implementation(platform("software.amazon.awssdk:bom"))
 
@@ -45,14 +47,14 @@ dependencies {
   implementation("software.amazon.awssdk:netty-nio-client")
   implementation("software.amazon.awssdk:url-connection-client")
 
-  testImplementation(platform(rootProject))
-  testImplementation(enforcedPlatform("io.quarkus:quarkus-bom"))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation("io.quarkus:quarkus-test-amazon-lambda")
   testImplementation("io.quarkus:quarkus-jacoco")
 
   testImplementation("org.mockito:mockito-core")
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -27,9 +27,15 @@ plugins {
 extra["maven.name"] = "Nessie - Quarkus CLI"
 
 dependencies {
-  compileOnly(platform(rootProject))
+  compileOnly(platform(project(":nessie-deps-build-only")))
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  implementation(platform(project(":nessie-deps-persist")))
+  implementation(platform(project(":nessie-deps-quarkus")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
+  implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
+  implementation(enforcedPlatform("io.quarkus.platform:quarkus-amazon-services-bom"))
+  implementation(platform("com.fasterxml.jackson:jackson-bom"))
+
   implementation(project(":nessie-quarkus-common"))
   implementation(project(":nessie-services"))
   implementation(project(":nessie-server-store"))
@@ -43,8 +49,6 @@ dependencies {
   implementation(project(":nessie-versioned-persist-rocks"))
   implementation(project(":nessie-versioned-persist-transactional"))
 
-  implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
-  implementation(enforcedPlatform("io.quarkus.platform:quarkus-amazon-services-bom"))
   implementation("io.quarkus:quarkus-picocli")
 
   implementation("com.google.protobuf:protobuf-java")
@@ -52,7 +56,6 @@ dependencies {
   implementation("com.google.code.findbugs:jsr305")
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  implementation(platform("com.fasterxml.jackson:jackson-bom"))
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.core:jackson-annotations")
 
@@ -60,18 +63,18 @@ dependencies {
   compileOnly("org.immutables:value-annotations")
   annotationProcessor("org.immutables:value-processor")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-quarkus-tests"))
   testImplementation(project(":nessie-versioned-persist-mongodb")) { testJarCapability() }
   testImplementation(project(":nessie-versioned-tests"))
-  testImplementation(enforcedPlatform("io.quarkus:quarkus-bom"))
   testImplementation("io.quarkus:quarkus-jacoco")
   testImplementation("io.quarkus:quarkus-junit5")
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -26,6 +26,11 @@ extra["maven.name"] = "Nessie - Quarkus Common"
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-quarkus")))
+  implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
+  implementation(enforcedPlatform("io.quarkus.platform:quarkus-amazon-services-bom"))
+  compileOnly(platform("com.fasterxml.jackson:jackson-bom"))
+
   implementation(project(":nessie-model"))
   implementation(project(":nessie-server-store"))
   implementation(project(":nessie-services"))
@@ -38,8 +43,6 @@ dependencies {
   implementation(project(":nessie-versioned-persist-dynamodb"))
   implementation(project(":nessie-versioned-persist-mongodb"))
   implementation(project(":nessie-versioned-persist-transactional"))
-  implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
-  implementation(enforcedPlatform("io.quarkus.platform:quarkus-amazon-services-bom"))
   implementation("io.quarkus:quarkus-hibernate-validator")
   implementation("jakarta.validation:jakarta.validation-api")
   implementation("com.google.protobuf:protobuf-java")
@@ -52,7 +55,6 @@ dependencies {
   }
   implementation("io.quarkus:quarkus-mongodb-client")
 
-  compileOnly(platform("com.fasterxml.jackson:jackson-bom"))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 }

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -36,6 +36,12 @@ val openapiSource by
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-persist")))
+  implementation(platform(project(":nessie-deps-quarkus")))
+  implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
+  implementation(enforcedPlatform("io.quarkus.platform:quarkus-amazon-services-bom"))
+  implementation(platform("org.projectnessie.cel:cel-bom"))
+
   implementation(project(":nessie-model"))
   implementation(project(":nessie-services"))
   implementation(project(":nessie-quarkus-common"))
@@ -44,8 +50,6 @@ dependencies {
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-store"))
   implementation(project(":nessie-ui"))
-  implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
-  implementation(enforcedPlatform("io.quarkus.platform:quarkus-amazon-services-bom"))
   implementation("org.jboss.resteasy:resteasy-core-spi")
   implementation("io.quarkus:quarkus-resteasy")
   implementation("io.quarkus:quarkus-resteasy-jackson")
@@ -61,7 +65,6 @@ dependencies {
   implementation("io.quarkiverse.loggingsentry:quarkus-logging-sentry")
   implementation("io.smallrye:smallrye-open-api-jaxrs")
   implementation("io.micrometer:micrometer-registry-prometheus")
-  implementation(platform("org.projectnessie.cel:cel-bom"))
   implementation("org.projectnessie.cel:cel-tools")
   implementation("org.projectnessie.cel:cel-jackson")
 
@@ -77,12 +80,13 @@ dependencies {
 
   openapiSource(project(":nessie-model", "openapiSource"))
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-client"))
   testImplementation(project(":nessie-jaxrs-tests"))
   testImplementation(project(":nessie-quarkus-tests"))
   testImplementation(project(":nessie-versioned-tests"))
-  testImplementation(enforcedPlatform("io.quarkus:quarkus-bom"))
   testImplementation("io.quarkus:quarkus-rest-client")
   testImplementation("io.quarkus:quarkus-test-security")
   testImplementation("io.quarkus:quarkus-test-oidc-server")
@@ -90,7 +94,6 @@ dependencies {
 
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/servers/quarkus-tests/build.gradle.kts
+++ b/servers/quarkus-tests/build.gradle.kts
@@ -26,6 +26,11 @@ extra["maven.name"] = "Nessie - Quarkus Tests"
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-testing")))
+  implementation(platform(project(":nessie-deps-quarkus")))
+  implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
+  implementation(platform("software.amazon.awssdk:bom"))
+  implementation(platform("io.quarkus.platform:quarkus-amazon-services-bom"))
   implementation(project(":nessie-quarkus-common"))
   implementation(project(":nessie-versioned-tests"))
   implementation(project(":nessie-versioned-persist-adapter"))
@@ -36,14 +41,11 @@ dependencies {
   implementation(project(":nessie-versioned-persist-mongodb")) { testJarCapability() }
   implementation(project(":nessie-versioned-persist-transactional"))
   implementation(project(":nessie-versioned-persist-transactional")) { testJarCapability() }
-  implementation(enforcedPlatform("io.quarkus:quarkus-bom"))
   implementation("io.quarkus:quarkus-junit5")
   implementation("org.testcontainers:testcontainers")
   implementation("org.testcontainers:postgresql")
   implementation("org.testcontainers:mongodb")
   implementation("com.github.docker-java:docker-java-api")
-  implementation(platform("software.amazon.awssdk:bom"))
-  implementation(platform("io.quarkus.platform:quarkus-amazon-services-bom"))
   implementation("software.amazon.awssdk:dynamodb") {
     exclude("software.amazon.awssdk", "apache-client")
   }

--- a/servers/rest-services/build.gradle.kts
+++ b/servers/rest-services/build.gradle.kts
@@ -26,6 +26,8 @@ extra["maven.name"] = "Nessie - REST Services"
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform("com.fasterxml.jackson:jackson-bom"))
+
   implementation(project(":nessie-model"))
   implementation(project(":nessie-services"))
   implementation(project(":nessie-versioned-spi"))
@@ -39,14 +41,14 @@ dependencies {
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
   compileOnly("jakarta.validation:jakarta.validation-api")
 
-  implementation(platform("com.fasterxml.jackson:jackson-bom"))
   implementation("com.fasterxml.jackson.core:jackson-databind")
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform("org.junit:junit-bom"))
+  testImplementation(platform(project(":nessie-deps-testing")))
+
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/servers/services/build.gradle.kts
+++ b/servers/services/build.gradle.kts
@@ -26,11 +26,14 @@ extra["maven.name"] = "Nessie - Services"
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
+  implementation(platform("org.projectnessie.cel:cel-bom"))
+  compileOnly(platform("com.fasterxml.jackson:jackson-bom"))
+
   implementation(project(":nessie-model"))
   implementation(project(":nessie-versioned-spi"))
   implementation("org.slf4j:slf4j-api")
-  implementation(platform("org.projectnessie.cel:cel-bom"))
   implementation("org.projectnessie.cel:cel-tools")
   implementation("org.projectnessie.cel:cel-jackson")
   compileOnly("org.immutables:builder")
@@ -39,18 +42,18 @@ dependencies {
   implementation("com.google.guava:guava")
   implementation("com.google.code.findbugs:jsr305")
 
-  compileOnly(platform("com.fasterxml.jackson:jackson-bom"))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
   compileOnly("jakarta.validation:jakarta.validation-api")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+  testCompileOnly(platform("com.fasterxml.jackson:jackson-bom"))
+
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  testCompileOnly(platform("com.fasterxml.jackson:jackson-bom"))
   testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/servers/store/build.gradle.kts
+++ b/servers/store/build.gradle.kts
@@ -26,6 +26,7 @@ extra["maven.name"] = "Nessie - Server - Store"
 
 dependencies {
   implementation(platform(rootProject))
+
   implementation(project(":nessie-model"))
   implementation(project(":nessie-versioned-spi"))
   api(project(":nessie-server-store-proto"))
@@ -38,15 +39,16 @@ dependencies {
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
   compileOnly("jakarta.validation:jakarta.validation-api")
 
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+  testCompileOnly(platform("com.fasterxml.jackson:jackson-bom"))
+
   testImplementation(project(":nessie-servers-iceberg-fixtures"))
-  testImplementation(platform(rootProject))
   testImplementation("com.google.guava:guava")
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  testCompileOnly(platform("com.fasterxml.jackson:jackson-bom"))
   testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -112,7 +112,17 @@ gradle.beforeProject {
   group = "org.projectnessie"
 }
 
-include("code-coverage")
+listOf(
+    "code-coverage",
+    "nessie-deps-antlr",
+    "nessie-deps-build-only",
+    "nessie-deps-iceberg",
+    "nessie-deps-managed-only",
+    "nessie-deps-persist",
+    "nessie-deps-quarkus",
+    "nessie-deps-testing"
+  )
+  .forEach { include(it) }
 
 fun nessieProject(name: String, directory: File): ProjectDescriptor {
   include(name)

--- a/tools/content-generator/build.gradle.kts
+++ b/tools/content-generator/build.gradle.kts
@@ -28,7 +28,10 @@ plugins {
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
+  implementation(platform("com.fasterxml.jackson:jackson-bom"))
+
   implementation(project(":nessie-client"))
 
   implementation("jakarta.validation:jakarta.validation-api")
@@ -39,14 +42,15 @@ dependencies {
   compileOnly("com.google.code.findbugs:jsr305")
   compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
-  implementation(platform("com.fasterxml.jackson:jackson-bom"))
   implementation("com.fasterxml.jackson.core:jackson-annotations")
   implementation("com.fasterxml.jackson.core:jackson-databind")
+
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
 
   testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/persist/adapter/build.gradle.kts
+++ b/versioned/persist/adapter/build.gradle.kts
@@ -26,7 +26,11 @@ extra["maven.name"] = "Nessie - Versioned - Persist - Adapter"
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  implementation(platform(project(":nessie-deps-persist")))
+  implementation(platform(project(":nessie-deps-quarkus")))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
+  implementation(platform("io.quarkus:quarkus-bom"))
 
   implementation(project(":nessie-versioned-spi"))
   compileOnly("org.immutables:value-annotations")
@@ -38,16 +42,15 @@ dependencies {
   implementation("org.slf4j:slf4j-api")
   implementation("org.agrona:agrona")
 
-  implementation(platform("io.quarkus:quarkus-bom"))
   implementation("io.opentracing:opentracing-api")
   implementation("io.opentracing:opentracing-util")
   implementation("io.micrometer:micrometer-core")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
 
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/persist/bench/build.gradle.kts
+++ b/versioned/persist/bench/build.gradle.kts
@@ -27,7 +27,9 @@ plugins {
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  implementation(platform(project(":nessie-deps-persist")))
+  implementation(platform(project(":nessie-deps-testing")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
   implementation(project(":nessie-versioned-tests"))
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-persist-adapter"))

--- a/versioned/persist/dynamodb/build.gradle.kts
+++ b/versioned/persist/dynamodb/build.gradle.kts
@@ -27,7 +27,10 @@ extra["maven.name"] = "Nessie - Versioned - Persist - DynamoDB"
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  implementation(platform(project(":nessie-deps-quarkus")))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
+  implementation(platform("software.amazon.awssdk:bom"))
 
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-non-transactional"))
@@ -37,14 +40,15 @@ dependencies {
   annotationProcessor("org.immutables:value-processor")
   implementation("com.google.code.findbugs:jsr305")
   implementation("com.google.guava:guava")
-  implementation(platform("software.amazon.awssdk:bom"))
   implementation("software.amazon.awssdk:dynamodb") {
     exclude("software.amazon.awssdk", "apache-client")
   }
   implementation("software.amazon.awssdk:netty-nio-client")
   implementation("software.amazon.awssdk:url-connection-client")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-versioned-tests"))
   testImplementation(project(":nessie-versioned-persist-tests"))
   testImplementation(project(":nessie-versioned-persist-non-transactional")) { testJarCapability() }
@@ -52,7 +56,6 @@ dependencies {
   testImplementation("com.github.docker-java:docker-java-api")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/persist/inmem/build.gradle.kts
+++ b/versioned/persist/inmem/build.gradle.kts
@@ -27,7 +27,8 @@ extra["maven.name"] = "Nessie - Versioned - Persist - In-Memory"
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
 
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-non-transactional"))
@@ -38,13 +39,14 @@ dependencies {
   annotationProcessor("org.immutables:value-processor")
   implementation("com.google.code.findbugs:jsr305")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-versioned-tests"))
   testImplementation(project(":nessie-versioned-persist-tests"))
   testImplementation(project(":nessie-versioned-persist-non-transactional")) { testJarCapability() }
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/persist/mongodb/build.gradle.kts
+++ b/versioned/persist/mongodb/build.gradle.kts
@@ -27,7 +27,9 @@ extra["maven.name"] = "Nessie - Versioned - Persist - MongoDB"
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  implementation(platform(project(":nessie-deps-persist")))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
 
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-non-transactional"))
@@ -39,7 +41,9 @@ dependencies {
   implementation("com.google.code.findbugs:jsr305")
   implementation("org.mongodb:mongodb-driver-sync")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-versioned-tests"))
   testImplementation(project(":nessie-versioned-persist-adapter"))
   testImplementation(project(":nessie-versioned-persist-tests"))
@@ -47,7 +51,6 @@ dependencies {
   testImplementation("org.testcontainers:mongodb")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/persist/nontx/build.gradle.kts
+++ b/versioned/persist/nontx/build.gradle.kts
@@ -27,7 +27,8 @@ extra["maven.name"] = "Nessie - Versioned - Persist - Non-Transactional"
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
 
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-serialize"))
@@ -37,9 +38,10 @@ dependencies {
   annotationProcessor("org.immutables:value-processor")
 
   testImplementation(project(":nessie-versioned-persist-tests"))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/persist/rocks/build.gradle.kts
+++ b/versioned/persist/rocks/build.gradle.kts
@@ -27,7 +27,9 @@ extra["maven.name"] = "Nessie - Versioned - Persist - Rocks"
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  implementation(platform(project(":nessie-deps-persist")))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
 
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-non-transactional"))
@@ -40,12 +42,13 @@ dependencies {
   implementation("org.rocksdb:rocksdbjni")
   compileOnly("org.graalvm.nativeimage:svm")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-versioned-tests"))
   testImplementation(project(":nessie-versioned-persist-tests"))
   testImplementation(project(":nessie-versioned-persist-non-transactional")) { testJarCapability() }
 
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/versioned/persist/serialize/build.gradle.kts
+++ b/versioned/persist/serialize/build.gradle.kts
@@ -26,16 +26,17 @@ extra["maven.name"] = "Nessie - Versioned - Persist - Serialization"
 
 dependencies {
   implementation(platform(rootProject))
+
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-persist-adapter"))
   api(project(":nessie-versioned-persist-serialize-proto"))
   implementation("com.google.guava:guava")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
 
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/persist/tests/build.gradle.kts
+++ b/versioned/persist/tests/build.gradle.kts
@@ -26,20 +26,22 @@ extra["maven.name"] = "Nessie - Versioned - Persist - Tests"
 
 dependencies {
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-quarkus")))
+  implementation(platform(project(":nessie-deps-testing")))
+  implementation(platform("io.quarkus:quarkus-bom"))
+  implementation(platform("org.junit:junit-bom"))
 
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-store"))
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-tests"))
   implementation("com.google.guava:guava")
-  implementation(platform("io.quarkus:quarkus-bom"))
   implementation("io.micrometer:micrometer-core")
   implementation("io.opentracing:opentracing-mock")
   implementation("com.google.protobuf:protobuf-java")
 
   implementation("org.assertj:assertj-core")
   implementation("org.mockito:mockito-core")
-  implementation(platform("org.junit:junit-bom"))
   implementation("org.junit.jupiter:junit-jupiter-api")
   implementation("org.junit.jupiter:junit-jupiter-params")
 }

--- a/versioned/persist/tx/build.gradle.kts
+++ b/versioned/persist/tx/build.gradle.kts
@@ -27,7 +27,9 @@ extra["maven.name"] = "Nessie - Versioned - Persist - Transactional"
 
 dependencies {
   implementation(platform(rootProject))
-  annotationProcessor(platform(rootProject))
+  implementation(platform(project(":nessie-deps-persist")))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
 
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-serialize"))
@@ -42,8 +44,11 @@ dependencies {
   compileOnly("com.h2database:h2")
   compileOnly("org.postgresql:postgresql")
 
-  testImplementation(platform(rootProject))
-  testAnnotationProcessor(platform(rootProject))
+  testCompileOnly(platform(project(":nessie-deps-build-only")))
+  testAnnotationProcessor(platform(project(":nessie-deps-build-only")))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+
   testImplementation(project(":nessie-versioned-tests"))
   testCompileOnly("org.immutables:value-annotations")
   testAnnotationProcessor("org.immutables:value-processor")
@@ -57,7 +62,6 @@ dependencies {
   testRuntimeOnly("org.postgresql:postgresql")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/versioned/spi/build.gradle.kts
+++ b/versioned/spi/build.gradle.kts
@@ -26,9 +26,11 @@ plugins {
 extra["maven.name"] = "Nessie - Versioned Store SPI"
 
 dependencies {
-  compileOnly(platform(rootProject))
-  annotationProcessor(platform(rootProject))
   implementation(platform(rootProject))
+  implementation(platform(project(":nessie-deps-quarkus")))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
+  compileOnly(platform("io.quarkus:quarkus-bom"))
 
   implementation("com.google.protobuf:protobuf-java")
   compileOnly("org.immutables:builder")
@@ -38,21 +40,20 @@ dependencies {
   implementation("com.google.guava:guava")
   implementation("com.google.code.findbugs:jsr305")
 
-  testImplementation(platform(rootProject))
+  testImplementation(platform(project(":nessie-deps-testing")))
+  testImplementation(platform("org.junit:junit-bom"))
+  testImplementation(platform("io.quarkus:quarkus-bom"))
 
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
-  testImplementation(platform("org.junit:junit-bom"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
   // Need a few things from Quarkus, but don't leak the dependencies
-  compileOnly(platform("io.quarkus:quarkus-bom"))
   compileOnly("io.opentracing:opentracing-api")
   compileOnly("io.opentracing:opentracing-util")
   compileOnly("io.micrometer:micrometer-core")
-  testImplementation(platform("io.quarkus:quarkus-bom"))
   testImplementation("io.opentracing:opentracing-api")
   testImplementation("io.opentracing:opentracing-util")
   testImplementation("io.micrometer:micrometer-core")

--- a/versioned/tests/build.gradle.kts
+++ b/versioned/tests/build.gradle.kts
@@ -25,8 +25,10 @@ plugins {
 extra["maven.name"] = "Nessie - Versioned Store Integration Tests"
 
 dependencies {
-  annotationProcessor(platform(rootProject))
   implementation(platform(rootProject))
+  compileOnly(platform(project(":nessie-deps-build-only")))
+  annotationProcessor(platform(project(":nessie-deps-build-only")))
+  implementation(platform(project(":nessie-deps-testing")))
 
   implementation(project(":nessie-versioned-spi"))
   implementation("com.google.guava:guava")


### PR DESCRIPTION
While trying to bump Nessie in Iceberg to 0.40.1, the Iceberg build failed,
because it now receives "other" Iceberg artifacts via `nessie-client`.
This happens, because Nessie's dependency management (more precisely the
published Gradle module metadata) leaks into Iceberg's Gradle build.
Obviously, a workaround like adding an exclude-rule to the Iceberg build
would work, but it's not a solid fix.

This change tackles the problem by splitting the dependency-constraints
in `:nessie` into multiple dependency-constraints:
* `:nessie` stays, but is heavily reduced to (mostly) the bare minimum
  required by clients.
* `:nessie-deps-antlr` just for antlr
* `:nessie-deps-build-only` dependencies that are only required for the
  build (like annotation processors)
* `:nessie-deps-managed-only` only managed dependencies, that are used
  by plugins to e.g. google-java-formatter
* `:nessie-deps-persist` server-ish dependencies
* `:nessie-deps-quarkus` Quarkus related dependencies
* `:nessie-deps-testing` testing + microbenchmarks
* `:nessie-deps-iceberg` Iceberg, Spark + Deltalake

Sadly, this change also requires updating nearly all `build.gradle.kts`
files. (This "bulk work" is split out into a separate commit in the PR.)

Another sad thing is a "hack" to workaround an issue in Gradle regarding
multiple dependency-constraints from/via/using included-builds, in
`buildSrc/.../Utilities.kt`

`nessie-iceberg/settings.gradle.kts` has been updated to match the main
one for IntelliJ imports.
