### PR TITLE
Disable datasource dev services

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -72,6 +72,8 @@ quarkus.datasource.db-kind=postgresql
 #quarkus.datasource.username=<your username>
 #quarkus.datasource.password=<your password>
 #quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/my_database
+# Nessie tests manage PostgreSQL test containers explicitly. Datasource dev services are not necessary.
+quarkus.datasource.devservices.enabled=false
 
 ## RocksDB version store specific configuration
 #nessie.version.store.rocks.db-path=nessie-rocksdb


### PR DESCRIPTION
Quarkus dev services-managed PostgreSQL containers interfere with
running local integration tests multiple times.