### PR TITLE
Add support for API v2 to the compatibility test framework

### DIFF
--- a/clients/client/build.gradle.kts
+++ b/clients/client/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   implementation(libs.jackson.annotations)
   implementation(libs.microprofile.openapi)
   compileOnly(libs.jakarta.validation.api)
+  implementation(libs.slf4j.api)
   implementation(libs.javax.ws.rs)
   implementation(libs.findbugs.jsr305)
   compileOnly(libs.errorprone.annotations)

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
@@ -24,6 +24,9 @@ import java.util.Objects;
  */
 public class Version implements Comparable<Version> {
 
+  public static final Version VERSIONED_REST_URI_START = Version.parseVersion("0.46.0");
+  public static final Version REFLOG_FOR_COMMIT_REMOVED = Version.parseVersion("0.44.0");
+
   public static final String CURRENT_STRING = "current";
   public static final String NOT_CURRENT_STRING = "not-current";
   private final int[] tuple;

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
@@ -26,6 +26,14 @@ public class Version implements Comparable<Version> {
 
   public static final Version VERSIONED_REST_URI_START = Version.parseVersion("0.46.0");
   public static final Version REFLOG_FOR_COMMIT_REMOVED = Version.parseVersion("0.44.0");
+  // OPENTRACING_VERSION_MISMATCH_* is the version range where Nessie declared dependencies on
+  // incompatible versions of some OpenTracing artifacts.
+  public static final Version OPENTRACING_VERSION_MISMATCH_LOW = Version.parseVersion("0.40.0");
+  public static final Version OPENTRACING_VERSION_MISMATCH_HIGH = Version.parseVersion("0.41.0");
+  // CLIENT_LOG4J_UNDECLARED_* is the version range where :nessie-client uses log4j without
+  // declaring an explicit dependency in its POM.
+  public static final Version CLIENT_LOG4J_UNDECLARED_LOW = Version.parseVersion("0.46.0");
+  public static final Version CLIENT_LOG4J_UNDECLARED_HIGH = Version.parseVersion("0.47.1");
 
   public static final String CURRENT_STRING = "current";
   public static final String NOT_CURRENT_STRING = "not-current";

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
@@ -55,7 +55,7 @@ final class CurrentNessieServer implements NessieServer {
 
   @Override
   public URI getUri(Class<? extends NessieApi> apiType) {
-    return Util.resolve(jersey.getUri(), apiType);
+    return Util.resolveNessieUri(jersey.getUri(), apiType);
   }
 
   @Override

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
@@ -24,6 +24,7 @@ import static org.projectnessie.tools.compatibility.jersey.ServerConfigExtension
 import java.net.URI;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.projectnessie.client.api.NessieApi;
 import org.projectnessie.tools.compatibility.jersey.JerseyServer;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.DatabaseConnectionConfig;
@@ -53,8 +54,8 @@ final class CurrentNessieServer implements NessieServer {
   }
 
   @Override
-  public URI getUri() {
-    return jersey.getUri().resolve("v1");
+  public URI getUri(Class<? extends NessieApi> apiType) {
+    return Util.resolve(jersey.getUri(), apiType);
   }
 
   @Override

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieServer.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.projectnessie.client.api.NessieApi;
 import org.projectnessie.tools.compatibility.api.Version;
 
 interface NessieServer extends CloseableResource {
@@ -42,5 +43,5 @@ interface NessieServer extends CloseableResource {
     }
   }
 
-  URI getUri();
+  URI getUri(Class<? extends NessieApi> apiType);
 }

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessie.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessie.java
@@ -86,6 +86,19 @@ final class OldNessie {
                                     "io.opentracing", artifactId, "jar", opentracingVersion),
                                 "runtime")));
           };
