### PR TITLE
Add v2 attributes to `CommitMeta`

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -54,6 +54,7 @@ public interface HttpClient {
   class Builder {
     private URI baseUri;
     private ObjectMapper mapper;
+    private Class<?> jsonView;
     private SSLContext sslContext;
     private SSLParameters sslParameters;
     private int readTimeoutMillis =
@@ -85,6 +86,11 @@ public interface HttpClient {
 
     public Builder setObjectMapper(ObjectMapper mapper) {
       this.mapper = mapper;
+      return this;
+    }
+
+    public Builder setJsonView(Class<?> jsonView) {
+      this.jsonView = jsonView;
       return this;
     }
 
@@ -160,6 +166,7 @@ public interface HttpClient {
           HttpRuntimeConfig.builder()
               .baseUri(baseUri)
               .mapper(mapper)
+              .jsonView(jsonView)
               .readTimeoutMillis(readTimeoutMillis)
               .connectionTimeoutMillis(connectionTimeoutMillis)
               .isDisableCompression(disableCompression)

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -37,6 +37,8 @@ import java.util.stream.Collectors;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
+import org.projectnessie.api.v1.ApiAttributesV1;
+import org.projectnessie.api.v2.ApiAttributesV2;
 import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.api.NessieApi;
@@ -285,11 +287,13 @@ public class HttpClientBuilder implements NessieClientBuilder<HttpClientBuilder>
     Objects.requireNonNull(apiVersion, "API version class must be non-null");
 
     if (apiVersion.isAssignableFrom(HttpApiV1.class)) {
+      builder.setJsonView(ApiAttributesV1.class);
       NessieHttpClient client = new NessieHttpClient(authentication, tracing, builder);
       return (API) new HttpApiV1(client);
     }
 
     if (apiVersion.isAssignableFrom(HttpApiV2.class)) {
+      builder.setJsonView(ApiAttributesV2.class);
       HttpClient httpClient = NessieHttpClient.buildClient(authentication, tracing, builder);
       return (API) new HttpApiV2(httpClient);
     }

--- a/clients/client/src/main/java/org/projectnessie/client/http/impl/BaseHttpRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/impl/BaseHttpRequest.java
@@ -24,6 +24,7 @@ import static org.projectnessie.client.http.impl.HttpUtils.HEADER_CONTENT_TYPE;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -86,7 +87,11 @@ public abstract class BaseHttpRequest extends HttpRequest {
       throws IOException {
     Class<?> bodyType = body.getClass();
     if (bodyType != String.class) {
-      config.getMapper().writerFor(bodyType).writeValue(out, body);
+      ObjectWriter writer = config.getMapper().writer();
+      if (config.getJsonView() != null) {
+        writer = writer.withView(config.getJsonView());
+      }
+      writer.forType(bodyType).writeValue(out, body);
     } else {
       // This is mostly used for testing bad/broken JSON
       out.write(((String) body).getBytes(StandardCharsets.UTF_8));

--- a/clients/client/src/main/java/org/projectnessie/client/http/impl/HttpRuntimeConfig.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/impl/HttpRuntimeConfig.java
@@ -47,6 +47,9 @@ public interface HttpRuntimeConfig {
 
   ObjectMapper getMapper();
 
+  @Nullable
+  Class<?> getJsonView();
+
   int getReadTimeoutMillis();
 
   int getConnectionTimeoutMillis();

--- a/model/src/main/java/org/projectnessie/api/v1/ApiAttributesV1.java
+++ b/model/src/main/java/org/projectnessie/api/v1/ApiAttributesV1.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.v1;
+
+/** This class is used to define JSON views for REST API v1 parameters and payload objects. */
+public final class ApiAttributesV1 {}

--- a/model/src/main/java/org/projectnessie/api/v1/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/v1/http/HttpTreeApi.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.api.v1.http;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -35,6 +36,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.projectnessie.api.v1.ApiAttributesV1;
 import org.projectnessie.api.v1.TreeApi;
 import org.projectnessie.api.v1.params.CommitLogParams;
 import org.projectnessie.api.v1.params.EntriesParams;
@@ -75,6 +77,7 @@ public interface HttpTreeApi extends TreeApi {
                 schema = @Schema(implementation = ReferencesResponse.class))),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
   })
+  @JsonView(ApiAttributesV1.class)
   ReferencesResponse getAllReferences(@BeanParam ReferencesParams params);
 
   @Override
@@ -94,6 +97,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
     @APIResponse(responseCode = "404", description = "Default branch not found.")
   })
+  @JsonView(ApiAttributesV1.class)
   Branch getDefaultBranch() throws NessieNotFoundException;
 
   @Override
@@ -127,6 +131,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "403", description = "Not allowed to create reference"),
     @APIResponse(responseCode = "409", description = "Reference already exists"),
   })
