### PR TITLE
Reduce memory pressure during Quarkus CLI integration tests.

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -103,6 +103,14 @@ tasks.withType<QuarkusBuild>().configureEach {
   }
 }
 
+tasks.named<Test>("intTest") {
+  // Quarkus accumulates stuff in QuarkusClassLoader.transformedClasses throughout CLI
+  // re-invocations during testing. Therefore, we restart the test JVM after running 2 test
+  // classes. The number is rather arbitrary since the real factor seems to be the number
+  // of CLI launches performed in the same JVM.
+  setForkEvery(2)
+}
+
 if (withUberJar()) {
   afterEvaluate {
     publishing {

--- a/servers/quarkus-cli/src/main/resources/application.properties
+++ b/servers/quarkus-cli/src/main/resources/application.properties
@@ -62,6 +62,8 @@ quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%X{traceId},
 quarkus.log.category."io.netty".level=WARN
 # Don't log toggling warnings about "FlushCommand errors" + "FlushCommand working again" - see https://github.com/projectnessie/nessie/issues/1500
 quarkus.log.category."io.jaegertracing.internal.reporters".level=ERROR
+# Instruct jacoco to reuse output files to preserve coverage data across multiple test JVM restarts.
+quarkus.jacoco.reuse-data-file=true
 
 # Do not print the banner, because that prints _after_ the CLI output :(
 quarkus.banner.enabled=false


### PR DESCRIPTION
* Restart test JVM after processing 2 test classes

* Make JaCoCo reuse output files to accumulate results across test JVM restarts