### PR TITLE
Support method-level NessieApiVersions annotations

### DIFF
--- a/clients/client-testextension/src/main/java/org/projectnessie/client/ext/MultiVersionApiTest.java
+++ b/clients/client-testextension/src/main/java/org/projectnessie/client/ext/MultiVersionApiTest.java
@@ -65,10 +65,16 @@ public class MultiVersionApiTest implements MultiEnvTestExtension, ExecutionCond
     NessieApiVersion apiVersion = apiVersion(context);
     boolean matches =
         Arrays.asList(
-                AnnotationUtils.findAnnotation(
-                        context.getRequiredTestClass(), NessieApiVersions.class)
+                context
+                    .getTestMethod()
+                    .flatMap(m -> AnnotationUtils.findAnnotation(m, NessieApiVersions.class))
                     .map(NessieApiVersions::versions)
-                    .orElseGet(() -> new NessieApiVersion[] {DEFAULT_API_VERSION}))
+                    .orElseGet(
+                        () ->
+                            AnnotationUtils.findAnnotation(
+                                    context.getRequiredTestClass(), NessieApiVersions.class)
+                                .map(NessieApiVersions::versions)
+                                .orElseGet(() -> new NessieApiVersion[] {DEFAULT_API_VERSION})))
             .contains(apiVersion);
     return matches
         ? ConditionEvaluationResult.enabled(null)

--- a/clients/client-testextension/src/main/java/org/projectnessie/client/ext/NessieApiVersions.java
+++ b/clients/client-testextension/src/main/java/org/projectnessie/client/ext/NessieApiVersions.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>This annotation activates {@link MultiVersionApiTest}. Actual API-specific parameter injection
  * is handled by related JUnit5 extensions, such as {@link NessieClientResolver} sub-classes.
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(MultiVersionApiTest.class)
 @Inherited

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/AbstractRestMergeTransplant.java
@@ -25,9 +25,9 @@ import static org.assertj.core.data.MapEntry.entry;
 import com.google.common.collect.ImmutableList;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -51,9 +51,20 @@ import org.projectnessie.model.Reference;
 public abstract class AbstractRestMergeTransplant extends AbstractRestInvalid {
 
   @ParameterizedTest
-  @CsvSource(
-      value = {"true,true", "true,false", "false,true", "false,false"}) // merge requires the hash
-  public void transplant(boolean withDetachedCommit, boolean keepIndividualCommits)
+  @ValueSource(booleans = {true, false})
+  public void transplantKeepCommits(boolean withDetachedCommit)
+      throws BaseNessieClientServerException {
+    testTransplant(withDetachedCommit, true);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void transplantSquashed(boolean withDetachedCommit)
+      throws BaseNessieClientServerException {
+    testTransplant(withDetachedCommit, false);
+  }
+
+  private void testTransplant(boolean withDetachedCommit, boolean keepIndividualCommits)
       throws BaseNessieClientServerException {
     mergeTransplant(
         false,
@@ -70,14 +81,18 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalid {
   }
 
   @ParameterizedTest
-  @CsvSource(
-      value = {
-        "UNCHANGED,true",
-        "UNCHANGED,false",
-        "DETACHED,true",
-        "DETACHED,false"
-      }) // merge requires the hash
-  public void merge(ReferenceMode refMode, boolean keepIndividualCommits)
+  @EnumSource(names = {"UNCHANGED", "DETACHED"}) // hash is required
+  public void mergeKeepCommits(ReferenceMode refMode) throws BaseNessieClientServerException {
+    testMerge(refMode, true);
+  }
+
+  @ParameterizedTest
+  @EnumSource(names = {"UNCHANGED", "DETACHED"}) // hash is required
+  public void mergeSquashed(ReferenceMode refMode) throws BaseNessieClientServerException {
+    testMerge(refMode, false);
+  }
+
+  private void testMerge(ReferenceMode refMode, boolean keepIndividualCommits)
       throws BaseNessieClientServerException {
     mergeTransplant(
         !keepIndividualCommits,


### PR DESCRIPTION
Default to class-level annotations if not set at method level.

Filter-out test methods that do not apply to a particular API version in MultiVersionApiTest. This is cleaner than using assumptions to skip test because execution conditions also block before/after callbacks.

PR does not add any specific applications of method-level test conditions based on API versions because there is only one API version available.

However, the refactoring in AbstractRestMergeTransplant prepares for the introduction of API v2, in which case some test methods will apply only to some API versions.