### PR TITLE
Remove Quarkus-BOM from non-Quarkus code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,10 +80,12 @@ val versionJunit = "5.9.0"
 val versionLogback = "1.2.11"
 val versionMavenResolver = "1.7.3"
 val versionMaven = "3.8.6"
+val versionMicrometer = "1.9.2"
 val versionMockito = "4.6.1"
 val versionMongodbDriverSync = "4.7.1"
 val versionNessieApprunner = "0.21.4"
 val versionOpenapi = "3.0"
+val versionOpentracing = "0.33.0"
 val versionQuarkus = dependencyVersion("versionQuarkus") // ensure that plugin version is the same
 val versionQuarkusAmazon = "2.11.1.Final"
 val versionQuarkusLoggingSentry = "1.2.1"
@@ -105,6 +107,7 @@ versionIceberg = System.getProperty("nessie.versionIceberg", versionIceberg)
 versionClientNessie = System.getProperty("nessie.versionClientNessie", versionClientNessie)
 
 mapOf(
+    "versionAwssdk" to versionAwssdk,
     "versionCheckstyle" to versionCheckstyle,
     "versionClientNessie" to versionClientNessie,
     "versionErrorProneAnnotations" to versionErrorProneAnnotations,
@@ -114,6 +117,8 @@ mapOf(
     "versionGoogleJavaFormat" to versionGoogleJavaFormat,
     "versionJacoco" to versionJacoco,
     "versionJandex" to versionJandex,
+    "versionMicrometer" to versionMicrometer,
+    "versionOpentracing" to versionOpentracing,
     "versionProtobuf" to versionProtobuf,
     "versionRocksDb" to versionRocksDb,
     "quarkus.builder-image" to "quay.io/quarkus/ubi-quarkus-native-image:22.1-java17"
@@ -157,6 +162,10 @@ dependenciesProject("nessie-deps-managed-only", "Only managed dependencies (for 
   api("jp.skypencil.errorprone.slf4j:errorprone-slf4j:$versionErrorProneSlf4j")
   api("org.jacoco:jacoco-maven-plugin:$versionJacoco")
   api("org.jboss:jandex:$versionJandex")
+  api("io.opentracing:opentracing-api:${dependencyVersion("versionOpentracing")}")
+  api("io.opentracing:opentracing-mock:${dependencyVersion("versionOpentracing")}")
+  api("io.opentracing:opentracing-util:${dependencyVersion("versionOpentracing")}")
+  api("io.micrometer:micrometer-core:${dependencyVersion("versionMicrometer")}")
 }
 
 dependenciesProject("nessie-deps-persist", "Persistence/server dependency management") {

--- a/versioned/persist/adapter/build.gradle.kts
+++ b/versioned/persist/adapter/build.gradle.kts
@@ -27,10 +27,8 @@ extra["maven.name"] = "Nessie - Versioned - Persist - Adapter"
 dependencies {
   implementation(platform(rootProject))
   implementation(platform(project(":nessie-deps-persist")))
-  implementation(platform(project(":nessie-deps-quarkus")))
   compileOnly(platform(project(":nessie-deps-build-only")))
   annotationProcessor(platform(project(":nessie-deps-build-only")))
-  implementation(platform("io.quarkus:quarkus-bom"))
 
   implementation(project(":nessie-versioned-spi"))
   compileOnly("org.immutables:value-annotations")
@@ -42,9 +40,9 @@ dependencies {
   implementation("org.slf4j:slf4j-api")
   implementation("org.agrona:agrona")
 
-  implementation("io.opentracing:opentracing-api")
-  implementation("io.opentracing:opentracing-util")
-  implementation("io.micrometer:micrometer-core")
+  implementation("io.opentracing:opentracing-api:${dependencyVersion("versionOpentracing")}")
+  implementation("io.opentracing:opentracing-util:${dependencyVersion("versionOpentracing")}")
+  implementation("io.micrometer:micrometer-core:${dependencyVersion("versionMicrometer")}")
 
   testImplementation(platform(project(":nessie-deps-testing")))
   testImplementation(platform("org.junit:junit-bom"))

--- a/versioned/persist/dynamodb/build.gradle.kts
+++ b/versioned/persist/dynamodb/build.gradle.kts
@@ -27,10 +27,9 @@ extra["maven.name"] = "Nessie - Versioned - Persist - DynamoDB"
 
 dependencies {
   implementation(platform(rootProject))
-  implementation(platform(project(":nessie-deps-quarkus")))
   compileOnly(platform(project(":nessie-deps-build-only")))
   annotationProcessor(platform(project(":nessie-deps-build-only")))
-  implementation(platform("software.amazon.awssdk:bom"))
+  implementation(platform("software.amazon.awssdk:bom:${dependencyVersion("versionAwssdk")}"))
 
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-persist-non-transactional"))

--- a/versioned/persist/tests/build.gradle.kts
+++ b/versioned/persist/tests/build.gradle.kts
@@ -26,9 +26,7 @@ extra["maven.name"] = "Nessie - Versioned - Persist - Tests"
 
 dependencies {
   implementation(platform(rootProject))
-  implementation(platform(project(":nessie-deps-quarkus")))
   implementation(platform(project(":nessie-deps-testing")))
-  implementation(platform("io.quarkus:quarkus-bom"))
   implementation(platform("org.junit:junit-bom"))
 
   implementation(project(":nessie-versioned-persist-adapter"))
@@ -36,8 +34,8 @@ dependencies {
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-tests"))
   implementation("com.google.guava:guava")
-  implementation("io.micrometer:micrometer-core")
-  implementation("io.opentracing:opentracing-mock")
+  implementation("io.micrometer:micrometer-core:${dependencyVersion("versionMicrometer")}")
+  implementation("io.opentracing:opentracing-mock:${dependencyVersion("versionOpentracing")}")
   implementation("com.google.protobuf:protobuf-java")
 
   implementation("org.assertj:assertj-core")

--- a/versioned/spi/build.gradle.kts
+++ b/versioned/spi/build.gradle.kts
@@ -27,10 +27,8 @@ extra["maven.name"] = "Nessie - Versioned Store SPI"
 
 dependencies {
   implementation(platform(rootProject))
-  implementation(platform(project(":nessie-deps-quarkus")))
   compileOnly(platform(project(":nessie-deps-build-only")))
   annotationProcessor(platform(project(":nessie-deps-build-only")))
-  compileOnly(platform("io.quarkus:quarkus-bom"))
 
   implementation("com.google.protobuf:protobuf-java")
   compileOnly("org.immutables:builder")
@@ -42,7 +40,6 @@ dependencies {
 
   testImplementation(platform(project(":nessie-deps-testing")))
   testImplementation(platform("org.junit:junit-bom"))
-  testImplementation(platform("io.quarkus:quarkus-bom"))
 
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
@@ -51,10 +48,10 @@ dependencies {
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
   // Need a few things from Quarkus, but don't leak the dependencies
-  compileOnly("io.opentracing:opentracing-api")
-  compileOnly("io.opentracing:opentracing-util")
-  compileOnly("io.micrometer:micrometer-core")
-  testImplementation("io.opentracing:opentracing-api")
-  testImplementation("io.opentracing:opentracing-util")
-  testImplementation("io.micrometer:micrometer-core")
+  compileOnly("io.opentracing:opentracing-api:${dependencyVersion("versionOpentracing")}")
+  compileOnly("io.opentracing:opentracing-util:${dependencyVersion("versionOpentracing")}")
+  compileOnly("io.micrometer:micrometer-core:${dependencyVersion("versionMicrometer")}")
+  testImplementation("io.opentracing:opentracing-api:${dependencyVersion("versionOpentracing")}")
+  testImplementation("io.opentracing:opentracing-util:${dependencyVersion("versionOpentracing")}")
+  testImplementation("io.micrometer:micrometer-core:${dependencyVersion("versionMicrometer")}")
 }


### PR DESCRIPTION
The Quarkus-BOM references some dependencies that require at least
Java 11 (like `jboss-logging:3.5.0.Final`), which lets Iceberg's
Java 8 CI (and potentially other code running with Java 8) fail
with
```
java.lang.UnsupportedClassVersionError: org/jboss/logging/BasicLogger has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

This change removes all references to the `quarkus-bom` from non
Quarkus related Nessie projects.