### PR TITLE
CI: Do not cache Python stuff

### DIFF
--- a/.github/actions/dev-tool-python/action.yml
+++ b/.github/actions/dev-tool-python/action.yml
@@ -12,8 +12,6 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
-        cache: 'pip'
-        cache-dependency-path: '**/requirements*.txt'
     - name: Install dependencies
       shell: bash
       run: |


### PR DESCRIPTION
... it's a lot, for every Python version and OS combination, and the jobs do not run long.