### PR TITLE
Automatic patch releases

### DIFF
--- a/.github/actions/bump-versions/action.yml
+++ b/.github/actions/bump-versions/action.yml
@@ -24,23 +24,18 @@ runs:
 
     - name: Bump versions in site/ to ${{ inputs.new-version }}
       shell: bash
-      working-directory: ./site
       env:
         NEW_VERSION: ${{ inputs.new-version }}
       run: |
-        cp mkdocs.yml /tmp/nessie-mkdocs.yml
-        cat /tmp/nessie-mkdocs.yml | sed "s/^    java: [0-9.]*$/    java: ${NEW_VERSION}/" | sed "s/^    python: v[0-9.]*$/    python: v${NEW_VERSION}/"> mkdocs.yml
-        rm /tmp/nessie-mkdocs.yml
+        sed -i "s/^    java: [0-9.]*$/    java: ${NEW_VERSION}/"  site/mkdocs.yml
+        sed -i "s/^    python: v[0-9.]*$/    python: v${NEW_VERSION}/" site/mkdocs.yml
 
     - name: Bump version in helm/nessie to ${{ inputs.new-version }}
       shell: bash
-      working-directory: ./helm/nessie
       env:
         NEW_VERSION: ${{ inputs.new-version }}
       run: |
-        cp Chart.yaml /tmp/nessie-Chart.yaml
-        cat /tmp/nessie-Chart.yaml | sed "s/^version: [0-9.]*$/version: ${NEW_VERSION}/" > Chart.yaml
-        rm /tmp/nessie-Chart.yaml
+        sed -i "s/^version: [0-9.]*$/version: ${NEW_VERSION}/" helm/nessie/Chart.yaml
 
     - name: Bump UI release version ${{ inputs.new-version }}
       shell: bash
@@ -48,9 +43,5 @@ runs:
       env:
         NEW_VERSION: ${{ inputs.new-version }}
       run: |
-        cp package.json /tmp/nessie-ui-package.json
-        cp package-lock.json /tmp/nessie-ui-package-lock.json
-        cat /tmp/nessie-ui-package.json | jq ".version = \"${NEW_VERSION}\"" > package.json
-        cat /tmp/nessie-ui-package-lock.json | jq ".version = \"${NEW_VERSION}\" | .packages[\"\"].version = \"${NEW_VERSION}\"" > package-lock.json
-        rm /tmp/nessie-ui-package.json
-        rm /tmp/nessie-ui-package-lock.json
+        jq ".version = \"${NEW_VERSION}\"" < package.json > /tmp/package.json && mv /tmp/package.json package.json
+        jq ".version = \"${NEW_VERSION}\" | .packages[\"\"].version = \"${NEW_VERSION}\"" < package-lock.json > /tmp/package-lock.json && mv /tmp/package-lock.json package-lock.json

--- a/.github/actions/bump-versions/action.yml
+++ b/.github/actions/bump-versions/action.yml
@@ -1,0 +1,56 @@
+name: 'Bump versions'
+description: 'Updates versions for Python, UI, helm + site'
+inputs:
+  new-version:
+    required: true
+    description: 'Version to bump to'
+runs:
+  using: "composite"
+  steps:
+    - name: Bump Python release version ${{ inputs.new-version }}
+      shell: bash
+      working-directory: ./python
+      env:
+        NEW_VERSION: ${{ inputs.new-version }}
+      run: |
+        # bump2version 1.0.1 has a bug: https://github.com/c4urself/bump2version/issues/214
+        if [[ "$(cd python/ ; python -c 'import pynessie; print(pynessie.__version__)')" != ${NEW_VERSION} ]] ; then
+          bump2version --no-commit --no-tag --allow-dirty --new-version ${NEW_VERSION} minor
+          # Call into pynessie to ensure bump2version didn't mess up anything
+          echo "pynessie at release-version $(python -c 'import pynessie; print(pynessie.__version__)')"
+        else
+          echo "pynessie already at release-version ${NEW_VERSION}"
+        fi
+
+    - name: Bump versions in site/ to ${{ inputs.new-version }}
+      shell: bash
+      working-directory: ./site
+      env:
+        NEW_VERSION: ${{ inputs.new-version }}
+      run: |
+        cp mkdocs.yml /tmp/nessie-mkdocs.yml
+        cat /tmp/nessie-mkdocs.yml | sed "s/^    java: [0-9.]*$/    java: ${NEW_VERSION}/" | sed "s/^    python: v[0-9.]*$/    python: v${NEW_VERSION}/"> mkdocs.yml
+        rm /tmp/nessie-mkdocs.yml
+
+    - name: Bump version in helm/nessie to ${{ inputs.new-version }}
+      shell: bash
+      working-directory: ./helm/nessie
+      env:
+        NEW_VERSION: ${{ inputs.new-version }}
+      run: |
+        cp Chart.yaml /tmp/nessie-Chart.yaml
+        cat /tmp/nessie-Chart.yaml | sed "s/^version: [0-9.]*$/version: ${NEW_VERSION}/" > Chart.yaml
+        rm /tmp/nessie-Chart.yaml
+
+    - name: Bump UI release version ${{ inputs.new-version }}
+      shell: bash
+      working-directory: ./ui
+      env:
+        NEW_VERSION: ${{ inputs.new-version }}
+      run: |
+        cp package.json /tmp/nessie-ui-package.json
+        cp package-lock.json /tmp/nessie-ui-package-lock.json
+        cat /tmp/nessie-ui-package.json | jq ".version = \"${NEW_VERSION}\"" > package.json
+        cat /tmp/nessie-ui-package-lock.json | jq ".version = \"${NEW_VERSION}\" | .packages[\"\"].version = \"${NEW_VERSION}\"" > package-lock.json
+        rm /tmp/nessie-ui-package.json
+        rm /tmp/nessie-ui-package-lock.json

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 
-# Projectnessie Update development version on 'main'
+# Projectnessie Update development version on 'main' (or another branch) to the next
+# patch/minor/major version as a -SNAPSHOT version.
 
-# Manually triggered workflow, takes the "next-version" argument.
-# This workflow creates the git commit to bump the development version.
+# Manually triggered workflow, takes the optional "bumpType" and "bumpBranch" arguments.
+# This workflow creates a Git commit to bump the development version.
 
 # Secrets:
 #   NESSIE_BUILDER  GH access-token to push the release-commits+tag to the branch,
@@ -28,33 +29,34 @@ on:
   # Manually triggered
   workflow_dispatch:
     inputs:
-      nextVersion:
-        description: 'The new version - e.g. `0.5.0`'
+      bumpType:
+        description: 'Bump what (`patch`, `minor`, `major`), defaults to `patch`'
         required: true
+        type: string
+        default: "patch"
+      bumpBranch:
+        description: 'The branch name to bump the version in, leave empty to bump the version on the `main` branch.'
+        required: true
+        type: string
+        default: "main"
 
 jobs:
   create-release:
     name: Bump version
     runs-on: ubuntu-20.04
     env:
-      NEXT_VERSION: ${{ github.event.inputs.nextVersion }}
+      BUMP_ON_BRANCH: ${{ github.event.inputs.bumpBranch }}
+      BUMP_TYPE: ${{ github.event.inputs.bumpType }}
 
     steps:
