### PR TITLE
Add `.scalafmt.conf` for IntelliJ

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+# File req'd for IntelliJ, configure the scalafmt formatter in 'Editor -> Code Style -> Scala'
+version = 2.7.5


### PR DESCRIPTION
... to let IJ format the same way as spotless, after updating IJ's Scala formatter in 'Editor -> Code Style -> Scala' to `scalafmt`