+  @JsonView(ApiAttributesV1.class)
   Reference createReference(
       @Parameter(description = "Source named reference") @QueryParam("sourceRefName")
           String sourceRefName,
@@ -160,6 +165,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "403", description = "Not allowed to view the given reference"),
     @APIResponse(responseCode = "404", description = "Ref not found")
   })
+  @JsonView(ApiAttributesV1.class)
   Reference getReferenceByName(@BeanParam GetReferenceParams params) throws NessieNotFoundException;
 
   @Override
@@ -209,6 +215,7 @@ public interface HttpTreeApi extends TreeApi {
         description = "Not allowed to view the given reference or fetch entries for it"),
     @APIResponse(responseCode = "404", description = "Ref not found")
   })
+  @JsonView(ApiAttributesV1.class)
   EntriesResponse getEntries(
       @Parameter(
               description = "name of ref to fetch from",
@@ -264,6 +271,7 @@ public interface HttpTreeApi extends TreeApi {
         description = "Not allowed to view the given reference or get commit log for it"),
     @APIResponse(responseCode = "404", description = "Ref doesn't exists")
   })
+  @JsonView(ApiAttributesV1.class)
   LogResponse getCommitLog(
       @Parameter(
               description = "ref to show log from",
@@ -289,6 +297,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "One or more references don't exist"),
     @APIResponse(responseCode = "409", description = "Update conflict")
   })
+  @JsonView(ApiAttributesV1.class)
   void assignReference(
       @Parameter(
               description = "Reference type to reassign",
@@ -329,6 +338,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "Ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "update conflict"),
   })
+  @JsonView(ApiAttributesV1.class)
   void deleteReference(
       @Parameter(
               description = "Reference type to delete",
@@ -382,6 +392,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "Ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "update conflict")
   })
+  @JsonView(ApiAttributesV1.class)
   MergeResponse transplantCommitsIntoBranch(
       @Parameter(
               description = "Branch to transplant into",
@@ -443,6 +454,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "Ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "update conflict")
   })
+  @JsonView(ApiAttributesV1.class)
   MergeResponse mergeRefIntoBranch(
       @Parameter(
               description = "Branch to merge into",
@@ -494,6 +506,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "Update conflict")
   })
+  @JsonView(ApiAttributesV1.class)
   Branch commitMultipleOperations(
       @Parameter(
               description = "Branch to change, defaults to default branch.",

--- a/model/src/main/java/org/projectnessie/api/v2/ApiAttributesV2.java
+++ b/model/src/main/java/org/projectnessie/api/v2/ApiAttributesV2.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.v2;
+
+/** This class is used to define JSON views for REST API v2 parameters and payload objects. */
+public final class ApiAttributesV2 {}

--- a/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
@@ -25,6 +25,7 @@ import static org.projectnessie.api.v2.doc.ApiDoc.REF_NAME_DESCRIPTION;
 import static org.projectnessie.api.v2.doc.ApiDoc.REF_PARAMETER_DESCRIPTION;
 import static org.projectnessie.model.Validation.REF_NAME_PATH_ELEMENT_REGEX;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import java.util.List;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
@@ -46,6 +47,7 @@ import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.projectnessie.api.v2.ApiAttributesV2;
 import org.projectnessie.api.v2.TreeApi;
 import org.projectnessie.api.v2.params.CommitLogParams;
 import org.projectnessie.api.v2.params.DiffParams;
@@ -63,7 +65,6 @@ import org.projectnessie.model.DiffResponse;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.GetMultipleContentsRequest;
 import org.projectnessie.model.GetMultipleContentsResponse;
-import org.projectnessie.model.ImmutableGetMultipleContentsRequest;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.MergeResponse;
 import org.projectnessie.model.Operations;
@@ -96,6 +97,7 @@ public interface HttpTreeApi extends TreeApi {
                 schema = @Schema(implementation = ReferencesResponse.class))),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
   })
+  @JsonView(ApiAttributesV2.class)
   ReferencesResponse getAllReferences(@BeanParam ReferencesParams params);
 
   @Override
@@ -129,6 +131,7 @@ public interface HttpTreeApi extends TreeApi {
         responseCode = "409",
         description = "Another reference with the same name already exists"),
   })
