### PR TITLE
Disable JVM monitoring in native images

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -160,8 +160,10 @@ quarkus.native.additional-build-args=\
   -J-Duser.language=en,\
   -J-Duser.country=US,\
   -J-Duser.variant=,\
-  -J-Dfile.encoding=UTF-8,\
-  --enable-monitoring
+  -J-Dfile.encoding=UTF-8
+# Disable monitoring due to https://github.com/oracle/graal/issues/5303, reported via
+# https://github.com/projectnessie/nessie/issues/5900
+#   --enable-monitoring
 
 ## quarkus container specific settings
 # fixed at buildtime


### PR DESCRIPTION
Disable monitoring due to https://github.com/oracle/graal/issues/5303, reported via #5900.