### PR TITLE
GH release WF: default to "minor" version bump

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -40,10 +40,10 @@ on:
         description: 'The branch name the release from, leave empty to release from latest commit on main.'
         required: false
       bumpType:
-        description: 'Optional: bump patch, minor or major version (`patch`, `minor`, `major`). Default is `none` to release the current in-tree SNAPSHOT version.'
+        description: 'Optional: bump patch, minor or major version (`patch`, `minor`, `major`). Default is `minor`.'
         required: true
         type: string
-        default: "none"
+        default: "minor"
 
 jobs:
   create-release:


### PR DESCRIPTION
This change finally allows to create & publish a new Nessie release without providing any information (aka manual workflow run and accept the default parameter values).