### PR TITLE
Allow publishing Gradle build scans from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,18 +42,18 @@ jobs:
     - name: Gradle / compile
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: checkstyleMain checkstyleTest jar testClasses
+        arguments: checkstyleMain checkstyleTest jar testClasses --scan
 
     - name: Gradle / unit test
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: test
+        arguments: test --scan
 
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
       with:
         # '-x spotlessCheck': workaround until https://github.com/diffplug/spotless/issues/1215 is fixed
-        arguments: check -x spotlessCheck
+        arguments: check -x spotlessCheck --scan
 
     - name: Gradle / Gatling simulations
       uses: gradle/gradle-build-action@v2
@@ -68,6 +68,7 @@ jobs:
           codeCoverageReport -x test -x intTest
           publishToMavenLocal
           -Puber-jar
+          --scan
 
     - name: Gradle / build tools integration tests
       uses: gradle/gradle-build-action@v2
@@ -109,6 +110,7 @@ jobs:
             :nessie-quarkus:intTest
             -Pnative
             -Pdocker
+            --scan
 
       - name: Capture Test Reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/newer-java.yml
+++ b/.github/workflows/newer-java.yml
@@ -39,18 +39,18 @@ jobs:
     - name: Gradle / compile
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: checkstyleMain checkstyleTest jar testClasses
+        arguments: checkstyleMain checkstyleTest jar testClasses --scan
 
     - name: Gradle / unit test
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: test
+        arguments: test --scan
 
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
       with:
         # '-x spotlessCheck': workaround until https://github.com/diffplug/spotless/issues/1215 is fixed
-        arguments: check -x spotlessCheck
+        arguments: check -x spotlessCheck --scan
 
     - name: Gradle / Gatling simulations
       uses: gradle/gradle-build-action@v2
@@ -65,6 +65,7 @@ jobs:
           codeCoverageReport -x test -x intTest
           publishToMavenLocal
           -Puber-jar
+          --scan
 
     - name: Gradle / build tools integration tests
       uses: gradle/gradle-build-action@v2
@@ -80,6 +81,7 @@ jobs:
           :nessie-quarkus:intTest
           -Pnative
           -Pdocker
+          --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/pull-request-integ.yml
+++ b/.github/workflows/pull-request-integ.yml
@@ -89,22 +89,22 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: true
-          arguments: :iceberg:iceberg-nessie:test
+          arguments: :iceberg:iceberg-nessie:test --scan
 
       - name: Nessie Spark 3.1 Extensions test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :nessie-iceberg:nessie-spark-extensions-3.1_2.12:test :nessie-iceberg:nessie-spark-extensions-3.1_2.12:intTest
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.1_2.12:test :nessie-iceberg:nessie-spark-extensions-3.1_2.12:intTest --scan
 
       - name: Nessie Spark 3.2 / 2.12 Extensions test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest --scan
 
       - name: Nessie Spark 3.3 / 2.12 Extensions test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest --scan
 
       - name: Stop Gradle daemon
         uses: gradle/gradle-build-action@v2
@@ -114,7 +114,7 @@ jobs:
       - name: Publish Nessie + Iceberg to local Maven repo
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishLocal
+          arguments: publishLocal --scan
 
       - name: Gather locally published versions
         run: |

--- a/.github/workflows/pull-request-native.yml
+++ b/.github/workflows/pull-request-native.yml
@@ -49,6 +49,7 @@ jobs:
           :nessie-quarkus:intTest
           -Pnative
           -Pdocker
+          --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,25 +55,25 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         # 'spotlessCheck' separate: workaround until https://github.com/diffplug/spotless/issues/1215 is fixed
-        arguments: spotlessCheck
+        arguments: spotlessCheck --scan
 
     - name: Gradle / compile
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: checkstyleMain checkstyleTest jar testClasses
+        arguments: checkstyleMain checkstyleTest jar testClasses --scan
 
     - name: Gradle / unit test
       uses: gradle/gradle-build-action@v2
       env:
         SPARK_LOCAL_IP: localhost
       with:
-        arguments: test
+        arguments: test --scan
 
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
       with:
         # '-x spotlessCheck': workaround until https://github.com/diffplug/spotless/issues/1215 is fixed
-        arguments: check -x spotlessCheck
+        arguments: check -x spotlessCheck --scan
 
     - name: Gradle / Gatling simulations
       uses: gradle/gradle-build-action@v2
@@ -88,6 +88,7 @@ jobs:
           assemble
           publishToMavenLocal
           codeCoverageReport -x test -x intTest
+          --scan
 
     - name: Gradle / build tools integration tests
       uses: gradle/gradle-build-action@v2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,44 @@ pluginManagement {
   }
 }
 
+plugins { id("com.gradle.enterprise") version ("3.12") }
+
+gradleEnterprise {
+  if (System.getenv("CI") != null) {
+    buildScan {
+      termsOfServiceUrl = "https://gradle.com/terms-of-service"
+      termsOfServiceAgree = "yes"
+      // Add some potentially interesting information from the environment
+      listOf(
+          "GITHUB_ACTION_REPOSITORY",
+          "GITHUB_ACTOR",
+          "GITHUB_BASE_REF",
+          "GITHUB_HEAD_REF",
+          "GITHUB_JOB",
+          "GITHUB_REF",
+          "GITHUB_REPOSITORY",
+          "GITHUB_RUN_ID",
+          "GITHUB_RUN_NUMBER",
+          "GITHUB_SHA",
+          "GITHUB_WORKFLOW"
+        )
+        .forEach { e ->
+          val v = System.getenv(e)
+          if (v != null) {
+            value(e, v)
+          }
+        }
+      val ghUrl = System.getenv("GITHUB_SERVER_URL")
+      if (ghUrl != null) {
+        val ghRepo = System.getenv("GITHUB_REPOSITORY")
+        val ghRunId = System.getenv("GITHUB_RUN_ID")
+        link("Summary", "$ghUrl/$ghRepo/actions/runs/$ghRunId")
+        link("PRs", "$ghUrl/$ghRepo/pulls")
+      }
+    }
+  }
+}
+
 gradle.beforeProject {
   version = baseVersion
   group = "org.projectnessie"


### PR DESCRIPTION
But not automatically for every build to protect sensitve workflows, like releasw workflows that have access to sensitive secrets. Gradle build scans are available for free (Gradle Enterprise is not required). The scans help identifying build issues, dependency issues, build performance issues. Also interesting: it shows the result of each test of a CI run.

Build scans are not published for every run - especially sensitive workflows (release workflows w/ access to secrets) are _not_ scanned/published.

Links to the build scans are available from the _Summary_ page of the workflow runs.