### PR TITLE
Update `DatabaseAdapter` with functionality for export/import

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -399,7 +399,7 @@ public interface DatabaseAdapter {
    * Populates the aggregated key-list for the given {@code entry} and returns it.
    *
    * @param entry the {@link CommitLogEntry} to build the aggregated key list for
-   * @param inMemoryCommits when
+   * @param inMemoryCommits function to retrieve not-yet-written commit-log-entries
    * @return commit-log-entry with the aggregated key-list. The returned {@link CommitLogEntry} has
    *     not been persisted.
    */

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -209,7 +209,7 @@ public abstract class AbstractDatabaseAdapter<
   }
 
   @Override
-  public CommitLogEntry modifyCommitLogEntryWithKeyList(
+  public CommitLogEntry rebuildKeyList(
       CommitLogEntry entry, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
     try (OP_CONTEXT ctx = borrowConnection()) {
@@ -1677,7 +1677,7 @@ public abstract class AbstractDatabaseAdapter<
 
   protected final void writeMultipleCommits(OP_CONTEXT ctx, List<CommitLogEntry> entries)
       throws ReferenceConflictException {
-    try (Traced ignore = trace("writeMultipleCommits")) {
+    try (Traced ignore = trace("writeMultipleCommits").tag(TAG_COUNT, entries.size())) {
       doWriteMultipleCommits(ctx, entries);
     }
   }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/BatchSpliterator.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/BatchSpliterator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.nontx;
+package org.projectnessie.versioned.persist.adapter.spi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,8 +22,13 @@ import java.util.Spliterators;
 import java.util.Spliterators.AbstractSpliterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
-final class BatchSpliterator<SRC, DST> extends AbstractSpliterator<DST> {
+/**
+ * Helper to implement batched retrieval of {@code DST} elements using a stream of keys of type
+ * {@code SRC}, or batched mapping of {@code SRC} to {@code DST}.
+ */
+public final class BatchSpliterator<SRC, DST> extends AbstractSpliterator<DST> {
 
   private final Spliterator<SRC> source;
   private final int batchSize;
@@ -46,7 +51,15 @@ final class BatchSpliterator<SRC, DST> extends AbstractSpliterator<DST> {
 
   private Spliterator<DST> mapped = Spliterators.emptySpliterator();
 
-  BatchSpliterator(
+  public BatchSpliterator(
+      int batchSize,
+      Stream<SRC> source,
+      Function<List<SRC>, Spliterator<DST>> batchMapper,
+      int characteristics) {
+    this(batchSize, source.spliterator(), batchMapper, characteristics);
+  }
+
+  public BatchSpliterator(
       int batchSize,
       Spliterator<SRC> source,
       Function<List<SRC>, Spliterator<DST>> batchMapper,

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -112,7 +112,7 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
 
   @Override
   public Stream<CommitLogEntry> fetchCommitLogEntries(Stream<Hash> hashes) {
-    try (Traced ignore = trace("fetchCommitLogEntries")) {
+    try (Traced ignore = trace("fetchCommitLogEntries.stream")) {
       return delegate.fetchCommitLogEntries(hashes);
     }
   }
@@ -315,12 +315,11 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
   }
 
   @Override
-  public CommitLogEntry modifyCommitLogEntryWithKeyList(
+  public CommitLogEntry rebuildKeyList(
       CommitLogEntry entry, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
-    try (Traced ignore =
-        trace("updateCommitLogEntryWithKeyList").tag(TAG_HASH, entry.getHash().asString())) {
-      return delegate.modifyCommitLogEntryWithKeyList(entry, inMemoryCommits);
+    try (Traced ignore = trace("rebuildKeyList").tag(TAG_HASH, entry.getHash().asString())) {
+      return delegate.rebuildKeyList(entry, inMemoryCommits);
     }
   }
 }

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestBatchSpliterator.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestBatchSpliterator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.persist.nontx;
+package org.projectnessie.versioned.persist.adapter.spi;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,7 +58,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(0, 0).boxed().spliterator(),
+            IntStream.range(0, 0).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -73,7 +73,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().spliterator(),
+            IntStream.range(10, 20).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -89,7 +89,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().spliterator(),
+            IntStream.range(10, 20).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -105,7 +105,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().spliterator(),
+            IntStream.range(10, 20).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -121,7 +121,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().spliterator(),
+            IntStream.range(10, 20).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -137,7 +137,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().spliterator(),
+            IntStream.range(10, 20).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -153,7 +153,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().spliterator(),
+            IntStream.range(10, 20).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -170,7 +170,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().spliterator(),
+            IntStream.range(10, 20).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -189,7 +189,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().spliterator(),
+            IntStream.range(10, 20).boxed(),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -208,7 +208,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().skip(4).spliterator(),
+            IntStream.range(10, 20).boxed().skip(4),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 
@@ -226,7 +226,7 @@ public class TestBatchSpliterator {
     BatchSpliterator<Integer, String> batchSpliterator =
         new BatchSpliterator<>(
             3,
-            IntStream.range(10, 20).boxed().skip(4).limit(5).spliterator(),
+            IntStream.range(10, 20).boxed().skip(4).limit(5),
             intMapper,
             Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.IMMUTABLE);
 

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -252,6 +252,16 @@ public class DynamoDatabaseAdapter
   @Override
   protected void doWriteMultipleCommits(
       NonTransactionalOperationContext ctx, List<CommitLogEntry> entries) {
+    persistMultipleCommits(entries);
+  }
+
+  @Override
+  protected void doUpdateMultipleCommits(
+      NonTransactionalOperationContext ctx, List<CommitLogEntry> entries) {
+    persistMultipleCommits(entries);
+  }
+
+  private void persistMultipleCommits(List<CommitLogEntry> entries) {
     batchWrite(
         TABLE_COMMIT_LOG,
         entries,

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryDatabaseAdapter.java
@@ -298,6 +298,17 @@ public class InmemoryDatabaseAdapter
   }
 
   @Override
+  protected void doUpdateMultipleCommits(
+      NonTransactionalOperationContext ctx, List<CommitLogEntry> entries)
+      throws ReferenceNotFoundException {
+    for (CommitLogEntry entry : entries) {
+      if (store.commitLog.replace(dbKey(entry.getHash()), toProto(entry).toByteString()) == null) {
+        throw referenceNotFound(entry.getHash());
+      }
+    }
+  }
+
+  @Override
   protected List<ReferenceNames> doFetchReferenceNames(
       NonTransactionalOperationContext ctx, int segment, int prefetchSegments) {
     return IntStream.rangeClosed(segment, segment + prefetchSegments)

--- a/versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/TestDatabaseAdapterInmemory.java
+++ b/versioned/persist/inmem/src/test/java/org/projectnessie/versioned/persist/inmem/TestDatabaseAdapterInmemory.java
@@ -19,4 +19,9 @@ import org.projectnessie.versioned.persist.nontx.AbstractNonTxDatabaseAdapterTes
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
-class TestDatabaseAdapterInmemory extends AbstractNonTxDatabaseAdapterTest {}
+class TestDatabaseAdapterInmemory extends AbstractNonTxDatabaseAdapterTest {
+  @Override
+  protected boolean commitWritesValidated() {
+    return true;
+  }
+}

--- a/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/ITDatabaseAdapterMongo.java
+++ b/versioned/persist/mongodb/src/test/java/org/projectnessie/versioned/persist/mongodb/ITDatabaseAdapterMongo.java
@@ -21,4 +21,10 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
 
 @NessieExternalDatabase(LocalMongoTestConnectionProviderSource.class)
 public class ITDatabaseAdapterMongo extends AbstractNonTxDatabaseAdapterTest
-    implements LongerCommitTimeouts {}
+    implements LongerCommitTimeouts {
+
+  @Override
+  protected boolean commitWritesValidated() {
+    return true;
+  }
+}

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -180,6 +180,16 @@ public class RocksDatabaseAdapter
   @Override
   protected void doWriteMultipleCommits(
       NonTransactionalOperationContext ctx, List<CommitLogEntry> entries) {
+    persistMultipleCommits(entries);
+  }
+
+  @Override
+  protected void doUpdateMultipleCommits(
+      NonTransactionalOperationContext ctx, List<CommitLogEntry> entries) {
+    persistMultipleCommits(entries);
+  }
+
+  private void persistMultipleCommits(List<CommitLogEntry> entries) {
     Lock lock = dbInstance.getLock().writeLock();
     lock.lock();
     try {

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitLogScan.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractCommitLogScan.java
@@ -109,7 +109,8 @@ public abstract class AbstractCommitLogScan {
 
     ReferencesUtil referencesUtil = ReferencesUtil.forDatabaseAdapter(databaseAdapter);
 
-    HeadsAndForkPoints headsAndForkPoints = referencesUtil.identifyAllHeadsAndForkPoints(100);
+    HeadsAndForkPoints headsAndForkPoints =
+        referencesUtil.identifyAllHeadsAndForkPoints(100, e -> {});
 
     ReferencedAndUnreferencedHeads refAndUnref =
         referencesUtil.identifyReferencedAndUnreferencedHeads(headsAndForkPoints);

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterTest.java
@@ -33,6 +33,10 @@ import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterConfig
 public abstract class AbstractDatabaseAdapterTest {
   @NessieDbAdapter protected static DatabaseAdapter databaseAdapter;
 
+  protected boolean commitWritesValidated() {
+    return false;
+  }
+
   @Nested
   @SuppressWarnings("ClassCanBeStatic")
   public class CommitLogScan extends AbstractCommitLogScan {
@@ -70,6 +74,14 @@ public abstract class AbstractDatabaseAdapterTest {
   public class ManyCommits extends AbstractManyCommits {
     ManyCommits() {
       super(databaseAdapter);
+    }
+  }
+
+  @Nested
+  @SuppressWarnings("ClassCanBeStatic")
+  public class WriteUpdateCommits extends AbstractWriteUpdateCommits {
+    WriteUpdateCommits() {
+      super(databaseAdapter, commitWritesValidated());
     }
   }
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractWriteUpdateCommits.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractWriteUpdateCommits.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.persist.tests;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import com.google.protobuf.ByteString;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitLogEntry;
+
+public abstract class AbstractWriteUpdateCommits {
+
+  private final DatabaseAdapter databaseAdapter;
+  private final boolean commitWritesValidated;
+
+  protected AbstractWriteUpdateCommits(
+      DatabaseAdapter databaseAdapter, boolean commitWritesValidated) {
+    this.databaseAdapter = databaseAdapter;
+    this.commitWritesValidated = commitWritesValidated;
+  }
+
+  Hash intAsHash(int i) {
+    return Hash.of(String.format("%08x", i));
+  }
+
+  private CommitLogEntry helloCommit(int i) {
+    return CommitLogEntry.of(
+        i,
+        intAsHash(i),
+        i,
+        singletonList(intAsHash(i - 1)),
+        ByteString.copyFromUtf8("hello " + i),
+        emptyList(),
+        emptyList(),
+        0,
+        null,
+        emptyList(),
+        emptyList(),
+        emptyList());
+  }
+
+  @Test
+  void writeMultipleCommits() throws Exception {
+    List<Hash> hashes =
+        IntStream.rangeClosed(1, 10).mapToObj(this::intAsHash).collect(Collectors.toList());
+    List<CommitLogEntry> commits =
+        hashes.stream()
+            .mapToInt(h -> Integer.parseInt(h.asString(), 16))
+            .mapToObj(this::helloCommit)
+            .collect(Collectors.toList());
+
+    databaseAdapter.writeMultipleCommits(commits);
+
+    try (Stream<CommitLogEntry> retrieved =
+        databaseAdapter.fetchCommitLogEntries(hashes.stream())) {
+      assertThat(retrieved).containsExactlyInAnyOrderElementsOf(commits);
+    }
+
+    List<CommitLogEntry> updatedCommits =
+        commits.stream()
+            .map(
+                commit ->
+                    ImmutableCommitLogEntry.builder()
+                        .from(commit)
+                        .metadata(ByteString.copyFromUtf8("updated " + commit.getHash().asString()))
+                        .build())
+            .collect(Collectors.toList());
+
+    databaseAdapter.updateMultipleCommits(updatedCommits);
+
+    try (Stream<CommitLogEntry> retrieved =
+        databaseAdapter.fetchCommitLogEntries(hashes.stream())) {
+      assertThat(retrieved).containsExactlyInAnyOrderElementsOf(updatedCommits);
+    }
+  }
+
+  @Test
+  void validateWriteUpdateCommitPreconditions() throws Exception {
+    assumeThat(commitWritesValidated).isTrue();
+
+    List<Hash> hashes =
+        IntStream.rangeClosed(1, 10).mapToObj(this::intAsHash).collect(Collectors.toList());
+    List<CommitLogEntry> commits =
+        hashes.stream()
+            .mapToInt(h -> Integer.parseInt(h.asString(), 16))
+            .mapToObj(this::helloCommit)
+            .collect(Collectors.toList());
+
+    databaseAdapter.writeMultipleCommits(commits.subList(0, 2));
+    assertThatThrownBy(() -> databaseAdapter.writeMultipleCommits(commits.subList(0, 2)))
+        .isInstanceOf(ReferenceConflictException.class);
+
+    assertThatThrownBy(() -> databaseAdapter.updateMultipleCommits(commits))
+        .isInstanceOf(ReferenceNotFoundException.class);
+  }
+}

--- a/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
+++ b/versioned/persist/tx/src/main/java/org/projectnessie/versioned/persist/tx/SqlStatements.java
@@ -104,6 +104,9 @@ public final class SqlStatements {
   public static final String INSERT_COMMIT_LOG =
       String.format(
           "INSERT INTO %s (\"repo_id\", \"hash\", \"value\") VALUES (?, ?, ?)", TABLE_COMMIT_LOG);
+  public static final String UPDATE_COMMIT_LOG =
+      String.format(
+          "UPDATE %s SET \"value\" = ? WHERE \"repo_id\" = ? AND \"hash\" = ?", TABLE_COMMIT_LOG);
   public static final String SELECT_COMMIT_LOG_FULL =
       String.format("SELECT \"value\" FROM %s WHERE \"repo_id\" = ?", TABLE_COMMIT_LOG);
   public static final String SELECT_COMMIT_LOG_MANY =

--- a/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/AbstractTxDatabaseAdapterTest.java
+++ b/versioned/persist/tx/src/test/java/org/projectnessie/versioned/persist/tx/AbstractTxDatabaseAdapterTest.java
@@ -25,6 +25,12 @@ import org.projectnessie.versioned.persist.tests.AbstractDatabaseAdapterTest;
 import org.projectnessie.versioned.persist.tx.TxDatabaseAdapter.NessieSqlDataType;
 
 public abstract class AbstractTxDatabaseAdapterTest extends AbstractDatabaseAdapterTest {
+
+  @Override
+  protected boolean commitWritesValidated() {
+    return true;
+  }
+
   @Test
   void insertOnConflict() throws Exception {
     TxDatabaseAdapter txDatabaseAdapter = (TxDatabaseAdapter) databaseAdapter;


### PR DESCRIPTION
* Fetch multiple commit-log-entries
* Write multiple commit-log-entries
* Update (multiple) commit-log-entries
* Add aggregated key-list to a commit-log-entry