### PR TITLE
Update V2 commit-response to include generated content-IDs

### DIFF
--- a/model/src/main/java/org/projectnessie/model/CommitResponse.java
+++ b/model/src/main/java/org/projectnessie/model/CommitResponse.java
@@ -15,12 +15,16 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
+import org.projectnessie.model.ser.Views;
 
 @Schema(type = SchemaType.OBJECT, title = "Commit Response")
 @Value.Immutable
@@ -39,4 +43,25 @@ public interface CommitResponse {
    */
   @NotNull
   Branch getTargetBranch();
+
+  @JsonView(Views.V2.class)
+  @Nullable // for V1 backwards compatibility
+  List<AddedContent> getAddedContents();
+
+  @Value.Immutable
+  @JsonSerialize(as = ImmutableAddedContent.class)
+  @JsonDeserialize(as = ImmutableAddedContent.class)
+  interface AddedContent {
+    @NotNull
+    @Value.Parameter(order = 1)
+    ContentKey getKey();
+
+    @NotNull
+    @Value.Parameter(order = 2)
+    String contentId();
+
+    static AddedContent addedContent(ContentKey key, String contentId) {
+      return ImmutableAddedContent.of(key, contentId);
+    }
+  }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -177,6 +177,8 @@ public class RestTreeResource implements HttpTreeApi {
   public Branch commitMultipleOperations(
       String branchName, String expectedHash, Operations operations)
       throws NessieNotFoundException, NessieConflictException {
-    return resource().commitMultipleOperations(branchName, expectedHash, operations);
+    return resource()
+        .commitMultipleOperations(branchName, expectedHash, operations)
+        .getTargetBranch();
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -258,7 +258,6 @@ public class RestV2TreeResource implements HttpTreeApi {
   public CommitResponse commitMultipleOperations(String branch, Operations operations)
       throws NessieNotFoundException, NessieConflictException {
     Reference ref = resolveRef(branch);
-    Branch head = tree().commitMultipleOperations(ref.getName(), ref.getHash(), operations);
-    return CommitResponse.builder().targetBranch(head).build();
+    return tree().commitMultipleOperations(ref.getName(), ref.getHash(), operations);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -347,6 +347,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
             Optional.empty(),
             commitMetaUpdate(null).rewriteSingle(CommitMeta.fromMessage(commitMsg)),
             Collections.singletonList(contentOperation),
-            validator);
+            validator,
+            (k, c) -> {});
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.services.impl;
 
+import static org.projectnessie.model.CommitResponse.AddedContent.addedContent;
 import static org.projectnessie.services.cel.CELUtil.COMMIT_LOG_DECLARATIONS;
 import static org.projectnessie.services.cel.CELUtil.COMMIT_LOG_TYPES;
 import static org.projectnessie.services.cel.CELUtil.CONTAINER;
@@ -58,6 +59,7 @@ import org.projectnessie.error.NessieReferenceConflictException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.CommitResponse;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Detached;
@@ -65,6 +67,7 @@ import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.FetchOption;
 import org.projectnessie.model.ImmutableBranch;
 import org.projectnessie.model.ImmutableCommitMeta;
+import org.projectnessie.model.ImmutableCommitResponse;
 import org.projectnessie.model.ImmutableContentKeyDetails;
 import org.projectnessie.model.ImmutableEntriesResponse;
 import org.projectnessie.model.ImmutableLogEntry;
@@ -651,7 +654,8 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
   }
 
   @Override
-  public Branch commitMultipleOperations(String branch, String expectedHash, Operations operations)
+  public CommitResponse commitMultipleOperations(
+      String branch, String expectedHash, Operations operations)
       throws NessieNotFoundException, NessieConflictException {
     List<org.projectnessie.versioned.Operation> ops =
         operations.getOperations().stream()
@@ -665,15 +669,22 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
     }
 
     try {
+      ImmutableCommitResponse.Builder commitResponse = ImmutableCommitResponse.builder();
+
       Hash newHash =
           getStore()
               .commit(
                   BranchName.of(Optional.ofNullable(branch).orElse(getConfig().getDefaultBranch())),
                   Optional.ofNullable(expectedHash).map(Hash::of),
                   commitMetaUpdate(null).rewriteSingle(commitMeta),
-                  ops);
+                  ops,
+                  () -> null,
+                  (key, cid) -> {
+                    commitResponse.addAddedContents(
+                        addedContent(ContentKey.of(key.getElements()), cid));
+                  });
 
-      return Branch.of(branch, newHash.asString());
+      return commitResponse.targetBranch(Branch.of(branch, newHash.asString())).build();
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     } catch (ReferenceConflictException e) {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImplWithAuthorization.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitResponse;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.FetchOption;
 import org.projectnessie.model.ImmutableLogEntry;
@@ -303,7 +303,8 @@ public class TreeApiImplWithAuthorization extends TreeApiImpl {
   }
 
   @Override
-  public Branch commitMultipleOperations(String branch, String expectedHash, Operations operations)
+  public CommitResponse commitMultipleOperations(
+      String branch, String expectedHash, Operations operations)
       throws NessieNotFoundException, NessieConflictException {
     BranchName branchName = BranchName.of(branch);
     BatchAccessChecker check = startAccessCheck().canCommitChangeAgainstReference(branchName);

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.Pattern;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitResponse;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.FetchOption;
 import org.projectnessie.model.LogResponse;
@@ -159,7 +160,7 @@ public interface TreeService {
       @Nullable String filter)
       throws NessieNotFoundException;
 
-  Branch commitMultipleOperations(
+  CommitResponse commitMultipleOperations(
       @Valid
           @NotNull
           @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -108,7 +108,8 @@ public class PersistVersionStore implements VersionStore {
       @Nonnull Optional<Hash> expectedHead,
       @Nonnull CommitMeta metadata,
       @Nonnull List<Operation> operations,
-      @Nonnull Callable<Void> validator)
+      @Nonnull Callable<Void> validator,
+      BiConsumer<Key, String> addedContents)
       throws ReferenceNotFoundException, ReferenceConflictException {
 
     ImmutableCommitParams.Builder commitAttempt =
@@ -135,7 +136,9 @@ public class PersistVersionStore implements VersionStore {
               op.getKey());
 
           // assign content-ID
-          content = STORE_WORKER.applyId(content, UUID.randomUUID().toString());
+          String cid = UUID.randomUUID().toString();
+          content = STORE_WORKER.applyId(content, cid);
+          addedContents.accept(op.getKey(), cid);
         }
 
         ContentId contentId = ContentId.of(content.getId());

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
@@ -77,10 +78,13 @@ public final class MetricsVersionStore implements VersionStore {
       @Nonnull Optional<Hash> referenceHash,
       @Nonnull CommitMeta metadata,
       @Nonnull List<Operation> operations,
-      @Nonnull Callable<Void> validator)
+      @Nonnull Callable<Void> validator,
+      @Nonnull BiConsumer<Key, String> addedContents)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return this.<Hash, ReferenceNotFoundException, ReferenceConflictException>delegate2ExR(
-        "commit", () -> delegate.commit(branch, referenceHash, metadata, operations, validator));
+        "commit",
+        () ->
+            delegate.commit(branch, referenceHash, metadata, operations, validator, addedContents));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -93,7 +94,8 @@ public class TracingVersionStore implements VersionStore {
       @Nonnull Optional<Hash> referenceHash,
       @Nonnull CommitMeta metadata,
       @Nonnull List<Operation> operations,
-      @Nonnull Callable<Void> validator)
+      @Nonnull Callable<Void> validator,
+      @Nonnull BiConsumer<Key, String> addedContents)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return TracingVersionStore
         .<Hash, ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(
@@ -102,7 +104,9 @@ public class TracingVersionStore implements VersionStore {
                 b.withTag(TAG_BRANCH, safeRefName(branch))
                     .withTag(TAG_HASH, safeToString(referenceHash))
                     .withTag(TAG_NUM_OPS, safeSize(operations)),
-            () -> delegate.commit(branch, referenceHash, metadata, operations, validator));
+            () ->
+                delegate.commit(
+                    branch, referenceHash, metadata, operations, validator, addedContents));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
@@ -75,6 +76,7 @@ public interface VersionStore {
    * @param operations The set of operations to apply.
    * @param validator Gets called during the atomic commit operations, callers can implement
    *     validation logic.
+   * @param addedContents callback that receives the content-ID of _new_ content per content-key
    * @throws ReferenceConflictException if {@code referenceHash} values do not match the stored
    *     values for {@code branch}
    * @throws ReferenceNotFoundException if {@code branch} is not present in the store
@@ -85,7 +87,8 @@ public interface VersionStore {
       @Nonnull Optional<Hash> referenceHash,
       @Nonnull CommitMeta metadata,
       @Nonnull List<Operation> operations,
-      @Nonnull Callable<Void> validator)
+      @Nonnull Callable<Void> validator,
+      @Nonnull BiConsumer<Key, String> addedContents)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   default Hash commit(
@@ -94,7 +97,7 @@ public interface VersionStore {
       @Nonnull CommitMeta metadata,
       @Nonnull List<Operation> operations)
       throws ReferenceNotFoundException, ReferenceConflictException {
-    return commit(branch, referenceHash, metadata, operations, () -> null);
+    return commit(branch, referenceHash, metadata, operations, () -> null, (k, c) -> {});
   }
 
   /**

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -132,7 +132,8 @@ class TestMetricsVersionStore {
                         Optional.empty(),
                         CommitMeta.fromMessage("metadata"),
                         Collections.emptyList(),
-                        () -> null),
+                        () -> null,
+                        (k, c) -> {}),
                 () -> Hash.of("cafebabedeadbeef"),
                 refNotFoundAndRefConflictThrows),
             new VersionStoreInvocation<>(

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -121,7 +121,8 @@ class TestTracingVersionStore {
                             Optional.empty(),
                             CommitMeta.fromMessage("metadata"),
                             Collections.emptyList(),
-                            () -> null),
+                            () -> null,
+                            (k, c) -> {}),
                     () -> Hash.of("deadbeefcafebabe")),
             new TestedTraceingStoreInvocation<VersionStore>(
                     "Transplant", refNotFoundAndRefConflictThrows)

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
@@ -577,14 +577,12 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
     BranchName branch = BranchName.of("main");
     Key key = Key.of("my", "table0");
     Hash branchHead = store().getNamedRef(branch.getName(), GetNamedRefsParams.DEFAULT).getHash();
-    String cid = "cid-0";
 
     RuntimeException exception = new ArithmeticException("Whatever");
     soft.assertThatThrownBy(
             () ->
                 doCommitWithValidation(
                     branch,
-                    cid,
                     key,
                     () -> {
                       // do some operations here
@@ -605,7 +603,7 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
     soft.assertThat(store().getValue(branch, key)).isNull();
   }
 
-  void doCommitWithValidation(BranchName branch, String cid, Key key, Callable<Void> validator)
+  void doCommitWithValidation(BranchName branch, Key key, Callable<Void> validator)
       throws Exception {
     store()
         .commit(
@@ -613,7 +611,8 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             Optional.empty(),
             CommitMeta.fromMessage("initial commit meta"),
             Collections.singletonList(Put.of(key, newOnRef("some value"))),
-            validator);
+            validator,
+            (k, c) -> {});
   }
 
   @Test


### PR DESCRIPTION
This changes `org.projectnessie.model.CommitResponse` to include the content-IDs of the _newly_ added `Content` objects - for REST API v2.

The Nessie API requires people to _not_ set the `Content.id` for _new_ content (think: `CREATE TABLE`), Nessie will generate the content-ID in that case. This behavior will be strictly enforced with #5641. So this change adds a new `List<AddedContent>` to `CommitResponse`, which contains the generated content-IDs, so use cases that need the content-ID can just inspect the `CommitResponse` and do not have to issue a `getContents()` to get the generated content-ID.
