### PR TITLE
Allow `-` as a reference name in v2 REST paths

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpApiV2.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpApiV2.java
@@ -69,7 +69,7 @@ public class HttpApiV2 implements NessieApiV2 {
     return (Branch)
         client
             .newRequest()
-            .path("trees/main") // TODO: use trees/-
+            .path("trees/-")
             .unwrap(NessieNotFoundException.class)
             .get()
             .readEntity(SingleReferenceResponse.class)

--- a/model/src/main/java/org/projectnessie/api/v2/doc/ApiDoc.java
+++ b/model/src/main/java/org/projectnessie/api/v2/doc/ApiDoc.java
@@ -80,7 +80,6 @@ public interface ApiDoc {
       "Specifies a named branch or tag reference.\n"
           + "\n"
           + "A named reference can be specification in these forms:\n"
-          + "- \\- (literal minus character) - Identifies the default branch.\n"
           + "- name - Identifies a branch or tag without a concrete HEAD 'hash' value.\n"
           + "- name@hash - Identifies the 'hash' commit on a branch or tag.\n"
           + "\n"

--- a/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
@@ -357,7 +357,6 @@ public interface HttpTreeApi extends TreeApi {
               examples = {
                 @ExampleObject(ref = "ref"),
                 @ExampleObject(ref = "refWithHash"),
-                @ExampleObject(ref = "refDefault"),
               })
           @PathParam("ref")
           String ref,
@@ -405,7 +404,6 @@ public interface HttpTreeApi extends TreeApi {
               examples = {
                 @ExampleObject(ref = "ref"),
                 @ExampleObject(ref = "refWithHash"),
-                @ExampleObject(ref = "refDefault"),
               })
           @PathParam("ref")
           String ref)

--- a/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/model/src/main/java/org/projectnessie/model/Validation.java
@@ -36,7 +36,7 @@ public final class Validation {
   public static final String REF_NAME_OR_HASH_REGEX =
       "^((" + HASH_RAW_REGEX + ")|(" + REF_NAME_RAW_REGEX + "))$";
   public static final String REF_NAME_PATH_REGEX =
-      "^(" + REF_NAME_RAW_REGEX + "(@(" + HASH_RAW_REGEX + ")?)?|@" + HASH_RAW_REGEX + ")$";
+      "^(" + REF_NAME_RAW_REGEX + "(@(" + HASH_RAW_REGEX + ")?)?|@" + HASH_RAW_REGEX + ")|-$";
   public static final String REF_NAME_PATH_ELEMENT_REGEX = "([^/]+|[^@]+(@|%40)[^@/]*)";
 
   public static final Pattern HASH_PATTERN = Pattern.compile(HASH_REGEX);


### PR DESCRIPTION
The literal minus char was meant to be used as a well-known placeholder for the default branch in v2 REST paths.

However, #5004 missed those use cases. This PR fixes the path RegEx to allow `-` as a reference specification and adjusts RestV2TreeResource to treat it as the configured default branch name.

Fixes #5606