### PR TITLE
Nessie client tests: Replace JDK's HTTP server w/ Jetty

### DIFF
--- a/clients/client/build.gradle.kts
+++ b/clients/client/build.gradle.kts
@@ -58,6 +58,8 @@ dependencies {
   testImplementation(libs.jaeger.core)
   testImplementation(platform(libs.awssdk.bom))
   testImplementation(libs.awssdk.auth)
+  testImplementation(platform(libs.jetty.bom))
+  testImplementation(libs.jetty.http2.server)
 }
 
 jandex { skipDefaultProcessing() }

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
@@ -121,34 +121,46 @@ public class TestHttpClient {
 
           ArrayBean inputBean = ArrayBean.construct(10_000, num);
 
-          soft.assertThat(
-                  get(server.getAddress(), disableCompression)
-                      .queryParam("len", Integer.toString(len))
-                      .queryParam("num", Integer.toString(num))
-                      .get()
-                      .readEntity(ArrayBean.class))
+          soft.assertThatCode(
+                  () ->
+                      assertThat(
+                              get(server.getAddress(), disableCompression)
+                                  .queryParam("len", Integer.toString(len))
+                                  .queryParam("num", Integer.toString(num))
+                                  .get()
+                                  .readEntity(ArrayBean.class))
+                          .isEqualTo(inputBean))
               .describedAs("GET, disableCompression:%s, num:%d", disableCompression, num)
-              .isEqualTo(inputBean);
-          soft.assertThat(
-                  get(server.getAddress(), disableCompression)
-                      .queryParam("len", Integer.toString(len))
-                      .queryParam("num", Integer.toString(num))
-                      .delete()
-                      .readEntity(ArrayBean.class))
+              .isNull();
+          soft.assertThatCode(
+                  () ->
+                      assertThat(
+                              get(server.getAddress(), disableCompression)
+                                  .queryParam("len", Integer.toString(len))
+                                  .queryParam("num", Integer.toString(num))
+                                  .delete()
+                                  .readEntity(ArrayBean.class))
+                          .isEqualTo(inputBean))
               .describedAs("DELETE, disableCompression:%s, num:%d", disableCompression, num)
-              .isEqualTo(inputBean);
-          soft.assertThat(
-                  get(server.getAddress(), disableCompression)
-                      .put(inputBean)
-                      .readEntity(ArrayBean.class))
+              .isNull();
+          soft.assertThatCode(
+                  () ->
+                      assertThat(
+                              get(server.getAddress(), disableCompression)
+                                  .put(inputBean)
+                                  .readEntity(ArrayBean.class))
+                          .isEqualTo(inputBean))
               .describedAs("PUT, disableCompression:%s, num:%d", disableCompression, num)
-              .isEqualTo(inputBean);
-          soft.assertThat(
-                  get(server.getAddress(), disableCompression)
-                      .post(inputBean)
-                      .readEntity(ArrayBean.class))
+              .isNull();
+          soft.assertThatCode(
+                  () ->
+                      assertThat(
+                              get(server.getAddress(), disableCompression)
+                                  .post(inputBean)
+                                  .readEntity(ArrayBean.class))
+                          .isEqualTo(inputBean))
               .describedAs("POST, disableCompression:%s, num:%d", disableCompression, num)
-              .isEqualTo(inputBean);
+              .isNull();
         }
       }
     }

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
@@ -182,18 +182,6 @@ public class TestHttpClient {
   }
 
   @Test
