### PR TITLE
Workaround OOMs during Quarkus test runs

### DIFF
--- a/buildSrc/src/main/kotlin/nessie-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/nessie-conventions.gradle.kts
@@ -101,10 +101,6 @@ fun Project.testTasks() {
       if (testJvmArgs != null) {
         jvmArgs((testJvmArgs as String).split(" "))
       }
-      if (testHeapSize != null) {
-        setMinHeapSize(testHeapSize)
-        setMaxHeapSize(testHeapSize)
-      }
 
       systemProperty("file.encoding", "UTF-8")
       systemProperty("user.language", "en")
@@ -126,6 +122,19 @@ fun Project.testTasks() {
       }
       if (name != "test") {
         mustRunAfter(tasks.named<Test>("test"))
+      }
+
+      if (plugins.withType<QuarkusPlugin>().isNotEmpty()) {
+        jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+        systemProperty("quarkus.log.level", testLogLevel())
+        systemProperty("quarkus.log.console.level", testLogLevel())
+        systemProperty("http.access.log.level", testLogLevel())
+
+        minHeapSize = if (testHeapSize != null) testHeapSize as String else "512m"
+        maxHeapSize = if (testHeapSize != null) testHeapSize as String else "1536m"
+      } else if (testHeapSize != null) {
+        setMinHeapSize(testHeapSize)
+        setMaxHeapSize(testHeapSize)
       }
     }
     val intTest =

--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -92,15 +92,6 @@ tasks.withType<ProcessResources>().configureEach {
   }
 }
 
-tasks.withType<Test>().configureEach {
-  systemProperty("quarkus.log.level", testLogLevel())
-  systemProperty("quarkus.log.console.level", testLogLevel())
-
-  val testHeapSize: String? by project
-  minHeapSize = if (testHeapSize != null) testHeapSize as String else "256m"
-  maxHeapSize = if (testHeapSize != null) testHeapSize as String else "1024m"
-}
-
 // nessie-quarkus-cli module needs to be adopted before we can generate a native runner
 project.extra["quarkus.package.type"] =
   if (withUberJar() || project.hasProperty("native")) "uber-jar" else "fast-jar"

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -150,10 +150,6 @@ val quarkusBuild =
   }
 
 tasks.withType<Test>().configureEach {
-  jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
-  systemProperty("quarkus.log.level", testLogLevel())
-  systemProperty("quarkus.log.console.level", testLogLevel())
-  systemProperty("http.access.log.level", testLogLevel())
   if (project.hasProperty("native")) {
     systemProperty("native.image.path", quarkusBuild.get().nativeRunner)
   }
@@ -161,10 +157,6 @@ tasks.withType<Test>().configureEach {
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
   // TODO requires adjusting the tests - systemProperty("quarkus.http.test-port", "0") -  set this
   //  property in application.properties
-
-  val testHeapSize: String? by project
-  minHeapSize = if (testHeapSize != null) testHeapSize as String else "256m"
-  maxHeapSize = if (testHeapSize != null) testHeapSize as String else "1024m"
 }
 
 tasks.named<Test>("intTest") { filter { excludeTestsMatching("ITNative*") } }


### PR DESCRIPTION
A recent PR CI run timed out, because of OOMs during
`:nessie-quarkus-cli:intTest`. This is reproducible locally, and
investigating some heap and thread dumps showed that the heap
pressure is actually caused by jacoco/class-instrumentation, which
reads many jar files. This might be a combination of Quarkus class
loading and jacoco instrumentation.

TL;DR the code added to `:nessie-quarkus-cli` caused more code to
instrumented, which led to the increased heap pressure, which in
turn caused the OOMs.

The default heap sizes for Quarkus tests is 256m..1024m. This
change bumps those values to 512m..1536m and moves that
configuration to `nessie-conventions`.

Note: the heap size for tests can also be controlled manually
using for example `-PtestHeapSize=2g` on the command line.