### PR TITLE
Build: Fix task dependency warnings for code coverage

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -128,6 +128,11 @@ val prepareJacocoReport by
 
 val jacocoReport by
   tasks.registering(JacocoReport::class) {
+    dependsOn(
+      tasks.named("compileIntegrationTestJava"),
+      tasks.named("compileNativeTestJava"),
+      tasks.named("compileQuarkusGeneratedSourcesJava")
+    )
     executionData.from(file("${project.buildDir}/jacoco-quarkus.exec"))
     jacocoClasspath = jacocoRuntime
     classDirectories.from(layout.buildDirectory.dir("classes"))

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -170,6 +170,11 @@ val prepareJacocoReport by
 
 val jacocoReport by
   tasks.registering(JacocoReport::class) {
+    dependsOn(
+      tasks.named("compileIntegrationTestJava"),
+      tasks.named("compileNativeTestJava"),
+      tasks.named("compileQuarkusGeneratedSourcesJava")
+    )
     executionData.from(file("${project.buildDir}/jacoco-quarkus.exec"))
     jacocoClasspath = jacocoRuntime
     classDirectories.from(layout.buildDirectory.dir("classes"))


### PR DESCRIPTION
Fixes this one:
```
Execution optimizations have been disabled for task ':nessie-quarkus-cli:jacocoReport' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/runner/work/nessie/nessie/servers/quarkus-cli/build/classes'. Reason: Task ':nessie-quarkus-cli:jacocoReport' uses this output of task ':nessie-quarkus-cli:compileIntegrationTestJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/runner/work/nessie/nessie/servers/quarkus-cli/build/classes'. Reason: Task ':nessie-quarkus-cli:jacocoReport' uses this output of task ':nessie-quarkus-cli:compileNativeTestJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/runner/work/nessie/nessie/servers/quarkus-cli/build/classes'. Reason: Task ':nessie-quarkus-cli:jacocoReport' uses this output of task ':nessie-quarkus-cli:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```