### PR TITLE
Documentation accommodating new version format of Iceberg and Nessie artifacts

### DIFF
--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -4,9 +4,12 @@
     Detailed steps on how to set up Pyspark + Iceberg + Nessie with Python is available on [Binder](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=notebooks/nessie-iceberg-demo-nba.ipynb)
 
 To access Nessie from a spark cluster make sure the `spark.jars` spark option is set to include
-the [Spark 2](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark/{{ versions.iceberg }}/iceberg-spark-{{ versions.iceberg }}.jar)
-or [Spark 3](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark3/{{ versions.iceberg }}/iceberg-spark3-{{ versions.iceberg }}.jar) or
-[Spark 3.2](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) Nessie plugin jar. This fat jar
+the [Spark 2.4](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark24 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark24 }}-{{ versions.iceberg }}.jar)
+or [Spark 3.1](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
+[Spark 3.2_2.12](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
+[Spark 3.2_2.13](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala213 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala213 }}-{{ versions.iceberg }}.jar) or
+[Spark 3.3_2.12](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
+[Spark 3.3_2.13](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala213 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala213 }}-{{ versions.iceberg }}.jar) Nessie plugin jar. This fat jar
 is distributed by the Apache Iceberg project and contains all Apache Iceberg libraries required for operation, including the built-in Nessie Catalog.
 
 In pyspark this would look like

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -21,7 +21,7 @@ To access Nessie on Iceberg from a spark cluster make sure the `spark.jars` spar
 
 The `iceberg-spark-runtime` fat jars are distributed by the Apache Iceberg project and contains all Apache Iceberg libraries required for operation, including the built-in Nessie Catalog.
 
