### PR TITLE
IDE: Also detect Eclipse IDE

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -70,7 +70,10 @@ dependencies {
       api(project(":nessie-spark-extensions-grammar"))
       api(project(":nessie-gc-base"))
 
-      val ideaSyncActive = System.getProperty("idea.sync.active").toBoolean()
+      val ideSyncActive =
+        System.getProperty("idea.sync.active").toBoolean() ||
+          System.getProperty("eclipse.product") != null ||
+          gradle.startParameter.taskNames.any { it.startsWith("eclipse") }
       val sparkVersions = rootProject.extra["sparkVersions"].toString().split(",").map { it.trim() }
       val allScalaVersions = LinkedHashSet<String>()
       for (sparkVersion in sparkVersions) {
@@ -82,18 +85,18 @@ dependencies {
         for (scalaVersion in scalaVersions) {
           allScalaVersions.add(scalaVersion)
           api(project(":nessie-spark-extensions-${sparkVersion}_$scalaVersion"))
-          if (ideaSyncActive) {
+          if (ideSyncActive) {
             break
           }
         }
       }
       for (scalaVersion in allScalaVersions) {
         api(project(":nessie-spark-extensions-base_$scalaVersion"))
-        if (ideaSyncActive) {
+        if (ideSyncActive) {
           break
         }
       }
-      if (!ideaSyncActive) {
+      if (!ideSyncActive) {
         // Relocated projects, to be removed in a future Nessie version
         api(project(":nessie-spark-extensions-base"))
         api(project(":nessie-spark-extensions"))

--- a/buildSrc/src/main/kotlin/nessie-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/nessie-conventions.gradle.kts
@@ -49,6 +49,7 @@ plugins {
   id("org.projectnessie.buildsupport.spotless")
   id("org.projectnessie.buildsupport.errorprone")
   id("org.projectnessie.buildsupport.publishing")
+  `eclipse`
 }
 
 configureJava()

--- a/nessie-iceberg/settings.gradle.kts
+++ b/nessie-iceberg/settings.gradle.kts
@@ -136,7 +136,10 @@ fun loadProjects(file: String) {
   }
 }
 
-val ideaSyncActive = System.getProperty("idea.sync.active").toBoolean()
+val ideSyncActive =
+  System.getProperty("idea.sync.active").toBoolean() ||
+    System.getProperty("eclipse.product") != null ||
+    gradle.startParameter.taskNames.any { it.startsWith("eclipse") }
 
 loadProjects("../gradle/projects.iceberg.properties")
 
@@ -155,7 +158,7 @@ for (sparkVersion in sparkVersions) {
     val artifactId = "nessie-spark-extensions-${sparkVersion}_$scalaVersion"
     nessieProject(artifactId, file("../clients/spark-extensions/v${sparkVersion}")).buildFileName =
       "../build.gradle.kts"
-    if (ideaSyncActive) {
+    if (ideSyncActive) {
       break
     }
   }
@@ -166,12 +169,12 @@ for (scalaVersion in allScalaVersions) {
     "nessie-spark-extensions-base_$scalaVersion",
     file("../clients/spark-extensions-base")
   )
-  if (ideaSyncActive) {
+  if (ideSyncActive) {
     break
   }
 }
 
-if (!ideaSyncActive) {
+if (!ideSyncActive) {
   nessieProject("nessie-spark-extensions", file("../clients/spark-extensions/v3.1")).buildFileName =
     "../build.gradle.kts"
   nessieProject("nessie-spark-3.2-extensions", file("../clients/spark-extensions/v3.2"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -146,13 +146,16 @@ fun loadProjects(file: String) {
 
 loadProjects("gradle/projects.main.properties")
 
-val ideaSyncActive = System.getProperty("idea.sync.active").toBoolean()
+val ideSyncActive =
+  System.getProperty("idea.sync.active").toBoolean() ||
+    System.getProperty("eclipse.product") != null ||
+    gradle.startParameter.taskNames.any { it.startsWith("eclipse") }
 
 // Needed when loading/syncing the whole integrations-tools-testing project with Nessie as an
 // included build. IDEA gets here two times: the first run _does_ have the properties from the
 // integrations-tools-testing build's `gradle.properties` file, while the 2nd invocation only runs
 // from the included build.
-if (gradle.parent != null && ideaSyncActive) {
+if (gradle.parent != null && ideSyncActive) {
   val f = file("./build/additional-build.properties")
   if (f.isFile) {
     System.getProperties().putAll(loadProperties(f))
@@ -178,7 +181,7 @@ if (!System.getProperty("nessie.integrationsTesting.enable").toBoolean()) {
       val artifactId = "nessie-spark-extensions-${sparkVersion}_$scalaVersion"
       nessieProject(artifactId, file("clients/spark-extensions/v${sparkVersion}")).buildFileName =
         "../build.gradle.kts"
-      if (ideaSyncActive) {
+      if (ideSyncActive) {
         break
       }
     }
@@ -189,12 +192,12 @@ if (!System.getProperty("nessie.integrationsTesting.enable").toBoolean()) {
       "nessie-spark-extensions-base_$scalaVersion",
       file("clients/spark-extensions-base")
     )
-    if (ideaSyncActive) {
+    if (ideSyncActive) {
       break
     }
   }
 
-  if (!ideaSyncActive) {
+  if (!ideSyncActive) {
     nessieProject("nessie-spark-extensions", file("clients/spark-extensions/v3.1")).buildFileName =
       "../build.gradle.kts"
     nessieProject("nessie-spark-3.2-extensions", file("clients/spark-extensions/v3.2"))


### PR DESCRIPTION
IDE "detection" currently works fine for IntelliJ, but not for
Eclipse and related (VSCode) IDEs.

Gradle "command line" builds run for all Spark + Scala combinations,
reusing the same source folders for all Scala versions. But IDEs are
quite allergic when one source folder is used for multiple projects.
Therefore only one Scala version (usually 2.12) is "exposed" to IDEs.
This worked fine for IntelliJ, but did not for Eclipse.

This change adds Eclipse to the IDE "detection". (Sadly it has to be
duplicated in a few places.)