+    } else if (Version.parseVersion("0.46.0").isLessThanOrEqual(version)
+        && Version.parseVersion("0.47.1").isGreaterThanOrEqual(version)) {
+
+      collect =
+          r -> {
+            r.setRoot(mainDependency);
+
+            // Nessie clients in versions 0.46.0 - 0.47.1 use slf4j (through transitive compile-only
+            // dependencies), but do not declare an explicit runtime dependency on it.
+            r.addDependency(
+                new Dependency(
+                    new DefaultArtifact("org.slf4j", "slf4j-api", "jar", "1.7.36"), "runtime"));
+          };
     }
 
     Stream<Artifact> resolvedArtifacts = resolve(collect);

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessie.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessie.java
@@ -50,8 +50,8 @@ final class OldNessie {
 
     Consumer<CollectRequest> collect = r -> r.setRoot(mainDependency);
 
-    if (Version.parseVersion("0.40.0").isLessThanOrEqual(version)
-        && Version.parseVersion("0.41.0").isGreaterThanOrEqual(version)) {
+    if (Version.OPENTRACING_VERSION_MISMATCH_LOW.isLessThanOrEqual(version)
+        && Version.OPENTRACING_VERSION_MISMATCH_HIGH.isGreaterThanOrEqual(version)) {
       // Need to align the io.opentracing dependencies to the correct version.
       // Nessie versions 0.40.0 up to 0.41.0 used _different_ versions for
       // opentracing-noop (0.30.0) + opentracing-api (0.33.0), which are unfortunately
@@ -86,8 +86,8 @@ final class OldNessie {
                                     "io.opentracing", artifactId, "jar", opentracingVersion),
                                 "runtime")));
           };
