### PR TITLE
Update pretty-ms to 8.x

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -38,7 +38,7 @@
         "postcss-normalize": "10.0.1",
         "postcss-preset-env": "7.8.2",
         "postcss-safe-parser": "6.0.0",
-        "pretty-ms": "^7.0.1",
+        "pretty-ms": "^8.0.0",
         "prompts": "2.4.2",
         "ramda": "^0.28.0",
         "react": "^18.2.0",
@@ -15770,11 +15770,14 @@
       }
     },
     "node_modules/parse-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -17212,14 +17215,14 @@
       }
     },
     "node_modules/pretty-ms": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
       "dependencies": {
-        "parse-ms": "^2.1.0"
+        "parse-ms": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -32126,9 +32129,9 @@
       }
     },
     "parse-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="
     },
     "parse5": {
       "version": "7.0.0",
@@ -33001,11 +33004,11 @@
       }
     },
     "pretty-ms": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
       "requires": {
-        "parse-ms": "^2.1.0"
+        "parse-ms": "^3.0.0"
       }
     },
     "process-nextick-args": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,7 @@
     "postcss-normalize": "10.0.1",
     "postcss-preset-env": "7.8.2",
     "postcss-safe-parser": "6.0.0",
-    "pretty-ms": "^7.0.1",
+    "pretty-ms": "^8.0.0",
     "prompts": "2.4.2",
     "ramda": "^0.28.0",
     "react": "^18.2.0",
@@ -163,7 +163,7 @@
       "^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
     "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",
+      "([/\\\\]node_modules[/\\\\])(?!(parse-ms|pretty-ms)).+\\.(js|jsx|mjs|cjs|ts|tsx)$",
       "^.+\\.module\\.(css|sass|scss)$"
     ],
     "modulePaths": [],


### PR DESCRIPTION
This branch is based on https://github.com/projectnessie/nessie/pull/5306 and contains a following fix:
* Fixed jest pattern to exclude `parse-ms` and `pretty-ms` in `node_modules` from transformation. This allows to import `prettyMilliseconds` in `CommitHeader.test.tsx` without error during test.