### PR TITLE
picocli loses output to stdout

### DIFF
--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/NessieContentGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/NessieContentGenerator.java
@@ -73,6 +73,11 @@ public class NessieContentGenerator extends ContentGenerator<NessieApiV1> {
     if (null != out) {
       commandLine = commandLine.setOut(out);
     }
-    return commandLine.execute(arguments);
+    try {
+      return commandLine.execute(arguments);
+    } finally {
+      commandLine.getOut().flush();
+      commandLine.getErr().flush();
+    }
   }
 }


### PR DESCRIPTION
The default `PrintWriter`s created by picocli are derived from
`System.out/err`, but sadly not flushed when a command finishes.

This change adds "safety flush".