### PR TITLE
Isolate http-level test from java client-level tests

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRest.java
@@ -45,8 +45,6 @@ import org.projectnessie.model.Tag;
 public abstract class AbstractRest {
 
   private NessieApiV1 api;
-  private HttpClient httpClient;
-  private URI uri;
 
   static {
     // Note: REST tests validate some locale-specific error messages, but expect on the messages to
@@ -67,13 +65,11 @@ public abstract class AbstractRest {
     HttpClient.Builder httpClient = HttpClient.builder().setBaseUri(uri).setObjectMapper(mapper);
     httpClient.addResponseFilter(new NessieHttpResponseFilter(mapper));
 
-    init(api, httpClient, uri);
+    init(api, httpClient);
   }
 
-  protected void init(NessieApiV1 api, @Nullable HttpClient.Builder httpClient, URI uri) {
+  protected void init(NessieApiV1 api, @Nullable HttpClient.Builder httpClient) {
     this.api = api;
-    this.httpClient = httpClient != null ? httpClient.build() : null;
-    this.uri = uri;
   }
 
   @BeforeEach
@@ -102,14 +98,6 @@ public abstract class AbstractRest {
 
   public NessieApiV1 getApi() {
     return api;
-  }
-
-  public HttpClient getHttpClient() {
-    return httpClient;
-  }
-
-  public URI getUri() {
-    return uri;
   }
 
   protected String createCommits(

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
@@ -48,7 +48,7 @@ import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Reference;
 
 /** See {@link AbstractTestRest} for details about and reason for the inheritance model. */
-public abstract class AbstractRestMergeTransplant extends AbstractRestInvalidWithHttp {
+public abstract class AbstractRestMergeTransplant extends AbstractRestInvalid {
 
   @ParameterizedTest
   @CsvSource(

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyRestNaiveClientInMemory.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/TestJerseyRestNaiveClientInMemory.java
@@ -18,7 +18,6 @@ package org.projectnessie.jaxrs;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.projectnessie.client.http.impl.HttpUtils.HEADER_ACCEPT;
 
-import java.net.URI;
 import javax.annotation.Nullable;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpAuthentication;
@@ -49,7 +48,7 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
 class TestJerseyRestNaiveClientInMemory extends AbstractTestJerseyRest {
 
   @Override
-  protected void init(NessieApiV1 api, @Nullable HttpClient.Builder httpClient, URI uri) {
+  protected void init(NessieApiV1 api, @Nullable HttpClient.Builder httpClient) {
     assumeThat(httpClient).isNotNull();
 
     // Intentionally remove the `Accept` header from requests.
@@ -68,6 +67,6 @@ class TestJerseyRestNaiveClientInMemory extends AbstractTestJerseyRest {
             .withUri(httpClient.getBaseUri())
             .build(NessieApiV1.class);
 
-    super.init(api, httpClient, uri);
+    super.init(api, httpClient);
   }
 }


### PR DESCRIPTION
Some tests in AbstractRestInvalidWithHttp used to construct HTTP requests directly (by using an HttpClient). However, the majority of tests in the "AbstractRest" suite rely on the Java client implementation to perform actual HTTP requests.

Those tests are moved to AbstractResteasyTest for the sake of clarity and uniformity of test approach and dependencies.

The now unused getHttpClient() is removed from AbstractRest. The unused getUri() method is removed too.