### PR TITLE
GH/WF: Use `temurin` instead of 'zulu`

### DIFF
--- a/.github/actions/dev-tool-java/action.yml
+++ b/.github/actions/dev-tool-java/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Set up JDK ${{ inputs.java-version }}
       uses: actions/setup-java@v3
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
         server-id: ossrh
         server-username: MAVEN_USERNAME

--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -59,7 +59,7 @@ jobs:
       if: steps.check_status.outputs.result == 'OK'
       uses: actions/setup-java@v3
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: 11
 
     - name: Create simlog-dir

--- a/.github/workflows/pull-request-integ.yml
+++ b/.github/workflows/pull-request-integ.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Iceberg Nessie test


### PR DESCRIPTION
Just saves a few seconds, because `temurin` Java distribution are already present and do not need to be downloaded.