### PR TITLE
Support merge/transplant message overrides

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
@@ -27,6 +27,18 @@ import org.projectnessie.model.Reference;
  * @since {@link NessieApiV1}
  */
 public interface MergeReferenceBuilder extends MergeTransplantBuilder<MergeReferenceBuilder> {
+
+  /**
+   * Sets a custom merge commit message. The message is auto-generated if not set.
+   *
+   * <p>How the auto-generated message is constructed is not specified, but in general it will be
+   * based on the individual messages of the merged commits.
+   *
+   * @since {@link NessieApiV2}
+   */
+  @Override
+  MergeReferenceBuilder message(String message);
+
   MergeReferenceBuilder fromHash(@NotBlank String fromHash);
 
   /**

--- a/clients/client/src/main/java/org/projectnessie/client/api/MergeTransplantBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/MergeTransplantBuilder.java
@@ -22,6 +22,10 @@ import org.projectnessie.model.Validation;
 
 public interface MergeTransplantBuilder<R extends MergeTransplantBuilder<R>>
     extends OnBranchBuilder<R> {
+
+  /** See javadoc on overriding methods for details. */
+  R message(String message);
+
   R fromRefName(
       @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String fromRefName);

--- a/clients/client/src/main/java/org/projectnessie/client/api/TransplantCommitsBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/TransplantCommitsBuilder.java
@@ -28,6 +28,16 @@ import org.projectnessie.model.MergeResponse;
  * @since {@link NessieApiV1}
  */
 public interface TransplantCommitsBuilder extends MergeTransplantBuilder<TransplantCommitsBuilder> {
+
+  /**
+   * Sets an override for the transplanted commit message. If an override is not set, messages from
+   * the original commits are reused during transplanting.
+   *
+   * <p>Note: The message override is ignored when {@link #keepIndividualCommits(boolean) more than
+   * one commit} is transplanted without squashing. In other words, the message override is
+   * effective only when exactly one commit is produced on the target branch.
+   */
+  @Override
   TransplantCommitsBuilder message(String message);
 
   TransplantCommitsBuilder hashesToTransplant(

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
@@ -32,6 +32,12 @@ public abstract class BaseMergeTransplantBuilder<B extends OnBranchBuilder<B>>
   protected Boolean fetchAdditionalInfo;
   protected MergeBehavior defaultMergeMode;
   protected Map<ContentKey, MergeKeyBehavior> mergeModes;
+  protected String message;
+
+  public B message(String message) {
+    this.message = message;
+    return (B) this;
+  }
 
   public B fromRefName(String fromRefName) {
     this.fromRefName = fromRefName;

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.v1.params.ImmutableMerge;
+import org.projectnessie.client.api.MergeReferenceBuilder;
 import org.projectnessie.client.builder.BaseMergeReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
@@ -28,6 +29,11 @@ final class HttpMergeReference extends BaseMergeReferenceBuilder {
 
   HttpMergeReference(NessieApiClient client) {
     this.client = client;
+  }
+
+  @Override
+  public MergeReferenceBuilder message(String message) {
+    throw new UnsupportedOperationException("Merge message overrides are not supported in API v1.");
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpMergeReference.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpMergeReference.java
@@ -41,11 +41,11 @@ final class HttpMergeReference extends BaseMergeReferenceBuilder {
 
   @Override
   public MergeResponse merge() throws NessieNotFoundException, NessieConflictException {
-    // TODO: message
     ImmutableMerge.Builder merge =
         ImmutableMerge.builder()
             .fromHash(fromHash)
             .fromRefName(fromRefName)
+            .message(message)
             .isDryRun(dryRun)
             .isFetchAdditionalInfo(fetchAdditionalInfo)
             .isReturnConflictAsResult(returnConflictAsResult);

--- a/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpMergeReference.java
+++ b/clients/client/src/test/java/org/projectnessie/client/http/v1api/TestHttpMergeReference.java
@@ -13,20 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.builder;
+package org.projectnessie.client.http.v1api;
 
-import java.util.List;
-import org.projectnessie.client.api.TransplantCommitsBuilder;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public abstract class BaseTransplantCommitsBuilder
-    extends BaseMergeTransplantBuilder<TransplantCommitsBuilder>
-    implements TransplantCommitsBuilder {
+import org.junit.jupiter.api.Test;
 
-  protected List<String> hashesToTransplant;
+class TestHttpMergeReference {
 
-  @Override
-  public TransplantCommitsBuilder hashesToTransplant(List<String> hashesToTransplant) {
-    this.hashesToTransplant = hashesToTransplant;
-    return this;
+  @Test
+  public void testMessageOverrideDenied() {
+    assertThatThrownBy(() -> new HttpMergeReference(null).message("test"))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Merge message overrides are not supported in API v1.");
   }
 }

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestMergeTransplant.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestMergeTransplant.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.assertj.core.data.MapEntry.entry;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -362,6 +363,126 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalid {
         .extracting(LogEntry::getCommitMeta)
         .extracting(CommitMeta::getMessage)
         .containsAnyOf("test-branch2", "test-branch1", "test-main");
+  }
+
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2) // Merge message is not settable in V1
+  public void mergeMessage() throws BaseNessieClientServerException {
+    testMergeTransplantMessage(
+        (target, source, committed1, committed2, returnConflictAsResult) ->
+            getApi()
+                .mergeRefIntoBranch()
+                .message("test-message-override-123")
+                .branch(target)
+                .fromRef(source)
+                .returnConflictAsResult(returnConflictAsResult)
+                .merge(),
+        ImmutableList.of("test-message-override-123"));
+  }
+
+  @Test
+  public void mergeMessageDefault() throws BaseNessieClientServerException {
+    testMergeTransplantMessage(
+        (target, source, committed1, committed2, returnConflictAsResult) ->
+            getApi()
+                .mergeRefIntoBranch()
+                .branch(target)
+                .fromRef(source)
+                .returnConflictAsResult(returnConflictAsResult)
+                .merge(),
+        ImmutableList.of(
+            "test-commit-1\n---------------------------------------------\ntest-commit-2"));
+  }
+
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V1) // V2 does not allow squashed transplants
+  public void transplantMessageSquashed() throws BaseNessieClientServerException {
+    testMergeTransplantMessage(
+        (target, source, committed1, committed2, returnConflictAsResult) ->
+            getApi()
+                .transplantCommitsIntoBranch()
+                .message("test-message-override-123")
+                .branch(target)
+                .fromRefName(source.getName())
+                .keepIndividualCommits(false)
+                .hashesToTransplant(
+                    ImmutableList.of(
+                        Objects.requireNonNull(committed1.getHash()),
+                        Objects.requireNonNull(committed2.getHash())))
+                .returnConflictAsResult(returnConflictAsResult)
+                .transplant(),
+        ImmutableList.of("test-message-override-123"));
+  }
+
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V1) // V2 does not allow squashed transplants
+  public void transplantMessageSingle() throws BaseNessieClientServerException {
+    testMergeTransplantMessage(
+        (target, source, committed1, committed2, returnConflictAsResult) ->
+            getApi()
+                .transplantCommitsIntoBranch()
+                .message("test-message-override-123")
+                .branch(target)
+                .fromRefName(source.getName())
+                .hashesToTransplant(ImmutableList.of(Objects.requireNonNull(committed1.getHash())))
+                .returnConflictAsResult(returnConflictAsResult)
+                .transplant(),
+        ImmutableList.of("test-message-override-123"));
+  }
+
+  @Test
+  public void transplantMessageOverrideMultiple() throws BaseNessieClientServerException {
+    testMergeTransplantMessage(
+        (target, source, committed1, committed2, returnConflictAsResult) ->
+            getApi()
+                .transplantCommitsIntoBranch()
+                .message("ignored-message-override")
+                .keepIndividualCommits(true)
+                .branch(target)
+                .fromRefName(source.getName())
+                .hashesToTransplant(
+                    ImmutableList.of(
+                        Objects.requireNonNull(committed1.getHash()),
+                        Objects.requireNonNull(committed2.getHash())))
+                .returnConflictAsResult(returnConflictAsResult)
+                .transplant(),
+        // Note: the expected messages are given in the commit log order (newest to oldest)
+        ImmutableList.of("test-commit-2", "test-commit-1"));
+  }
+
+  private void testMergeTransplantMessage(
+      MergeTransplantActor actor, Collection<String> expectedMessages)
+      throws BaseNessieClientServerException {
+    Branch target = createBranch("merge-transplant-msg-target");
+    Branch source = createBranch("merge-transplant-msg-source");
+
+    ContentKey key1 = ContentKey.of("test-key1");
+    ContentKey key2 = ContentKey.of("test-key2");
+
+    source =
+        getApi()
+            .commitMultipleOperations()
+            .branch(source)
+            .commitMeta(CommitMeta.fromMessage("test-commit-1"))
+            .operation(Put.of(key1, IcebergTable.of("table1", 42, 43, 44, 45)))
+            .commit();
+
+    Branch firstCommitOnSource = source;
+
+    source =
+        getApi()
+            .commitMultipleOperations()
+            .branch(source)
+            .commitMeta(CommitMeta.fromMessage("test-commit-2"))
+            .operation(Put.of(key2, IcebergTable.of("table2", 42, 43, 44, 45)))
+            .commit();
+
+    actor.act(target, source, firstCommitOnSource, source, false);
+
+    soft.assertThat(getApi().getCommitLog().refName(target.getName()).stream())
+        .isNotEmpty()
+        .extracting(e -> e.getCommitMeta().getMessage())
+        .containsExactlyElementsOf(expectedMessages);
   }
 
   @ParameterizedTest

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -168,6 +168,7 @@ public class RestTreeResource implements HttpTreeApi {
             merge.getFromRefName(),
             merge.getFromHash(),
             merge.keepIndividualCommits(),
+            null,
             merge.getKeyMergeModes(),
             merge.getDefaultKeyMergeMode(),
             merge.isDryRun(),

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -234,6 +234,7 @@ public class RestV2TreeResource implements HttpTreeApi {
             merge.getFromRefName(),
             merge.getFromHash(),
             false,
+            merge.getMessage(),
             merge.getKeyMergeModes(),
             merge.getDefaultKeyMergeMode(),
             merge.isDryRun(),

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -341,7 +341,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
         .commit(
             branch,
             Optional.empty(),
-            commitMetaUpdate().rewriteSingle(CommitMeta.fromMessage(commitMsg)),
+            commitMetaUpdate(null).rewriteSingle(CommitMeta.fromMessage(commitMsg)),
             Collections.singletonList(contentOperation),
             validator);
   }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -272,6 +273,7 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
       String fromRefName,
       String fromHash,
       Boolean keepIndividualCommits,
+      @Nullable String message,
       Collection<MergeKeyBehavior> keyMergeTypes,
       MergeBehavior defaultMergeType,
       Boolean dryRun,
@@ -288,6 +290,7 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
         fromRefName,
         fromHash,
         keepIndividualCommits,
+        message,
         keyMergeTypes,
         defaultMergeType,
         dryRun,

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -17,6 +17,7 @@ package org.projectnessie.services.spi;
 
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -90,6 +91,7 @@ public interface TreeService {
       String fromRefName,
       String fromHash,
       Boolean keepIndividualCommits,
+      @Nullable String message,
       Collection<MergeKeyBehavior> keyMergeTypes,
       MergeBehavior defaultMergeType,
       Boolean dryRun,


### PR DESCRIPTION
Commit message may be overridden when the operation results in exactly one commit on the target branch.

That is overriding messages in unsquashed transplants is not supported.

Merge message overrides are supported only in API v2 at this point because v1 does not have the commit message in merge HTTP payloads.

Closes #4430