### PR TITLE
Nessie GC: JDBC Live-Set-Repository

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     api(project(":nessie-compatibility-tests"))
     api(project(":nessie-compatibility-jersey"))
     api(project(":nessie-gc-base"))
+    api(project(":nessie-gc-repository-jdbc"))
     api(project(":nessie-model"))
     api(project(":nessie-jaxrs"))
     api(project(":nessie-jaxrs-testextension"))

--- a/gc/gc-repository-jdbc/build.gradle.kts
+++ b/gc/gc-repository-jdbc/build.gradle.kts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  `java-library`
+  jacoco
+  `maven-publish`
+  signing
+  `nessie-conventions`
+}
+
+extra["maven.name"] = "Nessie - GC - JDBC live-contents-set persistence"
+
+dependencies {
+  implementation(platform(nessieRootProject()))
+  implementation(platform(project(":nessie-deps-persist")))
+  compileOnly(nessieProjectPlatform("nessie-deps-build-only", gradle))
+  annotationProcessor(nessieProjectPlatform("nessie-deps-build-only", gradle))
+  compileOnly(platform("com.fasterxml.jackson:jackson-bom"))
+
+  compileOnly("com.google.errorprone:error_prone_annotations")
+  compileOnly("org.immutables:value-annotations")
+  annotationProcessor("org.immutables:value-processor")
+  compileOnly("org.jetbrains", "annotations")
+
+  implementation(nessieProject("nessie-model"))
+  implementation(nessieProject("nessie-gc-base"))
+
+  implementation("com.google.guava:guava")
+
+  implementation("io.agroal:agroal-pool")
+  implementation("org.postgresql:postgresql")
+  implementation("com.h2database:h2")
+
+  implementation("org.slf4j:slf4j-api")
+
+  compileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
+  compileOnly("jakarta.validation:jakarta.validation-api")
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+  compileOnly("com.google.code.findbugs:jsr305")
+
+  testImplementation(nessieProjectPlatform("nessie-deps-testing", gradle))
+  testImplementation(platform("com.fasterxml.jackson:jackson-bom"))
+  testImplementation(platform("org.junit:junit-bom"))
+  testCompileOnly(nessieProjectPlatform("nessie-deps-build-only", gradle))
+  testAnnotationProcessor(nessieProjectPlatform("nessie-deps-build-only", gradle))
+
+  testImplementation(project(":nessie-gc-base-tests"))
+
+  testRuntimeOnly("ch.qos.logback:logback-classic")
+
+  testImplementation("com.google.guava:guava")
+
+  testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
+  testCompileOnly("org.eclipse.microprofile.openapi:microprofile-openapi-api")
+
+  testImplementation("org.assertj:assertj-core")
+  testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/AgroalJdbcDataSourceProvider.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/AgroalJdbcDataSourceProvider.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation;
+import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
+import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import io.agroal.api.security.AgroalSecurityProvider;
+import io.agroal.api.security.NamePrincipal;
+import io.agroal.api.security.SimplePassword;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class AgroalJdbcDataSourceProvider implements JdbcDataSourceProvider {
+
+  public static Builder builder() {
+    return ImmutableAgroalJdbcDataSourceProvider.builder();
+  }
+
+  @SuppressWarnings({"UnusedReturnValue", "unused"})
+  public interface Builder {
+    Builder poolMinSize(int minSize);
+
+    Builder poolMaxSize(int maxSize);
+
+    Builder poolInitialSize(int initialSize);
+
+    Builder poolConnectionLifetime(Duration connectionLifetime);
+
+    Builder poolAcquisitionTimeout(Duration acquisitionTimeout);
+
+    Builder jdbcUrl(String jdbcUrl);
+
+    Builder addCredentials(Object credentials);
+
+    Builder addCredentials(Object... credentials);
+
+    Builder addAllCredentials(Iterable<?> credentials);
+
+    Builder addSecurityProviders(AgroalSecurityProvider securityProvider);
+
+    Builder addSecurityProviders(AgroalSecurityProvider... securityProviders);
+
+    Builder addAllSecurityProviders(Iterable<? extends AgroalSecurityProvider> securityProviders);
+
+    default Builder usernamePasswordCredentials(String jdbcUser, String jdbcPassword) {
+      addCredentials(new NamePrincipal(jdbcUser), new SimplePassword(jdbcPassword));
+      return this;
+    }
+
+    Builder transactionIsolation(TransactionIsolation transactionIsolation);
+
+    Builder putJdbcProperties(String key, String value);
+
+    Builder putAllJdbcProperties(Map<String, ? extends String> entries);
+
+    AgroalJdbcDataSourceProvider build();
+  }
+
+  @Value.Default
+  int poolMinSize() {
+    return 2;
+  }
+
+  @Value.Default
+  int poolMaxSize() {
+    return 5;
+  }
+
+  @Value.Default
+  int poolInitialSize() {
+    return 2;
+  }
+
+  @Value.Default
+  Duration poolConnectionLifetime() {
+    return Duration.of(5, ChronoUnit.MINUTES);
+  }
+
+  @Value.Default
+  Duration poolAcquisitionTimeout() {
+    return Duration.of(10, ChronoUnit.SECONDS);
+  }
+
+  abstract String jdbcUrl();
+
+  abstract List<AgroalSecurityProvider> securityProviders();
+
+  abstract List<Object> credentials();
+
+  @Value.Default
+  TransactionIsolation transactionIsolation() {
+    return TransactionIsolation.READ_COMMITTED;
+  }
+
+  abstract Map<String, String> jdbcProperties();
+
+  @Value.Lazy
+  @Override
+  public DataSource dataSource() throws SQLException {
+    AgroalDataSourceConfigurationSupplier dataSourceConfiguration =
+        new AgroalDataSourceConfigurationSupplier();
+    AgroalConnectionPoolConfigurationSupplier poolConfiguration =
+        dataSourceConfiguration.connectionPoolConfiguration();
+    AgroalConnectionFactoryConfigurationSupplier connectionFactoryConfiguration =
+        poolConfiguration.connectionFactoryConfiguration();
+
+    poolConfiguration
+        .initialSize(poolInitialSize())
+        .maxSize(poolMaxSize())
+        .minSize(poolMinSize())
+        .maxLifetime(poolConnectionLifetime())
+        .acquisitionTimeout(poolAcquisitionTimeout());
+
+    securityProviders().forEach(connectionFactoryConfiguration::addSecurityProvider);
+    connectionFactoryConfiguration.jdbcUrl(jdbcUrl());
+    jdbcProperties().forEach(connectionFactoryConfiguration::jdbcProperty);
+    credentials().forEach(connectionFactoryConfiguration::credential);
+    connectionFactoryConfiguration.jdbcTransactionIsolation(transactionIsolation());
+    connectionFactoryConfiguration.autoCommit(false);
+
+    return AgroalDataSource.from(dataSourceConfiguration.get());
+  }
+}

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcDataSourceProvider.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcDataSourceProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+@FunctionalInterface
+public interface JdbcDataSourceProvider {
+  DataSource dataSource() throws SQLException;
+}

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcHelper.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcHelper.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Spliterators.AbstractSpliterator;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public final class JdbcHelper {
+  private JdbcHelper() {}
+
+  public static void createTables(Connection connection) throws SQLException {
+    try (Statement st = connection.createStatement()) {
+      for (String createTable : getCreateTableStatements()) {
+        st.execute(createTable);
+      }
+    }
+  }
+
+  public static List<String> getCreateTableStatements() {
+    return SqlDmlDdl.ALL_CREATES;
+  }
+
+  static Exception forClose(List<AutoCloseable> closeables, Exception e) {
+    for (int i = closeables.size() - 1; i >= 0; i--) {
+      try {
+        closeables.get(i).close();
+      } catch (Exception ex) {
+        if (e != null) {
+          e.addSuppressed(ex);
+        } else {
+          e = ex;
+        }
+      }
+    }
+    return e;
+  }
+
+  @FunctionalInterface
+  interface WithStatement<R> {
+    R withStatement(Connection connection, PreparedStatement preparedStatement) throws SQLException;
+  }
+
+  @FunctionalInterface
+  interface Prepare {
+    void prepare(PreparedStatement preparedStatement) throws SQLException;
+  }
+
+  @FunctionalInterface
+  interface FromRow<R> {
+    R fromRow(ResultSet resultSet) throws SQLException;
+  }
+
+  static final class ResultSetSplit<R> extends AbstractSpliterator<R> {
+    private final Supplier<Connection> connectionSupplier;
+    private final Consumer<AutoCloseable> closeables;
+    private final String sql;
+    private final Prepare prepare;
+    private final FromRow<R> fromRow;
+    private ResultSet resultSet;
+
+    ResultSetSplit(
+        Supplier<Connection> connectionSupplier,
+        Consumer<AutoCloseable> closeables,
+        String sql,
+        Prepare prepare,
+        FromRow<R> fromRow) {
+      super(Long.MAX_VALUE, 0);
+      this.connectionSupplier = connectionSupplier;
+      this.closeables = closeables;
+      this.sql = sql;
+      this.prepare = prepare;
+      this.fromRow = fromRow;
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super R> action) {
+      try {
+        if (resultSet == null) {
+          Connection conn = connectionSupplier.get();
+          closeables.accept(conn);
+          PreparedStatement stmt = conn.prepareStatement(sql);
+          closeables.accept(stmt);
+          prepare.prepare(stmt);
+          resultSet = stmt.executeQuery();
+          closeables.accept(resultSet);
+        }
+
+        if (!resultSet.next()) {
+          return false;
+        }
+
+        R value = fromRow.fromRow(resultSet);
+
+        action.accept(value);
+
+        return true;
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  /**
+   * Check whether the given {@link Throwable} represents an exception that indicates an
+   * integrity-constraint-violation.
+   */
+  static boolean isIntegrityConstraintViolation(Throwable e) {
+    if (e instanceof SQLException) {
+      SQLException sqlException = (SQLException) e;
+      return sqlException instanceof SQLIntegrityConstraintViolationException
+          // e.g. H2
+          || CONSTRAINT_VIOLATION_SQL_CODE == sqlException.getErrorCode()
+          // e.g. Postgres & Cockroach
+          || CONSTRAINT_VIOLATION_SQL_STATE.equals(sqlException.getSQLState());
+    }
+    return false;
+  }
+  /** Postgres &amp; Cockroach integrity constraint violation. */
+  static final String CONSTRAINT_VIOLATION_SQL_STATE = "23505";
+  /** H2 integrity constraint violation. */
+  static final int CONSTRAINT_VIOLATION_SQL_CODE = 23505;
+}

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcPersistenceSpi.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import static org.projectnessie.gc.contents.jdbc.JdbcHelper.isIntegrityConstraintViolation;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.ADD_CONTENT;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.DELETE_FILE_DELETIONS;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.DELETE_LIVE_CONTENTS;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.DELETE_LIVE_CONTENT_SET;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.DELETE_LIVE_SET_LOCATIONS;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.FINISH_EXPIRE;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.FINISH_IDENTIFY;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.INSERT_CONTENT_LOCATION;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.INSERT_FILE_DELETIONS;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.SELECT_ALL_LIVE_CONTENT_SETS;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.SELECT_CONTENT_COUNT;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.SELECT_CONTENT_IDS;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.SELECT_CONTENT_LOCATION;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.SELECT_CONTENT_LOCATION_ALL;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.SELECT_CONTENT_REFERENCES;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.SELECT_FILE_DELETIONS;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.SELECT_LIVE_CONTENT_SET;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.START_EXPIRE;
+import static org.projectnessie.gc.contents.jdbc.SqlDmlDdl.START_IDENTIFY;
+
+import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.MustBeClosed;
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
+import javax.sql.DataSource;
+import org.immutables.value.Value;
+import org.intellij.lang.annotations.Language;
+import org.projectnessie.gc.contents.ContentReference;
+import org.projectnessie.gc.contents.LiveContentSet;
+import org.projectnessie.gc.contents.LiveContentSetNotFoundException;
+import org.projectnessie.gc.contents.jdbc.JdbcHelper.FromRow;
+import org.projectnessie.gc.contents.jdbc.JdbcHelper.Prepare;
+import org.projectnessie.gc.contents.jdbc.JdbcHelper.ResultSetSplit;
+import org.projectnessie.gc.contents.jdbc.JdbcHelper.WithStatement;
+import org.projectnessie.gc.contents.spi.PersistenceSpi;
+import org.projectnessie.gc.files.FileReference;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.types.ContentTypes;
+
+@Value.Immutable
+public abstract class JdbcPersistenceSpi implements PersistenceSpi {
+
+  public static Builder builder() {
+    return ImmutableJdbcPersistenceSpi.builder();
+  }
+
+  @SuppressWarnings({"UnusedReturnValue", "unused"})
+  public interface Builder {
+    Builder dataSource(DataSource dataSource);
+
+    JdbcPersistenceSpi build();
+  }
+
+  @Override
+  public void startIdentifyLiveContents(UUID liveSetId, Instant created) {
+    singleStatement(
+        START_IDENTIFY,
+        (conn, stmt) -> {
+          stmt.setString(1, liveSetId.toString());
+          stmt.setTimestamp(2, Timestamp.from(created));
+          stmt.setString(3, LiveContentSet.Status.IDENTIFY_IN_PROGRESS.name());
+          try {
+            stmt.executeUpdate();
+          } catch (SQLException e) {
+            if (isIntegrityConstraintViolation(e)) {
+              throw new IllegalStateException("Duplicate liveSetId " + liveSetId);
+            }
+            throw e;
+          }
+          return null;
+        },
+        true);
+  }
+
+  @Override
+  public void finishedIdentifyLiveContents(
+      UUID liveSetId, Instant finished, @Nullable Throwable failure) {
+    singleStatement(
+        FINISH_IDENTIFY,
+        (conn, stmt) -> {
+          stmt.setTimestamp(1, Timestamp.from(finished));
+          if (failure != null) {
+            stmt.setString(2, LiveContentSet.Status.IDENTIFY_FAILED.name());
+            stmt.setString(3, failure.toString());
+          } else {
+            stmt.setString(2, LiveContentSet.Status.IDENTIFY_SUCCESS.name());
+            stmt.setNull(3, Types.VARCHAR);
+          }
+          stmt.setString(4, liveSetId.toString());
+          stmt.setString(5, LiveContentSet.Status.IDENTIFY_IN_PROGRESS.name());
+          verifyStatusUpdate(conn, stmt, LiveContentSet.Status.IDENTIFY_IN_PROGRESS, liveSetId);
+          return null;
+        },
+        true);
+  }
+
+  @Override
+  public LiveContentSet startExpireContents(UUID liveSetId, Instant started) {
+    return singleStatement(
+        START_EXPIRE,
+        (conn, stmt) -> {
+          stmt.setTimestamp(1, Timestamp.from(started));
+          stmt.setString(2, LiveContentSet.Status.EXPIRY_IN_PROGRESS.name());
+          stmt.setString(3, liveSetId.toString());
+          stmt.setString(4, LiveContentSet.Status.IDENTIFY_SUCCESS.name());
+          verifyStatusUpdate(conn, stmt, LiveContentSet.Status.IDENTIFY_SUCCESS, liveSetId);
+          return currentLiveSet(conn, liveSetId);
+        },
+        true);
+  }
+
+  @Override
+  public LiveContentSet finishedExpireContents(
+      UUID liveSetId, Instant finished, @Nullable Throwable failure) {
+    return singleStatement(
+        FINISH_EXPIRE,
+        (conn, stmt) -> {
+          stmt.setTimestamp(1, Timestamp.from(finished));
+          if (failure != null) {
+            stmt.setString(2, LiveContentSet.Status.EXPIRY_FAILED.name());
+            stmt.setString(3, failure.toString());
+          } else {
+            stmt.setString(2, LiveContentSet.Status.EXPIRY_SUCCESS.name());
+            stmt.setNull(3, Types.VARCHAR);
+          }
+          stmt.setString(4, liveSetId.toString());
+          stmt.setString(5, LiveContentSet.Status.EXPIRY_IN_PROGRESS.name());
+          verifyStatusUpdate(conn, stmt, LiveContentSet.Status.EXPIRY_IN_PROGRESS, liveSetId);
+          return currentLiveSet(conn, liveSetId);
+        },
+        true);
+  }
+
+  private void verifyStatusUpdate(
+      Connection conn, PreparedStatement stmt, LiveContentSet.Status expectedStatus, UUID liveSetId)
+      throws SQLException {
+    if (stmt.executeUpdate() != 1) {
+      LiveContentSet current = currentLiveSet(conn, liveSetId);
+      Preconditions.checkState(
+          current.status() == expectedStatus,
+          "Expected current status of " + expectedStatus + ", but is " + current.status());
+    }
+  }
+
+  @Override
+  public long fetchDistinctContentIdCount(UUID liveSetId) {
+    return singleStatement(
+        SELECT_CONTENT_COUNT,
+        (conn, stmt) -> {
+          stmt.setString(1, liveSetId.toString());
+          try (ResultSet rs = stmt.executeQuery()) {
+            rs.next();
+            return rs.getLong(1);
+          }
+        },
+        false);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<String> fetchContentIds(UUID liveSetId) {
+    return streamingResult(
+        SELECT_CONTENT_IDS, stmt -> stmt.setString(1, liveSetId.toString()), rs -> rs.getString(1));
+  }
+
+  @Override
+  public long addIdentifiedLiveContent(UUID liveSetId, Stream<ContentReference> contentReference) {
+    return singleStatement(
+        ADD_CONTENT,
+        (conn, stmt) -> {
+          stmt.setString(1, liveSetId.toString());
+          long count = 0L;
+          for (Iterator<ContentReference> iter = contentReference.iterator(); iter.hasNext(); ) {
+            ContentReference ref = iter.next();
+            stmt.setString(2, ref.contentId());
+            stmt.setString(3, ref.commitId());
+            stmt.setString(4, ref.contentKey().toPathString());
+            stmt.setString(5, ref.contentType().name());
+            if (ref.contentType().equals(Content.Type.ICEBERG_TABLE)) {
+              stmt.setString(
+                  6,
+                  Objects.requireNonNull(
+                      ref.metadataLocation(),
+                      "Illegal null metadataLocation in ContentReference for ICEBERG_TABLE"));
+              stmt.setLong(
+                  7,
+                  Objects.requireNonNull(
+                      ref.snapshotId(),
+                      "Illegal null snapshotId in ContentReference for ICEBERG_TABLE"));
+            } else {
+              throw new UnsupportedOperationException(
+                  "Unsupported content type " + ref.contentType());
+            }
+            try {
+              // TODO add batch updates
+              stmt.executeUpdate();
+              count++;
+            } catch (SQLException e) {
+              if (!isIntegrityConstraintViolation(e)) {
+                throw e;
+              }
+            }
+          }
+          return count;
+        },
+        true);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<ContentReference> fetchContentReferences(UUID liveSetId, String contentId) {
+    return streamingResult(
+        SELECT_CONTENT_REFERENCES,
+        stmt -> {
+          stmt.setString(1, liveSetId.toString());
+          stmt.setString(2, contentId);
+        },
+        JdbcPersistenceSpi::contentReference);
+  }
+
+  @Override
+  public void associateBaseLocations(
+      UUID liveSetId, String contentId, Collection<URI> baseLocations) {
+    singleStatement(
+        INSERT_CONTENT_LOCATION,
+        (conn, stmt) -> {
+          stmt.setString(1, liveSetId.toString());
+          stmt.setString(2, contentId);
+          for (URI baseLocation : baseLocations) {
+            stmt.setString(3, baseLocation.toString());
+            try {
+              stmt.executeUpdate();
+            } catch (SQLException e) {
+              if (!isIntegrityConstraintViolation(e)) {
+                throw e;
+              }
+            }
+          }
+          return null;
+        },
+        true);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<URI> fetchBaseLocations(UUID liveSetId, String contentId) {
+    return streamingResult(
+        SELECT_CONTENT_LOCATION,
+        stmt -> {
+          stmt.setString(1, liveSetId.toString());
+          stmt.setString(2, contentId);
+        },
+        rs -> URI.create(rs.getString(1)));
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<URI> fetchAllBaseLocations(UUID liveSetId) {
+    return streamingResult(
+        SELECT_CONTENT_LOCATION_ALL,
+        stmt -> stmt.setString(1, liveSetId.toString()),
+        rs -> URI.create(rs.getString(1)));
+  }
+
+  @Override
+  public void deleteLiveContentSet(UUID liveSetId) {
+    singleStatement(
+        DELETE_FILE_DELETIONS,
+        (conn, stmt) -> {
+          stmt.setString(1, liveSetId.toString());
+          stmt.executeUpdate();
+          try (PreparedStatement stmt2 = conn.prepareStatement(DELETE_LIVE_SET_LOCATIONS)) {
+            stmt2.setString(1, liveSetId.toString());
+            stmt2.executeUpdate();
+          }
+          try (PreparedStatement stmt2 = conn.prepareStatement(DELETE_LIVE_CONTENTS)) {
+            stmt2.setString(1, liveSetId.toString());
+            stmt2.executeUpdate();
+          }
+          try (PreparedStatement stmt2 = conn.prepareStatement(DELETE_LIVE_CONTENT_SET)) {
+            stmt2.setString(1, liveSetId.toString());
+            int cnt = stmt2.executeUpdate();
+            Preconditions.checkState(cnt == 1, "Live content set not found %s", liveSetId);
+          }
+          return null;
+        },
+        true);
+  }
+
+  private LiveContentSet currentLiveSet(Connection conn, UUID liveSetId) throws SQLException {
+    try (PreparedStatement stmt = conn.prepareStatement(SELECT_LIVE_CONTENT_SET)) {
+      return queryLiveContentSet(liveSetId, stmt);
+    }
+  }
+
+  @Override
+  public LiveContentSet getLiveContentSet(UUID liveSetId) throws LiveContentSetNotFoundException {
+    try {
+      return singleStatement(
+          SELECT_LIVE_CONTENT_SET, (conn, stmt) -> queryLiveContentSet(liveSetId, stmt), false);
+    } catch (IllegalStateException e) {
+      if (e.getCause() instanceof LiveContentSetNotFoundException) {
+        throw (LiveContentSetNotFoundException) e.getCause();
+      }
+      throw e;
+    }
+  }
+
+  private LiveContentSet queryLiveContentSet(UUID liveSetId, PreparedStatement stmt)
+      throws SQLException {
+    stmt.setString(1, liveSetId.toString());
+    try (ResultSet rs = stmt.executeQuery()) {
+      if (!rs.next()) {
+        throw new IllegalStateException(new LiveContentSetNotFoundException(liveSetId));
+      }
+      return liveContentSet(rs);
+    }
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<LiveContentSet> getAllLiveContents() {
+    return streamingResult(SELECT_ALL_LIVE_CONTENT_SETS, stmt -> {}, this::liveContentSet);
+  }
+
+  @Override
+  public long addFileDeletions(UUID liveSetId, Stream<FileReference> files) {
+    return singleStatement(
+        INSERT_FILE_DELETIONS,
+        (conn, stmt) -> {
+          long count = 0L;
+          for (Iterator<FileReference> iter = files.iterator(); iter.hasNext(); ) {
+            FileReference f = iter.next();
+            stmt.setString(1, liveSetId.toString());
+            stmt.setString(2, f.base().toString());
+            stmt.setString(3, f.path().toString());
+            stmt.setLong(4, f.modificationTimeMillisEpoch());
+            try {
+              stmt.executeUpdate();
+              count++;
+            } catch (SQLException e) {
+              if (!isIntegrityConstraintViolation(e)) {
+                throw e;
+              }
+            }
+          }
+          return count;
+        },
+        true);
+  }
+
+  @Override
+  public Stream<FileReference> fetchFileDeletions(UUID liveSetId) {
+    return streamingResult(
+        SELECT_FILE_DELETIONS,
+        stmt -> stmt.setString(1, liveSetId.toString()),
+        JdbcPersistenceSpi::fileObject);
+  }
+
+  static FileReference fileObject(ResultSet rs) throws SQLException {
+    return FileReference.of(
+        URI.create(rs.getString(2)), URI.create(rs.getString(1)), rs.getLong(3));
+  }
+
+  static ContentReference contentReference(ResultSet rs) throws SQLException {
+    String contentId = rs.getString(1);
+    String commitId = rs.getString(2);
+    ContentKey contentKey = ContentKey.fromPathString(rs.getString(3));
+    Content.Type contentType = ContentTypes.forName(rs.getString(4));
+    if (contentType.equals(Content.Type.ICEBERG_TABLE)) {
+      String metadataLocation = rs.getString(5);
+      long snapshotId = rs.getLong(6);
+      return ContentReference.icebergTable(
+          contentId, commitId, contentKey, metadataLocation, snapshotId);
+    } else {
+      throw new IllegalStateException(
+          "Unsupported content type '" + contentType + "' in repository");
+    }
+  }
+
+  LiveContentSet liveContentSet(ResultSet rs) throws SQLException {
+    Function<Timestamp, Instant> toInstant = t -> t != null ? t.toInstant() : null;
+    return LiveContentSet.builder()
+        .id(UUID.fromString(rs.getString(1)))
+        .status(LiveContentSet.Status.valueOf(rs.getString(2)))
+        .created(toInstant.apply(rs.getTimestamp(3)))
+        .identifyCompleted(toInstant.apply(rs.getTimestamp(4)))
+        .expiryStarted(toInstant.apply(rs.getTimestamp(5)))
+        .expiryCompleted(toInstant.apply(rs.getTimestamp(6)))
+        .errorMessage(rs.getString(7))
+        .persistenceSpi(this)
+        .build();
+  }
+
+  private Connection connection() {
+    try {
+      return dataSource().getConnection();
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  <R> R singleStatement(
+      @Language("SQL") String sql, WithStatement<R> withStatement, boolean modifyingStatement) {
+    try (Connection conn = connection()) {
+      boolean failed = true;
+      try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+        R r = withStatement.withStatement(conn, stmt);
+        if (modifyingStatement) {
+          conn.commit();
+        }
+        failed = false;
+        return r;
+      } finally {
+        if (modifyingStatement && failed) {
+          conn.rollback();
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  <R> Stream<R> streamingResult(@Language("SQL") String sql, Prepare prepare, FromRow<R> fromRow) {
+    List<AutoCloseable> closeables = new ArrayList<>();
+
+    ResultSetSplit<R> split =
+        new ResultSetSplit<>(this::connection, closeables::add, sql, prepare, fromRow);
+
+    return StreamSupport.stream(split, false)
+        .onClose(
+            () -> {
+              Exception ex = JdbcHelper.forClose(closeables, null);
+              if (ex instanceof RuntimeException) {
+                throw (RuntimeException) ex;
+              }
+              if (ex != null) {
+                throw new RuntimeException(ex);
+              }
+            });
+  }
+
+  abstract DataSource dataSource();
+}

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/SqlDmlDdl.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/SqlDmlDdl.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.intellij.lang.annotations.Language;
+
+final class SqlDmlDdl {
+
+  private SqlDmlDdl() {}
+
+  @Language("SQL")
+  static final String CREATE_LIVE_SETS =
+      "CREATE TABLE gc_live_sets (\n"
+          + "    live_set_id VARCHAR(40), \n"
+          + "    set_status VARCHAR(40), \n"
+          + "    identify_started TIMESTAMP, \n"
+          + "    identify_finished TIMESTAMP, \n"
+          + "    expire_started TIMESTAMP, \n"
+          + "    expire_finished TIMESTAMP, \n"
+          + "    error_message VARCHAR(2000), \n"
+          + "    PRIMARY KEY (live_set_id))";
+
+  @Language("SQL")
+  static final String CREATE_LIVE_SET_CONTENTS =
+      "CREATE TABLE gc_live_set_contents (\n"
+          + "    live_set_id VARCHAR(40), \n"
+          + "    content_id VARCHAR(200), \n"
+          + "    commit_id VARCHAR(100), \n"
+          + "    content_key VARCHAR(500), \n"
+          + "    content_type VARCHAR(40), \n"
+          + "    metadata_location VARCHAR(500), \n"
+          + "    snapshot_id BIGINT, \n"
+          + "    PRIMARY KEY(live_set_id, content_id, commit_id))";
+
+  @Language("SQL")
+  static final String CREATE_LIVE_SET_LOCATIONS =
+      "CREATE TABLE gc_live_set_content_locations (\n"
+          + "    live_set_id VARCHAR(40), \n"
+          + "    content_id VARCHAR(200), \n"
+          + "    base_location VARCHAR(500), \n"
+          + "    PRIMARY KEY (live_set_id, content_id, base_location))";
+
+  @Language("SQL")
+  static final String CREATE_FILE_DELETIONS =
+      "CREATE TABLE gc_file_deletions (\n"
+          + "    live_set_id VARCHAR(40), \n"
+          + "    base_uri VARCHAR(250), \n"
+          + "    path_uri VARCHAR(250), \n"
+          + "    modification_timestamp BIGINT, \n"
+          + "    PRIMARY KEY (live_set_id, base_uri, path_uri))";
+
+  @Language("SQL")
+  static final String INSERT_FILE_DELETIONS =
+      "INSERT INTO gc_file_deletions \n"
+          + "    (live_set_id, base_uri, path_uri, modification_timestamp) VALUES (?, ?, ?, ?)";
+
+  @Language("SQL")
+  static final String SELECT_FILE_DELETIONS =
+      "SELECT base_uri, path_uri, modification_timestamp \n"
+          + "    FROM gc_file_deletions \n"
+          + "    WHERE live_set_id = ? \n"
+          + "    ORDER BY base_uri";
+
+  @Language("SQL")
+  static final String DELETE_FILE_DELETIONS = "DELETE FROM gc_file_deletions WHERE live_set_id = ?";
+
+  @Language("SQL")
+  static final String SELECT_LIVE_CONTENT_SET =
+      "SELECT live_set_id, set_status, identify_started, identify_finished, expire_started, expire_finished, error_message \n"
+          + "    FROM gc_live_sets \n"
+          + "    WHERE live_set_id = ?";
+
+  @Language("SQL")
+  static final String SELECT_ALL_LIVE_CONTENT_SETS =
+      "SELECT live_set_id, set_status, identify_started, identify_finished, expire_started, expire_finished, error_message \n"
+          + "    FROM gc_live_sets";
+
+  @Language("SQL")
+  static final String DELETE_LIVE_CONTENTS =
+      "DELETE FROM gc_live_set_contents WHERE live_set_id = ?";
+
+  @Language("SQL")
+  static final String DELETE_LIVE_CONTENT_SET = "DELETE FROM gc_live_sets WHERE live_set_id = ?";
+
+  @Language("SQL")
+  static final String DELETE_LIVE_SET_LOCATIONS =
+      "DELETE FROM gc_live_set_content_locations WHERE live_set_id = ?";
+
+  @Language("SQL")
+  static final String INSERT_CONTENT_LOCATION =
+      "INSERT INTO gc_live_set_content_locations \n"
+          + "    (live_set_id, content_id, base_location) VALUES (?, ?, ?)";
+
+  @Language("SQL")
+  static final String SELECT_CONTENT_LOCATION =
+      "SELECT base_location \nFROM gc_live_set_content_locations \n"
+          + "    WHERE live_set_id = ? AND content_id = ?";
+
+  @Language("SQL")
+  static final String SELECT_CONTENT_LOCATION_ALL =
+      "SELECT base_location \nFROM gc_live_set_content_locations \n" + "    WHERE live_set_id = ?";
+
+  @Language("SQL")
+  static final String SELECT_CONTENT_IDS =
+      "SELECT DISTINCT content_id \nFROM gc_live_set_contents \n" + "    WHERE live_set_id = ?";
+
+  @Language("SQL")
+  static final String SELECT_CONTENT_COUNT =
+      "SELECT COUNT(DISTINCT content_id) \n"
+          + "    FROM gc_live_set_contents \n"
+          + "    WHERE live_set_id = ?";
+
+  @Language("SQL")
+  static final String START_IDENTIFY =
+      "INSERT INTO gc_live_sets \n"
+          + "    (live_set_id, identify_started, set_status) \n"
+          + "    VALUES (?, ?, ?)";
+
+  @Language("SQL")
+  static final String FINISH_IDENTIFY =
+      "UPDATE gc_live_sets \n"
+          + "    SET identify_finished = ?, set_status = ?, error_message = ? \n"
+          + "    WHERE live_set_id = ? AND set_status = ?";
+
+  @Language("SQL")
+  static final String START_EXPIRE =
+      "UPDATE gc_live_sets \n"
+          + "    SET expire_started = ?, set_status = ? \n"
+          + "    WHERE live_set_id = ? AND set_status = ?";
+
+  @Language("SQL")
+  static final String FINISH_EXPIRE =
+      "UPDATE gc_live_sets \n"
+          + "    SET expire_finished = ?, set_status = ?, error_message = ? \n"
+          + "    WHERE live_set_id = ? AND set_status = ?";
+
+  @Language("SQL")
+  static final String ADD_CONTENT =
+      "INSERT INTO gc_live_set_contents \n"
+          + "    (live_set_id, content_id, commit_id, content_key, content_type, metadata_location, snapshot_id) \n"
+          + "    VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+  @Language("SQL")
+  static final String SELECT_CONTENT_REFERENCES =
+      "SELECT content_id, commit_id, content_key, content_type, metadata_location, snapshot_id \n"
+          + "    FROM gc_live_set_contents \n"
+          + "    WHERE live_set_id = ? AND content_id = ?";
+
+  static final List<String> ALL_CREATES =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              CREATE_LIVE_SETS,
+              CREATE_LIVE_SET_CONTENTS,
+              CREATE_LIVE_SET_LOCATIONS,
+              CREATE_FILE_DELETIONS));
+
+  static final List<String> ALL_TABLE_NAMES =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              "gc_live_set_content_locations",
+              "gc_live_set_contents",
+              "gc_live_sets",
+              "gc_file_deletions"));
+}

--- a/gc/gc-repository-jdbc/src/test/java/org/projectnessie/gc/contents/jdbc/TestJdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/test/java/org/projectnessie/gc/contents/jdbc/TestJdbcPersistenceSpi.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.projectnessie.gc.contents.spi.PersistenceSpi;
+import org.projectnessie.gc.contents.tests.AbstractPersistenceSpi;
+
+public class TestJdbcPersistenceSpi extends AbstractPersistenceSpi {
+
+  private static DataSource dataSource;
+
+  @BeforeAll
+  static void createDataSource() throws Exception {
+    AgroalJdbcDataSourceProvider dsProvider =
+        AgroalJdbcDataSourceProvider.builder()
+            .jdbcUrl("jdbc:h2:mem:nessie")
+            .poolMinSize(1)
+            .poolMaxSize(1)
+            .poolInitialSize(1)
+            .build();
+    dataSource = dsProvider.dataSource();
+  }
+
+  @AfterAll
+  static void closeDataSource() throws Exception {
+    if (dataSource instanceof AutoCloseable) {
+      ((AutoCloseable) dataSource).close();
+    }
+  }
+
+  @Override
+  protected PersistenceSpi createPersistenceSpi() {
+    return JdbcPersistenceSpi.builder().dataSource(dataSource).build();
+  }
+
+  @BeforeEach
+  void setup() throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      JdbcHelper.createTables(conn);
+    }
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      try (Statement st = conn.createStatement()) {
+        for (String tableName : SqlDmlDdl.ALL_TABLE_NAMES) {
+          st.execute(String.format("DROP TABLE %s", tableName));
+        }
+      }
+    }
+  }
+
+  @Override
+  protected void assertDeleted(UUID id) throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      for (String tableName : SqlDmlDdl.ALL_TABLE_NAMES) {
+        try (PreparedStatement st =
+            conn.prepareStatement(
+                String.format("SELECT * FROM %s WHERE live_set_id = ?", tableName))) {
+          st.setString(1, id.toString());
+          try (ResultSet rs = st.executeQuery()) {
+            soft.assertThat(rs.next()).as(tableName).isFalse();
+          }
+        }
+      }
+    }
+  }
+}

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -6,6 +6,7 @@ nessie-compatibility-jersey=compatibility/jersey
 nessie-model=model
 nessie-gc-base=gc/gc-base
 nessie-gc-base-tests=gc/gc-base-tests
+nessie-gc-repository-jdbc=gc/gc-repository-jdbc
 nessie-perftest-gatling=perftest/gatling
 nessie-perftest-simulations=perftest/simulations
 nessie-jaxrs=servers/jax-rs


### PR DESCRIPTION
Adds functionality to persist the live-content-sets from #5144 (#4991) in a JDBC database (H2 or PostgreSQL or compatible).