### PR TITLE
Add content-info Quarkus CLI command

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
   implementation(libs.protobuf.java)
 
   implementation(libs.findbugs.jsr305)
+  compileOnly(libs.errorprone.annotations)
   compileOnly(libs.microprofile.openapi)
 
   implementation(platform(libs.jackson.bom))

--- a/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/ContentInfo.java
+++ b/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/ContentInfo.java
@@ -166,7 +166,9 @@ public class ContentInfo extends BaseCommand {
             });
       }
 
-      check(head, batch, generator); // check remaining keys
+      if (!batch.isEmpty()) {
+        check(head, batch, generator); // check remaining keys
+      }
     }
   }
 

--- a/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/ContentInfo.java
+++ b/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/ContentInfo.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.cli;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.projectnessie.versioned.persist.adapter.spi.DatabaseAdapterUtil.takeUntilExcludeLast;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.errorprone.annotations.MustBeClosed;
+import com.google.protobuf.ByteString;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.versioned.DetachedRef;
+import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.ReferenceInfo;
+import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
+import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
+import org.projectnessie.versioned.persist.adapter.KeyListEntry;
+import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+import org.projectnessie.versioned.store.DefaultStoreWorker;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "content-info",
+    mixinStandardHelpOptions = true,
+    description = "Get information about how content is stored for a given set of keys.")
+public class ContentInfo extends BaseCommand {
+
+  @CommandLine.Option(
+      names = {"-o", "--output"},
+      description =
+          "JSON output file name or '-' for STDOUT. If not set, per-key status is not reported.")
+  private String outputSpec;
+
+  @CommandLine.Option(
+      names = {"-k", "--key-element"},
+      description =
+          "Elements or a specific content key to check (zero or more). If not set, all current keys will be reported.")
+  private List<String> keyElements;
+
+  @CommandLine.Option(
+      names = {"-B", "--batch"},
+      defaultValue = "1000",
+      description = "The maximum number of keys to process at the same time.")
+  private int batchSize;
+
+  @CommandLine.Option(
+      names = {"-r", "--ref"},
+      description = "Reference name to use (all branches, if not set).")
+  private String ref;
+
+  @CommandLine.Option(
+      names = {"-H", "--hash"},
+      description = "Commit hash to use (defaults to the HEAD of the specified reference).")
+  private String hash;
+
+  @CommandLine.Option(
+      names = {"-s", "--summary"},
+      description = "Print a summary of results to STDOUT (irrespective of the --output option).")
+  private boolean summary;
+
+  private final AtomicInteger keysProcessed = new AtomicInteger();
+  private final AtomicInteger activeGlobalStateEntries = new AtomicInteger();
+  private final AtomicInteger missingContentFound = new AtomicInteger();
+
+  @Override
+  public Integer call() throws Exception {
+    warnOnInMemory();
+
+    if (outputSpec != null) {
+      if ("-".equals(outputSpec)) {
+        check(spec.commandLine().getOut());
+        spec.commandLine().getOut().println();
+      } else {
+        try (PrintWriter out = new PrintWriter(outputSpec, UTF_8)) {
+          check(out);
+        }
+      }
+    } else {
+      check(new PrintWriter(OutputStream.nullOutputStream(), false, UTF_8));
+    }
+
+    if (summary) {
+      spec.commandLine()
+          .getOut()
+          .printf(
+              "Processed %d keys: %d entries have global state; %d missing entries.%n",
+              keysProcessed.get(), activeGlobalStateEntries.get(), missingContentFound.get());
+    }
+
+    return missingContentFound.get() > 0 ? 3 : 0;
+  }
+
+  private void check(PrintWriter out) throws Exception {
+    // Note: Do not use try-with-resources to avoid closing the output. The caller takes care of
+    // that.
+    JsonGenerator generator =
+        new ObjectMapper()
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            .getFactory()
+            .createGenerator(out);
+
+    generator.writeStartArray();
+
+    check(generator);
+
+    generator.writeEndArray();
+    generator.flush();
+  }
+
+  private void check(JsonGenerator generator) throws Exception {
+    try (Stream<ReferenceInfo<ByteString>> heads = heads()) {
+      heads.forEach(
+          head -> {
+            try {
+              check(generator, head);
+            } catch (Exception e) {
+              throw new IllegalStateException(e);
+            }
+          });
+    }
+  }
+
+  private void check(JsonGenerator generator, ReferenceInfo<ByteString> head) throws Exception {
+    if (keyElements != null && !keyElements.isEmpty()) {
+      check(head, Collections.singleton(Key.of(keyElements)), generator);
+    } else {
+      Set<Key> batch = new HashSet<>(batchSize);
+      try (Stream<KeyListEntry> keys =
+          databaseAdapter.keys(head.getHash(), KeyFilterPredicate.ALLOW_ALL)) {
+        keys.forEach(
+            keyListEntry -> {
+              batch.add(keyListEntry.getKey());
+
+              if (batch.size() >= batchSize) {
+                check(head, batch, generator);
+                batch.clear();
+              }
+            });
+      }
+
+      check(head, batch, generator); // check remaining keys
+    }
+  }
+
+  @MustBeClosed
+  private Stream<ReferenceInfo<ByteString>> heads() throws ReferenceNotFoundException {
+    if (hash != null) {
+      return Stream.of(ReferenceInfo.of(Hash.of(hash), DetachedRef.INSTANCE));
+    }
+
+    if (ref != null) {
+      ReferenceInfo<ByteString> refInfo =
+          databaseAdapter.namedRef(serverConfig.getDefaultBranch(), GetNamedRefsParams.DEFAULT);
+      return Stream.of(refInfo);
+    }
+
+    return databaseAdapter.namedRefs(GetNamedRefsParams.DEFAULT);
+  }
+
+  private void check(ReferenceInfo<ByteString> head, Set<Key> keys, JsonGenerator generator) {
+    try {
+      AtomicInteger distanceFromHead = new AtomicInteger();
+      try (Stream<CommitLogEntry> commitLog = databaseAdapter.commitLog(head.getHash());
+          Stream<CommitLogEntry> filteredLog =
+              takeUntilExcludeLast(commitLog, e -> keys.isEmpty())) {
+        filteredLog.forEach(
+            commitLogEntry -> {
+              commitLogEntry
+                  .getPuts()
+                  .forEach(
+                      keyWithBytes -> {
+                        if (keys.remove(keyWithBytes.getKey())) {
+                          report(
+                              generator,
+                              head.getNamedRef().getName(),
+                              keyWithBytes.getKey(),
+                              keyWithBytes,
+                              commitLogEntry,
+                              distanceFromHead.get(),
+                              null);
+                        }
+                      });
+              distanceFromHead.incrementAndGet();
+            });
+      }
+    } catch (Exception e) {
+      keys.forEach(k -> report(generator, head.getNamedRef().getName(), k, null, null, -1, e));
+      return;
+    }
+
+    missingContentFound.addAndGet(keys.size());
+    keys.forEach(
+        k ->
+            report(
+                generator,
+                head.getNamedRef().getName(),
+                k,
+                null,
+                null,
+                -1,
+                new IllegalArgumentException("Missing content")));
+  }
+
+  private void report(
+      JsonGenerator generator,
+      String referenceName,
+      Key key,
+      KeyWithBytes value,
+      CommitLogEntry entry,
+      long distanceFromHead,
+      Throwable error) {
+    keysProcessed.incrementAndGet();
+
+    ImmutableContentInfoEntry.Builder builder = ImmutableContentInfoEntry.builder();
+    builder.reference(referenceName);
+    builder.key(ContentKey.of(key.getElements()));
+    builder.distanceFromHead(distanceFromHead);
+
+    if (entry != null) {
+      builder.distanceFromRoot(entry.getCommitSeq());
+      builder.hash(entry.getHash().asString());
+    }
+
+    Content.Type type = Content.Type.UNKNOWN;
+    String storageModel = "UNKNOWN";
+
+    if (error == null && entry != null) {
+      try {
+        type = DefaultStoreWorker.instance().getType(value.getPayload(), value.getValue());
+        boolean globalState =
+            DefaultStoreWorker.instance().requiresGlobalState(value.getPayload(), value.getValue());
+        if (globalState) {
+          activeGlobalStateEntries.incrementAndGet();
+          storageModel = "GLOBAL_STATE";
+        } else {
+          storageModel = "ON_REF_STATE";
+        }
+      } catch (Exception ex) {
+        error = ex;
+      }
+    }
+
+    builder.type(type);
+    builder.storageModel(storageModel);
+
+    if (error != null) {
+      builder.errorMessage(error.getMessage());
+
+      try (StringWriter wr = new StringWriter();
+          PrintWriter pw = new PrintWriter(wr)) {
+        error.printStackTrace(pw);
+        pw.flush();
+        builder.exceptionStackTrace(wr.toString());
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    try {
+      generator.writeObject(builder.build());
+
+      // Write a new line after each object to make monitoring I/O more pleasant and predictable
+      Object out = generator.getOutputTarget();
+      if (out instanceof PrintWriter) {
+        ((PrintWriter) out).println();
+      }
+      generator.flush();
+
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/ContentInfoEntry.java
+++ b/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/ContentInfoEntry.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.cli;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableContentInfoEntry.class)
+@JsonDeserialize(as = ImmutableContentInfoEntry.class)
+public interface ContentInfoEntry {
+
+  String getReference();
+
+  String getStorageModel();
+
+  ContentKey getKey();
+
+  Content.Type getType();
+
+  @JsonInclude(NON_EMPTY)
+  @Nullable
+  String getHash();
+
+  @JsonInclude(NON_EMPTY)
+  @Nullable
+  Long getDistanceFromRoot();
+
+  @JsonInclude(NON_EMPTY)
+  @Nullable
+  Long getDistanceFromHead();
+
+  @JsonInclude(NON_EMPTY)
+  @Nullable
+  String getErrorMessage();
+
+  @JsonInclude(NON_EMPTY)
+  @Nullable
+  String getExceptionStackTrace();
+}

--- a/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/NessieCli.java
+++ b/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/NessieCli.java
@@ -31,6 +31,7 @@ import picocli.CommandLine.HelpCommand;
       RepoMaintenance.class,
       HelpCommand.class,
       CheckContent.class,
+      ContentInfo.class,
       EraseRepository.class,
       ExportRepository.class,
       ImportRepository.class

--- a/servers/quarkus-cli/src/test/java/org/projectnessie/quarkus/cli/BaseContentTest.java
+++ b/servers/quarkus-cli/src/test/java/org/projectnessie/quarkus/cli/BaseContentTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.cli;
+
+import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.io.TempDir;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.CommitMetaSerializer;
+import org.projectnessie.versioned.Key;
+import org.projectnessie.versioned.persist.adapter.ContentId;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
+import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+import org.projectnessie.versioned.store.DefaultStoreWorker;
+
+abstract class BaseContentTest<OutputType> {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final Class<OutputType> outputClass;
+
+  @TempDir File tempDir;
+
+  protected LaunchResult result;
+  protected List<OutputType> entries;
+
+  BaseContentTest(Class<OutputType> outputClass) {
+    this.outputClass = outputClass;
+  }
+
+  protected void launchNoFile(QuarkusMainLauncher launcher, String... args) {
+    launch(launcher, null, args);
+  }
+
+  protected void launch(QuarkusMainLauncher launcher, String... args) throws Exception {
+    File output = new File(tempDir, "check-content.json");
+    launch(launcher, output, args);
+    JavaType type = MAPPER.getTypeFactory().constructCollectionType(List.class, outputClass);
+    entries = MAPPER.readValue(output, type);
+  }
+
+  private void launch(QuarkusMainLauncher launcher, File outputFile, String... args) {
+    List<String> cmdArgs = new ArrayList<>(Arrays.asList(args));
+
+    if (outputFile != null) {
+      cmdArgs.add("--output");
+      cmdArgs.add(outputFile.getAbsolutePath());
+    }
+
+    result = launcher.launch(cmdArgs.toArray(new String[0]));
+  }
+
+  protected void commit(IcebergTable table, DatabaseAdapter adapter) throws Exception {
+    commit(table, adapter, DefaultStoreWorker.instance().toStoreOnReferenceState(table, att -> {}));
+  }
+
+  protected void commit(IcebergTable table, DatabaseAdapter adapter, ByteString serialized)
+      throws Exception {
+    commit(table.getId(), payloadForContent(table), serialized, adapter);
+  }
+
+  protected void commit(String testId, byte payload, ByteString value, DatabaseAdapter adapter)
+      throws Exception {
+    Key key = Key.of("test_namespace", "table_" + testId);
+    ContentId id = ContentId.of(testId);
+
+    adapter.commit(
+        ImmutableCommitParams.builder()
+            .toBranch(BranchName.of("main"))
+            .commitMetaSerialized(
+                CommitMetaSerializer.METADATA_SERIALIZER.toBytes(CommitMeta.fromMessage(testId)))
+            .addPuts(KeyWithBytes.of(key, id, payload, value))
+            .build());
+  }
+}

--- a/servers/quarkus-cli/src/test/java/org/projectnessie/quarkus/cli/ITContentInfo.java
+++ b/servers/quarkus-cli/src/test/java/org/projectnessie/quarkus/cli/ITContentInfo.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.server.store.proto.ObjectTypes;
+import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.ReferenceInfo;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+
+@QuarkusMainTest
+@TestProfile(QuarkusCliTestProfileMongo.class)
+@ExtendWith(NessieCliTestExtension.class)
+class ITContentInfo extends BaseContentTest<ContentInfoEntry> {
+
+  private static final IcebergTable table1 = IcebergTable.of("meta_111", 1, 2, 3, 4, "111");
+  private static final IcebergTable table2 = IcebergTable.of("meta_222", 2, 3, 4, 5, "222");
+  private static final IcebergTable table3 = IcebergTable.of("meta_333", 2, 3, 4, 5, "333");
+
+  ITContentInfo() {
+    super(ContentInfoEntry.class);
+  }
+
+  @Test
+  public void testEmptyRepo(QuarkusMainLauncher launcher) {
+    launchNoFile(launcher, "content-info");
+    assertThat(result.exitCode()).isEqualTo(0);
+  }
+
+  @Test
+  public void testNonExistingKey(QuarkusMainLauncher launcher) throws Exception {
+    launch(launcher, "content-info", "-k", "namespace123", "-k", "unknown12345");
+    assertThat(entries).hasSize(1);
+    assertThat(entries)
+        .first()
+        .extracting(ContentInfoEntry::getKey, ContentInfoEntry::getErrorMessage)
+        .containsExactly(ContentKey.of("namespace123", "unknown12345"), "Missing content");
+    assertThat(result.exitCode()).isEqualTo(3);
+  }
+
+  @Test
+  public void testDetached(QuarkusMainLauncher launcher, DatabaseAdapter adapter) throws Exception {
+    commit(table1, adapter);
+
+    ReferenceInfo<ByteString> main = adapter.namedRef("main", GetNamedRefsParams.DEFAULT);
+    launch(launcher, "content-info", "--hash", main.getHash().asString());
+    assertThat(entries).hasSize(1);
+    assertThat(entries)
+        .first()
+        .extracting(
+            ContentInfoEntry::getKey,
+            ContentInfoEntry::getReference,
+            ContentInfoEntry::getDistanceFromHead,
+            ContentInfoEntry::getHash)
+        .containsExactly(
+            ContentKey.of("test_namespace", "table_111"),
+            "DETACHED",
+            0L,
+            main.getHash().asString());
+    assertThat(result.exitCode()).isEqualTo(0);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3, 4, 100})
+  public void testValidData(int batchSize, QuarkusMainLauncher launcher, DatabaseAdapter adapter)
+      throws Exception {
+
+    commit(table1, adapter);
+    commit(table2, adapter);
+    commit(table3, adapter);
+
+    launch(launcher, "content-info", "--batch", "" + batchSize);
+    assertThat(entries).hasSize(3);
+    assertThat(entries).allSatisfy(e -> assertThat(e.getStorageModel()).isEqualTo("ON_REF_STATE"));
+    assertThat(entries)
+        .anySatisfy(
+            e -> {
+              assertThat(e.getKey()).isEqualTo(ContentKey.of("test_namespace", "table_111"));
+              assertThat(e.getDistanceFromRoot()).isEqualTo(1);
+              assertThat(e.getDistanceFromHead()).isEqualTo(2);
+            })
+        .anySatisfy(
+            e -> {
+              assertThat(e.getKey()).isEqualTo(ContentKey.of("test_namespace", "table_222"));
+              assertThat(e.getDistanceFromRoot()).isEqualTo(2);
+              assertThat(e.getDistanceFromHead()).isEqualTo(1);
+            })
+        .anySatisfy(
+            e -> {
+              assertThat(e.getKey()).isEqualTo(ContentKey.of("test_namespace", "table_333"));
+              assertThat(e.getDistanceFromRoot()).isEqualTo(3);
+              assertThat(e.getDistanceFromHead()).isEqualTo(0);
+            });
+    assertThat(result.exitCode()).isEqualTo(0);
+  }
+
+  @Test
+  public void testGlobalState(QuarkusMainLauncher launcher, DatabaseAdapter adapter)
+      throws Exception {
+
+    ByteString emptyContent = ObjectTypes.Content.newBuilder().build().toByteString();
+
+    commit(table1, adapter);
+    commit(table2, adapter, emptyContent);
+
+    launch(launcher, "content-info", "--summary");
+    assertThat(entries).hasSize(2);
+    assertThat(entries)
+        .anySatisfy(
+            e -> {
+              assertThat(e.getKey()).isEqualTo(ContentKey.of("test_namespace", "table_111"));
+              assertThat(e.getStorageModel()).isEqualTo("ON_REF_STATE");
+              assertThat(e.getReference()).isEqualTo("main");
+            })
+        .anySatisfy(
+            e -> {
+              assertThat(e.getKey()).isEqualTo(ContentKey.of("test_namespace", "table_222"));
+              assertThat(e.getStorageModel()).isEqualTo("GLOBAL_STATE");
+              assertThat(e.getReference()).isEqualTo("main");
+            });
+    assertThat(result.exitCode()).isEqualTo(0);
+
+    assertThat(result.getOutput())
+        .contains("Processed 2 keys: 1 entries have global state; 0 missing entries.");
+  }
+
+  @Test
+  public void testInvalidData(QuarkusMainLauncher launcher, DatabaseAdapter adapter)
+      throws Exception {
+
+    ByteString invalidContent = ByteString.copyFrom(new byte[] {1, 2, 3});
+
+    commit(table1, adapter);
+    commit(table2, adapter, invalidContent);
+
+    launch(launcher, "content-info");
+    assertThat(entries).hasSize(2);
+    assertThat(entries)
+        .anySatisfy(
+            e -> {
+              assertThat(e.getKey()).isEqualTo(ContentKey.of("test_namespace", "table_111"));
+              assertThat(e.getType()).isEqualTo(Content.Type.ICEBERG_TABLE);
+              assertThat(e.getStorageModel()).isEqualTo("ON_REF_STATE");
+              assertThat(e.getErrorMessage()).isNull();
+            })
+        .anySatisfy(
+            e -> {
+              assertThat(e.getKey()).isEqualTo(ContentKey.of("test_namespace", "table_222"));
+              assertThat(e.getType()).isEqualTo(Content.Type.ICEBERG_TABLE);
+              assertThat(e.getStorageModel()).isEqualTo("UNKNOWN");
+              assertThat(e.getErrorMessage()).isEqualTo("Failure parsing data");
+              assertThat(e.getExceptionStackTrace())
+                  .contains("Protocol message contained an invalid tag");
+            });
+    assertThat(result.exitCode()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
* This command can help to analyse how data is stored in older repositories that was produced by older Nessie versions.

In particular, this command can detect the presence of content objects using the obsolete "global state" storage model.

* Also factor out common test code into BaseContentTest