### PR TITLE
Remove unnecessary code-coverage usage

### DIFF
--- a/clients/antlr-runtime/build.gradle.kts
+++ b/clients/antlr-runtime/build.gradle.kts
@@ -18,7 +18,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   id("com.github.johnrengelman.shadow")

--- a/clients/spark-antlr-grammar/build.gradle.kts
+++ b/clients/spark-antlr-grammar/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   antlr

--- a/perftest/gatling/build.gradle.kts
+++ b/perftest/gatling/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 plugins {
-  jacoco
   `maven-publish`
   signing
   scala

--- a/perftest/simulations/build.gradle.kts
+++ b/perftest/simulations/build.gradle.kts
@@ -17,7 +17,6 @@
 import io.gatling.gradle.GatlingRunTask
 
 plugins {
-  jacoco
   `maven-publish`
   signing
   id("io.gatling.gradle")

--- a/servers/jax-rs-tests/build.gradle.kts
+++ b/servers/jax-rs-tests/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   `nessie-conventions`

--- a/servers/quarkus-tests/build.gradle.kts
+++ b/servers/quarkus-tests/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   `nessie-conventions`

--- a/servers/store-proto/build.gradle.kts
+++ b/servers/store-proto/build.gradle.kts
@@ -18,7 +18,6 @@ import com.google.protobuf.gradle.protoc
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   id("org.projectnessie.buildsupport.reflectionconfig")

--- a/versioned/persist/bench/build.gradle.kts
+++ b/versioned/persist/bench/build.gradle.kts
@@ -18,7 +18,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   id("com.github.johnrengelman.shadow")

--- a/versioned/persist/serialize-proto/build.gradle.kts
+++ b/versioned/persist/serialize-proto/build.gradle.kts
@@ -18,7 +18,6 @@ import com.google.protobuf.gradle.protoc
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   id("org.projectnessie.buildsupport.reflectionconfig")

--- a/versioned/persist/tests/build.gradle.kts
+++ b/versioned/persist/tests/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   `nessie-conventions`

--- a/versioned/tests/build.gradle.kts
+++ b/versioned/tests/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   `nessie-conventions`


### PR DESCRIPTION
Projects that only contain test classes or only grammar/protobuf specs do not need jacoco at all.