+  @JsonView(ApiAttributesV2.class)
   SingleReferenceResponse createReference(
       @Parameter(required = true, description = REF_NAME_DESCRIPTION) @QueryParam("name")
           String name,
@@ -169,6 +172,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "403", description = "Not allowed to view the given reference"),
     @APIResponse(responseCode = "404", description = "Ref not found")
   })
+  @JsonView(ApiAttributesV2.class)
   SingleReferenceResponse getReferenceByName(@BeanParam GetReferenceParams params)
       throws NessieNotFoundException;
 
@@ -209,6 +213,7 @@ public interface HttpTreeApi extends TreeApi {
         description = "Not allowed to view the given reference or fetch entries for it"),
     @APIResponse(responseCode = "404", description = "Ref not found")
   })
+  @JsonView(ApiAttributesV2.class)
   EntriesResponse getEntries(
       @Parameter(
               schema = @Schema(pattern = REF_NAME_PATH_ELEMENT_REGEX),
@@ -265,6 +270,7 @@ public interface HttpTreeApi extends TreeApi {
         description = "Not allowed to view the given reference or get commit log for it"),
     @APIResponse(responseCode = "404", description = "Ref doesn't exists")
   })
+  @JsonView(ApiAttributesV2.class)
   LogResponse getCommitLog(
       @Parameter(
               schema = @Schema(pattern = REF_NAME_PATH_ELEMENT_REGEX),
@@ -319,6 +325,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "403", description = "Not allowed to view the given fromRef/toRef"),
     @APIResponse(responseCode = "404", description = "fromRef/toRef not found"),
   })
+  @JsonView(ApiAttributesV2.class)
   DiffResponse getDiff(@BeanParam DiffParams params) throws NessieNotFoundException;
 
   @Override
@@ -346,6 +353,7 @@ public interface HttpTreeApi extends TreeApi {
         responseCode = "409",
         description = "Update conflict or expected hash / type mismatch")
   })
+  @JsonView(ApiAttributesV2.class)
   SingleReferenceResponse assignReference(
       @Parameter(
               description = "Optional expected type of the reference being reassigned",
@@ -390,6 +398,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "Ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "update conflict"),
   })
+  @JsonView(ApiAttributesV2.class)
   SingleReferenceResponse deleteReference(
       @Parameter(
               description = "Optional expected type of the reference being deleted",
@@ -432,6 +441,7 @@ public interface HttpTreeApi extends TreeApi {
         responseCode = "404",
         description = "Table not found on 'ref' or non-existent reference")
   })
+  @JsonView(ApiAttributesV2.class)
   ContentResponse getContent(
       @Parameter(description = KEY_PARAMETER_DESCRIPTION) @PathParam("key") ContentKey key,
       @Parameter(
@@ -475,18 +485,15 @@ public interface HttpTreeApi extends TreeApi {
         description = "Not allowed to view the given reference or read object content for a key"),
     @APIResponse(responseCode = "404", description = "Provided ref doesn't exists")
   })
-  default GetMultipleContentsResponse getSeveralContents(
+  @JsonView(ApiAttributesV2.class)
+  GetMultipleContentsResponse getSeveralContents(
       @Parameter(
               description = "Reference to use.",
               examples = {@ExampleObject(ref = "ref")})
           @PathParam("ref")
           String ref,
       @Parameter(description = KEY_PARAMETER_DESCRIPTION) @QueryParam("key") List<String> keys)
-      throws NessieNotFoundException {
-    ImmutableGetMultipleContentsRequest.Builder request = GetMultipleContentsRequest.builder();
-    keys.forEach(k -> request.addRequestedKeys(ContentKey.fromPathString(k)));
-    return getMultipleContents(ref, request.build());
-  }
+      throws NessieNotFoundException;
 
   @Override
   @POST
@@ -519,6 +526,7 @@ public interface HttpTreeApi extends TreeApi {
         description = "Not allowed to view the given reference or read object content for a key"),
     @APIResponse(responseCode = "404", description = "Provided ref doesn't exists")
   })
+  @JsonView(ApiAttributesV2.class)
   GetMultipleContentsResponse getMultipleContents(
       @Parameter(
               schema = @Schema(pattern = REF_NAME_PATH_ELEMENT_REGEX),
@@ -576,6 +584,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "Ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "update conflict")
   })
+  @JsonView(ApiAttributesV2.class)
   MergeResponse transplantCommitsIntoBranch(
       @Parameter(
               schema = @Schema(pattern = REF_NAME_PATH_ELEMENT_REGEX),
@@ -634,6 +643,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "Ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "update conflict")
   })
