### PR TITLE
Add PVC for RocksDB in Nessie Helm chart

### DIFF
--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if eq .Values.versionStoreType "ROCKS" }}
+          volumeMounts:
+            - name: rocks-storage
+              mountPath: {{ .Values.rocksdb.dbPath }}
+          {{- end }}
           env:
             - name: NESSIE_VERSION_STORE_TYPE
               value: {{ .Values.versionStoreType }}
@@ -185,6 +190,12 @@ spec:
             timeoutSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if eq .Values.versionStoreType "ROCKS" }}
+      volumes:
+        - name: rocks-storage
+          persistentVolumeClaim:
+            claimName: {{ include "nessie.fullname" . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/nessie/templates/storage.yaml
+++ b/helm/nessie/templates/storage.yaml
@@ -1,0 +1,18 @@
+{{- if eq .Values.versionStoreType "ROCKS" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "nessie.fullname" . }}
+  labels:
+    {{- include "nessie.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ .Values.rocksdb.storageSize }}
+  selector:
+    matchLabels:
+      app.projectnessie.org/file-storage-for: {{ include "nessie.fullname" . }}
+{{- end }}

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -14,7 +14,8 @@ versionStoreType: INMEMORY
 
 # this is needed when selecting ROCKS
 rocksdb:
-  dbPath: /tmp/rocks-nessie
+  storageSize: 1Gi
+  dbPath: /rocks-nessie
 
 # this is needed when selecting DYNAMO
 dynamodb:


### PR DESCRIPTION
* Add a PVC for use with RocksDB storage backend.

* Remove /tmp prefix from the RocksDB directory path for clarity.

* Set RocksDB example storage size request to 1 GB.

Fixes #5937