### PR TITLE
Add key range parameters to REST API v2

### DIFF
--- a/model/src/main/java/org/projectnessie/api/v2/TreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/v2/TreeApi.java
@@ -256,6 +256,27 @@ public interface TreeApi {
       throws NessieNotFoundException;
 
   /**
+   * Similar to {@link #getContent(ContentKey, String)}, but takes min and max {@link ContentKey}s
+   * and returns the {@link Content} objects having their keys in that range in a named-reference (a
+   * {@link org.projectnessie.model.Branch} or {@link org.projectnessie.model.Tag}).
+   *
+   * @param ref named-reference to retrieve the content for
+   * @param minKey the lower bound of the content key range to retrieve (inclusive).
+   * @param maxKey the upper bound of the content key range to retrieve (exclusive).
+   * @return list of {@link GetMultipleContentsResponse.ContentWithKey}s
+   * @throws NessieNotFoundException if {@code ref} or {@code hashOnRef} does not exist
+   */
+  GetMultipleContentsResponse getRangeOfContents(
+      @Valid
+          @Pattern(
+              regexp = Validation.REF_NAME_PATH_REGEX,
+              message = Validation.REF_NAME_PATH_MESSAGE)
+          String ref,
+      @Valid ContentKey minKey,
+      @Valid ContentKey maxKey)
+      throws NessieNotFoundException;
+
+  /**
    * Similar to {@link #getContent(ContentKey, String)}, but takes multiple {@link ContentKey}s and
    * returns the {@link Content} for the one or more {@link ContentKey}s in a named-reference (a
    * {@link org.projectnessie.model.Branch} or {@link org.projectnessie.model.Tag}).

--- a/model/src/main/java/org/projectnessie/api/v2/doc/ApiDoc.java
+++ b/model/src/main/java/org/projectnessie/api/v2/doc/ApiDoc.java
@@ -103,11 +103,19 @@ public interface ApiDoc {
           + "'type' parameter may be used to ensure the operation is performed on the same object that the user "
           + "expects.\n";
 
-  String KEY_PARAMETER_DESCRIPTION =
-      "The key to a content object.\n"
-          + "\n"
-          + "Key components (namespaces) are separated by the dot ('.') character. Dot ('.') characters that are not "
+  String KEY_ELEMENTS_DESCRIPTION =
+      "Key components (namespaces) are separated by the dot ('.') character. Dot ('.') characters that are not "
           + "Nessie namespace separators must be encoded as the 'group separator' ASCII character (0x1D).\n";
+
+  String KEY_PARAMETER_DESCRIPTION = "The key to a content object.\n\n" + KEY_ELEMENTS_DESCRIPTION;
+
+  String KEY_MIN_PARAMETER_DESCRIPTION =
+      "[Future] The lower bound of the content key range to retrieve (inclusive).\n\n"
+          + KEY_ELEMENTS_DESCRIPTION;
+
+  String KEY_MAX_PARAMETER_DESCRIPTION =
+      "[Future] The upper bound of the content key range to retrieve (exclusive).\n\n"
+          + KEY_ELEMENTS_DESCRIPTION;
 
   String DEFAULT_KEY_MERGE_MODE_DESCRIPTION =
       "The default merge mode. If not set, `NORMAL` is assumed.\n"

--- a/model/src/main/java/org/projectnessie/api/v2/params/AbstractParams.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/AbstractParams.java
@@ -36,7 +36,7 @@ public abstract class AbstractParams<IMPL extends AbstractParams<IMPL>> {
 
   protected AbstractParams() {}
 
-  protected AbstractParams(Integer maxRecords, String pageToken) {
+  protected AbstractParams(@Nullable Integer maxRecords, @Nullable String pageToken) {
     this.maxRecords = maxRecords;
     this.pageToken = pageToken;
   }

--- a/model/src/main/java/org/projectnessie/api/v2/params/DiffParams.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/DiffParams.java
@@ -24,6 +24,7 @@ import javax.ws.rs.PathParam;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.immutables.builder.Builder.Constructor;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Validation;
 
 /**
@@ -33,7 +34,7 @@ import org.projectnessie.model.Validation;
  * intention is to allow clients to request a diff on a sub-set of keys (e.g. in one particular
  * namespace) or just for one particular key.
  */
-public class DiffParams extends AbstractParams<DiffParams> {
+public class DiffParams extends KeyRangeParams<DiffParams> {
 
   @NotNull
   @Pattern(regexp = Validation.REF_NAME_PATH_REGEX, message = Validation.REF_NAME_PATH_MESSAGE)
@@ -63,8 +64,10 @@ public class DiffParams extends AbstractParams<DiffParams> {
       @NotNull String fromRef,
       @NotNull String toRef,
       @Nullable Integer maxRecords,
-      @Nullable String pageToken) {
-    super(maxRecords, pageToken);
+      @Nullable String pageToken,
+      @Nullable ContentKey minKey,
+      @Nullable ContentKey maxKey) {
+    super(maxRecords, pageToken, minKey, maxKey);
     this.fromRef = fromRef;
     this.toRef = toRef;
   }
@@ -83,6 +86,6 @@ public class DiffParams extends AbstractParams<DiffParams> {
 
   @Override
   public DiffParams forNextPage(String pageToken) {
-    return new DiffParams(fromRef, toRef, maxRecords(), pageToken);
+    return new DiffParams(fromRef, toRef, maxRecords(), pageToken, minKey(), maxKey());
   }
 }

--- a/model/src/main/java/org/projectnessie/api/v2/params/EntriesParams.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/EntriesParams.java
@@ -20,6 +20,7 @@ import javax.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.immutables.builder.Builder.Constructor;
+import org.projectnessie.model.ContentKey;
 
 /**
  * The purpose of this class is to include optional parameters that can be passed to {@code
@@ -28,7 +29,7 @@ import org.immutables.builder.Builder.Constructor;
  * <p>For easier usage of this class, there is {@link EntriesParams#builder()}, which allows
  * configuring/setting the different parameters.
  */
-public class EntriesParams extends AbstractParams<EntriesParams> {
+public class EntriesParams extends KeyRangeParams<EntriesParams> {
 
   @Nullable
   @Parameter(
@@ -46,8 +47,13 @@ public class EntriesParams extends AbstractParams<EntriesParams> {
   public EntriesParams() {}
 
   @Constructor
-  EntriesParams(@Nullable Integer maxRecords, @Nullable String pageToken, @Nullable String filter) {
-    super(maxRecords, pageToken);
+  EntriesParams(
+      @Nullable Integer maxRecords,
+      @Nullable String pageToken,
+      @Nullable ContentKey minKey,
+      @Nullable ContentKey maxKey,
+      @Nullable String filter) {
+    super(maxRecords, pageToken, minKey, maxKey);
     this.filter = filter;
   }
 
@@ -66,6 +72,6 @@ public class EntriesParams extends AbstractParams<EntriesParams> {
 
   @Override
   public EntriesParams forNextPage(String pageToken) {
-    return new EntriesParams(maxRecords(), pageToken, filter);
+    return new EntriesParams(maxRecords(), pageToken, minKey(), maxKey(), filter);
   }
 }

--- a/model/src/main/java/org/projectnessie/api/v2/params/KeyRangeParams.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/KeyRangeParams.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.v2.params;
+
+import static org.projectnessie.api.v2.doc.ApiDoc.KEY_MAX_PARAMETER_DESCRIPTION;
+import static org.projectnessie.api.v2.doc.ApiDoc.KEY_MIN_PARAMETER_DESCRIPTION;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.QueryParam;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.projectnessie.model.ContentKey;
+
+public abstract class KeyRangeParams<IMPL extends KeyRangeParams<IMPL>>
+    extends AbstractParams<IMPL> {
+
+  @Parameter(
+      description = KEY_MIN_PARAMETER_DESCRIPTION,
+      examples = @ExampleObject(ref = "ContentKeyGet"))
+  @QueryParam("min-key")
+  @Nullable
+  private ContentKey minKey;
+
+  @Parameter(
+      description = KEY_MAX_PARAMETER_DESCRIPTION,
+      examples = @ExampleObject(ref = "ContentKeyGet"))
+  @QueryParam("max-key")
+  @Nullable
+  private ContentKey maxKey;
+
+  protected KeyRangeParams() {}
+
+  public KeyRangeParams(
+      @Nullable Integer maxRecords,
+      @Nullable String pageToken,
+      @Nullable ContentKey minKey,
+      @Nullable ContentKey maxKey) {
+    super(maxRecords, pageToken);
+    this.minKey = minKey;
+    this.maxKey = maxKey;
+  }
+
+  @Nullable
+  public ContentKey minKey() {
+    return minKey;
+  }
+
+  @Nullable
+  public ContentKey maxKey() {
+    return maxKey;
+  }
+}

--- a/model/src/main/java/org/projectnessie/error/NessieContentNotFoundException.java
+++ b/model/src/main/java/org/projectnessie/error/NessieContentNotFoundException.java
@@ -24,6 +24,10 @@ public class NessieContentNotFoundException extends NessieNotFoundException {
     super(String.format("Could not find content for key '%s' in reference '%s'.", key, ref));
   }
 
+  public NessieContentNotFoundException(String message) {
+    super(message);
+  }
+
   public NessieContentNotFoundException(NessieError error) {
     super(error);
   }

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractResteasyV2Test.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractResteasyV2Test.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.client.ext.NessieApiVersion;
 import org.projectnessie.client.ext.NessieApiVersions;
 import org.projectnessie.client.ext.NessieClientUri;
+import org.projectnessie.error.NessieError;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.CommitResponse;
@@ -159,6 +160,28 @@ public abstract class AbstractResteasyV2Test {
                         ((IcebergTable) content.getContent()).getMetadataLocation()));
 
     assertThat(entries).containsExactlyInAnyOrder(entry(key1, "loc1"), entry(key2, "loc2"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"rangeSimple", "range/With/slash"})
+  void testGetRangeOfContents(String branchName) {
+    Branch branch = createBranch(branchName);
+    ContentKey key1 = ContentKey.of("test.with.dot.and/slash", "Key");
+    ContentKey key2 = ContentKey.of("test/slash", "Key");
+
+    assertThat(
+            rest()
+                .get(
+                    "trees/{ref}/contents/{min}/{max}",
+                    branch.toPathString(),
+                    key1.toPathString(),
+                    key2.toPathString())
+                .then()
+                .statusCode(404) // Not implemented yet
+                .extract()
+                .as(NessieError.class)
+                .getMessage())
+        .isEqualTo("Content lookup by key range is not supported yet.");
   }
 
   /** Dedicated test for human-readable references in URL paths. */


### PR DESCRIPTION
* In "diff" API

* In "get entries"

* New "get contents" endpoint for range queries

This is just an API-level change to reserve REST paths and query 
parameters. Server-side implementation to be done separately.

Closes #5591