### PR TITLE
DynamoDB related test changes

### DIFF
--- a/buildSrc/src/main/kotlin/nessie-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/nessie-conventions.gradle.kts
@@ -140,6 +140,8 @@ fun Project.testTasks() {
         if (plugins.hasPlugin("io.quarkus")) {
           dependsOn(tasks.named("quarkusBuild"))
         }
+
+        systemProperty("nessie.integrationTest", "true")
       }
     tasks.named("check") { dependsOn(intTest) }
   }

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -90,6 +90,7 @@ quarkus.dynamodb.aws.region=us-west-2
 quarkus.dynamodb.aws.credentials.type=DEFAULT
 # quarkus.dynamodb.endpoint-override=http://localhost:8000
 quarkus.dynamodb.sync-client.type=url
+quarkus.dynamodb.devservices.enabled=false
 
 # Quarkus settings
 ## Visit here for all configs: https://quarkus.io/guides/all-config

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractManyKeys.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.versioned.BranchName;
@@ -550,6 +551,10 @@ public abstract class AbstractManyKeys {
    */
   @ParameterizedTest
   @MethodSource("progressivelyManyKeyNames")
+  @DisabledIfSystemProperty(
+      named = "nessie.integrationTest",
+      matches = "true",
+      disabledReason = "runs too long for integration tests, non-IT coverage's sufficient")
   void manyKeysProgressive(
       List<String> names,
       @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "2048")
@@ -569,6 +574,10 @@ public abstract class AbstractManyKeys {
    */
   @ParameterizedTest
   @MethodSource("progressivelyManyKeyNames")
+  @DisabledIfSystemProperty(
+      named = "nessie.integrationTest",
+      matches = "true",
+      disabledReason = "runs too long for integration tests, non-IT coverage's sufficient")
   void manyKeysProgressiveSmallLists(
       List<String> names,
       @NessieDbAdapterConfigItem(name = "max.key.list.size", value = "0")


### PR DESCRIPTION
Improves test runtimes, mostly for DynamoDB tests. #5174 introduced tests that run sets of 2x 100 parameters, which is extremely slow with Dynamo (longer than 4m locally).

Also changes the local Dynamo from `dimaqq/dynalite` back to `amazon/dynamodb-local` - dynalite's last update was already 2 years ago, considering it unmaintained. This reducse the duration of the Quarkus integration tests drastically (locally: 7m30s -> 30s).

As a related fix (Dynamo), also disable the devservices for DynamoDB. Native image tests started to fail after #5333 (bump of quarkus-amazon-services-bom to v2.13.1.final), disabling the devservices fixes this.

Fixes #5336