-
-    # Check the given version parameter strings for valid version patterns and inequality.
-    - name: Check parameters
-      run: |
-        # check if tag matches patterns like nessie-0.5, nessie-0.10.4.3-alpha1, etc
-        if [[ ${NEXT_VERSION} =~ ^[0-9]+[.][0-9.]*[0-9](-[a-zA-Z0-9]+)?$ ]]; then
-          echo "Parameter check OK"
-        else
-          echo "NEXT_VERSION is not a valid release version."
-          exit 1
-        fi
 
     ### BEGIN runner setup
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ env.BUMP_ON_BRANCH }}
+    - name: Setup Java, Maven
+      uses: ./.github/actions/dev-tool-java
     - name: Setup Python
       uses: ./.github/actions/dev-tool-python
       with:
@@ -68,32 +70,18 @@ jobs:
         python3 -m pip install -r python/requirements.txt
     ### END runner setup
 
-    - name: Bump Python version ${{ github.event.inputs.releaseVersion }}
-      working-directory: ./python
-      run: |
-        # bump2version 1.0.1 has a bug: https://github.com/c4urself/bump2version/issues/30
-        if [[ "$(cd python/ ; python -c 'import pynessie; print(pynessie.__version__)')" != ${NEXT_VERSION} ]] ; then
-          bump2version --no-commit --no-tag --new-version ${NEXT_VERSION} minor
-          # Call into pynessie to ensure bump2version didn't mess up anything
-          echo "pynessie at release-version $(python -c 'import pynessie; print(pynessie.__version__)')"
-        else
-          echo "pynessie already at release-version ${NEXT_VERSION}"
-        fi
+    - name: Bump to version
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: :bumpVersion --bumpType ${BUMP_TYPE}
 
-    # Update ui-version to next development iteration
-    - name: Bump UI to next development version
-      working-directory: ./ui
-      env:
-        NEXT_UI_VERSION: ${{ env.NEXT_VERSION }}-snapshot
-      run: |
-        cp package.json /tmp/nessie-ui-package.json
-        cp package-lock.json /tmp/nessie-ui-package-lock.json
-        cat /tmp/nessie-ui-package.json | jq ".version = \"${NEXT_UI_VERSION}\"" > package.json
-        cat /tmp/nessie-ui-package-lock.json | jq ".version = \"${NEXT_UI_VERSION}\" | .packages[\"\"].version = \"${NEXT_UI_VERSION}\"" > package-lock.json
+    - name: Get bumped version information
+      run: echo "NEXT_VERSION=$(cat version.txt | sed 's/-SNAPSHOT//')" >> ${GITHUB_ENV}
 
-    # Update versions in version.txt to next development iteration
-    - name: Bump to next development version version
-      run: echo "${NEXT_VERSION}-SNAPSHOT" > version.txt
+    - name: Bump versions for Python, site/, helm and UI
+      uses: ./.github/actions/bump-versions
+      with:
+        new-version: ${{ env.NEXT_VERSION }}
 
     - name: Configure bump-version-bot-user in git config
       run: |
@@ -104,14 +92,21 @@ jobs:
     - name: Record next development version in git
       run: git commit -a -m "[bump-version] bump to ${NEXT_VERSION}-SNAPSHOT"
 
-    # Record the next development iteration in git
-    - name: Show Git log
-      run: git log -n2
+    - name: Version information
+      run: |
+        CURRENT_VERSION=$(cat version.txt)
 
