### PR TITLE
Remove legacy Spark extensions

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -105,12 +105,6 @@ dependencies {
           break
         }
       }
-      if (!ideSyncActive) {
-        // Relocated projects, to be removed in a future Nessie version
-        api(project(":nessie-spark-extensions-base"))
-        api(project(":nessie-spark-extensions"))
-        api(project(":nessie-spark-3.2-extensions"))
-      }
     }
   }
 }

--- a/buildSrc/src/main/kotlin/Utilities.kt
+++ b/buildSrc/src/main/kotlin/Utilities.kt
@@ -219,44 +219,11 @@ fun Project.addRelocateTo(toArtifact: String) {
 fun Project.getSparkScalaVersionsForProject(): SparkScalaVersions {
   val sparkScala = project.name.split("-").last().split("_")
 
-  var sparkMajorVersion: String
-  var scalaMajorVersion: String
+  val sparkMajorVersion = if (sparkScala[0][0].isDigit()) sparkScala[0] else "3.2"
+  val scalaMajorVersion = sparkScala[1]
 
-  when (name) {
-    "nessie-spark-extensions-base" -> {
-      sparkMajorVersion = "3.1"
-      scalaMajorVersion = "2.12"
-      addRelocateTo("nessie-spark-extensions-base_$scalaMajorVersion")
+  useBuildSubDirectory(scalaMajorVersion)
 
-      tasks.withType<Test>().configureEach { enabled = false }
-
-      useBuildSubDirectory("legacy")
-    }
-    "nessie-spark-extensions" -> {
-      sparkMajorVersion = "3.1"
-      scalaMajorVersion = "2.12"
-      addRelocateTo("nessie-spark-extensions-${sparkMajorVersion}_$scalaMajorVersion")
-
-      tasks.withType<Test>().configureEach { enabled = false }
-
-      useBuildSubDirectory("legacy")
-    }
-    "nessie-spark-3.2-extensions" -> {
-      sparkMajorVersion = "3.2"
-      scalaMajorVersion = "2.12"
-      addRelocateTo("nessie-spark-extensions-${sparkMajorVersion}_$scalaMajorVersion")
-
-      tasks.withType<Test>().configureEach { enabled = false }
-
-      useBuildSubDirectory("legacy")
-    }
-    else -> {
-      sparkMajorVersion = if (sparkScala[0][0].isDigit()) sparkScala[0] else "3.2"
-      scalaMajorVersion = sparkScala[1]
-
-      useBuildSubDirectory(scalaMajorVersion)
-    }
-  }
   return useSparkScalaVersionsForProject(sparkMajorVersion, scalaMajorVersion)
 }
 

--- a/nessie-iceberg/settings.gradle.kts
+++ b/nessie-iceberg/settings.gradle.kts
@@ -98,12 +98,4 @@ for (scalaVersion in allScalaVersions) {
   }
 }
 
-if (!ideSyncActive) {
-  nessieProject("nessie-spark-extensions", file("../clients/spark-extensions/v3.1")).buildFileName =
-    "../build.gradle.kts"
-  nessieProject("nessie-spark-3.2-extensions", file("../clients/spark-extensions/v3.2"))
-    .buildFileName = "../build.gradle.kts"
-  nessieProject("nessie-spark-extensions-base", file("../clients/spark-extensions-base"))
-}
-
 rootProject.name = "nessie-iceberg"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -115,14 +115,6 @@ if (!System.getProperty("nessie.integrationsTesting.enable").toBoolean()) {
       break
     }
   }
-
-  if (!ideSyncActive) {
-    nessieProject("nessie-spark-extensions", file("clients/spark-extensions/v3.1")).buildFileName =
-      "../build.gradle.kts"
-    nessieProject("nessie-spark-3.2-extensions", file("clients/spark-extensions/v3.2"))
-      .buildFileName = "../build.gradle.kts"
-    nessieProject("nessie-spark-extensions-base", file("clients/spark-extensions-base"))
-  }
 }
 
 rootProject.name = "nessie"


### PR DESCRIPTION
* `:nessie-spark-extensions`
* `:nessie-spark-32-extensions`
* `:nessie-spark-extensions-base`

These three projects have been maintained for a while to aid migration to the `:nessie-spark-extensions-$sparkVersion_$scalaVersion` style project names.