### PR TITLE
Skip newer-java workflow on forks

### DIFF
--- a/.github/workflows/newer-java.yml
+++ b/.github/workflows/newer-java.yml
@@ -10,6 +10,7 @@ jobs:
   java:
     name: Exercise Java version
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'projectnessie'
     strategy:
       max-parallel: 4
       matrix:


### PR DESCRIPTION
this avoids 1 hr of CI runs every day on forks