### PR TITLE
Use dynamic ports for tests in nessie-quarkus

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRest.java
@@ -78,7 +78,8 @@ public abstract class AbstractRest {
 
   @BeforeEach
   public void setUp() {
-    init(URI.create("http://localhost:19121/api/v1"));
+    String port = System.getProperty("quarkus.http.test-port");
+    init(URI.create("http://localhost:" + port + "/api/v1"));
   }
 
   @AfterEach

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -148,8 +148,6 @@ tasks.withType<Test>().configureEach {
   }
   systemProperty("quarkus.container-image.build", useDocker)
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
-  // TODO requires adjusting the tests - systemProperty("quarkus.http.test-port", "0") -  set this
-  //  property in application.properties
   systemProperty(
     "it.nessie.container.postgres.tag",
     System.getProperty("it.nessie.container.postgres.tag", libs.versions.postgresContainerTag.get())

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -108,7 +108,7 @@ quarkus.log.category."io.quarkus.http.access-log".level=${HTTP_ACCESS_LOG_LEVEL:
 
 ## Quarkus http related settings
 quarkus.http.port=19120
-quarkus.http.test-port=19121
+quarkus.http.test-port=0
 quarkus.http.access-log.enabled=true
 # fixed at buildtime
 quarkus.resteasy.path=/api/v1

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
@@ -47,9 +47,10 @@ abstract class AbstractTestBasicOperations {
   }
 
   void getCatalog(String branch) throws BaseNessieClientServerException {
+    String port = System.getProperty("quarkus.http.test-port");
     api =
         HttpClientBuilder.builder()
-            .withUri("http://localhost:19121/api/v1")
+            .withUri("http://localhost:" + port + "/api/v1")
             .build(NessieApiV1.class);
     if (branch != null) {
       api.createReference().reference(Branch.of(branch, null)).sourceRefName("main").create();

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/BaseClientAuthTest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/BaseClientAuthTest.java
@@ -42,9 +42,9 @@ public abstract class BaseClientAuthTest {
     if (api != null) {
       return api;
     }
-
+    String port = System.getProperty("quarkus.http.test-port");
     HttpClientBuilder builder =
-        HttpClientBuilder.builder().withUri("http://localhost:19121/api/v1");
+        HttpClientBuilder.builder().withUri("http://localhost:" + port + "/api/v1");
 
     if (customizer != null) {
       customizer.accept(builder);

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNessieError.java
@@ -45,9 +45,10 @@ public class ITNessieError {
 
   @BeforeEach
   void init() {
+    String port = System.getProperty("quarkus.http.test-port");
     api =
         HttpClientBuilder.builder()
-            .withUri("http://localhost:19121/api/v1")
+            .withUri("http://localhost:" + port + "/api/v1")
             .build(NessieApiV1.class);
   }
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -50,7 +50,8 @@ import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
     QuarkusTestProfileInmemory.class) // use the QuarkusTestProfileInmemory, as it can be reused
 class TestNessieError {
 
-  static String baseURI = "http://localhost:19121/api/v1/nessieErrorTest";
+  static String port = System.getProperty("quarkus.http.test-port");
+  static String baseURI = "http://localhost:" + port + "/api/v1/nessieErrorTest";
 
   private static HttpClient client;
 


### PR DESCRIPTION
Tests in nessie-quarkus now uses dynamic port instead of fixed port 19121. 
"quarkus.http.test-port=0" property used in application.properties allows to choose random port number.

Fixes #4015