### PR TITLE
Separate version catalog for `buildSrc/`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
   implementation(gradleKotlinDsl())
-  val ver = libs.versions
+  val ver = baselibs.versions
   implementation("com.diffplug.spotless:spotless-plugin-gradle:${ver.spotlessPlugin.get()}")
   implementation("com.github.vlsi.gradle:jandex-plugin:${ver.jandexPlugin.get()}")
   implementation("gradle.plugin.com.github.johnrengelman:shadow:${ver.shadowPlugin.get()}")
@@ -39,11 +39,14 @@ dependencies {
   implementation("org.projectnessie.buildsupport:jandex:$nessieVer")
   implementation("org.projectnessie.buildsupport:publishing:$nessieVer")
   implementation("org.projectnessie.buildsupport:reflection-config:$nessieVer")
+  implementation("org.projectnessie.buildsupport:smallrye-openapi:$nessieVer")
   implementation("org.projectnessie.buildsupport:spotless:$nessieVer")
 
-  testImplementation(platform(libs.junit.bom))
-  testImplementation(libs.bundles.junit.testing)
-  testRuntimeOnly(libs.junit.jupiter.engine)
+  testImplementation(platform(baselibs.junit.bom))
+  testImplementation(baselibs.assertj.core)
+  testImplementation(baselibs.junit.jupiter.api)
+  testImplementation(baselibs.junit.jupiter.params)
+  testRuntimeOnly(baselibs.junit.jupiter.engine)
 }
 
 kotlinDslPluginOptions { jvmTarget.set(JavaVersion.VERSION_11.toString()) }