+  @JsonView(ApiAttributesV2.class)
   MergeResponse mergeRefIntoBranch(
       @Parameter(
               schema = @Schema(pattern = REF_NAME_PATH_ELEMENT_REGEX),
@@ -685,6 +695,7 @@ public interface HttpTreeApi extends TreeApi {
     @APIResponse(responseCode = "404", description = "Provided ref doesn't exists"),
     @APIResponse(responseCode = "409", description = "Update conflict")
   })
+  @JsonView(ApiAttributesV2.class)
   CommitResponse commitMultipleOperations(
       @Parameter(
               schema = @Schema(pattern = REF_NAME_PATH_ELEMENT_REGEX),

--- a/model/src/main/java/org/projectnessie/model/ser/CommitMetaDeserializer.java
+++ b/model/src/main/java/org/projectnessie/model/ser/CommitMetaDeserializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.ser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import org.projectnessie.model.CommitMeta;
+
+public class CommitMetaDeserializer extends StdDeserializer<CommitMeta> {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public CommitMetaDeserializer() {
+    super(CommitMeta.class);
+  }
+
+  private void toArray(ObjectNode node, String singleAttr, String arrayAttr) {
+    if (!node.has(arrayAttr)) {
+      ArrayNode array = node.withArray(arrayAttr);
+      if (node.has(singleAttr)) {
+        JsonNode value = node.get(singleAttr);
+        if (!value.isNull()) {
+          array.add(value);
+        }
+      }
+    }
+    node.remove(singleAttr);
+  }
+
+  @Override
+  public CommitMeta deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+    // First parse the serialized data as a generic object
+    ObjectNode node = p.readValueAs(ObjectNode.class);
+    // Convert old properties to new, array-based variants
+    toArray(node, "author", "authors");
+    toArray(node, "signedOffBy", "allSignedOffBy");
+
+    // Parse again using the standard a Bean deserializer to avoid infinite recursion.
+    // This adds a bit extra runtime work, but keeps the code simpler.
+    // Note: we do not use any Json views here. All attributes are processed. However,
+    // attributes specific to the v1 serialized form have been removed by the `toArray`
+    // methods above.
+    CommitMetaSer value = MAPPER.convertValue(node, CommitMetaSer.class);
+    return CommitMeta.builder().from(value).build();
+  }
+}

--- a/model/src/main/java/org/projectnessie/model/ser/CommitMetaSer.java
+++ b/model/src/main/java/org/projectnessie/model/ser/CommitMetaSer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.ser;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+import org.projectnessie.model.CommitMeta;
+
+/**
+ * A implementation of {@link CommitMeta} that has the same attributes, but uses standard Json Bean
+ * deserialization.
+ */
+@Value.Immutable
+@Value.Style(builder = "builderSer")
+@JsonDeserialize(as = ImmutableCommitMetaSer.class)
+public abstract class CommitMetaSer extends CommitMeta {}

--- a/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
@@ -35,7 +35,6 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
   static List<Case> goodCases() {
     final String branchName = "testBranch";
 
-    // TODO: add test for CommitMeta v1
     return Arrays.asList(
         new Case(
             ImmutableTransplant.builder()

--- a/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
@@ -35,6 +35,7 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
   static List<Case> goodCases() {
     final String branchName = "testBranch";
 
+    // TODO: add test for CommitMeta v1
     return Arrays.asList(
         new Case(
             ImmutableTransplant.builder()

--- a/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.api.v1.ApiAttributesV1;
 import org.projectnessie.model.LogResponse.LogEntry;
 
 /**
@@ -45,8 +46,8 @@ public class TestModelObjectsSerialization {
   @ParameterizedTest
   @MethodSource("goodCases")
   void testGoodSerDeCases(Case goodCase) throws IOException {
-    String json = MAPPER.writeValueAsString(goodCase.obj);
-    JsonNode j = MAPPER.readValue(json, JsonNode.class);
+    String json = MAPPER.writerWithView(ApiAttributesV1.class).writeValueAsString(goodCase.obj);
+    JsonNode j = MAPPER.readerWithView(ApiAttributesV1.class).readValue(json, JsonNode.class);
     JsonNode d = MAPPER.readValue(goodCase.deserializedJson, JsonNode.class);
     Assertions.assertThat(j).isEqualTo(d);
     Object deserialized = MAPPER.readValue(json, goodCase.deserializeAs);

--- a/model/src/test/java/org/projectnessie/model/ser/TestCommitMetaDeserializer.java
+++ b/model/src/test/java/org/projectnessie/model/ser/TestCommitMetaDeserializer.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.ser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.api.v1.ApiAttributesV1;
+import org.projectnessie.api.v2.ApiAttributesV2;
+import org.projectnessie.model.CommitMeta;
+
+class TestCommitMetaDeserializer {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private CommitMeta deser(Class<?> view, CommitMeta value) throws JsonProcessingException {
+    ObjectWriter writer = MAPPER.writer();
+    if (view != Object.class) {
+      writer = writer.withView(view);
+    }
+    return MAPPER.readValue(writer.writeValueAsString(value), CommitMeta.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {Object.class, ApiAttributesV1.class, ApiAttributesV2.class})
+  void testAuthor(Class<?> view) throws JsonProcessingException {
+    CommitMeta meta =
+        deser(view, CommitMeta.builder().message("m").author("t1").author("t2").build());
+    assertThat(meta.getAuthor()).isEqualTo("t1");
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {Object.class, ApiAttributesV2.class})
+  void testAllAuthors(Class<?> view) throws JsonProcessingException {
+    CommitMeta meta =
+        deser(
+            view, CommitMeta.builder().message("m").author("t1").author(null).author("t2").build());
+    assertThat(meta.getAllAuthors()).containsExactly("t1", "t2");
+  }
+
+  @Test
+  void testAllAuthorsTruncated() throws JsonProcessingException {
+    CommitMeta meta =
+        deser(
+            ApiAttributesV1.class,
+            CommitMeta.builder().message("m").author("t1").author("t2").build());
+    assertThat(meta.getAllAuthors()).containsExactly("t1");
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {Object.class, ApiAttributesV1.class, ApiAttributesV2.class})
+  void testSignedOffBy(Class<?> view) throws JsonProcessingException {
+    CommitMeta meta =
+        deser(
+            view,
+            CommitMeta.builder()
+                .message("m")
+                .signedOffBy("s1")
+                .signedOffBy(null)
+                .signedOffBy("s2")
+                .build());
+    assertThat(meta.getSignedOffBy()).isEqualTo("s1");
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {Object.class, ApiAttributesV2.class})
+  void testAllSignedOffBy(Class<?> view) throws JsonProcessingException {
+    CommitMeta meta =
+        deser(view, CommitMeta.builder().message("m").signedOffBy("s1").signedOffBy("s2").build());
+    assertThat(meta.getAllSignedOffBy()).containsExactly("s1", "s2");
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {Object.class, ApiAttributesV1.class, ApiAttributesV2.class})
+  void testSimpleProperties(Class<?> view) throws JsonProcessingException {
+    CommitMeta meta =
+        deser(
+            view,
+            CommitMeta.builder()
+                .message("m")
+                .putAllProperties("k0", Collections.singletonList("overwritten"))
+                .properties(Collections.singletonMap("k1", "overwritten"))
+                .putAllProperties(Collections.singletonMap("k1", "v1"))
+                .putProperties("k2", "v2")
+                .build());
+    assertThat(meta.getProperties()).hasSize(2).extracting("k1", "k2").containsExactly("v1", "v2");
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {Object.class, ApiAttributesV2.class})
+  void testListProperties(Class<?> view) throws JsonProcessingException {
+    CommitMeta meta =
+        deser(
+            view,
+            CommitMeta.builder()
+                .message("m")
+                .putAllProperties(Collections.singletonMap("k1", "v1"))
+                .putProperties("k2", "v2")
+                .putAllProperties("k3", Collections.singletonList("v3"))
+                .putAllProperties("k4", Arrays.asList("v4a", "v4b"))
+                .build());
+    assertThat(meta.getProperties())
+        .hasSize(4)
+        .extracting("k1", "k2", "k3", "k4")
+        .containsExactly("v1", "v2", "v3", "v4a");
+    assertThat(meta.getAllProperties())
+        .hasSize(4)
+        .extracting("k1", "k2", "k3", "k4")
+        .containsExactly(
+            Collections.singletonList("v1"),
+            Collections.singletonList("v2"),
+            Collections.singletonList("v3"),
+            Arrays.asList("v4a", "v4b"));
+  }
+
+  @Test
+  void testListPropertiesTruncated() throws JsonProcessingException {
+    CommitMeta meta =
+        deser(
+            ApiAttributesV1.class,
+            CommitMeta.builder()
+                .message("m")
+                .putAllProperties("k1", Arrays.asList("v1a", "v1b"))
+                .build());
+    assertThat(meta.getProperties()).isEqualTo(Collections.singletonMap("k1", "v1a"));
+    assertThat(meta.getAllProperties())
+        .isEqualTo(Collections.singletonMap("k1", Collections.singletonList("v1a")));
+  }
+}

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractResteasyV1Test.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractResteasyV1Test.java
@@ -663,4 +663,25 @@ public abstract class AbstractResteasyV1Test {
                 .contains(
                     "Could not resolve type id 'FOOBAR' as a subtype of `org.projectnessie.model.Reference`"));
   }
+
+  @Test
+  public void testCommitMetaAttributes() {
+    Branch branch = makeBranch("testCommitMetaAttributes");
+    commit("testCommitMetaAttributes", branch, "test-key", "meta", "test-author-123", "meta");
+
+    String response =
+        rest()
+            .get("trees/tree/{ref}/log", branch.getName())
+            .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+    assertThat(response)
+        .contains("\"author\"")
+        .contains("test-author-123")
+        .doesNotContain("authors") // only for API v2
+        .doesNotContain("allSignedOffBy") // only for API v2
+        .doesNotContain("parentCommitHashes") // only for API v2
+    ;
+  }
 }

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractResteasyV2Test.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractResteasyV2Test.java
@@ -231,4 +231,23 @@ public abstract class AbstractResteasyV2Test {
                 .getDiffs())
         .isEmpty();
   }
+
+  @Test
+  public void testCommitMetaAttributes() {
+    Branch branch = createBranch("testCommitMetaAttributes");
+    commit(branch, ContentKey.of("test-key"), IcebergTable.of("meta", 1, 2, 3, 4));
+
+    String response =
+        rest()
+            .get("trees/{ref}/history", branch.getName())
+            .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+    assertThat(response)
+        .doesNotContain("\"author\"") // only for API v1
+        .contains("\"authors\"")
+        .doesNotContain("\"signedOffBy\"") // only for API v1
+        .contains("allSignedOffBy");
+  }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.services.rest;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.base.Preconditions;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
+import org.projectnessie.api.v1.ApiAttributesV1;
 import org.projectnessie.api.v1.http.HttpTreeApi;
 import org.projectnessie.api.v1.params.CommitLogParams;
 import org.projectnessie.api.v1.params.EntriesParams;
@@ -76,17 +78,20 @@ public class RestTreeResource implements HttpTreeApi {
         securityContext == null ? null : securityContext.getUserPrincipal());
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public ReferencesResponse getAllReferences(ReferencesParams params) {
     Preconditions.checkArgument(params.pageToken() == null, "Paging not supported");
     return resource().getAllReferences(params.fetchOption(), params.filter());
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public Branch getDefaultBranch() throws NessieNotFoundException {
     return resource().getDefaultBranch();
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public Reference createReference(String sourceRefName, Reference reference)
       throws NessieNotFoundException, NessieConflictException {
@@ -95,11 +100,13 @@ public class RestTreeResource implements HttpTreeApi {
             reference.getName(), reference.getType(), reference.getHash(), sourceRefName);
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public Reference getReferenceByName(GetReferenceParams params) throws NessieNotFoundException {
     return resource().getReferenceByName(params.getRefName(), params.fetchOption());
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public EntriesResponse getEntries(String refName, EntriesParams params)
       throws NessieNotFoundException {
@@ -108,6 +115,7 @@ public class RestTreeResource implements HttpTreeApi {
         .getEntries(refName, params.hashOnRef(), params.namespaceDepth(), params.filter());
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public LogResponse getCommitLog(String ref, CommitLogParams params)
       throws NessieNotFoundException {
@@ -122,6 +130,7 @@ public class RestTreeResource implements HttpTreeApi {
             params.pageToken());
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public void assignReference(
       Reference.ReferenceType referenceType,
@@ -132,6 +141,7 @@ public class RestTreeResource implements HttpTreeApi {
     resource().assignReference(referenceType, referenceName, expectedHash, assignTo);
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public void deleteReference(
       Reference.ReferenceType referenceType, String referenceName, String expectedHash)
@@ -139,6 +149,7 @@ public class RestTreeResource implements HttpTreeApi {
     resource().deleteReference(referenceType, referenceName, expectedHash);
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public MergeResponse transplantCommitsIntoBranch(
       String branchName, String expectedHash, String message, Transplant transplant)
@@ -158,6 +169,7 @@ public class RestTreeResource implements HttpTreeApi {
             transplant.isReturnConflictAsResult());
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public MergeResponse mergeRefIntoBranch(String branchName, String expectedHash, Merge merge)
       throws NessieNotFoundException, NessieConflictException {
@@ -176,6 +188,7 @@ public class RestTreeResource implements HttpTreeApi {
             merge.isReturnConflictAsResult());
   }
 
+  @JsonView(ApiAttributesV1.class)
   @Override
   public Branch commitMultipleOperations(
       String branchName, String expectedHash, Operations operations)

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -15,10 +15,13 @@
  */
 package org.projectnessie.services.rest;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import java.util.List;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
+import org.projectnessie.api.v2.ApiAttributesV2;
 import org.projectnessie.api.v2.http.HttpTreeApi;
 import org.projectnessie.api.v2.params.CommitLogParams;
 import org.projectnessie.api.v2.params.DiffParams;
@@ -38,6 +41,7 @@ import org.projectnessie.model.DiffResponse;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.GetMultipleContentsRequest;
 import org.projectnessie.model.GetMultipleContentsResponse;
+import org.projectnessie.model.ImmutableGetMultipleContentsRequest;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.MergeResponse;
 import org.projectnessie.model.Operations;
@@ -114,11 +118,13 @@ public class RestV2TreeResource implements HttpTreeApi {
         securityContext == null ? null : securityContext.getUserPrincipal());
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public ReferencesResponse getAllReferences(ReferencesParams params) {
     return tree().getAllReferences(params.fetchOption(), params.filter());
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public SingleReferenceResponse createReference(
       String name, Reference.ReferenceType type, Reference reference)
@@ -134,6 +140,7 @@ public class RestV2TreeResource implements HttpTreeApi {
     return SingleReferenceResponse.builder().reference(created).build();
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public SingleReferenceResponse getReferenceByName(GetReferenceParams params)
       throws NessieNotFoundException {
@@ -143,6 +150,7 @@ public class RestV2TreeResource implements HttpTreeApi {
         .build();
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public EntriesResponse getEntries(String ref, EntriesParams params)
       throws NessieNotFoundException {
@@ -150,6 +158,7 @@ public class RestV2TreeResource implements HttpTreeApi {
     return tree().getEntries(reference.getName(), reference.getHash(), null, params.filter());
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public LogResponse getCommitLog(String ref, CommitLogParams params)
       throws NessieNotFoundException {
@@ -165,6 +174,7 @@ public class RestV2TreeResource implements HttpTreeApi {
             params.pageToken());
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public DiffResponse getDiff(DiffParams params) throws NessieNotFoundException {
     Reference from = resolveRef(params.getFromRef());
@@ -172,6 +182,7 @@ public class RestV2TreeResource implements HttpTreeApi {
     return diff().getDiff(from.getName(), from.getHash(), to.getName(), to.getHash());
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public SingleReferenceResponse assignReference(
       Reference.ReferenceType type, String ref, Reference assignTo)
@@ -182,6 +193,7 @@ public class RestV2TreeResource implements HttpTreeApi {
     return SingleReferenceResponse.builder().reference(updated).build();
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public SingleReferenceResponse deleteReference(Reference.ReferenceType type, String ref)
       throws NessieConflictException, NessieNotFoundException {
@@ -190,6 +202,7 @@ public class RestV2TreeResource implements HttpTreeApi {
     return SingleReferenceResponse.builder().reference(reference).build();
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public ContentResponse getContent(ContentKey key, String ref) throws NessieNotFoundException {
     Reference reference = resolveRef(ref);
@@ -197,6 +210,16 @@ public class RestV2TreeResource implements HttpTreeApi {
     return ContentResponse.builder().content(content).build();
   }
 
+  @JsonView(ApiAttributesV2.class)
+  @Override
+  public GetMultipleContentsResponse getSeveralContents(String ref, List<String> keys)
+      throws NessieNotFoundException {
+    ImmutableGetMultipleContentsRequest.Builder request = GetMultipleContentsRequest.builder();
+    keys.forEach(k -> request.addRequestedKeys(ContentKey.fromPathString(k)));
+    return getMultipleContents(ref, request.build());
+  }
+
+  @JsonView(ApiAttributesV2.class)
   @Override
   public GetMultipleContentsResponse getMultipleContents(
       String ref, GetMultipleContentsRequest request) throws NessieNotFoundException {
@@ -205,6 +228,7 @@ public class RestV2TreeResource implements HttpTreeApi {
         .getMultipleContents(reference.getName(), reference.getHash(), request.getRequestedKeys());
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public MergeResponse transplantCommitsIntoBranch(String branch, Transplant transplant)
       throws NessieNotFoundException, NessieConflictException {
@@ -224,6 +248,7 @@ public class RestV2TreeResource implements HttpTreeApi {
             transplant.isReturnConflictAsResult());
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public MergeResponse mergeRefIntoBranch(String branch, Merge merge)
       throws NessieNotFoundException, NessieConflictException {
@@ -243,6 +268,7 @@ public class RestV2TreeResource implements HttpTreeApi {
             merge.isReturnConflictAsResult());
   }
 
+  @JsonView(ApiAttributesV2.class)
   @Override
   public CommitResponse commitMultipleOperations(String branch, Operations operations)
       throws NessieNotFoundException, NessieConflictException {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/CommitMetaSerializer.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/CommitMetaSerializer.java
@@ -33,8 +33,8 @@ public class CommitMetaSerializer implements Serializer<CommitMeta> {
   @Override
   public ByteString toBytes(CommitMeta value) {
     try (Output out = ByteString.newOutput()) {
-      // Store commit metadata using v2 format. This is mostly to avoid duplicate data from v1
-      // attributes in the serialized form.
+      // Store commit metadata using v1 format. This is to allow rolling upgrades to server
+      // versions with v2 support.
       MAPPER.writerWithView(ApiAttributesV1.class).writeValue(out, value);
       return out.toByteString();
     } catch (IOException e) {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/CommitMetaSerializer.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/CommitMetaSerializer.java
@@ -20,6 +20,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.ByteString.Output;
 import java.io.IOException;
 import java.io.InputStream;
+import org.projectnessie.api.v1.ApiAttributesV1;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ImmutableCommitMeta;
 
@@ -32,7 +33,9 @@ public class CommitMetaSerializer implements Serializer<CommitMeta> {
   @Override
   public ByteString toBytes(CommitMeta value) {
     try (Output out = ByteString.newOutput()) {
-      MAPPER.writeValue(out, value);
+      // Store commit metadata using v2 format. This is mostly to avoid duplicate data from v1
+      // attributes in the serialized form.
+      MAPPER.writerWithView(ApiAttributesV1.class).writeValue(out, value);
       return out.toByteString();
     } catch (IOException e) {
       throw new RuntimeException(String.format("Couldn't serialize commit meta %s", value), e);

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestCommitMetaSerializer.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestCommitMetaSerializer.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.api.v1.ApiAttributesV1;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ImmutableCommitMeta;
 
@@ -40,7 +41,10 @@ public class TestCommitMetaSerializer {
             .build();
 
     ByteString expectedBytes =
-        ByteString.copyFrom(new ObjectMapper().writeValueAsBytes(expectedCommit));
+        ByteString.copyFrom(
+            new ObjectMapper()
+                .writerWithView(ApiAttributesV1.class)
+                .writeValueAsBytes(expectedCommit));
     CommitMeta actualCommit = CommitMetaSerializer.METADATA_SERIALIZER.fromBytes(expectedBytes);
     assertThat(actualCommit).isEqualTo(expectedCommit);
     ByteString actualBytes = CommitMetaSerializer.METADATA_SERIALIZER.toBytes(expectedCommit);

--- a/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/ExportImportTestUtil.java
+++ b/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/ExportImportTestUtil.java
@@ -23,6 +23,7 @@ import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.projectnessie.api.v1.ApiAttributesV1;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
@@ -39,7 +40,9 @@ final class ExportImportTestUtil {
   static ByteString commitMeta(int i) {
     try {
       return ByteString.copyFromUtf8(
-          MAPPER.writeValueAsString(CommitMeta.fromMessage("commit # " + i)));
+          MAPPER
+              .writerWithView(ApiAttributesV1.class)
+              .writeValueAsString(CommitMeta.fromMessage("commit # " + i)));
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Support multiple authors and "signed off by" names.

Add explicit parent hash getter.

Support list properties.

Support deserializing old v1 JSON form in all contexts.

Generate v1 (old) JSON in API v1 responses.

Generate v2 (new) JSON in API v2 responses.

Use v1 JSON for storage. We can switch to v2 JSON in storage in the next releases to make older versions capable of reading metadata JSON during rolling upgrades.

This means that the new `CommitMeta` capabilities are added to the API, but are not yet supported by servers.

Note: `@JsonView` annotations have to be both on the HTTP interface and the impl. class to allow both Quarkus and Jersey servers to work properly. Quarkus appears to see the annotation the interface, which Jersey appears to see the annotation on the impl. class.

Closes #5424