-  void testReadTimeout() {
-    HttpTestServer.RequestHandler handler = (req, resp) -> {};
-    Assertions.assertThrows(
-        HttpClientReadTimeoutException.class,
-        () -> {
-          try (HttpTestServer server = new HttpTestServer(handler)) {
-            get(server.getAddress(), 15000, 1, true).get().readEntity(ExampleBean.class);
-          }
-        });
-  }
-
-  @Test
   void testPut() throws Exception {
     ExampleBean inputBean = new ExampleBean("x", 1, NOW);
     HttpTestServer.RequestHandler handler =

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -35,8 +35,8 @@ import org.projectnessie.client.api.NessieApi;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.auth.BasicAuthenticationProvider;
 import org.projectnessie.client.auth.NessieAuthentication;
-import org.projectnessie.client.util.TestHttpUtil;
-import org.projectnessie.client.util.TestServer;
+import org.projectnessie.client.util.HttpTestServer;
+import org.projectnessie.client.util.HttpTestUtil;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class TestHttpClientBuilder {
@@ -119,7 +119,8 @@ public class TestHttpClientBuilder {
   void testAuthBasic(Function<HttpClientBuilder, HttpClientBuilder> config) throws Exception {
     AtomicReference<String> authHeader = new AtomicReference<>();
 
-    try (TestServer server = new TestServer(handlerForHeaderTest("Authorization", authHeader))) {
+    try (HttpTestServer server =
+        new HttpTestServer(handlerForHeaderTest("Authorization", authHeader))) {
       try (NessieApiV1 client =
           config
               .apply(HttpClientBuilder.builder().withUri(server.getUri()))
@@ -137,12 +138,12 @@ public class TestHttpClientBuilder {
                     UTF_8));
   }
 
-  static TestServer.RequestHandler handlerForHeaderTest(
+  static HttpTestServer.RequestHandler handlerForHeaderTest(
       String headerName, AtomicReference<String> receiver) {
     return (req, resp) -> {
       receiver.set(req.getHeader(headerName));
       req.getInputStream().close();
-      TestHttpUtil.writeResponseBody(resp, "{\"maxSupportedApiVersion\":1}");
+      HttpTestUtil.writeResponseBody(resp, "{\"maxSupportedApiVersion\":1}");
     };
   }
 }

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
@@ -59,8 +59,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.projectnessie.client.util.TestHttpUtil;
-import org.projectnessie.client.util.TestServer;
+import org.projectnessie.client.util.HttpTestServer;
+import org.projectnessie.client.util.HttpTestUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,14 +71,14 @@ class TestHttpsClient {
 
   @Test
   void testHttps() throws Exception {
-    TestServer.RequestHandler handler =
+    HttpTestServer.RequestHandler handler =
         (req, resp) -> {
           Assertions.assertEquals("GET", req.getMethod());
-          TestHttpUtil.writeResponseBody(resp, "hello");
+          HttpTestUtil.writeResponseBody(resp, "hello");
         };
     TrustManager[][] trustManager = new TrustManager[1][];
-    try (TestServer server =
-        new TestServer(
+    try (HttpTestServer server =
+        new HttpTestServer(
             "/",
             handler,
             s -> {

--- a/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/TestHttpsClient.java
@@ -17,11 +17,6 @@ package org.projectnessie.client.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsParameters;
-import com.sun.net.httpserver.HttpsServer;
 import java.math.BigInteger;
 import java.net.URI;
 import java.security.GeneralSecurityException;
@@ -37,8 +32,6 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import org.bouncycastle.asn1.DERSequence;
@@ -53,6 +46,15 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -69,10 +71,10 @@ class TestHttpsClient {
 
   @Test
   void testHttps() throws Exception {
-    HttpHandler handler =
-        h -> {
-          Assertions.assertEquals("GET", h.getRequestMethod());
-          TestHttpUtil.writeResponseBody(h, "hello");
+    TestServer.RequestHandler handler =
+        (req, resp) -> {
+          Assertions.assertEquals("GET", req.getMethod());
+          TestHttpUtil.writeResponseBody(resp, "hello");
         };
     TrustManager[][] trustManager = new TrustManager[1][];
     try (TestServer server =
@@ -108,15 +110,14 @@ class TestHttpsClient {
   }
 
   private static KeyPair generateKeyPair(SecureRandom random) throws Exception {
-    final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
     keyPairGenerator.initialize(2048, random);
-    final KeyPair keyPair = keyPairGenerator.generateKeyPair();
-    return keyPair;
+    return keyPairGenerator.generateKeyPair();
   }
 
   private static X509CertificateHolder generateCertHolder(
       SecureRandom random, ZonedDateTime now, KeyPair keyPair) throws Exception {
-    final X500NameBuilder nameBuilder =
+    X500NameBuilder nameBuilder =
         new X500NameBuilder(BCStyle.INSTANCE)
             .addRDN(BCStyle.CN, "localhost")
             .addRDN(BCStyle.OU, "Dremio Corp. (auto-generated)")
@@ -125,16 +126,16 @@ class TestHttpsClient {
             .addRDN(BCStyle.ST, "California")
             .addRDN(BCStyle.C, "US");
 
-    final Date notBefore = Date.from(now.minusDays(1).toInstant());
-    final Date notAfter = Date.from(now.plusYears(1).toInstant());
-    final BigInteger serialNumber = new BigInteger(128, random);
+    Date notBefore = Date.from(now.minusDays(1).toInstant());
+    Date notAfter = Date.from(now.plusYears(1).toInstant());
+    BigInteger serialNumber = new BigInteger(128, random);
 
     // create a certificate valid for 1 years from now
     // add the main hostname + the alternative hostnames to the SAN extension
-    final GeneralName[] alternativeSubjectNames = new GeneralName[1];
+    GeneralName[] alternativeSubjectNames = new GeneralName[1];
     alternativeSubjectNames[0] = new GeneralName(GeneralName.dNSName, "localhost");
 
-    final X509v3CertificateBuilder certificateBuilder =
+    X509v3CertificateBuilder certificateBuilder =
         new JcaX509v3CertificateBuilder(
                 nameBuilder.build(),
                 serialNumber,
@@ -146,7 +147,7 @@ class TestHttpsClient {
                 Extension.subjectAlternativeName, false, new DERSequence(alternativeSubjectNames));
 
     // sign the certificate using the private key
-    final ContentSigner contentSigner;
+    ContentSigner contentSigner;
     try {
       contentSigner =
           new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(keyPair.getPrivate());
@@ -159,8 +160,7 @@ class TestHttpsClient {
   private static X509Certificate generateCert(ZonedDateTime now, X509CertificateHolder certHolder)
       throws Exception {
 
-    final X509Certificate certificate =
-        new JcaX509CertificateConverter().getCertificate(certHolder);
+    X509Certificate certificate = new JcaX509CertificateConverter().getCertificate(certHolder);
 
     // check the validity
     certificate.checkValidity(Date.from(now.toInstant()));
@@ -168,7 +168,7 @@ class TestHttpsClient {
     // make sure the certificate is self-signed
     certificate.verify(certificate.getPublicKey());
 
-    final String fingerprint =
+    String fingerprint =
         BaseEncoding.base16()
             .withSeparator(":", 2)
             .encode(MessageDigest.getInstance("SHA-256").digest(certificate.getEncoded()));
@@ -176,17 +176,17 @@ class TestHttpsClient {
     return certificate;
   }
 
-  private static TrustManager[] ssl(HttpServer httpsServer) throws Exception {
+  private static TrustManager[] ssl(Server server) throws Exception {
     SSLContext sslContext = SSLContext.getInstance("TLS");
 
     // Initialise the keystore
-    final String storeType = KeyStore.getDefaultType();
-    final KeyStore keyStore = KeyStore.getInstance(storeType);
-    final KeyStore trustStore = KeyStore.getInstance(storeType);
+    String storeType = KeyStore.getDefaultType();
+    KeyStore keyStore = KeyStore.getInstance(storeType);
+    KeyStore trustStore = KeyStore.getInstance(storeType);
     keyStore.load(null, null);
     trustStore.load(null, null);
     ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
-    final SecureRandom random = new SecureRandom();
+    SecureRandom random = new SecureRandom();
 
     KeyPair keyPair = generateKeyPair(random);
     X509CertificateHolder certHolder = generateCertHolder(random, now, keyPair);
@@ -210,27 +210,28 @@ class TestHttpsClient {
 
     // Set up the HTTPS context and parameters
     sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
-    ((HttpsServer) httpsServer)
-        .setHttpsConfigurator(
-            new HttpsConfigurator(sslContext) {
-              @Override
-              public void configure(HttpsParameters params) {
-                try {
-                  // Initialise the SSL context
-                  SSLContext c = SSLContext.getDefault();
-                  SSLEngine engine = c.createSSLEngine();
-                  params.setNeedClientAuth(false);
-                  params.setCipherSuites(engine.getEnabledCipherSuites());
-                  params.setProtocols(engine.getEnabledProtocols());
 
-                  // Get the default parameters
-                  SSLParameters defaultSSLParameters = c.getDefaultSSLParameters();
-                  params.setSSLParameters(defaultSSLParameters);
-                } catch (Exception ex) {
-                  throw new RuntimeException(ex);
-                }
-              }
-            });
+    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+    sslContextFactory.setNeedClientAuth(false);
+    sslContextFactory.setSniRequired(false);
+    sslContextFactory.setWantClientAuth(false);
+    sslContextFactory.setKeyStore(keyStore);
+    sslContextFactory.setKeyStorePassword("password");
+    sslContextFactory.setTrustStore(trustStore);
+
+    HttpConfiguration httpsConfiguration = new HttpConfiguration();
+    httpsConfiguration.addCustomizer(new SecureRequestCustomizer(false));
+
+    ServerConnector httpsConnector =
+        new ServerConnector(
+            server,
+            new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()),
+            new HttpConnectionFactory(httpsConfiguration));
+
+    Connector connector = server.getConnectors()[0];
+    server.removeConnector(connector);
+    server.addConnector(httpsConnector);
+
     return tmf.getTrustManagers();
   }
 }

--- a/clients/client/src/test/java/org/projectnessie/client/util/HttpTestServer.java
+++ b/clients/client/src/test/java/org/projectnessie/client/util/HttpTestServer.java
@@ -27,7 +27,7 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 
 /** A HTTP test server. */
-public class TestServer implements AutoCloseable {
+public class HttpTestServer implements AutoCloseable {
 
   @FunctionalInterface
   public interface RequestHandler {
@@ -36,7 +36,7 @@ public class TestServer implements AutoCloseable {
 
   private final Server server;
 
-  public TestServer(String context, RequestHandler handler) throws Exception {
+  public HttpTestServer(String context, RequestHandler handler) throws Exception {
     this(context, handler, null);
   }
 
@@ -46,9 +46,8 @@ public class TestServer implements AutoCloseable {
    * @param context server context
    * @param handler http request handler
    * @param init init method (optional)
-   * @throws IOException maybe
    */
-  public TestServer(String context, RequestHandler handler, Consumer<Server> init)
+  public HttpTestServer(String context, RequestHandler handler, Consumer<Server> init)
       throws Exception {
     server = new Server(0);
 
@@ -80,7 +79,7 @@ public class TestServer implements AutoCloseable {
     server.start();
   }
 
-  public TestServer(RequestHandler handler) throws Exception {
+  public HttpTestServer(RequestHandler handler) throws Exception {
     this("/", handler);
   }
 

--- a/clients/client/src/test/java/org/projectnessie/client/util/HttpTestUtil.java
+++ b/clients/client/src/test/java/org/projectnessie/client/util/HttpTestUtil.java
@@ -20,11 +20,11 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletResponse;
 
-public class TestHttpUtil {
+public class HttpTestUtil {
 
-  private TestHttpUtil() {}
+  private HttpTestUtil() {}
 
-  public static void emptyResponse(HttpServletResponse resp) throws IOException {
+  public static void writeEmptyResponse(HttpServletResponse resp) throws IOException {
     writeResponseBody(resp, "", "text/plain");
   }
 

--- a/clients/client/src/test/java/org/projectnessie/client/util/TestHttpUtil.java
+++ b/clients/client/src/test/java/org/projectnessie/client/util/TestHttpUtil.java
@@ -15,25 +15,31 @@
  */
 package org.projectnessie.client.util;
 
-import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import javax.servlet.http.HttpServletResponse;
 
 public class TestHttpUtil {
 
   private TestHttpUtil() {}
 
-  public static void writeResponseBody(HttpExchange http, String response) throws IOException {
-    writeResponseBody(http, response, "application/json");
+  public static void emptyResponse(HttpServletResponse resp) throws IOException {
+    writeResponseBody(resp, "", "text/plain");
   }
 
-  public static void writeResponseBody(HttpExchange http, String response, String contentType)
+  public static void writeResponseBody(HttpServletResponse resp, String response)
       throws IOException {
-    http.getResponseHeaders().add("Content-Type", contentType);
+    writeResponseBody(resp, response, "application/json");
+  }
+
+  public static void writeResponseBody(
+      HttpServletResponse resp, String response, String contentType) throws IOException {
+    resp.addHeader("Content-Type", contentType);
     byte[] body = response.getBytes(StandardCharsets.UTF_8);
-    http.sendResponseHeaders(200, body.length);
-    try (OutputStream os = http.getResponseBody()) {
+    resp.setContentLength(body.length);
+    resp.setStatus(200);
+    try (OutputStream os = resp.getOutputStream()) {
       os.write(body);
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,6 +146,8 @@ javax-ws-rs = { module = "javax.ws.rs:javax.ws.rs-api", version = "2.1.1" }
 javax-ws-rs21 = { module = "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec", version = "2.0.2.Final" }
 jersey-bom = { module = "org.glassfish.jersey:jersey-bom", version = "2.37" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "23.0.0" }
+jetty-bom = { module = "org.eclipse.jetty:jetty-bom", version = "9.4.49.v20220914" }
+jetty-http2-server = { module = "org.eclipse.jetty.http2:http2-server" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
 jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }


### PR DESCRIPTION
Original intent was to just add a test that exercises bigger request + response bodies, but the test `TestHttpClient.testWriteWithVariousSizes` failed with JDK's `HttpServer`. Therefore, this change adds the test and migrates to Jetty using a version that still works with Java 8.