### PR TITLE
Fix Nessie Web UI build

### DIFF
--- a/ui/src/TableListing/TableListing.tsx
+++ b/ui/src/TableListing/TableListing.tsx
@@ -75,7 +75,7 @@ const fetchKeys = (
 const entryToKey = (entry: Entry): Key => {
   return {
     name: entry.name.elements[entry.name.elements.length - 1],
-    type: entry.type === "NAMESPACE" ? "CONTAINER" : "TABLE",
+    type: "NAMESPACE" === entry.type.toString() ? "CONTAINER" : "TABLE",
     contentKey: entry.name,
   };
 };


### PR DESCRIPTION
Before #4941 `Content.Type` was an enum and also generated as an
enum for JavaScript. Now `Content.type` is a plain string, and
the existing JS code now wrongly assumes that it's still the
previously generated JS enum type `Type`.