### PR TITLE
Revert "Make `QuarkusBuild` cacheable"

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -109,7 +109,6 @@ tasks.withType<QuarkusBuild>().configureEach {
     // THIS IS A WORKAROUND! the nativeArgs{} thing above doesn't really work
     System.setProperty("quarkus.native.builder-image", quarkusBuilderImage)
   }
-  outputs.cacheIf { !withUberJar() && !project.hasProperty("native") }
 }
 
 tasks.withType<QuarkusGenerateCode>().configureEach { outputs.cacheIf { true } }

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -151,7 +151,6 @@ val quarkusBuild =
         System.setProperty("quarkus.container-image.build", "true")
       }
     }
-    outputs.cacheIf { !withUberJar() && !project.hasProperty("native") }
   }
 
 tasks.withType<QuarkusGenerateCode>().configureEach { outputs.cacheIf { true } }


### PR DESCRIPTION
Reverts #5974, which unfortunately causes issues in PR builds. The PR builds say that the cached quarkusBuild result has been restored, but the PR builds fail saying `java.lang.IllegalStateException: Unable to locate the artifact metadata file created that must be created by Quarkus in order to run integration tests. Make sure this test is run after the 'quarkusBuild' Gradle task.`.