### PR TITLE
Unify github workflows

### DIFF
--- a/.github/actions/dev-tool-python/action.yml
+++ b/.github/actions/dev-tool-python/action.yml
@@ -17,6 +17,6 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        python3 -m pip install --upgrade pip
+        python3 -m pip install tox tox-gh-actions
       working-directory: ${{env.working-directory}}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   create-release:
     name: Bump version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       NEXT_VERSION: ${{ github.event.inputs.nextVersion }}
 
@@ -61,11 +61,11 @@ jobs:
         python-version: '3.8'
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install bump2version
+        python3 -m pip install --upgrade pip
+        python3 -m pip install bump2version
         # Remove the following, once https://github.com/c4urself/bump2version/issues/30 is fixed
         # and the two workarounds below are removed.
-        pip install -r python/requirements.txt
+        python3 -m pip install -r python/requirements.txt
     ### END runner setup
 
     - name: Bump Python version ${{ github.event.inputs.releaseVersion }}

--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -29,7 +29,7 @@ jobs:
   # For main-branch pushes & PRs
   report-upload:
     name: Report Upload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'projectnessie/nessie' }}
 
     env:
@@ -57,8 +57,9 @@ jobs:
 
     - name: Set up JDK 11
       if: steps.check_status.outputs.result == 'OK'
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'zulu'
         java-version: 11
 
     - name: Create simlog-dir

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   merge:
     name: "Dependabot Auto Merge"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Note: the check `github.actor == 'dependabot[bot]'` ensures that auto-approve-and-merge
     # only happens when dependabot triggers the workflow runs - but not when another user pushes.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   java:
     name: Java/Maven
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       SPARK_LOCAL_IP: localhost
       MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
@@ -88,7 +88,7 @@ jobs:
 
   native:
     name: Java/Maven/Native
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3
@@ -120,7 +120,7 @@ jobs:
 
   jackson-tests:
     name: Jackson Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3
@@ -158,7 +158,7 @@ jobs:
 
   python:
     name: Python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       working-directory: ./python
     strategy:

--- a/.github/workflows/newer-java.yml
+++ b/.github/workflows/newer-java.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   java:
     name: Exercise Java version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/pull-request-integ.yml
+++ b/.github/workflows/pull-request-integ.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   java:
     name: Integrations Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: contains(github.event.pull_request.labels.*.name, 'pr-integrations')
 
     steps:

--- a/.github/workflows/pull-request-jackson.yml
+++ b/.github/workflows/pull-request-jackson.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   jackson-tests:
     name: ITs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: contains(github.event.pull_request.labels.*.name, 'pr-jackson')
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pull-request-native.yml
+++ b/.github/workflows/pull-request-native.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   java:
     name: Java/Maven Native
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: contains(github.event.pull_request.labels.*.name, 'pr-native')
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   java:
     name: Java/Maven
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       SPARK_LOCAL_IP: localhost
 
@@ -108,7 +108,7 @@ jobs:
 
   python:
     name: Python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       working-directory: ./python
     strategy:
@@ -135,7 +135,7 @@ jobs:
 
   site:
     name: Build Website
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -153,19 +153,19 @@ jobs:
 
   helm-testing:
     name: Lint & Test Helm chart
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
           version: v3.8.1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - name: Set up chart-testing
         uses: helm/chart-testing-action@main
 

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   create-release:
     name: Create release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       RELEASE_FROM: ${{ github.event.inputs.releaseFromBranch }}
       GIT_TAG: nessie-${{ github.event.inputs.releaseVersion }}
@@ -90,11 +90,11 @@ jobs:
         python-version: '3.8'
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install bump2version
+        python3 -m pip install --upgrade pip
+        python3 -m pip install bump2version
         # Remove the following, once https://github.com/c4urself/bump2version/issues/30 is fixed
         # and the two workarounds below are removed.
