### PR TITLE
Validate runtime parameters in service implementations.

### DIFF
--- a/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/JerseyServer.java
+++ b/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/JerseyServer.java
@@ -59,6 +59,7 @@ public class JerseyServer implements AutoCloseable {
   public JerseyServer(Supplier<DatabaseAdapter> databaseAdapterSupplier) throws Exception {
     weld = new Weld();
     // Let Weld scan all the resources to discover injection points and dependencies
+    weld.addPackages(true, RestConfigResource.class);
     weld.addPackages(true, TreeApiImpl.class);
     // Inject external beans
     weld.addExtension(new ServerConfigExtension());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -203,6 +203,7 @@ testcontainers-testcontainers = { module = "org.testcontainers:testcontainers", 
 undertow-core = { module = "io.undertow:undertow-core", version.ref = "undertow" }
 undertow-servlet = { module = "io.undertow:undertow-servlet", version.ref = "undertow" }
 weld-se-core = { module = "org.jboss.weld.se:weld-se-core", version = "3.1.9.Final" }
+hibernate-validator-cdi = { module = "org.hibernate:hibernate-validator-cdi", version = "6.2.4.Final" }
 
 [plugins]
 errorprone = { id = "net.ltgt.errorprone", version = "3.0.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,6 +111,7 @@ h2 = { module = "com.h2database:h2", version = "2.1.214" }
 hadoop-aws = { module = "org.apache.hadoop:hadoop-aws", version.ref = "hadoop" }
 hadoop-client = { module = "org.apache.hadoop:hadoop-client", version.ref = "hadoop" }
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
+hibernate-validator-cdi = { module = "org.hibernate:hibernate-validator-cdi", version = "6.2.4.Final" }
 iceberg-api = { module = "org.apache.iceberg:iceberg-api", version.ref = "iceberg" }
 iceberg-aws = { module = "org.apache.iceberg:iceberg-aws", version.ref = "iceberg" }
 iceberg-bundled-guava = { module = "org.apache.iceberg:iceberg-bundled-guava", version.ref = "iceberg" }
@@ -203,7 +204,6 @@ testcontainers-testcontainers = { module = "org.testcontainers:testcontainers", 
 undertow-core = { module = "io.undertow:undertow-core", version.ref = "undertow" }
 undertow-servlet = { module = "io.undertow:undertow-servlet", version.ref = "undertow" }
 weld-se-core = { module = "org.jboss.weld.se:weld-se-core", version = "3.1.9.Final" }
-hibernate-validator-cdi = { module = "org.hibernate:hibernate-validator-cdi", version = "6.2.4.Final" }
 
 [plugins]
 errorprone = { id = "net.ltgt.errorprone", version = "3.0.1" }

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
@@ -216,6 +216,7 @@ public class NessieJaxRsExtension extends NessieClientResolver
     public EnvHolder(Extension versionStoreExtension) throws Exception {
       weld = new Weld();
       // Let Weld scan all the resources to discover injection points and dependencies
+      weld.addPackages(true, RestConfigResource.class);
       weld.addPackages(true, TreeApiImpl.class);
       // Inject external beans
       weld.addExtension(new ServerConfigExtension());

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestInvalid.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestInvalid.java
@@ -19,11 +19,13 @@ import static java.util.Collections.singletonList;
 import static org.projectnessie.model.Validation.HASH_RULE;
 import static org.projectnessie.model.Validation.REF_NAME_MESSAGE;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.projectnessie.error.NessieBadRequestException;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Operation;
 import org.projectnessie.model.Tag;
 
 /** See {@link AbstractTestRest} for details about and reason for the inheritance model. */
@@ -258,6 +260,21 @@ public abstract class AbstractRestInvalid extends AbstractRestInvalidRefs {
         .isInstanceOf(NessieBadRequestException.class)
         .hasMessageContaining("Bad Request (HTTP/400):")
         .hasMessageContaining(HASH_RULE);
+  }
+
+  @Test
+  public void missingExpectedHash() {
+    soft.assertThatThrownBy(
+            () ->
+                getApi()
+                    .commitMultipleOperations()
+                    .branchName("test") // note: missing expected hash
+                    .commitMeta(CommitMeta.fromMessage(""))
+                    .operation(Operation.Unchanged.of(ContentKey.of("test1")))
+                    .commit())
+        .isInstanceOf(NessieBadRequestException.class)
+        .hasMessageContaining("Bad Request (HTTP/400):")
+        .hasMessageContaining("expectedHash: must not be null");
   }
 
   @ParameterizedTest

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestMergeTransplant.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRestMergeTransplant.java
@@ -524,8 +524,8 @@ public abstract class AbstractRestMergeTransplant extends AbstractRestInvalid {
 
     // create the same namespace on both branches
     Namespace ns = Namespace.parse("a.b.c");
-    getApi().createNamespace().namespace(ns).refName(base.getName()).create();
-    getApi().createNamespace().namespace(ns).refName(branch.getName()).create();
+    getApi().createNamespace().namespace(ns).reference(base).create();
+    getApi().createNamespace().namespace(ns).reference(branch).create();
 
     base = (Branch) getApi().getReference().refName(base.getName()).get();
     branch = (Branch) getApi().getReference().refName(branch.getName()).get();

--- a/servers/jax-rs/build.gradle.kts
+++ b/servers/jax-rs/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
   api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jetty")
 
   api("org.jboss.weld.se:weld-se-core")
+  api(libs.hibernate.validator.cdi)
 
   compileOnly(libs.microprofile.openapi)
   compileOnly(libs.jakarta.validation.api)

--- a/servers/jax-rs/build.gradle.kts
+++ b/servers/jax-rs/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
   api(libs.jakarta.enterprise.cdi.api)
   api(libs.jakarta.annotation.api)
   api(libs.jakarta.validation.api)
+  api(libs.hibernate.validator.cdi)
 
   api(platform(libs.jackson.bom))
   api(libs.jackson.databind)
@@ -81,7 +82,6 @@ dependencies {
   api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jetty")
 
   api("org.jboss.weld.se:weld-se-core")
-  api(libs.hibernate.validator.cdi)
 
   compileOnly(libs.microprofile.openapi)
   compileOnly(libs.jakarta.validation.api)

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/authn/QuarkusPrincipalSupplier.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/authn/QuarkusPrincipalSupplier.java
@@ -15,18 +15,20 @@
  */
 package org.projectnessie.server.authn;
 
-import io.quarkus.security.identity.SecurityIdentity;
 import java.security.Principal;
+import java.util.function.Supplier;
+
 import javax.annotation.Priority;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
-import org.projectnessie.services.rest.PrincipalSupplier;
+
+import io.quarkus.security.identity.SecurityIdentity;
 
 @RequestScoped
 @Alternative
 @Priority(1)
-public class QuarkusPrincipalSupplier extends PrincipalSupplier {
+public class QuarkusPrincipalSupplier implements Supplier<Principal> {
   private final SecurityIdentity identity;
 
   @Inject

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/authn/QuarkusPrincipalSupplier.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/authn/QuarkusPrincipalSupplier.java
@@ -15,15 +15,13 @@
  */
 package org.projectnessie.server.authn;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import java.security.Principal;
 import java.util.function.Supplier;
-
 import javax.annotation.Priority;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
-
-import io.quarkus.security.identity.SecurityIdentity;
 
 @RequestScoped
 @Alternative

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/authn/QuarkusPrincipalSupplier.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/authn/QuarkusPrincipalSupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server.authn;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import java.security.Principal;
+import javax.annotation.Priority;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import org.projectnessie.services.rest.PrincipalSupplier;
+
+@RequestScoped
+@Alternative
+@Priority(1)
+public class QuarkusPrincipalSupplier extends PrincipalSupplier {
+  private final SecurityIdentity identity;
+
+  @Inject
+  public QuarkusPrincipalSupplier(SecurityIdentity identity) {
+    this.identity = identity;
+  }
+
+  @Override
+  public Principal get() {
+    return identity.getPrincipal();
+  }
+}

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/ConstraintViolationExceptionMapper.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/ConstraintViolationExceptionMapper.java
@@ -55,7 +55,12 @@ public class ConstraintViolationExceptionMapper
         }
       }
     }
+
+    // Construct the user-level message the same way for all validator implementations.
+    ConstraintViolationException canonical =
+        new ConstraintViolationException(exception.getConstraintViolations());
+
     return buildExceptionResponse(
-        errorCode, exception.getMessage(), exception, false, header -> {});
+        errorCode, canonical.getMessage(), exception, false, header -> {});
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/ContextPrincipalSupplier.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/ContextPrincipalSupplier.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 
 @RequestScoped
-public class PrincipalSupplier implements Supplier<Principal> {
+public class ContextPrincipalSupplier implements Supplier<Principal> {
 
   @Context SecurityContext securityContext;
 

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/PrincipalSupplier.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/PrincipalSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,30 +15,19 @@
  */
 package org.projectnessie.services.rest;
 
+import java.security.Principal;
+import java.util.function.Supplier;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import org.projectnessie.api.v1.http.HttpConfigApi;
-import org.projectnessie.model.NessieConfiguration;
-import org.projectnessie.services.spi.ConfigService;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
 
-/** REST endpoint to retrieve server settings. */
 @RequestScoped
-public class RestConfigResource implements HttpConfigApi {
+public class PrincipalSupplier implements Supplier<Principal> {
 
-  private final ConfigService configService;
-
-  // Mandated by CDI 2.0
-  public RestConfigResource() {
-    this(null);
-  }
-
-  @Inject
-  public RestConfigResource(ConfigService configService) {
-    this.configService = configService;
-  }
+  @Context SecurityContext securityContext;
 
   @Override
-  public NessieConfiguration getConfig() {
-    return configService.getConfig();
+  public Principal get() {
+    return securityContext == null ? null : securityContext.getUserPrincipal();
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,30 +15,20 @@
  */
 package org.projectnessie.services.rest;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import org.projectnessie.api.v1.http.HttpConfigApi;
-import org.projectnessie.model.NessieConfiguration;
-import org.projectnessie.services.spi.ConfigService;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.services.impl.ConfigApiImpl;
 
-/** REST endpoint to retrieve server settings. */
-@RequestScoped
-public class RestConfigResource implements HttpConfigApi {
-
-  private final ConfigService configService;
-
+@ApplicationScoped
+public class RestConfigService extends ConfigApiImpl {
   // Mandated by CDI 2.0
-  public RestConfigResource() {
+  public RestConfigService() {
     this(null);
   }
 
   @Inject
-  public RestConfigResource(ConfigService configService) {
-    this.configService = configService;
-  }
-
-  @Override
-  public NessieConfiguration getConfig() {
-    return configService.getConfig();
+  public RestConfigService(ServerConfig config) {
+    super(config);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
@@ -17,19 +17,13 @@ package org.projectnessie.services.rest;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.SecurityContext;
 import org.projectnessie.api.v1.http.HttpContentApi;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.GetMultipleContentsRequest;
 import org.projectnessie.model.GetMultipleContentsResponse;
-import org.projectnessie.services.authz.Authorizer;
-import org.projectnessie.services.config.ServerConfig;
-import org.projectnessie.services.impl.ContentApiImplWithAuthorization;
 import org.projectnessie.services.spi.ContentService;
-import org.projectnessie.versioned.VersionStore;
 
 /** REST endpoint for the content-API. */
 @RequestScoped
@@ -39,30 +33,20 @@ public class RestContentResource implements HttpContentApi {
   // to various symptoms: complaints about varying validation-constraints in HttpTreeApi + TreeAPi,
   // empty resources (no REST methods defined) and potentially other.
 
-  private final ServerConfig config;
-  private final VersionStore store;
-  private final Authorizer authorizer;
-
-  @Context SecurityContext securityContext;
+  private final ContentService contentService;
 
   // Mandated by CDI 2.0
   public RestContentResource() {
-    this(null, null, null);
+    this(null);
   }
 
   @Inject
-  public RestContentResource(ServerConfig config, VersionStore store, Authorizer authorizer) {
-    this.config = config;
-    this.store = store;
-    this.authorizer = authorizer;
+  public RestContentResource(ContentService contentService) {
+    this.contentService = contentService;
   }
 
   private ContentService resource() {
-    return new ContentApiImplWithAuthorization(
-        config,
-        store,
-        authorizer,
-        securityContext == null ? null : securityContext.getUserPrincipal());
+    return contentService;
   }
 
   @Override

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,38 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.services.impl;
+package org.projectnessie.services.rest;
 
 import java.security.Principal;
 import java.util.function.Supplier;
-import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.DiffResponse;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
-import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.services.impl.ContentApiImplWithAuthorization;
 import org.projectnessie.versioned.VersionStore;
-import org.projectnessie.versioned.WithHash;
 
-/** Does authorization checks (if enabled) on the {@link DiffApiImpl}. */
-public class DiffApiImplWithAuthorization extends DiffApiImpl {
+@RequestScoped
+@ValidateOnExecution(type = ExecutableType.ALL)
+public class RestContentService extends ContentApiImplWithAuthorization {
+  // Mandated by CDI 2.0
+  public RestContentService() {
+    this(null, null, null, null);
+  }
 
-  public DiffApiImplWithAuthorization(
+  @Inject
+  public RestContentService(
       ServerConfig config,
       VersionStore store,
       Authorizer authorizer,
       Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
-  }
-
-  @Override
-  public DiffResponse getDiff(String fromRef, String fromHash, String toRef, String toHash)
-      throws NessieNotFoundException {
-    WithHash<NamedRef> from = namedRefWithHashOrThrow(fromRef, fromHash);
-    WithHash<NamedRef> to = namedRefWithHashOrThrow(toRef, toHash);
-    startAccessCheck()
-        .canViewReference(from.getValue())
-        .canViewReference(to.getValue())
-        .checkAndThrow();
-    return getDiff(from.getHash(), to.getHash());
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
@@ -17,17 +17,11 @@ package org.projectnessie.services.rest;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.SecurityContext;
 import org.projectnessie.api.v1.http.HttpDiffApi;
 import org.projectnessie.api.v1.params.DiffParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.DiffResponse;
-import org.projectnessie.services.authz.Authorizer;
-import org.projectnessie.services.config.ServerConfig;
-import org.projectnessie.services.impl.DiffApiImplWithAuthorization;
 import org.projectnessie.services.spi.DiffService;
-import org.projectnessie.versioned.VersionStore;
 
 /** REST endpoint for the diff-API. */
 @RequestScoped
@@ -37,30 +31,20 @@ public class RestDiffResource implements HttpDiffApi {
   // to various symptoms: complaints about varying validation-constraints in HttpTreeApi + TreeAPi,
   // empty resources (no REST methods defined) and potentially other.
 
-  private final ServerConfig config;
-  private final VersionStore store;
-  private final Authorizer authorizer;
-
-  @Context SecurityContext securityContext;
+  private final DiffService diffService;
 
   // Mandated by CDI 2.0
   public RestDiffResource() {
-    this(null, null, null);
+    this(null);
   }
 
   @Inject
-  public RestDiffResource(ServerConfig config, VersionStore store, Authorizer authorizer) {
-    this.config = config;
-    this.store = store;
-    this.authorizer = authorizer;
+  public RestDiffResource(DiffService diffService) {
+    this.diffService = diffService;
   }
 
   private DiffService resource() {
-    return new DiffApiImplWithAuthorization(
-        config,
-        store,
-        authorizer,
-        securityContext == null ? null : securityContext.getUserPrincipal());
+    return diffService;
   }
 
   @Override

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,38 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.services.impl;
+package org.projectnessie.services.rest;
 
 import java.security.Principal;
 import java.util.function.Supplier;
-import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.DiffResponse;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
-import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.services.impl.DiffApiImplWithAuthorization;
 import org.projectnessie.versioned.VersionStore;
-import org.projectnessie.versioned.WithHash;
 
-/** Does authorization checks (if enabled) on the {@link DiffApiImpl}. */
-public class DiffApiImplWithAuthorization extends DiffApiImpl {
+@RequestScoped
+@ValidateOnExecution(type = ExecutableType.ALL)
+public class RestDiffService extends DiffApiImplWithAuthorization {
+  // Mandated by CDI 2.0
+  public RestDiffService() {
+    this(null, null, null, null);
+  }
 
-  public DiffApiImplWithAuthorization(
+  @Inject
+  public RestDiffService(
       ServerConfig config,
       VersionStore store,
       Authorizer authorizer,
       Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
-  }
-
-  @Override
-  public DiffResponse getDiff(String fromRef, String fromHash, String toRef, String toHash)
-      throws NessieNotFoundException {
-    WithHash<NamedRef> from = namedRefWithHashOrThrow(fromRef, fromHash);
-    WithHash<NamedRef> to = namedRefWithHashOrThrow(toRef, toHash);
-    startAccessCheck()
-        .canViewReference(from.getValue())
-        .canViewReference(to.getValue())
-        .checkAndThrow();
-    return getDiff(from.getHash(), to.getHash());
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
@@ -18,8 +18,6 @@ package org.projectnessie.services.rest;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.SecurityContext;
 import org.projectnessie.api.v1.http.HttpNamespaceApi;
 import org.projectnessie.api.v1.params.MultipleNamespacesParams;
 import org.projectnessie.api.v1.params.NamespaceParams;
@@ -30,11 +28,7 @@ import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.GetNamespacesResponse;
 import org.projectnessie.model.Namespace;
-import org.projectnessie.services.authz.Authorizer;
-import org.projectnessie.services.config.ServerConfig;
-import org.projectnessie.services.impl.NamespaceApiImplWithAuthorization;
 import org.projectnessie.services.spi.NamespaceService;
-import org.projectnessie.versioned.VersionStore;
 
 /** REST endpoint for the namespace-API. */
 @RequestScoped
@@ -44,30 +38,20 @@ public class RestNamespaceResource implements HttpNamespaceApi {
   // to various symptoms: complaints about varying validation-constraints in HttpNamespaceApi +
   // NamespaceApi, empty resources (no REST methods defined) and potentially other.
 
-  private final ServerConfig config;
-  private final VersionStore store;
-  private final Authorizer authorizer;
-
-  @Context SecurityContext securityContext;
+  private final NamespaceService namespaceService;
 
   // Mandated by CDI 2.0
   public RestNamespaceResource() {
-    this(null, null, null);
+    this(null);
   }
 
   @Inject
-  public RestNamespaceResource(ServerConfig config, VersionStore store, Authorizer authorizer) {
-    this.config = config;
-    this.store = store;
-    this.authorizer = authorizer;
+  public RestNamespaceResource(NamespaceService namespaceService) {
+    this.namespaceService = namespaceService;
   }
 
   private NamespaceService resource() {
-    return new NamespaceApiImplWithAuthorization(
-        config,
-        store,
-        authorizer,
-        securityContext == null ? null : securityContext.getUserPrincipal());
+    return namespaceService;
   }
 
   @Override

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,38 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.services.impl;
+package org.projectnessie.services.rest;
 
 import java.security.Principal;
 import java.util.function.Supplier;
-import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.DiffResponse;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
-import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.services.impl.NamespaceApiImplWithAuthorization;
 import org.projectnessie.versioned.VersionStore;
-import org.projectnessie.versioned.WithHash;
 
-/** Does authorization checks (if enabled) on the {@link DiffApiImpl}. */
-public class DiffApiImplWithAuthorization extends DiffApiImpl {
+@RequestScoped
+@ValidateOnExecution(type = ExecutableType.ALL)
+public class RestNamespaceService extends NamespaceApiImplWithAuthorization {
+  // Mandated by CDI 2.0
+  public RestNamespaceService() {
+    this(null, null, null, null);
+  }
 
-  public DiffApiImplWithAuthorization(
+  @Inject
+  public RestNamespaceService(
       ServerConfig config,
       VersionStore store,
       Authorizer authorizer,
       Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
-  }
-
-  @Override
-  public DiffResponse getDiff(String fromRef, String fromHash, String toRef, String toHash)
-      throws NessieNotFoundException {
-    WithHash<NamedRef> from = namedRefWithHashOrThrow(fromRef, fromHash);
-    WithHash<NamedRef> to = namedRefWithHashOrThrow(toRef, toHash);
-    startAccessCheck()
-        .canViewReference(from.getValue())
-        .canViewReference(to.getValue())
-        .checkAndThrow();
-    return getDiff(from.getHash(), to.getHash());
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogResource.java
@@ -17,46 +17,30 @@ package org.projectnessie.services.rest;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.SecurityContext;
 import org.projectnessie.api.v1.http.HttpRefLogApi;
 import org.projectnessie.api.v1.params.RefLogParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
-import org.projectnessie.services.authz.Authorizer;
-import org.projectnessie.services.config.ServerConfig;
-import org.projectnessie.services.impl.RefLogApiImplWithAuthorization;
 import org.projectnessie.services.spi.RefLogService;
-import org.projectnessie.versioned.VersionStore;
 
 /** REST endpoint for the reflog-API. */
 @RequestScoped
 public class RestRefLogResource implements HttpRefLogApi {
 
-  private final ServerConfig config;
-  private final VersionStore store;
-  private final Authorizer authorizer;
-
-  @Context SecurityContext securityContext;
+  private final RefLogService refLogService;
 
   // Mandated by CDI 2.0
   public RestRefLogResource() {
-    this(null, null, null);
+    this(null);
   }
 
   @Inject
-  public RestRefLogResource(ServerConfig config, VersionStore store, Authorizer authorizer) {
-    this.config = config;
-    this.store = store;
-    this.authorizer = authorizer;
+  public RestRefLogResource(RefLogService refLogService) {
+    this.refLogService = refLogService;
   }
 
   private RefLogService resource() {
-    return new RefLogApiImplWithAuthorization(
-        config,
-        store,
-        authorizer,
-        securityContext == null ? null : securityContext.getUserPrincipal());
+    return refLogService;
   }
 
   @Override

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogService.java
@@ -17,7 +17,6 @@ package org.projectnessie.services.rest;
 
 import java.security.Principal;
 import java.util.function.Supplier;
-
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.executable.ExecutableType;
@@ -37,7 +36,10 @@ public class RestRefLogService extends RefLogApiImplWithAuthorization {
 
   @Inject
   public RestRefLogService(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Supplier<Principal> principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogService.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.services.rest;
 
+import java.security.Principal;
+import java.util.function.Supplier;
+
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.executable.ExecutableType;
@@ -34,7 +37,7 @@ public class RestRefLogService extends RefLogApiImplWithAuthorization {
 
   @Inject
   public RestRefLogService(
-      ServerConfig config, VersionStore store, Authorizer authorizer, PrincipalSupplier principal) {
+      ServerConfig config, VersionStore store, Authorizer authorizer, Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,28 +17,24 @@ package org.projectnessie.services.rest;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import org.projectnessie.api.v1.http.HttpConfigApi;
-import org.projectnessie.model.NessieConfiguration;
-import org.projectnessie.services.spi.ConfigService;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
+import org.projectnessie.services.authz.Authorizer;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.services.impl.RefLogApiImplWithAuthorization;
+import org.projectnessie.versioned.VersionStore;
 
-/** REST endpoint to retrieve server settings. */
 @RequestScoped
-public class RestConfigResource implements HttpConfigApi {
-
-  private final ConfigService configService;
-
+@ValidateOnExecution(type = ExecutableType.ALL)
+public class RestRefLogService extends RefLogApiImplWithAuthorization {
   // Mandated by CDI 2.0
-  public RestConfigResource() {
-    this(null);
+  public RestRefLogService() {
+    this(null, null, null, null);
   }
 
   @Inject
-  public RestConfigResource(ConfigService configService) {
-    this.configService = configService;
-  }
-
-  @Override
-  public NessieConfiguration getConfig() {
-    return configService.getConfig();
+  public RestRefLogService(
+      ServerConfig config, VersionStore store, Authorizer authorizer, PrincipalSupplier principal) {
+    super(config, store, authorizer, principal);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.base.Preconditions;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.SecurityContext;
 import org.projectnessie.api.v1.http.HttpTreeApi;
 import org.projectnessie.api.v1.params.CommitLogParams;
 import org.projectnessie.api.v1.params.EntriesParams;
@@ -38,11 +36,7 @@ import org.projectnessie.model.Operations;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferencesResponse;
 import org.projectnessie.model.ser.Views;
-import org.projectnessie.services.authz.Authorizer;
-import org.projectnessie.services.config.ServerConfig;
-import org.projectnessie.services.impl.TreeApiImplWithAuthorization;
 import org.projectnessie.services.spi.TreeService;
-import org.projectnessie.versioned.VersionStore;
 
 /** REST endpoint for the tree-API. */
 @RequestScoped
@@ -52,30 +46,20 @@ public class RestTreeResource implements HttpTreeApi {
   // to various symptoms: complaints about varying validation-constraints in HttpTreeApi + TreeAPi,
   // empty resources (no REST methods defined) and potentially other.
 
-  private final ServerConfig config;
-  private final VersionStore store;
-  private final Authorizer authorizer;
-
-  @Context SecurityContext securityContext;
+  private final TreeService treeService;
 
   // Mandated by CDI 2.0
   public RestTreeResource() {
-    this(null, null, null);
+    this(null);
   }
 
   @Inject
-  public RestTreeResource(ServerConfig config, VersionStore store, Authorizer authorizer) {
-    this.config = config;
-    this.store = store;
-    this.authorizer = authorizer;
+  public RestTreeResource(TreeService treeService) {
+    this.treeService = treeService;
   }
 
   private TreeService resource() {
-    return new TreeApiImplWithAuthorization(
-        config,
-        store,
-        authorizer,
-        securityContext == null ? null : securityContext.getUserPrincipal());
+    return treeService;
   }
 
   @JsonView(Views.V1.class)

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeService.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.services.rest;
 
+import java.security.Principal;
+import java.util.function.Supplier;
+
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.executable.ExecutableType;
@@ -34,7 +37,7 @@ public class RestTreeService extends TreeApiImplWithAuthorization {
 
   @Inject
   public RestTreeService(
-      ServerConfig config, VersionStore store, Authorizer authorizer, PrincipalSupplier principal) {
+      ServerConfig config, VersionStore store, Authorizer authorizer, Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,28 +17,24 @@ package org.projectnessie.services.rest;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import org.projectnessie.api.v1.http.HttpConfigApi;
-import org.projectnessie.model.NessieConfiguration;
-import org.projectnessie.services.spi.ConfigService;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
+import org.projectnessie.services.authz.Authorizer;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.services.impl.TreeApiImplWithAuthorization;
+import org.projectnessie.versioned.VersionStore;
 
-/** REST endpoint to retrieve server settings. */
 @RequestScoped
-public class RestConfigResource implements HttpConfigApi {
-
-  private final ConfigService configService;
-
+@ValidateOnExecution(type = ExecutableType.ALL)
+public class RestTreeService extends TreeApiImplWithAuthorization {
   // Mandated by CDI 2.0
-  public RestConfigResource() {
-    this(null);
+  public RestTreeService() {
+    this(null, null, null, null);
   }
 
   @Inject
-  public RestConfigResource(ConfigService configService) {
-    this.configService = configService;
-  }
-
-  @Override
-  public NessieConfiguration getConfig() {
-    return configService.getConfig();
+  public RestTreeService(
+      ServerConfig config, VersionStore store, Authorizer authorizer, PrincipalSupplier principal) {
+    super(config, store, authorizer, principal);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeService.java
@@ -17,7 +17,6 @@ package org.projectnessie.services.rest;
 
 import java.security.Principal;
 import java.util.function.Supplier;
-
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.executable.ExecutableType;
@@ -37,7 +36,10 @@ public class RestTreeService extends TreeApiImplWithAuthorization {
 
   @Inject
   public RestTreeService(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Supplier<Principal> principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.CommitMeta;
@@ -41,14 +42,17 @@ import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.WithHash;
 
-abstract class BaseApiImpl {
+public abstract class BaseApiImpl {
   private final ServerConfig config;
   private final VersionStore store;
   private final Authorizer authorizer;
-  private final Principal principal;
+  private final Supplier<Principal> principal;
 
   protected BaseApiImpl(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     this.config = config;
     this.store = store;
     this.authorizer = authorizer;
@@ -109,7 +113,7 @@ abstract class BaseApiImpl {
   }
 
   protected Principal getPrincipal() {
-    return principal;
+    return principal.get();
   }
 
   protected Authorizer getAuthorizer() {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
@@ -18,6 +18,7 @@ package org.projectnessie.services.impl;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.projectnessie.error.NessieContentNotFoundException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -39,7 +40,10 @@ import org.projectnessie.versioned.WithHash;
 public class ContentApiImpl extends BaseApiImpl implements ContentService {
 
   public ContentApiImpl(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImplWithAuthorization.java
@@ -17,6 +17,7 @@ package org.projectnessie.services.impl;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.function.Supplier;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
@@ -32,7 +33,10 @@ import org.projectnessie.versioned.WithHash;
 public class ContentApiImplWithAuthorization extends ContentApiImpl {
 
   public ContentApiImplWithAuthorization(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -16,6 +16,7 @@
 package org.projectnessie.services.impl;
 
 import java.security.Principal;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
@@ -36,7 +37,10 @@ import org.projectnessie.versioned.WithHash;
 public class DiffApiImpl extends BaseApiImpl implements DiffService {
 
   public DiffApiImpl(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.projectnessie.api.v1.NamespaceApi;
@@ -61,7 +62,10 @@ import org.projectnessie.versioned.WithHash;
 public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
 
   public NamespaceApiImpl(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImplWithAuthorization.java
@@ -16,6 +16,7 @@
 package org.projectnessie.services.impl;
 
 import java.security.Principal;
+import java.util.function.Supplier;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.versioned.VersionStore;
@@ -24,7 +25,10 @@ import org.projectnessie.versioned.VersionStore;
 public class NamespaceApiImplWithAuthorization extends NamespaceApiImpl {
 
   public NamespaceApiImplWithAuthorization(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImpl.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import java.security.Principal;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -49,7 +50,10 @@ public class RefLogApiImpl extends BaseApiImpl implements RefLogService {
   private static final int MAX_REF_LOG_ENTRIES = 250;
 
   public RefLogApiImpl(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImplWithAuthorization.java
@@ -16,6 +16,7 @@
 package org.projectnessie.services.impl;
 
 import java.security.Principal;
+import java.util.function.Supplier;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.services.authz.Authorizer;
@@ -26,7 +27,10 @@ import org.projectnessie.versioned.VersionStore;
 public class RefLogApiImplWithAuthorization extends RefLogApiImpl {
 
   public RefLogApiImplWithAuthorization(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -114,7 +115,10 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
   private static final int MAX_COMMIT_LOG_ENTRIES = 250;
 
   public TreeApiImpl(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -57,7 +58,10 @@ import org.projectnessie.versioned.WithHash;
 public class TreeApiImplWithAuthorization extends TreeApiImpl {
 
   public TreeApiImplWithAuthorization(
-      ServerConfig config, VersionStore store, Authorizer authorizer, Principal principal) {
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
     super(config, store, authorizer, principal);
   }
 


### PR DESCRIPTION
This is to follow up on #5740, which introduced validation annotations to Nessie backend service interfaces, but did not enforce them.

This change introduced proper CDI beans for backend services in order for Quarkus and Weld to automatically validate method parameters in runtime.

Quarkus does the right validation out of the box.

Weld needs an explicit dependency on a CDI validator lib, for which the Hibernate Validator is used. The `@ValidateOnExecution` annotations are also required for this use case.

Namespace tests are adjusted to provide proper expected hashes during commit operations. These tests used to work fine over API v1, which is lenient in its NamespaceApi implementation, but using strict expected hashes is less ambiguous, matches old test behaviour in API v1, and works in both API versions.