### PR TITLE
Fix Jacoco reporting in Nessie Quarkus projects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: check --scan
+        arguments: check codeCoverageReport -x test --scan
 
     - name: Gradle / Gatling simulations
       uses: gradle/gradle-build-action@v2
@@ -58,7 +58,6 @@ jobs:
       with:
         arguments: |
           assemble
-          codeCoverageReport -x test -x intTest
           publishToMavenLocal
           -Puber-jar
           --scan

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: check -x spotlessCheck -x checkstyleMain -x checkstyleTest --scan
+        arguments: check codeCoverageReport -x test --scan
 
     - name: Gradle / Gatling simulations
       uses: gradle/gradle-build-action@v2
@@ -80,7 +80,6 @@ jobs:
         arguments: |
           assemble
           publishToMavenLocal
-          codeCoverageReport -x test -x intTest
           --scan
 
     - name: Gradle / build tools integration tests

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -141,6 +141,8 @@ jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
 jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml" }
 jackson-jaxrs-json-provider = { module = "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider" }
 jackson-jaxrs-xml-provider = { module = "com.fasterxml.jackson.jaxrs:jackson-jaxrs-xml-provider" }
+jacoco-ant = { module = "org.jacoco:org.jacoco.ant", version.ref = "jacoco" }
+jacoco-report = { module = "org.jacoco:org.jacoco.report", version.ref = "jacoco" }
 jacoco-maven-plugin = { module = "org.jacoco:jacoco-maven-plugin", version.ref = "jacoco" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version = "1.3.5" }
 jakarta-enterprise-cdi-api = { module = "jakarta.enterprise:jakarta.enterprise.cdi-api", version = "2.0.2" }

--- a/servers/quarkus-cli/src/main/resources/application.properties
+++ b/servers/quarkus-cli/src/main/resources/application.properties
@@ -60,8 +60,6 @@ quarkus.log.console.level=WARN
 quarkus.log.file.level=INFO
 quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%X{traceId},%X{spanId},%X{sampled}] [%c{3.}] (%t) %s%e%n
 quarkus.log.category."io.netty".level=WARN
-# Instruct jacoco to reuse output files to preserve coverage data across multiple test JVM restarts.
-quarkus.jacoco.reuse-data-file=true
 
 # Do not print the banner, because that prints _after_ the CLI output :(
 quarkus.banner.enabled=false
@@ -76,3 +74,5 @@ quarkus.index-dependency.protobuf.group-id=com.google.protobuf
 quarkus.index-dependency.protobuf.artifact-id=protobuf-java
 
 %test.quarkus.devservices.enabled=false
+%test.quarkus.jacoco.report=false
+%test.quarkus.jacoco.reuse-data-file=true

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -183,8 +183,6 @@ quarkus.opentelemetry.tracer.enabled=true
 %dev.quarkus.dynamodb.aws.credentials.static-provider.access-key-id=test-key
 %dev.quarkus.dynamodb.aws.credentials.static-provider.secret-access-key=test-secret
 
-%test.quarkus.devservices.enabled=false
-
 mp.openapi.extensions.smallrye.operationIdStrategy=METHOD
 
 # order matters below, since the first matching pattern will be used
@@ -210,3 +208,7 @@ quarkus.micrometer.binder.http-server.match-patterns=\
   /api/v1/namespaces/namespace/.*/.*=/api/v1/namespaces/namespace/{ref}/{name}, \
   /api/v1/namespaces/.*=/api/v1/namespaces/{ref}, \
   /contents/.*=/contents/{key}
+
+%test.quarkus.devservices.enabled=false
+%test.quarkus.jacoco.report=false
+%test.quarkus.jacoco.reuse-data-file=true


### PR DESCRIPTION
Jacoco report generation via Quarkus is not so great, there were a bunch of issues, some breaking the build (flaky)

This change disables Jacoco report generation by Quarkus and changes it to let the Jacoco report task generate the reports.