### PR TITLE
Content generator: allow functional key patterns and more

### DIFF
--- a/tools/content-generator/build.gradle.kts
+++ b/tools/content-generator/build.gradle.kts
@@ -43,6 +43,10 @@ dependencies {
   implementation(libs.jackson.annotations)
   implementation(libs.jackson.databind)
 
+  compileOnly(libs.immutables.builder)
+  compileOnly(libs.immutables.value.annotations)
+  annotationProcessor(libs.immutables.value.processor)
+
   testCompileOnly(libs.microprofile.openapi)
 
   testImplementation(platform(libs.junit.bom))

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
@@ -216,10 +216,10 @@ public class GenerateContent extends AbstractCommand {
                         .authorTime(Instant.now())
                         .build());
         for (ContentKey key : keys) {
-          Content ex = existing.get(key);
-          Content newContents = createContents(ex, random);
-          if (ex instanceof IcebergTable || ex instanceof IcebergView) {
-            commit.operation(Put.of(key, newContents, ex));
+          Content existingContent = existing.get(key);
+          Content newContents = createContents(existingContent, random);
+          if (existingContent instanceof IcebergTable || existingContent instanceof IcebergView) {
+            commit.operation(Put.of(key, newContents, existingContent));
           } else {
             commit.operation(Put.of(key, newContents));
           }

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
@@ -15,6 +15,10 @@
  */
 package org.projectnessie.tools.contentgenerator.cli;
 
+import static java.util.stream.Collectors.toList;
+import static org.projectnessie.model.ContentKey.fromPathString;
+import static org.projectnessie.tools.contentgenerator.keygen.KeyGenerator.newKeyGenerator;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -22,15 +26,18 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.validation.constraints.Min;
 import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.error.BaseNessieClientServerException;
+import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
@@ -44,6 +51,7 @@ import org.projectnessie.model.ImmutableIcebergView;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Tag;
 import org.projectnessie.model.types.ContentTypes;
+import org.projectnessie.tools.contentgenerator.keygen.KeyGenerator;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ITypeConverter;
 import picocli.CommandLine.Model.CommandSpec;
@@ -103,6 +111,15 @@ public class GenerateContent extends AbstractCommand {
       converter = ContentTypeConverter.class)
   private Content.Type contentType;
 
+  @Option(names = "--key-pattern")
+  private String keyPattern;
+
+  @Option(names = "--puts-per-commit", defaultValue = "1")
+  private int putsPerCommit;
+
+  @Option(names = "--continue-on-error", defaultValue = "false")
+  private boolean continueOnError;
+
   @Spec private CommandSpec spec;
 
   @Override
@@ -123,15 +140,7 @@ public class GenerateContent extends AbstractCommand {
     String runStartTime =
         DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss").format(LocalDateTime.now());
 
-    List<ContentKey> tableNames =
-        IntStream.range(0, numTables)
-            .mapToObj(
-                i ->
-                    ContentKey.of(
-                        String.format("create-contents-%s", runStartTime),
-                        "contents",
-                        Integer.toString(i)))
-            .collect(Collectors.toList());
+    List<ContentKey> tableNames = generateTableNames(runStartTime);
 
     try (NessieApiV1 api = createNessieApiInstance()) {
       Branch defaultBranch;
@@ -173,23 +182,27 @@ public class GenerateContent extends AbstractCommand {
           .getOut()
           .printf("Starting contents generation, %d commits...%n", numCommits);
 
-      for (int i = 0; i < numCommits; i++) {
+      for (int commitNum = 0; commitNum < numCommits; commitNum++) {
         // Choose a random branch to commit to
         String branchName = branches.get(random.nextInt(branches.size()));
 
         Branch commitToBranch = (Branch) api.getReference().refName(branchName).get();
 
-        ContentKey tableName = tableNames.get(random.nextInt(tableNames.size()));
+        List<ContentKey> keys =
+            IntStream.range(0, putsPerCommit)
+                .mapToObj(i -> tableNames.get(random.nextInt(tableNames.size())))
+                .distinct()
+                .collect(toList());
 
-        Content tableContents =
-            api.getContent().refName(branchName).key(tableName).get().get(tableName);
-        Content newContents = createContents(tableContents, random);
+        Map<ContentKey, Content> existing = api.getContent().refName(branchName).keys(keys).get();
 
         spec.commandLine()
             .getOut()
             .printf(
-                "Committing content-key '%s' to branch '%s' at %s%n",
-                tableName, commitToBranch.getName(), commitToBranch.getHash());
+                "Committing content-keys '%s' to branch '%s' at %s%n",
+                keys.stream().map(ContentKey::toString).collect(Collectors.joining(", ")),
+                commitToBranch.getName(),
+                commitToBranch.getHash());
 
         CommitMultipleOperationsBuilder commit =
             api.commitMultipleOperations()
@@ -198,29 +211,39 @@ public class GenerateContent extends AbstractCommand {
                     CommitMeta.builder()
                         .message(
                             String.format(
-                                "%s table %s on %s, commit #%d of %d",
-                                tableContents != null ? "Update" : "Create",
-                                tableName,
-                                branchName,
-                                i,
-                                numCommits))
+                                "Commit #%d of %d on %s", commitNum, numCommits, branchName))
                         .author(System.getProperty("user.name"))
                         .authorTime(Instant.now())
                         .build());
-        if (newContents instanceof IcebergTable || newContents instanceof IcebergView) {
-          commit.operation(Put.of(tableName, newContents, tableContents));
-        } else {
-          commit.operation(Put.of(tableName, newContents));
+        for (ContentKey key : keys) {
+          Content ex = existing.get(key);
+          Content newContents = createContents(ex, random);
+          if (ex instanceof IcebergTable || ex instanceof IcebergView) {
+            commit.operation(Put.of(key, newContents, ex));
+          } else {
+            commit.operation(Put.of(key, newContents));
+          }
         }
-        Branch newHead = commit.commit();
+        try {
+          Branch newHead = commit.commit();
 
-        if (random.nextDouble() < newTagProbability) {
-          Tag tag = Tag.of("new-tag-" + random.nextLong(), newHead.getHash());
+          if (random.nextDouble() < newTagProbability) {
+            Tag tag = Tag.of("new-tag-" + random.nextLong(), newHead.getHash());
+            spec.commandLine()
+                .getOut()
+                .printf(
+                    "Creating tag '%s' from '%s' at %s%n",
+                    tag.getName(), branchName, tag.getHash());
+            api.createReference().reference(tag).sourceRefName(branchName).create();
+          }
+        } catch (NessieConflictException e) {
+          if (!continueOnError) {
+            throw e;
+          }
+
           spec.commandLine()
-              .getOut()
-              .printf(
-                  "Creating tag '%s' from '%s' at %s%n", tag.getName(), branchName, tag.getHash());
-          api.createReference().reference(tag).sourceRefName(branchName).create();
+              .getErr()
+              .println(spec.commandLine().getColorScheme().errorText("Conflict: " + e));
         }
 
         try {
@@ -233,6 +256,23 @@ public class GenerateContent extends AbstractCommand {
     }
 
     spec.commandLine().getOut().printf("Done creating contents.%n");
+  }
+
+  private List<ContentKey> generateTableNames(String runStartTime) {
+    IntFunction<ContentKey> mapper;
+    if (keyPattern != null) {
+      KeyGenerator generator = newKeyGenerator(keyPattern);
+      mapper = i -> fromPathString(generator.generate());
+    } else {
+      mapper =
+          i ->
+              ContentKey.of(
+                  String.format("create-contents-%s", runStartTime),
+                  "contents",
+                  Integer.toString(i));
+    }
+
+    return IntStream.range(0, numTables).mapToObj(mapper).collect(toList());
   }
 
   private Content createContents(Content currentContents, ThreadLocalRandom random) {

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/Functions.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/Functions.java
@@ -16,13 +16,13 @@
 package org.projectnessie.tools.contentgenerator.keygen;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.UUID.randomUUID;
+import static java.util.UUID.nameUUIDFromBytes;
 
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Random;
 import org.projectnessie.tools.contentgenerator.keygen.KeyGenerator.Func;
 
@@ -78,22 +78,22 @@ public final class Functions {
 
   @FunctionalInterface
   interface FuncGenerator {
-    Optional<Func> generate(Deque<String> params);
+    Optional<Func> generate(Queue<String> params);
 
-    static double doubleParam(Deque<String> params) {
-      return Double.parseDouble(params.removeFirst());
+    static double doubleParam(Queue<String> params) {
+      return Double.parseDouble(params.remove());
     }
 
-    static int intParam(Deque<String> params) {
-      return Integer.parseInt(params.removeFirst());
+    static int intParam(Queue<String> params) {
+      return Integer.parseInt(params.remove());
     }
 
-    static long longParam(Deque<String> params) {
-      return Long.parseLong(params.removeFirst());
+    static long longParam(Queue<String> params) {
+      return Long.parseLong(params.remove());
     }
 
-    static Func funcParam(Deque<String> params) {
-      String name = params.removeFirst();
+    static Func funcParam(Queue<String> params) {
+      String name = params.remove();
       return resolveFunction(name)
           .generate(params)
           .orElseThrow(
@@ -108,7 +108,9 @@ public final class Functions {
 
     @Override
     public void apply(Random random, StringBuilder target) {
-      target.append(randomUUID());
+      byte[] uuid = new byte[16];
+      random.nextBytes(uuid);
+      target.append(nameUUIDFromBytes(uuid));
     }
   }
 
@@ -131,7 +133,7 @@ public final class Functions {
     private final int len;
 
     private static final char[] CHARS =
-        ("ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz" + "0123456789" + "b._-")
+        ("ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz" + "0123456789" + " ._-")
             .toCharArray();
 
     StringFunc(int len) {

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/Functions.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/Functions.java
@@ -21,7 +21,6 @@ import static java.util.UUID.nameUUIDFromBytes;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.Random;
 import org.projectnessie.tools.contentgenerator.keygen.KeyGenerator.Func;
@@ -41,44 +40,44 @@ public final class Functions {
   static Map<String, FuncGenerator> FUNCTIONS = new HashMap<>();
 
   static {
-    FUNCTIONS.put("uuid", params -> Optional.of(new UuidFunc()));
+    FUNCTIONS.put("uuid", params -> new UuidFunc());
     FUNCTIONS.put(
         "int",
         params -> {
           long bound = FuncGenerator.longParam(params);
-          return Optional.of(new IntFunc(bound));
+          return new IntFunc(bound);
         });
     FUNCTIONS.put(
         "string",
         params -> {
           int len = FuncGenerator.intParam(params);
-          return Optional.of(new StringFunc(len));
+          return new StringFunc(len);
         });
     FUNCTIONS.put(
         "seq",
         params -> {
           int offset = FuncGenerator.intParam(params);
-          return Optional.of(new SeqFunc(offset));
+          return new SeqFunc(offset);
         });
     FUNCTIONS.put(
         "prob",
         params -> {
           double prob = FuncGenerator.doubleParam(params);
           Func func = FuncGenerator.funcParam(params);
-          return Optional.of(new ProbFunc(prob, func));
+          return new ProbFunc(prob, func);
         });
     FUNCTIONS.put(
         "every",
         params -> {
           int seq = FuncGenerator.intParam(params);
           Func func = FuncGenerator.funcParam(params);
-          return Optional.of(new EveryFunc(seq, func));
+          return new EveryFunc(seq, func);
         });
   }
 
   @FunctionalInterface
   interface FuncGenerator {
-    Optional<Func> generate(Queue<String> params);
+    Func generate(Queue<String> params);
 
     static double doubleParam(Queue<String> params) {
       return Double.parseDouble(params.remove());
@@ -94,12 +93,7 @@ public final class Functions {
 
     static Func funcParam(Queue<String> params) {
       String name = params.remove();
-      return resolveFunction(name)
-          .generate(params)
-          .orElseThrow(
-              () ->
-                  new IllegalArgumentException(
-                      "Nested function pattern did not resolve to a function"));
+      return resolveFunction(name).generate(params);
     }
   }
 

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/Functions.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/Functions.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.keygen;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.UUID.randomUUID;
+
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import org.projectnessie.tools.contentgenerator.keygen.KeyGenerator.Func;
+
+public final class Functions {
+
+  private Functions() {}
+
+  public static FuncGenerator resolveFunction(String function) {
+    FuncGenerator generator = FUNCTIONS.get(function.toLowerCase(Locale.ROOT));
+    if (generator == null) {
+      throw new IllegalArgumentException("Unknown function '" + function + "'");
+    }
+    return generator;
+  }
+
+  static Map<String, FuncGenerator> FUNCTIONS = new HashMap<>();
+
+  static {
+    FUNCTIONS.put("uuid", params -> Optional.of(new UuidFunc()));
+    FUNCTIONS.put(
+        "int",
+        params -> {
+          long bound = FuncGenerator.longParam(params);
+          return Optional.of(new IntFunc(bound));
+        });
+    FUNCTIONS.put(
+        "string",
+        params -> {
+          int len = FuncGenerator.intParam(params);
+          return Optional.of(new StringFunc(len));
+        });
+    FUNCTIONS.put(
+        "seq",
+        params -> {
+          int offset = FuncGenerator.intParam(params);
+          return Optional.of(new SeqFunc(offset));
+        });
+    FUNCTIONS.put(
+        "prob",
+        params -> {
+          double prob = FuncGenerator.doubleParam(params);
+          Func func = FuncGenerator.funcParam(params);
+          return Optional.of(new ProbFunc(prob, func));
+        });
+    FUNCTIONS.put(
+        "every",
+        params -> {
+          int seq = FuncGenerator.intParam(params);
+          Func func = FuncGenerator.funcParam(params);
+          return Optional.of(new EveryFunc(seq, func));
+        });
+  }
+
+  @FunctionalInterface
+  interface FuncGenerator {
+    Optional<Func> generate(Deque<String> params);
+
+    static double doubleParam(Deque<String> params) {
+      return Double.parseDouble(params.removeFirst());
+    }
+
+    static int intParam(Deque<String> params) {
+      return Integer.parseInt(params.removeFirst());
+    }
+
+    static long longParam(Deque<String> params) {
+      return Long.parseLong(params.removeFirst());
+    }
+
+    static Func funcParam(Deque<String> params) {
+      String name = params.removeFirst();
+      return resolveFunction(name)
+          .generate(params)
+          .orElseThrow(
+              () ->
+                  new IllegalArgumentException(
+                      "Nested function pattern did not resolve to a function"));
+    }
+  }
+
+  static final class UuidFunc implements Func {
+    UuidFunc() {}
+
+    @Override
+    public void apply(Random random, StringBuilder target) {
+      target.append(randomUUID());
+    }
+  }
+
+  static final class IntFunc implements Func {
+    private final long bound;
+
+    IntFunc(long bound) {
+      checkArgument(bound > 0, "Bound for random must be positive");
+      this.bound = bound;
+    }
+
+    @Override
+    public void apply(Random random, StringBuilder target) {
+      long v = (random.nextLong() & Long.MAX_VALUE) % bound;
+      target.append(v);
+    }
+  }
+
+  static final class StringFunc implements Func {
+    private final int len;
+
+    private static final char[] CHARS =
+        ("ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz" + "0123456789" + "b._-")
+            .toCharArray();
+
+    StringFunc(int len) {
+      this.len = len;
+    }
+
+    @Override
+    public void apply(Random random, StringBuilder target) {
+      for (int i = 0; i < len; i++) {
+        char c = CHARS[random.nextInt(CHARS.length)];
+        target.append(c);
+      }
+    }
+  }
+
+  static final class SeqFunc implements Func {
+    private int num;
+
+    SeqFunc(int offset) {
+      this.num = offset;
+    }
+
+    @Override
+    public void apply(Random random, StringBuilder target) {
+      target.append(num);
+      num++;
+    }
+  }
+
+  static final class EveryFunc implements Func {
+    private final int seq;
+    private final Func delegate;
+    private int num;
+    private String current;
+
+    EveryFunc(int seq, Func delegate) {
+      this.seq = this.num = seq;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void apply(Random random, StringBuilder target) {
+      if (num >= seq) {
+        current = null;
+      }
+      if (current == null) {
+        StringBuilder sb = new StringBuilder();
+        delegate.apply(random, sb);
+        current = sb.toString();
+        num = 1;
+      } else {
+        num++;
+      }
+      target.append(current);
+    }
+  }
+
+  static final class ProbFunc implements Func {
+    private final double prob;
+    private final Func delegate;
+    private String current;
+
+    ProbFunc(double prob, Func delegate) {
+      this.prob = prob;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void apply(Random random, StringBuilder target) {
+      double v = random.nextDouble();
+      if (v < prob) {
+        current = null;
+      }
+      if (current == null) {
+        StringBuilder sb = new StringBuilder();
+        delegate.apply(random, sb);
+        current = sb.toString();
+      }
+      target.append(current);
+    }
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/KeyGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/KeyGenerator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.keygen;
+
+import java.util.List;
+import java.util.Random;
+import javax.annotation.Nonnull;
+import org.immutables.value.Value;
+
+public class KeyGenerator {
+
+  @Value.Immutable
+  interface Params {
+    @Value.Default
+    default long seed() {
+      return new Random().nextLong();
+    }
+
+    String pattern();
+  }
+
+  @FunctionalInterface
+  interface Func {
+    void apply(Random random, StringBuilder target);
+  }
+
+  public static KeyGenerator newKeyGenerator(@Nonnull String pattern) {
+    return newKeyGenerator(ImmutableParams.builder().pattern(pattern).build());
+  }
+
+  public static KeyGenerator newKeyGenerator(long seed, @Nonnull String pattern) {
+    return newKeyGenerator(ImmutableParams.builder().seed(seed).pattern(pattern).build());
+  }
+
+  public static KeyGenerator newKeyGenerator(@Nonnull Params params) {
+    PatternParser parser = new PatternParser(params.pattern());
+    List<Func> generators = parser.parse();
+    return new KeyGenerator(params, generators);
+  }
+
+  private final Params params;
+  private final Random random;
+  private final List<Func> generators;
+
+  private KeyGenerator(@Nonnull Params params, @Nonnull List<Func> generators) {
+    this.params = params;
+    this.random = new Random(params.seed());
+    this.generators = generators;
+  }
+
+  public String generate() {
+    StringBuilder sb = new StringBuilder();
+    generate(sb);
+    return sb.toString();
+  }
+
+  public void generate(StringBuilder target) {
+    generators.forEach(f -> f.apply(random, target));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof KeyGenerator)) {
+      return false;
+    }
+    KeyGenerator that = (KeyGenerator) o;
+    return params.equals(that.params);
+  }
+
+  @Override
+  public int hashCode() {
+    return params.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "KeyGenerator{" + "params=" + params + '}';
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/PatternParser.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/PatternParser.java
@@ -20,8 +20,8 @@ import static org.projectnessie.tools.contentgenerator.keygen.Functions.resolveF
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
+import java.util.Queue;
 import org.projectnessie.tools.contentgenerator.keygen.KeyGenerator.Func;
 
 class PatternParser {
@@ -139,7 +139,7 @@ class PatternParser {
       }
     }
 
-    Deque<String> params = new ArrayDeque<>(args);
+    Queue<String> params = new ArrayDeque<>(args);
     resolveFunction(name).generate(params).ifPresent(generators::add);
   }
 

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/PatternParser.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/PatternParser.java
@@ -140,7 +140,7 @@ class PatternParser {
     }
 
     Queue<String> params = new ArrayDeque<>(args);
-    resolveFunction(name).generate(params).ifPresent(generators::add);
+    generators.add(resolveFunction(name).generate(params));
   }
 
   private void maybeAddConstant(StringBuilder currentConstant) {

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/PatternParser.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/PatternParser.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.keygen;
+
+import static java.util.Collections.unmodifiableList;
+import static org.projectnessie.tools.contentgenerator.keygen.Functions.resolveFunction;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import org.projectnessie.tools.contentgenerator.keygen.KeyGenerator.Func;
+
+class PatternParser {
+
+  private final String pattern;
+  private final ArrayList<Func> generators = new ArrayList<>();
+
+  PatternParser(String pattern) {
+    this.pattern = pattern;
+  }
+
+  enum State {
+    CONST,
+    DOLLAR,
+    FUNC
+  }
+
+  IllegalArgumentException parseError(int i, String msg) {
+    return new IllegalArgumentException(
+        "Failure parsing pattern '" + pattern + "' at col #" + i + ": " + msg);
+  }
+
+  IllegalArgumentException parseError(int i, String msg, Exception e) {
+    return new IllegalArgumentException(
+        "Failure parsing pattern '" + pattern + "' at col #" + i + ": " + msg, e);
+  }
+
+  List<Func> parse() {
+    StringBuilder currentConstant = new StringBuilder();
+    StringBuilder currentFunc = new StringBuilder();
+    String p = pattern;
+    int l = p.length();
+    State state = State.CONST;
+    for (int i = 0; i < l; i++) {
+      char c = p.charAt(i);
+
+      switch (state) {
+        case CONST:
+          if (c == '$') {
+            maybeAddConstant(currentConstant);
+            state = State.DOLLAR;
+          } else {
+            currentConstant.append(c);
+          }
+          break;
+        case DOLLAR:
+          if (c == '{') {
+            state = State.FUNC;
+          } else if (c == '$') {
+            currentConstant.append('$');
+            state = State.CONST;
+          } else {
+            throw parseError(i, "illegal function declaration");
+          }
+          break;
+        case FUNC:
+          if (c == '}') {
+            try {
+              parseFuncPattern(currentFunc);
+              state = State.CONST;
+            } catch (Exception e) {
+              throw parseError(i, "failure parsing function declaration: " + e.getMessage(), e);
+            }
+          } else {
+            currentFunc.append(c);
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
+    switch (state) {
+      case DOLLAR:
+      case FUNC:
+        throw parseError(l, "unclosed function pattern at the end of the pattern");
+      default:
+        break;
+    }
+
+    maybeAddConstant(currentConstant);
+
+    generators.trimToSize();
+    return unmodifiableList(generators);
+  }
+
+  private void parseFuncPattern(StringBuilder currentFunc) {
+    parseFuncPattern(currentFunc.toString());
+    currentFunc.setLength(0);
+  }
+
+  private void parseFuncPattern(String func) {
+    func = func.trim();
+
+    int i = func.indexOf(',');
+    String name;
+    List<String> args = new ArrayList<>();
+    if (i == -1) {
+      name = func;
+    } else {
+      name = func.substring(0, i).trim();
+      while (true) {
+        i++;
+        if (i >= func.length()) {
+          break;
+        }
+
+        int next = func.indexOf(',', i);
+        if (next == -1) {
+          args.add(func.substring(i).trim());
+          break;
+        }
+        args.add(func.substring(i, next).trim());
+        i = next;
+      }
+    }
+
+    Deque<String> params = new ArrayDeque<>(args);
+    resolveFunction(name).generate(params).ifPresent(generators::add);
+  }
+
+  private void maybeAddConstant(StringBuilder currentConstant) {
+    if (currentConstant.length() > 0) {
+      String c = currentConstant.toString();
+      currentConstant.setLength(0);
+      generators.add((r, sb) -> sb.append(c));
+    }
+  }
+}

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/TestKeyGenerator.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/TestKeyGenerator.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.tools.contentgenerator.keygen.KeyGenerator;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestKeyGenerator {
+
+  private static final int MAX_RETRY = 10;
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  public void constantStrings() {
+    KeyGenerator gen = KeyGenerator.newKeyGenerator("hello world");
+    List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+    soft.assertThat(values).hasSize(20).allMatch("hello world"::equals);
+  }
+
+  @Test
+  public void intFunc() {
+    KeyGenerator gen = KeyGenerator.newKeyGenerator("hello world ${int,100} foo");
+    List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+    soft.assertThat(values)
+        .hasSize(20)
+        .allSatisfy(s -> assertThat(s).matches("hello world [0-9]+ foo"));
+  }
+
+  @Test
+  public void seqFunc() {
+    KeyGenerator gen = KeyGenerator.newKeyGenerator("hello world ${seq,20} foo");
+    List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+    soft.assertThat(values)
+        .hasSize(20)
+        .allSatisfy(s -> assertThat(s).matches("hello world [0-9]+ foo"))
+        .containsExactlyElementsOf(
+            IntStream.range(20, 40)
+                .mapToObj(i -> "hello world " + i + " foo")
+                .collect(Collectors.toList()));
+  }
+
+  @Test
+  public void everySeqFunc() {
+    KeyGenerator gen = KeyGenerator.newKeyGenerator("hello world ${every,5,seq,20} foo");
+    List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+    soft.assertThat(values)
+        .hasSize(20)
+        .allSatisfy(s -> assertThat(s).matches("hello world [0-9]+ foo"))
+        .containsExactlyElementsOf(
+            IntStream.range(20, 24)
+                .mapToObj(i -> "hello world " + i + " foo")
+                .flatMap(s -> Stream.of(s, s, s, s, s))
+                .collect(Collectors.toList()));
+  }
+
+  @Test
+  public void everyIntFunc() {
+    for (int retry = 0; ; retry++) {
+      KeyGenerator gen = KeyGenerator.newKeyGenerator("hello world ${every,5,int,100} foo");
+      List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+      soft.assertThat(values)
+          .hasSize(20)
+          .allSatisfy(s -> assertThat(s).matches("hello world [0-9]+ foo"));
+
+      soft.assertThat(values.subList(0, 5)).allMatch(values.get(0)::equals);
+      soft.assertThat(values.subList(5, 20)).noneMatch(values.get(0)::equals);
+
+      soft.assertThat(values.subList(5, 10)).allMatch(values.get(5)::equals);
+      soft.assertThat(values.subList(0, 5)).noneMatch(values.get(5)::equals);
+      soft.assertThat(values.subList(10, 20)).noneMatch(values.get(5)::equals);
+
+      soft.assertThat(values.subList(10, 15)).allMatch(values.get(10)::equals);
+      soft.assertThat(values.subList(0, 10)).noneMatch(values.get(10)::equals);
+      soft.assertThat(values.subList(15, 20)).noneMatch(values.get(10)::equals);
+
+      soft.assertThat(values.subList(15, 20)).allMatch(values.get(15)::equals);
+      soft.assertThat(values.subList(0, 15)).noneMatch(values.get(15)::equals);
+
+      // The generator pattern uses random values, it's unlikely, but possible to have the same
+      // value in the generated values.
+      try {
+        soft.assertAll();
+        break;
+      } catch (AssertionError e) {
+        if (retry == MAX_RETRY) {
+          throw e;
+        }
+      }
+    }
+  }
+
+  @Test
+  public void stringFunc() {
+    for (int retry = 0; ; retry++) {
+      KeyGenerator gen = KeyGenerator.newKeyGenerator("hello world ${string,5} foo");
+      List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+      soft.assertThat(values)
+          .hasSize(20)
+          .allSatisfy(s -> assertThat(s).matches("hello world [A-Za-z0-9 _.-]{5} foo"));
+
+      soft.assertThat(new HashSet<>(values)).hasSizeGreaterThan(15);
+
+      // The generator pattern uses random values, it's unlikely, but possible to have the same
+      // value in the generated values.
+      try {
+        soft.assertAll();
+        break;
+      } catch (AssertionError e) {
+        if (retry == MAX_RETRY) {
+          throw e;
+        }
+      }
+    }
+  }
+
+  @Test
+  public void probUuidFunc() {
+    for (int retry = 0; ; retry++) {
+      KeyGenerator gen = KeyGenerator.newKeyGenerator("hello world ${prob,.5,uuid} foo");
+      List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+      soft.assertThat(values)
+          .hasSize(20)
+          .allSatisfy(s -> assertThat(s).matches("hello world [0-9a-f-]+ foo"));
+
+      soft.assertThat(new HashSet<>(values)).hasSizeGreaterThan(1).hasSizeLessThan(20);
+
+      // The generator pattern uses random values, it's unlikely, but possible to have the same
+      // value in the generated values.
+      try {
+        soft.assertAll();
+        break;
+      } catch (AssertionError e) {
+        if (retry == MAX_RETRY) {
+          throw e;
+        }
+      }
+    }
+  }
+
+  @Test
+  public void longKeysScenario() {
+    for (int retry = 0; ; retry++) {
+      KeyGenerator gen =
+          KeyGenerator.newKeyGenerator(
+              "stuff-folders./stuff-${every,10,uuid}/foolish-key/${every,5,uuid}/${uuid}_0");
+      List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+      soft.assertThat(values).hasSize(20);
+      soft.assertThat(new HashSet<>(values)).hasSize(20);
+
+      // The generator pattern uses random values, it's unlikely, but possible to have the same
+      // value in the generated values.
+      try {
+        soft.assertAll();
+        break;
+      } catch (AssertionError e) {
+        if (retry == MAX_RETRY) {
+          throw e;
+        }
+      }
+    }
+  }
+}

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/TestKeyGenerator.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/TestKeyGenerator.java
@@ -43,6 +43,13 @@ public class TestKeyGenerator {
   }
 
   @Test
+  public void constantStringWithDollar() {
+    KeyGenerator gen = KeyGenerator.newKeyGenerator("hello $$world");
+    List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());
+    soft.assertThat(values).hasSize(20).allMatch("hello $world"::equals);
+  }
+
+  @Test
   public void intFunc() {
     KeyGenerator gen = KeyGenerator.newKeyGenerator("hello world ${int,100} foo");
     List<String> values = Stream.generate(gen::generate).limit(20).collect(Collectors.toList());


### PR DESCRIPTION
Adds ability to generate content keys in the content generator tool derived from a new key-generator, with support for random UUIDs, random strings, random integers or integer sequence. Ability to trigger a "next value" either always, after N uses or based on a probability.

Also enhances the content generator tool to optionally continue on errors (conflicts), and add more than one put operation to every commit.