### PR TITLE
Extract common java client builder code

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseAssignBranchBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseAssignBranchBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import org.projectnessie.client.api.AssignBranchBuilder;
+import org.projectnessie.model.Reference;
+
+public abstract class BaseAssignBranchBuilder extends BaseOnBranchBuilder<AssignBranchBuilder>
+    implements AssignBranchBuilder {
+
+  protected Reference assignTo;
+
+  @Override
+  public AssignBranchBuilder assignTo(Reference assignTo) {
+    this.assignTo = assignTo;
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseAssignTagBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseAssignTagBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import org.projectnessie.client.api.AssignTagBuilder;
+import org.projectnessie.model.Reference;
+
+public abstract class BaseAssignTagBuilder extends BaseOnTagBuilder<AssignTagBuilder>
+    implements AssignTagBuilder {
+
+  protected Reference assignTo;
+
+  @Override
+  public AssignTagBuilder assignTo(Reference assignTo) {
+    this.assignTo = assignTo;
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseCommitMultipleOperationsBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseCommitMultipleOperationsBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.List;
+import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ImmutableOperations;
+import org.projectnessie.model.Operation;
+
+public abstract class BaseCommitMultipleOperationsBuilder
+    extends BaseOnBranchBuilder<CommitMultipleOperationsBuilder>
+    implements CommitMultipleOperationsBuilder {
+
+  protected final ImmutableOperations.Builder operations = ImmutableOperations.builder();
+
+  @Override
+  public CommitMultipleOperationsBuilder commitMeta(CommitMeta commitMeta) {
+    operations.commitMeta(commitMeta);
+    return this;
+  }
+
+  @Override
+  public CommitMultipleOperationsBuilder operations(List<Operation> operations) {
+    this.operations.addAllOperations(operations);
+    return this;
+  }
+
+  @Override
+  public CommitMultipleOperationsBuilder operation(Operation operation) {
+    operations.addOperations(operation);
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseCreateNamespaceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseCreateNamespaceBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.projectnessie.client.api.CreateNamespaceBuilder;
+import org.projectnessie.model.Namespace;
+
+public abstract class BaseCreateNamespaceBuilder implements CreateNamespaceBuilder {
+
+  protected Namespace namespace;
+  protected String refName;
+  protected String hashOnRef;
+  protected final Map<String, String> properties = new HashMap<>();
+
+  @Override
+  public CreateNamespaceBuilder namespace(Namespace namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  @Override
+  public CreateNamespaceBuilder refName(String refName) {
+    this.refName = refName;
+    return this;
+  }
+
+  @Override
+  public CreateNamespaceBuilder hashOnRef(@Nullable String hashOnRef) {
+    this.hashOnRef = hashOnRef;
+    return this;
+  }
+
+  @Override
+  public CreateNamespaceBuilder properties(Map<String, String> properties) {
+    this.properties.putAll(properties);
+    return this;
+  }
+
+  @Override
+  public CreateNamespaceBuilder property(String key, String value) {
+    this.properties.put(key, value);
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseCreateReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseCreateReferenceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,29 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.http.v1api;
+package org.projectnessie.client.builder;
 
-import org.projectnessie.client.api.OnTagBuilder;
-import org.projectnessie.client.http.NessieApiClient;
+import org.projectnessie.client.api.CreateReferenceBuilder;
+import org.projectnessie.model.Reference;
 
-abstract class BaseHttpOnTagRequest<R extends OnTagBuilder<R>> extends BaseHttpRequest
-    implements OnTagBuilder<R> {
-  protected String tagName;
-  protected String hash;
+public abstract class BaseCreateReferenceBuilder implements CreateReferenceBuilder {
 
-  BaseHttpOnTagRequest(NessieApiClient client) {
-    super(client);
+  protected Reference reference;
+  protected String sourceRefName;
+
+  @Override
+  public CreateReferenceBuilder sourceRefName(String sourceRefName) {
+    this.sourceRefName = sourceRefName;
+    return this;
   }
 
   @Override
-  public R tagName(String tagName) {
-    this.tagName = tagName;
-    return (R) this;
-  }
-
-  @Override
-  public R hash(String hash) {
-    this.hash = hash;
-    return (R) this;
+  public CreateReferenceBuilder reference(Reference reference) {
+    this.reference = reference;
+    return this;
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseDeleteNamespaceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseDeleteNamespaceBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import javax.annotation.Nullable;
+import org.projectnessie.client.api.DeleteNamespaceBuilder;
+import org.projectnessie.model.Namespace;
+
+public abstract class BaseDeleteNamespaceBuilder implements DeleteNamespaceBuilder {
+
+  protected Namespace namespace;
+  protected String refName;
+  protected String hashOnRef;
+
+  @Override
+  public DeleteNamespaceBuilder namespace(Namespace namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  @Override
+  public DeleteNamespaceBuilder refName(String refName) {
+    this.refName = refName;
+    return this;
+  }
+
+  @Override
+  public DeleteNamespaceBuilder hashOnRef(@Nullable String hashOnRef) {
+    this.hashOnRef = hashOnRef;
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetAllReferencesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetAllReferencesBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.projectnessie.api.params.FetchOption;
+import org.projectnessie.client.StreamingUtil;
+import org.projectnessie.client.api.GetAllReferencesBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.ReferencesResponse;
+
+public abstract class BaseGetAllReferencesBuilder<PARAMS> implements GetAllReferencesBuilder {
+
+  private final BiFunction<PARAMS, String, PARAMS> paramsForPage;
+  private String pageToken;
+
+  protected Integer maxRecords;
+  protected FetchOption fetchOption;
+  protected String filter;
+
+  protected BaseGetAllReferencesBuilder(BiFunction<PARAMS, String, PARAMS> paramsForPage) {
+    this.paramsForPage = paramsForPage;
+  }
+
+  @Override
+  public GetAllReferencesBuilder maxRecords(int maxRecords) {
+    this.maxRecords = maxRecords;
+    return this;
+  }
+
+  @Override
+  public GetAllReferencesBuilder pageToken(String pageToken) {
+    this.pageToken = pageToken;
+    return this;
+  }
+
+  @Override
+  public GetAllReferencesBuilder fetch(FetchOption fetchOption) {
+    this.fetchOption = fetchOption;
+    return this;
+  }
+
+  @Override
+  public GetAllReferencesBuilder filter(String filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  protected abstract PARAMS params();
+
+  protected abstract ReferencesResponse get(PARAMS p);
+
+  @Override
+  public ReferencesResponse get() {
+    PARAMS p = paramsForPage.apply(params(), pageToken);
+    return get(p);
+  }
+
+  @Override
+  public Stream<Reference> stream() throws NessieNotFoundException {
+    PARAMS p = params();
+    return StreamingUtil.generateStream(
+        ReferencesResponse::getReferences, pageToken -> get(paramsForPage.apply(p, pageToken)));
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetCommitLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetCommitLogBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.projectnessie.api.params.FetchOption;
+import org.projectnessie.client.StreamingUtil;
+import org.projectnessie.client.api.GetCommitLogBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.LogResponse.LogEntry;
+
+public abstract class BaseGetCommitLogBuilder<PARAMS>
+    extends BaseOnReferenceBuilder<GetCommitLogBuilder> implements GetCommitLogBuilder {
+
+  private final BiFunction<PARAMS, String, PARAMS> paramsForPage;
+  private String pageToken;
+
+  protected Integer maxRecords;
+  protected FetchOption fetchOption;
+  protected String filter;
+  protected String untilHash;
+
+  protected BaseGetCommitLogBuilder(BiFunction<PARAMS, String, PARAMS> paramsForPage) {
+    this.paramsForPage = paramsForPage;
+  }
+
+  @Override
+  public GetCommitLogBuilder fetch(FetchOption fetchOption) {
+    this.fetchOption = fetchOption;
+    return this;
+  }
+
+  @Override
+  public GetCommitLogBuilder untilHash(String untilHash) {
+    this.untilHash = untilHash;
+    return this;
+  }
+
+  @Override
+  public GetCommitLogBuilder maxRecords(int maxRecords) {
+    this.maxRecords = maxRecords;
+    return this;
+  }
+
+  @Override
+  public GetCommitLogBuilder pageToken(String pageToken) {
+    this.pageToken = pageToken;
+    return this;
+  }
+
+  @Override
+  public GetCommitLogBuilder filter(String filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  protected abstract PARAMS params();
+
+  @Override
+  public LogResponse get() throws NessieNotFoundException {
+    return get(paramsForPage.apply(params(), pageToken));
+  }
+
+  protected abstract LogResponse get(PARAMS p) throws NessieNotFoundException;
+
+  @Override
+  public Stream<LogEntry> stream() throws NessieNotFoundException {
+    PARAMS p = params();
+    return StreamingUtil.generateStream(
+        LogResponse::getLogEntries, pageToken -> get(paramsForPage.apply(p, pageToken)));
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetContentBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetContentBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.List;
+import org.projectnessie.client.api.GetContentBuilder;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ImmutableGetMultipleContentsRequest;
+
+public abstract class BaseGetContentBuilder extends BaseOnReferenceBuilder<GetContentBuilder>
+    implements GetContentBuilder {
+
+  protected final ImmutableGetMultipleContentsRequest.Builder request =
+      ImmutableGetMultipleContentsRequest.builder();
+
+  @Override
+  public GetContentBuilder key(ContentKey key) {
+    request.addRequestedKeys(key);
+    return this;
+  }
+
+  @Override
+  public GetContentBuilder keys(List<ContentKey> keys) {
+    request.addAllRequestedKeys(keys);
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetDiffBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetDiffBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import org.projectnessie.client.api.GetDiffBuilder;
+
+public abstract class BaseGetDiffBuilder implements GetDiffBuilder {
+
+  protected String fromRefName;
+  protected String fromHashOnRef;
+  protected String toRefName;
+  protected String toHashOnRef;
+
+  @Override
+  public GetDiffBuilder fromRefName(String fromRefName) {
+    this.fromRefName = fromRefName;
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder fromHashOnRef(String fromHashOnRef) {
+    this.fromHashOnRef = fromHashOnRef;
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder toRefName(String toRefName) {
+    this.toRefName = toRefName;
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder toHashOnRef(String toHashOnRef) {
+    this.toHashOnRef = toHashOnRef;
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetEntriesBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.projectnessie.client.StreamingUtil;
+import org.projectnessie.client.api.GetEntriesBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.EntriesResponse;
+import org.projectnessie.model.EntriesResponse.Entry;
+
+public abstract class BaseGetEntriesBuilder<PARAMS>
+    extends BaseOnReferenceBuilder<GetEntriesBuilder> implements GetEntriesBuilder {
+
+  private final BiFunction<PARAMS, String, PARAMS> paramsForPage;
+  private String pageToken;
+
+  protected Integer maxRecords;
+  protected String filter;
+  protected Integer namespaceDepth;
+
+  protected BaseGetEntriesBuilder(BiFunction<PARAMS, String, PARAMS> paramsForPage) {
+    this.paramsForPage = paramsForPage;
+  }
+
+  @Override
+  public GetEntriesBuilder maxRecords(int maxRecords) {
+    this.maxRecords = maxRecords;
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder pageToken(String pageToken) {
+    this.pageToken = pageToken;
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder filter(String filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder namespaceDepth(Integer namespaceDepth) {
+    this.namespaceDepth = namespaceDepth;
+    return this;
+  }
+
+  protected abstract PARAMS params();
+
+  protected abstract EntriesResponse get(PARAMS p) throws NessieNotFoundException;
+
+  @Override
+  public EntriesResponse get() throws NessieNotFoundException {
+    return get(paramsForPage.apply(params(), pageToken));
+  }
+
+  @Override
+  public Stream<Entry> stream() throws NessieNotFoundException {
+    PARAMS p = params();
+    return StreamingUtil.generateStream(
+        EntriesResponse::getEntries, pageToken -> get(paramsForPage.apply(p, pageToken)));
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetMultipleNamespacesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetMultipleNamespacesBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import javax.annotation.Nullable;
+import org.projectnessie.client.api.GetMultipleNamespacesBuilder;
+import org.projectnessie.model.Namespace;
+
+public abstract class BaseGetMultipleNamespacesBuilder implements GetMultipleNamespacesBuilder {
+
+  protected Namespace namespace;
+  protected String refName;
+  protected String hashOnRef;
+
+  @Override
+  public GetMultipleNamespacesBuilder namespace(Namespace namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  @Override
+  public GetMultipleNamespacesBuilder refName(String refName) {
+    this.refName = refName;
+    return this;
+  }
+
+  @Override
+  public GetMultipleNamespacesBuilder hashOnRef(@Nullable String hashOnRef) {
+    this.hashOnRef = hashOnRef;
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetNamespaceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetNamespaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,29 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.http.v1api;
+package org.projectnessie.client.builder;
 
-import org.projectnessie.client.api.OnReferenceBuilder;
-import org.projectnessie.client.http.NessieApiClient;
+import javax.annotation.Nullable;
+import org.projectnessie.client.api.GetNamespaceBuilder;
+import org.projectnessie.model.Namespace;
 
-abstract class BaseHttpOnReferenceRequest<R extends OnReferenceBuilder<R>> extends BaseHttpRequest
-    implements OnReferenceBuilder<R> {
+public abstract class BaseGetNamespaceBuilder implements GetNamespaceBuilder {
+
+  protected Namespace namespace;
   protected String refName;
   protected String hashOnRef;
 
-  BaseHttpOnReferenceRequest(NessieApiClient client) {
-    super(client);
+  @Override
+  public BaseGetNamespaceBuilder namespace(Namespace namespace) {
+    this.namespace = namespace;
+    return this;
   }
 
   @Override
-  public R refName(String refName) {
+  public BaseGetNamespaceBuilder refName(String refName) {
     this.refName = refName;
-    return (R) this;
+    return this;
   }
 
   @Override
-  public R hashOnRef(String hashOnRef) {
+  public GetNamespaceBuilder hashOnRef(@Nullable String hashOnRef) {
     this.hashOnRef = hashOnRef;
-    return (R) this;
+    return this;
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetRefLogBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetRefLogBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.projectnessie.client.StreamingUtil;
+import org.projectnessie.client.api.GetRefLogBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.RefLogResponse;
+import org.projectnessie.model.RefLogResponse.RefLogResponseEntry;
+
+public abstract class BaseGetRefLogBuilder<PARAMS> implements GetRefLogBuilder {
+
+  private final BiFunction<PARAMS, String, PARAMS> paramsForPage;
+  private String pageToken;
+
+  protected String untilHash;
+  protected String fromHash;
+  protected String filter;
+  protected Integer maxRecords;
+
+  protected BaseGetRefLogBuilder(BiFunction<PARAMS, String, PARAMS> paramsForPage) {
+    this.paramsForPage = paramsForPage;
+  }
+
+  @Override
+  public GetRefLogBuilder untilHash(String untilHash) {
+    this.untilHash = untilHash;
+    return this;
+  }
+
+  @Override
+  public GetRefLogBuilder fromHash(String fromHash) {
+    this.fromHash = fromHash;
+    return this;
+  }
+
+  @Override
+  public GetRefLogBuilder filter(String filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  @Override
+  public GetRefLogBuilder maxRecords(int maxRecords) {
+    this.maxRecords = maxRecords;
+    return this;
+  }
+
+  @Override
+  public GetRefLogBuilder pageToken(String pageToken) {
+    this.pageToken = pageToken;
+    return this;
+  }
+
+  protected abstract PARAMS params();
+
+  protected abstract RefLogResponse get(PARAMS p) throws NessieNotFoundException;
+
+  @Override
+  public RefLogResponse get() throws NessieNotFoundException {
+    return get(paramsForPage.apply(params(), pageToken));
+  }
+
+  @Override
+  public Stream<RefLogResponseEntry> stream() throws NessieNotFoundException {
+    PARAMS p = params();
+    return StreamingUtil.generateStream(
+        RefLogResponse::getLogEntries, pageToken -> get(paramsForPage.apply(p, pageToken)));
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetReferenceBuilder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import org.projectnessie.api.params.FetchOption;
+import org.projectnessie.client.api.GetReferenceBuilder;
+
+public abstract class BaseGetReferenceBuilder implements GetReferenceBuilder {
+
+  protected String refName;
+  protected FetchOption fetchOption;
+
+  @Override
+  public GetReferenceBuilder refName(String refName) {
+    this.refName = refName;
+    return this;
+  }
+
+  @Override
+  public GetReferenceBuilder fetch(FetchOption fetchOption) {
+    this.fetchOption = fetchOption;
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseMergeReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseMergeReferenceBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import org.projectnessie.client.api.MergeReferenceBuilder;
+
+public abstract class BaseMergeReferenceBuilder
+    extends BaseMergeTransplantBuilder<MergeReferenceBuilder> implements MergeReferenceBuilder {
+
+  protected String fromHash;
+
+  @Override
+  public MergeReferenceBuilder fromHash(String fromHash) {
+    this.fromHash = fromHash;
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import org.projectnessie.client.api.OnBranchBuilder;
+
+public abstract class BaseMergeTransplantBuilder<B extends OnBranchBuilder<B>>
+    extends BaseOnBranchBuilder<B> {
+
+  protected String fromRefName;
+  protected Boolean keepIndividualCommits;
+  protected Boolean dryRun;
+  protected Boolean returnConflictAsResult;
+  protected Boolean fetchAdditionalInfo;
+
+  public B fromRefName(String fromRefName) {
+    this.fromRefName = fromRefName;
+    return (B) this;
+  }
+
+  public B keepIndividualCommits(boolean keepIndividualCommits) {
+    this.keepIndividualCommits = keepIndividualCommits;
+    return (B) this;
+  }
+
+  public B dryRun(boolean dryRun) {
+    this.dryRun = dryRun;
+    return (B) this;
+  }
+
+  public B fetchAdditionalInfo(boolean fetchAdditionalInfo) {
+    this.fetchAdditionalInfo = fetchAdditionalInfo;
+    return (B) this;
+  }
+
+  public B returnConflictAsResult(boolean returnConflictAsResult) {
+    this.returnConflictAsResult = returnConflictAsResult;
+    return (B) this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseOnBranchBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseOnBranchBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.http.v1api;
+package org.projectnessie.client.builder;
 
 import org.projectnessie.client.api.OnBranchBuilder;
-import org.projectnessie.client.http.NessieApiClient;
 
-abstract class BaseHttpOnBranchRequest<R extends OnBranchBuilder<R>> extends BaseHttpRequest
+public abstract class BaseOnBranchBuilder<R extends OnBranchBuilder<R>>
     implements OnBranchBuilder<R> {
   protected String branchName;
   protected String hash;
-
-  BaseHttpOnBranchRequest(NessieApiClient client) {
-    super(client);
-  }
 
   @Override
   public R branchName(String branchName) {

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseOnReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseOnReferenceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.http.v1api;
+package org.projectnessie.client.builder;
 
-import org.projectnessie.client.http.NessieApiClient;
+import org.projectnessie.client.api.OnReferenceBuilder;
 
-abstract class BaseHttpRequest {
+abstract class BaseOnReferenceBuilder<R extends OnReferenceBuilder<R>>
+    implements OnReferenceBuilder<R> {
+  protected String refName;
+  protected String hashOnRef;
 
-  protected final NessieApiClient client;
+  @Override
+  public R refName(String refName) {
+    this.refName = refName;
+    return (R) this;
+  }
 
-  BaseHttpRequest(NessieApiClient client) {
-    this.client = client;
+  @Override
+  public R hashOnRef(String hashOnRef) {
+    this.hashOnRef = hashOnRef;
+    return (R) this;
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseOnTagBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseOnTagBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import org.projectnessie.client.api.OnTagBuilder;
+
+public abstract class BaseOnTagBuilder<R extends OnTagBuilder<R>> implements OnTagBuilder<R> {
+  protected String tagName;
+  protected String hash;
+
+  @Override
+  public R tagName(String tagName) {
+    this.tagName = tagName;
+    return (R) this;
+  }
+
+  @Override
+  public R hash(String hash) {
+    this.hash = hash;
+    return (R) this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseTransplantCommitsBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseTransplantCommitsBuilder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.List;
+import org.projectnessie.client.api.TransplantCommitsBuilder;
+
+public abstract class BaseTransplantCommitsBuilder
+    extends BaseMergeTransplantBuilder<TransplantCommitsBuilder>
+    implements TransplantCommitsBuilder {
+
+  protected String message;
+  protected List<String> hashesToTransplant;
+
+  @Override
+  public TransplantCommitsBuilder message(String message) {
+    this.message = message;
+    return this;
+  }
+
+  @Override
+  public TransplantCommitsBuilder hashesToTransplant(List<String> hashesToTransplant) {
+    this.hashesToTransplant = hashesToTransplant;
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseUpdateNamespaceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseUpdateNamespaceBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.builder;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.projectnessie.client.api.UpdateNamespaceBuilder;
+import org.projectnessie.model.Namespace;
+
+public abstract class BaseUpdateNamespaceBuilder implements UpdateNamespaceBuilder {
+
+  protected final Map<String, String> propertyUpdates = new HashMap<>();
+  protected final Set<String> propertyRemovals = new HashSet<>();
+  protected Namespace namespace;
+  protected String refName;
+  protected String hashOnRef;
+
+  @Override
+  public UpdateNamespaceBuilder namespace(Namespace namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  @Override
+  public UpdateNamespaceBuilder refName(String refName) {
+    this.refName = refName;
+    return this;
+  }
+
+  @Override
+  public UpdateNamespaceBuilder hashOnRef(@Nullable String hashOnRef) {
+    this.hashOnRef = hashOnRef;
+    return this;
+  }
+
+  @Override
+  public UpdateNamespaceBuilder removeProperty(String key) {
+    this.propertyRemovals.add(key);
+    return this;
+  }
+
+  @Override
+  public UpdateNamespaceBuilder removeProperties(Set<String> propertyRemovals) {
+    this.propertyRemovals.addAll(propertyRemovals);
+    return this;
+  }
+
+  @Override
+  public UpdateNamespaceBuilder updateProperty(String key, String value) {
+    this.propertyUpdates.put(key, value);
+    return this;
+  }
+
+  @Override
+  public UpdateNamespaceBuilder updateProperties(Map<String, String> propertyUpdates) {
+    this.propertyUpdates.putAll(propertyUpdates);
+    return this;
+  }
+}

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
@@ -15,24 +15,18 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import org.projectnessie.client.api.AssignBranchBuilder;
+import org.projectnessie.client.builder.BaseAssignBranchBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
-final class HttpAssignBranch extends BaseHttpOnBranchRequest<AssignBranchBuilder>
-    implements AssignBranchBuilder {
-  private Reference assignTo;
+final class HttpAssignBranch extends BaseAssignBranchBuilder {
+
+  private final NessieApiClient client;
 
   HttpAssignBranch(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public AssignBranchBuilder assignTo(Reference assignTo) {
-    this.assignTo = assignTo;
-    return this;
+    this.client = client;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
@@ -15,25 +15,18 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import org.projectnessie.client.api.AssignTagBuilder;
+import org.projectnessie.client.builder.BaseAssignTagBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
-final class HttpAssignTag extends BaseHttpOnTagRequest<AssignTagBuilder>
-    implements AssignTagBuilder {
+final class HttpAssignTag extends BaseAssignTagBuilder {
 
-  private Reference assignTo;
+  private final NessieApiClient client;
 
   HttpAssignTag(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public AssignTagBuilder assignTo(Reference assignTo) {
-    this.assignTo = assignTo;
-    return this;
+    this.client = client;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCommitMultipleOperations.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCommitMultipleOperations.java
@@ -15,42 +15,18 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import java.util.List;
-import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
+import org.projectnessie.client.builder.BaseCommitMultipleOperationsBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.CommitMeta;
-import org.projectnessie.model.ImmutableOperations;
-import org.projectnessie.model.Operation;
 
-final class HttpCommitMultipleOperations
-    extends BaseHttpOnBranchRequest<CommitMultipleOperationsBuilder>
-    implements CommitMultipleOperationsBuilder {
+final class HttpCommitMultipleOperations extends BaseCommitMultipleOperationsBuilder {
 
-  private final ImmutableOperations.Builder operations = ImmutableOperations.builder();
+  private final NessieApiClient client;
 
   HttpCommitMultipleOperations(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public CommitMultipleOperationsBuilder commitMeta(CommitMeta commitMeta) {
-    operations.commitMeta(commitMeta);
-    return this;
-  }
-
-  @Override
-  public CommitMultipleOperationsBuilder operations(List<Operation> operations) {
-    this.operations.addAllOperations(operations);
-    return this;
-  }
-
-  @Override
-  public CommitMultipleOperationsBuilder operation(Operation operation) {
-    operations.addOperations(operation);
-    return this;
+    this.client = client;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateNamespace.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateNamespace.java
@@ -15,68 +15,34 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.Nullable;
 import org.projectnessie.api.params.NamespaceParams;
-import org.projectnessie.api.params.NamespaceParamsBuilder;
-import org.projectnessie.client.api.CreateNamespaceBuilder;
+import org.projectnessie.client.builder.BaseCreateNamespaceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNamespaceAlreadyExistsException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.ImmutableNamespace;
 import org.projectnessie.model.Namespace;
 
-final class HttpCreateNamespace extends BaseHttpRequest implements CreateNamespaceBuilder {
+final class HttpCreateNamespace extends BaseCreateNamespaceBuilder {
 
-  private final NamespaceParamsBuilder builder = NamespaceParams.builder();
-  private final Map<String, String> properties = new HashMap<>();
+  private final NessieApiClient client;
 
   HttpCreateNamespace(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public CreateNamespaceBuilder namespace(Namespace namespace) {
-    builder.namespace(namespace);
-    return this;
-  }
-
-  @Override
-  public CreateNamespaceBuilder refName(String refName) {
-    builder.refName(refName);
-    return this;
-  }
-
-  @Override
-  public CreateNamespaceBuilder hashOnRef(@Nullable String hashOnRef) {
-    builder.hashOnRef(hashOnRef);
-    return this;
-  }
-
-  @Override
-  public CreateNamespaceBuilder properties(Map<String, String> properties) {
-    this.properties.putAll(properties);
-    return this;
-  }
-
-  @Override
-  public CreateNamespaceBuilder property(String key, String value) {
-    this.properties.put(key, value);
-    return this;
+    this.client = client;
   }
 
   @Override
   public Namespace create()
       throws NessieNamespaceAlreadyExistsException, NessieReferenceNotFoundException {
-    NamespaceParams params = builder.build();
+    NamespaceParams params =
+        NamespaceParams.builder()
+            .namespace(namespace)
+            .refName(refName)
+            .hashOnRef(hashOnRef)
+            .build();
     return client
         .getNamespaceApi()
         .createNamespace(
-            params,
-            ImmutableNamespace.builder()
-                .from(params.getNamespace())
-                .properties(properties)
-                .build());
+            params, ImmutableNamespace.builder().from(namespace).properties(properties).build());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateReference.java
@@ -15,31 +15,18 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import org.projectnessie.client.api.CreateReferenceBuilder;
+import org.projectnessie.client.builder.BaseCreateReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
-final class HttpCreateReference extends BaseHttpRequest implements CreateReferenceBuilder {
+final class HttpCreateReference extends BaseCreateReferenceBuilder {
 
-  private Reference reference;
-  private String sourceRefName;
+  private final NessieApiClient client;
 
   HttpCreateReference(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public CreateReferenceBuilder sourceRefName(String sourceRefName) {
-    this.sourceRefName = sourceRefName;
-    return this;
-  }
-
-  @Override
-  public CreateReferenceBuilder reference(Reference reference) {
-    this.reference = reference;
-    return this;
+    this.client = client;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteBranch.java
@@ -16,15 +16,18 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.DeleteBranchBuilder;
+import org.projectnessie.client.builder.BaseOnBranchBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
-final class HttpDeleteBranch extends BaseHttpOnBranchRequest<DeleteBranchBuilder>
+final class HttpDeleteBranch extends BaseOnBranchBuilder<DeleteBranchBuilder>
     implements DeleteBranchBuilder {
+  private final NessieApiClient client;
+
   HttpDeleteBranch(NessieApiClient client) {
-    super(client);
+    this.client = client;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteNamespace.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteNamespace.java
@@ -15,46 +15,28 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import javax.annotation.Nullable;
 import org.projectnessie.api.params.NamespaceParams;
 import org.projectnessie.api.params.NamespaceParamsBuilder;
-import org.projectnessie.client.api.DeleteNamespaceBuilder;
+import org.projectnessie.client.builder.BaseDeleteNamespaceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNamespaceNotEmptyException;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
-import org.projectnessie.model.Namespace;
 
-final class HttpDeleteNamespace extends BaseHttpRequest implements DeleteNamespaceBuilder {
+final class HttpDeleteNamespace extends BaseDeleteNamespaceBuilder {
 
-  private final NamespaceParamsBuilder builder = NamespaceParams.builder();
+  private final NessieApiClient client;
 
   HttpDeleteNamespace(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public DeleteNamespaceBuilder namespace(Namespace namespace) {
-    builder.namespace(namespace);
-    return this;
-  }
-
-  @Override
-  public DeleteNamespaceBuilder refName(String refName) {
-    builder.refName(refName);
-    return this;
-  }
-
-  @Override
-  public DeleteNamespaceBuilder hashOnRef(@Nullable String hashOnRef) {
-    builder.hashOnRef(hashOnRef);
-    return this;
+    this.client = client;
   }
 
   @Override
   public void delete()
       throws NessieReferenceNotFoundException, NessieNamespaceNotEmptyException,
           NessieNamespaceNotFoundException {
+    NamespaceParamsBuilder builder =
+        NamespaceParams.builder().namespace(namespace).hashOnRef(hashOnRef).refName(refName);
     client.getNamespaceApi().deleteNamespace(builder.build());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteTag.java
@@ -16,16 +16,18 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.client.api.DeleteTagBuilder;
+import org.projectnessie.client.builder.BaseOnTagBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
-final class HttpDeleteTag extends BaseHttpOnTagRequest<DeleteTagBuilder>
-    implements DeleteTagBuilder {
+final class HttpDeleteTag extends BaseOnTagBuilder<DeleteTagBuilder> implements DeleteTagBuilder {
+
+  private final NessieApiClient client;
 
   HttpDeleteTag(NessieApiClient client) {
-    super(client);
+    this.client = client;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetContent.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetContent.java
@@ -15,38 +15,22 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.projectnessie.client.api.GetContentBuilder;
+import org.projectnessie.client.builder.BaseGetContentBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.GetMultipleContentsResponse;
 import org.projectnessie.model.GetMultipleContentsResponse.ContentWithKey;
-import org.projectnessie.model.ImmutableGetMultipleContentsRequest;
 
-final class HttpGetContent extends BaseHttpOnReferenceRequest<GetContentBuilder>
-    implements GetContentBuilder {
+final class HttpGetContent extends BaseGetContentBuilder {
 
-  private final ImmutableGetMultipleContentsRequest.Builder request =
-      ImmutableGetMultipleContentsRequest.builder();
+  private final NessieApiClient client;
 
   HttpGetContent(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public GetContentBuilder key(ContentKey key) {
-    request.addRequestedKeys(key);
-    return this;
-  }
-
-  @Override
-  public GetContentBuilder keys(List<ContentKey> keys) {
-    request.addAllRequestedKeys(keys);
-    return this;
+    this.client = client;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetDiff.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetDiff.java
@@ -17,45 +17,27 @@ package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.params.DiffParams;
 import org.projectnessie.api.params.DiffParamsBuilder;
-import org.projectnessie.client.api.GetDiffBuilder;
+import org.projectnessie.client.builder.BaseGetDiffBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.DiffResponse;
 
-final class HttpGetDiff extends BaseHttpRequest implements GetDiffBuilder {
+final class HttpGetDiff extends BaseGetDiffBuilder {
 
-  DiffParamsBuilder builder = DiffParams.builder();
+  private final NessieApiClient client;
 
   HttpGetDiff(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public GetDiffBuilder fromRefName(String fromRefName) {
-    builder.fromRef(fromRefName);
-    return this;
-  }
-
-  @Override
-  public GetDiffBuilder fromHashOnRef(String fromHashOnRef) {
-    builder.fromHashOnRef(fromHashOnRef);
-    return this;
-  }
-
-  @Override
-  public GetDiffBuilder toRefName(String toRefName) {
-    builder.toRef(toRefName);
-    return this;
-  }
-
-  @Override
-  public GetDiffBuilder toHashOnRef(String toHashOnRef) {
-    builder.toHashOnRef(toHashOnRef);
-    return this;
+    this.client = client;
   }
 
   @Override
   public DiffResponse get() throws NessieNotFoundException {
+    DiffParamsBuilder builder =
+        DiffParams.builder()
+            .fromRef(fromRefName)
+            .fromHashOnRef(fromHashOnRef)
+            .toRef(toRefName)
+            .toHashOnRef(toHashOnRef);
     return client.getDiffApi().getDiff(builder.build());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetMultipleNamespaces.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetMultipleNamespaces.java
@@ -15,51 +15,28 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import javax.annotation.Nullable;
 import org.projectnessie.api.params.MultipleNamespacesParams;
-import org.projectnessie.api.params.MultipleNamespacesParamsBuilder;
-import org.projectnessie.client.api.GetMultipleNamespacesBuilder;
+import org.projectnessie.client.builder.BaseGetMultipleNamespacesBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.GetNamespacesResponse;
-import org.projectnessie.model.Namespace;
 
-final class HttpGetMultipleNamespaces extends BaseHttpRequest
-    implements GetMultipleNamespacesBuilder {
+final class HttpGetMultipleNamespaces extends BaseGetMultipleNamespacesBuilder {
 
-  private final MultipleNamespacesParamsBuilder builder = MultipleNamespacesParams.builder();
+  private final NessieApiClient client;
 
   HttpGetMultipleNamespaces(NessieApiClient client) {
-    super(client);
-  }
-
-  /**
-   * The namespace prefix to search for.
-   *
-   * @param namespace The namespace prefix to search for
-   * @return this
-   */
-  @Override
-  public GetMultipleNamespacesBuilder namespace(Namespace namespace) {
-    builder.namespace(namespace);
-    return this;
-  }
-
-  @Override
-  public GetMultipleNamespacesBuilder refName(String refName) {
-    builder.refName(refName);
-    return this;
-  }
-
-  @Override
-  public GetMultipleNamespacesBuilder hashOnRef(@Nullable String hashOnRef) {
-    builder.hashOnRef(hashOnRef);
-    return this;
+    this.client = client;
   }
 
   @Override
   public GetNamespacesResponse get() throws NessieReferenceNotFoundException {
-    MultipleNamespacesParams build = builder.build();
-    return client.getNamespaceApi().getNamespaces(build);
+    MultipleNamespacesParams params =
+        MultipleNamespacesParams.builder()
+            .namespace(namespace)
+            .refName(refName)
+            .hashOnRef(hashOnRef)
+            .build();
+    return client.getNamespaceApi().getNamespaces(params);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetNamespace.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetNamespace.java
@@ -15,43 +15,26 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import javax.annotation.Nullable;
 import org.projectnessie.api.params.NamespaceParams;
 import org.projectnessie.api.params.NamespaceParamsBuilder;
-import org.projectnessie.client.api.GetNamespaceBuilder;
+import org.projectnessie.client.builder.BaseGetNamespaceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.Namespace;
 
-final class HttpGetNamespace extends BaseHttpRequest implements GetNamespaceBuilder {
+final class HttpGetNamespace extends BaseGetNamespaceBuilder {
 
-  private final NamespaceParamsBuilder builder = NamespaceParams.builder();
+  private final NessieApiClient client;
 
   HttpGetNamespace(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public HttpGetNamespace namespace(Namespace namespace) {
-    builder.namespace(namespace);
-    return this;
-  }
-
-  @Override
-  public HttpGetNamespace refName(String refName) {
-    builder.refName(refName);
-    return this;
-  }
-
-  @Override
-  public GetNamespaceBuilder hashOnRef(@Nullable String hashOnRef) {
-    builder.hashOnRef(hashOnRef);
-    return this;
+    this.client = client;
   }
 
   @Override
   public Namespace get() throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException {
+    NamespaceParamsBuilder builder =
+        NamespaceParams.builder().namespace(namespace).refName(refName).hashOnRef(hashOnRef);
     return client.getNamespaceApi().getNamespace(builder.build());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,35 +15,24 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import org.projectnessie.api.params.FetchOption;
 import org.projectnessie.api.params.GetReferenceParams;
-import org.projectnessie.api.params.GetReferenceParamsBuilder;
-import org.projectnessie.client.api.GetReferenceBuilder;
+import org.projectnessie.client.builder.BaseGetReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 
-final class HttpGetReference extends BaseHttpRequest implements GetReferenceBuilder {
-  private GetReferenceParamsBuilder builder = GetReferenceParams.builder();
+final class HttpGetReference extends BaseGetReferenceBuilder {
+  private final NessieApiClient client;
 
   HttpGetReference(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public GetReferenceBuilder refName(String refName) {
-    builder.refName(refName);
-    return this;
-  }
-
-  @Override
-  public GetReferenceBuilder fetch(FetchOption fetchOption) {
-    builder.fetchOption(fetchOption);
-    return this;
+    this.client = client;
   }
 
   @Override
   public Reference get() throws NessieNotFoundException {
-    return client.getTreeApi().getReferenceByName(builder.build());
+    return client
+        .getTreeApi()
+        .getReferenceByName(
+            GetReferenceParams.builder().refName(refName).fetchOption(fetchOption).build());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
@@ -15,60 +15,31 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import org.projectnessie.client.api.MergeReferenceBuilder;
+import org.projectnessie.client.builder.BaseMergeReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.ImmutableMerge;
 import org.projectnessie.model.MergeResponse;
 
-final class HttpMergeReference extends BaseHttpOnBranchRequest<MergeReferenceBuilder>
-    implements MergeReferenceBuilder {
+final class HttpMergeReference extends BaseMergeReferenceBuilder {
 
-  private final ImmutableMerge.Builder merge = ImmutableMerge.builder();
+  private final NessieApiClient client;
 
   HttpMergeReference(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public MergeReferenceBuilder fromRefName(String fromRefName) {
-    merge.fromRefName(fromRefName);
-    return this;
-  }
-
-  @Override
-  public MergeReferenceBuilder fromHash(String fromHash) {
-    merge.fromHash(fromHash);
-    return this;
-  }
-
-  @Override
-  public MergeReferenceBuilder keepIndividualCommits(boolean keepIndividualCommits) {
-    merge.keepIndividualCommits(keepIndividualCommits);
-    return this;
-  }
-
-  @Override
-  public MergeReferenceBuilder dryRun(boolean dryRun) {
-    merge.isDryRun(dryRun);
-    return this;
-  }
-
-  @Override
-  public MergeReferenceBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
-    merge.isFetchAdditionalInfo(fetchAdditionalInfo);
-    return this;
-  }
-
-  @Override
-  public MergeReferenceBuilder returnConflictAsResult(boolean returnConflictAsResult) {
-    merge.isReturnConflictAsResult(returnConflictAsResult);
-    return this;
+    this.client = client;
   }
 
   @Override
   public MergeResponse merge() throws NessieNotFoundException, NessieConflictException {
+    ImmutableMerge.Builder merge =
+        ImmutableMerge.builder()
+            .fromHash(fromHash)
+            .fromRefName(fromRefName)
+            .isDryRun(dryRun)
+            .isReturnConflictAsResult(returnConflictAsResult)
+            .isFetchAdditionalInfo(fetchAdditionalInfo)
+            .keepIndividualCommits(keepIndividualCommits);
     return client.getTreeApi().mergeRefIntoBranch(branchName, hash, merge.build());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
@@ -15,68 +15,31 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import java.util.List;
-import org.projectnessie.client.api.TransplantCommitsBuilder;
+import org.projectnessie.client.builder.BaseTransplantCommitsBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.ImmutableTransplant;
 import org.projectnessie.model.MergeResponse;
 
-final class HttpTransplantCommits extends BaseHttpOnBranchRequest<TransplantCommitsBuilder>
-    implements TransplantCommitsBuilder {
+final class HttpTransplantCommits extends BaseTransplantCommitsBuilder {
 
-  private final ImmutableTransplant.Builder transplant = ImmutableTransplant.builder();
-  private String message;
+  private final NessieApiClient client;
 
   HttpTransplantCommits(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public TransplantCommitsBuilder message(String message) {
-    this.message = message;
-    return this;
-  }
-
-  @Override
-  public TransplantCommitsBuilder fromRefName(String fromRefName) {
-    transplant.fromRefName(fromRefName);
-    return this;
-  }
-
-  @Override
-  public TransplantCommitsBuilder hashesToTransplant(List<String> hashesToTransplant) {
-    transplant.addAllHashesToTransplant(hashesToTransplant);
-    return this;
-  }
-
-  @Override
-  public TransplantCommitsBuilder keepIndividualCommits(boolean keepIndividualCommits) {
-    transplant.keepIndividualCommits(keepIndividualCommits);
-    return this;
-  }
-
-  @Override
-  public TransplantCommitsBuilder dryRun(boolean dryRun) {
-    transplant.isDryRun(dryRun);
-    return this;
-  }
-
-  @Override
-  public TransplantCommitsBuilder fetchAdditionalInfo(boolean fetchAdditionalInfo) {
-    transplant.isFetchAdditionalInfo(fetchAdditionalInfo);
-    return this;
-  }
-
-  @Override
-  public TransplantCommitsBuilder returnConflictAsResult(boolean returnConflictAsResult) {
-    transplant.isReturnConflictAsResult(returnConflictAsResult);
-    return this;
+    this.client = client;
   }
 
   @Override
   public MergeResponse transplant() throws NessieNotFoundException, NessieConflictException {
+    ImmutableTransplant.Builder transplant =
+        ImmutableTransplant.builder()
+            .fromRefName(fromRefName)
+            .hashesToTransplant(hashesToTransplant)
+            .isDryRun(dryRun)
+            .isReturnConflictAsResult(returnConflictAsResult)
+            .isFetchAdditionalInfo(fetchAdditionalInfo)
+            .keepIndividualCommits(keepIndividualCommits);
     return client
         .getTreeApi()
         .transplantCommitsIntoBranch(branchName, hash, message, transplant.build());

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpUpdateNamespace.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpUpdateNamespace.java
@@ -15,71 +15,32 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nullable;
 import org.projectnessie.api.params.ImmutableNamespaceUpdate;
 import org.projectnessie.api.params.NamespaceParams;
 import org.projectnessie.api.params.NamespaceParamsBuilder;
-import org.projectnessie.client.api.UpdateNamespaceBuilder;
+import org.projectnessie.client.builder.BaseUpdateNamespaceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
-import org.projectnessie.model.Namespace;
 
-final class HttpUpdateNamespace extends BaseHttpRequest implements UpdateNamespaceBuilder {
+final class HttpUpdateNamespace extends BaseUpdateNamespaceBuilder {
 
-  private final NamespaceParamsBuilder builder = NamespaceParams.builder();
-  private final ImmutableNamespaceUpdate.Builder updateBuilder = ImmutableNamespaceUpdate.builder();
+  private final NessieApiClient client;
 
   HttpUpdateNamespace(NessieApiClient client) {
-    super(client);
-  }
-
-  @Override
-  public UpdateNamespaceBuilder namespace(Namespace namespace) {
-    builder.namespace(namespace);
-    return this;
-  }
-
-  @Override
-  public UpdateNamespaceBuilder refName(String refName) {
-    builder.refName(refName);
-    return this;
-  }
-
-  @Override
-  public UpdateNamespaceBuilder hashOnRef(@Nullable String hashOnRef) {
-    builder.hashOnRef(hashOnRef);
-    return this;
-  }
-
-  @Override
-  public UpdateNamespaceBuilder removeProperties(Set<String> propertyRemovals) {
-    updateBuilder.addAllPropertyRemovals(propertyRemovals);
-    return this;
-  }
-
-  @Override
-  public UpdateNamespaceBuilder updateProperty(String key, String value) {
-    updateBuilder.putPropertyUpdates(key, value);
-    return this;
-  }
-
-  @Override
-  public UpdateNamespaceBuilder removeProperty(String key) {
-    updateBuilder.addPropertyRemovals(key);
-    return this;
-  }
-
-  @Override
-  public UpdateNamespaceBuilder updateProperties(Map<String, String> propertyUpdates) {
-    updateBuilder.putAllPropertyUpdates(propertyUpdates);
-    return this;
+    this.client = client;
   }
 
   @Override
   public void update() throws NessieNamespaceNotFoundException, NessieReferenceNotFoundException {
-    client.getNamespaceApi().updateProperties(builder.build(), updateBuilder.build());
+    NamespaceParamsBuilder namespaceParamsBuilder =
+        NamespaceParams.builder().namespace(namespace).refName(refName).hashOnRef(hashOnRef);
+    ImmutableNamespaceUpdate.Builder updateBuilder =
+        ImmutableNamespaceUpdate.builder()
+            .propertyUpdates(propertyUpdates)
+            .propertyRemovals(propertyRemovals);
+    client
+        .getNamespaceApi()
+        .updateProperties(namespaceParamsBuilder.build(), updateBuilder.build());
   }
 }


### PR DESCRIPTION
This is in preparation to API v2.

Common builder are intended to be reused for both v1 and v2 clients with differences only in how HTTP requests are constructed.