### PR TITLE
quarkus-server tests use dynamic port from env

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -62,10 +62,6 @@ public interface HttpClient {
 
     private Builder() {}
 
-    public URI getBaseUri() {
-      return baseUri;
-    }
-
     public Builder setBaseUri(URI baseUri) {
       this.baseUri = baseUri;
       return this;

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -62,6 +62,10 @@ public interface HttpClient {
 
     private Builder() {}
 
+    public URI getBaseUri() {
+      return baseUri;
+    }
+
     public Builder setBaseUri(URI baseUri) {
       this.baseUri = baseUri;
       return this;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRest.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import java.util.Locale;
 import java.util.Objects;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.BaseNessieClientServerException;
@@ -62,11 +61,6 @@ public abstract class AbstractRest {
 
   public NessieApiV1 getApi() {
     return Objects.requireNonNull(api, "Tests need to call initApi in @BeforeEach");
-  }
-
-  @BeforeEach
-  public void setUp() {
-    initApi(URI.create("http://localhost:19121/api/v1"));
   }
 
   @AfterEach

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyRest.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/AbstractTestJerseyRest.java
@@ -43,7 +43,6 @@ abstract class AbstractTestJerseyRest extends AbstractRestSecurityContext {
     nessieUri = uri;
   }
 
-  @Override
   @BeforeEach
   public void setUp() {
     initApi(nessieUri);

--- a/servers/lambda/build.gradle.kts
+++ b/servers/lambda/build.gradle.kts
@@ -94,8 +94,6 @@ tasks.withType<Test>().configureEach {
   systemProperty("native.image.path", quarkusBuild.nativeRunner)
   systemProperty("quarkus.container-image.build", useDocker)
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
-  // TODO requires adjusting the tests - systemProperty("quarkus.http.test-port", "0") -  set this
-  //  property in application.properties
 
   val testHeapSize: String? by project
   minHeapSize = if (testHeapSize != null) testHeapSize as String else "256m"

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -148,8 +148,6 @@ tasks.withType<Test>().configureEach {
   }
   systemProperty("quarkus.container-image.build", useDocker)
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
-  // TODO requires adjusting the tests - systemProperty("quarkus.http.test-port", "0") -  set this
-  //  property in application.properties
   systemProperty(
     "it.nessie.container.postgres.tag",
     System.getProperty("it.nessie.container.postgres.tag", libs.versions.postgresContainerTag.get())

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -109,7 +109,7 @@ quarkus.log.category."io.quarkus.http.access-log".level=${HTTP_ACCESS_LOG_LEVEL:
 
 ## Quarkus http related settings
 quarkus.http.port=19120
-quarkus.http.test-port=19121
+quarkus.http.test-port=0
 quarkus.http.access-log.enabled=true
 # fixed at buildtime
 quarkus.resteasy.path=/api/v1

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
@@ -19,13 +19,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
-import org.projectnessie.jaxrs.AbstractTestRest;
 
-public abstract class AbstractRestWithMetrics extends AbstractTestRest {
-  // We need to extend the AbstractTestRest because all Nessie metrics are created lazily.
+public abstract class AbstractQuarkusRestWithMetrics extends AbstractTestQuarkusRest {
+  // We need to extend the base class because all Nessie metrics are created lazily.
   // They will appear in the `/q/metrics` endpoint only when some REST actions are executed.
 
-  // this test is executed after all tests from the AbstractTestRest
+  // this test is executed after all tests from the base class
   @Test
   void smokeTestMetrics() {
     // when

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestBasicOperations.java
@@ -18,10 +18,13 @@ package org.projectnessie.server;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.security.TestSecurity;
+import java.net.URI;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
@@ -34,9 +37,15 @@ import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.Operation.Delete;
 import org.projectnessie.model.Operation.Put;
 
+@ExtendWith(QuarkusNessieUriResolver.class)
 abstract class AbstractTestBasicOperations {
 
   private NessieApiV1 api;
+
+  @BeforeEach
+  void setUp(URI quarkusNessieUri) {
+    api = HttpClientBuilder.builder().withUri(quarkusNessieUri).build(NessieApiV1.class);
+  }
 
   @AfterEach
   void closeClient() {
@@ -47,10 +56,6 @@ abstract class AbstractTestBasicOperations {
   }
 
   void getCatalog(String branch) throws BaseNessieClientServerException {
-    api =
-        HttpClientBuilder.builder()
-            .withUri("http://localhost:19121/api/v1")
-            .build(NessieApiV1.class);
     if (branch != null) {
       api.createReference().reference(Branch.of(branch, null)).sourceRefName("main").create();
     }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestQuarkusRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestQuarkusRest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,20 @@
  */
 package org.projectnessie.server;
 
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfilePostgres;
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.jaxrs.AbstractTestRest;
 
-@QuarkusIntegrationTest
-@TestProfile(QuarkusTestProfilePostgres.class)
-class ITRestApiPostgres extends AbstractTestQuarkusRest {}
+/**
+ * Tests need to subclass this class and use @QuarkusIntegrationTest or @QuarkusTest, so that the
+ * quarkus context is available to resolve the nessie URI.
+ */
+@ExtendWith(QuarkusNessieUriResolver.class)
+public abstract class AbstractTestQuarkusRest extends AbstractTestRest {
+
+  @BeforeEach
+  public void setUp(URI quarkusNessieUri) {
+    initApi(quarkusNessieUri);
+  }
+}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITRestApiDynamo.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITRestApiDynamo.java
@@ -17,9 +17,8 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractTestRest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileDynamo;
 
 @QuarkusIntegrationTest
 @TestProfile(QuarkusTestProfileDynamo.class)
-class ITRestApiDynamo extends AbstractTestRest {}
+class ITRestApiDynamo extends AbstractTestQuarkusRest {}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITRestApiInMemory.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITRestApiInMemory.java
@@ -21,4 +21,4 @@ import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 
 @QuarkusIntegrationTest
 @TestProfile(QuarkusTestProfileInmemory.class)
-public class ITRestApiInMemory extends AbstractRestWithMetrics {}
+public class ITRestApiInMemory extends AbstractQuarkusRestWithMetrics {}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITRestApiMongo.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITRestApiMongo.java
@@ -17,9 +17,8 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractTestRest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileMongo;
 
 @QuarkusIntegrationTest
 @TestProfile(QuarkusTestProfileMongo.class)
-class ITRestApiMongo extends AbstractTestRest {}
+class ITRestApiMongo extends AbstractTestQuarkusRest {}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITRestApiRocks.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITRestApiRocks.java
@@ -17,9 +17,8 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractTestRest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileRocks;
 
 @QuarkusIntegrationTest
 @TestProfile(QuarkusTestProfileRocks.class)
-class ITRestApiRocks extends AbstractTestRest {}
+class ITRestApiRocks extends AbstractTestQuarkusRest {}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/QuarkusNessieUriResolver.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/QuarkusNessieUriResolver.java
@@ -52,9 +52,6 @@ public class QuarkusNessieUriResolver implements ParameterResolver {
       return URI.create(getNessieApiV1Url());
     }
     throw new ParameterResolutionException(
-        "Unsupported annotation on parameter "
-            + paramCtx.getParameter()
-            + " on "
-            + paramCtx.getTarget());
+        "Unsupported parameter " + paramCtx.getParameter() + " on " + paramCtx.getTarget());
   }
 }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/QuarkusNessieUriResolver.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/QuarkusNessieUriResolver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server;
+
+import java.net.URI;
+import java.util.Objects;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class QuarkusNessieUriResolver implements ParameterResolver {
+
+  private static Integer getQuarkusTestPort() {
+    return Objects.requireNonNull(
+        Integer.getInteger("quarkus.http.test-port"),
+        "System property not set correctly: quarkus.http.test-port");
+  }
+
+  private static String getNessieApiV1Url() {
+    return String.format("http://localhost:%d/api/v1", getQuarkusTestPort());
+  }
+
+  private boolean isQuarkusNessieUriParam(ParameterContext paramCtx) {
+    return paramCtx.getParameter().getName().equals("quarkusNessieUri")
+        && paramCtx.getParameter().getType().equals(URI.class);
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext paramCtx, ExtensionContext extensionCtx)
+      throws ParameterResolutionException {
+    return isQuarkusNessieUriParam(paramCtx);
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext paramCtx, ExtensionContext extensionCtx)
+      throws ParameterResolutionException {
+    if (isQuarkusNessieUriParam(paramCtx)) {
+      return URI.create(getNessieApiV1Url());
+    }
+    throw new ParameterResolutionException(
+        "Unsupported annotation on parameter "
+            + paramCtx.getParameter()
+            + " on "
+            + paramCtx.getTarget());
+  }
+}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRestApiInMemory.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestRestApiInMemory.java
@@ -21,4 +21,4 @@ import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 
 @QuarkusTest
 @TestProfile(QuarkusTestProfileInmemory.class)
-class TestRestApiInMemory extends AbstractRestWithMetrics {}
+class TestRestApiInMemory extends AbstractQuarkusRestWithMetrics {}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/ITNessieError.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
+import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieBadRequestException;
@@ -30,6 +32,7 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
+import org.projectnessie.server.QuarkusNessieUriResolver;
 
 /**
  * Rudimentary version of {@link TestNessieError}, because we cannot dynamically add beans and
@@ -39,16 +42,14 @@ import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 @QuarkusIntegrationTest
 @TestProfile(
     QuarkusTestProfileInmemory.class) // use the QuarkusTestProfileInmemory, as it can be reused
+@ExtendWith(QuarkusNessieUriResolver.class)
 public class ITNessieError {
 
   private NessieApiV1 api;
 
   @BeforeEach
-  void init() {
-    api =
-        HttpClientBuilder.builder()
-            .withUri("http://localhost:19121/api/v1")
-            .build(NessieApiV1.class);
+  void init(URI quarkusNessieUri) {
+    api = HttpClientBuilder.builder().withUri(quarkusNessieUri).build(NessieApiV1.class);
   }
 
   @Test

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.HttpClientException;
@@ -40,6 +41,7 @@ import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.error.NessieUnsupportedMediaTypeException;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
+import org.projectnessie.server.QuarkusNessieUriResolver;
 
 /**
  * Test reported exceptions both for cases when {@code javax.validation} fails (when the Nessie
@@ -48,21 +50,20 @@ import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 @QuarkusTest
 @TestProfile(
     QuarkusTestProfileInmemory.class) // use the QuarkusTestProfileInmemory, as it can be reused
+@ExtendWith(QuarkusNessieUriResolver.class)
 class TestNessieError {
-
-  static String baseURI = "http://localhost:19121/api/v1/nessieErrorTest";
 
   private static HttpClient client;
 
   @BeforeAll
-  static void setup() {
+  static void setup(URI quarkusNessieUri) {
     ObjectMapper mapper =
         new ObjectMapper()
             .enable(SerializationFeature.INDENT_OUTPUT)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     client =
         HttpClient.builder()
-            .setBaseUri(URI.create(baseURI))
+            .setBaseUri(URI.create(quarkusNessieUri + "/nessieErrorTest"))
             .setObjectMapper(mapper)
             .addResponseFilter(new NessieHttpResponseFilter(mapper))
             .build();


### PR DESCRIPTION
adds `AbstractTestQuarkusRest` as common base class to configure the nessie api client with quarkus port

fixes https://github.com/projectnessie/nessie/issues/4015