### PR TITLE
Allow retrieval of `Content` with `get-entries` for API v2

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -30,6 +30,8 @@ public interface GetEntriesBuilder
 
   GetEntriesBuilder namespaceDepth(Integer namespaceDepth);
 
+  GetEntriesBuilder withContent(boolean withContent);
+
   @Override // kept for byte-code compatibility
   EntriesResponse get() throws NessieNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetEntriesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/builder/BaseGetEntriesBuilder.java
@@ -32,6 +32,7 @@ public abstract class BaseGetEntriesBuilder<PARAMS>
   protected Integer maxRecords;
   protected String filter;
   protected Integer namespaceDepth;
+  protected boolean withContent;
 
   protected BaseGetEntriesBuilder(BiFunction<PARAMS, String, PARAMS> paramsForPage) {
     this.paramsForPage = paramsForPage;
@@ -58,6 +59,12 @@ public abstract class BaseGetEntriesBuilder<PARAMS>
   @Override
   public GetEntriesBuilder namespaceDepth(Integer namespaceDepth) {
     this.namespaceDepth = namespaceDepth;
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder withContent(boolean withContent) {
+    this.withContent = withContent;
     return this;
   }
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
@@ -42,6 +42,9 @@ final class HttpGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
 
   @Override
   protected EntriesResponse get(EntriesParams p) throws NessieNotFoundException {
+    if (withContent) {
+      throw new IllegalArgumentException("'withContent' is not available with REST API v1");
+    }
     return client.getTreeApi().getEntries(refName, p);
   }
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpGetEntries.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v2api/HttpGetEntries.java
@@ -36,6 +36,7 @@ final class HttpGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
     return EntriesParams.builder() // TODO: namespace, derive prefix
         .filter(filter)
         .maxRecords(maxRecords)
+        .withContent(withContent)
         .build();
   }
 
@@ -46,6 +47,7 @@ final class HttpGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
         .path("trees/{ref}/entries")
         .resolveTemplate("ref", Reference.toPathString(refName, hashOnRef))
         .queryParam("filter", p.filter())
+        .queryParam("content", p.withContent() ? "true" : null)
         .queryParam("page-token", p.pageToken())
         .queryParam("max-records", p.maxRecords())
         .unwrap(NessieNotFoundException.class)

--- a/model/src/main/java/org/projectnessie/api/v2/params/EntriesParams.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/EntriesParams.java
@@ -43,12 +43,22 @@ public class EntriesParams extends AbstractParams<EntriesParams> {
   @QueryParam("filter")
   private String filter;
 
+  @Nullable
+  @Parameter(description = "Optionally request to return 'Content' objects for the returned keys.")
+  @QueryParam("content")
+  private Boolean withContent;
+
   public EntriesParams() {}
 
   @Constructor
-  EntriesParams(@Nullable Integer maxRecords, @Nullable String pageToken, @Nullable String filter) {
+  EntriesParams(
+      @Nullable Integer maxRecords,
+      @Nullable String pageToken,
+      @Nullable String filter,
+      @Nullable Boolean withContent) {
     super(maxRecords, pageToken);
     this.filter = filter;
+    this.withContent = withContent;
   }
 
   public static EntriesParamsBuilder builder() {
@@ -64,8 +74,12 @@ public class EntriesParams extends AbstractParams<EntriesParams> {
     return filter;
   }
 
+  public boolean withContent() {
+    return withContent != null && withContent;
+  }
+
   @Override
   public EntriesParams forNextPage(String pageToken) {
-    return new EntriesParams(maxRecords(), pageToken, filter);
+    return new EntriesParams(maxRecords(), pageToken, filter, withContent);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/EntriesResponse.java
+++ b/model/src/main/java/org/projectnessie/model/EntriesResponse.java
@@ -66,12 +66,21 @@ public interface EntriesResponse extends PaginatedResponse {
     @Nullable // for V1 backwards compatibility
     String getContentId();
 
+    @JsonView(Views.V2.class)
+    @Value.Parameter(order = 4)
+    @Nullable // for V1 backwards compatibility
+    Content getContent();
+
     static Entry entry(ContentKey name, Content.Type type) {
-      return entry(name, type, null);
+      return entry(name, type, (String) null);
     }
 
     static Entry entry(ContentKey name, Content.Type type, String contentId) {
-      return ImmutableEntry.of(name, type, contentId);
+      return ImmutableEntry.of(name, type, contentId, null);
+    }
+
+    static Entry entry(ContentKey name, Content.Type type, Content content) {
+      return ImmutableEntry.of(name, type, content.getId(), content);
     }
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -133,6 +133,7 @@ public class RestTreeResource implements HttpTreeApi {
             params.namespaceDepth(),
             params.filter(),
             params.pageToken(),
+            false,
             new PagedCountingResponseHandler<EntriesResponse, EntriesResponse.Entry>(maxRecords) {
               @Override
               public EntriesResponse build() {

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -183,6 +183,7 @@ public class RestV2TreeResource implements HttpTreeApi {
             null,
             params.filter(),
             params.pageToken(),
+            params.withContent(),
             new PagedCountingResponseHandler<EntriesResponse, EntriesResponse.Entry>(maxRecords) {
               @Override
               public EntriesResponse build() {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -133,7 +133,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
       Callable<Void> validator =
           () -> {
             try (PaginationIterator<KeyEntry> keys =
-                getStore().getKeys(refWithHash.getHash(), null)) {
+                getStore().getKeys(refWithHash.getHash(), null, false)) {
               while (keys.hasNext()) {
                 KeyEntry k = keys.next();
                 if (Namespace.of(k.getKey().getElements()).isSameOrSubElementOf(namespaceToDelete)
@@ -283,7 +283,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
   private Stream<KeyEntry> getNamespacesKeyStream(
       @Nullable Namespace namespace, Hash hash, Predicate<KeyEntry> earlyFilterPredicate)
       throws ReferenceNotFoundException {
-    PaginationIterator<KeyEntry> iter = getStore().getKeys(hash, null);
+    PaginationIterator<KeyEntry> iter = getStore().getKeys(hash, null, false);
     return stream(spliteratorUnknownSize(iter, 0), false)
         .onClose(iter::close)
         .filter(earlyFilterPredicate)

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -168,6 +168,7 @@ public interface TreeService {
       @Nullable Integer namespaceDepth,
       @Nullable String filter,
       @Nullable String pagingToken,
+      boolean withContent,
       PagedResponseHandler<R, Entry> pagedResponseHandler,
       Consumer<WithHash<NamedRef>> effectiveReference)
       throws NessieNotFoundException;

--- a/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestMisc.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestMisc.java
@@ -79,7 +79,7 @@ public abstract class AbstractTestMisc extends BaseTestServiceImpl {
   public void checkCelScriptFailureReporting() {
     String defaultBranch = config().getDefaultBranch();
 
-    soft.assertThatThrownBy(() -> entries(defaultBranch, null, null, "invalid_script"))
+    soft.assertThatThrownBy(() -> entries(defaultBranch, null, null, "invalid_script", false))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("undeclared reference to 'invalid_script'");
 

--- a/servers/services/src/test/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
@@ -206,21 +206,21 @@ public abstract class BaseTestServiceImpl {
 
   protected List<EntriesResponse.Entry> entries(Reference reference)
       throws NessieNotFoundException {
-    return entries(reference.getName(), reference.getHash(), null, null);
+    return entries(reference.getName(), reference.getHash(), null, null, false);
   }
 
   protected List<EntriesResponse.Entry> entries(String refName, String hashOnRef)
       throws NessieNotFoundException {
-    return entries(refName, hashOnRef, null, null);
+    return entries(refName, hashOnRef, null, null, false);
   }
 
   protected List<EntriesResponse.Entry> entries(
       Reference reference, Integer namespaceDepth, String filter) throws NessieNotFoundException {
-    return entries(reference.getName(), reference.getHash(), namespaceDepth, filter);
+    return entries(reference.getName(), reference.getHash(), namespaceDepth, filter, false);
   }
 
   protected List<EntriesResponse.Entry> entries(
-      String refName, String hashOnRef, Integer namespaceDepth, String filter)
+      String refName, String hashOnRef, Integer namespaceDepth, String filter, boolean withContent)
       throws NessieNotFoundException {
     return treeApi()
         .getEntries(
@@ -229,6 +229,7 @@ public abstract class BaseTestServiceImpl {
             namespaceDepth,
             filter,
             null,
+            withContent,
             new UnlimitedListResponseHandler<>(),
             h -> {});
   }
@@ -313,7 +314,8 @@ public abstract class BaseTestServiceImpl {
       String filter,
       int pageSize,
       int totalEntries,
-      Consumer<Reference> effectiveReference)
+      Consumer<Reference> effectiveReference,
+      boolean withContent)
       throws NessieNotFoundException {
 
     List<EntriesResponse.Entry> completeLog = new ArrayList<>();
@@ -328,6 +330,7 @@ public abstract class BaseTestServiceImpl {
                   null,
                   filter,
                   token,
+                  withContent,
                   new DirectPagedCountingResponseHandler<>(pageSize, nextToken::set),
                   h -> effectiveReference.accept(toReference(h)));
       completeLog.addAll(page);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/KeyEntry.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/KeyEntry.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.versioned;
 
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
 import org.projectnessie.model.Content;
 
@@ -28,11 +30,18 @@ public interface KeyEntry {
 
   String getContentId();
 
+  @Nullable
+  Content getContent();
+
   static ImmutableKeyEntry.Builder builder() {
     return ImmutableKeyEntry.builder();
   }
 
-  static KeyEntry of(Content.Type type, Key key, String contentId) {
+  static KeyEntry of(Content.Type type, Key key, @NotNull String contentId) {
     return builder().type(type).key(key).contentId(contentId).build();
+  }
+
+  static KeyEntry of(Content.Type type, Key key, @NotNull Content content) {
+    return builder().type(type).key(key).contentId(content.getId()).content(content).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -186,9 +186,10 @@ public final class MetricsVersionStore implements VersionStore {
   }
 
   @Override
-  public PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken)
+  public PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken, boolean withContent)
       throws ReferenceNotFoundException {
-    return delegatePaginationIterator("getkeys", () -> delegate.getKeys(ref, pagingToken));
+    return delegatePaginationIterator(
+        "getkeys", () -> delegate.getKeys(ref, pagingToken, withContent));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -235,12 +235,12 @@ public class TracingVersionStore implements VersionStore {
   }
 
   @Override
-  public PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken)
+  public PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken, boolean withContent)
       throws ReferenceNotFoundException {
     return callPaginationIterator(
         "GetKeys",
         b -> b.withTag(TAG_REF, safeToString(ref)),
-        () -> delegate.getKeys(ref, pagingToken));
+        () -> delegate.getKeys(ref, pagingToken, withContent));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -279,10 +279,11 @@ public interface VersionStore {
    *
    * @param ref The ref to get keys for.
    * @param pagingToken paging token to start at
+   * @param withContent whether to populate {@link KeyEntry#getContent()}
    * @return The stream of keys available for this ref.
    * @throws ReferenceNotFoundException if {@code ref} is not present in the store
    */
-  PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken)
+  PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken, boolean withContent)
       throws ReferenceNotFoundException;
 
   /**

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -198,7 +198,7 @@ class TestMetricsVersionStore {
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "getkeys",
-                vs -> vs.getKeys(Hash.of("cafe4242"), null),
+                vs -> vs.getKeys(Hash.of("cafe4242"), null, false),
                 () -> PaginationIterator.of(Key.of("hello", "world")),
                 refNotFoundThrows),
             new VersionStoreInvocation<>(

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -201,7 +201,7 @@ class TestTracingVersionStore {
             new TestedTraceingStoreInvocation<VersionStore>("GetKeys.stream", refNotFoundThrows)
                 .tag("nessie.version-store.ref", "Hash cafe4242")
                 .function(
-                    vs -> vs.getKeys(Hash.of("cafe4242"), null),
+                    vs -> vs.getKeys(Hash.of("cafe4242"), null, false),
                     () -> PaginationIterator.of(Key.of("hello", "world"))),
             new TestedTraceingStoreInvocation<VersionStore>("GetNamedRefs.stream", runtimeThrows)
                 .function(

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
@@ -161,17 +161,17 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             commit(secondCommit, "Second Commit", initialCommit),
             commit(initialCommit, "Initial Commit", base));
 
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(branch, null)) {
+    try (PaginationIterator<KeyEntry> keys = store().getKeys(branch, null, false)) {
       soft.assertThat(stream(keys).map(KeyEntry::getKey))
           .containsExactlyInAnyOrder(Key.of("t1"), Key.of("t2"), Key.of("t4"));
     }
 
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(secondCommit, null)) {
+    try (PaginationIterator<KeyEntry> keys = store().getKeys(secondCommit, null, false)) {
       soft.assertThat(stream(keys).map(KeyEntry::getKey))
           .containsExactlyInAnyOrder(Key.of("t1"), Key.of("t4"));
     }
 
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(initialCommit, null)) {
+    try (PaginationIterator<KeyEntry> keys = store().getKeys(initialCommit, null, false)) {
       soft.assertThat(stream(keys).map(KeyEntry::getKey))
           .containsExactlyInAnyOrder(Key.of("t1"), Key.of("t2"), Key.of("t3"));
     }
@@ -272,7 +272,7 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             commit(t1Commit, "T1 Commit", initialCommit),
             commit(initialCommit, "Initial Commit", base));
 
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(branch, null)) {
+    try (PaginationIterator<KeyEntry> keys = store().getKeys(branch, null, false)) {
       soft.assertThat(stream(keys).map(KeyEntry::getKey))
           .containsExactlyInAnyOrder(Key.of("t1"), Key.of("t2"), Key.of("t3"));
     }
@@ -594,7 +594,8 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
                       // do some operations here
                       try {
                         assertThat(store().getValue(branch, key)).isNull();
-                        try (PaginationIterator<KeyEntry> ignore = store().getKeys(branch, null)) {}
+                        try (PaginationIterator<KeyEntry> ignore =
+                            store().getKeys(branch, null, false)) {}
                       } catch (ReferenceNotFoundException e) {
                         throw new RuntimeException(e);
                       }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
@@ -134,14 +134,16 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
         // getKeys()
         new ReferenceNotFoundFunction("getKeys/branch")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.getKeys(BranchName.of("this-one-should-not-exist"), null)),
+            .function(s -> s.getKeys(BranchName.of("this-one-should-not-exist"), null, false)),
         new ReferenceNotFoundFunction("getKeys/tag")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.getKeys(TagName.of("this-one-should-not-exist"), null)),
+            .function(s -> s.getKeys(TagName.of("this-one-should-not-exist"), null, false)),
         new ReferenceNotFoundFunction("getKeys/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
             .function(
-                s -> s.getKeys(Hash.of("12341234123412341234123412341234123412341234"), null)),
+                s ->
+                    s.getKeys(
+                        Hash.of("12341234123412341234123412341234123412341234"), null, false)),
         // assign()
         new ReferenceNotFoundFunction("assign/branch/ok")
             .msg("Named reference 'this-one-should-not-exist' not found")

--- a/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/BaseExportImport.java
+++ b/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/BaseExportImport.java
@@ -347,7 +347,7 @@ public abstract class BaseExportImport {
   }
 
   List<KeyEntry> keys(VersionStore versionStore, Hash hash) {
-    try (PaginationIterator<KeyEntry> keys = versionStore.getKeys(hash, null)) {
+    try (PaginationIterator<KeyEntry> keys = versionStore.getKeys(hash, null, false)) {
       return newArrayList(keys);
     } catch (ReferenceNotFoundException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Since the `get-entries` API call supports paging it is fine to optionally also return the `Content` objects for the returned keys.