### PR TITLE
SQLExtension: Fix show reference command with use reference@hash

### DIFF
--- a/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/NessieUtils.scala
+++ b/clients/spark-extensions-base/src/main/scala/org/apache/spark/sql/execution/datasources/v2/NessieUtils.scala
@@ -245,15 +245,16 @@ object NessieUtils {
       currentCatalog: CatalogPlugin,
       catalog: Option[String]
   ): Reference = {
-    val refName = getCurrentRefName(currentCatalog, catalog)
+    val currentRef = getCurrentRef(currentCatalog, catalog)
+    val refName = currentRef._1
     try {
       var ref = api.getReference.refName(refName).get
-      val refHash = getCurrentRefHash(currentCatalog, catalog);
-      if (refHash != null) {
+      val refHash = currentRef._2
+      if (refHash.nonEmpty) {
         if (ref.getType == ReferenceType.BRANCH) {
-          ref = Branch.of(ref.getName, refHash)
+          ref = Branch.of(ref.getName, refHash.get)
         } else {
-          ref = Tag.of(ref.getName, refHash)
+          ref = Tag.of(ref.getName, refHash.get)
         }
       }
       ref
@@ -267,22 +268,23 @@ object NessieUtils {
     }
   }
 
-  def getCurrentRefName(
+  def getCurrentRef(
       currentCatalog: CatalogPlugin,
       catalog: Option[String]
-  ): String = {
+  ): (String, Option[String]) = {
     val catalogName = catalog.getOrElse(currentCatalog.name)
-    SparkSession.active.sparkContext.conf
+    val refName = SparkSession.active.sparkContext.conf
       .get(s"spark.sql.catalog.$catalogName.ref")
-  }
-
-  def getCurrentRefHash(
-      currentCatalog: CatalogPlugin,
-      catalog: Option[String]
-  ): String = {
-    val catalogName = catalog.getOrElse(currentCatalog.name)
-    SparkSession.active.sparkContext.conf
-      .get(s"spark.sql.catalog.$catalogName.ref.hash", null)
+    var refHash: Option[String] = None
+    try {
+      refHash = Some(
+        SparkSession.active.sparkContext.conf
+          .get(s"spark.sql.catalog.$catalogName.ref.hash")
+      )
+    } catch {
+      case _: NoSuchElementException =>
+    }
+    (refName, refHash)
   }
 
   def getRefType(ref: Reference): String = {

--- a/clients/spark-extensions-basetests/src/main/java/org/projectnessie/spark/extensions/AbstractNessieSparkSqlExtensionTest.java
+++ b/clients/spark-extensions-basetests/src/main/java/org/projectnessie/spark/extensions/AbstractNessieSparkSqlExtensionTest.java
@@ -367,7 +367,6 @@ public abstract class AbstractNessieSparkSqlExtensionTest extends SparkSqlTestBa
     SparkCommitLogEntry lastCommitBeforeTimePredicate = commits.get(0);
     commitAndReturnLog(refName, lastCommitBeforeTimePredicate.getHash());
 
-    String lastRefHashGlobally = api.getReference().refName(refName).get().getHash();
     // it should not include the current last hash
     // api.getReference().refName(refName).get().getHash()
     // because the last hash was committed after the commitTime

--- a/clients/spark-extensions-basetests/src/main/java/org/projectnessie/spark/extensions/AbstractNessieSparkSqlExtensionTest.java
+++ b/clients/spark-extensions-basetests/src/main/java/org/projectnessie/spark/extensions/AbstractNessieSparkSqlExtensionTest.java
@@ -374,7 +374,7 @@ public abstract class AbstractNessieSparkSqlExtensionTest extends SparkSqlTestBa
     assertThat(sql("USE REFERENCE %s AT `%s` IN nessie ", refName, timeWithZone))
         .containsExactly(row("Branch", refName, lastCommitBeforeTimePredicate.getHash()));
     assertThat(sql("SHOW REFERENCE IN nessie"))
-        .containsExactly(row("Branch", refName, lastRefHashGlobally));
+        .containsExactly(row("Branch", refName, lastCommitBeforeTimePredicate.getHash()));
   }
 
   private static Stream<Arguments> dateTimeFormatProvider() {
@@ -393,6 +393,8 @@ public abstract class AbstractNessieSparkSqlExtensionTest extends SparkSqlTestBa
     for (SparkCommitLogEntry commit : commits) {
       String currentHash = commit.getHash();
       assertThat(sql("USE REFERENCE %s AT %s IN nessie ", refName, currentHash))
+          .containsExactly(row("Branch", refName, currentHash));
+      assertThat(sql("SHOW REFERENCE IN nessie"))
           .containsExactly(row("Branch", refName, currentHash));
     }
   }


### PR DESCRIPTION
Whenever SQL "USE REFERENCE @ HASH" is used, It only updates the [NessieIcebergClient](https://github.com/apache/iceberg/blob/master/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java) 's `updatableReference`. So, there is no change in the actual Nessie reference in the backend.

But when current reference info is fetched, It fetches from the backend which is not aware of "USE REFERENCE @ HASH".  So, this is confusing for the users and also it is not the current state of the reference.  Hence, this fix.

Also, assign ref, create ref from, and merge ref will honor the value set by "use reference @hash" now. 
