### PR TITLE
Nit: Prevent java compilation warning

### DIFF
--- a/model/src/main/java/org/projectnessie/model/ser/CommitMetaSer.java
+++ b/model/src/main/java/org/projectnessie/model/ser/CommitMetaSer.java
@@ -26,4 +26,5 @@ import org.projectnessie.model.CommitMeta;
 @Value.Immutable
 @Value.Style(builder = "builderSer")
 @JsonDeserialize(as = ImmutableCommitMetaSer.class)
+@SuppressWarnings("immutables:subtype")
 public abstract class CommitMetaSer extends CommitMeta {}


### PR DESCRIPTION
Prevents this warning:
```
./model/src/main/java/org/projectnessie/model/ser/CommitMetaSer.java:29: warning: (immutables:subtype) Should not inherit org.projectnessie.model.CommitMeta which is a value type itself. Avoid extending from another abstract value type. Better to share common abstract class or interface which are not carrying @Immutable annotation. If still extending from immutable abstract type be ready to face some incoherences in generated types.
```
