### PR TITLE
REST v2: return parent commit IDs in `CommitMeta.getParentCommitHashes`

### DIFF
--- a/model/src/main/java/org/projectnessie/model/CommitMeta.java
+++ b/model/src/main/java/org/projectnessie/model/CommitMeta.java
@@ -61,6 +61,7 @@ public abstract class CommitMeta {
    * the key {@value #MERGE_PARENT_PROPERTY}, if the merge was performed with a Nessie server
    * version, after 0.30.0, that persists the merged reference.
    */
+  @Deprecated // for removal
   public static final String MERGE_PARENT_PROPERTY = "_merge_parent";
 
   /**

--- a/model/src/main/java/org/projectnessie/model/LogResponse.java
+++ b/model/src/main/java/org/projectnessie/model/LogResponse.java
@@ -17,6 +17,7 @@ package org.projectnessie.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
@@ -25,6 +26,7 @@ import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
+import org.projectnessie.model.ser.Views;
 
 @Value.Immutable
 @Schema(type = SchemaType.OBJECT, title = "LogResponse")
@@ -51,7 +53,8 @@ public interface LogResponse extends PaginatedResponse {
     @NotNull
     CommitMeta getCommitMeta();
 
-    /** Currently always empty or null, reserved for future use. */
+    @JsonView(Views.V1.class)
+    @Deprecated // for removal - duplicated in CommitMeta
     @JsonInclude(Include.NON_EMPTY)
     List<String> getAdditionalParents();
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -484,9 +484,9 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
   private static CommitMeta enhanceCommitMeta(Hash hash, CommitMeta commitMeta) {
     if (commitMeta.getParentCommitHashes().size() > 1) {
       ImmutableCommitMeta.Builder updatedCommitMeta = commitMeta.toBuilder().hash(hash.asString());
-      // Only add the 1st commit ID to the legacy MERGE_PARENT_PROPERTY. It was introduced for
-      // compatibility with older clients. There is currently only one use case for the
-      // property: exposing the commit ID of the merged commit.
+      // Only add the 1st commit ID (merge parent) to the legacy MERGE_PARENT_PROPERTY. It was
+      // introduced for compatibility with older clients. There is currently only one use case for
+      // the property: exposing the commit ID of the merged commit.
       updatedCommitMeta.putProperties(
           CommitMeta.MERGE_PARENT_PROPERTY, commitMeta.getParentCommitHashes().get(1));
       return updatedCommitMeta.build();

--- a/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
@@ -233,14 +233,13 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
           .first()
           .extracting(LogEntry::getAdditionalParents)
           .asInstanceOf(list(String.class))
-          // When we can assume that all relevant Nessie clients are aware of the
-          // org.projectnessie.model.LogResponse.LogEntry.getAdditionalParents field,
-          // the following code can be uncommented. See also
-          // TreeApiImpl.commitToLogEntry().
-          // .hasSize(1)
-          // .first()
-          // .isEqualTo(committed2.getHash()),
           .isEmpty();
+      soft.assertThat(logOfMerged)
+          .first()
+          .extracting(LogEntry::getCommitMeta)
+          .extracting(CommitMeta::getParentCommitHashes)
+          .asInstanceOf(list(String.class))
+          .containsExactly(committed2.getHash());
       soft.assertThat(logOfMerged)
           .first()
           .extracting(LogEntry::getCommitMeta)

--- a/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
@@ -239,7 +239,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
           .extracting(LogEntry::getCommitMeta)
           .extracting(CommitMeta::getParentCommitHashes)
           .asInstanceOf(list(String.class))
-          .containsExactly(committed2.getHash());
+          .containsExactly(baseHead.getHash(), committed2.getHash());
       soft.assertThat(logOfMerged)
           .first()
           .extracting(LogEntry::getCommitMeta)

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -774,6 +774,8 @@ public abstract class AbstractDatabaseAdapter<
               .from(ref)
               .headCommitMeta(logEntry.getMetadata())
               .commitSeq(logEntry.getCommitSeq())
+              .addParentHashes(logEntry.getParents().get(0))
+              .addAllParentHashes(logEntry.getAdditionalParents())
               .build();
         });
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Commit.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Commit.java
@@ -28,8 +28,6 @@ public interface Commit {
 
   Hash getHash();
 
-  List<Hash> getAdditionalParents();
-
   CommitMeta getCommitMeta();
 
   @Nullable

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceInfo.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceInfo.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned;
 
+import java.util.List;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
@@ -43,6 +44,8 @@ public interface ReferenceInfo<METADATA> {
   METADATA getHeadCommitMeta();
 
   ReferenceInfo<METADATA> withHeadCommitMeta(@Nullable METADATA value);
+
+  List<Hash> getParentHashes();
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   default <UPDATED_METADATA> ReferenceInfo<UPDATED_METADATA> withUpdatedCommitMeta(

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNestedVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNestedVersionStore.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.tests;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,12 +72,15 @@ public abstract class AbstractNestedVersionStore {
     }
   }
 
-  protected static Commit commit(Hash hash, String commitMeta) {
-    return commit(hash, commitMeta, null);
-  }
-
   protected static Commit commit(Hash hash, String commitMeta, Hash parentHash) {
-    return commit(hash, CommitMeta.fromMessage(commitMeta), parentHash);
+    return commit(
+        hash,
+        CommitMeta.builder()
+            .message(commitMeta)
+            .hash(hash.asString())
+            .addParentCommitHashes(parentHash.asString())
+            .build(),
+        parentHash);
   }
 
   protected static Commit commit(Hash hash, CommitMeta commitMessage) {
@@ -123,6 +127,10 @@ public abstract class AbstractNestedVersionStore {
       MetadataRewriter<CommitMeta> commitMetaModifier) {
     soft.assertThat(current)
         .map(Commit::getCommitMeta)
+        .map(
+            m ->
+                (CommitMeta)
+                    CommitMeta.builder().from(m).hash(null).parentCommitHashes(emptyList()).build())
         .containsExactlyElementsOf(
             expected.stream()
                 .map(Commit::getCommitMeta)

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractSingleBranch.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractSingleBranch.java
@@ -161,12 +161,3 @@ public abstract class AbstractSingleBranch extends AbstractNestedVersionStore {
     return ops;
   }
 }
-
-//   [CommitMeta{hash=89ed3813d41d9b3f15ee1b62ea6a41d81743be8a7372e7c047159065c8db4406,
-// committer=null, author=null, allAuthors=[], signedOffBy=null, allSignedOffBy=[], message=user
-// 002/commit 019, commitTime=null, authorTime=null, allProperties={},
-// parentCommitHashes=[35fdf4b429911fd5b24bf45222703600c9fc63f93cae16118cf2d60769428792]},
-//   [CommitMeta{hash=89ed3813d41d9b3f15ee1b62ea6a41d81743be8a7372e7c047159065c8db4406,
-// committer=null, author=null, allAuthors=[], signedOffBy=null, allSignedOffBy=[], message=user
-// 002/commit 019, commitTime=null, authorTime=null, allProperties={},
-// parentCommitHashes=[ec2e96fe02635ef44d101f72df75f1082eb1880cc7eb0f19ef3b0c86709e8460]},

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
@@ -78,7 +78,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
     return new MetadataRewriter<CommitMeta>() {
       @Override
       public CommitMeta rewriteSingle(CommitMeta metadata) {
-        return metadata;
+        return CommitMeta.fromMessage(metadata.getMessage());
       }
 
       @Override


### PR DESCRIPTION
Also deprecate `LogEntry.getAdditionalParents()` for removal, it's a duplicate of `CommitMeta.getParentCommitHashes`.