### PR TITLE
Use constructors instead of builder-instance

### DIFF
--- a/model/src/main/java/org/projectnessie/model/BaseMergeTransplant.java
+++ b/model/src/main/java/org/projectnessie/model/BaseMergeTransplant.java
@@ -66,8 +66,10 @@ public interface BaseMergeTransplant {
   @JsonSerialize(as = ImmutableMergeKeyBehavior.class)
   @JsonDeserialize(as = ImmutableMergeKeyBehavior.class)
   interface MergeKeyBehavior {
+    @Value.Parameter(order = 1)
     ContentKey getKey();
 
+    @Value.Parameter(order = 2)
     MergeBehavior getMergeBehavior();
 
     static ImmutableMergeKeyBehavior.Builder builder() {
@@ -75,7 +77,7 @@ public interface BaseMergeTransplant {
     }
 
     static MergeKeyBehavior of(ContentKey key, MergeBehavior mergeBehavior) {
-      return builder().key(key).mergeBehavior(mergeBehavior).build();
+      return ImmutableMergeKeyBehavior.of(key, mergeBehavior);
     }
   }
 

--- a/model/src/main/java/org/projectnessie/model/Branch.java
+++ b/model/src/main/java/org/projectnessie/model/Branch.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -34,7 +36,14 @@ import org.immutables.value.Value;
 public interface Branch extends Reference {
 
   @Override
+  @NotBlank
+  @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+  @Value.Parameter(order = 1)
+  String getName();
+
+  @Override
   @Nullable
+  @Value.Parameter(order = 2)
   String getHash();
 
   /**
@@ -55,6 +64,6 @@ public interface Branch extends Reference {
   }
 
   static Branch of(String name, @Nullable String hash) {
-    return builder().name(name).hash(hash).build();
+    return ImmutableBranch.of(name, hash);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/ContentKey.java
+++ b/model/src/main/java/org/projectnessie/model/ContentKey.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
@@ -43,6 +44,7 @@ public abstract class ContentKey {
 
   @NotNull
   @Size(min = 1)
+  @Value.Parameter(order = 1)
   public abstract List<String> getElements();
 
   /**
@@ -74,13 +76,13 @@ public abstract class ContentKey {
 
   public static ContentKey of(String... elements) {
     Objects.requireNonNull(elements, "Elements array must not be null");
-    return ImmutableContentKey.builder().addElements(elements).build();
+    return ImmutableContentKey.of(Arrays.asList(elements));
   }
 
   @JsonCreator
   public static ContentKey of(@JsonProperty("elements") List<String> elements) {
     Objects.requireNonNull(elements);
-    return ImmutableContentKey.builder().elements(elements).build();
+    return ImmutableContentKey.of(elements);
   }
 
   @Value.Check

--- a/model/src/main/java/org/projectnessie/model/Detached.java
+++ b/model/src/main/java/org/projectnessie/model/Detached.java
@@ -49,6 +49,7 @@ public interface Detached extends Reference {
 
   @Override
   @NotEmpty
+  @Value.Parameter(order = 1)
   String getHash();
 
   /** Validation rule using {@link Validation#validateReferenceName(String)}. */
@@ -68,6 +69,6 @@ public interface Detached extends Reference {
   }
 
   static Detached of(String hash) {
-    return builder().hash(hash).build();
+    return ImmutableDetached.of(hash);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/DiffResponse.java
+++ b/model/src/main/java/org/projectnessie/model/DiffResponse.java
@@ -35,13 +35,16 @@ public interface DiffResponse {
   @JsonSerialize(as = ImmutableDiffEntry.class)
   @JsonDeserialize(as = ImmutableDiffEntry.class)
   interface DiffEntry {
+    @Value.Parameter(order = 1)
     ContentKey getKey();
 
     @Nullable
     @SuppressWarnings("immutables:from")
+    @Value.Parameter(order = 2)
     Content getFrom();
 
     @Nullable
+    @Value.Parameter(order = 3)
     Content getTo();
   }
 }

--- a/model/src/main/java/org/projectnessie/model/EntriesResponse.java
+++ b/model/src/main/java/org/projectnessie/model/EntriesResponse.java
@@ -31,6 +31,7 @@ public interface EntriesResponse extends PaginatedResponse {
   }
 
   @NotNull
+  @Value.Parameter(order = 1)
   List<Entry> getEntries();
 
   @Value.Immutable
@@ -42,10 +43,16 @@ public interface EntriesResponse extends PaginatedResponse {
       return ImmutableEntry.builder();
     }
 
+    static Entry of(Content.Type type, ContentKey name) {
+      return ImmutableEntry.of(type, name);
+    }
+
     @NotNull
+    @Value.Parameter(order = 1)
     Content.Type getType();
 
     @NotNull
+    @Value.Parameter(order = 2)
     ContentKey getName();
   }
 }

--- a/model/src/main/java/org/projectnessie/model/GenericMetadata.java
+++ b/model/src/main/java/org/projectnessie/model/GenericMetadata.java
@@ -29,12 +29,14 @@ import org.immutables.value.Value;
 public interface GenericMetadata {
 
   @NotEmpty
+  @Value.Parameter(order = 1)
   String getVariant();
 
   @Schema(type = SchemaType.OBJECT)
+  @Value.Parameter(order = 2)
   JsonNode getMetadata();
 
   static GenericMetadata of(String variant, JsonNode metadata) {
-    return ImmutableGenericMetadata.builder().variant(variant).metadata(metadata).build();
+    return ImmutableGenericMetadata.of(variant, metadata);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/GetMultipleContentsRequest.java
+++ b/model/src/main/java/org/projectnessie/model/GetMultipleContentsRequest.java
@@ -32,6 +32,7 @@ public interface GetMultipleContentsRequest {
 
   @NotNull
   @Size(min = 1)
+  @Value.Parameter(order = 1)
   List<ContentKey> getRequestedKeys();
 
   static ImmutableGetMultipleContentsRequest.Builder builder() {
@@ -43,6 +44,6 @@ public interface GetMultipleContentsRequest {
   }
 
   static GetMultipleContentsRequest of(List<ContentKey> keys) {
-    return builder().addAllRequestedKeys(keys).build();
+    return ImmutableGetMultipleContentsRequest.of(keys);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/GetMultipleContentsResponse.java
+++ b/model/src/main/java/org/projectnessie/model/GetMultipleContentsResponse.java
@@ -30,10 +30,11 @@ import org.immutables.value.Value;
 public interface GetMultipleContentsResponse {
 
   @NotNull
+  @Value.Parameter(order = 1)
   List<ContentWithKey> getContents();
 
   static GetMultipleContentsResponse of(List<ContentWithKey> items) {
-    return ImmutableGetMultipleContentsResponse.builder().addAllContents(items).build();
+    return ImmutableGetMultipleContentsResponse.of(items);
   }
 
   @Value.Immutable
@@ -42,13 +43,15 @@ public interface GetMultipleContentsResponse {
   interface ContentWithKey {
 
     @NotNull
+    @Value.Parameter(order = 1)
     ContentKey getKey();
 
     @NotNull
+    @Value.Parameter(order = 2)
     Content getContent();
 
     static ContentWithKey of(ContentKey key, Content content) {
-      return ImmutableContentWithKey.builder().key(key).content(content).build();
+      return ImmutableContentWithKey.of(key, content);
     }
   }
 }

--- a/model/src/main/java/org/projectnessie/model/IcebergTable.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergTable.java
@@ -55,24 +55,34 @@ import org.immutables.value.Value;
 @JsonTypeName("ICEBERG_TABLE")
 public abstract class IcebergTable extends IcebergContent {
 
+  @Override
+  @Nullable
+  @Value.Parameter(order = 1)
+  public abstract String getId();
+
   /**
    * Location where Iceberg stored its {@code TableMetadata} file. The location depends on the
    * (implementation of) Iceberg's {@code FileIO} configured for the particular Iceberg table.
    */
   @NotNull
   @NotBlank
+  @Value.Parameter(order = 2)
   public abstract String getMetadataLocation();
 
   /** Corresponds to Iceberg's {@code currentSnapshotId}. */
+  @Value.Parameter(order = 3)
   public abstract long getSnapshotId();
 
   /** Corresponds to Iceberg's {@code currentSchemaId}. */
+  @Value.Parameter(order = 4)
   public abstract int getSchemaId();
 
   /** Corresponds to Iceberg's {@code defaultSpecId}. */
+  @Value.Parameter(order = 5)
   public abstract int getSpecId();
 
   /** Corresponds to Iceberg's {@code defaultSortOrderId}. */
+  @Value.Parameter(order = 6)
   public abstract int getSortOrderId();
 
   @Override
@@ -91,13 +101,8 @@ public abstract class IcebergTable extends IcebergContent {
 
   public static IcebergTable of(
       String metadataLocation, long snapshotId, int schemaId, int specId, int sortOrderId) {
-    return builder()
-        .metadataLocation(metadataLocation)
-        .snapshotId(snapshotId)
-        .schemaId(schemaId)
-        .specId(specId)
-        .sortOrderId(sortOrderId)
-        .build();
+    return ImmutableIcebergTable.of(
+        null, metadataLocation, snapshotId, schemaId, specId, sortOrderId);
   }
 
   public static IcebergTable of(
@@ -107,13 +112,7 @@ public abstract class IcebergTable extends IcebergContent {
       int specId,
       int sortOrderId,
       String contentId) {
-    return builder()
-        .metadataLocation(metadataLocation)
-        .snapshotId(snapshotId)
-        .schemaId(schemaId)
-        .specId(specId)
-        .sortOrderId(sortOrderId)
-        .id(contentId)
-        .build();
+    return ImmutableIcebergTable.of(
+        contentId, metadataLocation, snapshotId, schemaId, specId, sortOrderId);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/IcebergView.java
+++ b/model/src/main/java/org/projectnessie/model/IcebergView.java
@@ -31,24 +31,34 @@ import org.immutables.value.Value;
 @JsonTypeName("ICEBERG_VIEW")
 public abstract class IcebergView extends IcebergContent {
 
+  @Override
+  @Nullable
+  @Value.Parameter(order = 1)
+  public abstract String getId();
+
   /**
    * Location where Iceberg stored its {@code ViewMetadata} file. The location depends on the
    * (implementation of) Iceberg's {@code FileIO} configured for the particular Iceberg table.
    */
   @NotNull
   @NotBlank
+  @Value.Parameter(order = 2)
   public abstract String getMetadataLocation();
 
   /** Corresponds to Iceberg's {@code currentVersionId}. */
+  @Value.Parameter(order = 3)
   public abstract int getVersionId();
 
+  @Value.Parameter(order = 4)
   public abstract int getSchemaId();
 
   @NotBlank
   @NotNull
+  @Value.Parameter(order = 6)
   public abstract String getSqlText();
 
   @Nullable // TODO this is currently undefined in Iceberg
+  @Value.Parameter(order = 5)
   public abstract String getDialect();
 
   @Override
@@ -67,13 +77,7 @@ public abstract class IcebergView extends IcebergContent {
 
   public static IcebergView of(
       String metadataLocation, int versionId, int schemaId, String dialect, String sqlText) {
-    return builder()
-        .metadataLocation(metadataLocation)
-        .versionId(versionId)
-        .schemaId(schemaId)
-        .dialect(dialect)
-        .sqlText(sqlText)
-        .build();
+    return ImmutableIcebergView.of(null, metadataLocation, versionId, schemaId, dialect, sqlText);
   }
 
   public static IcebergView of(
@@ -83,13 +87,6 @@ public abstract class IcebergView extends IcebergContent {
       int schemaId,
       String dialect,
       String sqlText) {
-    return builder()
-        .id(id)
-        .metadataLocation(metadataLocation)
-        .versionId(versionId)
-        .schemaId(schemaId)
-        .dialect(dialect)
-        .sqlText(sqlText)
-        .build();
+    return ImmutableIcebergView.of(id, metadataLocation, versionId, schemaId, dialect, sqlText);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Derived;
@@ -50,7 +51,7 @@ public abstract class Namespace extends Content {
       "'%s' is not a valid namespace identifier (should not end with '.')";
 
   public static final Namespace EMPTY =
-      ImmutableNamespace.builder().elements(Collections.emptyList()).build();
+      ImmutableNamespace.of(Collections.emptyList(), Collections.emptyMap(), null);
 
   @Override
   public Type getType() {
@@ -71,11 +72,18 @@ public abstract class Namespace extends Content {
   }
 
   @NotNull
+  @Value.Parameter(order = 1)
   public abstract List<String> getElements();
 
   @NotNull
   @JsonInclude(Include.NON_EMPTY)
+  @Value.Parameter(order = 2)
   public abstract Map<String, String> getProperties();
+
+  @Override
+  @Nullable
+  @Value.Parameter(order = 3)
+  public abstract String getId();
 
   /**
    * Builds a {@link Namespace} instance for the given elements.
@@ -126,10 +134,7 @@ public abstract class Namespace extends Content {
           String.format(ERROR_MSG_TEMPLATE, Arrays.toString(elements)));
     }
 
-    return ImmutableNamespace.builder()
-        .elements(Arrays.asList(elements))
-        .properties(properties)
-        .build();
+    return ImmutableNamespace.of(Arrays.asList(elements), properties, null);
   }
 
   /**

--- a/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
+++ b/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
@@ -33,6 +33,7 @@ public abstract class NessieConfiguration {
    */
   @Nullable
   @Size(min = 1)
+  @Value.Parameter(order = 1)
   public abstract String getDefaultBranch();
 
   /**
@@ -40,5 +41,6 @@ public abstract class NessieConfiguration {
    *
    * <p>API versions are numbered sequentially, as they are developed.
    */
+  @Value.Parameter(order = 2)
   public abstract int getMaxSupportedApiVersion();
 }

--- a/model/src/main/java/org/projectnessie/model/Operation.java
+++ b/model/src/main/java/org/projectnessie/model/Operation.java
@@ -46,6 +46,7 @@ import org.immutables.value.Value;
 public interface Operation {
 
   @NotNull
+  @Value.Parameter(order = 1)
   ContentKey getKey();
 
   @Schema(
@@ -60,22 +61,25 @@ public interface Operation {
   @JsonDeserialize(as = ImmutablePut.class)
   @JsonTypeName("PUT")
   interface Put extends Operation {
+    @Override
     @NotNull
+    @Value.Parameter(order = 1)
+    ContentKey getKey();
+
+    @NotNull
+    @Value.Parameter(order = 2)
     Content getContent();
 
     @Nullable
+    @Value.Parameter(order = 3)
     Content getExpectedContent();
 
     static Put of(ContentKey key, Content content) {
-      return ImmutablePut.builder().key(key).content(content).build();
+      return ImmutablePut.of(key, content, null);
     }
 
     static Put of(ContentKey key, Content content, Content expectedContent) {
-      return ImmutablePut.builder()
-          .key(key)
-          .content(content)
-          .expectedContent(expectedContent)
-          .build();
+      return ImmutablePut.of(key, content, expectedContent);
     }
   }
 
@@ -86,7 +90,7 @@ public interface Operation {
   interface Delete extends Operation {
 
     static Delete of(ContentKey key) {
-      return ImmutableDelete.builder().key(key).build();
+      return ImmutableDelete.of(key);
     }
   }
 
@@ -97,7 +101,7 @@ public interface Operation {
   interface Unchanged extends Operation {
 
     static Unchanged of(ContentKey key) {
-      return ImmutableUnchanged.builder().key(key).build();
+      return ImmutableUnchanged.of(key);
     }
   }
 }

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -57,10 +57,12 @@ public interface Reference extends Base {
   /** Human-readable reference name. */
   @NotBlank
   @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+  @Value.Parameter(order = 1)
   String getName();
 
   /** backend system id. Usually the 32-byte hash of the commit this reference points to. */
   @Pattern(regexp = Validation.HASH_REGEX, message = Validation.HASH_MESSAGE)
+  @Value.Parameter(order = 2)
   String getHash();
 
   /** Validation rule using {@link org.projectnessie.model.Validation#validateHash(String)}. */

--- a/model/src/main/java/org/projectnessie/model/Tag.java
+++ b/model/src/main/java/org/projectnessie/model/Tag.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -32,9 +34,15 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTag.class)
 @JsonTypeName("TAG")
 public interface Tag extends Reference {
+  @Override
+  @NotBlank
+  @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
+  @Value.Parameter(order = 1)
+  String getName();
 
   @Override
   @Nullable
+  @Value.Parameter(order = 2)
   String getHash();
 
   /**
@@ -55,6 +63,6 @@ public interface Tag extends Reference {
   }
 
   static Tag of(String name, String hash) {
-    return builder().name(name).hash(hash).build();
+    return ImmutableTag.of(name, hash);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/AbstractBatchAccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/AbstractBatchAccessChecker.java
@@ -35,8 +35,8 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
 
   private final Collection<Check> checks = new LinkedHashSet<>();
 
-  private BatchAccessChecker add(ImmutableCheck.Builder builder) {
-    checks.add(builder.build());
+  private BatchAccessChecker add(Check check) {
+    checks.add(check);
     return this;
   }
 
@@ -46,80 +46,71 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
 
   @Override
   public BatchAccessChecker canViewReference(NamedRef ref) {
-    return add(Check.builder(CheckType.VIEW_REFERENCE).ref(ref));
+    return add(Check.of(CheckType.VIEW_REFERENCE, ref));
   }
 
   @Override
   public BatchAccessChecker canCreateReference(NamedRef ref) {
-    return add(Check.builder(CheckType.CREATE_REFERENCE).ref(ref));
+    return add(Check.of(CheckType.CREATE_REFERENCE, ref));
   }
 
   @Override
   public BatchAccessChecker canAssignRefToHash(NamedRef ref) {
     canViewReference(ref);
-    return add(Check.builder(CheckType.ASSIGN_REFERENCE_TO_HASH).ref(ref));
+    return add(Check.of(CheckType.ASSIGN_REFERENCE_TO_HASH, ref));
   }
 
   @Override
   public BatchAccessChecker canDeleteReference(NamedRef ref) {
     canViewReference(ref);
-    return add(Check.builder(CheckType.DELETE_REFERENCE).ref(ref));
+    return add(Check.of(CheckType.DELETE_REFERENCE, ref));
   }
 
   @Override
   public BatchAccessChecker canReadEntries(NamedRef ref) {
     canViewReference(ref);
-    return add(Check.builder(CheckType.READ_ENTRIES).ref(ref));
+    return add(Check.of(CheckType.READ_ENTRIES, ref));
   }
 
   @Override
   public BatchAccessChecker canReadContentKey(NamedRef ref, ContentKey key, String contentId) {
     canViewReference(ref);
-    ImmutableCheck.Builder builder = Check.builder(CheckType.READ_CONTENT_KEY).ref(ref).key(key);
-    if (contentId != null) {
-      builder.contentId(contentId);
-    }
-    return add(builder);
+    return add(Check.of(CheckType.READ_CONTENT_KEY, ref, key, contentId));
   }
 
   @Override
   public BatchAccessChecker canListCommitLog(NamedRef ref) {
     canViewReference(ref);
-    return add(Check.builder(CheckType.LIST_COMMIT_LOG).ref(ref));
+    return add(Check.of(CheckType.LIST_COMMIT_LOG, ref));
   }
 
   @Override
   public BatchAccessChecker canCommitChangeAgainstReference(NamedRef ref) {
     canViewReference(ref);
-    return add(Check.builder(CheckType.COMMIT_CHANGE_AGAINST_REFERENCE).ref(ref));
+    return add(Check.of(CheckType.COMMIT_CHANGE_AGAINST_REFERENCE, ref));
   }
 
   @Override
   public BatchAccessChecker canReadEntityValue(NamedRef ref, ContentKey key, String contentId) {
     canViewReference(ref);
-    return add(Check.builder(CheckType.READ_ENTITY_VALUE).ref(ref).key(key).contentId(contentId));
+    return add(Check.of(CheckType.READ_ENTITY_VALUE, ref, key, contentId));
   }
 
   @Override
   public BatchAccessChecker canUpdateEntity(
       NamedRef ref, ContentKey key, String contentId, Content.Type contentType) {
     canViewReference(ref);
-    return add(
-        Check.builder(CheckType.UPDATE_ENTITY)
-            .ref(ref)
-            .key(key)
-            .contentId(contentId)
-            .contentType(contentType));
+    return add(Check.of(CheckType.UPDATE_ENTITY, ref, key, contentId, contentType));
   }
 
   @Override
   public BatchAccessChecker canDeleteEntity(NamedRef ref, ContentKey key, String contentId) {
     canViewReference(ref);
-    return add(Check.builder(CheckType.DELETE_ENTITY).ref(ref).key(key).contentId(contentId));
+    return add(Check.of(CheckType.DELETE_ENTITY, ref, key, contentId));
   }
 
   @Override
   public BatchAccessChecker canViewRefLog() {
-    return add(Check.builder(CheckType.VIEW_REFLOG));
+    return add(Check.of(CheckType.VIEW_REFLOG));
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
@@ -24,19 +24,41 @@ import org.projectnessie.versioned.NamedRef;
 /** Describes a check operation. */
 @Value.Immutable
 public interface Check {
+  @Value.Parameter(order = 1)
   CheckType type();
 
   @Nullable
+  @Value.Parameter(order = 2)
   NamedRef ref();
 
   @Nullable
+  @Value.Parameter(order = 3)
   ContentKey key();
 
   @Nullable
+  @Value.Parameter(order = 4)
   String contentId();
 
   @Nullable
+  @Value.Parameter(order = 5)
   Content.Type contentType();
+
+  static Check of(CheckType type) {
+    return of(type, null);
+  }
+
+  static Check of(CheckType type, NamedRef ref) {
+    return of(type, ref, null, null);
+  }
+
+  static Check of(CheckType type, NamedRef ref, ContentKey key, String contentId) {
+    return of(type, ref, key, contentId, null);
+  }
+
+  static Check of(
+      CheckType type, NamedRef ref, ContentKey key, String contentId, Content.Type contentType) {
+    return ImmutableCheck.of(type, ref, key, contentId, contentType);
+  }
 
   static ImmutableCheck.Builder builder(CheckType type) {
     return ImmutableCheck.builder().type(type);

--- a/servers/services/src/main/java/org/projectnessie/services/authz/ServerAccessContext.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/ServerAccessContext.java
@@ -23,13 +23,15 @@ import org.immutables.value.Value;
 public abstract class ServerAccessContext implements AccessContext {
 
   @Override
+  @Value.Parameter(order = 1)
   public abstract String operationId();
 
   @Override
   @Nullable
+  @Value.Parameter(order = 2)
   public abstract Principal user();
 
   public static ServerAccessContext of(String operationId, Principal principal) {
-    return ImmutableServerAccessContext.builder().operationId(operationId).user(principal).build();
+    return ImmutableServerAccessContext.of(operationId, principal);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
@@ -30,9 +30,6 @@ public class ConfigApiImpl implements ConfigApi {
 
   @Override
   public NessieConfiguration getConfig() {
-    return ImmutableNessieConfiguration.builder()
-        .defaultBranch(this.config.getDefaultBranch())
-        .maxSupportedApiVersion(1)
-        .build();
+    return ImmutableNessieConfiguration.of(this.config.getDefaultBranch(), 1);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
@@ -69,12 +69,15 @@ public class ContentApiImpl extends BaseApiImpl implements ContentApi {
       List<Key> internalKeys =
           externalKeys.stream().map(ContentApiImpl::toKey).collect(Collectors.toList());
       Map<Key, Content> values = getStore().getValues(ref.getHash(), internalKeys);
-      List<ContentWithKey> output =
-          values.entrySet().stream()
-              .map(e -> ContentWithKey.of(toContentKey(e.getKey()), e.getValue()))
-              .collect(Collectors.toList());
 
-      return ImmutableGetMultipleContentsResponse.builder().contents(output).build();
+      ImmutableGetMultipleContentsResponse.Builder response =
+          ImmutableGetMultipleContentsResponse.builder();
+
+      values.entrySet().stream()
+          .map(e -> ContentWithKey.of(toContentKey(e.getKey()), e.getValue()))
+          .forEach(response::addContents);
+
+      return response.build();
     } catch (ReferenceNotFoundException ex) {
       throw new NessieReferenceNotFoundException(ex.getMessage(), ex);
     }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -56,11 +56,10 @@ public class DiffApiImpl extends BaseApiImpl implements DiffApi {
         diffs
             .map(
                 diff ->
-                    ImmutableDiffEntry.builder()
-                        .key(ContentKey.of(diff.getKey().getElements()))
-                        .from(diff.getFromValue().orElse(null))
-                        .to(diff.getToValue().orElse(null))
-                        .build())
+                    ImmutableDiffEntry.of(
+                        ContentKey.of(diff.getKey().getElements()),
+                        diff.getFromValue().orElse(null),
+                        diff.getToValue().orElse(null)))
             .forEach(builder::addDiffs);
       }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -145,11 +145,10 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
 
   private GetNamedRefsParams getGetNamedRefsParams(boolean fetchMetadata) {
     return fetchMetadata
-        ? GetNamedRefsParams.builder()
-            .baseReference(BranchName.of(this.getConfig().getDefaultBranch()))
-            .branchRetrieveOptions(RetrieveOptions.BASE_REFERENCE_RELATED_AND_COMMIT_META)
-            .tagRetrieveOptions(RetrieveOptions.COMMIT_META)
-            .build()
+        ? GetNamedRefsParams.of(
+            BranchName.of(this.getConfig().getDefaultBranch()),
+            RetrieveOptions.BASE_REFERENCE_RELATED_AND_COMMIT_META,
+            RetrieveOptions.COMMIT_META)
         : GetNamedRefsParams.DEFAULT;
   }
 
@@ -562,10 +561,8 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
             filterEntries(refWithHash, entryStream, params.filter())
                 .map(
                     key ->
-                        EntriesResponse.Entry.builder()
-                            .name(fromKey(key.getKey()))
-                            .type((Content.Type) key.getType())
-                            .build());
+                        EntriesResponse.Entry.of(
+                            (Content.Type) key.getType(), fromKey(key.getKey())));
         if (params.namespaceDepth() != null && params.namespaceDepth() > 0) {
           entriesStream =
               entriesStream
@@ -588,7 +585,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeApi {
     Content.Type type =
         entry.getName().getElements().size() > depth ? Content.Type.NAMESPACE : entry.getType();
     ContentKey key = ContentKey.of(entry.getName().getElements().subList(0, depth));
-    return EntriesResponse.Entry.builder().type(type).name(key).build();
+    return EntriesResponse.Entry.of(type, key);
   }
 
   /**

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentId.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentId.java
@@ -22,9 +22,10 @@ import org.immutables.value.Value;
 public abstract class ContentId {
   public static ContentId of(String id) {
     Objects.requireNonNull(id);
-    return ImmutableContentId.builder().id(id).build();
+    return ImmutableContentId.of(id);
   }
 
+  @Value.Parameter(order = 1)
   public abstract String getId();
 
   @Override

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentIdAndBytes.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentIdAndBytes.java
@@ -24,11 +24,13 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 public interface ContentIdAndBytes {
+  @Value.Parameter(order = 1)
   ContentId getContentId();
 
+  @Value.Parameter(order = 2)
   ByteString getValue();
 
   static ContentIdAndBytes of(ContentId contentId, ByteString value) {
-    return ImmutableContentIdAndBytes.builder().contentId(contentId).value(value).build();
+    return ImmutableContentIdAndBytes.of(contentId, value);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/HeadsAndForkPoints.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/HeadsAndForkPoints.java
@@ -21,13 +21,13 @@ import org.projectnessie.versioned.Hash;
 
 @Value.Immutable
 public interface HeadsAndForkPoints {
-  @Value.Parameter
+  @Value.Parameter(order = 1)
   Set<Hash> getHeads();
 
-  @Value.Parameter
+  @Value.Parameter(order = 2)
   Set<Hash> getForkPoints();
 
-  @Value.Parameter
+  @Value.Parameter(order = 3)
   long getScanStartedAtInMicros();
 
   static HeadsAndForkPoints of(Set<Hash> heads, Set<Hash> forkPoints, long scanStartedAtInMicros) {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyList.java
@@ -30,9 +30,10 @@ public interface KeyList {
   KeyList EMPTY = ImmutableKeyList.builder().build();
 
   @AllowNulls
+  @Value.Parameter(order = 1)
   List<KeyListEntry> getKeys();
 
   static KeyList of(List<KeyListEntry> keys) {
-    return ImmutableKeyList.builder().keys(keys).build();
+    return ImmutableKeyList.of(keys);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntity.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntity.java
@@ -24,11 +24,13 @@ import org.projectnessie.versioned.Hash;
  */
 @Value.Immutable
 public interface KeyListEntity {
+  @Value.Parameter(order = 1)
   Hash getId();
 
+  @Value.Parameter(order = 2)
   KeyList getKeys();
 
   static KeyListEntity of(Hash id, KeyList keys) {
-    return ImmutableKeyListEntity.builder().id(id).keys(keys).build();
+    return ImmutableKeyListEntity.of(id, keys);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyListEntry.java
@@ -23,21 +23,20 @@ import org.projectnessie.versioned.Key;
 /** Composite of key, content-id, content-type and commit-id. */
 @Value.Immutable(lazyhash = true) // this type is used as a map-key in an expensive test
 public interface KeyListEntry {
+  @Value.Parameter(order = 1)
   Key getKey();
 
+  @Value.Parameter(order = 2)
   ContentId getContentId();
 
+  @Value.Parameter(order = 3)
   byte getPayload();
 
   @Nullable
+  @Value.Parameter(order = 4)
   Hash getCommitId();
 
   static KeyListEntry of(Key key, ContentId contentId, byte payload, Hash commitId) {
-    ImmutableKeyListEntry.Builder builder =
-        ImmutableKeyListEntry.builder().key(key).payload(payload).contentId(contentId);
-    if (commitId != null) {
-      builder.commitId(commitId);
-    }
-    return builder.build();
+    return ImmutableKeyListEntry.of(key, contentId, payload, commitId);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyWithBytes.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/KeyWithBytes.java
@@ -22,20 +22,19 @@ import org.projectnessie.versioned.Key;
 /** Composite of key, content-id, content-type and content. */
 @Value.Immutable
 public interface KeyWithBytes {
+  @Value.Parameter(order = 1)
   Key getKey();
 
+  @Value.Parameter(order = 2)
   ContentId getContentId();
 
+  @Value.Parameter(order = 3)
   byte getPayload();
 
+  @Value.Parameter(order = 4)
   ByteString getValue();
 
   static KeyWithBytes of(Key key, ContentId contentId, byte payload, ByteString value) {
-    return ImmutableKeyWithBytes.builder()
-        .key(key)
-        .contentId(contentId)
-        .payload(payload)
-        .value(value)
-        .build();
+    return ImmutableKeyWithBytes.of(key, contentId, payload, value);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencedAndUnreferencedHeads.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencedAndUnreferencedHeads.java
@@ -23,10 +23,10 @@ import org.projectnessie.versioned.NamedRef;
 
 @Value.Immutable
 public interface ReferencedAndUnreferencedHeads {
-  @Value.Parameter
+  @Value.Parameter(order = 1)
   Map<Hash, Set<NamedRef>> getReferencedHeads();
 
-  @Value.Parameter
+  @Value.Parameter(order = 2)
   Set<Hash> getUnreferencedHeads();
 
   static ReferencedAndUnreferencedHeads of(

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/ProvidedDynamoClientConfig.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/ProvidedDynamoClientConfig.java
@@ -22,9 +22,10 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 public interface ProvidedDynamoClientConfig extends DynamoClientConfig {
 
   static ProvidedDynamoClientConfig of(DynamoDbClient db) {
-    return ImmutableProvidedDynamoClientConfig.builder().dynamoDbClient(db).build();
+    return ImmutableProvidedDynamoClientConfig.of(db);
   }
 
+  @Value.Parameter(order = 1)
   DynamoDbClient getDynamoDbClient();
 
   ProvidedDynamoClientConfig withDynamoDbClient(DynamoDbClient dynamoDbClient);

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoClientConfig.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoClientConfig.java
@@ -24,7 +24,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
 public interface MongoClientConfig extends DatabaseConnectionConfig {
 
   static MongoClientConfig of(MongoClient client) {
-    return ImmutableMongoClientConfig.builder().client(client).build();
+    return ImmutableMongoClientConfig.of(client);
   }
 
   @Nullable
@@ -38,6 +38,7 @@ public interface MongoClientConfig extends DatabaseConnectionConfig {
   MongoClientConfig withDatabaseName(String databaseName);
 
   @Nullable
+  @Value.Parameter(order = 1)
   MongoClient getClient();
 
   MongoClientConfig withClient(MongoClient client);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/BranchName.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/BranchName.java
@@ -30,6 +30,6 @@ public interface BranchName extends NamedRef {
    */
   @Nonnull
   static BranchName of(@Nonnull String name) {
-    return ImmutableBranchName.builder().name(name).build();
+    return ImmutableBranchName.of(name);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/ContentAttachmentKey.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/ContentAttachmentKey.java
@@ -25,14 +25,17 @@ public interface ContentAttachmentKey {
 
   /** Content ID to which the binary object identified by this key belongs to. */
   @NotBlank
+  @Value.Parameter(order = 1)
   String getContentId();
 
   /** The object type, for example {@code snapshot} or {@code schema}. */
   @NotBlank
+  @Value.Parameter(order = 2)
   String getAttachmentType();
 
   /** The object ID, for example the snapshot-ID or schema-ID. */
   @NotBlank
+  @Value.Parameter(order = 3)
   String getAttachmentId();
 
   @Value.Check
@@ -53,11 +56,7 @@ public interface ContentAttachmentKey {
   }
 
   static ContentAttachmentKey of(String contentId, String attachmentType, String attachmentId) {
-    return builder()
-        .contentId(contentId)
-        .attachmentType(attachmentType)
-        .attachmentId(attachmentId)
-        .build();
+    return ImmutableContentAttachmentKey.of(contentId, attachmentType, attachmentId);
   }
 
   default String asString() {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Delete.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Delete.java
@@ -30,6 +30,6 @@ public interface Delete extends Operation {
    */
   @Nonnull
   static Delete of(@Nonnull Key key) {
-    return ImmutableDelete.builder().key(key).build();
+    return ImmutableDelete.of(key);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Diff.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Diff.java
@@ -16,19 +16,22 @@
 package org.projectnessie.versioned;
 
 import java.util.Optional;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 import org.projectnessie.model.Content;
 
-@Immutable
+@Value.Immutable
 public interface Diff {
 
+  @Value.Parameter(order = 1)
   Key getKey();
 
+  @Value.Parameter(order = 2)
   Optional<Content> getFromValue();
 
+  @Value.Parameter(order = 3)
   Optional<Content> getToValue();
 
   static Diff of(Key key, Optional<Content> from, Optional<Content> to) {
-    return ImmutableDiff.builder().key(key).fromValue(from).toValue(to).build();
+    return ImmutableDiff.of(key, from, to);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/GetNamedRefsParams.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/GetNamedRefsParams.java
@@ -31,6 +31,13 @@ public interface GetNamedRefsParams {
     return ImmutableGetNamedRefsParams.builder();
   }
 
+  static GetNamedRefsParams of(
+      NamedRef baseReference,
+      RetrieveOptions branchRetrieveOptions,
+      RetrieveOptions tagRetrieveOptions) {
+    return ImmutableGetNamedRefsParams.of(baseReference, branchRetrieveOptions, tagRetrieveOptions);
+  }
+
   /**
    * Named reference to use as the base for the computation of {@link
    * ReferenceInfo#getAheadBehind()}. If this parameter is not {@code null}, the given reference
@@ -39,16 +46,19 @@ public interface GetNamedRefsParams {
    * @return name of the base reference. Can be {@code null}, if not needed.
    */
   @Nullable
+  @Value.Parameter(order = 1)
   NamedRef getBaseReference();
 
   /** Whether to retrieve branches, defaults to {@code true}. */
   @Value.Default
+  @Value.Parameter(order = 2)
   default RetrieveOptions getBranchRetrieveOptions() {
     return RetrieveOptions.BARE;
   }
 
   /** Whether to retrieve tags, defaults to {@code true}. */
   @Value.Default
+  @Value.Parameter(order = 3)
   default RetrieveOptions getTagRetrieveOptions() {
     return RetrieveOptions.BARE;
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Key.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Key.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned;
 
 import com.google.common.base.Preconditions;
+import java.util.Arrays;
 import java.util.List;
 import org.immutables.value.Value;
 
@@ -28,6 +29,7 @@ public abstract class Key implements Comparable<Key> {
   /** Maximum number of elemengts. */
   public static final int MAX_ELEMENTS = 20;
 
+  @Value.Parameter(order = 1)
   public abstract List<String> getElements();
 
   static ImmutableKey.Builder builder() {
@@ -72,11 +74,11 @@ public abstract class Key implements Comparable<Key> {
   }
 
   public static Key of(String... elements) {
-    return ImmutableKey.builder().addElements(elements).build();
+    return ImmutableKey.of(Arrays.asList(elements));
   }
 
   public static Key of(List<String> elements) {
-    return ImmutableKey.builder().addAllElements(elements).build();
+    return ImmutableKey.of(elements);
   }
 
   @Value.Check

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/KeyEntry.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/KeyEntry.java
@@ -22,10 +22,13 @@ import org.projectnessie.model.Content;
 public interface KeyEntry {
 
   /** Get the type of this entity. */
+  @Value.Parameter(order = 1)
   Content.Type getType();
 
+  @Value.Parameter(order = 1)
   Key getKey();
 
+  @Value.Parameter(order = 1)
   String getContentId();
 
   static ImmutableKeyEntry.Builder builder() {
@@ -33,6 +36,6 @@ public interface KeyEntry {
   }
 
   static KeyEntry of(Content.Type type, Key key, String contentId) {
-    return builder().type(type).key(key).contentId(contentId).build();
+    return ImmutableKeyEntry.of(type, key, contentId);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/NamedRef.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/NamedRef.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned;
 
 import javax.annotation.Nonnull;
+import org.immutables.value.Value;
 
 /** A ref that has a name. Includes both branches and tags. */
 public interface NamedRef extends Ref {
@@ -26,5 +27,6 @@ public interface NamedRef extends Ref {
    * @return the reference name
    */
   @Nonnull
+  @Value.Parameter(order = 1)
   String getName();
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Operation.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Operation.java
@@ -30,5 +30,6 @@ public interface Operation {
   }
 
   /** The key for this operation. */
+  @Value.Parameter(order = 1)
   Key getKey();
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Put.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Put.java
@@ -24,14 +24,20 @@ import org.projectnessie.model.Content;
 @Value.Immutable
 public interface Put extends Operation {
 
+  @Override
+  @Value.Parameter(order = 1)
+  Key getKey();
+
   /**
    * The value to store for this operation.
    *
    * @return the value
    */
+  @Value.Parameter(order = 2)
   Content getValue();
 
   @Nullable
+  @Value.Parameter(order = 3)
   Content getExpectedValue();
 
   /**
@@ -47,7 +53,7 @@ public interface Put extends Operation {
    */
   @Nonnull
   static Put of(@Nonnull Key key, @Nonnull Content value) {
-    return ImmutablePut.builder().key(key).value(value).build();
+    return ImmutablePut.of(key, value, null);
   }
 
   /**
@@ -65,6 +71,6 @@ public interface Put extends Operation {
    */
   @Nonnull
   static Put of(@Nonnull Key key, @Nonnull Content value, @Nonnull Content expectedValue) {
-    return ImmutablePut.builder().key(key).value(value).expectedValue(expectedValue).build();
+    return ImmutablePut.of(key, value, expectedValue);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceInfo.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceInfo.java
@@ -20,8 +20,10 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface ReferenceInfo<METADATA> {
+  @Value.Parameter(order = 2)
   NamedRef getNamedRef();
 
+  @Value.Parameter(order = 1)
   Hash getHash();
 
   @Value.Default
@@ -56,18 +58,20 @@ public interface ReferenceInfo<METADATA> {
   }
 
   static <METADATA> ReferenceInfo<METADATA> of(Hash hash, NamedRef namedRef) {
-    return ReferenceInfo.<METADATA>builder().namedRef(namedRef).hash(hash).build();
+    return ImmutableReferenceInfo.of(hash, namedRef);
   }
 
   @Value.Immutable
   interface CommitsAheadBehind {
 
+    @Value.Parameter(order = 2)
     int getBehind();
 
+    @Value.Parameter(order = 1)
     int getAhead();
 
     static CommitsAheadBehind of(int ahead, int behind) {
-      return ImmutableCommitsAheadBehind.builder().ahead(ahead).behind(behind).build();
+      return ImmutableCommitsAheadBehind.of(ahead, behind);
     }
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TagName.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TagName.java
@@ -30,6 +30,6 @@ public interface TagName extends NamedRef {
    */
   @Nonnull
   static TagName of(@Nonnull String name) {
-    return ImmutableTagName.builder().name(name).build();
+    return ImmutableTagName.of(name);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Unchanged.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Unchanged.java
@@ -40,6 +40,6 @@ public interface Unchanged extends Operation {
    */
   @Nonnull
   static Unchanged of(@Nonnull Key key) {
-    return ImmutableUnchanged.builder().key(key).build();
+    return ImmutableUnchanged.of(key);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/WithHash.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/WithHash.java
@@ -26,9 +26,11 @@ import org.immutables.value.Value;
 public interface WithHash<T> {
 
   /** Get the value of the hash associated with this commit. */
+  @Value.Parameter(order = 1)
   Hash getHash();
 
   /** Get the value this object wraps. */
+  @Value.Parameter(order = 2)
   T getValue();
 
   /**
@@ -40,6 +42,6 @@ public interface WithHash<T> {
    * @return A new WithHash object.
    */
   public static <T> WithHash<T> of(Hash hash, T value) {
-    return ImmutableWithHash.<T>builder().hash(hash).value(value).build();
+    return ImmutableWithHash.of(hash, value);
   }
 }


### PR DESCRIPTION
Immutables allows the generation of `.of(...)` methods that directly
invoke the constructor, bypassing a temporary builder-object instance
and the required copying.

The simple use cases have been changed in this PR, leaving the use
cases that actually leverage having a "composable builder".