--- a/buildSrc/src/main/kotlin/OpenApiPlugin.kt
+++ b/buildSrc/src/main/kotlin/OpenApiPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
-dependencyResolutionManagement {
-  versionCatalogs { create("baselibs") { from(files("../gradle/baselibs.versions.toml")) } }
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.projectnessie.buildtools.smallryeopenapi.SmallryeOpenApiPlugin
+
+/** Makes the generated sources available to IDEs, disables Checkstyle on generated code. */
+@Suppress("unused")
+class OpenApiPlugin : Plugin<Project> {
+  override fun apply(project: Project): Unit = project.run { apply<SmallryeOpenApiPlugin>() }
 }

--- a/gradle/baselibs.versions.toml
+++ b/gradle/baselibs.versions.toml
@@ -1,0 +1,32 @@
+# Dependencies needed by buildSrc/
+
+[versions]
+jandexPlugin = "1.86"
+junit = "5.9.2"
+nessieBuildPlugins = "0.2.15"
+protobufPlugin = "0.9.2"
+shadowPlugin = "7.1.2"
+spotlessPlugin = "6.13.0"
+
+[libraries]
+assertj-core = { module = "org.assertj:assertj-core", version = "3.24.2" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
+
+[plugins]
+jandex = { id = "com.github.vlsi.jandex", version.ref = "jandexPlugin" }
+nessie-build-checkstyle = { id = "org.projectnessie.buildsupport.checkstyle", version.ref = "nessieBuildPlugins" }
+nessie-build-errorprone = { id = "org.projectnessie.buildsupport.errorprone", version.ref = "nessieBuildPlugins" }
+nessie-build-ide-integration = { id = "org.projectnessie.buildsupport.ide-integration", version.ref = "nessieBuildPlugins" }
+nessie-build-jacoco = { id = "org.projectnessie.buildsupport.jacoco", version.ref = "nessieBuildPlugins" }
+nessie-build-jacoco-aggregator = { id = "org.projectnessie.buildsupport.jacoco-aggregator", version.ref = "nessieBuildPlugins" }
+nessie-build-jandex = { id = "org.projectnessie.buildsupport.jandex", version.ref = "nessieBuildPlugins" }
+nessie-build-publishing = { id = "org.projectnessie.buildsupport.publishing", version.ref = "nessieBuildPlugins" }
+nessie-build-reflectionconfig = { id = "org.projectnessie.buildsupport.reflectionconfig", version.ref = "nessieBuildPlugins" }
+nessie-build-smallrye-open-api = { id = "org.projectnessie.smallrye-open-api", version.ref = "nessieBuildPlugins" }
+nessie-build-spotless = { id = "org.projectnessie.buildsupport.spotless", version.ref = "nessieBuildPlugins" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadowPlugin" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,3 +1,5 @@
+# Nessie dependencies, without the dependencies needed by buildSrc/
+
 [versions]
 agrone = "1.17.1"
 antlr4 = "4.11.1"
@@ -14,14 +16,12 @@ iceberg = "1.1.0"
 immutables = "2.9.3"
 jacoco = "0.8.8"
 jandex = "3.0.5"
-jandexPlugin = "1.86"
 jmh = "1.36"
 junit = "5.9.2"
 logback = "1.2.11"
 maven = "3.8.7"
 mavenResolver = "1.7.3"
 micrometer = "1.10.3"
-nessieBuildPlugins = "0.2.15"
 nessieClientVersion = "0.44.0"
 opentelemetry = "1.22.0"
 opentelemetryAlpha = "1.20.1-alpha"
@@ -30,15 +30,12 @@ parquet = "1.12.3"
 picocli = "4.7.0"
 postgresContainerTag = "14"
 protobuf = "3.21.12"
-protobufPlugin = "0.9.2"
 quarkus = "2.15.3.Final"
 quarkusAmazon = "2.16.0.Final"
 quarkusLoggingSentry = "1.2.1"
 quarkusBuilderImage = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17"
 rocksdb = "7.9.2"
-shadowPlugin = "7.1.2"
 slf4j = "1.7.36"
-spotlessPlugin = "6.13.0"
 testcontainers = "1.17.6"
 undertow = "2.2.19.Final"
 
@@ -211,22 +208,8 @@ weld-se-core = { module = "org.jboss.weld.se:weld-se-core", version = "3.1.9.Fin
 errorprone = { id = "net.ltgt.errorprone", version = "3.0.1" }
 gatling = { id = "io.gatling.gradle", version = "3.9.0.2" }
 idea-ext = { id = "org.jetbrains.gradle.plugin.idea-ext", version = "1.1.7" }
-jandex = { id = "com.github.vlsi.jandex", version.ref = "jandexPlugin" }
 jmh = { id = "me.champeau.jmh", version = "0.6.8" }
-nessie-build-checkstyle = { id = "org.projectnessie.buildsupport.checkstyle", version.ref = "nessieBuildPlugins" }
-nessie-build-errorprone = { id = "org.projectnessie.buildsupport.errorprone", version.ref = "nessieBuildPlugins" }
-nessie-build-ide-integration = { id = "org.projectnessie.buildsupport.ide-integration", version.ref = "nessieBuildPlugins" }
-nessie-build-jacoco = { id = "org.projectnessie.buildsupport.jacoco", version.ref = "nessieBuildPlugins" }
-nessie-build-jacoco-aggregator = { id = "org.projectnessie.buildsupport.jacoco-aggregator", version.ref = "nessieBuildPlugins" }
-nessie-build-jandex = { id = "org.projectnessie.buildsupport.jandex", version.ref = "nessieBuildPlugins" }
-nessie-build-publishing = { id = "org.projectnessie.buildsupport.publishing", version.ref = "nessieBuildPlugins" }
-nessie-build-reflectionconfig = { id = "org.projectnessie.buildsupport.reflectionconfig", version.ref = "nessieBuildPlugins" }
-nessie-build-smallrye-open-api = { id = "org.projectnessie.smallrye-open-api", version.ref = "nessieBuildPlugins" }
-nessie-build-spotless = { id = "org.projectnessie.buildsupport.spotless", version.ref = "nessieBuildPlugins" }
 nessie-run = { id = "org.projectnessie", version = "0.28.1" }
 nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version = "1.1.0" }
 node-gradle = { id = "com.github.node-gradle.node", version = "3.5.1" }
-protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 quarkus = { id = "io.quarkus", version.ref = "quarkus" }
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadowPlugin" }
-spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.projectnessie.buildtools.smallryeopenapi.SmallryeOpenApiExtension
 import org.projectnessie.buildtools.smallryeopenapi.SmallryeOpenApiTask
 
 plugins {
@@ -22,9 +23,10 @@ plugins {
   jacoco
   `maven-publish`
   signing
-  alias(libs.plugins.nessie.build.smallrye.open.api)
   `nessie-conventions`
 }
+
+apply<OpenApiPlugin>()
 
 dependencies {
   implementation(platform(libs.jackson.bom))
@@ -47,7 +49,7 @@ dependencies {
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
-smallryeOpenApi {
+extensions.configure<SmallryeOpenApiExtension> {
   infoVersion.set(project.version.toString())
   schemaFilename.set("META-INF/openapi/openapi")
   operationIdStrategy.set("METHOD")


### PR DESCRIPTION
Have a separate version catalog into one for `buildSrc/`.

This helps Gradle to not invalidate the build cache for _every_ dependency update.

Background: `buildSrc/` used the `libs` version catalog, but if that one is updated, the cached build artifacts for `buildSrc/` are invalidated, which then in turn causes _all_ projects' build caches to be invalidated.