### PR TITLE
Fix erasing repo descriptions

### DIFF
--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseAdapter.java
@@ -127,8 +127,9 @@ public class MongoDatabaseAdapter
   @Override
   protected void doEraseRepo() {
     client.getGlobalPointers().deleteMany(Filters.eq(globalPointerKey));
+    client.getRepoDesc().deleteMany(Filters.eq(globalPointerKey));
     Bson idPrefixFilter = Filters.eq(ID_REPO_PATH, repositoryId);
-    client.allExceptGlobalPointer().forEach(coll -> coll.deleteMany(idPrefixFilter));
+    client.allWithCompositeId().forEach(coll -> coll.deleteMany(idPrefixFilter));
   }
 
   private Document toId(Hash id) {

--- a/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseClient.java
+++ b/versioned/persist/mongodb/src/main/java/org/projectnessie/versioned/persist/mongodb/MongoDatabaseClient.java
@@ -145,9 +145,8 @@ public class MongoDatabaseClient implements DatabaseConnectionProvider<MongoClie
     return attachmentKeys;
   }
 
-  public Stream<MongoCollection<Document>> allExceptGlobalPointer() {
+  public Stream<MongoCollection<Document>> allWithCompositeId() {
     return Stream.of(
-        repoDesc,
         globalLog,
         commitLog,
         keyLists,

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDatabaseAdapter.java
@@ -124,8 +124,9 @@ public class RocksDatabaseAdapter
   protected void doEraseRepo() {
     try {
       db.delete(dbInstance.getCfGlobalPointer(), globalPointerKey());
+      db.delete(dbInstance.getCfRepoProps(), globalPointerKey());
       dbInstance
-          .allExceptGlobalPointer()
+          .allWithCompositeKey()
           .forEach(
               cf -> {
                 try (RocksIterator iter = db.newIterator(cf)) {

--- a/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDbInstance.java
+++ b/versioned/persist/rocks/src/main/java/org/projectnessie/versioned/persist/rocks/RocksDbInstance.java
@@ -213,7 +213,7 @@ public class RocksDbInstance implements DatabaseConnectionProvider<RocksDbConfig
     return cfAttachmentKeys;
   }
 
-  public Stream<ColumnFamilyHandle> allExceptGlobalPointer() {
+  public Stream<ColumnFamilyHandle> allWithCompositeKey() {
     return Stream.of(
         cfGlobalLog,
         cfCommitLog,

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRepoDescription.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRepoDescription.java
@@ -69,4 +69,21 @@ public abstract class AbstractRepoDescription {
         });
     assertThat(databaseAdapter.fetchRepositoryDescription()).isEqualTo(update2);
   }
+
+  @Test
+  void emptyAfterEraseRepo() throws Exception {
+    RepoDescription update =
+        RepoDescription.builder().repoVersion(43).putProperties("e", "f").build();
+
+    databaseAdapter.updateRepositoryDescription(
+        d -> {
+          assertThat(d).isEqualTo(RepoDescription.DEFAULT);
+          return update;
+        });
+
+    assertThat(databaseAdapter.fetchRepositoryDescription()).isEqualTo(update);
+
+    databaseAdapter.eraseRepo();
+    assertThat(databaseAdapter.fetchRepositoryDescription()).isEqualTo(RepoDescription.DEFAULT);
+  }
 }


### PR DESCRIPTION
Mongo and RocksDB adapters used to miss the right rows due to key mismatch.

Add a dedicated test case.