### PR TITLE
CI: fix helm-testing action refs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@main
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -167,7 +167,9 @@ jobs:
         run: ct lint --debug --charts ./helm/nessie
 
       - name: Set up & Start Minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@v0.0.11
+        with:
+          cache: false
 
       - name: Show pods
         run: kubectl get pods -A

--- a/.github/workflows/pull-request-helm.yml
+++ b/.github/workflows/pull-request-helm.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@main
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -54,7 +54,9 @@ jobs:
         run: ct lint --debug --charts ./helm/nessie
 
       - name: Set up & Start Minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@v0.0.11
+        with:
+          cache: false
 
       - name: Show pods
         run: kubectl get pods -A


### PR DESCRIPTION
... do not use `main` and do not cache the minikube tarball (it's big and pollutes the actions cache).