-    # Push the 2 git commits and git tag. If this one fails, some other commit was pushed to the
+        cat <<! >> $GITHUB_STEP_SUMMARY
+        ## Version information
+
+        | **Previous Nessie version** | ${CURRENT_VERSION}        |
+        | **Bump type**               | ${BUMP_TYPE}              |
+        | Git HEAD                    | \`$(git rev-parse HEAD)\` |
+        !
+
+    # Push the Git commit. If this one fails, some other commit was pushed to the
     # 'main' branch and break the linear history for the Nessie git repo.
-    # The `release-publish.yml` job will run when the release tag `nessie-x.y.z` has been pushed.
-    - name: Push
+    - name: Push Git commit
       run: |
         # Push directly using the remote repo URL, which includes the secret so this job can push to the repo
         UPSTREAM="https://${{ secrets.NESSIE_BUILDER }}@github.com/${GITHUB_REPOSITORY}.git"
@@ -119,7 +114,7 @@ jobs:
         # Move the default auth settings in ~/.gitconfig out of the way, so the git-push can use the token
         git config --rename-section http.https://github.com/ http.https://save.github.com/
 
-        git push --no-verify "${UPSTREAM}" HEAD:${GITHUB_REF} ${GIT_TAG}
+        git push --no-verify "${UPSTREAM}" HEAD:${GITHUB_REF}
 
         # Move the default auth settings in ~/.gitconfig back
         git config --rename-section http.https://save.github.com/ http.https://github.com/

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -70,18 +70,23 @@ jobs:
         python3 -m pip install -r python/requirements.txt
     ### END runner setup
 
+    - name: Get previous version information
+      run: echo "PREVIOUS_VERSION=$(cat version.txt)" >> ${GITHUB_ENV}
+
     - name: Bump to version
       uses: gradle/gradle-build-action@v2
       with:
         arguments: :bumpVersion --bumpType ${BUMP_TYPE}
 
     - name: Get bumped version information
-      run: echo "NEXT_VERSION=$(cat version.txt | sed 's/-SNAPSHOT//')" >> ${GITHUB_ENV}
+      run: |
+        echo "BUMPED_VERSION=$(cat version.txt)" >> ${GITHUB_ENV}
+        echo "BUMPED_VERSION_NO_SNAPSHOT=${BUMPED_VERSION%-SNAPSHOT}" >> ${GITHUB_ENV}
 
     - name: Bump versions for Python, site/, helm and UI
       uses: ./.github/actions/bump-versions
       with:
-        new-version: ${{ env.NEXT_VERSION }}
+        new-version: ${{ env.BUMPED_VERSION_NO_SNAPSHOT }}
 
     - name: Configure bump-version-bot-user in git config
       run: |
@@ -90,16 +95,15 @@ jobs:
 
     # Record the next development iteration in git
     - name: Record next development version in git
-      run: git commit -a -m "[bump-version] bump to ${NEXT_VERSION}-SNAPSHOT"
+      run: git commit -a -m "[bump-version] bump to ${BUMPED_VERSION}"
 
     - name: Version information
       run: |
-        CURRENT_VERSION=$(cat version.txt)
-
         cat <<! >> $GITHUB_STEP_SUMMARY
         ## Version information
 
-        | **Previous Nessie version** | ${CURRENT_VERSION}        |
+        | **Previous Nessie version** | ${PREVIOUS_VERSION}       |
+        | **Current Nessie version**  | ${BUMPED_VERSION}         |
         | **Bump type**               | ${BUMP_TYPE}              |
         | Git HEAD                    | \`$(git rev-parse HEAD)\` |
         !

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -15,14 +15,12 @@
 
 # Projectnessie GitHub Release workflow
 
-# Manually triggered workflow, takes the "release-version" argument.
+# Creates a release tag for the current in-tree version from the main or another branch.
 
 # This workflow creates the git commits + git tag for a Nessie release.
-# It requires a fully successful CI status of the commit going to be released, i.e. we rely on
-# the "Main CI" workflow here.
 
 # When this workflow pushes the release tag (e.g. `nessie-0.5.1`), the `release-publish.yml`
-# workflow publishes the release artifacts
+# workflow publishes the release artifacts.
 
 # Projectnessie really prefers a linear git history - aka no merges. PRs must not be merged
 # while the release workflow runs. In case the git history would not be linear, this workflow will
@@ -38,12 +36,14 @@ on:
   # Manually triggered
   workflow_dispatch:
     inputs:
-      releaseVersion:
-        description: 'The version to release - e.g. `0.5.0`'
-        required: true
       releaseFromBranch:
         description: 'The branch name the release from, leave empty to release from latest commit on main.'
         required: false
+      bumpType:
+        description: 'Optional: bump patch, minor or major version (`patch`, `minor`, `major`). Default is `none` to release the current in-tree SNAPSHOT version.'
+        required: true
+        type: string
+        default: "none"
 
 jobs:
   create-release:
@@ -51,28 +51,16 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       RELEASE_FROM: ${{ github.event.inputs.releaseFromBranch }}
-      GIT_TAG: nessie-${{ github.event.inputs.releaseVersion }}
-      RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+      BUMP_TYPE: ${{ github.event.inputs.bumpType }}
 
     steps:
 
-    # Check the given version parameter strings for valid version patterns and inequality.
-    - name: Check parameters
-      run: |
-        # check if tag matches patterns like nessie-0.5, nessie-0.10.4.3-alpha1, etc
-        if [[ ${RELEASE_VERSION} =~ ^[0-9]+[.][0-9.]*[0-9](-[a-zA-Z0-9]+)?$ ]]; then
-          echo "Parameter check OK"
-        else
-          echo "RELEASE_VERSION is not a valid release version."
-          exit 1
-        fi
-
+    ### BEGIN runner setup
     - name: Checkout
       uses: actions/checkout@v3
       with:
         ref: ${{ env.RELEASE_FROM }}
-
-    ### BEGIN runner setup
+        fetch-depth: '0'
     - name: Setup Java, Maven
       uses: ./.github/actions/dev-tool-java
     - name: Setup Python
@@ -88,55 +76,99 @@ jobs:
         python3 -m pip install -r python/requirements.txt
     ### END runner setup
 
-    # Two steps that verify that the HISTORY.rst, server-upgrade.md and releases.md files contain
-    # information about the release
+    - name: Bump to release version
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: :bumpVersion --bumpType ${BUMP_TYPE} --bumpToRelease
+
+    - name: Get release version
+      run: |
+        RELEASE_VERSION=$(cat version.txt)
+        LAST_TAG=$(git describe --abbrev=0 --tags --match=nessie-*)
+
+        echo "LAST_TAG=${LAST_TAG}" >> ${GITHUB_ENV}
+        echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_ENV}
+        echo "GIT_TAG=nessie-${RELEASE_VERSION}" >> ${GITHUB_ENV}
+
+        cat <<! >> $GITHUB_STEP_SUMMARY
+        ## About to release
+        
+        Version information right before the Git release tag and commit:
+
+        | **Nessie release version** | ${RELEASE_VERSION}        | 
+        | **Git tag name**           | \`${GIT_TAG}\`            | 
+        | **Previous Git tag**       | \`${LAST_TAG}\`           | 
+        | **Release from branch**    | ${RELEASE_FROM}           | 
+        | **Bump type**              | ${BUMP_TYPE}              |
+        | Before release Git HEAD    | \`$(git rev-parse HEAD)\` |
+        !
+
+    # Two steps that verify that the README.md, SECURITY.md and server-upgrade.md files contain
+    # information about the release, ignoring the patch version
     - name: Check release version number in text files
       run: |
         FAILS=""
-        VERSION_PATTERH="$(echo ${RELEASE_VERSION} | sed 's/\./\\./g' )"
-        grep -q "^${VERSION_PATTERH} [(][0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][)]$" < python/HISTORY.rst || FAILS="${FAILS} python/HISTORY.rst"
-        grep -q "^## ${VERSION_PATTERH} Release [(][A-Z][a-z]* [0-9][0-9]*, [0-9][0-9][0-9][0-9][)]$" < site/docs/try/releases.md || FAILS="${FAILS} site/docs/try/releases.md"
-        grep -q " ${VERSION_PATTERH} " < site/docs/try/server-upgrade.md || FAILS="${FAILS} site/docs/try/server-upgrade.md"
-        grep -q "^| ${VERSION_PATTERH} .*check_mark.*$" < SECURITY.md || FAILS="${FAILS} SECURITY.md"
+        # version pattern without patch version
+        VERSION_PATTERN="$(echo ${RELEASE_VERSION} | sed 's/\([^.]*\)[.]\([^.]*\)[.].*/\1\\.\2/')\\."
+        grep -q " ${VERSION_PATTERN}" < site/docs/try/server-upgrade.md || FAILS="${FAILS} site/docs/try/server-upgrade.md"
+        grep -q "^| ${VERSION_PATTERN}" < README.md || FAILS="${FAILS} README.md"
+        grep -q "^| ${VERSION_PATTERN}.* .*check_mark.*$" < SECURITY.md || FAILS="${FAILS} SECURITY.md"
         if [[ -n ${FAILS} ]] ; then
-          echo ${FAILS} "do not contain the release version ${RELEASE_VERSION}."
+          echo ${FAILS} "do not match the version pattern ${VERSION_PATTERN}."
           exit 1
         fi
 
-    - name: Bump Python release version ${{ github.event.inputs.releaseVersion }}
-      working-directory: ./python
-      run: |
-        # bump2version 1.0.1 has a bug: https://github.com/c4urself/bump2version/issues/214
-        if [[ "$(cd python/ ; python -c 'import pynessie; print(pynessie.__version__)')" != ${RELEASE_VERSION} ]] ; then
-          bump2version --no-commit --no-tag --new-version ${RELEASE_VERSION} minor
-          # Call into pynessie to ensure bump2version didn't mess up anything
-          echo "pynessie at release-version $(python -c 'import pynessie; print(pynessie.__version__)')"
-        else
-          echo "pynessie already at release-version ${RELEASE_VERSION}"
-        fi
+    - name: Bump versions for Python, site/, helm and UI
+      uses: ./.github/actions/bump-versions
+      with:
+        new-version: ${{ env.RELEASE_VERSION }}
 
-    - name: Bump versions in site/ to ${{ github.event.inputs.releaseVersion }}
-      working-directory: ./site
+    # Updates the site/docs/try/releases.md file, takes the first four lines (the big heading),
+    # adds a heading with the version and a note referencing the release notes on GitHub,
+    # followed by the Git change log, finalized with the remainder of the
+    # previous site/docs/try/releases.md file.
+    - name: Update releases.md file
       run: |
-        cp mkdocs.yml /tmp/nessie-mkdocs.yml
-        cat /tmp/nessie-mkdocs.yml | sed "s/^    java: [0-9.]*$/    java: ${RELEASE_VERSION}/" | sed "s/^    python: v[0-9.]*$/    python: v${RELEASE_VERSION}/"> mkdocs.yml
+        head -4 site/docs/try/releases.md > /tmp/releases.md
+        cat <<!  >> /tmp/releases.md
+        ## ${RELEASE_VERSION} Release ($(date '+%B %d, %Y'))
+        
+        See [Release information on GitHub](https://github.com/projectnessie/nessie/releases/tag/nessie-${RELEASE_VERSION}).
+        
+        !
+        
+        git log --perl-regexp --author '^(?!.*dependabot(-preview)?|.*nessie-release-workflow).*$'\
+          --format='format:* %s' ${LAST_TAG}..HEAD |\
+          grep -v '^\* \[release\] .*$' >> /tmp/releases.md
+        
+        tail +4 site/docs/try/releases.md >> /tmp/releases.md
+        
+        cp /tmp/releases.md site/docs/try/releases.md
+        rm /tmp/releases.md
 
-    - name: Bump version in helm/nessie to ${{ github.event.inputs.releaseVersion }}
-      working-directory: ./helm/nessie
+    # Updates the python/HISTORY.rst file, takes the first four lines (the big heading),
+    # adds a heading with the version and a single item referencing the release notes on GitHub,
+    # followed by the Git change log for the python/ directory, finalized with the remainder of the
+    # previous python/HISTORY.rst file.
+    - name: Update HISTORY.rst file
       run: |
-        cp Chart.yaml /tmp/nessie-Chart.yaml
-        cat /tmp/nessie-Chart.yaml | sed "s/^version: [0-9.]*$/version: ${RELEASE_VERSION}/" > Chart.yaml
-
-    - name: Bump UI release version ${{ github.event.inputs.releaseVersion }}
-      working-directory: ./ui
-      run: |
-        cp package.json /tmp/nessie-ui-package.json
-        cp package-lock.json /tmp/nessie-ui-package-lock.json
-        cat /tmp/nessie-ui-package.json | jq ".version = \"${RELEASE_VERSION}\"" > package.json
-        cat /tmp/nessie-ui-package-lock.json | jq ".version = \"${RELEASE_VERSION}\" | .packages[\"\"].version = \"${RELEASE_VERSION}\"" > package-lock.json
-
-    - name: Bump to release version ${{ github.event.inputs.releaseVersion }}
-      run: echo "${RELEASE_VERSION}" > version.txt
+        head -4 python/HISTORY.rst > /tmp/HISTORY.rst
+        HEAD="${RELEASE_VERSION} ($(date '+%Y-%m-%d'))"
+        cat <<!  >> /tmp/HISTORY.rst
+        ${HEAD}
+        $(echo -n $HEAD | sed 's/./-/g')
+        
+        * See release notes and changelog on GitHub: https://github.com/projectnessie/nessie/releases/tag/nessie-${RELEASE_VERSION}
+        !
+        
+        git log --perl-regexp --author '^(?!.*dependabot(-preview)?|.*nessie-release-workflow).*$'\
+          --format='format:* %s' ${LAST_TAG}..HEAD python/ |\
+          grep -v '^\* \[release\] .*$' >> /tmp/HISTORY.rst
+        
+        tail +4 python/HISTORY.rst >> /tmp/HISTORY.rst
+        
+        cp /tmp/HISTORY.rst python/HISTORY.rst
+        rm /tmp/HISTORY.rst
 
     - name: Configure release-bot-user in git config
       run: |
@@ -144,40 +176,54 @@ jobs:
         git config --global user.name "Nessie Release Workflow [bot]"
 
     # Record the release-version in git and add the git tag for the release.
-    - name: Record ${{ github.event.inputs.releaseVersion }} release in git
+    - name: Record ${{ env.RELEASE_VERSION }} release in git
       run: |
         git commit -a -m "[release] release nessie-${RELEASE_VERSION}"
-        git tag -f ${GIT_TAG}
+        git tag -f -a -m "Release ${RELEASE_VERSION} from ${RELEASE_FROM} with bump-type ${BUMP_TYPE}" ${GIT_TAG}
 
-    # Update versions to next development iteration, use bump2version as the "source of truth" here
-    - name: Set Python to next development version version
-      id: next_version
-      working-directory: ./python
+        cat <<! >> $GITHUB_STEP_SUMMARY
+        ## Release version information
+        
+        Version information after the Git release tag:
+        
+        | **Nessie release version** | ${RELEASE_VERSION}        | 
+        | **Git tag name**           | \`${GIT_TAG}\`\           | 
+        | **Previous Git tag**       | \`${LAST_TAG}\`           | 
+        | **Release from branch**    | ${RELEASE_FROM}           | 
+        | **Bump type**              | ${BUMP_TYPE}              |
+        | Release Git HEAD           | \`$(git rev-parse HEAD)\` |
+        !
+
+    # Bump to the next patch version as a SNAPSHOT
+    - name: Bump to next patch version
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: bumpToNextPatchVersion
+
+    - name: Get next patch version
+      run: echo "NEXT_VERSION=$(cat version.txt | sed 's/-SNAPSHOT//')" >> ${GITHUB_ENV}
+
+    # Record the next development iteration in Git
+    - name: Record next development version in Git
+      run: git commit -a -m "[release] next development iteration ${NEXT_VERSION}"
+
+    - name: Get next patch version
       run: |
-        bump2version --no-commit --no-tag patch
-        # Call into pynessie to ensure bump2version didn't mess up anything. See https://github.com/c4urself/bump2version/issues/214
-        NEXT_VERSION="$(python -c 'import pynessie; print(pynessie.__version__)')"
-        echo "pynessie at next development iteration ${NEXT_VERSION}"
+        NEXT_VERSION=$(cat version.txt | sed 's/-SNAPSHOT//')
         echo "NEXT_VERSION=${NEXT_VERSION}" >> ${GITHUB_ENV}
 
-    # Update ui-version to next development iteration
-    - name: Bump UI to next development version
-      working-directory: ./ui
-      env:
-        NEXT_UI_VERSION: ${{ env.NEXT_VERSION }}-snapshot
-      run: |
-        cp package.json /tmp/nessie-ui-package.json
-        cp package-lock.json /tmp/nessie-ui-package-lock.json
-        cat /tmp/nessie-ui-package.json | jq ".version = \"${NEXT_UI_VERSION}\"" > package.json
-        cat /tmp/nessie-ui-package-lock.json | jq ".version = \"${NEXT_UI_VERSION}\" | .packages[\"\"].version = \"${NEXT_UI_VERSION}\"" > package-lock.json
+        cat <<! >> $GITHUB_STEP_SUMMARY
+        ## Next development version information
 
-    # Update versions in version.txt to next development iteration
-    - name: Bump to next development version version
-      run: echo "${NEXT_VERSION}-SNAPSHOT" > version.txt
+        | **Nessie development version**   | ${NEXT_VERSION}           |
+        | **\`version.txt\` content**      | \`$(cat version.txt)\`    |
+        | Git HEAD                         | \`$(git rev-parse HEAD)\` |
+        !
 
-    # Record the next development iteration in git
-    - name: Record next development version in git
-      run: git commit -a -m "[release] next development iteration"
+    - name: Bump versions for Python, site/, helm and UI
+      uses: ./.github/actions/bump-versions
+      with:
+        new-version: ${{ env.NEXT_VERSION }}
 
     # Push the 2 git commits and git tag. If this one fails, some other commit was pushed to the
     # 'main' branch and break the linear history for the Nessie git repo.

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -209,7 +209,7 @@ jobs:
     - name: Record next development version in Git
       run: git commit -a -m "[release] next development iteration ${NEXT_VERSION}"
 
-    - name: Get next patch version
+    - name: Next version information
       run: |
         cat <<! >> $GITHUB_STEP_SUMMARY
         ## Next development version information

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -201,7 +201,9 @@ jobs:
         arguments: bumpToNextPatchVersion
 
     - name: Get next patch version
-      run: echo "NEXT_VERSION=$(cat version.txt | sed 's/-SNAPSHOT//')" >> ${GITHUB_ENV}
+      run: |
+        echo "NEXT_VERSION=$(cat version.txt)" >> ${GITHUB_ENV}
+        echo "NEXT_VERSION_NO_SNAPSHOT=${NEXT_VERSION%-SNAPSHOT}" >> ${GITHUB_ENV}
 
     # Record the next development iteration in Git
     - name: Record next development version in Git
@@ -209,9 +211,6 @@ jobs:
 
     - name: Get next patch version
       run: |
-        NEXT_VERSION=$(cat version.txt | sed 's/-SNAPSHOT//')
-        echo "NEXT_VERSION=${NEXT_VERSION}" >> ${GITHUB_ENV}
-
         cat <<! >> $GITHUB_STEP_SUMMARY
         ## Next development version information
 
@@ -223,7 +222,7 @@ jobs:
     - name: Bump versions for Python, site/, helm and UI
       uses: ./.github/actions/bump-versions
       with:
-        new-version: ${{ env.NEXT_VERSION }}
+        new-version: ${{ env.NEXT_VERSION_NO_SNAPSHOT }}
 
     # Push the 2 git commits and git tag. If this one fails, some other commit was pushed to the
     # 'main' branch and break the linear history for the Nessie git repo.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -27,8 +27,6 @@
 #   PYPI_API_TOKEN
 #   DOCKER_USERNAME
 #   DOCKER_TOKEN
-#   GRADLE_PUBLISH_KEY
-#   GRADLE_PUBLISH_SECRET
 
 name: Publish release
 
@@ -58,7 +56,6 @@ jobs:
     # and provides the output `VERSION` or, in case of a manual run, uses the input `releaseTag` as
     # the input tag name.
     - name: Get release version
-      id: get_version
       run: |
         if [[ "${{ github.event_name }}" == "push" ]] ; then
           V="${GITHUB_REF/refs\/tags\/}"
@@ -68,6 +65,7 @@ jobs:
         # check if tag matches patterns like nessie-0.5, nessie-0.10.4.3-alpha1, etc
         if [[ ${V} =~ ^nessie-[0-9]+[.][0-9.]*[0-9](-[a-zA-Z0-9]+)?$ ]]; then
           echo "RELEASE_VERSION=${V/nessie-}" >> ${GITHUB_ENV}
+          echo "GIT_TAG=nessie-${RELEASE_VERSION}" >> ${GITHUB_ENV}
         else
           echo "Tag must start with nessie- followed by a valid version (got tag ${V}, ref is ${GITHUB_REF} )"
           exit 1
@@ -101,12 +99,15 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install -r python/requirements_dev.txt
+    - name: Install Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.6.3
     ### END runner setup
 
     # Deploys Maven artifacts. Build and test steps were already ran in previous steps.
     # Not running tests, because the environment contains secrets.
     - name: Publish Maven artifacts for release
-      id: build_maven
       env:
         # To release with Gradle
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
@@ -137,11 +138,6 @@ jobs:
 
         echo "## Successfully released ${RELEASE_VERSION} to Sonatype" >> $GITHUB_STEP_SUMMARY
 
-    - name: Install Helm
-      uses: azure/setup-helm@v1
-      with:
-        version: v3.6.3
-
       # Packages Nessie Helm chart
     - name: Package Nessie Helm chart for release
       run: |
@@ -149,7 +145,6 @@ jobs:
 
       # Rename Nessie Helm chart
     - name: Rename Nessie Helm chart for release
-      id: nessie_helm
       run: |
         mv nessie-${RELEASE_VERSION}.tgz nessie-helm-${RELEASE_VERSION}.tgz
         echo "NESSIE_HELM_CHART=nessie-helm-${RELEASE_VERSION}.tgz" >> ${GITHUB_ENV}
@@ -182,16 +177,24 @@ jobs:
       run: echo "## Successfully published pynessie ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
 
     # Deploys Docker images. Build and test steps were already ran in previous workflows
-    - name: Tag Docker image for release
-      run: |
-        docker tag projectnessie/nessie:${RELEASE_VERSION} projectnessie/nessie:latest
-
-    # Deploys Docker images. Build and test steps were already ran in previous workflows
     - name: Publish Docker image for release
       run: |
+        echo "## Docker publish ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
+
+        echo "::group::Tag Docker image"
+        docker tag projectnessie/nessie:${RELEASE_VERSION} projectnessie/nessie:latest
+        echo "Successfully tagged Docker image as \`projectnessie/nessie:${RELEASE_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "::endgroup::"
+
+        echo "::group::Docker Hub login"
         echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
+        echo "::endgroup::"
+
+        echo "::group::Push Docker image"
         docker push projectnessie/nessie:${RELEASE_VERSION} && docker push projectnessie/nessie:latest
-        echo "## Successfully pushed Docker image for ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
+        echo "::endgroup::"
+        echo "Successfully pushed Docker image for ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
 
     # Prepare Nessie release notes for GitHub
     #
@@ -200,26 +203,20 @@ jobs:
     # `LAST_TAG` is evaluated using `git describe`, which is the name of the git tag before the release tag
     # `NUM_COMMITS` is the total number of commits "between" LAST_TAG and GIT_TAG
     #
-    # Release highlights are extracted from `site/docs/try/releases.md`, highlights for the current
-    # release is the text between the first two lines starting with `## ` in `releases.md`.
-    #
     # "Full Changelog" is the output of a `git log` considering the commits "between" LAST_TAG and
     # GIT_TAG, removing the commits by `dependabot-preview` and `nessie-release-workflow`.
     # Also removes commits that start with `[release] `.
     #
     # The final markdown is just a `cat` of the above information including some basic markdown formatting.
     #
