### PR TITLE
Enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: sunday
 - package-ecosystem: gradle
   directory: "/"
   schedule:


### PR DESCRIPTION
basically copied from:
https://github.com/apache/iceberg/blob/1017bb11a98f075bcf5b7e1cf99bf32adcc797cf/.github/dependabot.yml#L28-L32

it should notify us about new major versions like here:
https://github.com/apache/iceberg/commit/e5d771b300e7ec5ed0a6da9e476697088a2978b8

we only run on sundays to avoid interference with the workweek