-The `nessie-spark-extensions` jars are distributed by the Nessie project and contain extensions that allow you to manage your tables with nessie's git-like syntax.
+The `nessie-spark-extensions` jars are distributed by the Nessie project and contain [SQL extensions](../sql.md) that allow you to manage your tables with nessie's git-like syntax.
 
 
 In pyspark, usage would look like...

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -75,7 +75,7 @@ The Nessie Catalog needs the following parameters set in the Spark/Hadoop config
 
 These are set as follows in code (or through other methods as described [here](https://spark.apache.org/docs/latest/configuration.html))
 
-In these examples, `spark.jars.packages` is configured for Spark 3.2.  Consult the table above to find the version of that correspond to your Spark deployment.
+In these examples, `spark.jars.packages` is configured for Spark 3.3.x.  Consult the table above to find the version of that correspond to your Spark deployment.
 
 === "Java"
 ``` java

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -6,7 +6,7 @@
 To access Nessie from a spark cluster make sure the `spark.jars` spark option is set to include
 the [Spark 2](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark/{{ versions.iceberg }}/iceberg-spark-{{ versions.iceberg }}.jar)
 or [Spark 3](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark3/{{ versions.iceberg }}/iceberg-spark3-{{ versions.iceberg }}.jar) or
-[Spark 3.2](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.iceberg_spark32 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.iceberg_spark32 }}-{{ versions.iceberg }}.jar) Nessie plugin jar. This fat jar
+[Spark 3.2](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) Nessie plugin jar. This fat jar
 is distributed by the Apache Iceberg project and contains all Apache Iceberg libraries required for operation, including the built-in Nessie Catalog.
 
 In pyspark this would look like
@@ -14,7 +14,7 @@ In pyspark this would look like
 ``` python
 SparkSession.builder
     .config('spark.jars.packages',
-            'org.apache.iceberg:iceberg-spark-runtime-{{ versions.iceberg_spark32 }}:{{ versions.iceberg }}')
+            'org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }}')
     ... rest of spark config
     .getOrCreate()
 ```
@@ -66,7 +66,7 @@ String authType = "NONE";
 
     //for a local spark instance
     conf.set("spark.jars.packages",
-            "org.apache.iceberg:iceberg-spark3-runtime-{{ versions.iceberg }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions:{{ versions.java }}")
+            "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.java }}")
         .set("spark.sql.extensions", 
             "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions")
         .set("spark.sql.catalog.nessie.uri", url)
@@ -96,7 +96,7 @@ auth_type = "NONE"
     # here we are assuming NONE authorisation
     spark = SparkSession.builder \
             .config("spark.jars.packages",
-                "org.apache.iceberg:iceberg-spark3-runtime-{{ versions.iceberg_spark32 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions:{{ versions.java }}") \
+                "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.java }}") \
             .config("spark.sql.extensions", 
                 "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions") \
             .config("spark.sql.catalog.nessie.uri", url) \
@@ -126,7 +126,7 @@ auth_type = "NONE"
 
     //for a local spark instance
     conf.set("spark.jars.packages",
-            "org.apache.iceberg:iceberg-spark-runtime-{{ versions.iceberg_spark32 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-3.2-extensions:{{ versions.java }}")
+            "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}")
         .set("spark.sql.extensions", 
             "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSpark32SessionExtensions")
         .set("spark.sql.catalog.nessie.uri", url)
@@ -156,7 +156,7 @@ auth_type = "NONE"
     # here we are assuming NONE authorisation
     spark = SparkSession.builder \
             .config("spark.jars.packages",
-                "org.apache.iceberg:iceberg-spark-runtime-{{ versions.iceberg_spark32 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-3.2-extensions:{{ versions.java }}") \
+                "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}") \
             .config("spark.sql.extensions", 
                 "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions") \
             .config("spark.sql.catalog.nessie.uri", url) \

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -7,14 +7,16 @@ To access Nessie on Iceberg from a spark cluster make sure the `spark.jars` spar
 
 | | `iceberg-spark-runtime` *(required)* | `nessie-spark-extensions` *(optional)* |
 |---|:---:|:---:|
-{%- for (sparkver, scalaver, iceberg_spark_runtime, nessie_spark_extensions) in [
-  ('3.3', '2.12', artifacts.iceberg_spark_runtime_33_212, artifacts.nessie_spark_extensions_33_212),
-  ('3.3', '2.13', artifacts.iceberg_spark_runtime_33_213, artifacts.nessie_spark_extensions_33_213),
-  ('3.2', '2.12', artifacts.iceberg_spark_runtime_32_212, artifacts.nessie_spark_extensions_32_212),
-  ('3.2', '2.13', artifacts.iceberg_spark_runtime_32_213, artifacts.nessie_spark_extensions_32_213),
-  ('3.1', '2.12', artifacts.iceberg_spark_runtime_31_212, artifacts.nessie_spark_extensions_31_212),
+{%- for (sparkver, scalaver) in [
+  ('3.3', '2.12'),
+  ('3.3', '2.13'),
+  ('3.2', '2.12'),
+  ('3.2', '2.13'),
+  ('3.1', '2.12'),
 ] %}
-| Spark **{{sparkver}}**, Scala **{{scalaver}}**: | `{{iceberg_spark_runtime.spark_jar_package}}`<br />*([All]({{iceberg_spark_runtime.all_versions_url}}), [Latest]({{iceberg_spark_runtime.jar_url}}))* | `{{nessie_spark_extensions.spark_jar_package}}`<br />*([All]({{nessie_spark_extensions.all_versions_url}}), [Latest]({{nessie_spark_extensions.jar_url}}))* |
+{%- set runtime = iceberg_spark_runtime(sparkver, scalaver) %}
+{%- set extensions = nessie_spark_extensions(sparkver, scalaver) %}
+| Spark **{{sparkver}}**, Scala **{{scalaver}}**: | `{{runtime.spark_jar_package}}`<br />*([All]({{runtime.all_versions_url}}), [Latest]({{runtime.jar_url}}))* | `{{extensions.spark_jar_package}}`<br />*([All]({{extensions.all_versions_url}}), [Latest]({{extensions.jar_url}}))* |
 {%- endfor %}
 
 The `iceberg-spark-runtime` fat jars are distributed by the Apache Iceberg project and contains all Apache Iceberg libraries required for operation, including the built-in Nessie Catalog.
@@ -28,7 +30,7 @@ In pyspark, usage would look like...
     ``` python
     SparkSession.builder
         .config('spark.jars.packages',
-                '{{ artifacts.iceberg_spark_runtime_33_212.spark_jar_package }}')
+                '{{ iceberg_spark_runtime().spark_jar_package }}')
         ... rest of spark config
         .getOrCreate()
     ```
@@ -40,7 +42,7 @@ In pyspark, usage would look like...
     ``` python
     SparkSession.builder
         .config('spark.jars.packages',
-                '{{ artifacts.iceberg_spark_runtime_33_212.spark_jar_package }},{{ artifacts.nessie_spark_extensions_33_212.spark_jar_package }}')
+                '{{ iceberg_spark_runtime().spark_jar_package }},{{ nessie_spark_extensions().spark_jar_package }}')
         ... rest of spark config
         .getOrCreate()
     ```
@@ -91,7 +93,7 @@ String ref = "main";
 String authType = "NONE";
 
     //for a local spark instance
-    conf.set("spark.jars.packages", "{{ artifacts.iceberg_spark_runtime_33_212.spark_jar_package }},{{ artifacts.nessie_spark_extensions_33_212.spark_jar_package }}")
+    conf.set("spark.jars.packages", "{{ iceberg_spark_runtime().spark_jar_package }},{{ nessie_spark_extensions().spark_jar_package }}")
         .set("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions")
         .set("spark.sql.catalog.nessie.uri", url)
         .set("spark.sql.catalog.nessie.ref", ref)
@@ -118,7 +120,7 @@ auth_type = "NONE"
 
     # here we are assuming NONE authorisation
     spark = SparkSession.builder \
-            .config("spark.jars.packages","{{ artifacts.iceberg_spark_runtime_33_212.spark_jar_package }},{{ artifacts.nessie_spark_extensions_33_212.spark_jar_package }}") \
+            .config("spark.jars.packages","{{ iceberg_spark_runtime().spark_jar_package }},{{ nessie_spark_extensions().spark_jar_package }}") \
             .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions") \
             .config("spark.sql.catalog.nessie.uri", url) \
             .config("spark.sql.catalog.nessie.ref", ref) \

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -133,7 +133,7 @@ auth_type = "NONE"
     conf.set("spark.jars.packages",
             "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}")
         .set("spark.sql.extensions", 
-            "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSpark32SessionExtensions")
+            "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions")
         .set("spark.sql.catalog.nessie.uri", url)
         .set("spark.sql.catalog.nessie.ref", ref)
         .set("spark.sql.catalog.nessie.authentication.type", authType)

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -4,13 +4,15 @@
     Detailed steps on how to set up Pyspark + Iceberg + Nessie with Python is available on [Binder](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=notebooks/nessie-iceberg-demo-nba.ipynb)
 
 To access Nessie from a spark cluster make sure the `spark.jars` spark option is set to include
-the [Spark 2.4](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark24 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark24 }}-{{ versions.iceberg }}.jar)
-or [Spark 3.1](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
+the 
+[Spark 2.4](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark24 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark24 }}-{{ versions.iceberg }}.jar) or 
+[Spark 3.0](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark30 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark30 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or 
+[Spark 3.1](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
 [Spark 3.2_2.12](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
 [Spark 3.2_2.13](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala213 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala213 }}-{{ versions.iceberg }}.jar) or
 [Spark 3.3_2.12](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
-[Spark 3.3_2.13](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala213 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala213 }}-{{ versions.iceberg }}.jar) Nessie plugin jar. This fat jar
-is distributed by the Apache Iceberg project and contains all Apache Iceberg libraries required for operation, including the built-in Nessie Catalog.
+[Spark 3.3_2.13](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala213 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala213 }}-{{ versions.iceberg }}.jar) Nessie plugin jar. 
+These fat jars are distributed by the Apache Iceberg project and contains all Apache Iceberg libraries required for operation, including the built-in Nessie Catalog.
 
 In pyspark this would look like
 

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -14,7 +14,7 @@ To access Nessie on Iceberg from a spark cluster make sure the `spark.jars` spar
   ('3.2', '2.13', artifacts.iceberg_spark_runtime_32_213, artifacts.nessie_spark_extensions_32_213),
   ('3.1', '2.12', artifacts.iceberg_spark_runtime_31_212, artifacts.nessie_spark_extensions_31_212),
 ] %}
-| Spark **{{sparkver}}**, Scala **{{scalaver}}**: | `{{iceberg_spark_runtime.spark_jar_package}}`<br />*([All]({{iceberg_spark_runtime.group_url}}), [Latest]({{iceberg_spark_runtime.jar_url}}))* | `{{nessie_spark_extensions.spark_jar_package}}`<br />*([All]({{nessie_spark_extensions.group_url}}), [Latest]({{nessie_spark_extensions.jar_url}}))* |
+| Spark **{{sparkver}}**, Scala **{{scalaver}}**: | `{{iceberg_spark_runtime.spark_jar_package}}`<br />*([All]({{iceberg_spark_runtime.all_versions_url}}), [Latest]({{iceberg_spark_runtime.jar_url}}))* | `{{nessie_spark_extensions.spark_jar_package}}`<br />*([All]({{nessie_spark_extensions.all_versions_url}}), [Latest]({{nessie_spark_extensions.jar_url}}))* |
 {%- endfor %}
 
 The `iceberg-spark-runtime` fat jars are distributed by the Apache Iceberg project and contains all Apache Iceberg libraries required for operation, including the built-in Nessie Catalog.

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -5,8 +5,6 @@
 
 To access Nessie from a spark cluster make sure the `spark.jars` spark option is set to include
 the 
-[Spark 2.4](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark24 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark24 }}-{{ versions.iceberg }}.jar) or 
-[Spark 3.0](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark30 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark30 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or 
 [Spark 3.1](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
 [Spark 3.2_2.12](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}-{{ versions.iceberg }}.jar) or
 [Spark 3.2_2.13](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala213 }}/{{ versions.iceberg }}/iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala213 }}-{{ versions.iceberg }}.jar) or

--- a/site/docs/tools/sql.md
+++ b/site/docs/tools/sql.md
@@ -30,7 +30,7 @@ Here's an example of how this is done when starting the `spark-sql` shell:
 ```
 bin/spark-sql 
   --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}"
