### PR TITLE
Test/CI: Introduce test parallelism constraints for test tasks

### DIFF
--- a/buildSrc/src/main/kotlin/DockerIntTest.kt
+++ b/buildSrc/src/main/kotlin/DockerIntTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+abstract class DockerIntTest : BuildService<BuildServiceParameters.None> {}

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -181,6 +181,9 @@ val npmTest =
     doFirst { delete(testCoverageDir) }
     npmCommand.add("test")
     args.addAll("--", "--coverage")
+    usesService(
+      gradle.sharedServices.registrations.named("testParallelismConstraint").get().service
+    )
   }
 
 val npmLint =


### PR DESCRIPTION
Leverage Gradle shared build services to implement constraints for concurrent `test` and `intTest` tasks.

Defaults are:
* `Runtime.getRuntime().availableProcessors()` for `test`
* `Runtime.getRuntime().availableProcessors() / 4` for `intTest`

Integration tests are usually more expensive (think: Docker containers), so those use a lower concurrency by default.

System properties to override the abive defaults:
* `nessie.testParallelism`
* `nessie.intTestParallelism`

This change allows removal of a potentially existing setting to limit the total number of Gradle workers, which is nice to have, because that global Gradle worker limit includes other build services like compilations (Java, Scala, etc). In other words: the new constraints allow a fine grained control compared to the "big hammer" `org.gradle.workers.max`.