### PR TITLE
CI: cross-check macOS + Windows

### DIFF
--- a/.github/actions/dev-tool-java/action.yml
+++ b/.github/actions/dev-tool-java/action.yml
@@ -26,5 +26,5 @@ runs:
       shell: bash
       run: |
         mkdir -p ~/.gradle
-        echo "org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" >> ~/.gradle/gradle.properties
+        echo "org.gradle.jvmargs=-Xmx1280m -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" >> ~/.gradle/gradle.properties
         echo "org.gradle.vfs.watch=false" >> ~/.gradle/gradle.properties

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -1,0 +1,119 @@
+# Copyright (C) 2022 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Projectnessie GitHub Pull-Request / macOS CI
+
+name: macOS Build Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    # Run daily on week days
+    - cron:  '0 4 * * 1-5'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  java:
+    name: Java/Gradle macOS
+    runs-on: macos-12
+    if: github.event.workflow_run.event != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+    env:
+      SPARK_LOCAL_IP: localhost
+
+    steps:
+    - name: Setup Colima
+      timeout-minutes: 30
+      run: |
+        echo "::group::Install Podman"
+        brew install podman
+        echo "::endgroup::"
+
+        echo "::group::Initializing Podman"
+        podman machine init
+        echo "::endgroup::"
+
+        echo "::group::Starting Podman"
+        podman machine start
+        echo "::endgroup::"
+
+        echo "::group::Aliasing Podman"
+        ln -s /usr/local/bin/podman /usr/local/bin/docker
+        echo "::endgroup::"
+
+        export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/podman-machine-default/podman.sock"
+        echo "DOCKER_HOST=$DOCKER_HOST" >> ${GITHUB_ENV}
+
+        # See https://www.testcontainers.org/supported_docker_environment/
+        echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> ${GITHUB_ENV}
+
+        echo "::group::Docker info"
+        docker info
+        echo "::endgroup::"
+
+    - uses: actions/checkout@v3.3.0
+    - name: Setup Java, Gradle
+      uses: ./.github/actions/dev-tool-java
+
+    - name: Gradle / compile
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: checkstyleMain checkstyleTest jar testClasses --scan
+
+    - name: Gradle / unit test
+      uses: gradle/gradle-build-action@v2
+      env:
+        SPARK_LOCAL_IP: localhost
+      with:
+        arguments: test --scan
+
+    - name: Gradle / check incl. integ-test
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: check -x spotlessCheck -x checkstyleMain -x checkstyleTest --scan
+
+    - name: Capture Test Reports
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: test-results
+        path: |
+          **/build/reports/*
+          **/build/test-results/*
+
+  python:
+    name: Python
+    runs-on: macos-12
+    if: github.event.workflow_run.event != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+    env:
+      working-directory: ./python
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+
+    steps:
+    - uses: actions/checkout@v3.3.0
+    - name: Setup Python
+      uses: ./.github/actions/dev-tool-python
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Test with tox
+      run: tox
+      working-directory: ${{env.working-directory}}

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -1,0 +1,129 @@
+# Copyright (C) 2022 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Projectnessie GitHub Pull-Request / macOS CI
+
+name: Windows Build Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    # Run daily on week days
+    - cron:  '0 4 * * 1-5'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  java:
+    name: Java/Gradle Windows
+    runs-on: windows-2022
+    if: github.event.workflow_run.event != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+    env:
+      SPARK_LOCAL_IP: localhost
+
+    steps:
+    - name: Git line ending config
+      # This is a workaround to pass the ui/ project's prettier configuration, which has the strict
+      # rule to allow only LF as the line ending.
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - uses: actions/checkout@v3.3.0
+      with:
+        repository: cdarlint/winutils
+        path: hadoop-winutils
+        ref: d018bd9c919dee1448b95519351cc591a6338a00
+
+    - name: Setup Hadoop
+      # A local Hadoop setup is required on Windows, very sad...
+      timeout-minutes: 30
+      run: |
+        cd $HOME
+        Invoke-WebRequest -Uri https://archive.apache.org/dist/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz -OutFile hadoop-3.3.2.tar.gz
+
+        echo "::group::Extract hadoop-3.3.2.tar.gz"
+        mkdir hadoop-3.3.2
+        cd hadoop-3.3.2
+        7z e ..\hadoop-3.3.2.tar.gz
+        echo "::endgroup::"
+
+        echo "HADOOP_HOME=$HOME\hadoop-3.3.2" >> $env:GITHUB_ENV
+    - name: Add Hadoop winutils
+      run: |
+        cd hadoop-winutils\hadoop-3.2.2\bin
+        copy *.dll $HADOOP_HOME\bin
+        copy *.exp $HADOOP_HOME\bin
+        copy *.lib $HADOOP_HOME\bin
+        copy *.pdb $HADOOP_HOME\bin
+        copy *.exe $HADOOP_HOME\bin
+        copy *.dll C:\windows\system32
+        cd ..\..\..
+        rm -r -fo hadoop-winutils
+
+    - uses: actions/checkout@v3.3.0
+    - name: Setup Java, Gradle
+      uses: ./.github/actions/dev-tool-java
+
+    - name: Gradle / compile
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: checkstyleMain checkstyleTest jar testClasses --scan
+
+    - name: Gradle / unit test
+      uses: gradle/gradle-build-action@v2
+      env:
+        SPARK_LOCAL_IP: localhost
+      with:
+        arguments: test --scan
+
+    - name: Gradle / check incl. integ-test
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: check -x spotlessCheck -x checkstyleMain -x checkstyleTest --scan
+
+    - name: Capture Test Reports
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: test-results
+        path: |
+          **/build/reports/*
+          **/build/test-results/*
+
+  python:
+    name: Python
+    runs-on: windows-2022
+    if: github.event.workflow_run.event != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+    env:
+      working-directory: ./python
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+
+    steps:
+    - uses: actions/checkout@v3.3.0
+    - name: Setup Python
+      uses: ./.github/actions/dev-tool-python
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Test with tox
+      run: tox
+      working-directory: ${{env.working-directory}}


### PR DESCRIPTION
Adds CI jobs to test Nessie on macOS and Windows (non-WSL/2). Unfortunately, both testing on macOS and Windows is far from "perfect" in the sense that all tests run on both platforms.
    
Setting up the GH runners takes a couple extra steps (setting up podman for macOS, setting up a local Hadoop on Windows), which can take some time.
    
The issues are:
* Docker on Windows (non-WSL) is not supported by testcontainers, so the tests that need testcontainers are disabled on Windows.
* testcontainers against podman (required on macOS) has issues inquiring information about the _fetched_ (locally present) image (workaround in the Nessie code base).
* Probably not related to macOS or Windows, but the npm-tests in `:nessie-ui` seem to be flaky. This podman & nessie-ui issue may require re-running CI jobs.
* Build times seem to vary a lot, from "normal" times as used w/ the Linux based runners to magnitudes of that.
    
The workflows shall run daily against `main`, on demand against `main` and against PRs having the `pr-macos-win` label.