-  --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSpark32SessionExtensions"
+  --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions"
   --conf <other settings>
 ```
 

--- a/site/docs/tools/sql.md
+++ b/site/docs/tools/sql.md
@@ -23,8 +23,6 @@ bin/spark-sql
 In order to be able to use Nessie's custom Spark SQL extensions with Spark 3.2.x, one needs to configure
 `org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }}`.
 
-This differentiates from Spark 3.1 usage: `NessieSpark32SessionExtensions` must be used instead of `NessieSparkSessionExtensions`.
-
 Here's an example of how this is done when starting the `spark-sql` shell:
 
 ```

--- a/site/docs/tools/sql.md
+++ b/site/docs/tools/sql.md
@@ -3,52 +3,26 @@ Spark SQL extensions provide an easy way to execute common Nessie commands via S
 
 ## How to use them
 
+{%- for (sparkver, iceberg_spark_runtime, nessie_spark_extensions) in [
+  ('3.3', artifacts.iceberg_spark_runtime_33_212, artifacts.nessie_spark_extensions_33_212),
+  ('3.2', artifacts.iceberg_spark_runtime_32_212, artifacts.nessie_spark_extensions_32_212),
+  ('3.1', artifacts.iceberg_spark_runtime_31_212, artifacts.nessie_spark_extensions_31_212),
+] %}
 
