### PR TITLE
Python: Fix CI build failure because of tox error

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -68,7 +68,7 @@ commands =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-passenv = TOXENV CI CODECOV_*
+passenv = TOXENV,CI,CODECOV_*
 deps =
     -r{toxinidir}/requirements_basedev.txt
 commands =


### PR DESCRIPTION
Build environment using the latest tox is breaking the builds because of this change from tox
https://github.com/tox-dev/tox/issues/2658

Hence fix the `tox.ini`.

Similar fixes from other tools that uses tox
https://github.com/readthedocs/readthedocs.org/pull/9803

Note:
This failure doesn't happen in local build as it uses older version of the `tox` from
https://github.com/projectnessie/nessie/blob/main/python/requirements_basedev.txt#L29

But the CI jobs install the latest tox instead of using the same as development 
https://github.com/projectnessie/nessie/blob/main/.github/actions/dev-tool-python/action.yml#L21