### PR TITLE
Minor open-addressing key-list hashing changes

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitLogEntry.java
@@ -70,14 +70,28 @@ public interface CommitLogEntry {
    */
   List<Hash> getKeyListsIds();
 
+  /** The indices of the first occupied bucket in each non-embedded segment of the key list. */
   @Nullable
   List<Integer> getKeyListEntityOffsets();
 
+  /**
+   * Load factor for key lists hashed using open-addressing.
+   *
+   * <p>This is a user-configured value, typically on {@code (0, 1)}. In practice, key lists may be
+   * hashed at a lower effective load factor than configured here (e.g. for alignment), but
+   * generally not a higher one.
+   */
   @Nullable
   Float getKeyListLoadFactor();
 
+  /**
+   * The cumulative total of buckets across all segments.
+   *
+   * <p>This is generally much greater than the segment count. Addressable buckets have indices on
+   * the interval {@code [0, this value)}.
+   */
   @Nullable
-  Integer getKeyListSegmentCount();
+  Integer getKeyListBucketCount();
 
   /** Number of commits since the last complete key-list. */
   int getKeyListDistance();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1254,10 +1254,10 @@ public abstract class AbstractDatabaseAdapter<
     return value;
   }
 
-  /** Calculate the expected size of the given {@link CommitLogEntry} in the database. */
+  /** Calculate the expected size of the given {@link CommitLogEntry} in the database (in bytes). */
   protected abstract int entitySize(CommitLogEntry entry);
 
