### PR TITLE
Deprecate commit lists in merge-results

### DIFF
--- a/model/src/main/java/org/projectnessie/model/MergeResponse.java
+++ b/model/src/main/java/org/projectnessie/model/MergeResponse.java
@@ -59,14 +59,11 @@ public interface MergeResponse {
   @Nullable
   String getExpectedHash();
 
-  /** List of commit-IDs to be merged or transplanted. */
+  @Deprecated // for removal and replaced with something else
   List<LogEntry> getSourceCommits();
 
-  /**
-   * List of commit-IDs between {@link #getExpectedHash()} and {@link #getEffectiveTargetHash()}, if
-   * the expected hash was provided.
-   */
   @Nullable
+  @Deprecated // for removal and replaced with something else
   List<LogEntry> getTargetCommits();
 
   /** Details of all keys encountered during the merge or transplant operation. */
@@ -86,8 +83,10 @@ public interface MergeResponse {
       return ContentKeyConflict.NONE;
     }
 
+    @Deprecated // for removal and replaced with something else
     List<String> getSourceCommits();
 
+    @Deprecated // for removal and replaced with something else
     List<String> getTargetCommits();
   }
 

--- a/model/src/main/java/org/projectnessie/model/MergeResponse.java
+++ b/model/src/main/java/org/projectnessie/model/MergeResponse.java
@@ -60,10 +60,12 @@ public interface MergeResponse {
   String getExpectedHash();
 
   @Deprecated // for removal and replaced with something else
+  @Schema(deprecated = true, hidden = true)
   List<LogEntry> getSourceCommits();
 
   @Nullable
   @Deprecated // for removal and replaced with something else
+  @Schema(deprecated = true, hidden = true)
   List<LogEntry> getTargetCommits();
 
   /** Details of all keys encountered during the merge or transplant operation. */
@@ -84,9 +86,11 @@ public interface MergeResponse {
     }
 
     @Deprecated // for removal and replaced with something else
+    @Schema(deprecated = true, hidden = true)
     List<String> getSourceCommits();
 
     @Deprecated // for removal and replaced with something else
+    @Schema(deprecated = true, hidden = true)
     List<String> getTargetCommits();
   }
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
@@ -421,6 +421,7 @@ public abstract class AbstractMergeTransplant {
         .isEqualTo(expectedMergeResult);
   }
 
+  @SuppressWarnings("deprecation")
   private MergeResult<CommitLogEntry> conflictExpectedMergeResult(
       boolean merge,
       BranchName conflict,
@@ -465,6 +466,7 @@ public abstract class AbstractMergeTransplant {
     return expectedMergeResult.build();
   }
 
+  @SuppressWarnings("deprecation")
   private static ImmutableMergeResult.Builder<CommitLogEntry> successExpectedMergeResult(
       boolean merge,
       BranchName targetBranch,

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
@@ -54,6 +54,7 @@ public interface MergeResult<COMMIT> {
   Hash getExpectedHash();
 
   /** List of commit-IDs to be merged or transplanted. */
+  @Deprecated // for removal and replaced with something else
   List<COMMIT> getSourceCommits();
 
   /**
@@ -61,6 +62,7 @@ public interface MergeResult<COMMIT> {
    * the expected hash was provided.
    */
   @Nullable
+  @Deprecated // for removal and replaced with something else
   List<COMMIT> getTargetCommits();
 
   /** Details of all keys encountered during the merge or transplant operation. */
@@ -75,8 +77,10 @@ public interface MergeResult<COMMIT> {
       return ConflictType.NONE;
     }
 
+    @Deprecated // for removal and replaced with something else
     List<Hash> getSourceCommits();
 
+    @Deprecated // for removal and replaced with something else
     List<Hash> getTargetCommits();
 
     static ImmutableKeyDetails.Builder builder() {


### PR DESCRIPTION
The commits lists in the merge results can become quite big, possibly "too big", and the value isn't clear. Deprecating those for removal.