### PR TITLE
Fix issue when looking up key in an open-addressing-key-list

### DIFF
--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestKeyListBuildState.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestKeyListBuildState.java
@@ -51,7 +51,7 @@ public class TestKeyListBuildState {
 
   static Stream<Arguments> keyNotFoundScenarios() {
     return Stream.of(
-        Arguments.of(singletonList(Key.of("existing", "key")), Key.of("non_existing.key"), 0),
+        Arguments.of(singletonList(Key.of("existing", "key")), Key.of("non_existing.key"), 2),
         Arguments.of(
             asList(
                 Key.of("db", "from_spark"),


### PR DESCRIPTION
A rather sad/stupid bug: `FetchValuesUsingOpenAddressing#segment`
used the _modulo_ operation to calculate the open-addressing bucket
index, but `KeyListBuildState#finish` uses binary-_and_.

Updating the code in `FetchValuesUsingOpenAddressing#segment`
fixes the lookup issue.