### PR TITLE
Remove payload from `Content.Type`

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Content.java
+++ b/model/src/main/java/org/projectnessie/model/Content.java
@@ -58,9 +58,6 @@ public abstract class Content {
     /** The name of the content-type. */
     String name();
 
-    /** Payload used for internal serialization (THIS FUNCTION WILL GO AWAY IN A FOLLOW-UP PR!). */
-    byte payload();
-
     Class<? extends Content> type();
   }
 

--- a/model/src/main/java/org/projectnessie/model/types/MainContentTypeBundle.java
+++ b/model/src/main/java/org/projectnessie/model/types/MainContentTypeBundle.java
@@ -29,9 +29,9 @@ public final class MainContentTypeBundle implements ContentTypeBundle {
 
   @Override
   public void register(Registrar registrar) {
-    registrar.register("ICEBERG_TABLE", (byte) 1, IcebergTable.class);
-    registrar.register("DELTA_LAKE_TABLE", (byte) 2, DeltaLakeTable.class);
-    registrar.register("ICEBERG_VIEW", (byte) 3, IcebergView.class);
-    registrar.register("NAMESPACE", (byte) 4, Namespace.class);
+    registrar.register("ICEBERG_TABLE", IcebergTable.class);
+    registrar.register("DELTA_LAKE_TABLE", DeltaLakeTable.class);
+    registrar.register("ICEBERG_VIEW", IcebergView.class);
+    registrar.register("NAMESPACE", Namespace.class);
   }
 }

--- a/servers/quarkus-cli/src/test/java/org/projectnessie/quarkus/cli/ITCheckContent.java
+++ b/servers/quarkus-cli/src/test/java/org/projectnessie/quarkus/cli/ITCheckContent.java
@@ -16,6 +16,7 @@
 package org.projectnessie.quarkus.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 import static org.projectnessie.versioned.testworker.OnRefOnly.onRef;
 
 import com.fasterxml.jackson.databind.JavaType;
@@ -123,7 +124,7 @@ class ITCheckContent {
                 KeyWithBytes.of(
                     k1,
                     ContentId.of("id123"),
-                    Content.Type.ICEBERG_TABLE.payload(),
+                    payloadForContent(Content.Type.ICEBERG_TABLE),
                     ByteString.copyFrom(new byte[] {1, 2, 3})))
             .build());
 
