### PR TITLE
python: upgrade safety to 2.3.4

### DIFF
--- a/python/requirements_lint.txt
+++ b/python/requirements_lint.txt
@@ -25,6 +25,6 @@ flake8-isort==5.0.3
 isort==5.10.1
 mypy==0.991
 pytest-mypy==0.10.2
-safety==2.3.3
+safety==2.3.4
 pylint==2.15.7
 pylintfileheader==0.3.2


### PR DESCRIPTION
we need https://github.com/pyupio/safety/commit/2c4bb4bdb934558396a7274b4109439559bbb201 because linting currently fails with:
```
ImportError: cannot import name 'LegacyVersion' from 'packaging.version'
 (/home/runner/work/nessie/nessie/python/.tox/lint/lib/python3.8/site-packages/packaging/version.py)
```