### PR TITLE
Build UI against Nessie API v1 from 0.44.0

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -32,10 +32,6 @@ plugins {
   `nessie-conventions`
 }
 
-val openapi by configurations.creating { description = "Used to reference OpenAPI spec files" }
-
-dependencies { openapi(project(":nessie-model", "openapi")) }
-
 node {
   download.set(true)
   version.set("16.14.2")
@@ -45,7 +41,7 @@ node {
 val dotGradle = project.projectDir.resolve(".gradle")
 val npmBuildTarget = project.buildDir.resolve("npm")
 val npmBuildDir = npmBuildTarget.resolve("META-INF/resources")
-val openApiSpecDir = project.buildDir.resolve("openapi")
+val openApiSpecDir = project.projectDir.resolve("src/openapi")
 val generatedOpenApiCodeUnfixed = project.buildDir.resolve("generated/ts")
 val generatedOpenApiCode = project.projectDir.resolve("src/generated")
 val testCoverageDir = project.projectDir.resolve("coverage")
@@ -61,12 +57,6 @@ val clean =
       delete(testCoverageDir)
       delete(generatedOpenApiCode)
     }
-  }
-
-val pullOpenApiSpec by
-  tasks.registering(Sync::class) {
-    destinationDir = openApiSpecDir
-    from(project.objects.property(Configuration::class).value(openapi))
   }
 
 val nodeSetup =
