### PR TITLE
Build: remove unused `test.jar`s

### DIFF
--- a/clients/client/build.gradle.kts
+++ b/clients/client/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
   `maven-publish`
   signing
   `nessie-conventions`
-  id("org.projectnessie.buildsupport.attach-test-jar")
 }
 
 extra["maven.name"] = "Nessie - Client"

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -23,7 +23,6 @@ plugins {
   signing
   id("org.projectnessie.smallrye-open-api")
   `nessie-conventions`
-  id("org.projectnessie.buildsupport.attach-test-jar")
 }
 
 dependencies {


### PR DESCRIPTION
`nessie-model` + `nessie-client` generate Maven test jars, which
are never used.

Related: #4954