### PR TITLE
Run Native image and Integration test for Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,11 @@
     ":preserveSemverRanges"
   ],
 
-  "labels": ["dependencies"],
+  "labels": [
+    "dependencies",
+    "pr-integrations",
+    "pr-native",
+  ],
 
   packageRules: [
     // Check for updates, merge automatically


### PR DESCRIPTION
Sometimes bumping a lib version breaks the Native image.

Running Integration tests also adds assurance that auto-merged version bumps do not break Nessie in various environments.