### PR TITLE
Exclude compatibility tests from code-coverage

### DIFF
--- a/compatibility/compatibility-tests/build.gradle.kts
+++ b/compatibility/compatibility-tests/build.gradle.kts
@@ -18,7 +18,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   `nessie-conventions`


### PR DESCRIPTION
CI emits the following message:
```
> Task :code-coverage:codeCoverageReport
[ant:jacocoReport] Classes in bundle 'code-coverage' do not match with execution data. For report generation the same class files must be used as at runtime.
[ant:jacocoReport] Execution data for class org/projectnessie/client/http/RequestContext does not match.
```

Probably because jacoco collects _old_ Nessie version class information, which is not intended.

Depends on https://github.com/projectnessie/gradle-build-plugins/pull/77