### PR TITLE
Cleanup model reflections

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/reflect/ModelReflections.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/reflect/ModelReflections.java
@@ -17,7 +17,6 @@ package org.projectnessie.quarkus.reflect;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.projectnessie.error.NessieError;
-import org.projectnessie.model.types.ContentTypeIdResolver;
 import org.projectnessie.services.cel.CELUtil;
 
 /**
@@ -33,7 +32,6 @@ import org.projectnessie.services.cel.CELUtil;
       CELUtil.KeyedEntityForCel.class,
       CELUtil.OperationForCel.class,
       CELUtil.ContentForCel.class,
-      CELUtil.KeyEntryForCel.class,
-      ContentTypeIdResolver.class
+      CELUtil.KeyEntryForCel.class
     })
 public abstract class ModelReflections {}


### PR DESCRIPTION
Quarkus 2.12 is now released and used in Nessie, with https://github.com/quarkusio/quarkus/pull/27357

Fixes #4955