### PR TITLE
python: ignore unimportant CVE to fix linting

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -43,7 +43,8 @@ commands =
     # flake8 includes black check due to flake8-black
     # flake8 includes isort check which checks for import order due to flake8-isort
     flake8 pynessie tests tools
-    safety check
+    # ignore https://pyup.io/v/51457/f17 -> https://github.com/pytest-dev/py/issues/287
+    safety check --ignore=51457
     pylint --jobs=0 pynessie tests tools
     mypy --install-types --non-interactive -p pynessie -p tests -p tools
 


### PR DESCRIPTION
linting on main branch is currently broken:
```
   +==============================================================================+
   VULNERABILITIES FOUND 
  +==============================================================================+
  
  -> Vulnerability found in py version 1.11.0
     Vulnerability ID: 51457
     Affected spec: <=1.11.0
     ADVISORY: Py throughout 1.11.0 allows remote attackers to conduct a
     ReDoS (Regular expression Denial of Service) attack via a Subversion...
     CVE-2022-42969
     For more information, please visit https://pyup.io/v/51457/f17
  
   Scan was completed. 1 vulnerability was found. 
```
https://github.com/projectnessie/nessie/actions/runs/3494273046/jobs/5849906328