### PR TITLE
Simulate puts against large existing keysets

### DIFF
--- a/perftest/simulations/README.md
+++ b/perftest/simulations/README.md
@@ -92,16 +92,17 @@ as in most cases, returned form the actions' code.
 
 ## Running a single Nessie Gatling simulation
 
-Gatling's Gradle plugin recognizes tasks in the form `gatlingRun-<fqcn>`, where `<fqcn>` is a dot-separated package-and-classname.  For instance, to run `KeyListSpillingSimulation` from this directory, execute:
+Gatling's Gradle plugin recognizes tasks in the form `gatlingRun-<fqcn>`, where `<fqcn>` is a dot-separated package-and-classname.  For instance, to run `KeyListSpillingSimulation` from the top-level project directory, execute:
 
 ```
-../../gradlew gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation
+./gradlew :nessie-perftest-simulations:gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation
+
 ```
 
 The simluations in this package take most configuration as JVM system properties passed to the `gradlew` wrapper command.  An example follows.  The `sim.` prefix on properties is pure convention.  Simulations could define properties with arbitrary names.
 
 ```
-../../gradlew gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
+./gradlew :nessie-perftest-simulations:gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
 	-Dsim.putsPerBaseCommit=1000 \
 	-Dsim.duration.seconds=60 \
 	-Dsim.putsPerTestCommit=1
@@ -110,14 +111,14 @@ The simluations in this package take most configuration as JVM system properties
 This works for other system properties related to client configuration.  For instance, to point the Gatling simulation's Nessie client at a different backend than the Quarkus instance started by the task's dependencies, pass `-Dnessie.uri=...`, e.g.:
 
 ```
-../../gradlew gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
+./gradlew :nessie-perftest-simulations:gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
 	-Dnessie.uri=http://127.0.0.1:19120/api/v1
 ```
 
 The system property `gatling.logLevel` is also specifically checked in build.gradle.kts.  When `-Dgatling.logLevel=...` is passed to the `gradlew` wrapper command, its value will be configured as the logLevel parameter on Gatling's Gradle plugin, changing what Gatling and the simulation logs.  This has no effect on the Nessie/server side.  This check is unique to `gatling.logLevel`; the plugin has other parameters that can't be configured this way, as of the time of writing.
 
 ```