-### Spark 3.1
+### Spark {{sparkver}}
 
-In order to be able to use Nessie's custom Spark SQL extensions with Spark 3.1.x, one needs to configure
-`org.projectnessie:nessie-spark-extensions-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.iceberg }}`.
-
-Here's an example of how this is done when starting the `spark-sql` shell:
-
-```
-bin/spark-sql 
-  --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.java }}"
-  --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions"
-  --conf <other settings>
-```
-
-### Spark 3.2
-
-In order to be able to use Nessie's custom Spark SQL extensions with Spark 3.2.x, one needs to configure
-`org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }}`.
-
-Artifacts are available that support for both scala 2.12 and 2.13.
+In order to be able to use Nessie's custom Spark SQL extensions with Spark {{sparkver}}.x, one needs to configure
+`{{iceberg_spark_runtime.spark_jar_package}}` along with `{{nessie_spark_extensions.spark_jar_package}}`.
 
 Here's an example of how this is done when starting the `spark-sql` shell:
 
-```
+``` sh
 bin/spark-sql 
-  --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}"
+  --packages "{{iceberg_spark_runtime.spark_jar_package}},{{nessie_spark_extensions.spark_jar_package}}"
   --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions"
   --conf <other settings>
 ```
-
-### Spark 3.3
-
-In order to be able to use Nessie's custom Spark SQL extensions with Spark 3.3.x, one needs to configure
-`org.projectnessie:nessie-spark-extensions-{{ versions.spark33 }}_{{ versions.scala212 }}:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala212 }}:{{ versions.iceberg }}`.
-
-Artifacts are available that support for both scala 2.12 and 2.13.
-
-Here's an example of how this is done when starting the `spark-sql` shell:
-
-```
-bin/spark-sql 
-  --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark33 }}_{{ versions.scala212 }}:{{ versions.java }}"
-  --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions"
-  --conf <other settings>
-```
+{%- endfor %}
 
 Additional configuration details can be found in the [Spark via Iceberg](iceberg/spark.md) docs.
 

--- a/site/docs/tools/sql.md
+++ b/site/docs/tools/sql.md
@@ -6,13 +6,14 @@ Spark SQL extensions provide an easy way to execute common Nessie commands via S
 
 ### Spark 3.1
 
-In order to be able to use Nessie's custom Spark SQL extensions, one needs to configure
-`org.projectnessie:nessie-spark-extensions:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.iceberg_spark32 }}:{{ versions.iceberg }}`.
+In order to be able to use Nessie's custom Spark SQL extensions with Spark 3.1.x, one needs to configure
+`org.projectnessie:nessie-spark-extensions-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.iceberg }}`.
+
 Here's an example of how this is done when starting the `spark-sql` shell:
 
 ```
 bin/spark-sql 
-  --packages "org.apache.iceberg:iceberg-spark3-runtime-{{ versions.iceberg }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions:{{ versions.java }}"
+  --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark31 }}_{{ versions.scala212 }}:{{ versions.java }}"
   --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions"
   --conf <other settings>
 ```
@@ -20,12 +21,15 @@ bin/spark-sql
 ### Spark 3.2
 
 In order to be able to use Nessie's custom Spark SQL extensions with Spark 3.2.x, one needs to configure
-`org.projectnessie:nessie-spark-3.2-extensions:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.iceberg_spark32 }}:{{ versions.iceberg }}`.
+`org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }}`.
+
+This differentiates from Spark 3.1 usage: `NessieSpark32SessionExtensions` must be used instead of `NessieSparkSessionExtensions`.
+
 Here's an example of how this is done when starting the `spark-sql` shell:
 
 ```
 bin/spark-sql 
