### PR TITLE
Build: Make `QuarkusGenerateCode` tasks cacheable

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import io.quarkus.gradle.tasks.QuarkusBuild
+import io.quarkus.gradle.tasks.QuarkusGenerateCode
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
@@ -109,6 +110,8 @@ tasks.withType<QuarkusBuild>().configureEach {
     System.setProperty("quarkus.native.builder-image", quarkusBuilderImage)
   }
 }
+
+tasks.withType<QuarkusGenerateCode>().configureEach { outputs.cacheIf { true } }
 
 val prepareJacocoReport by
   tasks.registering {

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import io.quarkus.gradle.tasks.QuarkusBuild
+import io.quarkus.gradle.tasks.QuarkusGenerateCode
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
@@ -151,6 +152,8 @@ val quarkusBuild =
       }
     }
   }
+
+tasks.withType<QuarkusGenerateCode>().configureEach { outputs.cacheIf { true } }
 
 val prepareJacocoReport by
   tasks.registering {


### PR DESCRIPTION
saves a couple of seconds during (CI) builds