### PR TITLE
CI: auto-destruct spawned Nessie Quarkus runner JVM

### DIFF
--- a/clients/deltalake/build.gradle.kts
+++ b/clients/deltalake/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 nessieQuarkusApp {
   includeTask(tasks.named<Test>("intTest"))
   environmentNonInput.put("HTTP_ACCESS_LOG_LEVEL", testLogLevel())
+  jvmArgumentsNonInput.add("-XX:SelfDestructTimer=30")
 }
 
 forceJava11ForTests()

--- a/clients/spark-extensions/build.gradle.kts
+++ b/clients/spark-extensions/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
 nessieQuarkusApp {
   includeTask(tasks.named<Test>("intTest"))
   environmentNonInput.put("HTTP_ACCESS_LOG_LEVEL", testLogLevel())
+  jvmArgumentsNonInput.add("-XX:SelfDestructTimer=30")
 }
 
 forceJava11ForTests()

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
 nessieQuarkusApp {
   includeTask(tasks.named<Test>("intTest"))
   environmentNonInput.put("HTTP_ACCESS_LOG_LEVEL", testLogLevel())
+  jvmArgumentsNonInput.add("-XX:SelfDestructTimer=30")
 }
 
 forceJava11ForTests()

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -108,6 +108,7 @@ intTest { systemProperty("aws.region", "us-east-1") }
 nessieQuarkusApp {
   includeTask(intTest)
   environmentNonInput.put("HTTP_ACCESS_LOG_LEVEL", testLogLevel())
+  jvmArgumentsNonInput.add("-XX:SelfDestructTimer=30")
 }
 
 forceJava11ForTests()

--- a/perftest/simulations/build.gradle.kts
+++ b/perftest/simulations/build.gradle.kts
@@ -52,6 +52,7 @@ nessieQuarkusApp {
     )
   }
   environmentNonInput.put("HTTP_ACCESS_LOG_LEVEL", testLogLevel())
+  jvmArgumentsNonInput.add("-XX:SelfDestructTimer=30")
   System.getProperties()
     .filter { e ->
       e.key.toString().startsWith("nessie.") || e.key.toString().startsWith("quarkus.")

--- a/tools/content-generator/build.gradle.kts
+++ b/tools/content-generator/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
 nessieQuarkusApp {
   includeTask(tasks.named<Test>("intTest"))
   environmentNonInput.put("HTTP_ACCESS_LOG_LEVEL", testLogLevel())
+  jvmArgumentsNonInput.add("-XX:SelfDestructTimer=30")
 }
 
 tasks.named<ShadowJar>("shadowJar") {


### PR DESCRIPTION
It can sometimes happen that the JVMs running Nessie spawned by CI linger around. This JVM settings automatically destructs thos JVMs after 30 minutes.