-../../gradlew gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
+./gradlew :nessie-perftest-simulations:gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
 	-Dgatling.logLevel=DEBUG
 ```
 

--- a/perftest/simulations/README.md
+++ b/perftest/simulations/README.md
@@ -90,6 +90,37 @@ Important note: The Gatling `Session` object is _immutable_! This means, when yo
 to the `Session`, you receive a cloned object, which needs to be passed downstream in your code or,
 as in most cases, returned form the actions' code.
 
+## Running a single Nessie Gatling simulation
+
+Gatling's Gradle plugin recognizes tasks in the form `gatlingRun-<fqcn>`, where `<fqcn>` is a dot-separated package-and-classname.  For instance, to run `KeyListSpillingSimulation` from this directory, execute:
+
+```
+../../gradlew gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation
+```
+
+The simluations in this package take most configuration as JVM system properties passed to the `gradlew` wrapper command.  An example follows.  The `sim.` prefix on properties is pure convention.  Simulations could define properties with arbitrary names.
+
+```
+../../gradlew gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
+	-Dsim.putsPerBaseCommit=1000 \
+	-Dsim.duration.seconds=60 \
+	-Dsim.putsPerTestCommit=1
+```
+
+This works for other system properties related to client configuration.  For instance, to point the Gatling simulation's Nessie client at a different backend than the Quarkus instance started by the task's dependencies, pass `-Dnessie.uri=...`, e.g.:
+
+```
+../../gradlew gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
+	-Dnessie.uri=http://127.0.0.1:19120/api/v1
+```
+
+The system property `gatling.logLevel` is also specifically checked in build.gradle.kts.  When `-Dgatling.logLevel=...` is passed to the `gradlew` wrapper command, its value will be configured as the logLevel parameter on Gatling's Gradle plugin, changing what Gatling and the simulation logs.  This has no effect on the Nessie/server side.  This check is unique to `gatling.logLevel`; the plugin has other parameters that can't be configured this way, as of the time of writing.
+
+```
+../../gradlew gatlingRun-org.projectnessie.perftest.gatling.KeyListSpillingSimulation \
+	-Dgatling.logLevel=DEBUG
+```
+
 ## Gatling links
 
 * [Intro to Gatling](https://www.baeldung.com/introduction-to-gatling)

--- a/perftest/simulations/build.gradle.kts
+++ b/perftest/simulations/build.gradle.kts
@@ -56,4 +56,9 @@ nessieQuarkusApp {
   environmentNonInput.put("HTTP_ACCESS_LOG_LEVEL", testLogLevel())
 }
 
-gatling { gatlingVersion = dependencyVersion("versionGatling") }
+gatling {
+  gatlingVersion = dependencyVersion("versionGatling")
+  if (null != System.getProperty("gatling.logLevel")) {
+    logLevel = System.getProperty("gatling.logLevel")
+  }
+}

--- a/perftest/simulations/build.gradle.kts
+++ b/perftest/simulations/build.gradle.kts
@@ -58,7 +58,6 @@ nessieQuarkusApp {
 
 gatling {
   gatlingVersion = dependencyVersion("versionGatling")
-  if (null != System.getProperty("gatling.logLevel")) {
-    logLevel = System.getProperty("gatling.logLevel")
-  }
+  // Null is OK (io.gatling.gradle.LogbackConfigTask checks for it)
+  logLevel = System.getProperty("gatling.logLevel")
 }

--- a/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/KeyListSpillingParams.scala
+++ b/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/KeyListSpillingParams.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.perftest.gatling
+
+import io.gatling.core.session.Session
+
+/** Options for testing effects of large live keylists on new commits
+ *
+ * Each put has a key which is distinct compared to all others that appear in
+ * any given execution of the simulation.
+ *
+ * @param baseCommitCount the number of times to commit to a shared base branch, which is deleted if
+ *                        necessary and (re)created once before beginning Gatling measurement
+ * @param putsPerBaseCommit the number of put operations to include in each commit to the shared base branch
+ * @param testCommitCount the number of times to commit to a short-lived test branch during Gatling measurement before
+ *                        creating a new short-lived test branch; all short-lived test branches start from the shared
+ *                        base branch
+ * @param putsPerTestCommit the number of put operations to include in each commit to a short-lived test branch
+ * @param targetDurationSeconds the wall-clock time, in seconds, that should elapse while Gatling performs operations
+ *                              on short-lived test branches before terminating the simulation
+ *
+ * @see [[KeyListSpillingSimulation]]
+  */
+case class KeyListSpillingParams(
+                                  baseCommitCount: Int,
+                                  putsPerBaseCommit: Int,
+                                  testCommitCount: Int,
+                                  putsPerTestCommit: Int,
+                                  targetDurationSeconds: Int
+                                ) {
+
+  private val prefix = "keylist_spilling_"
+
+  def asPrintableString(): String = {
+    s"""
+    |   base-commit-count:   $baseCommitCount
+    |   puts-per-base-commit:   $putsPerBaseCommit
+    |   test-commit-count:   $testCommitCount
+    |   puts-per-test-commit    $putsPerTestCommit
+    |   target-duration-seconds:       $targetDurationSeconds
+    |""".stripMargin
+  }
+
+  def getBaseBranchName(): String = {
+    prefix + "base"
+  }
+
+  def makeTableName(session: Session): String = {
+    prefix + "table"
+  }
+
+  def getTestBranchName(session: Session): String = {
+    prefix + session.userId
+  }
+}
+
+object KeyListSpillingParams {
+  def fromSystemProperties(): KeyListSpillingParams = {
+    val baseCommitCount: Int = Integer.getInteger("sim.baseCommitCount", 98).toInt
+    val putsPerBaseCommit: Int = Integer.getInteger("sim.putsPerBaseCommit", 10).toInt
+    val testCommitCount: Int = Integer.getInteger("sim.testCommitCount", 40).toInt
+    val putsPerTestCommit: Int = Integer.getInteger("sim.putsPerTestCommit", 1).toInt
+    val targetDurationSeconds: Int =
+      Integer.getInteger("sim.duration.seconds", 60).toInt
+    KeyListSpillingParams(
+      baseCommitCount,
+      putsPerBaseCommit,
+      testCommitCount,
+      putsPerTestCommit,
+      targetDurationSeconds
+    )
+  }
+}

--- a/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/KeyListSpillingParams.scala
+++ b/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/KeyListSpillingParams.scala
@@ -54,12 +54,8 @@ case class KeyListSpillingParams(
     |""".stripMargin
   }
 
-  def getBaseBranchName(): String = {
+  def getBaseBranchName: String = {
     prefix + "base"
-  }
-
-  def makeTableName(session: Session): String = {
-    prefix + "table"
   }
 
   def getTestBranchName(session: Session): String = {

--- a/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/KeyListSpillingSimulation.scala
+++ b/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/KeyListSpillingSimulation.scala
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.perftest.gatling
+
+import io.gatling.core.Predef._
+import io.gatling.core.scenario.Simulation
+import io.gatling.core.structure.{ChainBuilder, ScenarioBuilder}
+import org.projectnessie.error.NessieReferenceNotFoundException
+import org.projectnessie.model.Operation.Put
+import org.projectnessie.model._
+import org.projectnessie.perftest.gatling.Predef.nessie
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
+import scala.jdk.CollectionConverters._
+
+/**
+ * Measure throughput of incremental put commits against an existing HEAD with a preexisting live keylist.
+ *
+ * @see [[KeyListSpillingParams]]
+ */
+class KeyListSpillingSimulation extends Simulation {
+
+  private val log = LoggerFactory.getLogger(classOf[KeyListSpillingSimulation])
+
+  /**
+   * Fixed-size key padding (256 chars, repeating every 8 chars)
+   */
+  private val paddingBuilder: mutable.StringBuilder = new mutable.StringBuilder()
+  for (i <- 1 to 32) {
+    paddingBuilder.append("abcdefg_")
+  }
+  val padding: String = paddingBuilder.toString();
+
+  /**
+   * Configuration specific to this simulation and scenario.
+   */
+  private val params: KeyListSpillingParams = KeyListSpillingParams.fromSystemProperties()
+
+  /**
+   * Session key for the zero-indexed commit number associated with the current simulated Gatling user.
+   *
+   * Gatling initializes and increments this for us via [[repeat]].
+   */
+  private val commitIndexKey = "commitIndex"
+
+  /**
+   * Commit once to a branch conveyed via the [[Session]].
+   *
+   * Although the returned chain fragment will commit only once, the number of put operations in that commit is
+   * determined by [[KeyListSpillingParams.putsPerTestCommit]].
+   */
+  private def commitToBranch: ChainBuilder = {
+      exec(
+        nessie("TestBranchCommit")
+          .execute { (client, session) =>
+
+            // This is initialized and incremented on our behalf by Gatling (see buildScenario)
+            val commitIndex = session(commitIndexKey).as[Int]
+            val commitNum = commitIndex + 1
+            val testBranch = session("branch").as[Branch]
+            val userId = session.userId
+            val putOps: List[Operation] = List.range(0, params.putsPerTestCommit).map(
+              i => {
+                val key = ContentKey.of(s"${userId} ${commitIndex} ${i}" + padding)
+                val table = IcebergTable.of(s"metadata_${userId}_${commitNum}_${i}", 42, 43, 44, 45)
+                Put.of(key, table, null)
+              }
+            )
+
+            // Call the Nessie client operation to perform a commit with one or more put ops
+            val updatedBranch = client
+              .commitMultipleOperations()
+              .branch(testBranch)
+              .commitMeta(
+                CommitMeta.fromMessage(s"worker commit userId=${userId} testCommitNum=${commitNum}")
+              )
+              .operations(putOps.asJava)
+              .commit()
+
+            session.set("branch", updatedBranch)
+          }
+      )
+  }
+
+  /**
+   * Delete a test [[Branch]] (if it exists), then (re)create it.
+   *
+   * The test branch's name ends in the Gatling userId (as conveyed through the [[Session]].
+   */
+  private def dropAndCreateTestBranch: ChainBuilder = {
+    exec(
+      nessie(s"DeleteTestBranchIfExists")
+        .execute { (client, session) =>
+          val testBranchName = params.getTestBranchName(session)
+
+          // Get the test branch (we must know its hash to delete it)
+          try {
+            val testBranch: Reference = client
+              .getReference
+              .refName(testBranchName)
+              .get()
+              .asInstanceOf[Branch]
+
+            // Delete the test branch
+            if (null != testBranch) {
+              client
+                .deleteBranch()
+                .branchName(testBranchName)
+                .hash(testBranch.getHash)
+                .delete()
+            }
+          } catch {
+            case e: NessieReferenceNotFoundException =>
+              log.debug("Test branch did not exist during delete-if-exists operation" +
+                "(this is normal on a clean Nessie backend, or when changing some benchmark parameters on a dirty one)", e)
+          }
+
+          session
+        }
+    ).exec(
+      nessie(s"CreateTestBranch")
+        .execute { (client, session) =>
+          // Get the base branch
+          val parentBranch: Reference = client
+            .getReference
+            .refName(params.getBaseBranchName())
+            .get()
+
+          // Create a new test branch from the base branch
+          val testBranch = client
+            .createReference()
+            .sourceRefName(params.getBaseBranchName())
+            .reference(Branch.of(params.getTestBranchName(session), parentBranch.getHash))
+            .create()
+            .asInstanceOf[Branch]
+
+          session.set("branch", testBranch)
+        }
+    )
+  }
+
+  /**
+   * Constructs a scenario to prep and commit to a test branch.
+   *
+   * The test branch is deleted if it exists, then created.  Commits to the new branch are repeated
+   * [[KeyListSpillingParams.testCommitCount]] times.
+   */
+  private def buildScenario(): ScenarioBuilder = {
+    scenario("KeyList-Spilling")
+      .exec(dropAndCreateTestBranch)
+      .repeat(params.testCommitCount, commitIndexKey) {
+        commitToBranch
+      }
+  }
+
+  /**
+   * Creates our simulation and invokes Gatling's [[io.gatling.core.scenario.Simulation.setUp]]
+   */
+  private def doSetUp(): SetUp = {
+    val nessieProtocol: NessieProtocol = nessie().clientFromSystemProperties()
+
+    val branchName = params.getBaseBranchName();
+
+    // Drop base branch, if it exists
+    try {
+      val ref = nessieProtocol.client.getReference.refName(branchName).get()
+
+      if (null != ref) {
+        nessieProtocol.client.deleteBranch().branch(Branch.of(params.getBaseBranchName(), ref.getHash)).delete()
+      }
+    } catch {
+      case e: NessieReferenceNotFoundException => {
+        log.info(s"Base branch $branchName does not exist, " +
+          s"not attempting to delete (this is normal when running against a clean Nessie backend)", e)
+      }
+    }
+
+    // Create base branch
+    nessieProtocol.client.createReference().reference(Branch.of(params.getBaseBranchName(), null)).create()
+
+    // Load test fixture into base branch
+    val branch = nessieProtocol.client.getReference.refName(branchName).get().asInstanceOf[Branch]
+    loadData(nessieProtocol, branch)
+
+    // Leave branch-and-commit cycles to Gatling via our scenario
+    val s: SetUp = setUp(buildScenario().inject(
+      constantConcurrentUsers(1).during(FiniteDuration(params.targetDurationSeconds, SECONDS))
+    )).maxDuration(FiniteDuration(params.targetDurationSeconds, SECONDS))
+
+    s.protocols(nessieProtocol)
+  }
+
+  /**
+   * Commit one or more puts of Iceberg Tables to the given branch, each uniquely keyed.
+   *
+   * @param nessieProtocol the client attached to this protocol will be used for commits
+   * @param branch the target branch upon which to commit
+   */
+  private def loadData(nessieProtocol: NessieProtocol, branch: Branch): Unit = {
+
+    val commitCount = params.baseCommitCount
+    val operationCount = params.putsPerBaseCommit
+
+    log.info("Loading shared fixture into branch {}: {} commits, each with {} distinctly-keyed put operations",
+      branch, commitCount, operationCount)
+
+    for (i <- 1 to commitCount) {
+
+      val operations: List[Operation] = LazyList.from(i * operationCount)
+        .take(operationCount)
+        .map(commitNum => String.valueOf(commitNum) + " " + padding)
+        .map(keyName => Operation.Put.of(
+          ContentKey.of(keyName),
+          IcebergTable.of("/iceberg/table", 42, 42, 42, 42)))
+        .toList
+
+      log.debug("Preparing {} put operations in commit {}/{}", operations.size, i, commitCount)
+
+      nessieProtocol.client.commitMultipleOperations()
+        .operations(operations.asJava)
+        .branch(branch)
+        .commitMeta(CommitMeta.fromMessage(s"Base branch commit ${i}/${commitCount}"))
+        .commit();
+    }
+  }
+
+  // Instantiate Simulation, Scenario, Protocol, etc. and return a Gatling SetUp
+  doSetUp()
+}


### PR DESCRIPTION
This is related to, but does not implement, #3832.  Without adding
additional index structures, an exploratory implementation needed to add
a read-before-write on puts to support #3832.  The cost of the read was
sensitive to both the size of the set of keys present at the commit's
target branch, and to the number of puts in the commit.

This commit adds a simulation that exercises a related workload in a
simplified, single-user way.  The simulation could be generalized to
multiple users (it already uses a branch-to-Gatling-userid
correspondence that would support multiuser without changes).  However,
single-user was sufficient to explore the costs at the time.

The simulation might be more broadly useful regardless of what happens
with #3832.  This commit adds the sim without the exploratory impl it
was originally meant to test.  It also adds some
perftest/simulations/README.md hints for running individual simulations
with parameters, and adds a way to control the gatling loglevel from the
gradle commandline.