### PR TITLE
Expose updated reference data in java client APIs

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/AssignBranchBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/AssignBranchBuilder.java
@@ -19,6 +19,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 
 /**
@@ -30,4 +31,11 @@ public interface AssignBranchBuilder extends OnBranchBuilder<AssignBranchBuilder
   AssignBranchBuilder assignTo(@Valid @NotNull Reference assignTo);
 
   void assign() throws NessieNotFoundException, NessieConflictException;
+
+  /**
+   * Assigns the branch to the specified hash and returns its updated information.
+   *
+   * @since {@link NessieApiV2}
+   */
+  Branch assignAndGet() throws NessieNotFoundException, NessieConflictException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/AssignTagBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/AssignTagBuilder.java
@@ -20,6 +20,7 @@ import javax.validation.constraints.NotNull;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
 
 /**
  * Request builder for "assign tag".
@@ -30,4 +31,11 @@ public interface AssignTagBuilder extends OnTagBuilder<AssignTagBuilder> {
   AssignTagBuilder assignTo(@Valid @NotNull Reference assignTo);
 
   void assign() throws NessieNotFoundException, NessieConflictException;
+
+  /**
+   * Assigns the tag to the specified hash and returns its updated information.
+   *
+   * @since {@link NessieApiV2}
+   */
+  Tag assignAndGet() throws NessieNotFoundException, NessieConflictException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/DeleteBranchBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/DeleteBranchBuilder.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.api;
 
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 
 /**
  * Request builder for "delete branch".
@@ -24,5 +25,13 @@ import org.projectnessie.error.NessieNotFoundException;
  * @since {@link NessieApiV1}
  */
 public interface DeleteBranchBuilder extends OnBranchBuilder<DeleteBranchBuilder> {
+
   void delete() throws NessieConflictException, NessieNotFoundException;
+
+  /**
+   * Deletes the branch and returns its information as it was just before deletion.
+   *
+   * @since {@link NessieApiV2}
+   */
+  Branch getAndDelete() throws NessieNotFoundException, NessieConflictException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/api/DeleteTagBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/DeleteTagBuilder.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.api;
 
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Tag;
 
 /**
  * Request builder for "delete tag".
@@ -24,5 +25,13 @@ import org.projectnessie.error.NessieNotFoundException;
  * @since {@link NessieApiV1}
  */
 public interface DeleteTagBuilder extends OnTagBuilder<DeleteTagBuilder> {
+
   void delete() throws NessieConflictException, NessieNotFoundException;
+
+  /**
+   * Deletes the tag and returns its information as it was just before deletion.
+   *
+   * @since {@link NessieApiV2}
+   */
+  Tag getAndDelete() throws NessieNotFoundException, NessieConflictException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
@@ -19,6 +19,7 @@ import org.projectnessie.client.builder.BaseAssignBranchBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 
 final class HttpAssignBranch extends BaseAssignBranchBuilder {
@@ -32,5 +33,11 @@ final class HttpAssignBranch extends BaseAssignBranchBuilder {
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
     client.getTreeApi().assignReference(Reference.ReferenceType.BRANCH, branchName, hash, assignTo);
+  }
+
+  @Override
+  public Branch assignAndGet() {
+    throw new UnsupportedOperationException(
+        "The assignAndGet operation is not supported for branches in API v1");
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
@@ -20,6 +20,7 @@ import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
 
 final class HttpAssignTag extends BaseAssignTagBuilder {
 
@@ -32,5 +33,11 @@ final class HttpAssignTag extends BaseAssignTagBuilder {
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
     client.getTreeApi().assignReference(Reference.ReferenceType.TAG, tagName, hash, assignTo);
+  }
+
+  @Override
+  public Tag assignAndGet() {
+    throw new UnsupportedOperationException(
+        "The assignAndGet operation is not supported for tags in API v1");
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteBranch.java
@@ -20,6 +20,7 @@ import org.projectnessie.client.builder.BaseOnBranchBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 
 final class HttpDeleteBranch extends BaseOnBranchBuilder<DeleteBranchBuilder>
@@ -33,5 +34,11 @@ final class HttpDeleteBranch extends BaseOnBranchBuilder<DeleteBranchBuilder>
   @Override
   public void delete() throws NessieConflictException, NessieNotFoundException {
     client.getTreeApi().deleteReference(Reference.ReferenceType.BRANCH, branchName, hash);
+  }
+
+  @Override
+  public Branch getAndDelete() {
+    throw new UnsupportedOperationException(
+        "The getAndDelete operation is not supported for branches in API v1");
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteTag.java
@@ -21,6 +21,7 @@ import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
 
 final class HttpDeleteTag extends BaseOnTagBuilder<DeleteTagBuilder> implements DeleteTagBuilder {
 
@@ -33,5 +34,11 @@ final class HttpDeleteTag extends BaseOnTagBuilder<DeleteTagBuilder> implements 
   @Override
   public void delete() throws NessieConflictException, NessieNotFoundException {
     client.getTreeApi().deleteReference(Reference.ReferenceType.TAG, tagName, hash);
+  }
+
+  @Override
+  public Tag getAndDelete() {
+    throw new UnsupportedOperationException(
+        "The getAndDelete operation is not supported for tags in API v1");
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignTag.java
@@ -20,6 +20,8 @@ import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.SingleReferenceResponse;
+import org.projectnessie.model.Tag;
 
 final class HttpAssignTag extends BaseAssignTagBuilder {
   private final HttpClient client;
@@ -30,12 +32,20 @@ final class HttpAssignTag extends BaseAssignTagBuilder {
 
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
-    client
-        .newRequest()
-        .path("trees/{ref}")
-        .resolveTemplate("ref", Reference.toPathString(tagName, hash))
-        .queryParam("type", Reference.ReferenceType.TAG.name())
-        .unwrap(NessieNotFoundException.class, NessieConflictException.class)
-        .put(assignTo);
+    assignAndGet();
+  }
+
+  @Override
+  public Tag assignAndGet() throws NessieNotFoundException, NessieConflictException {
+    return (Tag)
+        client
+            .newRequest()
+            .path("trees/{ref}")
+            .resolveTemplate("ref", Reference.toPathString(tagName, hash))
+            .queryParam("type", Reference.ReferenceType.TAG.name())
+            .unwrap(NessieNotFoundException.class, NessieConflictException.class)
+            .put(assignTo)
+            .readEntity(SingleReferenceResponse.class)
+            .getReference();
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteBranch.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteBranch.java
@@ -20,7 +20,9 @@ import org.projectnessie.client.builder.BaseOnBranchBuilder;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.SingleReferenceResponse;
 
 final class HttpDeleteBranch extends BaseOnBranchBuilder<DeleteBranchBuilder>
     implements DeleteBranchBuilder {
@@ -32,12 +34,20 @@ final class HttpDeleteBranch extends BaseOnBranchBuilder<DeleteBranchBuilder>
 
   @Override
   public void delete() throws NessieConflictException, NessieNotFoundException {
-    client
-        .newRequest()
-        .path("trees/{ref}")
-        .resolveTemplate("ref", Reference.toPathString(branchName, hash))
-        .queryParam("type", Reference.ReferenceType.BRANCH.name())
-        .unwrap(NessieConflictException.class, NessieNotFoundException.class)
-        .delete();
+    getAndDelete();
+  }
+
+  @Override
+  public Branch getAndDelete() throws NessieNotFoundException, NessieConflictException {
+    return (Branch)
+        client
+            .newRequest()
+            .path("trees/{ref}")
+            .resolveTemplate("ref", Reference.toPathString(branchName, hash))
+            .queryParam("type", Reference.ReferenceType.BRANCH.name())
+            .unwrap(NessieConflictException.class, NessieNotFoundException.class)
+            .delete()
+            .readEntity(SingleReferenceResponse.class)
+            .getReference();
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteTag.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteTag.java
@@ -21,6 +21,8 @@ import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.SingleReferenceResponse;
+import org.projectnessie.model.Tag;
 
 final class HttpDeleteTag extends BaseOnTagBuilder<DeleteTagBuilder> implements DeleteTagBuilder {
   private final HttpClient client;
@@ -31,12 +33,20 @@ final class HttpDeleteTag extends BaseOnTagBuilder<DeleteTagBuilder> implements 
 
   @Override
   public void delete() throws NessieConflictException, NessieNotFoundException {
-    client
-        .newRequest()
-        .path("trees/{ref}")
-        .resolveTemplate("ref", Reference.toPathString(tagName, hash))
-        .queryParam("type", Reference.ReferenceType.TAG.name())
-        .unwrap(NessieConflictException.class, NessieNotFoundException.class)
-        .delete();
+    getAndDelete();
+  }
+
+  @Override
+  public Tag getAndDelete() throws NessieNotFoundException, NessieConflictException {
+    return (Tag)
+        client
+            .newRequest()
+            .path("trees/{ref}")
+            .resolveTemplate("ref", Reference.toPathString(tagName, hash))
+            .queryParam("type", Reference.ReferenceType.TAG.name())
+            .unwrap(NessieConflictException.class, NessieNotFoundException.class)
+            .delete()
+            .readEntity(SingleReferenceResponse.class)
+            .getReference();
   }
 }

--- a/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpAssignBranch.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpAssignBranch.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v1api;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TestHttpAssignBranch {
+
+  @Test
+  public void testAssignAndGetDenied() {
+    assertThatThrownBy(() -> new HttpAssignBranch(null).assignAndGet())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("The assignAndGet operation is not supported for branches in API v1");
+  }
+}

--- a/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpAssignTag.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpAssignTag.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v1api;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TestHttpAssignTag {
+  @Test
+  public void testAssignAndGetDenied() {
+    assertThatThrownBy(() -> new HttpAssignTag(null).assignAndGet())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("The assignAndGet operation is not supported for tags in API v1");
+  }
+}

--- a/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpDeleteBranch.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpDeleteBranch.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v1api;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TestHttpDeleteBranch {
+  @Test
+  public void testGetAndDeleteDenied() {
+    assertThatThrownBy(() -> new HttpDeleteBranch(null).getAndDelete())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("The getAndDelete operation is not supported for branches in API v1");
+  }
+}

--- a/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpDeleteTag.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpDeleteTag.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v1api;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TestHttpDeleteTag {
+  @Test
+  public void testGetAndDeleteDenied() {
+    assertThatThrownBy(() -> new HttpDeleteTag(null).getAndDelete())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("The getAndDelete operation is not supported for tags in API v1");
+  }
+}

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRest.java
@@ -167,25 +167,19 @@ public abstract class AbstractRest {
     return expectedBranch;
   }
 
+  protected Tag createTag(String name, Reference from) throws BaseNessieClientServerException {
+    Reference created =
+        getApi()
+            .createReference()
+            .sourceRefName(from.getName())
+            .reference(Tag.of(name, from.getHash()))
+            .create();
+    assertThat(created).isInstanceOf(Tag.class);
+    return (Tag) created;
+  }
+
   protected Branch createBranch(String name) throws BaseNessieClientServerException {
     return createBranch(name, null);
-  }
-
-  protected static void getOrCreateEmptyBranch(NessieApiV1 api, String gcBranchName) {
-    try {
-      api.getReference().refName(gcBranchName).get();
-    } catch (NessieNotFoundException e) {
-      // create a reference pointing to NO_ANCESTOR hash.
-      try {
-        api.createReference().reference(Branch.of(gcBranchName, null)).create();
-      } catch (NessieNotFoundException | NessieConflictException ex) {
-        throw new RuntimeException(ex);
-      }
-    }
-  }
-
-  protected void deleteBranch(String name, String hash) throws BaseNessieClientServerException {
-    getApi().deleteBranch().branchName(name).hash(hash).delete();
   }
 
   /**

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestReferences.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestReferences.java
@@ -28,6 +28,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.ext.NessieApiVersions;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.NessieBadRequestException;
 import org.projectnessie.error.NessieConflictException;
@@ -177,6 +179,20 @@ public abstract class AbstractRestReferences extends AbstractRestMisc {
             .reference(Branch.of(branchName2, mainHash))
             .create();
     soft.assertThat(refBranch2).isEqualTo(Branch.of(branchName2, mainHash));
+  }
+
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void getAndDeleteBranch() throws Exception {
+    Branch branch = createBranch("testBranch");
+    assertThat(getApi().deleteBranch().branch(branch).getAndDelete()).isEqualTo(branch);
+  }
+
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void getAndDeleteTag() throws Exception {
+    Tag tag = createTag("testTag", getApi().getDefaultBranch());
+    assertThat(getApi().deleteTag().tag(tag).getAndDelete()).isEqualTo(tag);
   }
 
   @ParameterizedTest

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -177,8 +177,9 @@ public class RestV2TreeResource implements HttpTreeApi {
       Reference.ReferenceType type, String ref, Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
     Reference reference = resolveRef(ref, type);
-    tree().assignReference(type, reference.getName(), reference.getHash(), assignTo);
-    return SingleReferenceResponse.builder().reference(reference).build();
+    Reference updated =
+        tree().assignReference(type, reference.getName(), reference.getHash(), assignTo);
+    return SingleReferenceResponse.builder().reference(updated).build();
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -241,13 +241,13 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
   }
 
   @Override
-  public void assignReference(
+  public Reference assignReference(
       Reference.ReferenceType referenceType,
       String referenceName,
       String expectedHash,
       Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
-    assignReference(toNamedRef(referenceType, referenceName), expectedHash, assignTo);
+    return assignReference(toNamedRef(referenceType, referenceName), expectedHash, assignTo);
   }
 
   @Override
@@ -703,17 +703,15 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
     }
   }
 
-  protected void assignReference(NamedRef ref, String expectedHash, Reference assignTo)
+  protected Reference assignReference(NamedRef ref, String expectedHash, Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
     try {
       ReferenceInfo<CommitMeta> resolved =
           getStore().getNamedRef(ref.getName(), GetNamedRefsParams.DEFAULT);
 
-      getStore()
-          .assign(
-              resolved.getNamedRef(),
-              toHash(expectedHash, true),
-              toHash(assignTo.getName(), assignTo.getHash()));
+      Hash targetHash = toHash(assignTo.getName(), assignTo.getHash());
+      getStore().assign(resolved.getNamedRef(), toHash(expectedHash, true), targetHash);
+      return RefUtil.toReference(ref, targetHash);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     } catch (ReferenceConflictException e) {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
@@ -111,14 +111,14 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
   }
 
   @Override
-  protected void assignReference(NamedRef ref, String expectedHash, Reference assignTo)
+  protected Reference assignReference(NamedRef ref, String expectedHash, Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
     startAccessCheck()
         .canViewReference(
             namedRefWithHashOrThrow(assignTo.getName(), assignTo.getHash()).getValue())
         .canAssignRefToHash(ref)
         .checkAndThrow();
-    super.assignReference(ref, expectedHash, assignTo);
+    return super.assignReference(ref, expectedHash, assignTo);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -49,7 +49,7 @@ public interface TreeService {
       String refName, Reference.ReferenceType type, String hash, String sourceRefName)
       throws NessieNotFoundException, NessieConflictException;
 
-  void assignReference(
+  Reference assignReference(
       Reference.ReferenceType referenceType,
       String referenceName,
       String expectedHash,


### PR DESCRIPTION
For assign and delete operations.

This is supported only in API v2 because API v1 does not return the required information from the server.

Fixes #5595