### PR TITLE
Fix Quarkus logging during build

### DIFF
--- a/servers/lambda/build.gradle.kts
+++ b/servers/lambda/build.gradle.kts
@@ -105,8 +105,7 @@ tasks.withType<Test>().configureEach {
   systemProperty("quarkus.container-image.build", useDocker)
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
   // TODO requires adjusting the tests - systemProperty("quarkus.http.test-port", "0") -  set this
-  // property in application.properties
-  systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+  //  property in application.properties
 
   val testHeapSize: String? by project
   minHeapSize = if (testHeapSize != null) testHeapSize as String else "256m"

--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -95,7 +95,6 @@ tasks.withType<ProcessResources>().configureEach {
 tasks.withType<Test>().configureEach {
   systemProperty("quarkus.log.level", testLogLevel())
   systemProperty("quarkus.log.console.level", testLogLevel())
-  systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
 
   val testHeapSize: String? by project
   minHeapSize = if (testHeapSize != null) testHeapSize as String else "256m"

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -159,8 +159,7 @@ tasks.withType<Test>().configureEach {
   systemProperty("quarkus.container-image.build", useDocker)
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
   // TODO requires adjusting the tests - systemProperty("quarkus.http.test-port", "0") -  set this
-  // property in application.properties
-  systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+  //  property in application.properties
 
   val testHeapSize: String? by project
   minHeapSize = if (testHeapSize != null) testHeapSize as String else "256m"


### PR DESCRIPTION
Quarkus log messages are currently not properly formatted and look like this:
```
Detected a split package usage which is considered a bad practice and should be avoided. Following packages were detected in multiple archives: %s
```
but should really look like this:
```
WARN: Detected a split package usage which is considered a bad practice and should be avoided. Following packages were detected in multiple archives:
- "org.projectnessie.versioned.persist.mongodb" found in [org.projectnessie:nessie-versioned-persist-mongodb::jar, org.projectnessie:nessie-versioned-persist-mongodb:tests:jar]
```

Turns out that configuring the JBoss LogManager class was wrong, removing the configuration fixes the issue.