### PR TITLE
python: fix lint with new mypy version

### DIFF
--- a/python/pynessie/__init__.py
+++ b/python/pynessie/__init__.py
@@ -14,6 +14,7 @@
 #
 """Top-level package for Python API and CLI for Nessie."""
 import os
+from typing import Optional
 
 import confuse
 
@@ -25,14 +26,14 @@ __email__ = "nessie-release-builder@dremio.com"
 __version__ = "0.44.1"
 
 
-def get_config(config_dir: str = None, args: dict = None) -> confuse.Configuration:
+def get_config(config_dir: Optional[str] = None, args: Optional[dict] = None) -> confuse.Configuration:
     """Retrieve a confuse Configuration object."""
     if config_dir:
         os.environ["NESSIE_CLIENTDIR"] = config_dir
     return build_config(args)
 
 
-def init(config_dir: str = None, config_dict: dict = None) -> NessieClient:
+def init(config_dir: Optional[str] = None, config_dict: Optional[dict] = None) -> NessieClient:
     """Create a new Nessie client object.
 
     :param config_dir: optional directory to look for config in

--- a/python/pynessie/auth/aws.py
+++ b/python/pynessie/auth/aws.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 #
 """Use AWS4Auth and botocore to fetch credentials and sign requests."""
+from typing import Optional
+
 from botocore.credentials import get_credentials
 from botocore.session import Session
 from requests_aws4auth import AWS4Auth
 
 
-def setup_aws_auth(region: str, profile: str = None) -> AWS4Auth:
+def setup_aws_auth(region: str, profile: Optional[str] = None) -> AWS4Auth:
     """For a given region sign a request to the execute-api with standard credentials."""
     credentials = get_credentials(Session(profile=profile))
     auth = AWS4Auth(credentials.access_key, credentials.secret_key, region, "execute-api", session_token=credentials.token)

--- a/python/pynessie/client/_endpoints.py
+++ b/python/pynessie/client/_endpoints.py
@@ -44,7 +44,7 @@ def _get_headers(has_body: bool = False) -> dict:
 
 
 def _get(
-    url: str, auth: Optional[AuthBase], ssl_verify: bool = True, params: dict = None, timeout_sec: Optional[int] = None
+    url: str, auth: Optional[AuthBase], ssl_verify: bool = True, params: Optional[dict] = None, timeout_sec: Optional[int] = None
 ) -> Union[str, dict, list]:
     timeout_sec = _sanitize_timeout(timeout_sec)
     r = requests.get(url, headers=_get_headers(), verify=ssl_verify, params=params, auth=auth, timeout=timeout_sec)
@@ -54,9 +54,9 @@ def _get(
 def _post(
     url: str,
     auth: Optional[AuthBase],
-    json: Union[str, dict] = None,
+    json: Union[str, dict, None] = None,
     ssl_verify: bool = True,
-    params: dict = None,
+    params: Optional[dict] = None,
     timeout_sec: Optional[int] = None,
 ) -> Union[str, dict, list]:
     timeout_sec = _sanitize_timeout(timeout_sec)
@@ -69,7 +69,7 @@ def _post(
 
 
 def _delete(
-    url: str, auth: Optional[AuthBase], ssl_verify: bool = True, params: dict = None, timeout_sec: Optional[int] = None
+    url: str, auth: Optional[AuthBase], ssl_verify: bool = True, params: Optional[dict] = None, timeout_sec: Optional[int] = None
 ) -> Union[str, dict, list]:
     timeout_sec = _sanitize_timeout(timeout_sec)
     r = requests.delete(url, headers=_get_headers(), verify=ssl_verify, params=params, auth=auth, timeout=timeout_sec)
@@ -79,9 +79,9 @@ def _delete(
 def _put(
     url: str,
     auth: Optional[AuthBase],
-    json: Union[str, dict] = None,
+    json: Union[str, dict, None] = None,
     ssl_verify: bool = True,
-    params: dict = None,
+    params: Optional[dict] = None,
     timeout_sec: Optional[int] = None,
 ) -> Any:
     timeout_sec = _sanitize_timeout(timeout_sec)
@@ -141,7 +141,9 @@ def get_reference(base_url: str, auth: Optional[AuthBase], ref: str, ssl_verify:
     return cast(dict, _get(base_url + "/trees/tree/{}".format(ref), auth, ssl_verify=ssl_verify))
 
 
-def create_reference(base_url: str, auth: Optional[AuthBase], ref_json: dict, source_ref: str = None, ssl_verify: bool = True) -> dict:
+def create_reference(
+    base_url: str, auth: Optional[AuthBase], ref_json: dict, source_ref: Optional[str] = None, ssl_verify: bool = True
+) -> dict:
     """Create a reference.
 
     :param base_url: base Nessie url

