### PR TITLE
Automatically add labels for common cases requiring native tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Pull Request Labeler GitHub Action Configuration: https://github.com/marketplace/actions/labeler
+pr-native:
+  # Run native tests on any quarkus-related changes
+  - servers/*quarkus*/**/*
+  # CELUtil wrappers and NessieError are accessed via reflection so their changes need to be tested in native builds.
+  - "**/NessieError.java"
+  - "**/CELUtil.java"

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -1,0 +1,31 @@
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Pull Request Labeler"
+
+on:
+  - pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-20.04
+    steps:
+      # Configured via ../labeler.yml
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Apparently the `pull_request_target` trigger type requires that we merge the change before it can be used (it uses the base of the pull request for running the job)