### PR TITLE
Adopt error-prone-rules to v2.15.0

### DIFF
--- a/codestyle/errorprone-rules.properties
+++ b/codestyle/errorprone-rules.properties
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+# Contains bug patterns up to Error Prone 2.15.0
+
 ####################################################################################################
 # On by default : ERROR
 # See https://errorprone.info/bugpatterns
@@ -364,6 +366,10 @@ MustBeClosedChecker=ERROR
 #NCopiesOfChar=ERROR
 # The first argument to nCopies is the number of copies, and the second is the item to copy
 
+#NoCanIgnoreReturnValueOnClasses=ERROR
+# @CanIgnoreReturnValue should not be applied to classes as it almost always overmatches (as it
+# applies to constructors and all methods), and the CIRVness isn't conferred to its subclasses.
+
 #NonCanonicalStaticImport=ERROR
 # Static import of type uses non-canonical name
 
@@ -372,6 +378,9 @@ MustBeClosedChecker=ERROR
 
 #NonRuntimeAnnotation=ERROR
 # Calling getAnnotation on an annotation that is not retained at runtime.
+
+#NullArgumentForNonNullParameter=ERROR
+# Null is not permitted for this parameter.
 
 #NullTernary=ERROR
 # This conditional expression may evaluate to null, which will result in an NPE when the result is unboxed.
@@ -517,6 +526,9 @@ UnicodeInCode=OFF
 #UnnecessaryTypeArgument=ERROR
 # Non-generic methods should not be invoked with type arguments
 
+#UnsafeWildcard=ERROR
+# Certain wildcard types can confuse the compiler.
+
 #UnusedAnonymousClass=ERROR
 # Instance created but never used
 
@@ -603,11 +615,17 @@ BoxedPrimitiveConstructor=ERROR
 #BugPatternNaming=WARN
 # Giving BugPatterns a name different to the enclosing class can be confusing
 
+#BuilderReturnThis=WARN
+# Builder instance method does not return 'this'
+
 ByteBufferBackingArray=ERROR
 # ByteBuffer.array() shouldn't be called unless ByteBuffer.arrayOffset() is used or if the ByteBuffer was initialized using ByteBuffer.wrap() or ByteBuffer.allocate().
 
 #CacheLoaderNull=WARN
 # The result of CacheLoader#load must be non-null.
+
+CanIgnoreReturnValueSuggester=OFF
+# Methods that always 'return this' should be annotated with @CanIgnoreReturnValue
 
 #CannotMockFinalClass=WARN
 # Mockito cannot mock final classes
@@ -666,6 +684,9 @@ DefaultCharset=ERROR
 #DeprecatedVariable=WARN
 # Applying the @Deprecated annotation to local variables or parameters has no effect
 
+#DirectInvocationOnMock=WARN
+# Methods should not be directly invoked on mocks. Should this be part of a verify(..) call?
+
 DistinctVarargsChecker=ERROR
 # Method expects distinct arguments at some/all positions
 
@@ -713,6 +734,9 @@ EscapedEntity=ERROR
 
 #ExtendingJUnitAssert=WARN
 # When only using JUnit Assert's static methods, you should import statically instead of extending.
+
+#ExtendsObject=WARN
+# `T extends Object` is redundant (unless you are using the Checker Framework).
 
 #FallThrough=WARN
 # Switch case may fall through
@@ -945,6 +969,10 @@ MissingOverride=ERROR
 #ModifiedButNotUsed=WARN
 # A collection or proto builder was created, but its values were never accessed.
 
+#MockNotUsedInProduction=WARN
+# This mock is instantiated and configured, but is never passed to production code. It should be
+# either removed or used.
+
 #ModifyCollectionInEnhancedForLoop=WARN
 # Modifying a collection while iterating over it in a loop may cause a ConcurrentModificationException to be thrown or lead to undefined behavior.
 
@@ -1074,6 +1102,9 @@ Overrides=ERROR
 #SameNameButDifferent=WARN
 # This type name shadows another in a way that may be confusing.
 
+#SelfAlwaysReturnsThis=WARN
+# Non-abstract instance methods named 'self()' that return the enclosing class must always 'return this'.
+
 #ShortCircuitBoolean=WARN
 # Prefer the short-circuiting boolean operators && and || to & and |.
 
@@ -1194,6 +1225,9 @@ UnusedMethod=ERROR
 #UnusedNestedClass=WARN
 # This nested class is unused, and can be removed.
 
+#UnusedTypeParameter=WARN
+# This type parameter is unused and can be removed.
+
 #UnusedVariable=WARN
 # Unused.
 
@@ -1305,6 +1339,9 @@ UseCorrectAssertInTests=ERROR
 
 #BindingToUnqualifiedCommonType=WARN
 # This code declares a binding for a common value type without a Qualifier annotation.
+
+#CannotMockFinalClass=WARN
+# Mockito cannot mock final classes
 
 #CatchingUnchecked=WARN
 # This catch block catches `Exception`, but can only catch unchecked exceptions. Consider catching RuntimeException (or something more specific) instead so it is more apparent that no checked exceptions are being handled.


### PR DESCRIPTION
Add new rules to errorprone-rules.properties.

Disables new `CanIgnoreReturnValueSuggester`, which causes a lot of false-positive warnings.