### PR TITLE
Upgrade desert to 2022.9.22

### DIFF
--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -276,9 +276,9 @@ class OperationsSchema(OneOfSchema):
 class CommitMeta:
     """Dataclass for commit metadata."""
 
-    hash_: str = desert.ib(fields.Str(data_key="hash"), default=None)
-    commitTime: datetime = desert.ib(fields.DateTime(), default=None)
-    authorTime: datetime = desert.ib(fields.DateTime(), default=None)
+    hash_: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(data_key="hash")))
+    commitTime: datetime = attr.ib(default=None, metadata=desert.metadata(fields.DateTime()))
+    authorTime: datetime = attr.ib(default=None, metadata=desert.metadata(fields.DateTime()))
     committer: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(allow_none=True)))
     author: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(allow_none=True)))
     signedOffBy: str = attr.ib(default=None, metadata=desert.metadata(fields.Str(allow_none=True)))

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,7 +17,7 @@ attrs==22.1.0
 botocore==1.27.87
 Click==8.1.3
 confuse==2.0.0
-desert==2020.11.18
+desert==2022.9.22
 marshmallow==3.18.0
 marshmallow_oneofschema==3.0.1
 python-dateutil>=2.8.0


### PR DESCRIPTION
Replaced `desert.ib` by `attr.ib` to fix `tox` lint error message. 