### PR TITLE
Proper put-update-operation for namespace-update

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -254,7 +254,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
 
       Namespace updatedNamespace = ImmutableNamespace.copyOf(namespace).withProperties(properties);
 
-      Put put = Put.of(ContentKey.of(updatedNamespace.getElements()), updatedNamespace);
+      Put put = Put.of(ContentKey.of(updatedNamespace.getElements()), updatedNamespace, namespace);
       commit(
           BranchName.of(refWithHash.getValue().getName()),
           "update properties for namespace " + updatedNamespace.name(),


### PR DESCRIPTION
Nessie `Put` operations must include the _expected_ content, this change adds the existing as the expected content.