### PR TITLE
Disable quarkus-jacoco on `:nessie-quarkus-cli`

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -67,7 +67,9 @@ dependencies {
   testImplementation(project(":nessie-quarkus-tests"))
   testImplementation(project(":nessie-versioned-persist-mongodb-test"))
   testImplementation(project(":nessie-versioned-tests"))
-  testImplementation("io.quarkus:quarkus-jacoco")
+  // TODO re-add quarkus-jacoco once https://github.com/quarkusio/quarkus/issues/30264
+  //  has been fixed.
+  //  testImplementation("io.quarkus:quarkus-jacoco")
   testImplementation("io.quarkus:quarkus-junit5")
   testCompileOnly(libs.microprofile.openapi)
 


### PR DESCRIPTION
Builds fail regularly with messages like the following:
```
> Task :nessie-quarkus-cli:intTest
Generated Jacoco reports in /home/runner/work/nessie/nessie/servers/quarkus-cli/build/jacoco-report
Generated Jacoco reports in /home/runner/work/nessie/nessie/servers/quarkus-cli/build/jacoco-report
Generated Jacoco reports in /home/runner/work/nessie/nessie/servers/quarkus-cli/build/jacoco-report
...
Failed to generate Jacoco reports
java.io.EOFException
	at java.base/java.io.DataInputStream.readByte(DataInputStream.java:272)
	at org.jacoco.core.internal.data.CompactDataInput.readBooleanArray(CompactDataInput.java:64)
	at org.jacoco.core.data.ExecutionDataReader.readExecutionData(ExecutionDataReader.java:150)
	at org.jacoco.core.data.ExecutionDataReader.readBlock(ExecutionDataReader.java:116)
	at org.jacoco.core.data.ExecutionDataReader.read(ExecutionDataReader.java:93)
	at org.jacoco.core.tools.ExecFileLoader.load(ExecFileLoader.java:60)
	at org.jacoco.core.tools.ExecFileLoader.load(ExecFileLoader.java:74)
	at io.quarkus.jacoco.runtime.ReportCreator.run(ReportCreator.java:72)
	at java.base/java.lang.Thread.run(Thread.java:829)
...
```

There is not much we can do on the Nessie side to fix this, except disabling Jacoco in that module until the underlying issue has been fixed.

Related Quarkus issue is https://github.com/quarkusio/quarkus/issues/30264