### PR TITLE
Fix `@Parameter` annotations in `DiffParams`

### DIFF
--- a/model/src/main/java/org/projectnessie/api/v1/params/DiffParams.java
+++ b/model/src/main/java/org/projectnessie/api/v1/params/DiffParams.java
@@ -32,30 +32,18 @@ public class DiffParams {
 
   @NotNull
   @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-  @Parameter(
-      description = "The 'from' reference to start the diff from",
-      examples = {@ExampleObject(ref = "ref")})
   private String fromRef;
 
   @Nullable
   @Pattern(regexp = HASH_OPTIONAL_REGEX, message = Validation.HASH_MESSAGE)
-  @Parameter(
-      description = "Optional hash on the 'from' reference to start the diff from",
-      examples = {@ExampleObject(ref = "hash")})
   private String fromHashOnRef;
 
   @NotNull
   @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-  @Parameter(
-      description = "The 'to' reference to end the diff at.",
-      examples = {@ExampleObject(ref = "ref")})
   private String toRef;
 
   @Nullable
   @Pattern(regexp = HASH_OPTIONAL_REGEX, message = Validation.HASH_MESSAGE)
-  @Parameter(
-      description = "Optional hash on the 'to' reference to end the diff at.",
-      examples = {@ExampleObject(ref = "hash")})
   private String toHashOnRef;
 
   public DiffParams() {}
@@ -72,12 +60,18 @@ public class DiffParams {
     this.toHashOnRef = toHashOnRef;
   }
 
+  @Parameter(
+      description = "The 'from' reference (and optional hash) to start the diff from",
+      examples = {@ExampleObject(ref = "ref"), @ExampleObject(ref = "refForDiffWithHash")})
   @PathParam("fromRefWithHash")
   public void setFromRefWithHash(String value) {
     this.fromRef = parseRefName(value);
     this.fromHashOnRef = parseHash(value);
   }
 
+  @Parameter(
+      description = "The 'to' reference (and optional hash) to end the diff at.",
+      examples = {@ExampleObject(ref = "ref"), @ExampleObject(ref = "refForDiffWithHash")})
   @PathParam("toRefWithHash")
   public void setToRefWithHash(String value) {
     this.toRef = parseRefName(value);

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -39,6 +39,9 @@ components:
     ref:
       value: "main"
 
+    refForDiffWithHash:
+      value: "main*2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+
     referenceType:
       value: "branch"
 


### PR DESCRIPTION
This is a follow-up fix for #5584.

----

Flagged by Quarkus:

```
2022-11-29 17:08:42,189 WARN  [io.sma.ope.run.sca.spi] (build-8) SROAP07902: @Parameter annotation missing JAX-RS 
parameter. Class: org.projectnessie.api.v1.http.HttpDiffApi, Method: org.projectnessie.model.DiffResponse 
getDiff(org.projectnessie.api.v1.params.DiffParams params) throws org.projectnessie.error.NessieNotFoundException, 
Parameter.name: null, Parameter.in: null
```