@@ -122,7 +112,7 @@ val npmInstall =
 val npmGenerateAPI =
   tasks.register<NpmTask>("npmGenerateApi") {
     description = "Generate from OpenAPI spec"
-    dependsOn(pullOpenApiSpec, npmInstall)
+    dependsOn(npmInstall)
     inputs.dir(openApiSpecDir).withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.dir(generatedOpenApiCodeUnfixed)
     doFirst {

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,7 +61,7 @@
     "build": "node scripts/build.js",
     "test": "node scripts/test.js",
     "lint": "eslint src/**/*.{ts,tsx} --fix",
-    "generate-api": "openapi-generator-cli generate -g typescript-fetch -i build/openapi/META-INF/openapi/openapi.yaml -o build/generated/ts/src/generated/utils/api --skip-validate-spec --additional-properties=supportsES6=true",
+    "generate-api": "openapi-generator-cli generate -g typescript-fetch -i src/openapi/nessie-openapi-0.44.0.yaml -o build/generated/ts/src/generated/utils/api --skip-validate-spec --additional-properties=supportsES6=true",
     "fix-generated-client": "node src/build-scripts/fix-generated-client.js"
   },
   "eslintConfig": {

--- a/ui/src/openapi/nessie-openapi-0.44.0.yaml
+++ b/ui/src/openapi/nessie-openapi-0.44.0.yaml
@@ -1,0 +1,2324 @@
+---
+# A copy of OpenAPI definition of Nessie 0.44.0, a.k.a. API v1
+openapi: 3.0.3
+info:
+  title: Nessie API
+  contact:
+    name: Project Nessie
+    url: https://projectnessie.org
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 0.44.0
+paths:
+  /config:
+    get:
+      summary: List all configuration settings
+      operationId: getConfig
+      responses:
+        default:
+          description: Configuration settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NessieConfiguration'
+        "401":
+          description: Invalid credentials provided
+        "400":
+          description: Unknown Error
+  /contents:
+    post:
+      summary: Get multiple objects' content.
+      description: |-
+        Similar to 'getContent', but takes multiple 'ContentKey's and returns the content-values for the one or more content-keys in a named-reference (a branch or tag).
+
+        If the table-metadata is tracked globally (Iceberg), Nessie returns a 'Content' object, that contains the most up-to-date part for the globally tracked part (Iceberg: table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-ID,schema-ID, partition-spec-ID, default-sort-order-ID).
+      operationId: getMultipleContents
+      parameters:
+      - name: hashOnRef
+        in: query
+        description: a particular hash on the given ref
+        schema:
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      - name: ref
+        in: query
+        description: Reference to use. Defaults to default branch if not provided.
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      requestBody:
+        description: Keys to retrieve.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetMultipleContentsRequest'
+            examples:
+              multiGetRequest:
+                $ref: '#/components/examples/multiGetRequest'
+      responses:
+        "200":
+          description: Retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMultipleContentsResponse'
+              examples:
+                multiGetResponse:
+                  $ref: '#/components/examples/multiGetResponse'
+        "400":
+          description: "Invalid input, ref name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given reference or read object content
+            for a key
+        "404":
+          description: Provided ref doesn't exists
+  /contents/{key}:
+    get:
+      summary: Get object content associated with a key.
+      description: |-
+        This operation returns the content-value for a content-key in a named-reference (a branch or tag).
+
+        If the table-metadata is tracked globally (Iceberg), Nessie returns a 'Content' object, that contains the most up-to-date part for the globally tracked part (Iceberg: table-metadata) plus the per-Nessie-reference/hash specific part (Iceberg: snapshot-id, schema-id, partition-spec-id, default-sort-order-id).
+      operationId: getContent
+      parameters:
+      - name: key
+        in: path
+        description: object name to search for
+        required: true
+        schema:
+          type: string
+        examples:
+          ContentKeyGet:
+            $ref: '#/components/examples/ContentKeyGet'
+      - name: hashOnRef
+        in: query
+        description: a particular hash on the given ref
+        schema:
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      - name: ref
+        in: query
+        description: Reference to use. Defaults to default branch if not provided.
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      responses:
+        "200":
+          description: Information for table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Content'
+              examples:
+                iceberg:
+                  $ref: '#/components/examples/iceberg'
+        "400":
+          description: "Invalid input, ref name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given reference or read object content
+            for a key
+        "404":
+          description: Table not found on ref
+  /diffs/{fromRef}{f}{fromHashOnRef}...{toRef}{t}{toHashOnRef}:
+    get:
+      summary: Get a diff for two given references
+      description: "The URL pattern is basically 'from' and 'to' separated by '...'\
+        \ (three dots). 'from' and 'to' must start with a reference name, optionally\
+        \ followed by hash on that reference, the hash prefixed with the'*' character.\n\
+        \nExamples: \n  diffs/main...myBranch\n  diffs/main...myBranch*1234567890123456\n\
+        \  diffs/main*1234567890123456...myBranch\n  diffs/main*1234567890123456...myBranch*1234567890123456\n"
+      operationId: getDiff
+      parameters:
+      - name: fromHashOnRef
+        in: path
+        description: Optional hash on the 'from' reference to start the diff from
+        required: true
+        schema:
+          pattern: "(^[0-9a-fA-F]{8,64}$)?"
+          type: string
+        examples:
+          hash:
+            $ref: '#/components/examples/hash'
+      - name: fromRef
+        in: path
+        description: The 'from' reference to start the diff from
+        required: true
+        schema:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: toHashOnRef
+        in: path
+        description: Optional hash on the 'to' reference to end the diff at.
+        required: true
+        schema:
+          pattern: "(^[0-9a-fA-F]{8,64}$)?"
+          type: string
+        examples:
+          hash:
+            $ref: '#/components/examples/hash'
+      - name: toRef
+        in: path
+        description: The 'to' reference to end the diff at.
+        required: true
+        schema:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      responses:
+        "200":
+          description: Returned diff for the given references.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiffResponse'
+              examples:
+                diffResponse:
+                  $ref: '#/components/examples/diffResponse'
+        "400":
+          description: "Invalid input, fromRef/toRef name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given fromRef/toRef
+        "404":
+          description: fromRef/toRef not found
+  /namespaces/namespace/{ref}/{name}:
+    get:
+      summary: Retrieves a Namespace
+      operationId: getNamespace
+      parameters:
+      - name: name
+        in: path
+        description: the name of the namespace
+        required: true
+        schema:
+          $ref: '#/components/schemas/Namespace'
+        examples:
+          namespaceName:
+            $ref: '#/components/examples/namespaceName'
+      - name: ref
+        in: path
+        description: name of ref to fetch
+        required: true
+        schema:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: hashOnRef
+        in: query
+        description: a particular hash on the given ref
+        schema:
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      responses:
+        "200":
+          description: Returned Namespace.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+              examples:
+                namespace:
+                  $ref: '#/components/examples/namespace'
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to retrieve namespace
+        "404":
+          description: Reference or Namespace not found
+    put:
+      summary: Creates a Namespace
+      operationId: createNamespace
+      parameters:
+      - name: name
+        in: path
+        description: the name of the namespace
+        required: true
+        schema:
+          $ref: '#/components/schemas/Namespace'
+        examples:
+          namespaceName:
+            $ref: '#/components/examples/namespaceName'
+      - name: ref
+        in: path
+        description: name of ref to fetch
+        required: true
+        schema:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: hashOnRef
+        in: query
+        description: a particular hash on the given ref
+        schema:
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Namespace'
+      responses:
+        "200":
+          description: Returned Namespace.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+              examples:
+                namespace:
+                  $ref: '#/components/examples/namespace'
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to create namespace
+        "404":
+          description: Reference not found
+        "409":
+          description: Namespace already exists
+    post:
+      operationId: updateProperties
+      parameters:
+      - name: name
+        in: path
+        description: the name of the namespace
+        required: true
+        schema:
+          $ref: '#/components/schemas/Namespace'
+        examples:
+          namespaceName:
+            $ref: '#/components/examples/namespaceName'
+      - name: ref
+        in: path
+        description: name of ref to fetch
+        required: true
+        schema:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: hashOnRef
+        in: query
+        description: a particular hash on the given ref
+        schema:
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      requestBody:
+        description: Namespace properties to update/delete.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NamespaceUpdate'
+            examples:
+              namespaceUpdate:
+                $ref: '#/components/examples/namespaceUpdate'
+      responses:
+        "200":
+          description: Updates namespace properties for the given namespace.
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to update namespace properties
+        "404":
+          description: Reference or Namespace not found
+    delete:
+      summary: Deletes a Namespace
+      operationId: deleteNamespace
+      parameters:
+      - name: name
+        in: path
+        description: the name of the namespace
+        required: true
+        schema:
+          $ref: '#/components/schemas/Namespace'
+        examples:
+          namespaceName:
+            $ref: '#/components/examples/namespaceName'
+      - name: ref
+        in: path
+        description: name of ref to fetch
+        required: true
+        schema:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: hashOnRef
+        in: query
+        description: a particular hash on the given ref
+        schema:
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      responses:
+        "200":
+          description: Namespace successfully deleted.
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to delete namespace
+        "404":
+          description: Reference or Namespace not found
+        "409":
+          description: Namespace not empty
+  /namespaces/{ref}:
+    get:
+      operationId: getNamespaces
+      parameters:
+      - name: ref
+        in: path
+        description: name of ref to fetch
+        required: true
+        schema:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: hashOnRef
+        in: query
+        description: a particular hash on the given ref
+        schema:
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      - name: name
+        in: query
+        description: the name of the namespace
+        schema:
+          $ref: '#/components/schemas/Namespace'
+        examples:
+          namespaceName:
+            $ref: '#/components/examples/namespaceName'
+          emptyNamespaceName:
+            $ref: '#/components/examples/emptyNamespaceName'
+      responses:
+        "200":
+          description: Returns Namespaces with a given prefix.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetNamespacesResponse'
+              examples:
+                namespacesResponse:
+                  $ref: '#/components/examples/namespacesResponse'
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to retrieve namespaces
+        "404":
+          description: Reference not found
+  /reflogs:
+    get:
+      summary: Get reflog entries (DEPRECATED)
+      description: |+
+        The Nessie reflog in this form is deprecated, likely for removal.
+        Retrieve the reflog entries from a specified endHash or from the current HEAD if the endHash is null, potentially truncated by the backend.
+
+        Retrieves up to 'maxRecords' refLog-entries starting at the endHash or HEAD.The backend may respect the given 'max' records hint, but return less or more entries. Backends may also cap the returned entries at a hard-coded limit, the default REST server implementation has such a hard-coded limit.
+
+        To implement paging, check 'hasMore' in the response and, if 'true', pass the value returned as 'token' in the next invocation as the 'pageToken' parameter.
+
+        The content and meaning of the returned 'token' is "private" to the implementation,treat is as an opaque value.
+
+        It is wrong to assume that invoking this method with a very high 'maxRecords' value will return all reflog entries.
+
+      operationId: getRefLog
+      parameters:
+      - name: endHash
+        in: query
+        description: "Hash of the reflog (inclusive) to end at (in chronological sense),\
+          \ the 'near' end of the reflog, returned 'early' in the result."
+        schema:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+      - name: filter
+        in: query
+        description: |-
+          A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.
+
+          Usable variables within the expression are:
+
+          - 'reflog' with fields 'refLogId' (string), 'refName' (string), 'commitHash' (string), 'parentRefLogId' (string), ',operation' (string), 'operationTime' (long)
+
+          Hint: when filtering entries, you can determine whether entries are "missing" (filtered) by checking whether 'ReflogResponseEntry.parentRefLogId' is different from the hash of the previous reflog in the log response.
+        schema:
+          type: string
+      - name: maxRecords
+        in: query
+        description: "maximum number of entries to return, just a hint for the server"
+        schema:
+          format: int32
+          type: integer
+      - name: pageToken
+        in: query
+        description: "paging continuation token, as returned in the previous value\
+          \ of the field 'token' in the corresponding 'EntriesResponse' or 'LogResponse'\
+          \ or 'ReferencesResponse' or 'RefLogResponse'."
+        schema:
+          type: string
+      - name: startHash
+        in: query
+        description: "Hash of the reflog (inclusive) to start from (in chronological\
+          \ sense), the 'far' end of the reflog, returned 'late' in the result."
+        schema:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+      responses:
+        "200":
+          description: Returned reflog entries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefLogResponse'
+        "401":
+          description: Invalid credentials provided
+        "400":
+          description: Unknown Error
+        "404":
+          description: Reflog id doesn't exists
+  /trees:
+    get:
+      summary: Get all references
+      operationId: getAllReferences
+      parameters:
+      - name: fetch
+        in: query
+        description: |-
+          Specify how much information to be returned. Will fetch additional metadata for references if set to 'ALL'.
+
+          A returned Branch instance will have the following information:
+
+          - numCommitsAhead (number of commits ahead of the default branch)
+
+          - numCommitsBehind (number of commits behind the default branch)
+
+          - commitMetaOfHEAD (the commit metadata of the HEAD commit)
+
+          - commonAncestorHash (the hash of the common ancestor in relation to the default branch).
+
+          - numTotalCommits (the total number of commits in this reference).
+
+          A returned Tag instance will only contain the 'commitMetaOfHEAD' and 'numTotalCommits' fields.
+
+          Note that computing & fetching additional metadata might be computationally expensive on the server-side, so this flag should be used with care.
+        schema:
+          $ref: '#/components/schemas/FetchOption'
+      - name: filter
+        in: query
+        description: |-
+          A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.
+          Usable variables within the expression are:
+
+          - ref (Reference) describes the reference, with fields name (String), hash (String), metadata (ReferenceMetadata)
+
+          - metadata (ReferenceMetadata) shortcut to ref.metadata, never null, but possibly empty
+
+          - commit (CommitMeta) - shortcut to ref.metadata.commitMetaOfHEAD, never null, but possibly empty
+
+          - refType (String) - the reference type, either BRANCH or TAG
+
+          Note that the expression can only test attributes metadata and commit, if 'fetchOption' is set to 'ALL'.
+        schema:
+          type: string
+        examples:
+          expr_by_refType:
+            $ref: '#/components/examples/expr_by_refType'
+          expr_by_ref_name:
+            $ref: '#/components/examples/expr_by_ref_name'
+          expr_by_ref_commit:
+            $ref: '#/components/examples/expr_by_ref_commit'
+      - name: maxRecords
+        in: query
+        description: "maximum number of entries to return, just a hint for the server"
+        schema:
+          format: int32
+          type: integer
+      - name: pageToken
+        in: query
+        description: "paging continuation token, as returned in the previous value\
+          \ of the field 'token' in the corresponding 'EntriesResponse' or 'LogResponse'\
+          \ or 'ReferencesResponse' or 'RefLogResponse'."
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Returned references.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReferencesResponse'
+              examples:
+                referencesResponse:
+                  $ref: '#/components/examples/referencesResponse'
+                referencesResponseWithMetadata:
+                  $ref: '#/components/examples/referencesResponseWithMetadata'
+        "401":
+          description: Invalid credentials provided
+  /trees/branch/{branchName}/commit:
+    post:
+      summary: Commit multiple operations against the given branch expecting that
+        branch to have the given hash as its latest commit. The hash in the successful
+        response contains the hash of the commit that contains the operations of the
+        invocation.
+      operationId: commitMultipleOperations
+      parameters:
+      - name: branchName
+        in: path
+        description: "Branch to change, defaults to default branch."
+        required: true
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: expectedHash
+        in: query
+        description: Expected hash of branch.
+        schema:
+          type: string
+        examples:
+          hash:
+            $ref: '#/components/examples/hash'
+      requestBody:
+        description: Operations
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Operations'
+            examples:
+              operations:
+                $ref: '#/components/examples/operations'
+      responses:
+        "200":
+          description: Updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Branch'
+              examples:
+                refObj:
+                  $ref: '#/components/examples/refObj'
+        "400":
+          description: "Invalid input, ref/hash name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given reference or perform commits
+        "404":
+          description: Provided ref doesn't exists
+        "409":
+          description: Update conflict
+  /trees/branch/{branchName}/merge:
+    post:
+      summary: Merge commits from 'mergeRef' onto 'branchName'.
+      description: "Merge items from an existing hash in 'mergeRef' into the requested\
+        \ branch. The merge is always a rebase + fast-forward merge and is only completed\
+        \ if the rebase is conflict free. The set of commits added to the branch will\
+        \ be all of those until we arrive at a common ancestor. Depending on the underlying\
+        \ implementation, the number of commits allowed as part of this operation\
+        \ may be limited."
+      operationId: mergeRefIntoBranch
+      parameters:
+      - name: branchName
+        in: path
+        description: Branch to merge into
+        required: true
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: expectedHash
+        in: query
+        description: Expected current HEAD of 'branchName'
+        schema:
+          type: string
+        examples:
+          hash:
+            $ref: '#/components/examples/hash'
+      requestBody:
+        description: "Merge operation that defines the source reference name and an\
+          \ optional hash. If 'fromHash' is not present, the current 'sourceRef's\
+          \ HEAD will be used."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Merge'
+            examples:
+              merge:
+                $ref: '#/components/examples/merge'
+      responses:
+        "204":
+          description: "Merge operation completed. The actual merge might have failed\
+            \ and reported as successful=false, if the client asked to return a conflict\
+            \ as a result instead of returning an error."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeResponse'
+              examples:
+                mergeResponseSuccess:
+                  $ref: '#/components/examples/mergeResponseSuccess'
+                mergeResponseFail:
+                  $ref: '#/components/examples/mergeResponseFail'
+        "400":
+          description: "Invalid input, ref/hash name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given reference or merge commits
+        "404":
+          description: Ref doesn't exists
+        "409":
+          description: update conflict
+  /trees/branch/{branchName}/transplant:
+    post:
+      summary: Transplant commits from 'transplant' onto 'branchName'
+      description: This is done as an atomic operation such that only the last of
+        the sequence is ever visible to concurrent readers/writers. The sequence to
+        transplant must be contiguous and in order.
+      operationId: transplantCommitsIntoBranch
+      parameters:
+      - name: branchName
+        in: path
+        description: Branch to transplant into
+        required: true
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: expectedHash
+        in: query
+        description: Expected hash of tag.
+        schema:
+          type: string
+        examples:
+          hash:
+            $ref: '#/components/examples/hash'
+      - name: message
+        in: query
+        description: commit message
+        schema:
+          type: string
+        examples:
+          commitMessage:
+            $ref: '#/components/examples/commitMessage'
+      requestBody:
+        description: Hashes to transplant
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Transplant'
+            examples:
+              transplant:
+                $ref: '#/components/examples/transplant'
+      responses:
+        "204":
+          description: "Transplant operation completed. The actual transplant might\
+            \ have failed and reported as successful=false, if the client asked to\
+            \ return a conflict as a result instead of returning an error. Note: the\
+            \ 'commonAncestor' field in a response will always be null for a transplant."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeResponse'
+              examples:
+                mergeResponseSuccess:
+                  $ref: '#/components/examples/mergeResponseSuccess'
+                mergeResponseFail:
+                  $ref: '#/components/examples/mergeResponseFail'
+        "400":
+          description: "Invalid input, ref/hash name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given reference or transplant commits
+        "404":
+          description: Ref doesn't exists
+        "409":
+          description: update conflict
+  /trees/tree:
+    get:
+      summary: Get default branch for commits and reads
+      operationId: getDefaultBranch
+      responses:
+        "200":
+          description: Returns name and latest hash of the default branch.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Branch'
+              examples:
+                refObj:
+                  $ref: '#/components/examples/refObj'
+        "401":
+          description: Invalid credentials provided
+        "404":
+          description: Default branch not found.
+    post:
+      summary: Create a new reference
+      description: |-
+        The type of 'refObj', which can be either a 'Branch' or 'Tag', determines the type of the reference to be created.
+
+        'Reference.name' defines the the name of the reference to be created,'Reference.hash' is the hash of the created reference, the HEAD of the created reference. 'sourceRefName' is the name of the reference which contains 'Reference.hash', and must be present if 'Reference.hash' is present.
+
+        Specifying no 'Reference.hash' means that the new reference will be created "at the beginning of time".
+      operationId: createReference
+      parameters:
+      - name: sourceRefName
+        in: query
+        description: Source named reference
+        schema:
+          type: string
+      requestBody:
+        description: Reference to create.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Reference'
+            examples:
+              refObjNew:
+                $ref: '#/components/examples/refObjNew'
+      responses:
+        "200":
+          description: Created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reference'
+              examples:
+                refObjNew:
+                  $ref: '#/components/examples/refObjNew'
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to create reference
+        "409":
+          description: Reference already exists
+  /trees/tree/{ref}:
+    get:
+      summary: Fetch details of a reference
+      operationId: getReferenceByName
+      parameters:
+      - name: ref
+        in: path
+        description: name of ref to fetch
+        required: true
+        schema:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: fetch
+        in: query
+        description: |-
+          Specify how much information to be returned. Will fetch additional metadata for references if set to 'ALL'.
+
+          A returned Branch instance will have the following information:
+
+          - numCommitsAhead (number of commits ahead of the default branch)
+
+          - numCommitsBehind (number of commits behind the default branch)
+
+          - commitMetaOfHEAD (the commit metadata of the HEAD commit)
+
+          - commonAncestorHash (the hash of the common ancestor in relation to the default branch).
+
+          - numTotalCommits (the total number of commits in this reference).
+
+          A returned Tag instance will only contain the 'commitMetaOfHEAD' and 'numTotalCommits' fields.
+
+          Note that computing & fetching additional metadata might be computationally expensive on the server-side, so this flag should be used with care.
+        schema:
+          $ref: '#/components/schemas/FetchOption'
+      responses:
+        "200":
+          description: Found and returned reference.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reference'
+              examples:
+                refObj:
+                  $ref: '#/components/examples/refObj'
+        "400":
+          description: "Invalid input, ref name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given reference
+        "404":
+          description: Ref not found
+  /trees/tree/{ref}/entries:
+    get:
+      summary: Fetch all entries for a given reference
+      description: "Retrieves objects for a ref, potentially truncated by the backend.\n\
+        \nRetrieves up to 'maxRecords' entries for the given named reference (tag\
+        \ or branch) or the given hash. The backend may respect the given 'max' records\
+        \ hint, but return less or more entries. Backends may also cap the returned\
+        \ entries at a hard-coded limit, the default REST server implementation has\
+        \ such a hard-coded limit.\n\nTo implement paging, check 'hasMore' in the\
+        \ response and, if 'true', pass the value returned as 'token' in the next\
+        \ invocation as the 'pageToken' parameter.\n\nThe content and meaning of the\
+        \ returned 'token' is \"private\" to the implementation,treat is as an opaque\
+        \ value.\n\nIt is wrong to assume that invoking this method with a very high\
+        \ 'maxRecords' value will return all commit log entries.\n\nThe 'filter' parameter\
+        \ allows for advanced filtering capabilities using the Common Expression Language\
+        \ (CEL).\nAn intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.\n\
+        \nThe 'namespaceDepth' parameter returns only the ContentKey components up\
+        \ to the depth of 'namespaceDepth'.\nFor example they key 'a.b.c.d' with a\
+        \ depth of 3 will return 'a.b.c'. The operation is guaranteed to not return\
+        \ \nduplicates and therefore will never page."
+      operationId: getEntries
+      parameters:
+      - name: ref
+        in: path
+        description: name of ref to fetch from
+        required: true
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: filter
+        in: query
+        description: |-
+          A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.
+          Usable variables within the expression are 'entry.namespace' (string) & 'entry.contentType' (string)
+        schema:
+          type: string
+        examples:
+          expr_by_namespace:
+            $ref: '#/components/examples/expr_by_namespace'
+          expr_by_contentType:
+            $ref: '#/components/examples/expr_by_contentType'
+          expr_by_namespace_and_contentType:
+            $ref: '#/components/examples/expr_by_namespace_and_contentType'
+      - name: hashOnRef
+        in: query
+        description: a particular hash on the given ref
+        schema:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      - name: maxRecords
+        in: query
+        description: "maximum number of entries to return, just a hint for the server"
+        schema:
+          format: int32
+          type: integer
+      - name: namespaceDepth
+        in: query
+        description: |-
+          If set > 0 will filter the results to only return namespaces/tables to the depth of namespaceDepth. If not set or <=0 has no effect
+          Setting this parameter > 0 will turn off paging.
+        schema:
+          format: int32
+          type: integer
+      - name: pageToken
+        in: query
+        description: "paging continuation token, as returned in the previous value\
+          \ of the field 'token' in the corresponding 'EntriesResponse' or 'LogResponse'\
+          \ or 'ReferencesResponse' or 'RefLogResponse'."
+        schema:
+          type: string
+      responses:
+        default:
+          description: all objects for a reference
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntriesResponse'
+              examples:
+                entriesResponse:
+                  $ref: '#/components/examples/entriesResponse'
+        "200":
+          description: Returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntriesResponse'
+        "400":
+          description: "Invalid input, ref name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given reference or fetch entries for
+            it
+        "404":
+          description: Ref not found
+  /trees/tree/{ref}/log:
+    get:
+      summary: Get commit log for a reference
+      description: |
+        Retrieve the commit log for a ref, potentially truncated by the backend.
+
+        Retrieves up to 'maxRecords' commit-log-entries starting at the HEAD of the given named reference (tag or branch) or the given hash. The backend may respect the given 'max' records hint, but return less or more entries. Backends may also cap the returned entries at a hard-coded limit, the default REST server implementation has such a hard-coded limit.
+
+        To implement paging, check 'hasMore' in the response and, if 'true', pass the value returned as 'token' in the next invocation as the 'pageToken' parameter.
+
+        The content and meaning of the returned 'token' is "private" to the implementation,treat is as an opaque value.
+
+        It is wrong to assume that invoking this method with a very high 'maxRecords' value will return all commit log entries.
+
+        The 'filter' parameter allows for advanced filtering capabilities using the Common Expression Language (CEL).
+        An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.
+      operationId: getCommitLog
+      parameters:
+      - name: ref
+        in: path
+        description: ref to show log from
+        required: true
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: endHash
+        in: query
+        description: "Hash on the given ref to end at (in chronological sense), the\
+          \ 'near' end of the commit log, returned 'early' in the result."
+        schema:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      - name: fetch
+        in: query
+        description: "Specify how much information to be returned. Will fetch additional\
+          \ metadata such as parent commit hash and operations in a commit, for each\
+          \ commit if set to 'ALL'."
+        schema:
+          $ref: '#/components/schemas/FetchOption'
+      - name: filter
+        in: query
+        description: |-
+          A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.
+
+          Usable variables within the expression are:
+
+          - 'commit' with fields 'author' (string), 'committer' (string), 'commitTime' (timestamp), 'hash' (string), ',message' (string), 'properties' (map)
+
+          - 'operations' (list), each operation has the fields 'type' (string, either 'PUT' or 'DELETE'), 'key' (string, namespace + table name), 'keyElements' (list of strings), 'namespace' (string), 'namespaceElements' (list of strings) and 'name' (string, the "simple" table name)
+
+          Note that the expression can only test against 'operations', if 'fetch' is set to 'ALL'.
+
+          Hint: when filtering commits, you can determine whether commits are "missing" (filtered) by checking whether 'LogEntry.parentCommitHash' is different from the hash of the previous commit in the log response.
+        schema:
+          type: string
+        examples:
+          expr_by_commit_author:
+            $ref: '#/components/examples/expr_by_commit_author'
+          expr_by_commit_committer:
+            $ref: '#/components/examples/expr_by_commit_committer'
+          expr_by_commitTime:
+            $ref: '#/components/examples/expr_by_commitTime'
+          expr_by_commit_operations_table_name:
+            $ref: '#/components/examples/expr_by_commit_operations_table_name'
+          expr_by_commit_operations_type:
+            $ref: '#/components/examples/expr_by_commit_operations_type'
+      - name: maxRecords
+        in: query
+        description: "maximum number of entries to return, just a hint for the server"
+        schema:
+          format: int32
+          type: integer
+      - name: pageToken
+        in: query
+        description: "paging continuation token, as returned in the previous value\
+          \ of the field 'token' in the corresponding 'EntriesResponse' or 'LogResponse'\
+          \ or 'ReferencesResponse' or 'RefLogResponse'."
+        schema:
+          type: string
+      - name: startHash
+        in: query
+        description: "Hash on the given ref to start from (in chronological sense),\
+          \ the 'far' end of the commit log, returned 'late' in the result."
+        schema:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+        examples:
+          nullHash:
+            $ref: '#/components/examples/nullHash'
+          hash:
+            $ref: '#/components/examples/hash'
+      responses:
+        "200":
+          description: Returned commits.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogResponse'
+              examples:
+                logResponseAdditionalInfo:
+                  $ref: '#/components/examples/logResponseAdditionalInfo'
+                logResponseSimple:
+                  $ref: '#/components/examples/logResponseSimple'
+        "400":
+          description: "Invalid input, ref name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view the given reference or get commit log for
+            it
+        "404":
+          description: Ref doesn't exists
+  /trees/{referenceType}/{referenceName}:
+    put:
+      summary: Set a named reference to a specific hash via a named-reference.
+      description: This operation takes the name of the named reference to reassign
+        and the hash and the name of a named-reference via which the caller has access
+        to that hash.
+      operationId: assignReference
+      parameters:
+      - name: referenceName
+        in: path
+        description: Reference name to reassign
+        required: true
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: referenceType
+        in: path
+        description: Reference type to reassign
+        required: true
+        schema:
+          $ref: '#/components/schemas/ReferenceType'
+        examples:
+          referenceType:
+            $ref: '#/components/examples/referenceType'
+      - name: expectedHash
+        in: query
+        description: Expected previous hash of reference
+        schema:
+          type: string
+        examples:
+          hash:
+            $ref: '#/components/examples/hash'
+      requestBody:
+        description: "Reference hash to which 'referenceName' shall be assigned to.\
+          \ This must be either a 'Transaction', 'Branch' or 'Tag' via which the hash\
+          \ is visible to the caller."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Reference'
+            examples:
+              refObj:
+                $ref: '#/components/examples/refObj'
+              tagObj:
+                $ref: '#/components/examples/tagObj'
+      responses:
+        "204":
+          description: Assigned successfully
+        "400":
+          description: "Invalid input, ref/hash name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view or assign reference
+        "404":
+          description: One or more references don't exist
+        "409":
+          description: Update conflict
+    delete:
+      summary: Delete a reference endpoint
+      operationId: deleteReference
+      parameters:
+      - name: referenceName
+        in: path
+        description: Reference name to delete
+        required: true
+        schema:
+          type: string
+        examples:
+          ref:
+            $ref: '#/components/examples/ref'
+      - name: referenceType
+        in: path
+        description: Reference type to delete
+        required: true
+        schema:
+          $ref: '#/components/schemas/ReferenceType'
+        examples:
+          referenceType:
+            $ref: '#/components/examples/referenceType'
+      - name: expectedHash
+        in: query
+        description: Expected hash of tag
+        schema:
+          type: string
+        examples:
+          hash:
+            $ref: '#/components/examples/hash'
+      responses:
+        "204":
+          description: Deleted successfully.
+        "400":
+          description: "Invalid input, ref/hash name not valid"
+        "401":
+          description: Invalid credentials provided
+        "403":
+          description: Not allowed to view or delete reference
+        "404":
+          description: Ref doesn't exists
+        "409":
+          description: update conflict
+components:
+  schemas:
+    Branch:
+      title: Branch
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        metadata:
+          $ref: '#/components/schemas/ReferenceMetadata'
+        hash:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+    CommitMeta:
+      title: CommitMeta
+      required:
+      - message
+      - properties
+      type: object
+      properties:
+        hash:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+        committer:
+          type: string
+        author:
+          type: string
+        signedOffBy:
+          type: string
+        message:
+          pattern: \S
+          type: string
+        commitTime:
+          format: date-time
+          type: string
+          example: 2022-03-10T16:15:50Z
+        authorTime:
+          format: date-time
+          type: string
+          example: 2022-03-10T16:15:50Z
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+    Content:
+      title: Content
+      type: object
+      properties:
+        id:
+          type: string
+      oneOf:
+      - $ref: '#/components/schemas/IcebergTable'
+      - $ref: '#/components/schemas/DeltaLakeTable'
+      - $ref: '#/components/schemas/IcebergView'
+      - $ref: '#/components/schemas/Namespace'
+      discriminator:
+        propertyName: type
+        mapping:
+          ICEBERG_TABLE: '#/components/schemas/IcebergTable'
+          DELTA_LAKE_TABLE: '#/components/schemas/DeltaLakeTable'
+          ICEBERG_VIEW: '#/components/schemas/IcebergView'
+          NAMESPACE: '#/components/schemas/Namespace'
+    ContentKey:
+      required:
+      - elements
+      type: object
+      properties:
+        elements:
+          minItems: 1
+          type: array
+          items:
+            type: string
+    ContentKeyConflict:
+      enum:
+      - NONE
+      - UNRESOLVABLE
+      type: string
+    ContentKeyDetails:
+      title: Merge Per-Content-Key details
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+        mergeBehavior:
+          $ref: '#/components/schemas/MergeBehavior'
+        conflictType:
+          $ref: '#/components/schemas/ContentKeyConflict'
+        sourceCommits:
+          type: array
+          items:
+            type: string
+        targetCommits:
+          type: array
+          items:
+            type: string
+    ContentWithKey:
+      required:
+      - key
+      - content
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+        content:
+          $ref: '#/components/schemas/Content'
+    Delete:
+      required:
+      - key
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+    DeltaLakeTable:
+      required:
+      - metadataLocationHistory
+      - checkpointLocationHistory
+      type: object
+      properties:
+        id:
+          type: string
+        metadataLocationHistory:
+          type: array
+          items:
+            type: string
+        checkpointLocationHistory:
+          type: array
+          items:
+            type: string
+        lastCheckpoint:
+          type: string
+    Detached:
+      title: Detached commit hash
+      required:
+      - hash
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/ReferenceMetadata'
+        hash:
+          minLength: 1
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+    DiffEntry:
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+        from:
+          $ref: '#/components/schemas/Content'
+        to:
+          $ref: '#/components/schemas/Content'
+    DiffResponse:
+      title: DiffResponse
+      type: object
+      properties:
+        diffs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DiffEntry'
+    EntriesResponse:
+      required:
+      - entries
+      type: object
+      properties:
+        hasMore:
+          type: boolean
+        token:
+          minLength: 1
+          type: string
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/Entry'
+    Entry:
+      required:
+      - type
+      - name
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/Type'
+        name:
+          $ref: '#/components/schemas/ContentKey'
+    FetchOption:
+      enum:
+      - MINIMAL
+      - ALL
+      type: string
+    GenericMetadata:
+      required:
+      - variant
+      type: object
+      properties:
+        variant:
+          minLength: 1
+          type: string
+        metadata:
+          type: object
+    GetMultipleContentsRequest:
+      title: GetMultipleContentsRequest
+      required:
+      - requestedKeys
+      type: object
+      properties:
+        requestedKeys:
+          minItems: 1
+          type: array
+          items:
+            $ref: '#/components/schemas/ContentKey'
+    GetMultipleContentsResponse:
+      title: GetMultipleContentsResponse
+      required:
+      - contents
+      type: object
+      properties:
+        contents:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContentWithKey'
+    GetNamespacesResponse:
+      required:
+      - namespaces
+      type: object
+      properties:
+        namespaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/Namespace'
+    IcebergTable:
+      title: Iceberg table state
+      description: |-
+        Represents the state of an Iceberg table in Nessie. An Iceberg table is globally identified via its unique 'Content.id'.
+
+        A Nessie commit-operation, performed via 'TreeApi.commitMultipleOperations',for Iceberg consists of a 'Operation.Put' with an 'IcebergTable' as in the 'content' field and the previous value of 'IcebergTable' in the 'expectedContent' field.
+      required:
+      - metadataLocation
+      type: object
+      properties:
+        id:
+          type: string
+        metadataLocation:
+          pattern: \S
+          type: string
+        snapshotId:
+          format: int64
+          type: integer
+        schemaId:
+          format: int32
+          type: integer
+        specId:
+          format: int32
+          type: integer
+        sortOrderId:
+          format: int32
+          type: integer
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/GenericMetadata'
+          - deprecated: true
+    IcebergView:
+      required:
+      - metadataLocation
+      - sqlText
+      type: object
+      properties:
+        id:
+          type: string
+        metadataLocation:
+          pattern: \S
+          type: string
+        versionId:
+          format: int32
+          type: integer
+        schemaId:
+          format: int32
+          type: integer
+        sqlText:
+          pattern: \S
+          type: string
+        dialect:
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/GenericMetadata'
+          - deprecated: true
+    LogEntry:
+      title: LogEntry
+      required:
+      - commitMeta
+      type: object
+      properties:
+        commitMeta:
+          $ref: '#/components/schemas/CommitMeta'
+        additionalParents:
+          type: array
+          items:
+            type: string
+        parentCommitHash:
+          type: string
+        operations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Operation'
+    LogResponse:
+      title: LogResponse
+      required:
+      - logEntries
+      type: object
+      properties:
+        hasMore:
+          type: boolean
+        token:
+          minLength: 1
+          type: string
+        logEntries:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogEntry'
+    Merge:
+      title: Merge Operation
+      required:
+      - fromRefName
+      - fromHash
+      type: object
+      properties:
+        fromRefName:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        fromHash:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+        keyMergeModes:
+          type: array
+          items:
+            $ref: '#/components/schemas/MergeKeyBehavior'
+        defaultKeyMergeMode:
+          $ref: '#/components/schemas/MergeBehavior'
+        dryRun:
+          type: boolean
+        fetchAdditionalInfo:
+          type: boolean
+        returnConflictAsResult:
+          type: boolean
+    MergeBehavior:
+      enum:
+      - NORMAL
+      - FORCE
+      - DROP
+      type: string
+    MergeKeyBehavior:
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+        mergeBehavior:
+          $ref: '#/components/schemas/MergeBehavior'
+    MergeResponse:
+      title: Merge Response
+      type: object
+      properties:
+        resultantTargetHash:
+          type: string
+        commonAncestor:
+          type: string
+        targetBranch:
+          type: string
+        effectiveTargetHash:
+          type: string
+        expectedHash:
+          type: string
+        sourceCommits:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogEntry'
+        targetCommits:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogEntry'
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContentKeyDetails'
+    Namespace:
+      required:
+      - elements
+      - properties
+      type: object
+      properties:
+        id:
+          type: string
+        elements:
+          type: array
+          items:
+            type: string
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+    NamespaceUpdate:
+      type: object
+      properties:
+        propertyUpdates:
+          type: object
+          additionalProperties:
+            type: string
+        propertyRemovals:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+    NessieConfiguration:
+      type: object
+      properties:
+        defaultBranch:
+          minLength: 1
+          type: string
+        maxSupportedApiVersion:
+          format: int32
+          type: integer
+    Operation:
+      title: Operation
+      required:
+      - key
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+      oneOf:
+      - $ref: '#/components/schemas/Put'
+      - $ref: '#/components/schemas/Unchanged'
+      - $ref: '#/components/schemas/Delete'
+      discriminator:
+        propertyName: type
+        mapping:
+          PUT: '#/components/schemas/Put'
+          UNCHANGED: '#/components/schemas/Unchanged'
+          DELETE: '#/components/schemas/Delete'
+    Operations:
+      title: Operations
+      required:
+      - commitMeta
+      - operations
+      type: object
+      properties:
+        commitMeta:
+          $ref: '#/components/schemas/CommitMeta'
+        operations:
+          minItems: 1
+          type: array
+          items:
+            $ref: '#/components/schemas/Operation'
+    Put:
+      title: Put-'Content'-operation for a 'ContentKey'.
+      description: "Add or replace (put) a 'Content' object for a 'ContentKey'. If\
+        \ the actual table type tracks the 'global state' of individual tables (Iceberg\
+        \ as of today), every 'Put'-operation must contain a non-null value for 'expectedContent'."
+      required:
+      - key
+      - content
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+        content:
+          $ref: '#/components/schemas/Content'
+        expectedContent:
+          $ref: '#/components/schemas/Content'
+    RefLogResponse:
+      title: RefLogResponse
+      required:
+      - logEntries
+      type: object
+      properties:
+        hasMore:
+          type: boolean
+        token:
+          minLength: 1
+          type: string
+        logEntries:
+          type: array
+          items:
+            $ref: '#/components/schemas/RefLogResponseEntry'
+    RefLogResponseEntry:
+      title: RefLogResponseEntry
+      required:
+      - refLogId
+      - refName
+      - refType
+      - commitHash
+      - parentRefLogId
+      - operationTime
+      - operation
+      - sourceHashes
+      type: object
+      properties:
+        refLogId:
+          type: string
+        refName:
+          type: string
+        refType:
+          type: string
+        commitHash:
+          type: string
+        parentRefLogId:
+          type: string
+        operationTime:
+          format: int64
+          type: integer
+        operation:
+          type: string
+        sourceHashes:
+          type: array
+          items:
+            type: string
+    Reference:
+      title: Reference
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        hash:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/ReferenceMetadata'
+          - nullable: true
+      oneOf:
+      - $ref: '#/components/schemas/Branch'
+      - $ref: '#/components/schemas/Tag'
+      - $ref: '#/components/schemas/Detached'
+      discriminator:
+        propertyName: type
+        mapping:
+          TAG: '#/components/schemas/Tag'
+          BRANCH: '#/components/schemas/Branch'
+          DETACHED: '#/components/schemas/Detached'
+    ReferenceMetadata:
+      title: ReferenceMetadata
+      description: |+
+        Only returned by the server when explicitly requested by the client and contains the following information:
+
+        - numCommitsAhead (number of commits ahead of the default branch)
+
+        - numCommitsBehind (number of commits behind the default branch)
+
+        - commitMetaOfHEAD (the commit metadata of the HEAD commit)
+
+        - commonAncestorHash (the hash of the common ancestor in relation to the default branch).
+
+        - numTotalCommits (the total number of commits in this reference).
+
+      type: object
+      properties:
+        numCommitsAhead:
+          format: int32
+          type: integer
+        numCommitsBehind:
+          format: int32
+          type: integer
+        commitMetaOfHEAD:
+          $ref: '#/components/schemas/CommitMeta'
+        commonAncestorHash:
+          type: string
+        numTotalCommits:
+          format: int64
+          type: integer
+    ReferenceType:
+      enum:
+      - branch
+      - tag
+      type: string
+    ReferencesResponse:
+      required:
+      - references
+      type: object
+      properties:
+        hasMore:
+          type: boolean
+        token:
+          minLength: 1
+          type: string
+        references:
+          type: array
+          items:
+            $ref: '#/components/schemas/Reference'
+    Tag:
+      title: Tag
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        metadata:
+          $ref: '#/components/schemas/ReferenceMetadata'
+        hash:
+          pattern: "^[0-9a-fA-F]{8,64}$"
+          type: string
+    Transplant:
+      title: Transplant
+      required:
+      - fromRefName
+      - hashesToTransplant
+      type: object
+      properties:
+        fromRefName:
+          pattern: "^[A-Za-z](((?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?$"
+          type: string
+        hashesToTransplant:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        keyMergeModes:
+          type: array
+          items:
+            $ref: '#/components/schemas/MergeKeyBehavior'
+        defaultKeyMergeMode:
+          $ref: '#/components/schemas/MergeBehavior'
+        dryRun:
+          type: boolean
+        fetchAdditionalInfo:
+          type: boolean
+        returnConflictAsResult:
+          type: boolean
+    Type:
+      type: object
+    Unchanged:
+      required:
+      - key
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/ContentKey'
+  examples:
+    namespace:
+      value: a.b.c
+    ref:
+      value: main
+    referenceType:
+      value: branch
+    hash:
+      value: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+    nullHash: {}
+    refObj:
+      value:
+        type: BRANCH
+        hash: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+        name: main
+    refObjNew:
+      value:
+        type: BRANCH
+        hash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        name: exampleBranch
+    tagObj:
+      value:
+        type: TAG
+        hash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        name: exampleTag
+    ContentKeyGet:
+      value: example.key
+    ContentKey:
+      value:
+        elements:
+        - example
+        - key
+    namespaceName:
+      value: a.b.c
+    emptyNamespaceName: {}
+    namespacesResponse:
+      value:
+        namespaces:
+        - type: NAMESPACE
+          elements:
+          - a
+          - b.c
+          - d
+        - type: NAMESPACE
+          elements:
+          - a
+          - b
+          - d
+    namespaceUpdate:
+      value:
+        propertyUpdates:
+          key1: value1
+          key2: value2
+        propertyRemovals:
+        - key3
+        - key4
+    iceberg:
+      value:
+        type: ICEBERG_TABLE
+        id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+        metadataLocation: /path/to/metadata/
+        snapshotId: 1
+        schemaId: 2
+        specId: 3
+        sortOrderId: 4
+    expr_by_namespace:
+      value: entry.namespace.startsWith('a.b.c')
+    expr_by_contentType:
+      value: "entry.contentType in ['ICEBERG_TABLE','DELTA_LAKE_TABLE']"
+    expr_by_namespace_and_contentType:
+      value: "entry.namespace.startsWith('some.name.space') && entry.contentType in\
+        \ ['ICEBERG_TABLE','DELTA_LAKE_TABLE']"
+    expr_by_commit_author:
+      value: commit.author=='nessie_author'
+    expr_by_commit_committer:
+      value: commit.committer=='nessie_committer'
+    expr_by_commitTime:
+      value: timestamp(commit.commitTime) > timestamp('2021-05-31T08:23:15Z')
+    expr_by_commit_operations_in_namespace:
+      value: "operations.exists(op, op.key.startsWith('some.name.space.'))"
+    expr_by_commit_operations_table_name:
+      value: "operations.exists(op, op.name == 'BaseTable')"
+    expr_by_commit_operations_type:
+      value: "operations.exists(op, op.type == 'PUT')"
+    expr_by_refType:
+      value: refType == 'BRANCH'
+    expr_by_ref_name:
+      value: ref.name == 'my-tag-or-branch'
+    expr_by_ref_commit:
+      value: commit.message == 'invent awesome things'
+    commitMessage:
+      value: Example Commit Message
+    multiGetResponse:
+      value:
+        contents:
+        - content:
+            type: ICEBERG_TABLE
+            id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+            metadataLocation: /path/to/metadata/
+            snapshotId: 1
+            schemaId: 2
+            specId: 3
+            sortOrderId: 4
+          key:
+            elements:
+            - example
+            - key
+    multiGetRequest:
+      value:
+        requestedKeys:
+        - elements:
+          - example
+          - key
+    entriesResponse:
+      value:
+        token: xxx
+        entries:
+        - name:
+            elements:
+            - example
+            - key
+          type: ICEBERG_TABLE
+    types:
+      value:
+      - ICEBERG_TABLE
+    merge:
+      value:
+        fromHash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        fromRefName: source-ref-name
+        keepIndividualCommits: false
+        defaultKeyMergeMode: NORMAL
+        keyMergeModes:
+        - key:
+            elements:
+            - example
+            - key
+            mergeBehavior: FORCE
+        dryRun: false
+        fetchAdditionalInfo: false
+        returnConflictAsResult: true
+    transplant:
+      value:
+        hashesToTransplant:
+        - abcdef4242424242424242424242beef00dead42112233445566778899001122
+        fromRefName: source-ref-name
+        keepIndividualCommits: false
+        defaultKeyMergeMode: NORMAL
+        keyMergeModes:
+        - key:
+            elements:
+            - example
+            - key
+            mergeBehavior: FORCE
+        dryRun: false
+        fetchAdditionalInfo: false
+        returnConflictAsResult: true
+    mergeResponseSuccess:
+      value:
+        wasApplied: true
+        wasSuccessful: true
+        resultantTargetHash: 8a2f19888eb620c25b0d2cbcddfdf56fb2d3e9dd443c6d29e37c567493fc5d3b
+        commonAncestor: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        targetBranch: main
+        effectiveTargetHash: e9058b675c519b3542cd8155aed42ecf1ddb4e55874e3eb241b30b96f861566a
+        expectedHash: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+        sourceCommits:
+        - commitMeta:
+            author: authorName <authorName@example.com>
+            authorTime: 2021-04-07T14:42:25.534748Z
+            hash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+            message: Example Commit Message
+          operations:
+          - type: PUT
+            key:
+              elements:
+              - example
+              - key
+            content:
+              type: ICEBERG_TABLE
+              id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+              metadataLocation: /path/to/metadata/
+              snapshotId: 1
+              schemaId: 2
+              specId: 3
+              sortOrderId: 4
+          parentCommitHash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        targetCommits:
+        - commitMeta:
+            author: authorName <authorName@example.com>
+            authorTime: 2021-04-07T14:42:25.534748Z
+            hash: e9058b675c519b3542cd8155aed42ecf1ddb4e55874e3eb241b30b96f861566a
+            message: Example Commit Message
+          operations:
+          - type: PUT
+            key:
+              elements:
+              - example
+              - key
+            content:
+              type: ICEBERG_TABLE
+              id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+              metadataLocation: /path/to/metadata/
+              snapshotId: 1
+              schemaId: 2
+              specId: 3
+              sortOrderId: 4
+          parentCommitHash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        details:
+        - key:
+            elements:
+            - example
+            - key
+          mergeBehavior: NORMAL
+          conflictType: NONE
+          targetCommits:
+          - e9058b675c519b3542cd8155aed42ecf1ddb4e55874e3eb241b30b96f861566a
+    mergeResponseFail:
+      value:
+        wasApplied: false
+        wasSuccessful: false
+        resultantTargetHash: 8a2f19888eb620c25b0d2cbcddfdf56fb2d3e9dd443c6d29e37c567493fc5d3b
+        commonAncestor: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        targetBranch: main
+        effectiveTargetHash: 8a2f19888eb620c25b0d2cbcddfdf56fb2d3e9dd443c6d29e37c567493fc5d3b
+        expectedHash: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+        sourceCommits:
+        - commitMeta:
+            author: authorName <authorName@example.com>
+            authorTime: 2021-04-07T14:42:25.534748Z
+            hash: 88012047ce424686ca55e8bb228ae9d9cbd6f7bbfc800d830a53a6edf2d55ffb
+            message: Example Commit Message
+          operations:
+          - type: PUT
+            key:
+              elements:
+              - example
+              - key
+            content:
+              type: ICEBERG_TABLE
+              id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+              metadataLocation: /path/to/metadata/
+              snapshotId: 1
+              schemaId: 2
+              specId: 3
+              sortOrderId: 4
+          parentCommitHash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        targetCommits:
+        - commitMeta:
+            author: authorName <authorName@example.com>
+            authorTime: 2021-04-07T14:42:25.534748Z
+            hash: 54388c80e6387b8cfa4cf3e7c7909073ffc761f9c7f0d6154ec0d5c5829a4503
+            message: Example Commit Message
+          operations:
+          - type: PUT
+            key:
+              elements:
+              - example
+              - key
+            content:
+              type: ICEBERG_TABLE
+              id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+              metadataLocation: /path/to/metadata/
+              snapshotId: 1
+              schemaId: 2
+              specId: 3
+              sortOrderId: 4
+          parentCommitHash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+        details:
+        - key:
+            elements:
+            - example
+            - key
+          mergeBehavior: NORMAL
+          conflictType: UNRESOLVABLE
+          sourceCommits:
+          - 88012047ce424686ca55e8bb228ae9d9cbd6f7bbfc800d830a53a6edf2d55ffb
+          targetCommits:
+          - 54388c80e6387b8cfa4cf3e7c7909073ffc761f9c7f0d6154ec0d5c5829a4503
+    operations:
+      value:
+        commitMeta:
+          author: authorName <authorName@example.com>
+          authorTime: 2021-04-07T14:42:25.534748Z
+          hash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+          message: Example Commit Message
+          properties:
+            additionalProp1: xxx
+            additionalProp2: yyy
+            additionalProp3: zzz
+          signedOffBy: signedOffByName <signedOffBy@example.com>
+        operations:
+        - type: PUT
+          key:
+            elements:
+            - example
+            - key
+          content:
+            type: ICEBERG_TABLE
+            id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+            metadataLocation: /path/to/metadata/
+            snapshotId: 1
+            schemaId: 2
+            specId: 3
+            sortOrderId: 4
+    logResponseAdditionalInfo:
+      value:
+        token: xxx
+        logEntries:
+        - commitMeta:
+            author: authorName <authorName@example.com>
+            authorTime: 2021-04-07T14:42:25.534748Z
+            commitTime: 2021-04-07T14:42:25.534748Z
+            committer: committerName <committerName@example.com>
+            hash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+            message: Example Commit Message
+            properties:
+              additionalProp1: xxx
+              additionalProp2: yyy
+              additionalProp3: zzz
+            signedOffBy: signedOffByName <signedOffBy@example.com>
+          parentCommitHash: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+          operations:
+          - type: DELETE
+            key:
+              elements:
+              - deleted
+              - table
+          - type: PUT
+            key:
+              elements:
+              - example
+              - key
+            content:
+              type: ICEBERG_TABLE
+              id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+              metadataLocation: /path/to/metadata/
+              snapshotId: 1
+              schemaId: 2
+              specId: 3
+              sortOrderId: 4
+    logResponseSimple:
+      value:
+        token: xxx
+        logEntries:
+        - commitMeta:
+            author: authorName <authorName@example.com>
+            authorTime: 2021-04-07T14:42:25.534748Z
+            commitTime: 2021-04-07T14:42:25.534748Z
+            committer: committerName <committerName@example.com>
+            hash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+            message: Example Commit Message
+            properties:
+              additionalProp1: xxx
+              additionalProp2: yyy
+              additionalProp3: zzz
+            signedOffBy: signedOffByName <signedOffBy@example.com>
+    referencesResponse:
+      value:
+        hasMore: false
+        references:
+        - type: BRANCH
+          hash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+          name: exampleBranch
+        - type: TAG
+          hash: abcdef4242424242424242424242beef00dead42112233445566778899001122
+          name: exampleTag
+        - type: BRANCH
+          hash: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+          name: main
+    referencesResponseWithMetadata:
+      value:
+        hasMore: false
+        references:
+        - type: BRANCH
+          hash: 84c57a20c5e956af4af40f3cc34ecc8a9028b9586da135c79011b1867aa3191d
+          name: main
+          metadata:
+            commitMetaOfHEAD:
+              hash: 84c57a20c5e956af4af40f3cc34ecc8a9028b9586da135c79011b1867aa3191d
+              committer: ""
+              author: nessie-author
+              message: update table
+              commitTime: 2021-11-26T08:01:13.855974Z
+              authorTime: 2021-11-26T08:01:13.852826Z
+              properties: {}
+        - type: BRANCH
+          hash: da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5
+          name: dev
+          metadata:
+            numCommitsAhead: 1
+            numCommitsBehind: 2
+            commonAncestorHash: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+            numTotalCommits: 42
+            commitMetaOfHEAD:
+              hash: da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5
+              committer: ""
+              author: nessie-author
+              message: update table X
+              commitTime: 2021-11-26T08:01:13.834397Z
+              authorTime: 2021-11-26T08:01:13.831371Z
+              properties: {}
+        - type: BRANCH
+          hash: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+          name: dev2
+          metadata:
+            numCommitsAhead: 0
+            numCommitsBehind: 2
+            commonAncestorHash: 2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
+        - type: TAG
+          hash: a682bfdcd5d357b5c964ef07e2eef61fabba42cb8effa8d62357df45a6cc0371
+          name: testTag1
+          metadata:
+            numTotalCommits: 42
+            commitMetaOfHEAD:
+              hash: a682bfdcd5d357b5c964ef07e2eef61fabba42cb8effa8d62357df45a6cc0371
+              committer: ""
+              author: nessie-author
+              message: update table Y
+              commitTime: 2021-11-23T08:01:14.834397Z
+              authorTime: 2021-11-23T08:01:14.831371Z
+              properties: {}
+        - type: TAG
+          hash: da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5
+          name: testTag2
+          metadata:
+            numTotalCommits: 42
+            commitMetaOfHEAD:
+              hash: da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5
+              committer: ""
+              author: nessie-author
+              message: update table X
+              commitTime: 2021-11-26T08:01:13.834397Z
+              authorTime: 2021-11-26T08:01:13.831371Z
+              properties: {}
+    diffResponse:
+      value:
+        diffs:
+        - key:
+            elements:
+            - example
+            - key
+          from:
+            type: ICEBERG_TABLE
+            id: f350b391-f492-41eb-9959-730a8c49f01e
+            metadataLocation: /path/to/metadata/
+            snapshotId: 23
+            schemaId: 15
+            specId: 15
+            sortOrderId: 15
+          to:
+            type: ICEBERG_TABLE
+            id: dec31d0a-7d4b-4534-8c24-24f08eda33b2
+            metadataLocation: /path/to/metadata/
+            snapshotId: 24
+            schemaId: 16
+            specId: 16
+            sortOrderId: 16


### PR DESCRIPTION
This is a temporary pin in preparation for API V2.

Newer builds will not publish OpenAPI YAML, which is why it is
necessary to refer to an older Nessie version in the UI build script.

The build uses a checked-in copy of Nessie 0.44.0 OpenAPI YAML file
at ui/src/openapi/

UI is to be updated to the upcoming V2 Nessie API eventually.