### PR TITLE
Revert "build(deps): bump versionSlf4j from 1.7.36 to 2.0.0 (#4967)"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ val versionProtobuf = "3.21.5"
 val versionReactor = "2020.0.21"
 val versionRestAssured = "5.1.1"
 val versionRocksDb = "7.4.5"
-val versionSlf4j = "2.0.0"
+val versionSlf4j = "1.7.36"
 val versionTestcontainers = "1.17.3"
 val versionWeld = "3.1.8.Final"
 


### PR DESCRIPTION
slf4j-api 2 relies on the `ServiceLoader` mechanism, but logback has
no release version supporting this yet. As a consequence, logback is
not found and nothing is logged at the moment. Therefore reverting
the slf4j-api bump to version 2.x.x.

See https://www.slf4j.org/faq.html#changesInVersion200

This reverts commit c4ab93c37d1e6fb0e18d7ff90cf2efea96820734.