### PR TITLE
Move tests from o.p.jaxrs to o.p.jaxrs.tests

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestAssign.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestAssign.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestCommitLog.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestCommitLog.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestContents.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestContents.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestDiff.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestDiff.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestEntries.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestEntries.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestInvalid.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestInvalid.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestInvalidRefs.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestInvalidRefs.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestMergeTransplant.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestMergeTransplant.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestMisc.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestMisc.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestNamespace.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestNamespace.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestRefLog.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestRefLog.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestReferences.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestReferences.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractResteasyTest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractResteasyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractTestRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractTestRest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 /**
  * Base test class for Nessie REST APIs.

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractRestAccessChecks.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractRestAccessChecks.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractRestSecurityContext.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractRestSecurityContext.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestDatabaseAdapterRest.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestDatabaseAdapterRest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -24,7 +24,7 @@ import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
 
 /** See {@link AbstractTestRest} for details about and reason for the inheritance model. */
 @ExtendWith(DatabaseAdapterExtension.class)
-abstract class AbstractTestJerseyRest extends AbstractRestSecurityContext {
+abstract class AbstractTestDatabaseAdapterRest extends AbstractRestSecurityContext {
 
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestDatabaseAdapterResteasy.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestDatabaseAdapterResteasy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -29,7 +29,7 @@ import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtens
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
 
 @ExtendWith(DatabaseAdapterExtension.class)
-abstract class AbstractTestJerseyResteasy extends AbstractResteasyTest {
+abstract class AbstractTestDatabaseAdapterResteasy extends AbstractResteasyTest {
 
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyRestDynamo.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyRestDynamo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
-import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
-import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.dynamodb.DynamoDatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.dynamodb.LocalDynamoTestConnectionProviderSource;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
-@NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
-@NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
-class TestJerseyResteasyInMemory extends AbstractTestJerseyResteasy {}
+@NessieDbAdapterName(DynamoDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(LocalDynamoTestConnectionProviderSource.class)
+class ITJerseyRestDynamo extends AbstractTestDatabaseAdapterRest {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyRestMongo.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyRestMongo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
-import org.projectnessie.versioned.persist.rocks.RocksDatabaseAdapterFactory;
-import org.projectnessie.versioned.persist.rocks.RocksTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.mongodb.LocalMongoTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.mongodb.MongoDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
-@NessieDbAdapterName(RocksDatabaseAdapterFactory.NAME)
-@NessieExternalDatabase(RocksTestConnectionProviderSource.class)
-class ITJerseyResteasyRocks extends AbstractTestJerseyResteasy {}
+@NessieDbAdapterName(MongoDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(LocalMongoTestConnectionProviderSource.class)
+class ITJerseyRestMongo extends AbstractTestDatabaseAdapterRest {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyRestRocks.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyRestRocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import org.projectnessie.versioned.persist.rocks.RocksDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.rocks.RocksTestConnectionProviderSource;
@@ -22,4 +22,4 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
 
 @NessieDbAdapterName(RocksDatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(RocksTestConnectionProviderSource.class)
-class ITJerseyRestRocks extends AbstractTestJerseyRest {}
+class ITJerseyRestRocks extends AbstractTestDatabaseAdapterRest {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyResteasyDynamo.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyResteasyDynamo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import org.projectnessie.versioned.persist.dynamodb.DynamoDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.dynamodb.LocalDynamoTestConnectionProviderSource;
@@ -22,4 +22,4 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
 
 @NessieDbAdapterName(DynamoDatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(LocalDynamoTestConnectionProviderSource.class)
-class ITJerseyRestDynamo extends AbstractTestJerseyRest {}
+class ITJerseyResteasyDynamo extends AbstractTestDatabaseAdapterResteasy {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyResteasyMongo.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyResteasyMongo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
+import org.projectnessie.versioned.persist.mongodb.LocalMongoTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.mongodb.MongoDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
-import org.projectnessie.versioned.persist.tx.h2.H2DatabaseAdapterFactory;
-import org.projectnessie.versioned.persist.tx.h2.H2TestConnectionProviderSource;
 
-@NessieDbAdapterName(H2DatabaseAdapterFactory.NAME)
-@NessieExternalDatabase(H2TestConnectionProviderSource.class)
-class TestJerseyRestH2 extends AbstractTestJerseyRest {}
+@NessieDbAdapterName(MongoDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(LocalMongoTestConnectionProviderSource.class)
+class ITJerseyResteasyMongo extends AbstractTestDatabaseAdapterResteasy {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyResteasyRocks.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/ITJerseyResteasyRocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
-import org.projectnessie.client.ext.NessieApiVersions;
-import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
-import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.rocks.RocksDatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.rocks.RocksTestConnectionProviderSource;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
-@NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
-@NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
-@NessieApiVersions // all versions
-class TestJerseyRestInMemory extends AbstractTestJerseyRest {}
+@NessieDbAdapterName(RocksDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(RocksTestConnectionProviderSource.class)
+class ITJerseyResteasyRocks extends AbstractTestDatabaseAdapterResteasy {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyRestH2.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyRestH2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
-import org.projectnessie.versioned.persist.mongodb.LocalMongoTestConnectionProviderSource;
-import org.projectnessie.versioned.persist.mongodb.MongoDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
+import org.projectnessie.versioned.persist.tx.h2.H2DatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.tx.h2.H2TestConnectionProviderSource;
 
-@NessieDbAdapterName(MongoDatabaseAdapterFactory.NAME)
-@NessieExternalDatabase(LocalMongoTestConnectionProviderSource.class)
-class ITJerseyRestMongo extends AbstractTestJerseyRest {}
+@NessieDbAdapterName(H2DatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(H2TestConnectionProviderSource.class)
+class TestJerseyRestH2 extends AbstractTestDatabaseAdapterRest {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyRestInMemory.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyRestInMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
-import org.projectnessie.versioned.persist.mongodb.LocalMongoTestConnectionProviderSource;
-import org.projectnessie.versioned.persist.mongodb.MongoDatabaseAdapterFactory;
+import org.projectnessie.client.ext.NessieApiVersions;
+import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
-@NessieDbAdapterName(MongoDatabaseAdapterFactory.NAME)
-@NessieExternalDatabase(LocalMongoTestConnectionProviderSource.class)
-class ITJerseyResteasyMongo extends AbstractTestJerseyResteasy {}
+@NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
+@NessieApiVersions // all versions
+class TestJerseyRestInMemory extends AbstractTestDatabaseAdapterRest {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyRestNaiveClientInMemory.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyRestNaiveClientInMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.client.http.impl.HttpUtils.HEADER_ACCEPT;
@@ -44,7 +44,7 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
  */
 @NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
-class TestJerseyRestNaiveClientInMemory extends AbstractTestJerseyRest
+class TestJerseyRestNaiveClientInMemory extends AbstractTestDatabaseAdapterRest
     implements NessieClientCustomizer {
 
   private boolean headersProcessed;

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyResteasyH2.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyResteasyH2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
@@ -22,4 +22,4 @@ import org.projectnessie.versioned.persist.tx.h2.H2TestConnectionProviderSource;
 
 @NessieDbAdapterName(H2DatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(H2TestConnectionProviderSource.class)
-class TestJerseyResteasyH2 extends AbstractTestJerseyResteasy {}
+class TestJerseyResteasyH2 extends AbstractTestDatabaseAdapterResteasy {}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyResteasyInMemory.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestJerseyResteasyInMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2022 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.jaxrs;
+package org.projectnessie.jaxrs.tests;
 
-import org.projectnessie.versioned.persist.dynamodb.DynamoDatabaseAdapterFactory;
-import org.projectnessie.versioned.persist.dynamodb.LocalDynamoTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
 import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
 
-@NessieDbAdapterName(DynamoDatabaseAdapterFactory.NAME)
-@NessieExternalDatabase(LocalDynamoTestConnectionProviderSource.class)
-class ITJerseyResteasyDynamo extends AbstractTestJerseyResteasy {}
+@NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
+class TestJerseyResteasyInMemory extends AbstractTestDatabaseAdapterResteasy {}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestQuarkusRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractTestQuarkusRest.java
@@ -16,7 +16,7 @@
 package org.projectnessie.server;
 
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.projectnessie.jaxrs.AbstractTestRest;
+import org.projectnessie.jaxrs.tests.AbstractTestRest;
 
 /**
  * Tests need to subclass this class and use @QuarkusIntegrationTest or @QuarkusTest, so that the

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyDynamo.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyDynamo.java
@@ -17,7 +17,7 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractResteasyTest;
+import org.projectnessie.jaxrs.tests.AbstractResteasyTest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileDynamo;
 
 @QuarkusIntegrationTest

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyInMemory.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyInMemory.java
@@ -17,7 +17,7 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractResteasyTest;
+import org.projectnessie.jaxrs.tests.AbstractResteasyTest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 
 @QuarkusIntegrationTest

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyMongo.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyMongo.java
@@ -17,7 +17,7 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractResteasyTest;
+import org.projectnessie.jaxrs.tests.AbstractResteasyTest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileMongo;
 
 @QuarkusIntegrationTest

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyPostgres.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyPostgres.java
@@ -17,7 +17,7 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractResteasyTest;
+import org.projectnessie.jaxrs.tests.AbstractResteasyTest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfilePostgres;
 
 @QuarkusIntegrationTest

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyRocks.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyRocks.java
@@ -17,7 +17,7 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractResteasyTest;
+import org.projectnessie.jaxrs.tests.AbstractResteasyTest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileRocks;
 
 @QuarkusIntegrationTest

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestResteasyInMemory.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestResteasyInMemory.java
@@ -17,7 +17,7 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import org.projectnessie.jaxrs.AbstractResteasyTest;
+import org.projectnessie.jaxrs.tests.AbstractResteasyTest;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 
 @QuarkusTest


### PR DESCRIPTION
... and rename two base classes to indicate those use the DatabaseAdapter.