### PR TITLE
Pull `ProtobufHelperPlugin` from `gradle-build-plugins`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation("com.diffplug.spotless:spotless-plugin-gradle:${ver.spotlessPlugin.get()}")
   implementation("com.github.vlsi.gradle:jandex-plugin:${ver.jandexPlugin.get()}")
   implementation("gradle.plugin.com.github.johnrengelman:shadow:${ver.shadowPlugin.get()}")
+  implementation("com.google.protobuf:protobuf-gradle-plugin:${ver.protobufPlugin.get()}")
   val nessieVer = ver.nessieBuildPlugins.get()
   implementation("org.projectnessie.buildsupport:checkstyle:$nessieVer")
   implementation("org.projectnessie.buildsupport:errorprone:$nessieVer")

--- a/buildSrc/src/main/kotlin/ProtobufHelperPlugin.kt
+++ b/buildSrc/src/main/kotlin/ProtobufHelperPlugin.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.protobuf.gradle.ProtobufPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.plugins.quality.Checkstyle
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+
+/** Makes the generated sources available to IDEs, disables Checkstyle on generated code. */
+@Suppress("unused")
+class ProtobufHelperPlugin : Plugin<Project> {
+  override fun apply(project: Project): Unit =
+    project.run {
+      apply<ProtobufPlugin>()
+      plugins.withType<ProtobufPlugin>().configureEach {
+        val sourceSets = project.extensions.getByType<JavaPluginExtension>().sourceSets
+
+        val sourceSetJavaMain = sourceSets.getByName("main").java
+        sourceSetJavaMain.srcDir(project.buildDir.resolve("generated/source/proto/main/java"))
+        sourceSetJavaMain.destinationDirectory.set(
+          project.buildDir.resolve("classes/java/generated")
+        )
+
+        val sourceSetJavaTest = sourceSets.getByName("test").java
+        sourceSetJavaTest.srcDir(project.buildDir.resolve("generated/source/proto/test/java"))
+        sourceSetJavaTest.destinationDirectory.set(
+          project.buildDir.resolve("classes/java/generatedTest")
+        )
+      }
+
+      tasks.withType(Checkstyle::class.java).configureEach {
+        exclude("org/projectnessie/**/*Types.java")
+      }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ parquet = "1.12.3"
 picocli = "4.7.0"
 postgresContainerTag = "14"
 protobuf = "3.21.9"
+protobufPlugin = "0.8.19"
 quarkus = "2.14.0.Final"
 quarkusAmazon = "2.14.0.Final"
 quarkusLoggingSentry = "1.2.1"
@@ -208,7 +209,6 @@ nessie-build-ide-integration = { id = "org.projectnessie.buildsupport.ide-integr
 nessie-build-jacoco = { id = "org.projectnessie.buildsupport.jacoco", version.ref = "nessieBuildPlugins" }
 nessie-build-jacoco-aggregator = { id = "org.projectnessie.buildsupport.jacoco-aggregator", version.ref = "nessieBuildPlugins" }
 nessie-build-jandex = { id = "org.projectnessie.buildsupport.jandex", version.ref = "nessieBuildPlugins" }
-nessie-build-protobuf = { id = "org.projectnessie.buildsupport.protobuf", version.ref = "nessieBuildPlugins" }
 nessie-build-publishing = { id = "org.projectnessie.buildsupport.publishing", version.ref = "nessieBuildPlugins" }
 nessie-build-reflectionconfig = { id = "org.projectnessie.buildsupport.reflectionconfig", version.ref = "nessieBuildPlugins" }
 nessie-build-smallrye-open-api = { id = "org.projectnessie.smallrye-open-api", version.ref = "nessieBuildPlugins" }
@@ -216,6 +216,7 @@ nessie-build-spotless = { id = "org.projectnessie.buildsupport.spotless", versio
 nessie-run = { id = "org.projectnessie", version = "0.27.3" }
 nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version = "1.1.0" }
 node-gradle = { id = "com.github.node-gradle.node", version = "3.5.0" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 quarkus = { id = "io.quarkus", version.ref = "quarkus" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadowPlugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }

--- a/servers/store-proto/build.gradle.kts
+++ b/servers/store-proto/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
 
 plugins {
@@ -21,9 +22,10 @@ plugins {
   `maven-publish`
   signing
   id("org.projectnessie.buildsupport.reflectionconfig")
-  id("org.projectnessie.buildsupport.protobuf")
   `nessie-conventions`
 }
+
+apply<ProtobufHelperPlugin>()
 
 extra["maven.name"] = "Nessie - Server - Store (Proto)"
 
@@ -33,7 +35,7 @@ dependencies { api(libs.protobuf.java) }
 // submodule
 protobuf {
   // Configure the protoc executable
-  protobuf.protoc {
+  protoc {
     // Download from repositories
     artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
   }

--- a/versioned/persist/serialize-proto/build.gradle.kts
+++ b/versioned/persist/serialize-proto/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
 
 plugins {
@@ -21,9 +22,10 @@ plugins {
   `maven-publish`
   signing
   id("org.projectnessie.buildsupport.reflectionconfig")
-  id("org.projectnessie.buildsupport.protobuf")
   `nessie-conventions`
 }
+
+apply<ProtobufHelperPlugin>()
 
 extra["maven.name"] = "Nessie - Versioned - Persist - Serialization (Proto)"
 
@@ -33,7 +35,7 @@ dependencies { api(libs.protobuf.java) }
 // submodule
 protobuf {
   // Configure the protoc executable
-  protobuf.protoc {
+  protoc {
     // Download from repositories
     artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
   }

--- a/versioned/transfer-proto/build.gradle.kts
+++ b/versioned/transfer-proto/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
 
 plugins {
@@ -21,9 +22,10 @@ plugins {
   `maven-publish`
   signing
   id("org.projectnessie.buildsupport.reflectionconfig")
-  id("org.projectnessie.buildsupport.protobuf")
   `nessie-conventions`
 }
+
+apply<ProtobufHelperPlugin>()
 
 extra["maven.name"] = "Nessie - Export/Import - Serialization (Proto)"
 
@@ -31,7 +33,7 @@ dependencies { implementation(libs.protobuf.java) }
 
 protobuf {
   // Configure the protoc executable
-  protobuf.protoc {
+  protoc {
     // Download from repositories
     artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
   }


### PR DESCRIPTION
Pull `ProtobufHelperPlugin` from `gradle-build-plugins` and hence remove one dependency on the "meta-plugin". This also prepares the version bump of the protobuf plugin to 0.9.1.