### PR TITLE
Remove misleading, wrong information from retry-error message

### DIFF
--- a/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
+++ b/versioned/persist/nontx/src/main/java/org/projectnessie/versioned/persist/nontx/NonTransactionalDatabaseAdapter.java
@@ -847,12 +847,11 @@ public abstract class NonTransactionalDatabaseAdapter<
         newTryLoopState(
             opName,
             ts ->
-                repoDescUpdateConflictMessage(
-                    String.format(
-                        "%s after %d retries, %d ms",
-                        retryErrorMessage.get(),
-                        ts.getRetries(),
-                        ts.getDuration(TimeUnit.MILLISECONDS))),
+                String.format(
+                    "%s after %d retries, %d ms",
+                    retryErrorMessage.get(),
+                    ts.getRetries(),
+                    ts.getDuration(TimeUnit.MILLISECONDS)),
             this::tryLoopStateCompletion,
             config)) {
       while (true) {

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/TxDatabaseAdapter.java
@@ -853,12 +853,11 @@ public abstract class TxDatabaseAdapter
             newTryLoopState(
                 opName,
                 ts ->
-                    repoDescUpdateConflictMessage(
-                        String.format(
-                            "%s after %d retries, %d ms",
-                            retryErrorMessage.get(),
-                            ts.getRetries(),
-                            ts.getDuration(TimeUnit.MILLISECONDS))),
+                    String.format(
+                        "%s after %d retries, %d ms",
+                        retryErrorMessage.get(),
+                        ts.getRetries(),
+                        ts.getDuration(TimeUnit.MILLISECONDS)),
                 this::tryLoopStateCompletion,
                 config)) {
       while (true) {


### PR DESCRIPTION
All retry-error-messages contain the suffix `during update of the repository description`, which is wrong.