### PR TITLE
REST API v2 : Let 'get-content(s)' return the reference

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetContentBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetContentBuilder.java
@@ -21,6 +21,8 @@ import javax.validation.Valid;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ContentResponse;
+import org.projectnessie.model.GetMultipleContentsResponse;
 
 /**
  * Request builder for "get content".
@@ -32,5 +34,9 @@ public interface GetContentBuilder extends OnReferenceBuilder<GetContentBuilder>
 
   GetContentBuilder keys(List<ContentKey> keys);
 
+  ContentResponse getSingle(@Valid ContentKey key) throws NessieNotFoundException;
+
   Map<ContentKey, Content> get() throws NessieNotFoundException;
+
+  GetMultipleContentsResponse getWithResponse() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetContent.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetContent.java
@@ -22,6 +22,7 @@ import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ContentResponse;
 import org.projectnessie.model.GetMultipleContentsResponse;
 import org.projectnessie.model.GetMultipleContentsResponse.ContentWithKey;
 
@@ -39,5 +40,16 @@ final class HttpGetContent extends BaseGetContentBuilder {
         client.getContentApi().getMultipleContents(refName, hashOnRef, request.build());
     return resp.getContents().stream()
         .collect(Collectors.toMap(ContentWithKey::getKey, ContentWithKey::getContent));
+  }
+
+  @Override
+  public ContentResponse getSingle(ContentKey key) {
+    throw new UnsupportedOperationException("Get single content is not available in API v1");
+  }
+
+  @Override
+  public GetMultipleContentsResponse getWithResponse() {
+    throw new UnsupportedOperationException(
+        "Extended contents response data is not available in API v1");
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpGetContent.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpGetContent.java
@@ -16,14 +16,13 @@
 package org.projectnessie.client.http.v2api;
 
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.projectnessie.client.builder.BaseGetContentBuilder;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ContentResponse;
 import org.projectnessie.model.GetMultipleContentsResponse;
-import org.projectnessie.model.GetMultipleContentsResponse.ContentWithKey;
 import org.projectnessie.model.Reference;
 
 final class HttpGetContent extends BaseGetContentBuilder {
@@ -35,15 +34,33 @@ final class HttpGetContent extends BaseGetContentBuilder {
 
   @Override
   public Map<ContentKey, Content> get() throws NessieNotFoundException {
-    GetMultipleContentsResponse response =
-        client
-            .newRequest()
-            .path("trees/{ref}/contents")
-            .resolveTemplate("ref", Reference.toPathString(refName, hashOnRef))
-            .unwrap(NessieNotFoundException.class)
-            .post(request.build())
-            .readEntity(GetMultipleContentsResponse.class);
-    return response.getContents().stream()
-        .collect(Collectors.toMap(ContentWithKey::getKey, ContentWithKey::getContent));
+    return getWithResponse().toContentsMap();
+  }
+
+  @Override
+  public ContentResponse getSingle(ContentKey key) throws NessieNotFoundException {
+    if (!request.build().getRequestedKeys().isEmpty()) {
+      throw new IllegalStateException(
+          "Must not use getSingle() with key() or keys(), pass the single key to getSingle()");
+    }
+    return client
+        .newRequest()
+        .path("trees/{ref}/contents/{key}")
+        .resolveTemplate("ref", Reference.toPathString(refName, hashOnRef))
+        .resolveTemplate("key", key.toPathString())
+        .unwrap(NessieNotFoundException.class)
+        .get()
+        .readEntity(ContentResponse.class);
+  }
+
+  @Override
+  public GetMultipleContentsResponse getWithResponse() throws NessieNotFoundException {
+    return client
+        .newRequest()
+        .path("trees/{ref}/contents")
+        .resolveTemplate("ref", Reference.toPathString(refName, hashOnRef))
+        .unwrap(NessieNotFoundException.class)
+        .post(request.build())
+        .readEntity(GetMultipleContentsResponse.class);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/ContentResponse.java
+++ b/model/src/main/java/org/projectnessie/model/ContentResponse.java
@@ -26,6 +26,7 @@ import org.projectnessie.model.ser.Views;
 @Value.Immutable
 @JsonSerialize(as = ImmutableContentResponse.class)
 @JsonDeserialize(as = ImmutableContentResponse.class)
+@JsonView(Views.V2.class)
 public interface ContentResponse {
 
   static ImmutableContentResponse.Builder builder() {
@@ -42,7 +43,6 @@ public interface ContentResponse {
    */
   @Nullable
   @Value.Parameter(order = 2)