--- a/python/pynessie/client/nessie_client.py
+++ b/python/pynessie/client/nessie_client.py
@@ -110,7 +110,7 @@ class NessieClient:
         ref = ReferenceSchema().load(ref_obj)
         return ref
 
-    def create_branch(self, branch: str, ref: str = None, hash_on_ref: str = None) -> Branch:
+    def create_branch(self, branch: str, ref: Optional[str] = None, hash_on_ref: Optional[str] = None) -> Branch:
         """Create a branch.
 
         :param branch: name of new branch to create
@@ -130,7 +130,7 @@ class NessieClient:
         """
         delete_branch(self._base_url, self._auth, branch, hash_, self._ssl_verify)
 
-    def create_tag(self, tag: str, ref: str, hash_on_ref: str = None) -> Tag:
+    def create_tag(self, tag: str, ref: str, hash_on_ref: Optional[str] = None) -> Tag:
         """Create a tag.
 
         :param tag: name of new tag to create
@@ -153,7 +153,7 @@ class NessieClient:
     def list_keys(
         self,
         ref: str,
-        hash_on_ref: str = None,
+        hash_on_ref: Optional[str] = None,
         max_result_hint: Optional[int] = None,
         page_token: Optional[str] = None,
         query_filter: Optional[str] = None,
@@ -203,7 +203,7 @@ class NessieClient:
         ref_obj = commit(self._base_url, self._auth, branch, MultiContentSchema().dumps(MultiContents(meta, list(ops))), old_hash)
         return cast(Branch, ReferenceSchema().load(ref_obj))
 
-    def _assign_to(self, to_ref: str, to_ref_hash: str = None) -> Reference:
+    def _assign_to(self, to_ref: str, to_ref_hash: Optional[str] = None) -> Reference:
         ref_name, ref_hash = split_into_reference_and_hash(to_ref)
 
         if ref_hash and to_ref_hash and ref_hash != to_ref_hash:
@@ -223,7 +223,7 @@ class NessieClient:
 
         return ref
 
-    def assign_branch(self, branch: str, to_ref: str, to_ref_hash: str = None, old_hash: Optional[str] = None) -> None:
+    def assign_branch(self, branch: str, to_ref: str, to_ref_hash: Optional[str] = None, old_hash: Optional[str] = None) -> None:
         """Assign a hash to a branch."""
         if not old_hash:
             old_hash = self.get_reference(branch).hash_
@@ -231,7 +231,7 @@ class NessieClient:
         ref_json = ReferenceSchema().dumps(self._assign_to(to_ref, to_ref_hash))
         assign_branch(self._base_url, self._auth, branch, ref_json, old_hash, self._ssl_verify)
 
-    def assign_tag(self, tag: str, to_ref: str, to_ref_hash: str = None, old_hash: Optional[str] = None) -> None:
+    def assign_tag(self, tag: str, to_ref: str, to_ref_hash: Optional[str] = None, old_hash: Optional[str] = None) -> None:
         """Assign a hash to a tag."""
         if not old_hash:
             old_hash = self.get_reference(tag).hash_

--- a/python/pynessie/conf/config_parser.py
+++ b/python/pynessie/conf/config_parser.py
@@ -14,6 +14,7 @@
 #
 """Parser for confuse Configuration object."""
 import os
+from typing import Optional
 
 import confuse
 
@@ -29,7 +30,7 @@ def _get_env_args() -> dict:
     return args
 
 
-def build_config(args: dict = None) -> confuse.Configuration:
+def build_config(args: Optional[dict] = None) -> confuse.Configuration:
     """Build configuration object from input params, env variables and yaml file."""
     config = confuse.Configuration("nessie", __name__)
     env_args = _get_env_args()

--- a/python/pynessie/error.py
+++ b/python/pynessie/error.py
@@ -27,7 +27,7 @@ class NessieException(Exception):
         status: int,
         url: str,
         reason: str,
-        msg: str = None,
+        msg: Optional[str] = None,
     ) -> None:
         """Construct base Nessie Exception."""
         if "message" in parsed_response:
@@ -137,7 +137,7 @@ class NessieServerException(NessieException):
 class NessieCliError(Exception):
     """Base Nessie CLI related errors."""
 
-    def __init__(self, title: str, msg: str = None) -> None:
+    def __init__(self, title: str, msg: Optional[str] = None) -> None:
         """Construct base Nessie CLI Error."""
         super().__init__()
 

--- a/python/pynessie/model.py
+++ b/python/pynessie/model.py
@@ -68,7 +68,7 @@ class Content:
 
     def pretty_print(self) -> str:
         """Print out for cli."""
-        pass
+        raise NotImplementedError
 
 
 @attr.dataclass
@@ -209,7 +209,7 @@ class Operation:
 
     def pretty_print(self) -> str:
         """Print out for cli."""
-        pass
+        raise NotImplementedError
 
 
 @attr.dataclass
@@ -245,7 +245,10 @@ DeleteOperationSchema = desert.schema_class(Delete)
 class Unchanged(Operation):
     """Unchanged single key."""
 
-    pass
+    def pretty_print(self) -> str:
+        """Print out for cli."""
+        # pylint: disable=E1101
+        return f"Unchanged of {self.key.to_string()}"
 
 
 UnchangedOperationSchema = desert.schema_class(Unchanged)

--- a/python/requirements_basedev.txt
+++ b/python/requirements_basedev.txt
@@ -25,7 +25,6 @@ pip==22.2.2
 pytest==7.1.3
 pytest-cov==3.0.0
 pytest-mock==3.8.2
-pytest-mypy==0.9.1
 pytest-recording==0.12.1
 tox==3.26.0
 twine==4.0.1

--- a/python/requirements_lint.txt
+++ b/python/requirements_lint.txt
@@ -23,7 +23,8 @@ flake8-bugbear==22.9.23
 flake8-docstrings==1.6.0
 flake8-isort==4.2.0
 isort==5.10.1
-pytest-mypy==0.9.1
+mypy==0.991
+pytest-mypy==0.10.1
 safety==2.2.0
 pylint==2.15.3
 pylintfileheader==0.3.2

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -83,7 +83,7 @@ def ref_hash(ref: str) -> str:
 
 
 def make_commit(
-    key: str, table: Content, branch: str, head_hash: str = None, message: str = "test message", author: str = "nessie test"
+    key: str, table: Content, branch: str, head_hash: Optional[str] = None, message: str = "test message", author: str = "nessie test"
 ) -> None:
     """Make commit through Nessie CLI."""
     if not head_hash:

--- a/python/tests/test_nessie_cli_content.py
+++ b/python/tests/test_nessie_cli_content.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for `content CLI command`."""
-from typing import List
+from typing import List, Optional
 
 import pytest
 import simplejson
