### PR TITLE
Remove grep -v from the HISTORY.rst generation script

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -177,7 +177,7 @@ jobs:
         
         git log --perl-regexp --author '^(?!.*dependabot(-preview)?|.*renovate|.*nessie-release-workflow).*$'\
           --format='format:* %s' ${LAST_TAG}..HEAD python/ |\
-          grep -v '^\* \[release\] .*$' >> /tmp/HISTORY.rst
+          >> /tmp/HISTORY.rst
         
         tail +4 python/HISTORY.rst >> /tmp/HISTORY.rst
         


### PR DESCRIPTION
This `grep` invocation produces exit code 1 if there are no lines in the input and breaks the workflow.

Auto-generated commit log entries with `[release]` messages are already excluded by the author filter in the `git log` command.