### PR TITLE
Fix key list lookup when the embedded segment is empty.

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
@@ -168,6 +168,11 @@ final class FetchValuesUsingOpenAddressing {
         KeyListEntry keyListEntry = i < keys.length ? keys[i] : null;
         if (keyListEntry == null) {
           // key _not_ found
+          if (keys.length == 0 && segment == 0) {
+            // ... however, the first (embedded) segment may be empty due to size restrictions.
+            // This means its keys had to be moved to key list entities - keep searching.
+            keysForNextRound.add(key);
+          }
           break;
         } else if (keyListEntry.getKey().equals(key)) {
           resultConsumer.accept(keyListEntry);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/FetchValuesUsingOpenAddressing.java
@@ -140,8 +140,16 @@ final class FetchValuesUsingOpenAddressing {
       int round, Collection<Key> remainingKeys, Consumer<KeyListEntry> resultConsumer) {
     List<Key> keysForNextRound = new ArrayList<>();
     // If we've already examined every segment (implying a miss on a completely full hashmap),
-    // then return an empty collection early
-    if (keyListsArray.length <= round) {
+    // then return an empty collection early. Note that the initial segment may need to be examined
+    // twice when the key is moved in front of its natural position due to key collisions. This
+    // is achieved by the `less than` comparison with `round`. On the first round the initial
+    // segment is scanned from the natural key position. On the last round the initial segment is
+    // scanned from index zero. This may incur some extra key comparisons if the segment is full and
+    // the scanning overtakes the "natural" key position on the last round. However, this is
+    // probably a rare case and not worth complicating the lookup logic to avoid it. In any case,
+    // the double lookup in the initial segment does not cause extra I/O because the segment is
+    // pre-fetched by the time it is reused.
+    if (keyListsArray.length < round) {
       return keysForNextRound;
     }
     for (Key key : remainingKeys) {

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestFetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestFetchValuesUsingOpenAddressing.java
@@ -266,7 +266,7 @@ public class TestFetchValuesUsingOpenAddressing {
         List<Hash> hashes = fetch.entityIdsToFetch(r, 0, ImmutableList.of(key));
         hashes.forEach(
             h -> {
-              int segment = Integer.parseInt(h.asString());
+              int segment = Integer.parseInt(h.asString(), 16);
               int startingBucket = (skipEmbedded ? 0 : segmentSize) + ((segment - 1) * segmentSize);
               KeyListEntity keyListEntity =
                   getKeyListEntity(startingBucket, segment, segmentSize, bucketToKey);
@@ -439,7 +439,13 @@ public class TestFetchValuesUsingOpenAddressing {
         return false;
       }
       Key that = (Key) o;
-      return Objects.equals(elements, that.getElements());
+      boolean equals = Objects.equals(elements, that.getElements());
+      if (equals) {
+        assertThat(hashCode)
+            .describedAs("equals/hashCode mismatch between %s and %s", this, that)
+            .isEqualTo(that.hashCode());
+      }
+      return equals;
     }
 
     @Override

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -38,6 +38,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -557,6 +558,30 @@ public abstract class AbstractManyKeys {
           @NessieDbAdapterConfigItem(name = "key.list.hash.load.factor", value = "0.65")
           @NessieDbAdapter
           DatabaseAdapter databaseAdapter)
+      throws Exception {
+    testManyKeysProgressive(names, databaseAdapter);
+  }
+
+  /**
+   * Same as {@link #manyKeysProgressive(List, DatabaseAdapter)} but uses zero key list size limits,
+   * which caused the "embedded" key list segment to be empty, and the external key list "entities"
+   * to have at most one entry each.
+   */
+  @ParameterizedTest
+  @MethodSource("progressivelyManyKeyNames")
+  void manyKeysProgressiveSmallLists(
+      List<String> names,
+      @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "0")
+          @NessieDbAdapterConfigItem(name = "max.key.list.entity.size", value = "0")
+          @NessieDbAdapterConfigItem(name = "key.list.distance", value = "20")
+          @NessieDbAdapterConfigItem(name = "key.list.hash.load.factor", value = "0.7")
+          @NessieDbAdapter
+          DatabaseAdapter databaseAdapter)
+      throws Exception {
+    testManyKeysProgressive(names, databaseAdapter);
+  }
+
+  private void testManyKeysProgressive(List<String> names, DatabaseAdapter databaseAdapter)
       throws Exception {
     BranchName main = BranchName.of("main");
     Hash head = databaseAdapter.hashOnReference(main, Optional.empty());


### PR DESCRIPTION
This change fixes key lookup when hash collisions cause the empty embedded
segment to be processed during hash search wraparound.

----

Includes #5145 