### PR TITLE
Testing/benchmarking: fix configuration for persist-bench via system properties

### DIFF
--- a/versioned/persist/rocks-test/src/main/java/org/projectnessie/versioned/persist/rocks/RocksTestConnectionProviderSource.java
+++ b/versioned/persist/rocks-test/src/main/java/org/projectnessie/versioned/persist/rocks/RocksTestConnectionProviderSource.java
@@ -61,8 +61,18 @@ public class RocksTestConnectionProviderSource
 
   @Override
   public void start() throws Exception {
-    rocksDir = Files.createTempDirectory("junit-rocks");
-    configureConnectionProviderConfigFromDefaults(c -> c.withDbPath(rocksDir.toString()));
+    configureConnectionProviderConfigFromDefaults(
+        c -> {
+          if (c.getDbPath() == null) {
+            try {
+              rocksDir = Files.createTempDirectory("junit-rocks");
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+            c = c.withDbPath(rocksDir.toString());
+          }
+          return c;
+        });
     super.start();
   }
 

--- a/versioned/persist/testextension/src/main/java/org/projectnessie/versioned/persist/tests/extension/AbstractTestConnectionProviderSource.java
+++ b/versioned/persist/testextension/src/main/java/org/projectnessie/versioned/persist/tests/extension/AbstractTestConnectionProviderSource.java
@@ -28,7 +28,10 @@ public abstract class AbstractTestConnectionProviderSource<
   @Override
   public void configureConnectionProviderConfigFromDefaults(
       Function<CONN_CONFIG, CONN_CONFIG> configurer) {
-    CONN_CONFIG config = createDefaultConnectionProviderConfig();
+    CONN_CONFIG config = getConnectionProviderConfig();
+    if (config == null) {
+      config = createDefaultConnectionProviderConfig();
+    }
     config = configurer.apply(config);
     setConnectionProviderConfig(config);
   }


### PR DESCRIPTION
Configuring the RocksDB database directory via a system property did not work for `nessie-persist-bench`, because the `RocksTestConnectionProviderSource` unconditionally used a temporary directory.