-  /** Calculate the expected size of the given {@link CommitLogEntry} in the database. */
+  /** Calculate the expected size of the given {@link CommitLogEntry} in the database (in bytes). */
   protected abstract int entitySize(KeyListEntry entry);
 
   /**

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.persist.adapter.spi;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -86,6 +87,14 @@ final class FetchValuesUsingOpenAddressing {
    * for {@code remainingKeys}.
    */
   List<Hash> entityIdsToFetch(int round, int prefetchEntities, Collection<Key> remainingKeys) {
+    // prefetchEntities is user-configurable.  Throw an exception if it is negative, otherwise clamp
+    // the nonnegative value to the range [0, keyListCount-1] = [0, keyListArray.length-1].
+    Preconditions.checkArgument(
+        0 <= prefetchEntities,
+        "Key-list segment prefetch parameter %s cannot be negative",
+        prefetchEntities);
+    prefetchEntities = Math.min(prefetchEntities, keyListCount - 1);
+
     // Identify the key-list segments to fetch
     List<Hash> entitiesToFetch = new ArrayList<>();
     for (Key key : remainingKeys) {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
@@ -94,8 +94,6 @@ final class FetchValuesUsingOpenAddressing {
 
       for (int prefetch = 0; ; prefetch++) {
         if (segment > 0) {
-          checkSegmentIndexValidity(segment, key);
-
           // Decrement accounts for the embedded key-list segment
           int entitySegment = segment - 1;
 
@@ -148,8 +146,6 @@ final class FetchValuesUsingOpenAddressing {
         }
       }
 
-      checkSegmentIndexValidity(segment, key);
-
       KeyListEntry[] keys = keyListsArray[segment];
       for (int i = offsetInSegment; ; i++) {
         KeyListEntry keyListEntry = i < keys.length ? keys[i] : null;
@@ -166,17 +162,5 @@ final class FetchValuesUsingOpenAddressing {
       }
     }
     return keysForNextRound;
-  }
-
-  private void checkSegmentIndexValidity(final int segment, final Key key) {
-    // We expect segmentForKey to wrap in case the current round number is large enough to overrun
-    // the segment list, so this shouldn't happen
-    if (keyListsArray.length <= segment) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected open-addressing key-list segment index between "
-                  + "0 (inclusive) and %s (exclusive), but computed invalid index %s for key %s",
-              keyListsArray.length, segment, key));
-    }
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
@@ -96,8 +96,8 @@ class KeyListBuildState {
    * @throws IllegalArgumentException when {@code v} is outside the accepted range
    */
   static int nextPowerOfTwo(final int v) {
-    Preconditions.checkArgument(0 <= v && v <= (2<<29),
-        "Parameter %s must be between 0 and 2^30 (both inclusive)", v);
+    Preconditions.checkArgument(
+        0 <= v && v <= (2 << 29), "Parameter %s must be between 0 and 2^30 (both inclusive)", v);
     return 1 << (32 - numberOfLeadingZeros(v - 1));
   }
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
@@ -38,7 +38,8 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntry;
  * accessible via {@link CommitLogEntry#getKeyListsIds()}.
  *
  * <p>Commits with {@link CommitLogEntry.KeyListVariant#OPEN_ADDRESSING} are represented as an
- * open-addressing hash map with {@link org.projectnessie.versioned.Key} as the map key.
+ * open-addressing hash map with {@link org.projectnessie.versioned.Key} as the map key. "Bucket"
+ * refers to a cell in this hash map. Collisions are resolved with linear probing.
  *
  * <p>That open-addressing hash map is split into multiple segments, if necessary.
  *
@@ -48,6 +49,12 @@ import org.projectnessie.versioned.persist.adapter.KeyListEntry;
  * DatabaseAdapterConfig#getMaxKeyListEntitySize()} as the goal.
  *
  * <p>Maximum size constraints are fulfilled using a best-effort approach.
+ *
+ * <p>The first segment represented by the embedded key list is always present, even if it contains
+ * no elements. Zero or more non-embedded segments follow this first segment. The total number of
+ * segments is therefore the number of non-embedded segments plus one.
+ *
+ * <p>In general, the number of buckets should be significantly greater than the number of segments.
  *
  * <p>Used by {@link AbstractDatabaseAdapter#buildKeyList(AutoCloseable, CommitLogEntry, Consumer,
  * Function)}.
@@ -86,7 +93,7 @@ class KeyListBuildState {
 
   List<KeyListEntity> finish() {
     // Build open-addressing map
-    int openAddressingBuckets = openAddressingSegments();
+    int openAddressingBuckets = openAddressingBucketCount();
     int openAddressingMask = openAddressingBuckets - 1;
     KeyListEntry[] openAddressingHashMap = new KeyListEntry[openAddressingBuckets];
     for (KeyListEntry entry : entries) {
@@ -114,6 +121,7 @@ class KeyListBuildState {
     List<Integer> offsets = new ArrayList<>();
     List<KeyList> keyLists = new ArrayList<>();
 
+    // The units for both of these segment sizes are bytes
     int segmentSize = 0;
     int maxSegmentSize = maxEmbeddedKeyListSize;
     ImmutableKeyList.Builder keyListBuilder = ImmutableKeyList.builder();
@@ -135,6 +143,7 @@ class KeyListBuildState {
       }
       keyListBuilder.addKeys(entry);
     }
+
     if (segmentSize > 0) {
       // Only add the last key-list-entity if it actually contains entries (not all null)
       keyLists.add(keyListBuilder.build());
@@ -147,7 +156,7 @@ class KeyListBuildState {
       newCommitEntry.keyList(KeyList.EMPTY);
     }
     newCommitEntry.keyListLoadFactor(loadFactor);
-    newCommitEntry.keyListSegmentCount(openAddressingBuckets);
+    newCommitEntry.keyListBucketCount(openAddressingBuckets);
 
     List<KeyListEntity> builtEntities =
         keyLists.stream()
@@ -164,7 +173,7 @@ class KeyListBuildState {
   }
 
   @VisibleForTesting
-  int openAddressingSegments() {
+  int openAddressingBucketCount() {
     return nextPowerOfTwo((int) (entries.size() / loadFactor));
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/KeyListBuildState.java
@@ -19,6 +19,7 @@ import static java.lang.Integer.numberOfLeadingZeros;
 import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.randomHash;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -87,7 +88,16 @@ class KeyListBuildState {
     entries.add(entry);
   }
 
+  /**
+   * Return the least power of two greater than or equal to the parameter.
+   *
+   * <p>This method only supports {@code 0 <= v <= 2^30}.
+   *
+   * @throws IllegalArgumentException when {@code v} is outside the accepted range
+   */
   static int nextPowerOfTwo(final int v) {
+    Preconditions.checkArgument(0 <= v && v <= (2<<29),
+        "Parameter %s must be between 0 and 2^30 (both inclusive)", v);
     return 1 << (32 - numberOfLeadingZeros(v - 1));
   }
 

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestFetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestFetchValuesUsingOpenAddressing.java
@@ -209,14 +209,12 @@ public class TestFetchValuesUsingOpenAddressing {
    */
   @Test
   public void negativeSegmentPrefetchThrowsException() {
-    final int segmentSize = 2;
-    final int segmentCount = 4;
     final int invalidPrefetch = -1;
     final String expectedMessage =
         String.format("Key-list segment prefetch parameter %s cannot be negative", invalidPrefetch);
 
     FetchValuesUsingOpenAddressing fetch =
-        new FetchValuesUsingOpenAddressing(getCommitFixture(segmentSize, segmentCount));
+        new FetchValuesUsingOpenAddressing(getCommitFixture(2, 4));
     assertThatThrownBy(
             () ->
                 fetch.entityIdsToFetch(

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestFetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestFetchValuesUsingOpenAddressing.java
@@ -214,7 +214,7 @@ public class TestFetchValuesUsingOpenAddressing {
         .build();
   }
 
-  /** Convert an int to a hex string, left-padding with 0 until it has even length */
+  /** Convert an int to a hex string, left-padding with 0 until it has even length. */
   private static String intToPaddedHexString(int i) {
     String hexString = Integer.toHexString(i);
     if (1 == hexString.length() % 2) {
@@ -224,7 +224,7 @@ public class TestFetchValuesUsingOpenAddressing {
   }
 
   /**
-   * Builds a fake {@linkplain KeyListEntity}
+   * Builds a fake {@linkplain KeyListEntity}.
    *
    * <p>All keys appearing in this entity have acustom hashCode() that returns {@linkplain
    * Integer#MAX_VALUE}.

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestKeyListBuildState.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestKeyListBuildState.java
@@ -171,12 +171,12 @@ public class TestKeyListBuildState {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = { Integer.MIN_VALUE, -2, -1, (1<<30) + 1, (1<<30) + 2, Integer.MAX_VALUE })
+  @ValueSource(ints = {Integer.MIN_VALUE, -2, -1, (1 << 30) + 1, (1 << 30) + 2, Integer.MAX_VALUE})
   public void nextPowerOfTwoBucketCountException(int invalidParameter) {
     final String expectedMessageFragment = "must be between 0 and 2^30";
     assertThatThrownBy(() -> KeyListBuildState.nextPowerOfTwo(invalidParameter))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining(expectedMessageFragment);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(expectedMessageFragment);
   }
 
   @ParameterizedTest

--- a/versioned/persist/serialize-proto/src/main/proto/persist.proto
+++ b/versioned/persist/serialize-proto/src/main/proto/persist.proto
@@ -43,7 +43,7 @@ message CommitLogEntry {
   // Open-addressing bucket offsets. Same number of elements as key_list_ids.
   repeated int32 key_list_entity_offsets = 13;
   optional float key_list_load_factor = 14;
-  optional int32 key_list_segment_count = 15;
+  optional int32 key_list_bucket_count = 15;
 }
 
 // See CommitLogEntry.KeyListVariant

--- a/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
+++ b/versioned/persist/serialize/src/main/java/org/projectnessie/versioned/persist/adapter/serialize/ProtoSerialization.java
@@ -113,7 +113,7 @@ public final class ProtoSerialization {
     }
     if (entry.getKeyListLoadFactor() != null) {
       proto.setKeyListLoadFactor(entry.getKeyListLoadFactor());
-      proto.setKeyListSegmentCount(entry.getKeyListSegmentCount());
+      proto.setKeyListBucketCount(entry.getKeyListBucketCount());
     }
     entry.getAdditionalParents().forEach(p -> proto.addAdditionalParents(p.asBytes()));
 
@@ -180,7 +180,7 @@ public final class ProtoSerialization {
     proto.getAdditionalParentsList().forEach(p -> entry.addAdditionalParents(Hash.of(p)));
     if (proto.hasKeyListLoadFactor()) {
       entry.keyListLoadFactor(proto.getKeyListLoadFactor());
-      entry.keyListSegmentCount(proto.getKeyListSegmentCount());
+      entry.keyListBucketCount(proto.getKeyListBucketCount());
     }
 
     return entry.build();

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -373,7 +373,7 @@ public abstract class AbstractManyKeys {
    * size-one external key lists after that.
    *
    * <p>This case is covered with greater specificity in {@linkplain
-   * TestFetchValuesUsingOpenAddressing#segmentWrapAround}.
+   * org.projectnessie.versioned.persist.adapter.spi.TestFetchValuesUsingOpenAddressing#segmentWrapAround}.
    */
   @Test
   void pathologicallySmallSegments(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -372,8 +372,9 @@ public abstract class AbstractManyKeys {
    * It just required values small enough to generate a size-zero embedded key list and a series of
    * size-one external key lists after that.
    *
-   * <p>This case is covered with greater specificity in {@linkplain
-   * org.projectnessie.versioned.persist.adapter.spi.TestFetchValuesUsingOpenAddressing#segmentWrapAround}.
+   * <p>This case is covered with greater specificity in the {@code segmentWrapAround*} methods in
+   * {@linkplain
+   * org.projectnessie.versioned.persist.adapter.spi.TestFetchValuesUsingOpenAddressing}.
    */
   @Test
   void pathologicallySmallSegments(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -454,7 +454,7 @@ public abstract class AbstractManyKeys {
     checkKeysAndValuesIndividually(databaseAdapter, head, keyGen, valueGen, keyCount);
   }
 
-  /** Commit once, with puts from applying supplied functions to the ints {@code [0, keyCount)} */
+  /** Commit once, with puts from applying supplied functions to the ints {@code [0, keyCount)}. */
   private static void commitPutsOnGeneratedKeys(
       DatabaseAdapter databaseAdapter,
       BranchName branch,
@@ -477,7 +477,7 @@ public abstract class AbstractManyKeys {
             .build());
   }
 
-  /** Make an empty commit to the supplied branch, {@code commitCount} times */
+  /** Make an empty commit to the supplied branch, {@code commitCount} times. */
   private static Hash makeEmptyCommits(
       DatabaseAdapter databaseAdapter, BranchName toBranch, int commitCount)
       throws ReferenceNotFoundException, ReferenceConflictException {
@@ -495,7 +495,7 @@ public abstract class AbstractManyKeys {
     return head;
   }
 
-  /** Assert that every key and its expected value can be read from the supplied head */
+  /** Assert that every key and its expected value can be read from the supplied head. */
   private static void checkKeysAndValuesIndividually(
       DatabaseAdapter databaseAdapter,
       Hash head,

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -20,8 +20,11 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.spy;
 import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
 
+import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,6 +34,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -42,6 +47,8 @@ import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.GetNamedRefsParams;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.ContentAndState;
 import org.projectnessie.versioned.persist.adapter.ContentId;
@@ -333,6 +340,170 @@ public abstract class AbstractManyKeys {
     }
 
     for (int i = 0; i < keyNum; i++) {
+      Key key = keyGen.apply(i);
+      Map<Key, ContentAndState<ByteString>> values =
+          databaseAdapter.values(
+              head, Collections.singletonList(key), KeyFilterPredicate.ALLOW_ALL);
+      assertThat(values)
+          .extractingByKey(key)
+          .extracting(ContentAndState::getRefState)
+          .isEqualTo(valueGen.apply(i));
+    }
+  }
+
+  /**
+   * Exercise a key list with segments containing one entry each.
+   *
+   * <p>For background, I found that key list goal sizes too small to fit a single entry caused
+   * lookup failures on buckets within the highest-indexed segment.
+   *
+   * <p>When the config parameter max.key.list.size is small or zero, the effective max embedded key
+   * list size computed in {@link AbstractDatabaseAdapter#buildKeyList(AutoCloseable,
+   * CommitLogEntry, Consumer, Function)} can go negative. This makes {@link
+   * org.projectnessie.versioned.persist.adapter.spi.KeyListBuildState} produce a size-zero embedded
+   * key list. If the external key lists also have size 1, then the number of segments exceeds the
+   * number of buckets, which contributes to {@link
+   * org.projectnessie.versioned.persist.adapter.spi.FetchValuesUsingOpenAddressing#segmentForKey(int,
+   * int)} computing the wrong segment index for the final key, since it clamps a segment index to
+   * the bucket index interval. Applying the open-addressing bucket mask to the segment index is
+   * normally a no-op, except in the extreme edge case described above.
+   *
+   * <p>It was possible to induce this bug without setting the goal sizes all the way down to zero.
+   * It just required values small enough to generate a size-zero embedded key list and a series of
+   * size-one external key lists after that.
+   *
+   * <p>This case is covered with greater specificity in {@linkplain
+   * TestFetchValuesUsingOpenAddressing#segmentWrapAround}.
+   */
+  @Test
+  void pathologicallySmallSegments(
+      @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "0")
+          @NessieDbAdapterConfigItem(name = "max.key.list.entity.size", value = "0")
+          @NessieDbAdapterConfigItem(name = "key.list.distance", value = "20")
+          @NessieDbAdapterConfigItem(name = "key.list.hash.load.factor", value = "1.0")
+          @NessieDbAdapter
+          DatabaseAdapter databaseAdapter)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+
+    IntFunction<Key> keyGen = i -> Key.of("k-" + i);
+    IntFunction<ByteString> valueGen = i -> ByteString.copyFromUtf8("value-" + i);
+    BranchName branch = BranchName.of("main");
+
+    // This should be a power of two, so that the entries hashed by KeyListBuildState completely
+    // fill its buckets, but this specific power is an arbitrary choice and not significant.
+    final int keyCount = 4;
+
+    commitPutsOnGeneratedKeys(databaseAdapter, branch, keyGen, valueGen, keyCount);
+
+    Hash head = makeEmptyCommits(databaseAdapter, branch, 20);
+
+    checkKeysAndValuesIndividually(databaseAdapter, head, keyGen, valueGen, keyCount);
+  }
+
+  /**
+   * Test a completely full hashmap where each segment contains two elements.
+   *
+   * <p>This is the integration-test counterpart of the unit-test {@code
+   * TestFetchValuesUsingOpenAddressing#segmentWrapAroundWithPresentKey}.
+   *
+   * <p>When this failed, examining with a debugger showed an attempt to read a key from the final
+   * segment. The read missed in the final segment, though it was present in another segment
+   * (presumably due to all the collisions caused by the undersized table). Code surrounding {@link
+   * org.projectnessie.versioned.persist.adapter.spi.FetchValuesUsingOpenAddressing} would increment
+   * the round-count from zero to one, then retry. This generated a segment index that ran off the
+   * end of the segment space, which {@link
+   * org.projectnessie.versioned.persist.adapter.spi.FetchValuesUsingOpenAddressing#checkForKeys(int,
+   * Collection, Consumer)} would ignore, treating it as a miss, and not including it in the set of
+   * keys to be tried on the next round.
+   *
+   * <p>The figures {@code max.key.list(.entity).size} are hand-picked to leave 130 bytes in both
+   * the embedded segment (after embedded-segment-specific overhead) and the external segments of
+   * the key list. This is brittle, and could be more robustly derived from {@link
+   * AbstractDatabaseAdapter#entitySize(KeyListEntry)}, but I didn't want to widen the visibility
+   * modifier on that just for testing, besides having to configure the store in a way inconsistent
+   * with the rest of this test. It's also brittle in the sense that the adapter implementations
+   * currently serialize and size {@code KeyListEntry} instances in the same way, but that could
+   * theoretically change in the future, in which case there would be no one-size-fits-all set of
+   * annotation values. I was willing to tolerate these drawbacks because, at worst, changes in the
+   * underlying {@code KeyListEntry} serialization that invalidate this test's assumptions could
+   * cause false passage, but could not cause false failure.
+   */
+  @Test
+  void pathologicallyFrequentCollisions(
+      @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "892")
+          @NessieDbAdapterConfigItem(name = "max.key.list.entity.size", value = "130")
+          @NessieDbAdapterConfigItem(name = "key.list.distance", value = "20")
+          @NessieDbAdapterConfigItem(name = "key.list.hash.load.factor", value = "1.0")
+          @NessieDbAdapter
+          DatabaseAdapter databaseAdapter)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+
+    IntFunction<Key> keyGen = i -> Key.of("k-" + i);
+    IntFunction<ByteString> valueGen = i -> ByteString.copyFromUtf8("value-" + i);
+    BranchName branch = BranchName.of("main");
+    // This should be a power of two, so that the entries hashed by KeyListBuildState completely
+    // fill its buckets, but this specific power is an arbitrary choice and not significant.
+    final int keyCount = 128;
+
+    // Prepare keyCount unique keys, then put them in a single commit
+    commitPutsOnGeneratedKeys(databaseAdapter, branch, keyGen, valueGen, keyCount);
+
+    // Repeatedly commit until we exceed the key.list.distance, triggering a key summary
+    Hash head = makeEmptyCommits(databaseAdapter, branch, 20);
+
+    checkKeysAndValuesIndividually(databaseAdapter, head, keyGen, valueGen, keyCount);
+  }
+
+  /** Commit once, with puts from applying supplied functions to the ints {@code [0, keyCount)} */
+  private static void commitPutsOnGeneratedKeys(
+      DatabaseAdapter databaseAdapter,
+      BranchName branch,
+      IntFunction<Key> keyGen,
+      IntFunction<ByteString> valueGen,
+      int keyCount)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    List<KeyWithBytes> keys =
+        IntStream.range(0, keyCount)
+            .mapToObj(
+                i ->
+                    KeyWithBytes.of(
+                        keyGen.apply(i), ContentId.of("cid-" + i), (byte) 0, valueGen.apply(i)))
+            .collect(Collectors.toCollection(() -> new ArrayList<>(keyCount)));
+    databaseAdapter.commit(
+        ImmutableCommitParams.builder()
+            .toBranch(branch)
+            .commitMetaSerialized(ByteString.EMPTY)
+            .addAllPuts(keys)
+            .build());
+  }
+
+  /** Make an empty commit to the supplied branch, {@code commitCount} times */
+  private static Hash makeEmptyCommits(
+      DatabaseAdapter databaseAdapter, BranchName toBranch, int commitCount)
+      throws ReferenceNotFoundException, ReferenceConflictException {
+    Preconditions.checkArgument(0 < commitCount);
+    Hash head = null;
+    for (int i = 0; i < commitCount; i++) {
+      head =
+          databaseAdapter.commit(
+              ImmutableCommitParams.builder()
+                  .toBranch(toBranch)
+                  .commitMetaSerialized(ByteString.EMPTY)
+                  .build());
+    }
+    Preconditions.checkNotNull(head);
+    return head;
+  }
+
+  /** Assert that every key and its expected value can be read from the supplied head */
+  private static void checkKeysAndValuesIndividually(
+      DatabaseAdapter databaseAdapter,
+      Hash head,
+      IntFunction<Key> keyGen,
+      IntFunction<ByteString> valueGen,
+      int keyCount)
+      throws ReferenceNotFoundException {
+    for (int i = 0; i < keyCount; i++) {
       Key key = keyGen.apply(i);
       Map<Key, ContentAndState<ByteString>> values =
           databaseAdapter.values(


### PR DESCRIPTION
Hi @snazy.  Sorry I didn't review #4867 in time.  I saw the review ping, but I was too slow on the turnaround.

The code you wrote for open-addressing hashing of key-lists is clean and fascinating.  To understand the fix you pinged me about, I also looked the hash implementation generally (#4536) for background.  This is very nice.

#4867 looks good to me.  I may have found some minor tangential fixes to complement it.  I think there's basically one meaningful fix in here at most, which is described the first bullet point below.  The rest is either related to nomenclature consistency (bucket vs segment), testing or fixing extremely unlikely edge cases involving severe misconfiguration, or documentation and test additions.

I apologize for the size.  It's mostly tests and comments.  Furthermore, the only (intentional) substantive functionality changes are confined to `FetchValuesUsingOpenAddressing`, where the file-level diffstat is 60 lines.

_(With that, let me switch over to the PR branch's sole commit message, reproduced below)_

This commit makes a cluster of intertwined changes related to storage of keylists using open-addressing hashing:

* Fixes lookups of keys which hash to the highest-indexed segment of an  open-addressed key-list, but which physically reside in another   segment due to collisions (overwhelmingly likely to reside in the  embedded segment).  Also adds a unit test and integration test  exercising this case.  The unit test is  `TestFetchValuesUsingOpenAddressing#segmentWrapAroundWithPresentKey`,  which fails on `FetchValuesUsingOpenAddressing` from main (expect to  fix a method rename when mixing revs though: `getKeyListSegmentCount`  becomes `getKeyListBucketCount` in this commit).

* Attempts to make the word "segment" consistently refer to a collection  of contiguous hashtable cells, corresponding to either the embedded  keylist or a non-embedded keylist entity
* Attempts to make the word "bucket" consistently refer to a single cell  in the virtual keylist hashtable spread across all of the segments.  This extends to persist.proto, where I renamed a field, but did not  alter any tags, so it should remain wire-compatible.

* Made `FetchValuesUsingOpenAddressing#segmentForKey(bucket, round)` stop  clamping segment indices using the open addressing bucket index mask.  Instead, it sums the segment index and round, then applies the  remainder operator using the total segment count (embedded + not) as  the divisor.

* Added tests exercising some pathological edge cases.  Although these  elicited some failures against main, i.e. by checking out  `FetchValuesUsingOpenAddressing` from main, the importance is debatable.  Getting into these states generally requires major misconfiguration.  One case involving segment index overrun exercised by the new  `segmentWrapAround` test method might have come up, but the rest seem  low-probability.

* Made javadoc additions and changes on the read and write paths.