@@ -265,7 +265,10 @@ def _create_iceberg_table(
 
 
 def _create_delta_lake_table(
-    table_id: str, metadata_location_history: List[str] = None, checkpoint_location_history: List[str] = None, last_checkpoint: str = "x"
+    table_id: str,
+    metadata_location_history: Optional[List[str]] = None,
+    checkpoint_location_history: Optional[List[str]] = None,
+    last_checkpoint: str = "x",
 ) -> DeltaLakeTable:
     if checkpoint_location_history is None:
         checkpoint_location_history = ["def"]

--- a/python/tests/test_nessie_client.py
+++ b/python/tests/test_nessie_client.py
@@ -40,6 +40,7 @@ def test_client_interface_e2e() -> None:
     assert next(i for i in references if i.name == "test") == Branch("test", main_commit)
     reference = client.get_reference("test")
     assert created_reference == reference
+    assert isinstance(reference.hash_, str)
     tables = client.list_keys(reference.name, reference.hash_)
     assert isinstance(tables, Entries)
     assert len(tables.entries) == 0


### PR DESCRIPTION
mypy was pulled in through pytest-mypy without version constraints, thus we got a hidden upgrade causing linting to fail, due to: https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html

-> No Implicit Optional Types for Arguments

we explicitly pin mypy now and fix all related violations