### PR TITLE
Gradle: no longer run test classes concurrently

### DIFF
--- a/servers/jax-rs-tests/build.gradle.kts
+++ b/servers/jax-rs-tests/build.gradle.kts
@@ -53,5 +53,3 @@ dependencies {
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
-
-tasks.named<Test>("test") { maxParallelForks = Runtime.getRuntime().availableProcessors() }

--- a/versioned/persist/dynamodb/build.gradle.kts
+++ b/versioned/persist/dynamodb/build.gradle.kts
@@ -49,5 +49,3 @@ dependencies {
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
-
-tasks.named<Test>("test") { maxParallelForks = Runtime.getRuntime().availableProcessors() }

--- a/versioned/persist/inmem/build.gradle.kts
+++ b/versioned/persist/inmem/build.gradle.kts
@@ -44,5 +44,3 @@ dependencies {
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
-
-tasks.named<Test>("test") { maxParallelForks = Runtime.getRuntime().availableProcessors() }

--- a/versioned/persist/mongodb/build.gradle.kts
+++ b/versioned/persist/mongodb/build.gradle.kts
@@ -45,5 +45,3 @@ dependencies {
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
-
-tasks.named<Test>("test") { maxParallelForks = Runtime.getRuntime().availableProcessors() }

--- a/versioned/persist/tx/build.gradle.kts
+++ b/versioned/persist/tx/build.gradle.kts
@@ -52,8 +52,6 @@ dependencies {
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
-tasks.named<Test>("test") { maxParallelForks = Runtime.getRuntime().availableProcessors() }
-
 tasks.named<Test>("intTest") {
   systemProperty("it.nessie.dbs", System.getProperty("it.nessie.dbs", "postgres"))
   systemProperty(

--- a/versioned/transfer/build.gradle.kts
+++ b/versioned/transfer/build.gradle.kts
@@ -69,5 +69,3 @@ dependencies {
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
-
-tasks.named<Test>("test") { maxParallelForks = Runtime.getRuntime().availableProcessors() }


### PR DESCRIPTION
Running multiple test classes concurrently does not help (much) to improve test/build duration. In fact, it can have the opposite effect and slow down the build due to too much CPU pressure by running multiple `test` tasks, each running multiple test classes.