### PR TITLE
Fix v2 URL path mapping for getReferenceByName

### DIFF
--- a/model/src/main/java/org/projectnessie/api/v2/params/GetReferenceParams.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/GetReferenceParams.java
@@ -35,8 +35,8 @@ public class GetReferenceParams {
       examples = {@ExampleObject(ref = "ref")})
   @PathParam("ref")
   @NotNull
-  @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
-  private String refName;
+  @Pattern(regexp = Validation.REF_NAME_PATH_REGEX, message = Validation.REF_NAME_MESSAGE)
+  private String ref;
 
   @Parameter(
       description =
@@ -56,8 +56,8 @@ public class GetReferenceParams {
   public GetReferenceParams() {}
 
   @Constructor
-  GetReferenceParams(@NotNull String refName, @Nullable FetchOption fetchOption) {
-    this.refName = refName;
+  GetReferenceParams(@NotNull String ref, @Nullable FetchOption fetchOption) {
+    this.ref = ref;
     this.fetchOption = fetchOption;
   }
 
@@ -66,8 +66,8 @@ public class GetReferenceParams {
     return fetchOption;
   }
 
-  public String getRefName() {
-    return refName;
+  public String getRef() {
+    return ref;
   }
 
   public static GetReferenceParamsBuilder builder() {

--- a/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/model/src/main/java/org/projectnessie/model/Validation.java
@@ -37,7 +37,7 @@ public final class Validation {
       "^((" + HASH_RAW_REGEX + ")|(" + REF_NAME_RAW_REGEX + "))$";
   public static final String REF_NAME_PATH_REGEX =
       "^(" + REF_NAME_RAW_REGEX + "(@(" + HASH_RAW_REGEX + ")?)?|@" + HASH_RAW_REGEX + ")$";
-  public static final String REF_NAME_PATH_ELEMENT_REGEX = "([^/]+|[^@]+@[^@/]*?)";
+  public static final String REF_NAME_PATH_ELEMENT_REGEX = "([^/]+|[^@]+(@|%40)[^@/]*)";
 
   public static final Pattern HASH_PATTERN = Pattern.compile(HASH_REGEX);
   public static final Pattern REF_NAME_PATTERN = Pattern.compile(REF_NAME_REGEX);

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyV2InMemory.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/ITResteasyV2InMemory.java
@@ -17,9 +17,11 @@ package org.projectnessie.server;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.jaxrs.tests.AbstractResteasyV2Test;
 import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
 
 @QuarkusIntegrationTest
 @TestProfile(QuarkusTestProfileInmemory.class)
+@ExtendWith(QuarkusNessieClientResolver.class)
 public class ITResteasyV2InMemory extends AbstractResteasyV2Test {}

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -123,8 +123,9 @@ public class RestV2TreeResource implements HttpTreeApi {
   @Override
   public SingleReferenceResponse getReferenceByName(GetReferenceParams params)
       throws NessieNotFoundException {
+    Reference reference = Reference.fromPathString(params.getRef(), Reference.ReferenceType.BRANCH);
     return SingleReferenceResponse.builder()
-        .reference(tree().getReferenceByName(params.getRefName(), params.fetchOption()))
+        .reference(tree().getReferenceByName(reference.getName(), params.fetchOption()))
         .build();
   }
 


### PR DESCRIPTION
* Use the right RegEx constant for resolving path parameters for GET /trees/{ref}

* Other endpoints appear to use the right RegEx constant already.

* Correct URL path parameter RegEx to account for tools encoding the `@` char as `%40`.

* Drop the spurious `?` at the end of the RegEx

Fixes #584