### PR TITLE
python: add ruff linter

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,3 +1,40 @@
+[tool.ruff]
+exclude = ['docs']
+ignore = [
+    'ANN101',
+    'ANN401',
+    'S101',
+    'I001',  # ruff does not support flake8 "import-order-style = smarkets" yet
+]
+line-length = 140
+select = [
+    'ANN',
+    'B',
+    'C',
+    'E',
+    'F',
+    'I',
+    'S',
+    'W',
+]
+# equivalent to flake8 "--docstring-convention=google"
+extend-select = ["D"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D401",  # new: imperative mood
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D412",
+    "D413",
+]
+
 [tool.black]
 line-length = 140
 include = '\.pyi?$'

--- a/python/requirements_lint.txt
+++ b/python/requirements_lint.txt
@@ -28,3 +28,4 @@ mypy==1.3.0
 pytest-mypy==0.10.3
 pylint==2.17.4
 pylintfileheader==0.3.2
+ruff==0.0.267

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -17,7 +17,7 @@ universal = 1
 [flake8]
 exclude = docs
 select = ANN,B,B9,B950,BLK,C,D,E,F,I,S,W
-ignore = ANN101,ANN102,ANN401,S101,D412,W503
+ignore = ANN101,ANN401,S101,D412,W503
 max-line-length = 140
 max-complexity = 10
 application-import-names = pynessie,tests

--- a/python/tests/test_nessie_cli_content.py
+++ b/python/tests/test_nessie_cli_content.py
@@ -124,7 +124,7 @@ def test_content_list() -> None:
     )
     tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(2)
-    assert_that(set(t.kind for t in tables)).is_equal_to({"DELTA_LAKE_TABLE", "ICEBERG_TABLE"})
+    assert_that({t.kind for t in tables}).is_equal_to({"DELTA_LAKE_TABLE", "ICEBERG_TABLE"})
 
     result = execute_cli_command(
         ["--json", CONTENT_COMMAND, "list", "--ref", branch, "--filter", "entry.namespace.startsWith('this.is.del')"]
@@ -136,7 +136,7 @@ def test_content_list() -> None:
     result = execute_cli_command(["--json", CONTENT_COMMAND, "list", "--ref", branch, "--filter", "entry.namespace.startsWith('this.is')"])
     tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(3)
-    assert_that(set(i.kind for i in tables)).is_equal_to({"ICEBERG_TABLE", "ICEBERG_VIEW", "DELTA_LAKE_TABLE"})
+    assert_that({i.kind for i in tables}).is_equal_to({"ICEBERG_TABLE", "ICEBERG_VIEW", "DELTA_LAKE_TABLE"})
 
 
 @pytest.mark.vcr

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -40,6 +40,7 @@ basepython = python
 deps =
     -r{toxinidir}/requirements_lint.txt
 commands =
+    ruff pynessie tests tools
     # flake8 includes black check due to flake8-black
     # flake8 includes isort check which checks for import order due to flake8-isort
     flake8 pynessie tests tools


### PR DESCRIPTION
> Ruff aims to be orders of magnitude faster than alternative tools while integrating more functionality behind a single, common interface. Ruff can be used to replace Flake8 (plus a variety of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), and even a subset of [pyupgrade](https://pypi.org/project/pyupgrade/) and [autoflake](https://pypi.org/project/autoflake/) all while executing tens or hundreds of times faster than any individual tool. Ruff goes beyond the responsibilities of a traditional linter, instead functioning as an advanced code transformation tool capable of upgrading type annotations, rewriting class definitions, sorting imports, and more.

see https://github.com/charliermarsh/ruff/

just experimenting with this for now