### PR TITLE
Adopt versioned-tests to not set cid for "new" `Content`; minor refactoring for merge/transplant

### DIFF
--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRefLog.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractRefLog.java
@@ -183,7 +183,7 @@ public abstract class AbstractRefLog {
           databaseAdapter.commit(
               ImmutableCommitParams.builder()
                   .toBranch((BranchName) ref)
-                  .commitMetaSerialized(ByteString.copyFromUtf8("foo"))
+                  .commitMetaSerialized(ByteString.copyFromUtf8("foo on " + ref.getName()))
                   .addPuts(
                       KeyWithBytes.of(
                           Key.of("table", "c" + commit),

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractReferences.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractReferences.java
@@ -309,7 +309,7 @@ public abstract class AbstractReferences {
               databaseAdapter.commit(
                   ImmutableCommitParams.builder()
                       .toBranch((BranchName) ref)
-                      .commitMetaSerialized(ByteString.copyFromUtf8("foo"))
+                      .commitMetaSerialized(ByteString.copyFromUtf8("foo on " + ref.getName()))
                       .expectedHead(Optional.of(refHeads.get(ref)))
                       .addPuts(
                           KeyWithBytes.of(

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
@@ -172,37 +172,44 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
     }
 
     soft.assertThat(
-            store()
-                .getValues(
-                    secondCommit,
-                    Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
+            contentsWithoutId(
+                store()
+                    .getValues(
+                        secondCommit,
+                        Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(Key.of("t1"), V_1_2, Key.of("t4"), V_4_1));
 
     soft.assertThat(
-            store()
-                .getValues(
-                    initialCommit,
-                    Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
+            contentsWithoutId(
+                store()
+                    .getValues(
+                        initialCommit,
+                        Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_1,
                 Key.of("t2"), V_2_1,
                 Key.of("t3"), V_3_1));
 
-    soft.assertThat(store().getValue(branch, Key.of("t1"))).isEqualTo(V_1_2);
-    soft.assertThat(store().getValue(branch, Key.of("t2"))).isEqualTo(V_2_2);
+    soft.assertThat(contentWithoutId(store().getValue(branch, Key.of("t1")))).isEqualTo(V_1_2);
+    soft.assertThat(contentWithoutId(store().getValue(branch, Key.of("t2")))).isEqualTo(V_2_2);
     soft.assertThat(store().getValue(branch, Key.of("t3"))).isNull();
-    soft.assertThat(store().getValue(branch, Key.of("t4"))).isEqualTo(V_4_1);
+    soft.assertThat(contentWithoutId(store().getValue(branch, Key.of("t4")))).isEqualTo(V_4_1);
 
-    soft.assertThat(store().getValue(secondCommit, Key.of("t1"))).isEqualTo(V_1_2);
+    soft.assertThat(contentWithoutId(store().getValue(secondCommit, Key.of("t1"))))
+        .isEqualTo(V_1_2);
     soft.assertThat(store().getValue(secondCommit, Key.of("t2"))).isNull();
     soft.assertThat(store().getValue(secondCommit, Key.of("t3"))).isNull();
-    soft.assertThat(store().getValue(secondCommit, Key.of("t4"))).isEqualTo(V_4_1);
+    soft.assertThat(contentWithoutId(store().getValue(secondCommit, Key.of("t4"))))
+        .isEqualTo(V_4_1);
 
-    soft.assertThat(store().getValue(initialCommit, Key.of("t1"))).isEqualTo(V_1_1);
-    soft.assertThat(store().getValue(initialCommit, Key.of("t2"))).isEqualTo(V_2_1);
-    soft.assertThat(store().getValue(initialCommit, Key.of("t3"))).isEqualTo(V_3_1);
+    soft.assertThat(contentWithoutId(store().getValue(initialCommit, Key.of("t1"))))
+        .isEqualTo(V_1_1);
+    soft.assertThat(contentWithoutId(store().getValue(initialCommit, Key.of("t2"))))
+        .isEqualTo(V_2_1);
+    soft.assertThat(contentWithoutId(store().getValue(initialCommit, Key.of("t3"))))
+        .isEqualTo(V_3_1);
     soft.assertThat(store().getValue(initialCommit, Key.of("t4"))).isNull();
   }
 
@@ -259,7 +266,8 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
     }
 
     soft.assertThat(
-            store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
+            contentsWithoutId(
+                store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_3,
@@ -267,7 +275,10 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
                 Key.of("t3"), V_3_2));
 
     soft.assertThat(
-            store().getValues(newT2Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
+            contentsWithoutId(
+                store()
+                    .getValues(
+                        newT2Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_3,
@@ -275,28 +286,37 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
                 Key.of("t3"), V_3_2));
 
     soft.assertThat(
-            store().getValues(extraCommit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
+            contentsWithoutId(
+                store()
+                    .getValues(
+                        extraCommit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_3,
                 Key.of("t3"), V_3_2));
 
     soft.assertThat(
-            store().getValues(t3Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
+            contentsWithoutId(
+                store()
+                    .getValues(t3Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_2,
                 Key.of("t3"), V_3_1));
 
     soft.assertThat(
-            store().getValues(t2Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
+            contentsWithoutId(
+                store()
+                    .getValues(t2Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_2,
                 Key.of("t3"), V_3_1));
 
     soft.assertThat(
-            store().getValues(t1Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
+            contentsWithoutId(
+                store()
+                    .getValues(t1Commit, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_2,
@@ -404,7 +424,8 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
 
     soft.assertThat(store().hashOnReference(branch, Optional.empty())).isEqualTo(putCommit);
     soft.assertThat(
-            store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
+            contentsWithoutId(
+                store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_3,
@@ -419,7 +440,8 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             .toBranch(branch);
     soft.assertThat(store().hashOnReference(branch, Optional.empty())).isEqualTo(unchangedCommit);
     soft.assertThat(
-            store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"))))
+            contentsWithoutId(
+                store().getValues(branch, Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3")))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
                 Key.of("t1"), V_1_3,
@@ -451,8 +473,8 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             CommitMeta.fromMessage("metadata"),
             ImmutableList.of(put("keyA", foo1), put("keyB", foo2)));
 
-    soft.assertThat(store().getValue(branch, Key.of("keyA"))).isEqualTo(foo1);
-    soft.assertThat(store().getValue(branch, Key.of("keyB"))).isEqualTo(foo2);
+    soft.assertThat(contentWithoutId(store().getValue(branch, Key.of("keyA")))).isEqualTo(foo1);
+    soft.assertThat(contentWithoutId(store().getValue(branch, Key.of("keyB")))).isEqualTo(foo2);
   }
 
   /*
@@ -579,11 +601,10 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
     BranchName branch = BranchName.of("main");
 
     Key key = Key.of("my.awesome.table");
-    String oldContentsId = "cid";
     String tableRefState = "table ref state";
 
-    Content createValue1 = OnRefOnly.onRef("no no - not this", oldContentsId);
-    Content createValue2 = OnRefOnly.onRef(tableRefState, oldContentsId);
+    Content createValue1 = newOnRef("no no - not this");
+    Content createValue2 = newOnRef(tableRefState);
 
     soft.assertThatThrownBy(
             () ->

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractContents.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractContents.java
@@ -70,8 +70,8 @@ public abstract class AbstractContents extends AbstractNestedVersionStore {
                 Optional.empty(),
                 CommitMeta.fromMessage("create table"),
                 singletonList(Put.of(key, initialState)));
-    soft.assertThat(store().getValue(branch, key)).isEqualTo(initialState);
-    soft.assertThat(store().getValue(ancestor, key)).isEqualTo(initialState);
+    soft.assertThat(contentWithoutId(store().getValue(branch, key))).isEqualTo(initialState);
+    soft.assertThat(contentWithoutId(store().getValue(ancestor, key))).isEqualTo(initialState);
 
     Hash delete =
         store()
@@ -91,7 +91,7 @@ public abstract class AbstractContents extends AbstractNestedVersionStore {
                 Optional.empty(),
                 CommitMeta.fromMessage("drop table"),
                 ImmutableList.of(Put.of(key, recreateState)));
-    soft.assertThat(store().getValue(branch, key)).isEqualTo(recreateState);
-    soft.assertThat(store().getValue(recreate, key)).isEqualTo(recreateState);
+    soft.assertThat(contentWithoutId(store().getValue(branch, key))).isEqualTo(recreateState);
+    soft.assertThat(contentWithoutId(store().getValue(recreate, key))).isEqualTo(recreateState);
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractDiff.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractDiff.java
@@ -60,7 +60,7 @@ public abstract class AbstractDiff extends AbstractNestedVersionStore {
         commit("Second Commit").put("k2", V_2_A).put("k3", V_3).put("k1a", V_1_A).toBranch(branch);
 
     List<Diff> startToSecond = diffAsList(initial, secondCommit);
-    soft.assertThat(startToSecond)
+    soft.assertThat(diffsWithoutContentId(startToSecond))
         .containsExactlyInAnyOrder(
             Diff.of(Key.of("k1"), Optional.empty(), Optional.of(V_1)),
             Diff.of(Key.of("k2"), Optional.empty(), Optional.of(V_2_A)),
@@ -68,7 +68,7 @@ public abstract class AbstractDiff extends AbstractNestedVersionStore {
             Diff.of(Key.of("k1a"), Optional.empty(), Optional.of(V_1_A)));
 
     List<Diff> secondToStart = diffAsList(secondCommit, initial);
-    soft.assertThat(secondToStart)
+    soft.assertThat(diffsWithoutContentId(secondToStart))
         .containsExactlyInAnyOrder(
             Diff.of(Key.of("k1"), Optional.of(V_1), Optional.empty()),
             Diff.of(Key.of("k2"), Optional.of(V_2_A), Optional.empty()),
@@ -76,14 +76,14 @@ public abstract class AbstractDiff extends AbstractNestedVersionStore {
             Diff.of(Key.of("k1a"), Optional.of(V_1_A), Optional.empty()));
 
     List<Diff> firstToSecond = diffAsList(firstCommit, secondCommit);
-    soft.assertThat(firstToSecond)
+    soft.assertThat(diffsWithoutContentId(firstToSecond))
         .containsExactlyInAnyOrder(
             Diff.of(Key.of("k1a"), Optional.empty(), Optional.of(V_1_A)),
             Diff.of(Key.of("k2"), Optional.of(V_2), Optional.of(V_2_A)),
             Diff.of(Key.of("k3"), Optional.empty(), Optional.of(V_3)));
 
     List<Diff> secondToFirst = diffAsList(secondCommit, firstCommit);
-    soft.assertThat(secondToFirst)
+    soft.assertThat(diffsWithoutContentId(secondToFirst))
         .containsExactlyInAnyOrder(
             Diff.of(Key.of("k1a"), Optional.of(V_1_A), Optional.empty()),
             Diff.of(Key.of("k2"), Optional.of(V_2_A), Optional.of(V_2)),

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractDuplicateTable.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractDuplicateTable.java
@@ -15,9 +15,7 @@
  */
 package org.projectnessie.versioned.tests;
 
-import static java.util.Collections.singletonList;
 import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
-import static org.projectnessie.versioned.testworker.OnRefOnly.onRef;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -26,9 +24,8 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.versioned.BranchName;
@@ -46,40 +43,12 @@ public abstract class AbstractDuplicateTable extends AbstractNestedVersionStore 
     super(store);
   }
 
-  enum DuplicateTableMode {
-    /**
-     * Non-stateful tables (think: Delta, Hive).
-     *
-     * <p>Okay to "blindly re-create tables": {@code Put} operations are "blindly" executed.
-     */
-    NO_GLOBAL,
-    /**
-     * Stateful tables (think: Iceberg).
-     *
-     * <p>Global state uses the table's {@link Key} + {@code Content.id} as the global key.
-     *
-     * <p>Means: creating a table with the same key and same content-id on different branches does
-     * fail.
-     */
-    STATEFUL_SAME_CONTENT_ID,
-    /**
-     * Stateful tables (think: Iceberg).
-     *
-     * <p>Global state uses the table's {@link Key} + {@code Content.id} as the global key.
-     *
-     * <p>Means: creating a table with the same key but different content-ids on different branches
-     * does work.
-     */
-    STATEFUL_DIFFERENT_CONTENT_ID
-  }
-
   /**
    * Test behavior when a table (content-key) is created on two different branches using either
-   * table-types with and without global-states and same/different content-ids.
+   * table-types with equal and different content-ids.
    */
-  @ParameterizedTest
-  @EnumSource(value = DuplicateTableMode.class)
-  void duplicateTableOnBranches(DuplicateTableMode mode) throws Throwable {
+  @Test
+  void duplicateTableOnBranches() throws Throwable {
     Key key = Key.of("some", "table");
 
     BranchName branch0 = BranchName.of("globalStateDuplicateTable-main");
@@ -95,8 +64,6 @@ public abstract class AbstractDuplicateTable extends AbstractNestedVersionStore 
                 ImmutableList.of(Put.of(Key.of("unrelated", "table"), newOnRef("value"))));
 
     // Create a table with the same name on two branches.
-    // WITH global-states, that must fail
-    // WITHOUT global-state, it is okay to work
     BranchName branch1 = BranchName.of("globalStateDuplicateTable-branch1");
     BranchName branch2 = BranchName.of("globalStateDuplicateTable-branch2");
     soft.assertThat(store().create(branch1, Optional.of(ancestor))).isEqualTo(ancestor);
@@ -104,34 +71,15 @@ public abstract class AbstractDuplicateTable extends AbstractNestedVersionStore 
 
     List<Operation> putForBranch1;
     List<Operation> putForBranch2;
-    Content valuebranch1;
-    Content valuebranch2;
-    switch (mode) {
-      case NO_GLOBAL:
-        valuebranch1 = newOnRef("create table");
-        valuebranch2 = newOnRef("create table");
-        putForBranch1 = ImmutableList.of(Put.of(key, valuebranch1));
-        putForBranch2 = ImmutableList.of(Put.of(key, valuebranch2));
-        break;
-      case STATEFUL_SAME_CONTENT_ID:
-        valuebranch1 = onRef("create table", "content-id-equal");
-        valuebranch2 = onRef("create table", "content-id-equal");
-        putForBranch1 = singletonList(Put.of(key, onRef("create table", "content-id-equal")));
-        putForBranch2 = singletonList(Put.of(key, onRef("create table", "content-id-equal")));
-        break;
-      case STATEFUL_DIFFERENT_CONTENT_ID:
-        valuebranch1 = onRef("create table", "content-id-1");
-        valuebranch2 = onRef("create table", "content-id-2");
-        putForBranch1 = singletonList(Put.of(key, onRef("create table", "content-id-1")));
-        putForBranch2 = singletonList(Put.of(key, onRef("create table", "content-id-2")));
-        break;
-      default:
-        throw new IllegalStateException();
-    }
+    Content valuebranch1 = newOnRef("create table");
+    Content valuebranch2 = newOnRef("create table");
+
+    putForBranch1 = ImmutableList.of(Put.of(key, valuebranch1));
+    putForBranch2 = ImmutableList.of(Put.of(key, valuebranch2));
 
     store()
         .commit(branch1, Optional.empty(), CommitMeta.fromMessage("create table"), putForBranch1);
-    soft.assertThat(store().getValue(branch1, key)).isEqualTo(valuebranch1);
+    soft.assertThat(contentWithoutId(store().getValue(branch1, key))).isEqualTo(valuebranch1);
 
     ThrowingCallable createTableOnOtherBranch =
         () ->
@@ -143,6 +91,6 @@ public abstract class AbstractDuplicateTable extends AbstractNestedVersionStore 
                     putForBranch2);
 
     createTableOnOtherBranch.call();
-    soft.assertThat(store().getValue(branch2, key)).isEqualTo(valuebranch2);
+    soft.assertThat(contentWithoutId(store().getValue(branch2, key))).isEqualTo(valuebranch2);
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
@@ -48,6 +48,12 @@ import org.projectnessie.versioned.testworker.OnRefOnly;
 public abstract class AbstractTransplant extends AbstractNestedVersionStore {
   @InjectSoftAssertions protected SoftAssertions soft;
 
+  private static final String T_1 = "t1";
+  private static final String T_2 = "t2";
+  private static final String T_3 = "t3";
+  private static final String T_4 = "t4";
+  private static final String T_5 = "t5";
+
   private static final OnRefOnly V_1_1 = newOnRef("v1_1");
   private static final OnRefOnly V_1_2 = newOnRef("v1_2");
   private static final OnRefOnly V_1_4 = newOnRef("v1_4");
@@ -92,21 +98,17 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
     initialHash = store().hashOnReference(branch, Optional.empty());
 
     firstCommit =
-        commit("Initial Commit")
-            .put("t1", V_1_1)
-            .put("t2", V_2_1)
-            .put("t3", V_3_1)
-            .toBranch(branch);
+        commit("Initial Commit").put(T_1, V_1_1).put(T_2, V_2_1).put(T_3, V_3_1).toBranch(branch);
 
     secondCommit =
         commit("Second Commit")
-            .put("t1", V_1_2)
-            .delete("t2")
-            .delete("t3")
-            .put("t4", V_4_1)
+            .put(T_1, V_1_2)
+            .delete(T_2)
+            .delete(T_3)
+            .put(T_4, V_4_1)
             .toBranch(branch);
 
-    thirdCommit = commit("Third Commit").put("t2", V_2_2).unchanged("t4").toBranch(branch);
+    thirdCommit = commit("Third Commit").put(T_2, V_2_2).unchanged(T_4).toBranch(branch);
 
     commits = commitsList(branch, false);
   }
@@ -157,15 +159,16 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             false,
             false);
     soft.assertThat(
-            store()
-                .getValues(
-                    newBranch,
-                    Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
+            contentsWithoutId(
+                store()
+                    .getValues(
+                        newBranch,
+                        Arrays.asList(Key.of(T_1), Key.of(T_2), Key.of(T_3), Key.of(T_4)))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
-                Key.of("t1"), V_1_2,
-                Key.of("t2"), V_2_2,
-                Key.of("t4"), V_4_1));
+                Key.of(T_1), V_1_2,
+                Key.of(T_2), V_2_2,
+                Key.of(T_4), V_4_1));
 
     if (individualCommits) {
       assertCommitMeta(
@@ -181,7 +184,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
       throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_2");
     store().create(newBranch, Optional.empty());
-    commit("Unrelated commit").put("t5", V_5_1).toBranch(newBranch);
+    commit("Unrelated commit").put(T_5, V_5_1).toBranch(newBranch);
 
     store()
         .transplant(
@@ -195,17 +198,18 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             false,
             false);
     assertThat(
-            store()
-                .getValues(
-                    newBranch,
-                    Arrays.asList(
-                        Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"), Key.of("t5"))))
+            contentsWithoutId(
+                store()
+                    .getValues(
+                        newBranch,
+                        Arrays.asList(
+                            Key.of(T_1), Key.of(T_2), Key.of(T_3), Key.of(T_4), Key.of(T_5)))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
-                Key.of("t1"), V_1_2,
-                Key.of("t2"), V_2_2,
-                Key.of("t4"), V_4_1,
-                Key.of("t5"), V_5_1));
+                Key.of(T_1), V_1_2,
+                Key.of(T_2), V_2_2,
+                Key.of(T_4), V_4_1,
+                Key.of(T_5), V_5_1));
   }
 
   @ParameterizedTest
@@ -214,7 +218,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
       throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_3");
     store().create(newBranch, Optional.empty());
-    commit("Another commit").put("t1", V_1_4).toBranch(newBranch);
+    commit("Another commit").put(T_1, V_1_4).toBranch(newBranch);
 
     soft.assertThatThrownBy(
             () ->
@@ -237,8 +241,8 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
   protected void checkTransplantWithDelete(boolean individualCommits) throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_4");
     store().create(newBranch, Optional.empty());
-    commit("Another commit").put("t1", V_1_4).toBranch(newBranch);
-    commit("Another commit").delete("t1").toBranch(newBranch);
+    commit("Another commit").put(T_1, V_1_4).toBranch(newBranch);
+    commit("Another commit").delete(T_1).toBranch(newBranch);
 
     store()
         .transplant(
@@ -252,15 +256,16 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             false,
             false);
     soft.assertThat(
-            store()
-                .getValues(
-                    newBranch,
-                    Arrays.asList(Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"))))
+            contentsWithoutId(
+                store()
+                    .getValues(
+                        newBranch,
+                        Arrays.asList(Key.of(T_1), Key.of(T_2), Key.of(T_3), Key.of(T_4)))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
-                Key.of("t1"), V_1_2,
-                Key.of("t2"), V_2_2,
-                Key.of("t4"), V_4_1));
+                Key.of(T_1), V_1_2,
+                Key.of(T_2), V_2_2,
+                Key.of(T_4), V_4_1));
   }
 
   @ParameterizedTest
@@ -311,8 +316,8 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
       throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_7");
     store().create(newBranch, Optional.empty());
-    commit("Another commit").put("t5", V_5_1).toBranch(newBranch);
-    commit("Another commit").put("t1", V_1_4).toBranch(newBranch);
+    commit("Another commit").put(T_5, V_5_1).toBranch(newBranch);
+    commit("Another commit").put(T_1, V_1_4).toBranch(newBranch);
 
     store()
         .transplant(
@@ -326,17 +331,18 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             false,
             false);
     soft.assertThat(
-            store()
-                .getValues(
-                    newBranch,
-                    Arrays.asList(
-                        Key.of("t1"), Key.of("t2"), Key.of("t3"), Key.of("t4"), Key.of("t5"))))
+            contentsWithoutId(
+                store()
+                    .getValues(
+                        newBranch,
+                        Arrays.asList(
+                            Key.of(T_1), Key.of(T_2), Key.of(T_3), Key.of(T_4), Key.of(T_5)))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
-                Key.of("t1"), V_1_2,
-                Key.of("t2"), V_2_2,
-                Key.of("t4"), V_4_1,
-                Key.of("t5"), V_5_1));
+                Key.of(T_1), V_1_2,
+                Key.of(T_2), V_2_2,
+                Key.of(T_4), V_4_1,
+                Key.of(T_5), V_5_1));
   }
 
   @ParameterizedTest
@@ -369,9 +375,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
     store().create(anotherBranch, Optional.empty());
     final Hash unrelatedCommit =
         commit("Another Commit")
-            .put("t1", V_1_1)
-            .put("t2", V_2_1)
-            .put("t3", V_3_1)
+            .put(T_1, V_1_1)
+            .put(T_2, V_2_1)
+            .put(T_3, V_3_1)
             .toBranch(anotherBranch);
 
     final BranchName newBranch = BranchName.of("bar_1");
@@ -398,7 +404,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
   protected void transplantBasic(boolean individualCommits) throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_2");
     store().create(newBranch, Optional.empty());
-    commit("Unrelated commit").put("t5", V_5_1).toBranch(newBranch);
+    commit("Unrelated commit").put(T_5, V_5_1).toBranch(newBranch);
 
     store()
         .transplant(
@@ -412,11 +418,12 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             false,
             false);
     soft.assertThat(
-            store().getValues(newBranch, Arrays.asList(Key.of("t1"), Key.of("t4"), Key.of("t5"))))
+            contentsWithoutId(
+                store().getValues(newBranch, Arrays.asList(Key.of(T_1), Key.of(T_4), Key.of(T_5)))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
-                Key.of("t1"), V_1_2,
-                Key.of("t4"), V_4_1,
-                Key.of("t5"), V_5_1));
+                Key.of(T_1), V_1_2,
+                Key.of(T_4), V_4_1,
+                Key.of(T_5), V_5_1));
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/OnRefOnly.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/OnRefOnly.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.testworker;
 
 import com.google.protobuf.ByteString;
-import java.util.UUID;
 import org.immutables.value.Value;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.types.ContentTypes;
@@ -32,7 +31,7 @@ public abstract class OnRefOnly extends Content {
   }
 
   public static OnRefOnly newOnRef(String onRef) {
-    return ImmutableOnRefOnly.builder().onRef(onRef).id(UUID.randomUUID().toString()).build();
+    return ImmutableOnRefOnly.builder().onRef(onRef).build();
   }
 
   public abstract String getOnRef();
@@ -43,6 +42,10 @@ public abstract class OnRefOnly extends Content {
   }
 
   public ByteString serialized() {
-    return ByteString.copyFromUtf8(getType().name() + ":" + getId() + ":" + getOnRef());
+    String id = getId();
+    if (id == null) {
+      id = "";
+    }
+    return ByteString.copyFromUtf8(getType().name() + ":" + id + ":" + getOnRef());
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentSerializer.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentSerializer.java
@@ -55,6 +55,9 @@ abstract class TestContentSerializer<C extends Content> implements ContentSerial
 
     i = serialized.indexOf(':');
     String contentId = serialized.substring(0, i);
+    if (contentId.isEmpty()) {
+      contentId = null;
+    }
     i = serialized.indexOf(':');
     String onRef = serialized.substring(i + 1);
 


### PR DESCRIPTION
... and ignore cid returned by the version-store in assertions. Udpate some contents to make those "unique" (for new storage stuff).

Make AbstractMerge+AbstractTranspant use constants, add some new assertions.

Remove global-state testing from AbstractDuplicateTable.