### PR TITLE
REST v2: Correct namespace key evaluation for delete + get-multiple namespaces

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideDeleteNamespace.java
+++ b/clients/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideDeleteNamespace.java
@@ -67,7 +67,7 @@ public final class ClientSideDeleteNamespace extends BaseDeleteNamespaceBuilder 
           .getEntries()
           .refName(refName)
           .hashOnRef(hashOnRef)
-          .filter(String.format("entry.namespace.startsWith('%s')", key))
+          .filter(String.format("entry.encodedKey.startsWith('%s.')", namespace.name()))
           .stream()
           .findAny()
           .isPresent()) {

--- a/clients/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideGetMultipleNamespaces.java
+++ b/clients/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideGetMultipleNamespaces.java
@@ -51,9 +51,11 @@ public final class ClientSideGetMultipleNamespaces extends BaseGetMultipleNamesp
     try {
       GetEntriesBuilder getEntries = api.getEntries().refName(refName).hashOnRef(hashOnRef);
 
-      if (namespace != null) {
+      if (namespace != null && !namespace.isEmpty()) {
+        String nsName = namespace.name();
         getEntries.filter(
-            String.format("entry.key.startsWith('%s')", ContentKey.of(namespace.getElements())));
+            String.format(
+                "entry.encodedKey == '%s' || entry.encodedKey.startsWith('%s.')", nsName, nsName));
       }
 
       entries =

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -109,6 +109,8 @@ public final class CELUtil {
 
     String getKey();
 
+    String getEncodedKey();
+
     List<String> getNamespaceElements();
 
     String getName();
@@ -239,6 +241,11 @@ public final class CELUtil {
     @Override
     public String getKey() {
       return key().toString();
+    }
+
+    @Override
+    public String getEncodedKey() {
+      return key().toPathString();
     }
 
     @Override


### PR DESCRIPTION
The CEL expression used to find a namespace and its children (`entry.namespace.startsWith(%s)` using `ContentKey.toString()` is incorrect and leads to wrong results for two reasons:
* example: `foo.bar.meep` would match the above for the namespace `foo.bar.me` - it does not consider key element boundaries
* dots in key elements are not correctly respected - so a key consisting of `["a", "b.b", "c"]` would be "equal" to `["a", "b", "b", "c"]` - need to use the path-escaped representation