### PR TITLE
Refactor Nessie-Jax-RS extension a little bit

### DIFF
--- a/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
+++ b/clients/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
@@ -16,6 +16,7 @@
 package org.apache.iceberg.nessie;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.projectnessie.jaxrs.ext.NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -61,7 +62,7 @@ public class BaseIcebergTest {
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
-  static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
+  static NessieJaxRsExtension server = jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   @TempDir public Path temp;
 

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/identify/TestIdentifyLiveContents.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/identify/TestIdentifyLiveContents.java
@@ -16,6 +16,7 @@
 package org.projectnessie.gc.identify;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.projectnessie.jaxrs.ext.NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter;
 
 import java.time.Instant;
 import java.util.Set;
@@ -31,7 +32,6 @@ import org.projectnessie.gc.contents.LiveContentSetsRepository;
 import org.projectnessie.gc.contents.inmem.InMemoryPersistenceSpi;
 import org.projectnessie.gc.repository.NessieRepositoryConnector;
 import org.projectnessie.gc.repository.RepositoryConnector;
-import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
@@ -51,7 +51,7 @@ public class TestIdentifyLiveContents {
 
   @RegisterExtension
   static org.projectnessie.jaxrs.ext.NessieJaxRsExtension server =
-      new NessieJaxRsExtension(() -> databaseAdapter);
+      jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   private NessieApiV1 nessieApi;
 

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/identify/TestIdentifyLiveContents.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/identify/TestIdentifyLiveContents.java
@@ -32,6 +32,7 @@ import org.projectnessie.gc.contents.LiveContentSetsRepository;
 import org.projectnessie.gc.contents.inmem.InMemoryPersistenceSpi;
 import org.projectnessie.gc.repository.NessieRepositoryConnector;
 import org.projectnessie.gc.repository.RepositoryConnector;
+import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
@@ -50,8 +51,7 @@ public class TestIdentifyLiveContents {
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
-  static org.projectnessie.jaxrs.ext.NessieJaxRsExtension server =
-      jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
+  static NessieJaxRsExtension server = jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   private NessieApiV1 nessieApi;
 

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/repository/TestNessieRepositoryConnector.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/repository/TestNessieRepositoryConnector.java
@@ -40,6 +40,7 @@ import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
@@ -67,8 +68,7 @@ public class TestNessieRepositoryConnector {
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
-  static org.projectnessie.jaxrs.ext.NessieJaxRsExtension server =
-      jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
+  static NessieJaxRsExtension server = jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   private NessieApiV1 nessieApi;
 

--- a/gc/gc-base/src/test/java/org/projectnessie/gc/repository/TestNessieRepositoryConnector.java
+++ b/gc/gc-base/src/test/java/org/projectnessie/gc/repository/TestNessieRepositoryConnector.java
@@ -17,6 +17,7 @@ package org.projectnessie.gc.repository;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
+import static org.projectnessie.jaxrs.ext.NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -39,7 +40,6 @@ import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
@@ -68,7 +68,7 @@ public class TestNessieRepositoryConnector {
 
   @RegisterExtension
   static org.projectnessie.jaxrs.ext.NessieJaxRsExtension server =
-      new NessieJaxRsExtension(() -> databaseAdapter);
+      jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   private NessieApiV1 nessieApi;
 

--- a/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
+++ b/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
@@ -18,6 +18,7 @@ package org.projectnessie.gc.tool;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.projectnessie.jaxrs.ext.NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
@@ -71,7 +72,7 @@ public class TestCLI {
   @InjectSoftAssertions private SoftAssertions soft;
 
   @RegisterExtension
-  static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
+  static NessieJaxRsExtension server = jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   private static URI nessieUri;
 

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
@@ -83,7 +83,8 @@ public class NessieJaxRsExtension extends NessieClientResolver
     throw new UnsupportedOperationException();
   }
 
-  private NessieJaxRsExtension(Supplier<DatabaseAdapter> databaseAdapterSupplier) {
+  @Deprecated
+  public NessieJaxRsExtension(Supplier<DatabaseAdapter> databaseAdapterSupplier) {
     this.databaseAdapterSupplier = databaseAdapterSupplier;
   }
 

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javax.enterprise.inject.spi.Extension;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.SecurityContext;
@@ -82,8 +83,13 @@ public class NessieJaxRsExtension extends NessieClientResolver
     throw new UnsupportedOperationException();
   }
 
-  public NessieJaxRsExtension(Supplier<DatabaseAdapter> databaseAdapterSupplier) {
+  private NessieJaxRsExtension(Supplier<DatabaseAdapter> databaseAdapterSupplier) {
     this.databaseAdapterSupplier = databaseAdapterSupplier;
+  }
+
+  public static NessieJaxRsExtension jaxRsExtensionForDatabaseAdapter(
+      Supplier<DatabaseAdapter> databaseAdapterSupplier) {
+    return new NessieJaxRsExtension(databaseAdapterSupplier);
   }
 
   private EnvHolder getEnv(ExtensionContext extensionContext) {
@@ -107,7 +113,16 @@ public class NessieJaxRsExtension extends NessieClientResolver
             EnvHolder.class,
             key -> {
               try {
-                return new EnvHolder(databaseAdapterSupplier);
+                Extension versionStoreExtension =
+                    PersistVersionStoreExtension.forDatabaseAdapter(
+                        () -> {
+                          DatabaseAdapter databaseAdapter = databaseAdapterSupplier.get();
+                          databaseAdapter.eraseRepo();
+                          databaseAdapter.initializeRepo(SERVER_CONFIG.getDefaultBranch());
+                          return databaseAdapter;
+                        });
+
+                return new EnvHolder(versionStoreExtension);
               } catch (Exception e) {
                 throw new IllegalStateException(e);
               }
@@ -195,20 +210,13 @@ public class NessieJaxRsExtension extends NessieClientResolver
       this.accessChecker = accessChecker;
     }
 
-    public EnvHolder(Supplier<DatabaseAdapter> databaseAdapterSupplier) throws Exception {
+    public EnvHolder(Extension versionStoreExtension) throws Exception {
       weld = new Weld();
       // Let Weld scan all the resources to discover injection points and dependencies
       weld.addPackages(true, TreeApiImpl.class);
       // Inject external beans
       weld.addExtension(new ServerConfigExtension());
-      weld.addExtension(
-          PersistVersionStoreExtension.forDatabaseAdapter(
-              () -> {
-                DatabaseAdapter databaseAdapter = databaseAdapterSupplier.get();
-                databaseAdapter.eraseRepo();
-                databaseAdapter.initializeRepo(SERVER_CONFIG.getDefaultBranch());
-                return databaseAdapter;
-              }));
+      weld.addExtension(versionStoreExtension);
       weld.addExtension(new AuthorizerExtension().setAccessCheckerSupplier(this::createNewChecker));
       weld.initialize();
 

--- a/servers/jax-rs-testextension/src/test/java/org/projectnessie/jaxrs/ext/TestNessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/test/java/org/projectnessie/jaxrs/ext/TestNessieJaxRsExtension.java
@@ -16,6 +16,7 @@
 package org.projectnessie.jaxrs.ext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.jaxrs.ext.NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -41,7 +42,7 @@ class TestNessieJaxRsExtension {
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
-  static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
+  static NessieJaxRsExtension server = jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   private static NessieApiV1 api;
 

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestDatabaseAdapterRest.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestDatabaseAdapterRest.java
@@ -15,9 +15,10 @@
  */
 package org.projectnessie.jaxrs.tests;
 
+import static org.projectnessie.jaxrs.ext.NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter;
+
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
@@ -30,5 +31,5 @@ abstract class AbstractTestDatabaseAdapterRest extends AbstractRestSecurityConte
 
   @RegisterExtension
   static org.projectnessie.jaxrs.ext.NessieJaxRsExtension server =
-      new NessieJaxRsExtension(() -> databaseAdapter);
+      jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 }

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestDatabaseAdapterResteasy.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestDatabaseAdapterResteasy.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.jaxrs.tests;
 
+import static org.projectnessie.jaxrs.ext.NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter;
+
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -34,7 +36,7 @@ abstract class AbstractTestDatabaseAdapterResteasy extends AbstractResteasyTest 
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
-  static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
+  static NessieJaxRsExtension server = jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   @BeforeAll
   static void setup(@NessieClientUri URI uri) {


### PR DESCRIPTION
Uses a "factory method" instead of a constructor, making it less dependent on the "database adapter" code.