### PR TITLE
Add RefreshContent command

### DIFF
--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ContentGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ContentGenerator.java
@@ -27,6 +27,7 @@ import picocli.CommandLine;
       ReadCommits.class,
       ReadReferences.class,
       ReadContent.class,
+      RefreshContent.class,
       CommandLine.HelpCommand.class
     })
 public abstract class ContentGenerator<API extends NessieApiV1> {

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/RefreshContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/RefreshContent.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
+import org.projectnessie.client.api.GetContentBuilder;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.error.BaseNessieClientServerException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Operation;
+import org.projectnessie.model.Reference;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+@Command(
+    name = "content-refresh",
+    mixinStandardHelpOptions = true,
+    description = "Get and Put content objects without changes to refresh their storage model")
+public class RefreshContent extends AbstractCommand {
+
+  @Option(
+      names = {"--input"},
+      description =
+          "Input file name containing a JSON array of 'ContentInfoEntry' objects from 'content-info' CLI command. "
+              + "(if not set, use --key and --ref).")
+  private String input;
+
+  @Option(
+      names = {"-k", "--key"},
+      description =
+          "Key elements to use for loading and refreshing a content object (ignored if --input is set).")
+  private List<String> keyElements;
+
+  @Option(
+      names = {"-r", "--ref"},
+      description =
+          "Branch name for committing refreshed content objects (ignored if --input is set).")
+  private String ref;
+
+  @Option(
+      names = {"-B", "--batch"},
+      defaultValue = "100",
+      description = "The number of keys to process in each batched read operation.")
+  private int batchSize;
+
+  @Option(
+      names = {"-m", "--message"},
+      description = "Commit message to use for each refresh operation (auto-generated if not set).")
+  private String message;
+
+  @Option(
+      names = {"--storage-model"},
+      description =
+          "If set, only those entries that have the specified storage model will be refreshed "
+              + "(ignored if --input is not set).")
+  private String storageModel;
+
+  @Option(
+      names = {"--skip-tags"},
+      description =
+          "If set, input references that are not branches will be ignored (as opposed to reported as errors).")
+  private boolean skipTags;
+
+  @Spec private CommandLine.Model.CommandSpec spec;
+
+  @Override
+  public void execute() throws BaseNessieClientServerException {
+    try (NessieApiV1 api = createNessieApiInstance()) {
+      if (input == null) {
+        Reference reference = api.getReference().refName(ref).get();
+        refresh(api, reference, Collections.singletonList(ContentKey.of(keyElements)));
+      } else {
+        try (FileInputStream inputStream = new FileInputStream(input)) {
+          refresh(api, inputStream);
+        } catch (IOException e) {
+          throw new IllegalStateException(e);
+        }
+      }
+    }
+  }
+
+  private void refresh(NessieApiV1 api, InputStream input) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonParser parser = mapper.createParser(input);
+
+    JsonToken token = parser.nextToken();
+    if (!JsonToken.START_ARRAY.equals(token)) {
+      throw new IllegalArgumentException(
+          "Input data should be a JSON array of 'ContentInfoEntry' objects.");
+    }
+
+    List<JsonNode> batch = new ArrayList<>(batchSize);
+    while (JsonToken.START_OBJECT.equals(parser.nextToken())) {
+      batch.add(parser.readValueAs(JsonNode.class));
+      if (batch.size() >= batchSize) {
+        refresh(api, batch);
+        batch.clear();
+      }
+    }
+
+    if (!batch.isEmpty()) {
+      refresh(api, batch);
+    }
+  }
+
+  private void refresh(NessieApiV1 api, List<JsonNode> batch)
+      throws BaseNessieClientServerException {
+    Map<String, List<ContentKey>> perRef = new HashMap<>();
+    for (JsonNode node : batch) {
+      // Parse according to the structure of org.projectnessie.quarkus.cli.ContentInfoEntry
+      List<String> keyElements = new ArrayList<>();
+      node.required("key")
+          .required("elements")
+          .elements()
+          .forEachRemaining(n -> keyElements.add(n.asText()));
+
+      String refName = node.required("reference").asText();
+
+      String model = node.get("storageModel").asText();
+      if (storageModel != null && !storageModel.equals(model)) {
+        continue;
+      }
+
+      perRef.computeIfAbsent(refName, key -> new ArrayList<>()).add(ContentKey.of(keyElements));
+    }
+
+    for (Map.Entry<String, List<ContentKey>> entry : perRef.entrySet()) {
+      Reference reference = api.getReference().refName(entry.getKey()).get();
+      refresh(api, reference, entry.getValue());
+    }
+  }
+
+  private void refresh(NessieApiV1 api, Reference ref, List<ContentKey> keys)
+      throws BaseNessieClientServerException {
+    if (!(ref instanceof Branch)) {
+      if (skipTags) {
+        spec.commandLine()
+            .getOut()
+            .printf("Skipped %d keys because %s is not a branch.%n", keys.size(), ref);
+        return;
+      } else {
+        throw new IllegalArgumentException("Content can only be refreshed on branches: " + ref);
+      }
+    }
+
+    GetContentBuilder request = api.getContent().reference(ref);
+    keys.forEach(request::key);
+
+    Map<ContentKey, Content> contentMap = request.get();
+
+    commitSameContent(api, (Branch) ref, contentMap);
+  }
+
+  private void commitSameContent(
+      NessieApiV1 api, Branch branch, Map<ContentKey, Content> contentMap)
+      throws BaseNessieClientServerException {
+
+    if (contentMap.isEmpty()) {
+      return;
+    }
+
+    String msg = message == null ? ("Refresh " + contentMap.size() + " key(s)") : message;
+
+    CommitMultipleOperationsBuilder request =
+        api.commitMultipleOperations().branch(branch).commitMeta(CommitMeta.fromMessage(msg));
+
+    for (Map.Entry<ContentKey, Content> entry : contentMap.entrySet()) {
+      Content content = entry.getValue();
+      request.operation(Operation.Put.of(entry.getKey(), content, content));
+    }
+
+    Branch head = request.commit();
+
+    spec.commandLine()
+        .getOut()
+        .printf(
+            "Refreshed %d keys in %s at commit %s%n",
+            contentMap.size(), branch.getName(), head.getHash());
+  }
+}

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITRefreshContent.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/ITRefreshContent.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.api.params.FetchOption;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.Operation;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
+
+public class ITRefreshContent extends AbstractContentGeneratorTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static final ContentKey key1 = ContentKey.of("test", "key1");
+  private static final ContentKey key2 = ContentKey.of("test", "key2");
+  private static final ContentKey key3 = ContentKey.of("test_key3");
+  private static final IcebergTable table1 = IcebergTable.of("meta_111", 1, 2, 3, 4);
+  private static final IcebergTable table2 = IcebergTable.of("meta_222", 1, 2, 3, 4);
+  private static final IcebergTable table3 = IcebergTable.of("meta_333", 1, 2, 3, 4);
+
+  private NessieApiV1 api;
+
+  @BeforeEach
+  void setUp() {
+    api = buildNessieApi();
+  }
+
+  private void create(IcebergTable table, ContentKey key)
+      throws NessieConflictException, NessieNotFoundException {
+    api.commitMultipleOperations()
+        .branch(api.getDefaultBranch())
+        .commitMeta(CommitMeta.fromMessage("test-commit"))
+        .operation(Operation.Put.of(key, table))
+        .commit();
+  }
+
+  private IcebergTable get(ContentKey key) throws NessieNotFoundException {
+    return (IcebergTable) api.getContent().refName("main").key(key).get().get(key);
+  }
+
+  private List<LogResponse.LogEntry> log(int depth) throws NessieNotFoundException {
+    return log(depth, api.getDefaultBranch());
+  }
+
+  private List<LogResponse.LogEntry> log(int depth, Reference ref) throws NessieNotFoundException {
+    return api.getCommitLog().reference(ref).fetch(FetchOption.ALL).stream()
+        .limit(depth)
+        .collect(Collectors.toList());
+  }
+
+  private int runMain(String... args) {
+    List<String> allArgs = new ArrayList<>();
+    allArgs.add("content-refresh");
+    allArgs.add("--uri");
+    allArgs.add(NESSIE_API_URI);
+    allArgs.addAll(Arrays.asList(args));
+
+    return runGeneratorCmd(allArgs.toArray(new String[0])).getExitCode();
+  }
+
+  @Test
+  void refreshOneKey() throws NessieNotFoundException, NessieConflictException {
+    create(table1, key1);
+    IcebergTable stored1 = get(key1);
+
+    assertThat(
+            runMain(
+                "--key",
+                key1.getElements().get(0),
+                "--key",
+                key1.getElements().get(1),
+                "--ref",
+                api.getDefaultBranch().getName()))
+        .isEqualTo(0);
+
+    assertThat(get(key1)).isEqualTo(stored1);
+    assertThat(log(1))
+        .first()
+        .extracting(
+            logEntry -> logEntry.getCommitMeta().getMessage(),
+            logEntry -> Objects.requireNonNull(logEntry.getOperations()).get(0).getKey())
+        .containsExactly("Refresh 1 key(s)", key1);
+  }
+
+  @Test
+  void refreshEmptyBatch() throws NessieNotFoundException {
+    assertThat(runMain("--key", "unknown_key", "--ref", api.getDefaultBranch().getName()))
+        .isEqualTo(0);
+  }
+
+  @Test
+  void skipTags() throws NessieNotFoundException, NessieConflictException {
+    create(table3, key3);
+    IcebergTable stored3 = get(key3);
+
+    String tagName = "testTag_" + UUID.randomUUID();
+    Branch main = api.getDefaultBranch();
+    Reference tag =
+        api.createReference()
+            .reference(Tag.of(tagName, main.getHash()))
+            .sourceRefName(main.getName())
+            .create();
+
+    LogResponse.LogEntry head = log(1, tag).get(0);
+
+    assertThat(runMain("--key", key3.toString(), "--ref", tagName)).isEqualTo(1);
+
+    assertThat(log(1, tag).get(0)).isEqualTo(head); // no new commits
+    assertThat(get(key3)).isEqualTo(stored3);
+
+    assertThat(runMain("--key", key3.toString(), "--ref", tagName, "--skip-tags")).isEqualTo(0);
+
+    assertThat(log(1, tag).get(0)).isEqualTo(head); // still no new commits
+    assertThat(get(key3)).isEqualTo(stored3);
+  }
+
+  private void writeInputFile(File file, String storageModel, ContentKey... keys)
+      throws IOException {
+    String ref = api.getDefaultBranch().getName();
+    MAPPER.writeValue(
+        file,
+        Arrays.stream(keys)
+            .map(
+                k ->
+                    ImmutableMap.of(
+                        "reference",
+                        ref,
+                        "storageModel",
+                        storageModel,
+                        "key",
+                        ImmutableMap.of("elements", k.getElements())))
+            .collect(Collectors.toList()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3, 4, 100})
+  void refreshFromFile(int batchSize, @TempDir File tempDir) throws IOException {
+    create(table1, key1);
+    create(table2, key2);
+    create(table3, key3);
+    IcebergTable stored1 = get(key1);
+    IcebergTable stored2 = get(key2);
+    IcebergTable stored3 = get(key3);
+
+    File input = new File(tempDir, "refresh-keys.json");
+    writeInputFile(input, "TEST_MODEL", key1, key2, key3);
+
+    assertThat(
+            runMain(
+                "--input",
+                input.getAbsolutePath(),
+                "--batch",
+                String.valueOf(batchSize),
+                "--message",
+                "Test refresh message"))
+        .isEqualTo(0);
+
+    assertThat(get(key1)).isEqualTo(stored1);
+    assertThat(get(key2)).isEqualTo(stored2);
+    assertThat(get(key3)).isEqualTo(stored3);
+
+    int numRefreshCommits = (3 / batchSize) + (3 % batchSize > 0 ? 1 : 0);
+
+    assertThat(log(numRefreshCommits))
+        .allSatisfy(
+            logEntry ->
+                assertThat(logEntry.getCommitMeta().getMessage()).isEqualTo("Test refresh message"))
+        .flatExtracting(
+            logEntry ->
+                Objects.requireNonNull(logEntry.getOperations()).stream()
+                    .map(Operation::getKey)
+                    .collect(Collectors.toList()))
+        .containsExactlyInAnyOrder(key1, key2, key3);
+  }
+
+  @Test
+  void refreshWithModelFilter(@TempDir File tempDir) throws IOException {
+    create(table1, key1);
+    IcebergTable stored1 = get(key1);
+
+    File input = new File(tempDir, "refresh-keys-filtered.json");
+    // Note: the "unknown" key will be ignored
+    writeInputFile(input, "GLOBAL_STATE", key1, ContentKey.of("unknown", "key"));
+
+    LogResponse.LogEntry head = log(1).get(0);
+
+    assertThat(
+            runMain(
+                "--input",
+                input.getAbsolutePath(),
+                "--storage-model",
+                "TEST_MODEL" // Note: this does not match input data
+                ))
+        .isEqualTo(0);
+
+    assertThat(get(key1)).isEqualTo(stored1);
+    assertThat(log(1).get(0)).isEqualTo(head); // No extra commits
+
+    assertThat(runMain("--input", input.getAbsolutePath(), "--storage-model", "GLOBAL_STATE"))
+        .isEqualTo(0);
+
+    assertThat(get(key1)).isEqualTo(stored1);
+    LogResponse.LogEntry newHead = log(1).get(0);
+    assertThat(newHead).isNotEqualTo(head); // No extra commits
+    assertThat(Objects.requireNonNull(newHead.getOperations()).get(0).getKey()).isEqualTo(key1);
+  }
+}


### PR DESCRIPTION
The `content-refresh` command of the Content Generator tool can be to reinsert old content objects without modification to cause them to be stored in the most up-to-date and efficient way.

This command is mostly helpful with migrating old "global state" contents to "on reference state".