### PR TITLE
Expose MergeBehavior to java clients

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/MergeTransplantBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/MergeTransplantBuilder.java
@@ -16,6 +16,8 @@
 package org.projectnessie.client.api;
 
 import javax.validation.constraints.Pattern;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.MergeBehavior;
 import org.projectnessie.model.Validation;
 
 public interface MergeTransplantBuilder<R extends MergeTransplantBuilder<R>>
@@ -31,4 +33,8 @@ public interface MergeTransplantBuilder<R extends MergeTransplantBuilder<R>>
   R fetchAdditionalInfo(boolean fetchAdditionalInfo);
 
   R returnConflictAsResult(boolean returnConflictAsResult);
+
+  R defaultMergeMode(MergeBehavior mergeBehavior);
+
+  R mergeMode(ContentKey key, MergeBehavior mergeBehavior);
 }

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
@@ -15,7 +15,12 @@
  */
 package org.projectnessie.client.builder;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.projectnessie.client.api.OnBranchBuilder;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.MergeBehavior;
+import org.projectnessie.model.MergeKeyBehavior;
 
 public abstract class BaseMergeTransplantBuilder<B extends OnBranchBuilder<B>>
     extends BaseOnBranchBuilder<B> {
@@ -25,6 +30,8 @@ public abstract class BaseMergeTransplantBuilder<B extends OnBranchBuilder<B>>
   protected Boolean dryRun;
   protected Boolean returnConflictAsResult;
   protected Boolean fetchAdditionalInfo;
+  protected MergeBehavior defaultMergeMode;
+  protected Map<ContentKey, MergeKeyBehavior> mergeModes;
 
   public B fromRefName(String fromRefName) {
     this.fromRefName = fromRefName;
@@ -48,6 +55,20 @@ public abstract class BaseMergeTransplantBuilder<B extends OnBranchBuilder<B>>
 
   public B returnConflictAsResult(boolean returnConflictAsResult) {
     this.returnConflictAsResult = returnConflictAsResult;
+    return (B) this;
+  }
+
+  public B defaultMergeMode(MergeBehavior mergeBehavior) {
+    defaultMergeMode = mergeBehavior;
+    return (B) this;
+  }
+
+  public B mergeMode(ContentKey key, MergeBehavior mergeBehavior) {
+    if (mergeModes == null) {
+      mergeModes = new HashMap<>();
+    }
+
+    mergeModes.put(key, MergeKeyBehavior.of(key, mergeBehavior));
     return (B) this;
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
@@ -40,6 +40,15 @@ final class HttpMergeReference extends BaseMergeReferenceBuilder {
             .isReturnConflictAsResult(returnConflictAsResult)
             .isFetchAdditionalInfo(fetchAdditionalInfo)
             .keepIndividualCommits(keepIndividualCommits);
+
+    if (defaultMergeMode != null) {
+      merge.defaultKeyMergeMode(defaultMergeMode);
+    }
+
+    if (mergeModes != null) {
+      merge.keyMergeModes(mergeModes.values());
+    }
+
     return client.getTreeApi().mergeRefIntoBranch(branchName, hash, merge.build());
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpTransplantCommits.java
@@ -40,6 +40,15 @@ final class HttpTransplantCommits extends BaseTransplantCommitsBuilder {
             .isReturnConflictAsResult(returnConflictAsResult)
             .isFetchAdditionalInfo(fetchAdditionalInfo)
             .keepIndividualCommits(keepIndividualCommits);
+
+    if (defaultMergeMode != null) {
+      transplant.defaultKeyMergeMode(defaultMergeMode);
+    }
+
+    if (mergeModes != null) {
+      transplant.keyMergeModes(mergeModes.values());
+    }
+
     return client
         .getTreeApi()
         .transplantCommitsIntoBranch(branchName, hash, message, transplant.build());

--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpMergeReference.java
@@ -41,20 +41,29 @@ final class HttpMergeReference extends BaseMergeReferenceBuilder {
 
   @Override
   public MergeResponse merge() throws NessieNotFoundException, NessieConflictException {
-    ImmutableMerge merge =
+    // TODO: message
+    ImmutableMerge.Builder merge =
         ImmutableMerge.builder()
             .fromHash(fromHash)
             .fromRefName(fromRefName)
             .isDryRun(dryRun)
             .isFetchAdditionalInfo(fetchAdditionalInfo)
-            .isReturnConflictAsResult(returnConflictAsResult)
-            .build(); // TODO: message
+            .isReturnConflictAsResult(returnConflictAsResult);
+
+    if (defaultMergeMode != null) {
+      merge.defaultKeyMergeMode(defaultMergeMode);
+    }
+
+    if (mergeModes != null) {
+      merge.keyMergeModes(mergeModes.values());
+    }
+
     return client
         .newRequest()
         .path("trees/{ref}/history/merge")
         .resolveTemplate("ref", Reference.toPathString(branchName, hash))
         .unwrap(NessieNotFoundException.class, NessieConflictException.class)
-        .post(merge)
+        .post(merge.build())
         .readEntity(MergeResponse.class);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpTransplantCommits.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpTransplantCommits.java
@@ -50,6 +50,15 @@ final class HttpTransplantCommits extends BaseTransplantCommitsBuilder {
             .isDryRun(dryRun)
             .isReturnConflictAsResult(returnConflictAsResult)
             .isFetchAdditionalInfo(fetchAdditionalInfo);
+
+    if (defaultMergeMode != null) {
+      transplant.defaultKeyMergeMode(defaultMergeMode);
+    }
+
+    if (mergeModes != null) {
+      transplant.keyMergeModes(mergeModes.values());
+    }
+
     return client
         .newRequest()
         .path("trees/{ref}/history/transplant")

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITOlderClients.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITOlderClients.java
@@ -15,8 +15,11 @@
  */
 package org.projectnessie.tools.compatibility.tests;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.tools.compatibility.api.Version;
+import org.projectnessie.tools.compatibility.api.VersionCondition;
 import org.projectnessie.tools.compatibility.internal.OlderNessieClientsExtension;
 
 @ExtendWith(OlderNessieClientsExtension.class)
@@ -24,5 +27,13 @@ public class ITOlderClients extends AbstractCompatibilityTests {
   @Override
   Version getClientVersion() {
     return version;
+  }
+
+  // MergeBehavior is supported by the java client since the release following 0.45.0
+  @VersionCondition(minVersion = "0.45.1")
+  @Override
+  @Test
+  public void mergeBehavior() throws BaseNessieClientServerException {
+    super.mergeBehavior();
   }
 }

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
@@ -15,8 +15,11 @@
  */
 package org.projectnessie.tools.compatibility.tests;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.tools.compatibility.api.Version;
+import org.projectnessie.tools.compatibility.api.VersionCondition;
 import org.projectnessie.tools.compatibility.internal.OlderNessieServersExtension;
 
 @ExtendWith(OlderNessieServersExtension.class)
@@ -25,5 +28,13 @@ public class ITOlderServers extends AbstractCompatibilityTests {
   @Override
   Version getClientVersion() {
     return Version.CURRENT;
+  }
+
+  // MergeBehavior is supported in REST API by servers since 0.26.0
+  @VersionCondition(minVersion = "0.26.0")
+  @Override
+  @Test
+  public void mergeBehavior() throws BaseNessieClientServerException {
+    super.mergeBehavior();
   }
 }


### PR DESCRIPTION
Pure REST clients already have the ability to specify per-key merge behaviour. This change exposes the same functionality to java clients.

Available in both API v1 and v2.

Fixes #5415