@@ -149,7 +150,7 @@ class ITCheckContent {
 
   private void commit(IcebergTable table, DatabaseAdapter adapter, ByteString serializes)
       throws Exception {
-    commit(table.getId(), table.getType().payload(), serializes, adapter);
+    commit(table.getId(), payloadForContent(table), serializes, adapter);
   }
 
   private void commit(String testId, byte payload, ByteString value, DatabaseAdapter adapter)
@@ -260,7 +261,7 @@ class ITCheckContent {
     ReferenceInfo good = adapter.namedRef("main", GetNamedRefsParams.DEFAULT);
 
     OnRefOnly val = onRef("123", "222");
-    commit(val.getId(), val.getType().payload(), val.serialized(), adapter);
+    commit(val.getId(), payloadForContent(val), val.serialized(), adapter);
 
     launch(launcher, "check-content", "--hash", good.getHash().asString());
     assertThat(entries).hasSize(1);

--- a/servers/store/src/main/java/org/projectnessie/server/store/BaseSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/BaseSerializer.java
@@ -48,11 +48,6 @@ abstract class BaseSerializer<C extends Content> implements ContentSerializer<C>
   }
 
   @Override
-  public boolean requiresGlobalState(byte payload, ByteString onReferenceValue) {
-    return false;
-  }
-
-  @Override
   public C valueFromStore(
       byte payload,
       ByteString onReferenceValue,

--- a/servers/store/src/main/java/org/projectnessie/server/store/DeltaLakeTableSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/DeltaLakeTableSerializer.java
@@ -30,6 +30,11 @@ public final class DeltaLakeTableSerializer extends BaseSerializer<DeltaLakeTabl
   }
 
   @Override
+  public byte payload() {
+    return 2;
+  }
+
+  @Override
   protected void toStoreOnRefState(DeltaLakeTable content, ObjectTypes.Content.Builder builder) {
     ObjectTypes.DeltaLakeTable.Builder table =
         ObjectTypes.DeltaLakeTable.newBuilder()

--- a/servers/store/src/main/java/org/projectnessie/server/store/IcebergTableSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/IcebergTableSerializer.java
@@ -52,7 +52,7 @@ public final class IcebergTableSerializer extends BaseSerializer<IcebergTable> {
   }
 
   @Override
-  public boolean requiresGlobalState(byte payload, ByteString content) {
+  public boolean requiresGlobalState(ByteString content) {
     ObjectTypes.Content parsed = parse(content);
     return !parsed.getIcebergRefState().hasMetadataLocation();
   }

--- a/servers/store/src/main/java/org/projectnessie/server/store/IcebergTableSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/IcebergTableSerializer.java
@@ -29,6 +29,11 @@ public final class IcebergTableSerializer extends BaseSerializer<IcebergTable> {
   }
 
   @Override
+  public byte payload() {
+    return 1;
+  }
+
+  @Override
   protected void toStoreOnRefState(IcebergTable table, ObjectTypes.Content.Builder builder) {
     ObjectTypes.IcebergRefState.Builder stateBuilder =
         ObjectTypes.IcebergRefState.newBuilder()

--- a/servers/store/src/main/java/org/projectnessie/server/store/IcebergViewSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/IcebergViewSerializer.java
@@ -52,7 +52,7 @@ public final class IcebergViewSerializer extends BaseSerializer<IcebergView> {
   }
 
   @Override
-  public boolean requiresGlobalState(byte payload, ByteString content) {
+  public boolean requiresGlobalState(ByteString content) {
     ObjectTypes.Content parsed = parse(content);
     return !parsed.getIcebergViewState().hasMetadataLocation();
   }

--- a/servers/store/src/main/java/org/projectnessie/server/store/IcebergViewSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/IcebergViewSerializer.java
@@ -29,6 +29,11 @@ public final class IcebergViewSerializer extends BaseSerializer<IcebergView> {
   }
 
   @Override
+  public byte payload() {
+    return 3;
+  }
+
+  @Override
   protected void toStoreOnRefState(IcebergView view, ObjectTypes.Content.Builder builder) {
     ObjectTypes.IcebergViewState.Builder stateBuilder =
         ObjectTypes.IcebergViewState.newBuilder()

--- a/servers/store/src/main/java/org/projectnessie/server/store/NamespaceSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/NamespaceSerializer.java
@@ -30,6 +30,11 @@ public final class NamespaceSerializer extends BaseSerializer<Namespace> {
   }
 
   @Override
+  public byte payload() {
+    return 4;
+  }
+
+  @Override
   protected void toStoreOnRefState(Namespace content, ObjectTypes.Content.Builder builder) {
     builder.setNamespace(
         ObjectTypes.Namespace.newBuilder()

--- a/servers/store/src/main/java/org/projectnessie/server/store/UnknownSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/UnknownSerializer.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.server.store;
 
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
+
 import com.google.protobuf.ByteString;
 import java.util.function.Supplier;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.types.ContentTypes;
 import org.projectnessie.server.store.proto.ObjectTypes;
+import org.projectnessie.versioned.store.DefaultStoreWorker;
 
 /**
  * Provides content serialization functionality for the case when old Nessie versions persisted
@@ -30,6 +32,11 @@ public final class UnknownSerializer extends BaseSerializer<Content> {
   @Override
   public Content.Type contentType() {
     return Content.Type.UNKNOWN;
+  }
+
+  @Override
+  public byte payload() {
+    return 0;
   }
 
   @Override
@@ -45,7 +52,7 @@ public final class UnknownSerializer extends BaseSerializer<Content> {
   @Override
   public Content.Type getType(byte payload, ByteString onReferenceValue) {
     if (payload != 0) {
-      return ContentTypes.forPayload(payload);
+      return DefaultStoreWorker.contentTypeForPayload(payload);
     }
 
     ObjectTypes.Content parsed = parse(onReferenceValue);
@@ -69,8 +76,8 @@ public final class UnknownSerializer extends BaseSerializer<Content> {
   @Override
   public boolean requiresGlobalState(byte payload, ByteString content) {
     if (payload != 0
-        && payload != Content.Type.ICEBERG_TABLE.payload()
-        && payload != Content.Type.ICEBERG_VIEW.payload()) {
+        && payload != payloadForContent(Content.Type.ICEBERG_TABLE)
+        && payload != payloadForContent(Content.Type.ICEBERG_VIEW)) {
       return false;
     }
 

--- a/servers/store/src/main/java/org/projectnessie/server/store/UnknownSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/UnknownSerializer.java
@@ -15,13 +15,10 @@
  */
 package org.projectnessie.server.store;
 
-import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
-
 import com.google.protobuf.ByteString;
 import java.util.function.Supplier;
 import org.projectnessie.model.Content;
 import org.projectnessie.server.store.proto.ObjectTypes;
-import org.projectnessie.versioned.store.DefaultStoreWorker;
 
 /**
  * Provides content serialization functionality for the case when old Nessie versions persisted
@@ -50,11 +47,7 @@ public final class UnknownSerializer extends BaseSerializer<Content> {
   }
 
   @Override
-  public Content.Type getType(byte payload, ByteString onReferenceValue) {
-    if (payload != 0) {
-      return DefaultStoreWorker.contentTypeForPayload(payload);
-    }
-
+  public Content.Type getType(ByteString onReferenceValue) {
     ObjectTypes.Content parsed = parse(onReferenceValue);
 
     if (parsed.hasIcebergRefState()) {
@@ -74,13 +67,7 @@ public final class UnknownSerializer extends BaseSerializer<Content> {
   }
 
   @Override
-  public boolean requiresGlobalState(byte payload, ByteString content) {
-    if (payload != 0
-        && payload != payloadForContent(Content.Type.ICEBERG_TABLE)
-        && payload != payloadForContent(Content.Type.ICEBERG_VIEW)) {
-      return false;
-    }
-
+  public boolean requiresGlobalState(ByteString content) {
     ObjectTypes.Content parsed = parse(content);
     switch (parsed.getObjectTypeCase()) {
       case ICEBERG_REF_STATE:

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -18,6 +18,7 @@ package org.projectnessie.server.store;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
@@ -64,7 +65,7 @@ class TestStoreWorker {
     assertThatThrownBy(
             () ->
                 worker.valueFromStore(
-                    Content.Type.ICEBERG_TABLE.payload(),
+                    payloadForContent(Content.Type.ICEBERG_TABLE),
                     ObjectTypes.Content.newBuilder()
                         .setId(CID)
                         .setIcebergRefState(
@@ -85,7 +86,7 @@ class TestStoreWorker {
   void tableMetadataLocationGlobal() {
     Content value =
         worker.valueFromStore(
-            Content.Type.ICEBERG_TABLE.payload(),
+            payloadForContent(Content.Type.ICEBERG_TABLE),
             ObjectTypes.Content.newBuilder()
                 .setId(CID)
                 .setIcebergRefState(
@@ -121,7 +122,7 @@ class TestStoreWorker {
   void tableMetadataLocationOnRef() {
     Content value =
         worker.valueFromStore(
-            Content.Type.ICEBERG_TABLE.payload(),
+            payloadForContent(Content.Type.ICEBERG_TABLE),
             ObjectTypes.Content.newBuilder()
                 .setId(CID)
                 .setIcebergRefState(
@@ -152,7 +153,7 @@ class TestStoreWorker {
     assertThatThrownBy(
             () ->
                 worker.valueFromStore(
-                    Content.Type.ICEBERG_VIEW.payload(),
+                    payloadForContent(Content.Type.ICEBERG_VIEW),
                     ObjectTypes.Content.newBuilder()
                         .setId(CID)
                         .setIcebergViewState(
@@ -169,7 +170,7 @@ class TestStoreWorker {
   void viewMetadataLocationGlobal() {
     Content value =
         worker.valueFromStore(
-            Content.Type.ICEBERG_VIEW.payload(),
+            payloadForContent(Content.Type.ICEBERG_VIEW),
             ObjectTypes.Content.newBuilder()
                 .setId(CID)
                 .setIcebergViewState(ObjectTypes.IcebergViewState.newBuilder().setVersionId(42))
@@ -264,11 +265,11 @@ class TestStoreWorker {
 
     assertThat(onRef)
         .asInstanceOf(InstanceOfAssertFactories.type(ByteString.class))
-        .extracting(onRefContent -> worker.getType(content.getType().payload(), onRefContent))
+        .extracting(onRefContent -> worker.getType(payloadForContent(content), onRefContent))
         .isEqualTo(type);
     assertThat(
             worker.valueFromStore(
-                content.getType().payload(), onRef, () -> global, NO_ATTACHMENTS_RETRIEVER))
+                payloadForContent(content), onRef, () -> global, NO_ATTACHMENTS_RETRIEVER))
         .isEqualTo(content);
 
     assertThat(content)
@@ -282,7 +283,7 @@ class TestStoreWorker {
   void viewMetadataLocationOnRef() {
     Content value =
         worker.valueFromStore(
-            Content.Type.ICEBERG_VIEW.payload(),
+            payloadForContent(Content.Type.ICEBERG_VIEW),
             ObjectTypes.Content.newBuilder()
                 .setId(CID)
                 .setIcebergViewState(
@@ -305,7 +306,7 @@ class TestStoreWorker {
   void testDeserialization(Map.Entry<ByteString, Content> entry) {
     Content actual =
         worker.valueFromStore(
-            entry.getValue().getType().payload(), entry.getKey(), () -> null, x -> Stream.empty());
+            payloadForContent(entry.getValue()), entry.getKey(), () -> null, x -> Stream.empty());
     assertThat(actual).isEqualTo(entry.getValue());
   }
 
@@ -324,11 +325,11 @@ class TestStoreWorker {
         worker.toStoreOnReferenceState(entry.getValue(), ALWAYS_THROWING_ATTACHMENT_CONSUMER);
     assertThat(
             worker.valueFromStore(
-                entry.getValue().getType().payload(), actualBytes, () -> null, x -> Stream.empty()))
+                payloadForContent(entry.getValue()), actualBytes, () -> null, x -> Stream.empty()))
         .isEqualTo(entry.getValue());
     Content actualContent =
         worker.valueFromStore(
-            entry.getValue().getType().payload(), entry.getKey(), () -> null, x -> Stream.empty());
+            payloadForContent(entry.getValue()), entry.getKey(), () -> null, x -> Stream.empty());
     assertThat(worker.toStoreOnReferenceState(actualContent, ALWAYS_THROWING_ATTACHMENT_CONSUMER))
         .isEqualTo(entry.getKey());
   }

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.versioned.persist.store;
 
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
+
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.google.protobuf.ByteString;
@@ -33,7 +35,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
-import org.projectnessie.model.types.ContentTypes;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.CommitMetaSerializer;
@@ -142,7 +143,7 @@ public class PersistVersionStore implements VersionStore {
             KeyWithBytes.of(
                 op.getKey(),
                 contentId,
-                content.getType().payload(),
+                payloadForContent(content),
                 STORE_WORKER.toStoreOnReferenceState(content, commitAttempt::addAttachments)));
 
         if (expected != null) {
@@ -427,7 +428,7 @@ public class PersistVersionStore implements VersionStore {
         .map(
             entry ->
                 KeyEntry.of(
-                    ContentTypes.forPayload(entry.getPayload()),
+                    DefaultStoreWorker.contentTypeForPayload(entry.getPayload()),
                     entry.getKey(),
                     entry.getContentId().getId()));
   }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitLogScan.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitLogScan.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.protobuf.ByteString;
 import java.util.HashMap;
@@ -195,7 +196,7 @@ public abstract class AbstractCommitLogScan {
       ContentId cid = ContentId.of("cid-" + branchName.getName() + "-" + commitNum);
       OnRefOnly c =
           OnRefOnly.onRef("value for #" + commitNum + " in " + branchName.getName(), cid.getId());
-      byte payload = c.getType().payload();
+      byte payload = payloadForContent(c);
 
       head =
           databaseAdapter.commit(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitScenarios.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
 import static org.projectnessie.versioned.testworker.OnRefOnly.onRef;
 
@@ -147,7 +148,7 @@ public abstract class AbstractCommitScenarios {
 
     Content initialContent = newOnRef("initial commit content");
     Content renamContent = OnRefOnly.onRef("rename commit content", initialContent.getId());
-    byte payload = initialContent.getType().payload();
+    byte payload = payloadForContent(initialContent);
 
     commit =
         ImmutableCommitParams.builder()
@@ -280,7 +281,7 @@ public abstract class AbstractCommitScenarios {
           KeyWithBytes.of(
               key,
               ContentId.of(cid),
-              c.getType().payload(),
+              payloadForContent(c),
               DefaultStoreWorker.instance()
                   .toStoreOnReferenceState(c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
     }
@@ -300,7 +301,7 @@ public abstract class AbstractCommitScenarios {
             KeyWithBytes.of(
                 keys.get(i),
                 ContentId.of(cid),
-                newContent.getType().payload(),
+                payloadForContent(newContent),
                 DefaultStoreWorker.instance()
                     .toStoreOnReferenceState(newContent, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
       }
@@ -358,7 +359,7 @@ public abstract class AbstractCommitScenarios {
                 KeyWithBytes.of(
                     key,
                     ContentId.of(cid),
-                    c.getType().payload(),
+                    payloadForContent(c),
                     DefaultStoreWorker.instance()
                         .toStoreOnReferenceState(c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)))
             .putExpectedStates(ContentId.of(cid), Optional.empty())
@@ -377,9 +378,9 @@ public abstract class AbstractCommitScenarios {
 
     OnRefOnly noNo = onRef("no no", contentsId.getId());
     KeyWithBytes createPut1 =
-        KeyWithBytes.of(key, contentsId, noNo.getType().payload(), noNo.serialized());
+        KeyWithBytes.of(key, contentsId, payloadForContent(noNo), noNo.serialized());
     KeyWithBytes createPut2 =
-        KeyWithBytes.of(key, contentsId, tableRef.getType().payload(), tableRefState);
+        KeyWithBytes.of(key, contentsId, payloadForContent(tableRef), tableRefState);
 
     ImmutableCommitParams.Builder commit1 =
         ImmutableCommitParams.builder()
@@ -453,7 +454,7 @@ public abstract class AbstractCommitScenarios {
                 .commitMetaSerialized(ByteString.copyFromUtf8("commit nation"))
                 .addPuts(
                     KeyWithBytes.of(
-                        keyNation, idNation, onRefNation.getType().payload(), stateNation))
+                        keyNation, idNation, payloadForContent(onRefNation), stateNation))
                 .build());
 
     Hash commitRegion =
@@ -464,7 +465,7 @@ public abstract class AbstractCommitScenarios {
                 .commitMetaSerialized(ByteString.copyFromUtf8("commit region"))
                 .addPuts(
                     KeyWithBytes.of(
-                        keyRegion, idRegion, onRefRegion.getType().payload(), stateRegion))
+                        keyRegion, idRegion, payloadForContent(onRefRegion), stateRegion))
                 .build());
 
     List<Key> nonExistentKey = Collections.singletonList(Key.of("non_existent"));
@@ -474,7 +475,7 @@ public abstract class AbstractCommitScenarios {
     assertThat(
             mine.values(
                 commitNation, Collections.singletonList(keyNation), KeyFilterPredicate.ALLOW_ALL))
-        .containsEntry(keyNation, ContentAndState.of(onRefNation.getType().payload(), stateNation));
+        .containsEntry(keyNation, ContentAndState.of(payloadForContent(onRefNation), stateNation));
 
     assertThat(
             mine.values(
@@ -484,7 +485,7 @@ public abstract class AbstractCommitScenarios {
     assertThat(
             mine.values(
                 commitRegion, Collections.singletonList(keyNation), KeyFilterPredicate.ALLOW_ALL))
-        .containsEntry(keyNation, ContentAndState.of(onRefNation.getType().payload(), stateNation));
+        .containsEntry(keyNation, ContentAndState.of(payloadForContent(onRefNation), stateNation));
 
     assertThat(mine.values(commitNation, nonExistentKey, KeyFilterPredicate.ALLOW_ALL)).isEmpty();
     assertThat(mine.values(commitRegion, nonExistentKey, KeyFilterPredicate.ALLOW_ALL)).isEmpty();
@@ -492,7 +493,7 @@ public abstract class AbstractCommitScenarios {
     assertThat(
             mine.values(
                 commitRegion, Arrays.asList(keyNation, keyRegion), KeyFilterPredicate.ALLOW_ALL))
-        .containsEntry(keyNation, ContentAndState.of(onRefNation.getType().payload(), stateNation))
-        .containsEntry(keyRegion, ContentAndState.of(onRefRegion.getType().payload(), stateRegion));
+        .containsEntry(keyNation, ContentAndState.of(payloadForContent(onRefNation), stateNation))
+        .containsEntry(keyRegion, ContentAndState.of(payloadForContent(onRefRegion), stateRegion));
   }
 }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractConcurrency.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.tests;
 import static io.micrometer.core.instrument.Metrics.globalRegistry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.protobuf.ByteString;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -154,7 +155,7 @@ public abstract class AbstractConcurrency {
                         KeyWithBytes.of(
                             keys.get(ki),
                             contentId,
-                            c.getType().payload(),
+                            payloadForContent(c),
                             DefaultStoreWorker.instance()
                                 .toStoreOnReferenceState(c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
                   }
@@ -199,7 +200,7 @@ public abstract class AbstractConcurrency {
               KeyWithBytes.of(
                   k,
                   contentId,
-                  c.getType().payload(),
+                  payloadForContent(c),
                   DefaultStoreWorker.instance()
                       .toStoreOnReferenceState(c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
         }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDiff.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDiff.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.protobuf.ByteString;
 import java.util.Optional;
@@ -65,7 +66,7 @@ public abstract class AbstractDiff {
             KeyWithBytes.of(
                 Key.of("key", Integer.toString(k)),
                 ContentId.of("C" + k),
-                c.getType().payload(),
+                payloadForContent(c),
                 DefaultStoreWorker.instance()
                     .toStoreOnReferenceState(c, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
       }
@@ -95,7 +96,7 @@ public abstract class AbstractDiff {
                           OnRefOnly content =
                               OnRefOnly.onRef("on-ref " + c + " for " + k, "cid-" + c + "-" + k);
                           return Difference.of(
-                              content.getType().payload(),
+                              payloadForContent(content),
                               Key.of("key", Integer.toString(k)),
                               Optional.empty(),
                               Optional.empty(),
@@ -123,7 +124,7 @@ public abstract class AbstractDiff {
                           OnRefOnly content =
                               OnRefOnly.onRef("on-ref " + c + " for " + k, "cid-" + c + "-" + k);
                           return Difference.of(
-                              content.getType().payload(),
+                              payloadForContent(content),
                               Key.of("key", Integer.toString(k)),
                               Optional.empty(),
                               Optional.of(
@@ -154,7 +155,7 @@ public abstract class AbstractDiff {
                           OnRefOnly to =
                               OnRefOnly.onRef("on-ref " + c + " for " + k, "cid-" + c + "-" + k);
                           return Difference.of(
-                              from.getType().payload(),
+                              payloadForContent(from),
                               Key.of("key", Integer.toString(k)),
                               Optional.empty(),
                               Optional.of(

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractEvents.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractEvents.java
@@ -19,6 +19,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
@@ -165,7 +166,7 @@ public abstract class AbstractEvents {
         KeyWithBytes.of(
             Key.of("one", "two"),
             ContentId.of("cid-events-assign"),
-            OnRefOnly.ON_REF_ONLY.payload(),
+            payloadForContent(OnRefOnly.ON_REF_ONLY),
             DefaultStoreWorker.instance()
                 .toStoreOnReferenceState(OnRefOnly.onRef("foo", "cid-events-assign"), att -> {}));
 
@@ -212,7 +213,7 @@ public abstract class AbstractEvents {
         KeyWithBytes.of(
             Key.of("one", "two"),
             ContentId.of("cid-events-commit"),
-            OnRefOnly.ON_REF_ONLY.payload(),
+            payloadForContent(OnRefOnly.ON_REF_ONLY),
             DefaultStoreWorker.instance()
                 .toStoreOnReferenceState(OnRefOnly.onRef("foo", "cid-events-commit"), att -> {}));
 
@@ -265,7 +266,7 @@ public abstract class AbstractEvents {
         KeyWithBytes.of(
             Key.of("one", "two"),
             ContentId.of("cid-events-merge"),
-            OnRefOnly.ON_REF_ONLY.payload(),
+            payloadForContent(OnRefOnly.ON_REF_ONLY),
             DefaultStoreWorker.instance()
                 .toStoreOnReferenceState(OnRefOnly.onRef("foo", "cid-events-merge"), att -> {}));
 
@@ -337,7 +338,7 @@ public abstract class AbstractEvents {
         KeyWithBytes.of(
             Key.of("one", "two"),
             ContentId.of("cid-events-transplant"),
-            OnRefOnly.ON_REF_ONLY.payload(),
+            payloadForContent(OnRefOnly.ON_REF_ONLY),
             DefaultStoreWorker.instance()
                 .toStoreOnReferenceState(
                     OnRefOnly.onRef("foo", "cid-events-transplant"), att -> {}));

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyCommits.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.persist.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
@@ -73,7 +74,7 @@ public abstract class AbstractManyCommits {
     for (int i = 0; i < numCommits; i++) {
       Key key = Key.of("many", "commits", Integer.toString(numCommits));
       OnRefOnly c = OnRefOnly.onRef("value for #" + i + " of " + numCommits, fixed.getId());
-      byte payload = c.getType().payload();
+      byte payload = payloadForContent(c);
       ImmutableCommitParams.Builder commit =
           ImmutableCommitParams.builder()
               .toBranch(branch)
@@ -133,7 +134,7 @@ public abstract class AbstractManyCommits {
       ByteString expectValue =
           DefaultStoreWorker.instance()
               .toStoreOnReferenceState(expected, ALWAYS_THROWING_ATTACHMENT_CONSUMER);
-      ContentAndState expect = ContentAndState.of(expected.getType().payload(), expectValue);
+      ContentAndState expect = ContentAndState.of(payloadForContent(expected), expectValue);
       assertThat(values).containsExactly(Maps.immutableEntry(key, expect));
     } catch (ReferenceNotFoundException e) {
       throw new RuntimeException(e);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.spy;
 import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 import static org.projectnessie.versioned.testworker.OnRefOnly.onRef;
 
 import com.google.common.base.Preconditions;
@@ -134,7 +135,7 @@ public abstract class AbstractManyKeys {
               allKeys.add(key);
               OnRefOnly val = onRef("value " + i, "cid-" + i);
               return KeyWithBytes.of(
-                  key, ContentId.of(val.getId()), val.getType().payload(), val.serialized());
+                  key, ContentId.of(val.getId()), payloadForContent(val), val.serialized());
             })
         .forEach(kb -> commits.get(commitDist.incrementAndGet() % params.commits).addPuts(kb));
 
@@ -209,7 +210,7 @@ public abstract class AbstractManyKeys {
                       KeyWithBytes.of(
                           key,
                           ContentId.of("c" + i),
-                          OnRefOnly.ON_REF_ONLY.payload(),
+                          payloadForContent(OnRefOnly.ON_REF_ONLY),
                           DefaultStoreWorker.instance()
                               .toStoreOnReferenceState(
                                   onRef("r" + i, "c" + i), ALWAYS_THROWING_ATTACHMENT_CONSUMER)))
@@ -269,7 +270,7 @@ public abstract class AbstractManyKeys {
                       KeyWithBytes.of(
                           key,
                           ContentId.of("c" + i),
-                          OnRefOnly.ON_REF_ONLY.payload(),
+                          payloadForContent(OnRefOnly.ON_REF_ONLY),
                           DefaultStoreWorker.instance()
                               .toStoreOnReferenceState(
                                   onRef("pf" + i, "cpf" + i), ALWAYS_THROWING_ATTACHMENT_CONSUMER)))
@@ -337,7 +338,7 @@ public abstract class AbstractManyKeys {
                       KeyWithBytes.of(
                           keyGen.apply(keyNum),
                           ContentId.of(val.getId()),
-                          val.getType().payload(),
+                          payloadForContent(val),
                           val.serialized()))
                   .build());
     }
@@ -474,7 +475,7 @@ public abstract class AbstractManyKeys {
                   return KeyWithBytes.of(
                       keyGen.apply(i),
                       ContentId.of(val.getId()),
-                      val.getType().payload(),
+                      payloadForContent(val),
                       val.serialized());
                 })
             .collect(Collectors.toCollection(() -> new ArrayList<>(keyCount)));

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.projectnessie.versioned.persist.adapter.DatabaseAdapterConfig.DEFAULT_KEY_LIST_DISTANCE;
 import static org.projectnessie.versioned.persist.tests.DatabaseAdapterTestUtils.ALWAYS_THROWING_ATTACHMENT_CONSUMER;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.protobuf.ByteString;
 import java.util.Arrays;
@@ -266,9 +267,9 @@ public abstract class AbstractMergeTransplant {
         ByteString onRef =
             DefaultStoreWorker.instance()
                 .toStoreOnReferenceState(value, ALWAYS_THROWING_ATTACHMENT_CONSUMER);
-        keysAndValue.put(key, ContentAndState.of(value.getType().payload(), onRef));
+        keysAndValue.put(key, ContentAndState.of(payloadForContent(value), onRef));
         commit.addPuts(
-            KeyWithBytes.of(key, ContentId.of("C" + k), value.getType().payload(), onRef));
+            KeyWithBytes.of(key, ContentId.of("C" + k), payloadForContent(value), onRef));
       }
       commits[i] = databaseAdapter.commit(commit.build());
     }
@@ -380,7 +381,7 @@ public abstract class AbstractMergeTransplant {
           KeyWithBytes.of(
               Key.of("key", Integer.toString(k)),
               ContentId.of("C" + k),
-              conflictValue.getType().payload(),
+              payloadForContent(conflictValue),
               DefaultStoreWorker.instance()
                   .toStoreOnReferenceState(conflictValue, ALWAYS_THROWING_ATTACHMENT_CONSUMER)));
     }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractReferences.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 import static org.projectnessie.versioned.testworker.OnRefOnly.onRef;
 
 import com.google.protobuf.ByteString;
@@ -150,7 +151,7 @@ public abstract class AbstractReferences {
                     KeyWithBytes.of(
                         Key.of("foo"),
                         ContentId.of(hello.getId()),
-                        hello.getType().payload(),
+                        payloadForContent(hello),
                         hello.serialized()))
                 .build());
 
@@ -176,7 +177,7 @@ public abstract class AbstractReferences {
                                   KeyWithBytes.of(
                                       Key.of("bar"),
                                       ContentId.of(noNo.getId()),
-                                      noNo.getType().payload(),
+                                      payloadForContent(noNo),
                                       noNo.serialized()))
                               .build());
                     })
@@ -222,7 +223,7 @@ public abstract class AbstractReferences {
                       KeyWithBytes.of(
                           Key.of("bar", Integer.toString(i)),
                           ContentId.of(hello.getId()),
-                          hello.getType().payload(),
+                          payloadForContent(hello),
                           hello.serialized()))
                   .build());
     }
@@ -327,7 +328,7 @@ public abstract class AbstractReferences {
                           KeyWithBytes.of(
                               Key.of("table", "c" + commit),
                               ContentId.of("c" + commit),
-                              OnRefOnly.ON_REF_ONLY.payload(),
+                              payloadForContent(OnRefOnly.ON_REF_ONLY),
                               DefaultStoreWorker.instance()
                                   .toStoreOnReferenceState(
                                       OnRefOnly.newOnRef("c" + commit), att -> {})))

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRepositories.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRepositories.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.persist.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 import static org.projectnessie.versioned.testworker.OnRefOnly.onRef;
 
 import com.google.protobuf.ByteString;
@@ -90,7 +91,7 @@ public abstract class AbstractRepositories {
                 KeyWithBytes.of(
                     Key.of("foo"),
                     ContentId.of(fooValue.getId()),
-                    fooValue.getType().payload(),
+                    payloadForContent(fooValue),
                     fooValue.serialized()))
             .build());
     bar.commit(
@@ -101,7 +102,7 @@ public abstract class AbstractRepositories {
                 KeyWithBytes.of(
                     Key.of("bar"),
                     ContentId.of(barValue.getId()),
-                    barValue.getType().payload(),
+                    payloadForContent(barValue),
                     barValue.serialized()))
             .build());
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializer.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializer.java
@@ -41,9 +41,11 @@ public interface ContentSerializer<C extends Content> {
     return false;
   }
 
-  boolean requiresGlobalState(byte payload, ByteString onReferenceValue);
+  default boolean requiresGlobalState(ByteString onReferenceValue) {
+    return false;
+  }
 
-  default Content.Type getType(byte payload, ByteString onReferenceValue) {
+  default Content.Type getType(ByteString onReferenceValue) {
     return contentType();
   }
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializer.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializer.java
@@ -31,6 +31,8 @@ import org.projectnessie.versioned.ContentAttachmentKey;
 public interface ContentSerializer<C extends Content> {
   Content.Type contentType();
 
+  byte payload();
+
   ByteString toStoreOnReferenceState(C content, Consumer<ContentAttachment> attachmentConsumer);
 
   C applyId(C content, String id);

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/OnRefOnlySerializer.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/OnRefOnlySerializer.java
@@ -34,6 +34,11 @@ public class OnRefOnlySerializer extends TestContentSerializer<OnRefOnly> {
   }
 
   @Override
+  public byte payload() {
+    return 127;
+  }
+
+  @Override
   public ByteString toStoreOnReferenceState(
       OnRefOnly content, Consumer<ContentAttachment> attachmentConsumer) {
     return content.serialized();

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentSerializer.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentSerializer.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.testworker;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.protobuf.ByteString;
 import java.util.function.Function;
@@ -38,14 +39,14 @@ abstract class TestContentSerializer<C extends Content> implements ContentSerial
     }
     String typeString = serialized.substring(0, i);
     Content.Type contentType = ContentTypes.forName(typeString);
-    if (contentType.payload() != payload) {
+    if (payloadForContent(contentType) != payload) {
       throw new AssertionError(
           "Expected payload "
               + payload
               + " != "
               + contentType.name()
               + "'s payload "
-              + contentType.payload());
+              + payloadForContent(contentType));
     }
     return contentType;
   }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentSerializer.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentSerializer.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.testworker;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
 import com.google.protobuf.ByteString;
 import java.util.function.Function;
@@ -31,29 +30,14 @@ import org.projectnessie.versioned.store.ContentSerializer;
 abstract class TestContentSerializer<C extends Content> implements ContentSerializer<C> {
 
   @Override
-  public Content.Type getType(byte payload, ByteString onRefContent) {
+  public Content.Type getType(ByteString onRefContent) {
     String serialized = onRefContent.toStringUtf8();
     int i = serialized.indexOf(':');
     if (i == -1) {
       return OnRefOnly.ON_REF_ONLY;
     }
     String typeString = serialized.substring(0, i);
-    Content.Type contentType = ContentTypes.forName(typeString);
-    if (payloadForContent(contentType) != payload) {
-      throw new AssertionError(
-          "Expected payload "
-              + payload
-              + " != "
-              + contentType.name()
-              + "'s payload "
-              + payloadForContent(contentType));
-    }
-    return contentType;
-  }
-
-  @Override
-  public boolean requiresGlobalState(byte payload, ByteString content) {
-    return false;
+    return ContentTypes.forName(typeString);
   }
 
   @Override

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentTypeBundle.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentTypeBundle.java
@@ -22,7 +22,7 @@ public final class TestContentTypeBundle implements ContentTypeBundle {
 
   @Override
   public void register(Registrar registrar) {
-    registrar.register("ON_REF_ONLY", (byte) 127, OnRefOnly.class);
-    registrar.register("WITH_ATTACHMENTS", (byte) 126, WithAttachmentsContent.class);
+    registrar.register("ON_REF_ONLY", OnRefOnly.class);
+    registrar.register("WITH_ATTACHMENTS", WithAttachmentsContent.class);
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/WithAttachmentsSerializer.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/WithAttachmentsSerializer.java
@@ -35,6 +35,11 @@ public class WithAttachmentsSerializer extends TestContentSerializer<WithAttachm
   }
 
   @Override
+  public byte payload() {
+    return 126;
+  }
+
+  @Override
   public ByteString toStoreOnReferenceState(
       WithAttachmentsContent content, Consumer<ContentAttachment> attachmentConsumer) {
     String value = content.getOnRef();


### PR DESCRIPTION
The payload value is an internal concern and must not be visible to
users of the API.

This PR is split into two commits: one with the actual changes and another with the "boring stuff/changes" implied by the actual changes.

Depends on PRs: #4941 #4942 #4943 #4944

Fixes #4940
