### PR TITLE
Fix failing native image tests after bump of quarkus-amazon-services-bom to v2.13.1.final

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -90,6 +90,7 @@ quarkus.dynamodb.aws.region=us-west-2
 quarkus.dynamodb.aws.credentials.type=DEFAULT
 # quarkus.dynamodb.endpoint-override=http://localhost:8000
 quarkus.dynamodb.sync-client.type=url
+quarkus.dynamodb.devservices.enabled=false
 
 # Quarkus settings
 ## Visit here for all configs: https://quarkus.io/guides/all-config


### PR DESCRIPTION
Native image tests started to fail after #5333. Disabling the Quarkus devservices for DynamoDB seems to fix this.

Also changes the local Dynamo from `dimaqq/dynalite` back to `amazon/dynamodb-local` - dynalite's last update was already 2 years ago, considering it unmaintained. This seems to fix #5336, the test runtimes for the Quarkus integration tests are drastically reduced.