-  @JsonView(Views.V2.class)
   Reference getEffectiveReference();
 
   static ContentResponse of(Content content, Reference effectiveReference) {

--- a/model/src/main/java/org/projectnessie/model/ContentResponse.java
+++ b/model/src/main/java/org/projectnessie/model/ContentResponse.java
@@ -15,10 +15,13 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
+import org.projectnessie.model.ser.Views;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableContentResponse.class)
@@ -30,5 +33,19 @@ public interface ContentResponse {
   }
 
   @NotNull
+  @Value.Parameter(order = 1)
   Content getContent();
+
+  /**
+   * The effective reference (for example a branch or tag) including the commit ID from which the
+   * entries were fetched.
+   */
+  @Nullable
+  @Value.Parameter(order = 2)
+  @JsonView(Views.V2.class)
+  Reference getEffectiveReference();
+
+  static ContentResponse of(Content content, Reference effectiveReference) {
+    return ImmutableContentResponse.of(content, effectiveReference);
+  }
 }

--- a/model/src/main/java/org/projectnessie/model/ContentResponse.java
+++ b/model/src/main/java/org/projectnessie/model/ContentResponse.java
@@ -15,18 +15,15 @@
  */
 package org.projectnessie.model;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
-import org.projectnessie.model.ser.Views;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableContentResponse.class)
 @JsonDeserialize(as = ImmutableContentResponse.class)