-    - name: Prepare Nessie release in GitHub
-      id: prep_release
+    - name: Prepare Nessie release for GitHub
       env:
         GIT_TAG: nessie-${{ env.RELEASE_VERSION }}
       run: |
         DIR=$(mktemp -d)
         NOTES_FILE=${DIR}/release-notes.md
-        LAST_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))
-        NUM_COMMITS=$(git log --format='format:%h' ${LAST_TAG}..HEAD | wc -l)
-
-        csplit site/docs/try/releases.md '%##%' {0} '/##/' {0} '%##%' {*} -f ${DIR}/release-highlights -b '-%d.txt' > /dev/null
+        LAST_TAG=$(git describe --abbrev=0 --tags --match=nessie-* ${GIT_TAG}^1)
+        NUM_COMMITS=$(git log --format='format:%h' ${LAST_TAG}..HEAD^1 | wc -l)
 
         git log --perl-regexp --author '^(?!.*dependabot(-preview)?|.*nessie-release-workflow).*$' --format='format:* %s' ${LAST_TAG}..${GIT_TAG} | grep -v '^\* \[release\] .*$' > ${DIR}/release-log
 
@@ -228,14 +225,13 @@ jobs:
         Q_MC_URL="https://search.maven.org/search?q=g:org.projectnessie+AND+a:nessie-quarkus+AND+v:${RELEASE_VERSION}"
         Q_HELM_CHART_URL="https://github.com/projectnessie/nessie/releases/download/nessie-${RELEASE_VERSION}/nessie-helm-${RELEASE_VERSION}.tgz"
 
