### PR TITLE
Fix OpenAPI spec re-generation

### DIFF
--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -63,7 +63,9 @@ smallryeOpenApi {
   infoLicenseUrl.set("http://www.apache.org/licenses/LICENSE-2.0.html")
   schemaFilename.set("META-INF/openapi/openapi")
   operationIdStrategy.set("METHOD")
-  scanPackages.set(listOf("org.projectnessie.api", "org.projectnessie.model"))
+  scanPackages.set(
+    listOf("org.projectnessie.api", "org.projectnessie.api.http", "org.projectnessie.model")
+  )
 }
 
 val openapi by
@@ -82,9 +84,7 @@ val openapiSource by
 
 val generateOpenApiSpec =
   tasks.named<SmallryeOpenApiTask>("generateOpenApiSpec") {
-    inputs
-      .files("src/main/resources/META-INF/openapi.yaml")
-      .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files("src/main").withPathSensitivity(PathSensitivity.RELATIVE)
   }
 
 artifacts {


### PR DESCRIPTION
Changes to the API interfaces in `:nessie-model` do not correctly
lead to a re-generation of the `openapi.{json|yaml}` files.

This change makes the whole `src/main` tree an input to the Gradle
task generating the OpenAPI spec files.