-    } else if (Version.parseVersion("0.46.0").isLessThanOrEqual(version)
-        && Version.parseVersion("0.47.1").isGreaterThanOrEqual(version)) {
+    } else if (Version.CLIENT_LOG4J_UNDECLARED_LOW.isLessThanOrEqual(version)
+        && Version.CLIENT_LOG4J_UNDECLARED_HIGH.isGreaterThanOrEqual(version)) {
 
       collect =
           r -> {

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieServer.java
@@ -162,7 +162,7 @@ final class OldNessieServer implements NessieServer {
       return uri;
     }
 
-    return Util.resolve(uri, apiType);
+    return Util.resolveNessieUri(uri, apiType);
   }
 
   private void tryStart() {

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieServer.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.tools.compatibility.internal;
 
+import static org.projectnessie.tools.compatibility.api.Version.VERSIONED_REST_URI_START;
 import static org.projectnessie.tools.compatibility.internal.DependencyResolver.resolve;
 import static org.projectnessie.tools.compatibility.internal.DependencyResolver.toClassLoader;
 import static org.projectnessie.tools.compatibility.internal.OldNessie.oldNessieClassLoader;
@@ -31,6 +32,7 @@ import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.projectnessie.client.api.NessieApi;
 import org.projectnessie.tools.compatibility.api.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,11 +153,16 @@ final class OldNessieServer implements NessieServer {
   }
 
   @Override
-  public URI getUri() {
+  public URI getUri(Class<? extends NessieApi> apiType) {
     if (uri == null) {
       tryStart();
     }
-    return uri;
+
+    if (serverKey.getVersion().isLessThan(VERSIONED_REST_URI_START)) {
+      return uri;
+    }
+
+    return Util.resolve(uri, apiType);
   }
 
   private void tryStart() {

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieServersExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieServersExtension.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.projectnessie.client.http.v1api.HttpApiV1;
 import org.projectnessie.tools.compatibility.api.NessieBaseUri;
 import org.projectnessie.tools.compatibility.api.TargetVersion;
 import org.projectnessie.tools.compatibility.api.Version;
@@ -64,7 +65,7 @@ public class OlderNessieServersExtension extends AbstractMultiVersionExtension {
 
     populateNessieApiFields(context, instance, TargetVersion.TESTED, fieldValue);
 
-    URI serverUri = nessieServer.getUri();
+    URI serverUri = nessieServer.getUri(HttpApiV1.class);
     URI baseUri = serverUri.resolve("/"); // remove possible API version suffixes
     populateAnnotatedFields(context, instance, NessieBaseUri.class, a -> true, f -> baseUri);
   }

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
@@ -65,7 +65,7 @@ final class Util {
     }
   }
 
-  static URI resolve(URI base, Class<? extends NessieApi> apiType) {
+  static URI resolveNessieUri(URI base, Class<? extends NessieApi> apiType) {
     String suffix = NessieApiV2.class.isAssignableFrom(apiType) ? "v2" : "v1";
     return base.resolve(suffix);
   }

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
@@ -16,12 +16,15 @@
 package org.projectnessie.tools.compatibility.internal;
 
 import com.google.common.base.Throwables;
+import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.platform.engine.UniqueId;
+import org.projectnessie.client.api.NessieApi;
+import org.projectnessie.client.api.NessieApiV2;
 
 final class Util {
 
@@ -60,5 +63,10 @@ final class Util {
     } finally {
       Thread.currentThread().setContextClassLoader(appClassLoader);
     }
+  }
+
+  static URI resolve(URI base, Class<? extends NessieApi> apiType) {
+    String suffix = NessieApiV2.class.isAssignableFrom(apiType) ? "v2" : "v1";
+    return base.resolve(suffix);
   }
 }

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieServer.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieServer.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.engine.execution.ExtensionValuesStore;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.tools.compatibility.api.Version;
 
 class TestNessieServer {
@@ -53,7 +54,7 @@ class TestNessieServer {
       server = NessieServer.nessieServer(ctx, key, () -> true);
       assertThat(server)
           .isInstanceOf(CurrentNessieServer.class)
-          .extracting(NessieServer::getUri)
+          .extracting(s -> s.getUri(NessieApiV1.class))
           .isNotNull();
 
       when(ctx.getStore(any(Namespace.class))).thenReturn(store);
@@ -93,7 +94,7 @@ class TestNessieServer {
       server = NessieServer.nessieServer(ctx, key, () -> true);
       assertThat(server)
           .isInstanceOf(OldNessieServer.class)
-          .extracting(NessieServer::getUri)
+          .extracting(s -> s.getUri(NessieApiV1.class))
           .isNotNull();
 
       when(ctx.getStore(any(Namespace.class))).thenReturn(store);

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.projectnessie.client.StreamingUtil;
 import org.projectnessie.client.api.GetCommitLogBuilder;
 import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
@@ -57,6 +58,7 @@ public abstract class AbstractCompatibilityTests {
 
   public static final String NESSIE_0_30_0 = "0.30.0";
   @NessieAPI protected NessieApiV1 api;
+  @NessieAPI protected NessieApiV2 apiV2;
   @NessieVersion Version version;
 
   abstract Version getClientVersion();
@@ -87,6 +89,14 @@ public abstract class AbstractCompatibilityTests {
     assertThat(defaultBranch).extracting(Branch::getName).isEqualTo("main");
 
     assertThat(allReferences()).contains(defaultBranch);
+  }
+
+  @Test
+  @VersionCondition(minVersion = "0.47.0")
+  void getDefaultBranchV2() throws Exception {
+    Branch defaultBranch = apiV2.getDefaultBranch();
+    assertThat(defaultBranch).extracting(Branch::getName).isEqualTo("main");
+    assertThat(apiV2.getAllReferences().stream()).contains(defaultBranch);
   }
 
   @Test

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
@@ -243,7 +243,7 @@ public class ITUpgradePath {
 
   private void expectedRefLogEntry(String op) {
     if (version.isGreaterThanOrEqual(Version.parseVersion("0.18.0"))) {
-      if (version.isGreaterThanOrEqual(Version.CURRENT)) {
+      if (version.isGreaterThanOrEqual(Version.REFLOG_FOR_COMMIT_REMOVED)) {
         switch (op) {
           case "CREATE_REFERENCE":
           case "DROP_REFERENCE":

--- a/compatibility/compatibility-tests/src/test/resources/META-INF/nessie-compatibility.properties
+++ b/compatibility/compatibility-tests/src/test/resources/META-INF/nessie-compatibility.properties
@@ -31,4 +31,4 @@
 # 0.40.0:
 #   - changed references data model
 #   - introduced open-addressing key-list
-nessie.versions=0.15.0,0.18.0,0.26.0,0.30.0,0.40.3,0.41.0,current
+nessie.versions=0.15.0,0.18.0,0.26.0,0.30.0,0.40.3,0.41.0,0.47.0,current

--- a/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/JerseyServer.java
+++ b/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/JerseyServer.java
@@ -73,6 +73,8 @@ public class JerseyServer implements AutoCloseable {
           @Override
           protected Application configure() {
             ResourceConfig config = new ResourceConfig();
+            withClass("org.projectnessie.services.rest.RestV2ConfigResource", config::register);
+            withClass("org.projectnessie.services.rest.RestV2TreeResource", config::register);
             config.register(RestConfigResource.class);
             config.register(RestTreeResource.class);
             config.register(RestContentResource.class);


### PR DESCRIPTION
* Fix class loading for older clients

* Declare actual dependency on slf4j in :nessie-client

* Resolve `NessieApiV2` fields in test classes

* Load V2 REST resources when they are available in Jersey servers

Fixes #5998