### PR TITLE
Do not cache versioned-persist-bench shadow jar

### DIFF
--- a/versioned/persist/bench/build.gradle.kts
+++ b/versioned/persist/bench/build.gradle.kts
@@ -59,5 +59,6 @@ dependencies {
 
 val shadowJar =
   tasks.named<ShadowJar>("shadowJar") {
+    outputs.cacheIf { false } // very big jar
     manifest { attributes["Main-Class"] = "org.openjdk.jmh.Main" }
   }


### PR DESCRIPTION
The shadow jar takes a couple seconds to cache locally, which is wasted time, because it's rarely restored from the cache, and it is relatively fast to re-create it.