### PR TITLE
nessie-quarkus-cli/jacoco: use a fresh jacoco data file

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -115,6 +115,14 @@ tasks.named<Test>("intTest") {
   setForkEvery(2)
 }
 
+tasks.withType<Test>().configureEach {
+  doFirst {
+    // Must delete the Jacoco data file before running tests, because
+    // quarkus.jacoco.reuse-data-file=true in application.properties.
+    file("${project.buildDir}/jacoco-quarkus.exec").delete()
+  }
+}
+
 if (withUberJar()) {
   afterEvaluate {
     publishing {


### PR DESCRIPTION
Going to re-add quarkus-jacoco once the underlying issue in Quarkus has been fixed.