-        pip install -r python/requirements.txt
+        python3 -m pip install -r python/requirements.txt
     ### END runner setup
 
     # Two steps that verify that the HISTORY.rst, server-upgrade.md and releases.md files contain

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   publish-release:
     name: Publish release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Runs in the `release` environment, which has the necessary secrets and defines the reviewers.
     # See https://docs.github.com/en/actions/reference/environments
@@ -99,8 +99,8 @@ jobs:
         python-version: '3.8'
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r python/requirements_dev.txt
+        python3 -m pip install --upgrade pip
+        python3 -m pip install -r python/requirements_dev.txt
     ### END runner setup
 
     # Deploys Maven artifacts. Build and test steps were already ran in previous steps.

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -9,12 +9,12 @@ jobs:
 
   site:
     name: Build & Deploy Website
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'projectnessie/nessie' }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.8'
           cache: 'pip'

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   java:
     name: Publish from main
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       SPARK_LOCAL_IP: localhost
     if: github.repository_owner == 'projectnessie'


### PR DESCRIPTION
- some actions were using older versions that the majority
- also unify how pip is being called
- also pin to ubuntu-20.04 ahead of next ubuntu-latest bump

before `runs-on`:
```
~/code/nessie$ rg --no-filename -o 'runs-on:.*$' .github | sort | uniq -c
     19 runs-on: ubuntu-latest
```
after:
```
~/code/nessie$ rg --no-filename -o 'runs-on:.*$' .github | sort | uniq -c
     19 runs-on: ubuntu-20.04
```

before `uses`:
```
~/code/nessie$ rg --no-filename -o 'uses:.*$' .github | sort | uniq -c
      1 uses: actions/checkout@v2
     17 uses: actions/checkout@v3
      3 uses: "actions/github-script@v6"
      1 uses: actions/setup-java@v1
      1 uses: actions/setup-java@v3
      2 uses: actions/setup-python@v2
      1 uses: actions/setup-python@v3
      9 uses: actions/upload-artifact@v3
      2 uses: azure/setup-helm@v1
      4 uses: codecov/codecov-action@v2
      2 uses: ./.github/actions/ci-results
     10 uses: ./.github/actions/dev-tool-java
      6 uses: ./.github/actions/dev-tool-python
      9 uses: ./.github/actions/setup-runner
     34 uses: gradle/gradle-build-action@v2
      1 uses: helm/chart-testing-action@main
      1 uses: medyagh/setup-minikube@master
      1 uses: peaceiris/actions-gh-pages@v3
      1 uses: pypa/gh-action-pypi-publish@release/v1
      1 uses: smartbear/swaggerhub-cli@v0.6.1
```
after:
```
~/code/nessie$ rg --no-filename -o 'uses:.*$' .github | sort | uniq -c
     18 uses: actions/checkout@v3
      3 uses: "actions/github-script@v6"
      2 uses: actions/setup-java@v3
      3 uses: actions/setup-python@v3
      9 uses: actions/upload-artifact@v3
      2 uses: azure/setup-helm@v1
      4 uses: codecov/codecov-action@v2
      2 uses: ./.github/actions/ci-results
     10 uses: ./.github/actions/dev-tool-java
      6 uses: ./.github/actions/dev-tool-python
      9 uses: ./.github/actions/setup-runner
     34 uses: gradle/gradle-build-action@v2
      1 uses: helm/chart-testing-action@main
      1 uses: medyagh/setup-minikube@master
      1 uses: peaceiris/actions-gh-pages@v3
      1 uses: pypa/gh-action-pypi-publish@release/v1
      1 uses: smartbear/swaggerhub-cli@v0.6.1
```

before `pip install`:
```
~/code/nessie$ rg --no-filename -o '^.*pip install' .github | sort | uniq -c
      6         pip install
      1           python3 -m pip install
      4         python -m pip install
      2         run: python3 -m pip install
```
after:
```
~/code/nessie$ rg --no-filename -o '^.*pip install' .github | sort | uniq -c
      1           python3 -m pip install
     10         python3 -m pip install
      2         run: python3 -m pip install
```