-  --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.iceberg_spark32 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-3.2-extensions:{{ versions.java }}"
+  --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}"
   --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSpark32SessionExtensions"
   --conf <other settings>
 ```

--- a/site/docs/tools/sql.md
+++ b/site/docs/tools/sql.md
@@ -3,22 +3,22 @@ Spark SQL extensions provide an easy way to execute common Nessie commands via S
 
 ## How to use them
 
-{%- for (sparkver, iceberg_spark_runtime, nessie_spark_extensions) in [
-  ('3.3', artifacts.iceberg_spark_runtime_33_212, artifacts.nessie_spark_extensions_33_212),
-  ('3.2', artifacts.iceberg_spark_runtime_32_212, artifacts.nessie_spark_extensions_32_212),
-  ('3.1', artifacts.iceberg_spark_runtime_31_212, artifacts.nessie_spark_extensions_31_212),
+{%- for sparkver in [
+  '3.3',
+  '3.2',
+  '3.1',
 ] %}
 
 ### Spark {{sparkver}}
 
 In order to be able to use Nessie's custom Spark SQL extensions with Spark {{sparkver}}.x, one needs to configure
-`{{iceberg_spark_runtime.spark_jar_package}}` along with `{{nessie_spark_extensions.spark_jar_package}}`.
+`{{ iceberg_spark_runtime(sparkver).spark_jar_package }}` along with `{{ nessie_spark_extensions(sparkver).spark_jar_package }}`
 
 Here's an example of how this is done when starting the `spark-sql` shell:
 
 ``` sh
 bin/spark-sql 
-  --packages "{{iceberg_spark_runtime.spark_jar_package}},{{nessie_spark_extensions.spark_jar_package}}"
+  --packages "{{ iceberg_spark_runtime(sparkver).spark_jar_package }},{{ nessie_spark_extensions(sparkver).spark_jar_package }}"
   --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions"
   --conf <other settings>
 ```

--- a/site/docs/tools/sql.md
+++ b/site/docs/tools/sql.md
@@ -23,11 +23,29 @@ bin/spark-sql
 In order to be able to use Nessie's custom Spark SQL extensions with Spark 3.2.x, one needs to configure
 `org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }}`.
 
+Artifacts are available that support for both scala 2.12 and 2.13.
+
 Here's an example of how this is done when starting the `spark-sql` shell:
 
 ```
 bin/spark-sql 
   --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark32 }}_{{ versions.scala212 }}:{{ versions.java }}"
