### PR TITLE
GH workflows: Add missing `cache-read-only: true`

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -76,6 +76,7 @@ jobs:
     - name: Bump to version
       uses: gradle/gradle-build-action@v2
       with:
+        cache-read-only: true
         arguments: :bumpVersion --bumpType ${{ env.BUMP_TYPE }}
 
     - name: Get bumped version information

--- a/.github/workflows/pull-request-integ.yml
+++ b/.github/workflows/pull-request-integ.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Iceberg Nessie test
         uses: gradle/gradle-build-action@v2
         with:
+          cache-read-only: true
           arguments: :iceberg:iceberg-nessie:test
 
       - name: Nessie Spark 3.1 Extensions test

--- a/.github/workflows/pull-request-native.yml
+++ b/.github/workflows/pull-request-native.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Gradle / integration test native
       uses: gradle/gradle-build-action@v2
       with:
+        cache-read-only: true
         arguments: |
           --no-watch-fs
           :nessie-quarkus:quarkusBuild

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -79,6 +79,7 @@ jobs:
     - name: Bump to release version
       uses: gradle/gradle-build-action@v2
       with:
+        cache-read-only: true
         arguments: :bumpVersion --bumpType ${{ env.BUMP_TYPE }} --bumpToRelease
 
     - name: Get release version


### PR DESCRIPTION
Gradle action should not "pollute" GitHub's build cache with PR builds and builds from release workflows.