### PR TITLE
DatabaseAdapter/identifyHeadsAndForks: Do not return NO_ANCESTOR as fork point

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencesUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencesUtil.java
@@ -30,6 +30,7 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.persist.adapter.spi.AbstractDatabaseAdapter;
 
 @Beta
 public final class ReferencesUtil {
@@ -107,7 +108,9 @@ public final class ReferencesUtil {
                 if (!parents.add(parent)) {
                   // If "parent" has already been added to the set of parents, then it must be a
                   // fork point.
-                  forkPoints.add(parent);
+                  if (!AbstractDatabaseAdapter.NO_ANCESTOR.equals(parent)) {
+                    forkPoints.add(parent);
+                  }
                 } else {
                   // Commits in "parents" that are also contained in "heads" cannot be HEADs.
                   // This can happen because the commits are scanned in "random order".


### PR DESCRIPTION
`NO_ANCESTOR` is a commit ID that does not exist, so it is wrong to
return it as a fork point.