-        cat <<EOF > ${DIR}/release-notes.md
-        # Highlights
+        cat <<EOF > ${NOTES_FILE}
+        # Nessie ${RELEASE_VERSION} release
 
         * ${NUM_COMMITS} commits since ${LAST_TAG#nessie-}
-        $(cat ${DIR}/release-highlights* | grep -v '^[#][#] .*$' | grep -v '^$' | sed 's/^(.*)$/* $1/')
-        * Maven Central: https://search.maven.org/search?q=g:org.projectnessie
-        * Docker Hub: https://hub.docker.com/r/projectnessie/nessie
-        * PyPI: https://pypi.org/project/pynessie/
+        * Maven Central: https://search.maven.org/search?q=g:org.projectnessie+v:${RELEASE_VERSION}
+        * Docker Hub: https://hub.docker.com/r/projectnessie/nessie \`docker pull projectnessie/nessie:${RELEASE_VERSION}\`
+        * PyPI: https://pypi.org/project/pynessie/${RELEASE_VERSION}/
         * Helm Chart repo: https://charts.projectnessie.org/
 
         ## Try it

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -65,7 +65,7 @@ jobs:
         # check if tag matches patterns like nessie-0.5, nessie-0.10.4.3-alpha1, etc
         if [[ ${V} =~ ^nessie-[0-9]+[.][0-9.]*[0-9](-[a-zA-Z0-9]+)?$ ]]; then
           echo "RELEASE_VERSION=${V/nessie-}" >> ${GITHUB_ENV}
-          echo "GIT_TAG=nessie-${RELEASE_VERSION}" >> ${GITHUB_ENV}
+          echo "GIT_TAG=${V}" >> ${GITHUB_ENV}
         else
           echo "Tag must start with nessie- followed by a valid version (got tag ${V}, ref is ${GITHUB_REF} )"
           exit 1
@@ -210,8 +210,6 @@ jobs:
     # The final markdown is just a `cat` of the above information including some basic markdown formatting.
     #
     - name: Prepare Nessie release for GitHub
-      env:
-        GIT_TAG: nessie-${{ env.RELEASE_VERSION }}
       run: |
         DIR=$(mktemp -d)
         NOTES_FILE=${DIR}/release-notes.md
@@ -257,8 +255,6 @@ jobs:
         cat "${NOTES_FILE}" >> $GITHUB_STEP_SUMMARY
 
     - name: Create Nessie release in GitHub
-      env:
-        GIT_TAG: nessie-${{ env.RELEASE_VERSION }}
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
         gh release create ${GIT_TAG} \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ plugins {
   id("io.github.gradle-nexus.publish-plugin")
 }
 
+apply<ReleaseSupportPlugin>()
+
 extra["maven.name"] = "Nessie"
 
 description = "Transactional Catalog for Data Lakes"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -57,6 +57,14 @@ dependencies {
   implementation("org.projectnessie.buildsupport:reflection-config:$versionNessieBuildPlugins")
   implementation("org.projectnessie.buildsupport:smallrye-openapi:$versionNessieBuildPlugins")
   implementation("org.projectnessie.buildsupport:spotless:$versionNessieBuildPlugins")
+
+  testImplementation(platform("org.junit:junit-bom:5.9.0"))
+  testImplementation("org.assertj:assertj-core:3.23.1")
+  testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 
 kotlinDslPluginOptions { jvmTarget.set(JavaVersion.VERSION_11.toString()) }
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/buildSrc/src/main/kotlin/ReleaseSupportPlugin.kt
+++ b/buildSrc/src/main/kotlin/ReleaseSupportPlugin.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import java.nio.file.Files
 import java.nio.file.Path
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -93,7 +92,7 @@ class ReleaseSupportPlugin : Plugin<Project> {
       }
 
       if (finalVersion != currentVersion) {
-        Files.write(versionFile, finalVersion.toString().toByteArray(Charsets.UTF_8))
+        finalVersion.writeToFile(versionFile)
         logger.lifecycle("New version is $finalVersion.")
       } else {
         throw GradleException("Bump version tasks results in no change.")
@@ -102,6 +101,7 @@ class ReleaseSupportPlugin : Plugin<Project> {
   }
 
   enum class BumpType {
+    // lower-case, used as command line option values
     none,
     patch,
     minor,

--- a/buildSrc/src/main/kotlin/ReleaseSupportPlugin.kt
+++ b/buildSrc/src/main/kotlin/ReleaseSupportPlugin.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.kotlin.dsl.register
+import org.gradle.work.DisableCachingByDefault
+
+/** Registers some tasks to manage the `version.txt` file. */
+class ReleaseSupportPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+
+    project.tasks.register("showVersion") {
+      group = "Release Support"
+      description = "Show current version"
+
+      doFirst {
+        logger.lifecycle(
+          "Current version is ${VersionTuple.fromFile(versionTxtFile(this.project))}."
+        )
+      }
+    }
+
+    project.tasks.register<BumpVersionTask>("bumpVersion") {
+      group = "Release Support"
+      description =
+        "Bumps the version to the next patch/minor/major version as a snapshot, see ' ./gradlew help --task :bumpVersion '."
+    }
+  }
+
+  companion object {
+    private fun versionTxtFile(project: Project): Path =
+      project.rootDir.toPath().resolve("./version.txt")
+  }
+
+  @DisableCachingByDefault(because = "Version bumps cannot be cached")
+  open class BumpVersionTask : DefaultTask() {
+    @Option(
+      option = "bumpToRelease",
+      description = "Define whether to bump to a release version, defaults to snapshot release."
+    )
+    @Internal
+    var bumpToRelease: Boolean = false
+
+    @Option(
+      option = "bumpType",
+      description = "Defines which part of the version should be bumped, defaults to 'none'."
+    )
+    @Internal
+    var bumpType: BumpType = BumpType.none
+
+    @TaskAction
+    fun bumpVersion() {
+      val versionFile = versionTxtFile(project)
+      val currentVersion = VersionTuple.fromFile(versionFile)
+
+      logger.lifecycle("Current version is $currentVersion.")
+
+      val nextVersion =
+        when (bumpType) {
+          BumpType.none -> currentVersion
+          BumpType.patch -> currentVersion.bumpPatch()
+          BumpType.minor -> currentVersion.bumpMinor()
+          BumpType.major -> currentVersion.bumpMajor()
+        }
+
+      val finalVersion = if (bumpToRelease) nextVersion.asRelease() else nextVersion.asSnapshot()
+
+      if (finalVersion < currentVersion) {
+        throw GradleException(
+          "New version $finalVersion would be lower than current version $currentVersion"
+        )
+      }
+
+      if (finalVersion != currentVersion) {
+        Files.write(versionFile, finalVersion.toString().toByteArray(Charsets.UTF_8))
+        logger.lifecycle("New version is $finalVersion.")
+      } else {
+        throw GradleException("Bump version tasks results in no change.")
+      }
+    }
+  }
+
+  enum class BumpType {
+    none,
+    patch,
+    minor,
+    major
+  }
+}

--- a/buildSrc/src/main/kotlin/VersionTuple.kt
+++ b/buildSrc/src/main/kotlin/VersionTuple.kt
@@ -19,7 +19,7 @@ import java.nio.file.Path
 import java.util.regex.Pattern
 
 /** Represents a version tuple with mandatory major, minor and patch numbers and snapshot-flag. */
-class VersionTuple(val major: Int, val minor: Int, val patch: Int, val snapshot: Boolean) :
+data class VersionTuple(val major: Int, val minor: Int, val patch: Int, val snapshot: Boolean) :
   Comparable<VersionTuple> {
 
   companion object Factory {
@@ -28,8 +28,7 @@ class VersionTuple(val major: Int, val minor: Int, val patch: Int, val snapshot:
         "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
       )
 
-    fun fromFile(file: Path): VersionTuple =
-      create(String(Files.readAllBytes(file), Charsets.UTF_8).trim())
+    fun fromFile(file: Path): VersionTuple = create(Files.readString(file, Charsets.UTF_8).trim())
 
     @JvmStatic
     fun create(string: String): VersionTuple {
@@ -70,19 +69,7 @@ class VersionTuple(val major: Int, val minor: Int, val patch: Int, val snapshot:
 
   fun asRelease(): VersionTuple = VersionTuple(major, minor, patch, false)
 
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-
-    other as VersionTuple
-
-    if (major != other.major) return false
-    if (minor != other.minor) return false
-    if (patch != other.patch) return false
-    if (snapshot != other.snapshot) return false
-
-    return true
-  }
+  fun writeToFile(file: Path) = Files.writeString(file, toString(), Charsets.UTF_8)
 
   override fun compareTo(other: VersionTuple): Int {
     var cmp: Int
@@ -106,14 +93,6 @@ class VersionTuple(val major: Int, val minor: Int, val patch: Int, val snapshot:
       return 0
     }
     return if (snapshot) -1 else 1
-  }
-
-  override fun hashCode(): Int {
-    var result = major
-    result = 31 * result + minor
-    result = 31 * result + patch
-    result = 31 * result + snapshot.hashCode()
-    return result
   }
 
   override fun toString(): String {

--- a/buildSrc/src/main/kotlin/VersionTuple.kt
+++ b/buildSrc/src/main/kotlin/VersionTuple.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.regex.Pattern
+
+/** Represents a version tuple with mandatory major, minor and patch numbers and snapshot-flag. */
+class VersionTuple(val major: Int, val minor: Int, val patch: Int, val snapshot: Boolean) :
+  Comparable<VersionTuple> {
+
+  companion object Factory {
+    val pattern =
+      Pattern.compile(
+        "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
+      )
+
+    fun fromFile(file: Path): VersionTuple =
+      create(String(Files.readAllBytes(file), Charsets.UTF_8).trim())
+
+    @JvmStatic
+    fun create(string: String): VersionTuple {
+      val matcher = pattern.matcher(string)
+      if (!matcher.matches()) {
+        throw IllegalArgumentException("'$string' is not a valid version string")
+      }
+
+      val major = matcher.group(1)
+      val minor = matcher.group(2)
+      val patch = matcher.group(3)
+      val prerelease = matcher.group(4)
+      val buildmetadata = matcher.group(5)
+
+      if (buildmetadata != null) {
+        throw IllegalArgumentException("Build metadata not supported")
+      }
+
+      val snapshot = "SNAPSHOT" == prerelease
+
+      if (prerelease != null && !snapshot) {
+        throw IllegalArgumentException(
+          "Only SNAPSHOT prerelease supported, but $prerelease != SNAPSHOT"
+        )
+      }
+
+      return VersionTuple(major.toInt(), minor.toInt(), patch.toInt(), snapshot)
+    }
+  }
+
+  fun bumpMajor(): VersionTuple = VersionTuple(major + 1, 0, 0, false)
+
+  fun bumpMinor(): VersionTuple = VersionTuple(major, minor + 1, 0, false)
+
+  fun bumpPatch(): VersionTuple = VersionTuple(major, minor, patch + 1, false)
+
+  fun asSnapshot(): VersionTuple = VersionTuple(major, minor, patch, true)
+
+  fun asRelease(): VersionTuple = VersionTuple(major, minor, patch, false)
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as VersionTuple
+
+    if (major != other.major) return false
+    if (minor != other.minor) return false
+    if (patch != other.patch) return false
+    if (snapshot != other.snapshot) return false
+
+    return true
+  }
+
+  override fun compareTo(other: VersionTuple): Int {
+    var cmp: Int
+
+    cmp = major.compareTo(other.major)
+    if (cmp != 0) {
+      return cmp
+    }
+
+    cmp = minor.compareTo(other.minor)
+    if (cmp != 0) {
+      return cmp
+    }
+
+    cmp = patch.compareTo(other.patch)
+    if (cmp != 0) {
+      return cmp
+    }
+
+    if (snapshot == other.snapshot) {
+      return 0
+    }
+    return if (snapshot) -1 else 1
+  }
+
+  override fun hashCode(): Int {
+    var result = major
+    result = 31 * result + minor
+    result = 31 * result + patch
+    result = 31 * result + snapshot.hashCode()
+    return result
+  }
+
+  override fun toString(): String {
+    return "$major.$minor.$patch${if (snapshot) "-SNAPSHOT" else ""}"
+  }
+}

--- a/buildSrc/src/main/kotlin/VersionTuple.kt
+++ b/buildSrc/src/main/kotlin/VersionTuple.kt
@@ -28,7 +28,7 @@ data class VersionTuple(val major: Int, val minor: Int, val patch: Int, val snap
         "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
       )
 
-    fun fromFile(file: Path): VersionTuple = create(Files.readString(file, Charsets.UTF_8).trim())
+    fun fromFile(file: Path): VersionTuple = create(Files.readString(file).trim())
 
     @JvmStatic
     fun create(string: String): VersionTuple {
@@ -69,7 +69,7 @@ data class VersionTuple(val major: Int, val minor: Int, val patch: Int, val snap
 
   fun asRelease(): VersionTuple = VersionTuple(major, minor, patch, false)
 
-  fun writeToFile(file: Path) = Files.writeString(file, toString(), Charsets.UTF_8)
+  fun writeToFile(file: Path) = Files.writeString(file, toString())
 
   override fun compareTo(other: VersionTuple): Int {
     var cmp: Int

--- a/buildSrc/src/test/kotlin/TestVersionTuple.kt
+++ b/buildSrc/src/test/kotlin/TestVersionTuple.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.IllegalArgumentException
+import java.nio.file.Files
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class TestVersionTuple {
+  @ParameterizedTest
+  @ValueSource(strings = ["1", "v1", "1.0", "1.b"])
+  fun invalids(ver: String) {
+    assertThatThrownBy { VersionTuple.create(ver) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageEndingWith("is not a valid version string")
+  }
+
+  @Test
+  fun invalidPrerelease() {
+    assertThatThrownBy { VersionTuple.create("1.2.3-FOOBAR") }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Only SNAPSHOT prerelease supported, but FOOBAR != SNAPSHOT")
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["1.2.3-SNAPSHOT+BUILDMETA", "1.2.3+BUILDMETA"])
+  fun invalidBuildMetadata(ver: String) {
+    assertThatThrownBy { VersionTuple.create(ver) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Build metadata not supported")
+  }
+
+  @Test
+  fun asSnapshot() {
+    assertThat(VersionTuple(1, 2, 3, false).asSnapshot()).isEqualTo(VersionTuple(1, 2, 3, true))
+    assertThat(VersionTuple(1, 2, 3, true).asSnapshot()).isEqualTo(VersionTuple(1, 2, 3, true))
+  }
+
+  @Test
+  fun asRelease() {
+    assertThat(VersionTuple(1, 2, 3, false).asRelease()).isEqualTo(VersionTuple(1, 2, 3, false))
+    assertThat(VersionTuple(1, 2, 3, true).asRelease()).isEqualTo(VersionTuple(1, 2, 3, false))
+  }
+
+  @Test
+  fun bumpPatch() {
+    assertThat(VersionTuple(1, 2, 3, false).bumpPatch()).isEqualTo(VersionTuple(1, 2, 4, false))
+    assertThat(VersionTuple(1, 2, 3, true).bumpPatch()).isEqualTo(VersionTuple(1, 2, 4, false))
+  }
+
+  @Test
+  fun bumpMinor() {
+    assertThat(VersionTuple(1, 2, 3, false).bumpMinor()).isEqualTo(VersionTuple(1, 3, 0, false))
+    assertThat(VersionTuple(1, 2, 3, true).bumpMinor()).isEqualTo(VersionTuple(1, 3, 0, false))
+  }
+
+  @Test
+  fun bumpMajor() {
+    assertThat(VersionTuple(1, 2, 3, false).bumpMajor()).isEqualTo(VersionTuple(2, 0, 0, false))
+    assertThat(VersionTuple(1, 2, 3, true).bumpMajor()).isEqualTo(VersionTuple(2, 0, 0, false))
+  }
+
+  @Test
+  fun fromFile(@TempDir dir: Path) {
+    val file = dir.resolve("ver.txt")
+    Files.writeString(file, "1.2.3")
+    assertThat(VersionTuple.fromFile(file)).isEqualTo(VersionTuple(1, 2, 3, false))
+    Files.writeString(file, "1.2.3-SNAPSHOT")
+    assertThat(VersionTuple.fromFile(file)).isEqualTo(VersionTuple(1, 2, 3, true))
+    Files.writeString(file, "1.2.3\n")
+    assertThat(VersionTuple.fromFile(file)).isEqualTo(VersionTuple(1, 2, 3, false))
+    Files.writeString(file, "1.2.3-SNAPSHOT\n")
+    assertThat(VersionTuple.fromFile(file)).isEqualTo(VersionTuple(1, 2, 3, true))
+  }
+
+  @Test
+  fun validVersion() {
+    assertThat(VersionTuple.create("1.2.3"))
+      .extracting(
+        VersionTuple::major,
+        VersionTuple::minor,
+        VersionTuple::patch,
+        VersionTuple::snapshot,
+        VersionTuple::toString
+      )
+      .containsExactly(1, 2, 3, false, "1.2.3")
+  }
+
+  @Test
+  fun validSnapshotVersion() {
+    assertThat(VersionTuple.create("1.2.3-SNAPSHOT"))
+      .extracting(
+        VersionTuple::major,
+        VersionTuple::minor,
+        VersionTuple::patch,
+        VersionTuple::snapshot,
+        VersionTuple::toString
+      )
+      .containsExactly(1, 2, 3, true, "1.2.3-SNAPSHOT")
+  }
+
+  @Test
+  fun equals() {
+    assertThat(VersionTuple.create("1.2.3")).isEqualTo(VersionTuple(1, 2, 3, false))
+    assertThat(VersionTuple.create("1.2.3-SNAPSHOT")).isEqualTo(VersionTuple(1, 2, 3, true))
+  }
+
+  @ParameterizedTest
+  @MethodSource("compare")
+  fun compare(ver1: VersionTuple, ver2: VersionTuple, expected: Int) {
+    when (expected) {
+      1 -> assertThat(ver1).isGreaterThan(ver2)
+      -1 -> assertThat(ver1).isLessThan(ver2)
+      0 -> assertThat(ver1).isEqualByComparingTo(ver2)
+      else -> fail()
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    fun compare(): List<Arguments> =
+      listOf(
+        arguments(VersionTuple.create("2.2.4"), VersionTuple(1, 2, 3, false), 1),
+        arguments(VersionTuple.create("2.2.4"), VersionTuple(1, 2, 3, true), 1),
+        arguments(VersionTuple.create("1.3.4"), VersionTuple(1, 2, 3, false), 1),
+        arguments(VersionTuple.create("1.3.4"), VersionTuple(1, 2, 3, true), 1),
+        arguments(VersionTuple.create("1.2.3"), VersionTuple(1, 2, 4, false), -1),
+        arguments(VersionTuple.create("1.2.4"), VersionTuple(1, 2, 3, false), 1),
+        arguments(VersionTuple.create("1.2.4"), VersionTuple(1, 2, 3, true), 1),
+        arguments(VersionTuple.create("1.2.4-SNAPSHOT"), VersionTuple(1, 2, 3, true), 1),
+        arguments(VersionTuple.create("1.2.3-SNAPSHOT"), VersionTuple(1, 2, 4, true), -1),
+        arguments(VersionTuple.create("1.2.3-SNAPSHOT"), VersionTuple(1, 2, 4, true), -1),
+        arguments(VersionTuple.create("1.2.3"), VersionTuple(1, 2, 3, false), 0),
+        arguments(VersionTuple.create("1.2.3-SNAPSHOT"), VersionTuple(1, 2, 3, true), 0),
+        arguments(VersionTuple.create("1.2.3-SNAPSHOT"), VersionTuple(1, 2, 3, false), -1)
+      )
+  }
+}

--- a/site/docs/try/releases.md
+++ b/site/docs/try/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-See [Nessie Server upgrade notes](server-upgrade.md) for supported upgrade paths.
+**See [Nessie Server upgrade notes](server-upgrade.md) for supported upgrade paths.**
 
 ## 0.43.0 Release (September 15, 2022)
 


### PR DESCRIPTION
Updates the process to create Nessie releases to allow:
* "one click" patch releases (w/o manually entering the version
  to release)
* Semi-automatic minor and major version releases

Moves the logic to update the version from `bump2version` to Gradle
with tasks that support bumping the patch/minor/major version parts
as release or snapshot versions.

Also unifies the logic to update the related projects (UI, Python,
helm) in a new GH workflow action (bump-versions).

Release related files `release.md` and `HISTORY.rst` are generated
automatically with links to the GH release page. The `SECURITY.md`,
`server-upgrade.md` and `README.md` must (only) contain the
`major.minor` version, i.e. relaxed from the previous requirement to
contain the full (major.minor.patch) version.

This change might later be used for automatic daily or weekly patch
releases.