### PR TITLE
Fix MultiEnvTestFilter to pass inner test classes

### DIFF
--- a/clients/client-testextension/src/main/java/org/projectnessie/client/ext/MultiVersionApiTest.java
+++ b/clients/client-testextension/src/main/java/org/projectnessie/client/ext/MultiVersionApiTest.java
@@ -46,11 +46,6 @@ public class MultiVersionApiTest implements MultiEnvTestExtension, ExecutionCond
     return Arrays.stream(NessieApiVersion.values()).map(Enum::name).collect(Collectors.toList());
   }
 
-  @Override
-  public boolean accepts(Class<?> testClass) {
-    return AnnotationUtils.findAnnotation(testClass, NessieApiVersions.class).isPresent();
-  }
-
   static NessieApiVersion apiVersion(ExtensionContext context) {
     return UniqueId.parse(context.getUniqueId()).getSegments().stream()
         .filter(s -> API_VERSION_SEGMENT_TYPE.equals(s.getType()))

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/AbstractMultiVersionExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/AbstractMultiVersionExtension.java
@@ -73,8 +73,7 @@ abstract class AbstractMultiVersionExtension
     }
   }
 
-  @Override
-  public boolean accepts(Class<?> testClass) {
+  private void checkExtensions(Class<?> testClass) {
     long count = multiVersionExtensionsForTestClass(Stream.of(testClass)).count();
     if (count > 1) {
       // Sanity check, it's illegal to have multiple nessie-compatibility extensions on one test
@@ -84,8 +83,6 @@ abstract class AbstractMultiVersionExtension
               "Test class %s contains more than one Nessie multi-version extension",
               testClass.getName()));
     }
-
-    return count == 1;
   }
 
   @Override
@@ -158,6 +155,8 @@ abstract class AbstractMultiVersionExtension
   }
 
   Version populateNessieVersionAnnotatedFields(ExtensionContext context, Object instance) {
+    checkExtensions(context.getRequiredTestClass());
+
     Optional<Version> nessieVersion = nessieVersionFromContext(context);
     if (!nessieVersion.isPresent()) {
       return null;

--- a/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/MultiEnvExtensionRegistry.java
+++ b/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/MultiEnvExtensionRegistry.java
@@ -16,6 +16,8 @@
 package org.projectnessie.junit.engine;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
@@ -49,9 +51,15 @@ public class MultiEnvExtensionRegistry {
   }
 
   public Stream<? extends MultiEnvTestExtension> stream(Class<?> testClass) {
+    Set<ExtendWith> annotations = new HashSet<>();
+    // Find annotations following the class nesting chain
+    for (Class<?> cl = testClass; cl != null; cl = cl.getDeclaringClass()) {
+      annotations.addAll(AnnotationUtils.findRepeatableAnnotations(cl, ExtendWith.class));
+    }
+
     //noinspection unchecked
     return (Stream<? extends MultiEnvTestExtension>)
-        AnnotationUtils.findRepeatableAnnotations(testClass, ExtendWith.class).stream()
+        annotations.stream()
             .flatMap(e -> Arrays.stream(e.value()))
             .filter(MultiEnvTestExtension.class::isAssignableFrom)
             .flatMap(registry::stream);

--- a/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/MultiEnvTestExtension.java
+++ b/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/MultiEnvTestExtension.java
@@ -37,10 +37,4 @@ public interface MultiEnvTestExtension extends Extension {
    * invocations of this method to ensure a stable test case creation order.
    */
   List<String> allEnvironmentIds(ConfigurationParameters configuration);
-
-  /**
-   * Checks whether this extension recognizes the given test class as a multi-environment test
-   * class.
-   */
-  boolean accepts(Class<?> testClass);
 }

--- a/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/MultiEnvTestFilter.java
+++ b/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/MultiEnvTestFilter.java
@@ -53,20 +53,19 @@ public class MultiEnvTestFilter implements PostDiscoveryFilter {
     MultiEnvExtensionRegistry registry = registry();
 
     if (id.getEngineId().map("junit-jupiter"::equals).orElse(false)) {
-      if (registry.stream(testClass).anyMatch(ext -> ext.accepts(testClass))) {
+      if (registry.stream(testClass).findAny().isPresent()) {
         return FilterResult.excluded("Excluding multi-env test from Jupiter Engine: " + id);
       } else {
         return FilterResult.included(null);
       }
     } else {
-      // check acceptance only for extensions that own the test
+      // check whether any of the extensions declared by the test recognize the version segment
       boolean matched =
           registry.stream(testClass)
-              .filter(
+              .anyMatch(
                   ext ->
                       id.getSegments().stream()
-                          .anyMatch(s -> ext.segmentType().equals(s.getType())))
-              .anyMatch(ext -> ext.accepts(testClass));
+                          .anyMatch(s -> ext.segmentType().equals(s.getType())));
 
       if (matched) {
         return FilterResult.included(null);


### PR DESCRIPTION
Previously the filter required multi-version test extensions to recognise all test classes in their `accepts` method. This proved difficult for inner test classes that generally do not carry the `@ExtendWith` annotation.

Moreover, the old filtering logic was overzealous in requiring extensions to explicitly "accept" test classes, which would generally be annotated with the extension anyway.

This change removes the `accepts` method from `MultiEnvTestExtension` and simplifies the filtering logic to be based only on the presence of appropriate extension annotations.

MultiEnvExtensionRegistry is enhanced to follow class nesting chains to find extension annotations.