### PR TITLE
Fix missing version from content-generator tool

### DIFF
--- a/tools/content-generator/build.gradle.kts
+++ b/tools/content-generator/build.gradle.kts
@@ -68,3 +68,10 @@ tasks.named<ShadowJar>("shadowJar") {
     attributes["Main-Class"] = "org.projectnessie.tools.contentgenerator.cli.NessieContentGenerator"
   }
 }
+
+tasks.named<Test>("intTest") { systemProperty("expectedNessieVersion", project.version) }
+
+tasks.named<ProcessResources>("processResources") {
+  inputs.property("nessieVersion", project.version)
+  expand("nessieVersion" to project.version)
+}

--- a/tools/content-generator/src/main/resources/org/projectnessie/tools/contentgenerator/cli/version.properties
+++ b/tools/content-generator/src/main/resources/org/projectnessie/tools/contentgenerator/cli/version.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-nessie.version=${nessie.version}
+nessie.version=${nessieVersion}

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITNessieVersion.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITNessieVersion.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ITNessieVersion extends AbstractContentGeneratorTest {
+
+  @Test
+  void nessieVersion() {
+    ProcessResult proc = runGeneratorCmd("-V");
+    assertThat(proc.getExitCode()).isEqualTo(0);
+    List<String> output = proc.getStdOutLines();
+    assertThat(output)
+        .hasSize(1)
+        .anySatisfy(s -> assertThat(s).isEqualTo(System.getProperty("expectedNessieVersion")));
+  }
+}


### PR DESCRIPTION
The content generator tool has a command to print the Nessie version,
which didn't work anymore. This change fixes this.