+  --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions"
+  --conf <other settings>
+```
+
+### Spark 3.3
+
+In order to be able to use Nessie's custom Spark SQL extensions with Spark 3.3.x, one needs to configure
+`org.projectnessie:nessie-spark-extensions-{{ versions.spark33 }}_{{ versions.scala212 }}:{{ versions.java }}` along with `org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala212 }}:{{ versions.iceberg }}`.
+
+Artifacts are available that support for both scala 2.12 and 2.13.
+
+Here's an example of how this is done when starting the `spark-sql` shell:
+
+```
+bin/spark-sql 
+  --packages "org.apache.iceberg:iceberg-spark-runtime-{{ versions.spark33 }}_{{ versions.scala212 }}:{{ versions.iceberg }},org.projectnessie:nessie-spark-extensions-{{ versions.spark33 }}_{{ versions.scala212 }}:{{ versions.java }}"
   --conf spark.sql.extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions"
   --conf <other settings>
 ```

--- a/site/macros.py
+++ b/site/macros.py
@@ -28,18 +28,22 @@ def define_env(env):
             'all_versions_url': f"https://search.maven.org/artifact/{group}/{artifact}"
         }
 
+    __latest_iceberg_version = env.variables.versions['iceberg']
+
     @env.macro
-    def iceberg_spark_runtime(spark="3.3", scala="2.12"):
+    def iceberg_spark_runtime(spark="3.3", scala="2.12", version=__latest_iceberg_version):
         return __maven_artifact(
             "org.apache.iceberg",
             f"iceberg-spark-runtime-{spark}_{scala}",
-            env.variables.versions['iceberg']
+            version
         )
 
+    __latest_nessie_version = env.variables.versions['java']
+
     @env.macro
-    def nessie_spark_extensions(spark="3.3", scala="2.12"):
+    def nessie_spark_extensions(spark="3.3", scala="2.12", version=__latest_nessie_version):
         return __maven_artifact(
             "org.projectnessie",
             f"nessie-spark-extensions-{spark}_{scala}",
-            env.variables.versions['java']
+            version
         )

--- a/site/macros.py
+++ b/site/macros.py
@@ -1,0 +1,45 @@
+"""
+This file is enabled by mkdocs-macros-plugin: https://mkdocs-macros-plugin.readthedocs.io/en/latest/
+...and is directly targetted in the plugins.macros.module_name key of the mkdocs.yml configuration.
+"""
+
+from dataclasses import dataclass
+from tokenize import group
+
+
+def define_env(env):
+    """
+    This is the hook for defining variables, macros and filters.
+
+    - variables: the dictionary that contains the environment variables (extra in mkdocs.yml).
+    - macro: a decorator function, to declare a macro.  Will be universally available.
+    - filter: a function with one of more arguments, used to perform a transformation.  Will be universally available.
+    """ 
+
+    def __maven_artifact(group, artifact, version):
+        """
+        Create a package of useful things about a Maven artifact.
+        Follows Maven naming conventions: https://maven.apache.org/guides/mini/guide-naming-conventions.html
+        """
+        group_slashified = group.replace('.', '/')
+        return {
+            'spark_jar_package': f'{group}:{artifact}:{version}',
+            'jar_url': f'https://repo.maven.apache.org/maven2/{group_slashified}/{artifact}/{version}/{artifact}-{version}.jar',
+            'all_versions_url': f"https://search.maven.org/artifact/{group}/{artifact}"
+        }
+
+    @env.macro
+    def iceberg_spark_runtime(spark="3.3", scala="2.12"):
+        return __maven_artifact(
+            "org.apache.iceberg",
+            f"iceberg-spark-runtime-{spark}_{scala}",
+            env.variables.versions['iceberg']
+        )
+
+    @env.macro
+    def nessie_spark_extensions(spark="3.3", scala="2.12"):
+        return __maven_artifact(
+            "org.projectnessie",
+            f"nessie-spark-extensions-{spark}_{scala}",
+            env.variables.versions['java']
+        )

--- a/site/macros.py
+++ b/site/macros.py
@@ -3,10 +3,6 @@ This file is enabled by mkdocs-macros-plugin: https://mkdocs-macros-plugin.readt
 ...and is directly targetted in the plugins.macros.module_name key of the mkdocs.yml configuration.
 """
 
-from dataclasses import dataclass
-from tokenize import group
-
-
 def define_env(env):
     """
     This is the hook for defining variables, macros and filters.

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -72,11 +72,6 @@ extra:
     java: 0.43.0
     python: v0.43.0
     iceberg: 0.14.1
-    spark31: 3.1
-    spark32: 3.2
-    spark33: 3.3
-    scala212: 2.12
-    scala213: 2.13
   analytics:
     provider: google
     property: UA-177850801-1

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -25,47 +25,47 @@ extra:
   artifacts:
     # Spark 3.3 and Scala 2.12:
     iceberg_spark_runtime_33_212:
-        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.3_2.12
+        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.3_2.12
         jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/0.14.1/iceberg-spark-runtime-3.3_2.12-0.14.1.jar
         spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.1
     nessie_spark_extensions_33_212:
-        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.3_2.12
+        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.3_2.12
         jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.3_2.12/0.43.0/nessie-spark-extensions-3.3_2.12-0.43.0.jar
         spark_jar_package: org.projectnessie:nessie-spark-extensions-3.3_2.12:0.43.0
     # Spark 3.3 and Scala 2.13:
     iceberg_spark_runtime_33_213:
-        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.3_2.13
+        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.3_2.13
         jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.13/0.14.1/iceberg-spark-runtime-3.3_2.13-0.14.1.jar
         spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.3_2.13:0.14.1
     nessie_spark_extensions_33_213:
-        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.3_2.13
+        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.3_2.13
         jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.3_2.13/0.43.0/nessie-spark-extensions-3.3_2.13-0.43.0.jar
         spark_jar_package: org.projectnessie:nessie-spark-extensions-3.3_2.13:0.43.0
     # Spark 3.2 and Scala 2.12:
     iceberg_spark_runtime_32_212:
-        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.2_2.12
+        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.2_2.12
         jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.14.1/iceberg-spark-runtime-3.2_2.12-0.14.1.jar
         spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:0.14.1
     nessie_spark_extensions_32_212:
-        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.2_2.12
+        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.2_2.12
         jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.2_2.12/0.43.0/nessie-spark-extensions-3.2_2.12-0.43.0.jar
         spark_jar_package: org.projectnessie:nessie-spark-extensions-3.2_2.12:0.43.0
     # Spark 3.2 and Scala 2.13:
     iceberg_spark_runtime_32_213:
-        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.2_2.13
+        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.2_2.13
         jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.13/0.14.1/iceberg-spark-runtime-3.2_2.13-0.14.1.jar
         spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:0.14.1
     nessie_spark_extensions_32_213:
-        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.2_2.13
+        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.2_2.13
         jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.2_2.13/0.43.0/nessie-spark-extensions-3.2_2.13-0.43.0.jar
         spark_jar_package: org.projectnessie:nessie-spark-extensions-3.2_2.13:0.43.0    
     # Spark 3.1 and Scala 2.12:
     iceberg_spark_runtime_31_212:
-        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.1_2.12
+        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.1_2.12
         jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.1_2.12/0.14.1/iceberg-spark-runtime-3.1_2.12-0.14.1.jar
         spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:0.14.1
     nessie_spark_extensions_31_212:
-        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.1_2.12
+        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.1_2.12
         jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.1_2.12/0.43.0/nessie-spark-extensions-3.1_2.12-0.43.0.jar
         spark_jar_package: org.projectnessie:nessie-spark-extensions-3.1_2.12:0.43.0
   versions:

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -27,6 +27,7 @@ extra:
     python: v0.43.0
     iceberg: 0.14.1
     spark24: 2.4
+    spark30: 3.0
     spark31: 3.1
     spark32: 3.2
     spark33: 3.3

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -26,9 +26,12 @@ extra:
     java: 0.43.0
     python: v0.43.0
     iceberg: 0.14.1
+    spark24: 2.4
     spark31: 3.1
     spark32: 3.2
+    spark33: 3.3
     scala212: 2.12
+    scala213: 2.13
   analytics:
     provider: google
     property: UA-177850801-1

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -22,6 +22,52 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
+  artifacts:
+    # Spark 3.3 and Scala 2.12:
+    iceberg_spark_runtime_33_212:
+        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.3_2.12
+        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/0.14.1/iceberg-spark-runtime-3.3_2.12-0.14.1.jar
+        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.1
+    nessie_spark_extensions_33_212:
+        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.3_2.12
+        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.3_2.12/0.43.0/nessie-spark-extensions-3.3_2.12-0.43.0.jar
+        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.3_2.12:0.43.0
+    # Spark 3.3 and Scala 2.13:
+    iceberg_spark_runtime_33_213:
+        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.3_2.13
+        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.13/0.14.1/iceberg-spark-runtime-3.3_2.13-0.14.1.jar
+        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.3_2.13:0.14.1
+    nessie_spark_extensions_33_213:
+        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.3_2.13
+        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.3_2.13/0.43.0/nessie-spark-extensions-3.3_2.13-0.43.0.jar
+        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.3_2.13:0.43.0
+    # Spark 3.2 and Scala 2.12:
+    iceberg_spark_runtime_32_212:
+        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.2_2.12
+        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.14.1/iceberg-spark-runtime-3.2_2.12-0.14.1.jar
+        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:0.14.1
+    nessie_spark_extensions_32_212:
+        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.2_2.12
+        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.2_2.12/0.43.0/nessie-spark-extensions-3.2_2.12-0.43.0.jar
+        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.2_2.12:0.43.0
+    # Spark 3.2 and Scala 2.13:
+    iceberg_spark_runtime_32_213:
+        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.2_2.13
+        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.13/0.14.1/iceberg-spark-runtime-3.2_2.13-0.14.1.jar
+        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:0.14.1
+    nessie_spark_extensions_32_213:
+        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.2_2.13
+        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.2_2.13/0.43.0/nessie-spark-extensions-3.2_2.13-0.43.0.jar
+        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.2_2.13:0.43.0    
+    # Spark 3.1 and Scala 2.12:
+    iceberg_spark_runtime_31_212:
+        group_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.1_2.12
+        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.1_2.12/0.14.1/iceberg-spark-runtime-3.1_2.12-0.14.1.jar
+        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:0.14.1
+    nessie_spark_extensions_31_212:
+        group_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.1_2.12
+        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.1_2.12/0.43.0/nessie-spark-extensions-3.1_2.12-0.43.0.jar
+        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.1_2.12:0.43.0
   versions:
     java: 0.43.0
     python: v0.43.0

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -22,52 +22,6 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
-  artifacts:
-    # Spark 3.3 and Scala 2.12:
-    iceberg_spark_runtime_33_212:
-        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.3_2.12
-        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/0.14.1/iceberg-spark-runtime-3.3_2.12-0.14.1.jar
-        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.1
-    nessie_spark_extensions_33_212:
-        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.3_2.12
-        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.3_2.12/0.43.0/nessie-spark-extensions-3.3_2.12-0.43.0.jar
-        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.3_2.12:0.43.0
-    # Spark 3.3 and Scala 2.13:
-    iceberg_spark_runtime_33_213:
-        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.3_2.13
-        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.13/0.14.1/iceberg-spark-runtime-3.3_2.13-0.14.1.jar
-        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.3_2.13:0.14.1
-    nessie_spark_extensions_33_213:
-        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.3_2.13
-        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.3_2.13/0.43.0/nessie-spark-extensions-3.3_2.13-0.43.0.jar
-        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.3_2.13:0.43.0
-    # Spark 3.2 and Scala 2.12:
-    iceberg_spark_runtime_32_212:
-        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.2_2.12
-        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.14.1/iceberg-spark-runtime-3.2_2.12-0.14.1.jar
-        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:0.14.1
-    nessie_spark_extensions_32_212:
-        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.2_2.12
-        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.2_2.12/0.43.0/nessie-spark-extensions-3.2_2.12-0.43.0.jar
-        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.2_2.12:0.43.0
-    # Spark 3.2 and Scala 2.13:
-    iceberg_spark_runtime_32_213:
-        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.2_2.13
-        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.2_2.13/0.14.1/iceberg-spark-runtime-3.2_2.13-0.14.1.jar
-        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:0.14.1
-    nessie_spark_extensions_32_213:
-        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.2_2.13
-        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.2_2.13/0.43.0/nessie-spark-extensions-3.2_2.13-0.43.0.jar
-        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.2_2.13:0.43.0    
-    # Spark 3.1 and Scala 2.12:
-    iceberg_spark_runtime_31_212:
-        all_versions_url: https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime-3.1_2.12
-        jar_url: https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.1_2.12/0.14.1/iceberg-spark-runtime-3.1_2.12-0.14.1.jar
-        spark_jar_package: org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:0.14.1
-    nessie_spark_extensions_31_212:
-        all_versions_url: https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.1_2.12
-        jar_url: https://repo.maven.apache.org/maven2/org/projectnessie/nessie-spark-extensions-3.1_2.12/0.43.0/nessie-spark-extensions-3.1_2.12-0.43.0.jar
-        spark_jar_package: org.projectnessie:nessie-spark-extensions-3.1_2.12:0.43.0
   versions:
     java: 0.43.0
     python: v0.43.0

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -26,7 +26,9 @@ extra:
     java: 0.43.0
     python: v0.43.0
     iceberg: 0.14.1
-    iceberg_spark32: 3.2_2.12
+    spark31: 3.1
+    spark32: 3.2
+    scala212: 2.12
   analytics:
     provider: google
     property: UA-177850801-1

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -26,8 +26,6 @@ extra:
     java: 0.43.0
     python: v0.43.0
     iceberg: 0.14.1
-    spark24: 2.4
-    spark30: 3.0
     spark31: 3.1
     spark32: 3.2
     spark33: 3.3

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -84,10 +84,12 @@ extra:
       link: https://www.youtube.com/channel/UC5xjzYuGGuGPCY9FNtqZMsQ?view_as=subscriber
 repo_url: https://github.com/projectnessie/nessie
 plugins:
-  - markdownextradata
   - search
   - awesome-pages:
       filename: _config
+  - macros:
+      on_error_fail: true
+      module_name: macros
   - minify:
       minify_html: true
 markdown_extensions:

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -4,4 +4,4 @@ mkdocs-minify-plugin==0.5.0
 mkdocs-redirects==1.2.0
 pymdown-extensions==9.6
 mkdocs-awesome-pages-plugin==2.8.0
-mkdocs-markdownextradata-plugin==0.2.5
+mkdocs-macros-plugin==0.7.0


### PR DESCRIPTION
# Summary:
This is a documentation-only change for the Nessie site [here](https://projectnessie.org/tools/iceberg/spark/) and [here](https://projectnessie.org/tools/sql/).

It updates how nessie and iceberg artifacts are accessed by users to be in alignment with how they are now published. In addition, it makes some corrections where spark 3.2 were used on 3.1 documentation and calls out small differences in their usage. It also brings in spark 3.3 docs.

# Details:
- Updates [the existing entrypoint for nessie documentation](https://projectnessie.org/tools/sql/#spark-31) to use the new spark-scala-striped form of the [nessie-spark-extensions](https://search.maven.org/search?q=g:org.projectnessie%20AND%20a:nessie-spark-extensions*) and the [iceberg-spark-runtime](https://search.maven.org/search?q=g:org.apache.iceberg%20AND%20a:iceberg-spark-runtime*) artifacts.
- ...adding the spark and the scala versions onto the artifact names as they have been relocated on sonatype/maven
  - [nessie-spark-extensions](https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions/0.43.0/jar) has been relocated to [nessie-spark-extensions-3.1_2.12](https://search.maven.org/artifact/org.projectnessie/nessie-spark-extensions-3.1_2.12)
  - [iceberg-spark-runtime](https://search.maven.org/artifact/org.apache.iceberg/iceberg-spark-runtime/0.13.2/jar) hasn't been republished for iceberg 0.14.x, but [it's spark x.x counterparts have been](https://search.maven.org/search?q=g:org.apache.iceberg%20AND%20a:iceberg-spark-runtime*)
  - [iceberg-spark3](https://search.maven.org/search?q=g:org.apache.iceberg%20AND%20a:iceberg-spark3*) hasn't been republished for iceberg 0.14.x, so I have retargeted to the spark-specific artifacts
- Fixes the pyspark documentation for spark 3.1 to use 3.1-based iceberg artifacts rather than 3.2-based iceberg artifacts
- Preserves the version numbers in mkdocs, but changes how they are expressed/interpolated in the docs.
- Adds documentation for all the supported spark versions (3.1, 3.2, 3.3)
- ~~Adds an `artifacts` subsection for all the different permutations of iceberg & spark & nessie artifacts.~~ Adds macro support to template out the different permutations of iceberg & spark & nessie artifacts. This should support a subsequent migration for all artifacts later to make all versions of all artifacts more maintainable.
- Replaces `mkdocs-markdownextradata-plugin` with a superset plugin `mkdocs-macros-plugin` ([Commit `33de788`](https://github.com/projectnessie/nessie/pull/5371/commits/33de788800c9d2a0cb61a13a2dbfc5782a055435))

---

Apologies if I'm off-base here - very new to the Iceberg and Nessie space, but very used to scala/spark/maven.
Please review thoroughly.