### PR TITLE
docs: Fix several instances of Markdown list formatting

### DIFF
--- a/site/docs/develop/kernel.md
+++ b/site/docs/develop/kernel.md
@@ -60,6 +60,7 @@ operations like commit, transplants and merges as well as retrieving data.
 
 `AbstractDatabaseAdapter` implements the commit logic, commit conflict detection and operations
 to retrieve information. There are these subclasses: 
+
 * `NonTransactionalDatabaseAdapter` is used as a base for key-value stores.
   * Implementation for DynamoDB
   * Implementation for MongoDB
@@ -121,6 +122,7 @@ FunctionResult nessieWriteOperation(parameters...) {
 ### Transactional databases
 
 The data model for transactional databases defines tables for
+
 * the _global-state_, where the primary key is the globally unique _content-id_ and the
   value of the _global-state_,
 * the _named-references_, which define the commit hash/id of the "HEAD" of each named reference,

--- a/site/docs/develop/nessie_vs_git.md
+++ b/site/docs/develop/nessie_vs_git.md
@@ -21,7 +21,7 @@ copies. This allows several other dimensions to be substantially more powerful.
 
 While we describe the reasoning and differences above, we actually support running 
 Nessie on top of Git. In fact, the first version of Nessie was built on top of Git. 
-Once implemented, we then evaluated it against one of our key design criterion. This   
+Once implemented, we then evaluated it against one of our key design criteria. This   
 design criterion was to support commits in the situation where there are 100,000 tables
 and each table is changing every 5 minutes. (For reference, the 
 5 minutes comes from community guidance on commit speed per table for Iceberg. The 

--- a/site/docs/features/management.md
+++ b/site/docs/features/management.md
@@ -17,8 +17,9 @@ There are at least two steps to a garbage collection action. The first steps are
 
 ### Identify Unreferenced Assets
 
-This is a spark job which should be run periodically to identify no longer referenced assets. Assets are defined as the set of
-files, records, entries etc. that make up a table, view or other Nessie object. For example, iceberg assets are:
+This is a Spark job which should be run periodically to identify no longer referenced assets. Assets are defined as the set of
+files, records, entries etc. that make up a table, view or other Nessie object. For example, Iceberg assets are:
+
  * manifest files
  * manifest lists
  * data files
@@ -26,6 +27,7 @@ files, records, entries etc. that make up a table, view or other Nessie object. 
  * the entire table directory on disk (if it is empty)
 
 To be marked as unreferenced an asset must either be:
+
  1. No longer referenced by any branch or tag. For example, an entire branch was deleted, and a table on that branch is no longer accessible.
  2. Assets created in a commit which has passed the (configurable) commit age. *If they are not referenced by newer commits*
 

--- a/site/docs/features/metadata_authorization.md
+++ b/site/docs/features/metadata_authorization.md
@@ -147,6 +147,7 @@ nessie.server.authorization.rules.allow_listing_reflog=\
 ### Example authorization rules from Stories section
 
 As mentioned in the Stories section, a few common scenarios that are possible are:
+
 * Alice attempts to execute a query against the table `Foo` on branch `prod`. As she has read access to the table on this branch, Nessie allows the execution engine to get the table details.
 * Bob attempts to execute a query against the table `Foo` on branch `prod`. However, Bob does not have read access to the table. Nessie returns an authorization error, and the execution engine refuses to execute the query.
 * Carol has access to the content on branch `prod`, but not to the table `Foo` on this branch. Carol creates a new reference named `carol-branch` with the same hash as `prod`, and attempts to change permissions on table `Foo`. However, request is denied and Carol cannot access the content of `Foo`.

--- a/site/docs/tables/index.md
+++ b/site/docs/tables/index.md
@@ -40,7 +40,8 @@ There has been discussion about adding additional types of objects to Nessie for
 purpose of creating a consistent repository between input assets (jobs, models, etc.) 
 and output assets. This is something that will be evaluated based on demand. There are 
 currently three options being considered: 
-- more structured object types (such as spark job)
+
+- more structured object types (such as Spark job)
 - blob types
 - support for git sub-modules (where Nessie offers a new object type that refers to a particular commit within a git repository)
 

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -25,7 +25,7 @@ docker run -p 8080:8080 projectnessie/nessie \
 
 | Property                              | Default values | Type               | Description                                                                                                                      |
 |---------------------------------------|----------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `nessie.version.store.type`           | `INMEMORY`     | `VersionStoreType` | Sets which type of version store to use by Nessie. Possible values are: `DYNAMO`, `INMEMORY`, `ROCKS`, `MONGO`, 'TRANSACTIONAL'. |
+| `nessie.version.store.type`           | `INMEMORY`     | `VersionStoreType` | Sets which type of version store to use by Nessie. Possible values are: `DYNAMO`, `INMEMORY`, `ROCKS`, `MONGO`, `TRANSACTIONAL`. |
 | `nessie.version.store.trace.enable`   | `true`         | `boolean`          | Sets whether calls against the version-store are traced with OpenTracing/OpenTelemetry (Jaeger).                                 |
 | `nessie.version.store.metrics.enable` | `true`         | `boolean`          | Sets whether metrics for the version-store are enabled.                                                                          |
 


### PR DESCRIPTION
A few trivial edits made as I read through the docs, mostly Markdown formatting.

In particular, lists that aren't preceded by blank lines render as expected in GitHub-Flavored Markdown, but they run into the prior paragraph in other implementations like the mkdocs site.

![Screenshot of a paragraph from the Nessie docs site with broken rendered list formatting](https://user-images.githubusercontent.com/13277/190160266-b9b31671-1651-4d29-9e00-4e9e13107fe3.png)
