### PR TITLE
Schedule dependabot for npm + pip less frequently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,18 @@ updates:
 - package-ecosystem: pip
   directory: "/python"
   schedule:
-    interval: daily
+    interval: weekly
+    day: saturday
   open-pull-requests-limit: 10
 - package-ecosystem: pip
   directory: "/site"
   schedule:
-    interval: daily
+    interval: weekly
+    day: saturday
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: /ui
   schedule:
-    interval: daily
+    interval: weekly
+    day: sunday
   open-pull-requests-limit: 10


### PR DESCRIPTION
these parts are not super actively developed and they also have some libraries that receive almost daily upgrades, so running once a week should be sufficient.
we do it on the weekend to not block CI capacity during workdays.