### PR TITLE
Unify Postgres container version declaration for tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,7 @@ val versionParquet = "1.12.3"
 val versionPicocli = "4.6.3"
 val versionPostgres = "42.5.0"
 val versionProtobuf = "3.21.6"
+var versionPostgresContainerTag = "14"
 val versionReactor = "2020.0.21"
 val versionRestAssured = "5.2.0"
 val versionRocksDb = "7.5.3"
@@ -125,6 +126,7 @@ mapOf(
     "versionMicrometer" to versionMicrometer,
     "versionOpentracing" to versionOpentracing,
     "versionProtobuf" to versionProtobuf,
+    "versionPostgresContainerTag" to versionPostgresContainerTag,
     "versionRocksDb" to versionRocksDb,
     "quarkus.builder-image" to "quay.io/quarkus/ubi-quarkus-native-image:22.2-java17"
   )

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -156,6 +156,13 @@ tasks.withType<Test>().configureEach {
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
   // TODO requires adjusting the tests - systemProperty("quarkus.http.test-port", "0") -  set this
   //  property in application.properties
+  systemProperty(
+    "it.nessie.container.postgres.tag",
+    System.getProperty(
+      "it.nessie.container.postgres.tag",
+      dependencyVersion("versionPostgresContainerTag")
+    )
+  )
 }
 
 tasks.named<Test>("intTest") { filter { excludeTestsMatching("ITNative*") } }

--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/PostgresTestResourceLifecycleManager.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/PostgresTestResourceLifecycleManager.java
@@ -38,7 +38,11 @@ public class PostgresTestResourceLifecycleManager
 
   @Override
   public Map<String, String> start() {
-    String version = System.getProperty("it.nessie.container.postgres.tag", "14");
+    String version = System.getProperty("it.nessie.container.postgres.tag");
+    if (version == null) {
+      throw new RuntimeException(
+          "postgres container version is not specified. Please configure it using the system property it.nessie.container.postgres.tag");
+    }
 
     container = new PostgreSQLContainer<>("postgres:" + version).withLogConsumer(outputFrame -> {});
     containerNetworkId.ifPresent(container::withNetworkMode);

--- a/versioned/persist/tx-test/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresTestConnectionProviderSource.java
+++ b/versioned/persist/tx-test/src/main/java/org/projectnessie/versioned/persist/tx/postgres/PostgresTestConnectionProviderSource.java
@@ -34,7 +34,11 @@ public class PostgresTestConnectionProviderSource extends ContainerTestConnectio
 
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {
-    String version = System.getProperty("it.nessie.container.postgres.tag", "14");
+    String version = System.getProperty("it.nessie.container.postgres.tag");
+    if (version == null) {
+      throw new RuntimeException(
+          "postgres container version is not specified. Please configure it using the system property it.nessie.container.postgres.tag");
+    }
     return new PostgreSQLContainer<>("postgres:" + version);
   }
 }

--- a/versioned/persist/tx/build.gradle.kts
+++ b/versioned/persist/tx/build.gradle.kts
@@ -67,4 +67,11 @@ tasks.named<Test>("test") { maxParallelForks = Runtime.getRuntime().availablePro
 
 tasks.named<Test>("intTest") {
   systemProperty("it.nessie.dbs", System.getProperty("it.nessie.dbs", "postgres"))
+  systemProperty(
+    "it.nessie.container.postgres.tag",
+    System.getProperty(
+      "it.nessie.container.postgres.tag",
+      dependencyVersion("versionPostgresContainerTag")
+    )
+  )
 }


### PR DESCRIPTION
The changes made centralizes the [image + tag (version)] declaration of both PostgresTestResourceLifecycleManager and PostgresTestConnectionProviderSource as they both references the same version. 

Fixes #4135