### PR TITLE
Add Nessie version into nessie-model.jar

### DIFF
--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.apache.tools.ant.filters.ReplaceTokens
 import org.projectnessie.buildtools.smallryeopenapi.SmallryeOpenApiTask
 
 plugins {
@@ -54,6 +55,11 @@ smallryeOpenApi {
     listOf("org.projectnessie.api", "org.projectnessie.api.http", "org.projectnessie.model")
   )
 }
+
+val processResources =
+  tasks.named<ProcessResources>("processResources") {
+    filter(ReplaceTokens::class, mapOf("tokens" to mapOf("projectVersion" to project.version)))
+  }
 
 val openapi by
   configurations.creating {

--- a/model/src/main/java/org/projectnessie/api/NessieVersion.java
+++ b/model/src/main/java/org/projectnessie/api/NessieVersion.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+public final class NessieVersion {
+  private NessieVersion() {}
+
+  public static final String NESSIE_VERSION;
+
+  static {
+    URL nessieVersionResource = NessieVersion.class.getResource("nessie-version.properties");
+    try (InputStream in =
+        requireNonNull(
+                nessieVersionResource,
+                "Resource org/projectnessie/client/nessie-version.properties containing Nessie version does not exist")
+            .openConnection()
+            .getInputStream()) {
+      Properties p = new Properties();
+      p.load(in);
+      NESSIE_VERSION = p.getProperty("nessie.version");
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to load Nessie version from org/projectnessie/client/nessie-version.properties",
+          e);
+    }
+  }
+}

--- a/model/src/main/resources/org/projectnessie/api/nessie-version.properties
+++ b/model/src/main/resources/org/projectnessie/api/nessie-version.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2022 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+nessie.version=@projectVersion@


### PR DESCRIPTION
Adding a new resource containing the project version and a utility class to read the Nessie version from that resource.

Need to be careful to only include content that doesn't change for every build. Adding just the version is okay, because the version doesn't change that often. But adding a Git commit ID is problematic, as that would invalidate all Gradle caches for every little change.