### PR TITLE
Remove unused Jaeger properties

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -141,7 +141,6 @@ jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-da
 jackson-jaxrs-json-provider = { module = "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider" }
 jackson-jaxrs-xml-provider = { module = "com.fasterxml.jackson.jaxrs:jackson-jaxrs-xml-provider" }
 jacoco-maven-plugin = { module = "org.jacoco:jacoco-maven-plugin", version.ref = "jacoco" }
-jaeger-core = { module = "io.jaegertracing:jaeger-core", version = "1.8.1" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version = "1.3.5" }
 jakarta-enterprise-cdi-api = { module = "jakarta.enterprise:jakarta.enterprise.cdi-api", version = "2.0.2" }
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version = "2.0.2" }

--- a/servers/quarkus-cli/src/main/resources/application.properties
+++ b/servers/quarkus-cli/src/main/resources/application.properties
@@ -60,8 +60,6 @@ quarkus.log.console.level=WARN
 quarkus.log.file.level=INFO
 quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
 quarkus.log.category."io.netty".level=WARN
-# Don't log toggling warnings about "FlushCommand errors" + "FlushCommand working again" - see https://github.com/projectnessie/nessie/issues/1500
-quarkus.log.category."io.jaegertracing.internal.reporters".level=ERROR
 # Instruct jacoco to reuse output files to preserve coverage data across multiple test JVM restarts.
 quarkus.jacoco.reuse-data-file=true
 

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -102,8 +102,6 @@ quarkus.log.console.level=INFO
 quarkus.log.file.level=INFO
 quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
 quarkus.log.category."io.netty".level=WARN
-# Don't log toggling warnings about "FlushCommand errors" + "FlushCommand working again" - see https://github.com/projectnessie/nessie/issues/1500
-quarkus.log.category."io.jaegertracing.internal.reporters".level=ERROR
 # Effectively disable HTTP request logging to the console (HTTP access logs happen at INFO level)
 quarkus.log.category."io.quarkus.http.access-log".level=${HTTP_ACCESS_LOG_LEVEL:INFO}
 
@@ -132,15 +130,6 @@ quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.enable=true
 
 quarkus.application.name=Nessie
-
-## Quarkus monitoring and tracing settings
-## jaeger specific settings
-quarkus.jaeger.service-name=nessie
-quarkus.jaeger.sampler-type=ratelimiting
-quarkus.jaeger.sampler-param=1
-#quarkus.jaeger.endpoint=http://localhost:14268/api/traces
-# fixed at buildtime
-quarkus.jaeger.metrics.enabled=true
 
 ## sentry specific settings
 quarkus.log.sentry.level=ERROR
@@ -184,7 +173,6 @@ quarkus.opentelemetry.tracer.enabled=true
 
 # Overrides
 ## dev overrides - dev is used when running Nessie in dev mode `mvn quarkus:dev`
-%dev.quarkus.jaeger.sampler-type=const
 %dev.quarkus.dynamodb.endpoint-override=http://localhost:8000
 %dev.quarkus.dynamodb.aws.credentials.type=STATIC
 %dev.quarkus.dynamodb.aws.credentials.static-provider.access-key-id=test-key

--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/BaseConfigProfile.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/BaseConfigProfile.java
@@ -24,7 +24,7 @@ public class BaseConfigProfile implements QuarkusTestProfile {
   public static final String TEST_REPO_ID = "nessie-test";
 
   public static final Map<String, String> CONFIG_OVERRIDES =
-      ImmutableMap.<String, String>builder().put("quarkus.jaeger.sampler-type", "const").build();
+      ImmutableMap.<String, String>builder().build();
 
   public static final Map<String, String> VERSION_STORE_CONFIG;
 


### PR DESCRIPTION
This change is following up on #5605 and #5607

----

From Quarkus runtime log:
```
2022-12-06 16:38:10,324 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.jaeger.service-name" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
2022-12-06 16:38:10,324 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.jaeger.sampler-param" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
2022-12-06 16:38:10,324 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.jaeger.metrics.enabled" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
2022-12-06 16:38:10,324 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.jaeger.sampler-type" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```