-@JsonView(Views.V2.class)
 public interface ContentResponse {
 
   static ImmutableContentResponse.Builder builder() {

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRest.java
@@ -52,6 +52,7 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.ContentResponse;
 import org.projectnessie.model.DiffResponse;
 import org.projectnessie.model.EntriesResponse;
+import org.projectnessie.model.GetMultipleContentsRequest;
 import org.projectnessie.model.GetMultipleContentsResponse;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableBranch;
@@ -146,8 +147,20 @@ public abstract class BaseTestNessieRest extends BaseTestNessieApi {
             .statusCode(200)
             .extract()
             .as(Content.class);
+    soft.assertThat(withoutId(content)).isEqualTo(table);
 
-    assertThat(withoutId(content)).isEqualTo(table);
+    GetMultipleContentsResponse multi =
+        rest()
+            .queryParam("ref", branch.getName())
+            .queryParam("hashOnRef", branch.getHash())
+            .body(GetMultipleContentsRequest.of(key))
+            .post("contents")
+            .then()
+            .statusCode(200)
+            .extract()
+            .as(GetMultipleContentsResponse.class);
+    soft.assertThat(withoutId(multi.toContentsMap().get(key))).isEqualTo(table);
+    soft.assertThat(multi.getEffectiveReference()).isNull();
   }
 
   @Test

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
@@ -55,7 +55,7 @@ public class RestContentResource implements HttpContentApi {
   @JsonView(Views.V1.class)
   public Content getContent(ContentKey key, String ref, String hashOnRef)
       throws NessieNotFoundException {
-    return resource().getContent(key, ref, hashOnRef);
+    return resource().getContent(key, ref, hashOnRef).getContent();
   }
 
   @Override

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -33,7 +33,6 @@ import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitResponse;
-import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.ContentResponse;
 import org.projectnessie.model.DiffResponse;
@@ -303,8 +302,7 @@ public class RestV2TreeResource implements HttpTreeApi {
   @Override
   public ContentResponse getContent(ContentKey key, String ref) throws NessieNotFoundException {
     Reference reference = resolveRef(ref);
-    Content content = content().getContent(key, reference.getName(), reference.getHash());
-    return ContentResponse.builder().content(content).build();
+    return content().getContent(key, reference.getName(), reference.getHash());
   }
 
   @JsonView(Views.V2.class)

--- a/servers/services/src/main/java/org/projectnessie/services/spi/ContentService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/ContentService.java
@@ -21,8 +21,8 @@ import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ContentResponse;
 import org.projectnessie.model.GetMultipleContentsResponse;
 import org.projectnessie.model.Validation;
 
@@ -34,7 +34,7 @@ import org.projectnessie.model.Validation;
  */
 public interface ContentService {
 
-  Content getContent(
+  ContentResponse getContent(
       @Valid ContentKey key,
       @Valid @Pattern(regexp = Validation.REF_NAME_REGEX, message = Validation.REF_NAME_MESSAGE)
           String namedRef,

--- a/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestCommitLog.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestCommitLog.java
@@ -383,7 +383,7 @@ public abstract class AbstractTestCommitLog extends BaseTestServiceImpl {
 
       Put op;
       try {
-        Content existing = contentApi().getContent(key, branch.getName(), currentHash);
+        Content existing = contentApi().getContent(key, branch.getName(), currentHash).getContent();
         op =
             Put.of(
                 key, IcebergTable.of("some-file-" + i, 42, 42, 42, 42, existing.getId()), existing);

--- a/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestContents.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestContents.java
@@ -35,6 +35,7 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ContentResponse;
 import org.projectnessie.model.DiffResponse.DiffEntry;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.IcebergTable;
@@ -281,6 +282,7 @@ public abstract class AbstractTestContents extends BaseTestServiceImpl {
       // Compare content on HEAD commit with the committed content
       soft.assertThat(
               contentApi().getContent(fixedContentKey, committed.getName(), committed.getHash()))
+          .extracting(ContentResponse::getContent)
           .extracting(this::clearIdOnContent)
           .isEqualTo(put.getContent());
 
@@ -327,6 +329,7 @@ public abstract class AbstractTestContents extends BaseTestServiceImpl {
       // Compare content on HEAD commit with the committed content
       soft.assertThat(
               contentApi().getContent(fixedContentKey, committed.getName(), committed.getHash()))
+          .extracting(ContentResponse::getContent)
           .extracting(this::clearIdOnContent)
           .isEqualTo(contentAndOperationType.prepare.getContent());
 

--- a/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
@@ -171,7 +171,8 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
     soft.assertThat(committed1.getHash()).isNotNull();
 
     table1 =
-        (IcebergTable) contentApi().getContent(key1, committed1.getName(), committed1.getHash());
+        (IcebergTable)
+            contentApi().getContent(key1, committed1.getName(), committed1.getHash()).getContent();
 
     Branch committed2 =
         commit(
@@ -528,7 +529,8 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
     soft.assertThat(committed1.getHash()).isNotNull();
 
     table1 =
-        (IcebergTable) contentApi().getContent(key1, committed1.getName(), committed1.getHash());
+        (IcebergTable)
+            contentApi().getContent(key1, committed1.getName(), committed1.getHash()).getContent();
 
     Branch committed2 =
         commit(committed1, fromMessage("test-branch2"), Put.of(key1, table1, table1))

--- a/servers/services/src/test/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
@@ -405,7 +405,8 @@ public abstract class BaseTestServiceImpl {
 
         Put op;
         try {
-          Content existing = contentApi().getContent(key, branch.getName(), currentHash);
+          Content existing =
+              contentApi().getContent(key, branch.getName(), currentHash).getContent();
           op =
               Put.of(
                   key,


### PR DESCRIPTION
Clients can request content(s) by only specifying the reference name, omitting the commit ID. It is useful to return the `Reference` including the commit ID in the response. This allows omitting a 'get-reference' call.

Previous code example:
```java
Branch branch = (Branch) api.getReference().refName("my-branch").get();
Content content = api.getContent().key(contentKey).get().get(contentKey);
Content newContet = ...
Branch newHead = api.commitMultipleOperations().branch(branch)....
```

New code example:
```java
GetMultipleContentsResponse contentResponse = api.getContent().key(contentKey).getWithResponse();
Branch branch = (Branch) contentResponse.getReference();
Content content = contentResponse.toContentsMap().get(contentKey);
Content newContet = ...
Branch newHead = api.commitMultipleOperations().branch(branch)....
```

Also adds a convenience `GetContentBuilder.getSingle(ContentKey)` returning a `ContentResponse` as well.