### PR TITLE
Make OlderNessieServersExtension inject Nessie URIs

### DIFF
--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/NessieBaseUri.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/NessieBaseUri.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.compatibility.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.net.URI;
+
+/**
+ * Annotation for JUnit5 method parameters that need the base URI for a test Nessie Server.
+ *
+ * <p>The test is responsible for constructing Nessie REST API URI from the base URI, server version
+ * and the desired API version.
+ *
+ * <p>Note: the parameter's (or field's) declared type must be {@link URI}.
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface NessieBaseUri {}

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieServersExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieServersExtension.java
@@ -16,15 +16,18 @@
 package org.projectnessie.tools.compatibility.internal;
 
 import static org.projectnessie.tools.compatibility.internal.AbstractNessieApiHolder.apiInstanceForField;
+import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateAnnotatedFields;
 import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieApiFields;
 import static org.projectnessie.tools.compatibility.internal.NessieServer.nessieServer;
 import static org.projectnessie.tools.compatibility.internal.Util.classContext;
 
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.Collections;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.projectnessie.tools.compatibility.api.NessieBaseUri;
 import org.projectnessie.tools.compatibility.api.TargetVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 
@@ -60,5 +63,9 @@ public class OlderNessieServersExtension extends AbstractMultiVersionExtension {
             apiInstanceForField(classContext(context), field, Version.CURRENT, ctx -> nessieServer);
 
     populateNessieApiFields(context, instance, TargetVersion.TESTED, fieldValue);
+
+    URI serverUri = nessieServer.getUri();
+    URI baseUri = serverUri.resolve("/"); // remove possible API version suffixes
+    populateAnnotatedFields(context, instance, NessieBaseUri.class, a -> true, f -> baseUri);
   }
 }

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -31,6 +32,7 @@ import org.projectnessie.junit.engine.MultiEnvTestFilter;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.tools.compatibility.api.NessieAPI;
+import org.projectnessie.tools.compatibility.api.NessieBaseUri;
 import org.projectnessie.tools.compatibility.api.NessieVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.api.VersionCondition;
@@ -93,6 +95,9 @@ class TestNessieCompatibilityExtensions {
     assertThat(OldServersSample.minVersionHigh).containsExactly(Version.CURRENT);
     assertThat(OldServersSample.maxVersionHigh).containsExactly(Version.parseVersion("0.18.0"));
     assertThat(OldServersSample.never).isEmpty();
+
+    // Base URI should not include the API version suffix
+    assertThat(OldServersSample.uris).allSatisfy(uri -> assertThat(uri.getPath()).isEqualTo("/"));
   }
 
   @Test
@@ -155,6 +160,8 @@ class TestNessieCompatibilityExtensions {
   static class OldServersSample {
     @NessieAPI NessieApiV1 api;
     @NessieAPI static NessieApiV1 apiStatic;
+    @NessieBaseUri URI uri;
+    @NessieBaseUri static URI uriStatic;
     @NessieVersion Version version;
     @NessieVersion static Version versionStatic;
 
@@ -162,12 +169,15 @@ class TestNessieCompatibilityExtensions {
     static final List<Version> minVersionHigh = new ArrayList<>();
     static final List<Version> maxVersionHigh = new ArrayList<>();
     static final List<Version> never = new ArrayList<>();
+    static final List<URI> uris = new ArrayList<>();
 
     @Test
     void testSome() throws Exception {
       assertThat(api).isNotNull().isSameAs(apiStatic);
+      assertThat(uri).isNotNull().isEqualTo(uriStatic);
       assertThat(version).isNotNull().isEqualTo(versionStatic);
       allVersions.add(version);
+      uris.add(uri);
 
       assertThat(api.getConfig())
           .extracting(NessieConfiguration::getDefaultBranch)


### PR DESCRIPTION
Base URIs are injected. REST API version suffixes may need to be added by tests.