### PR TITLE
Renovate: limit to 2 PRs per hour

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,5 +47,5 @@
 
   // Max 50 PRs in total, 10 per hour
   prConcurrentLimit: 50,
-  prHourlyLimit: 10
+  prHourlyLimit: 2
 }


### PR DESCRIPTION
Unlike dependabot, renovatebot runs "constantly", so reducing the number of PRs per hour to 2 is nicer, because it reduces CI pressure, and also reduces the number of CI re-runs due to rebases.