### PR TITLE
REST API v2: get-multiple-namespaces w/ option for direct children

### DIFF
--- a/clients/client/src/main/java/org/projectnessie/client/api/GetMultipleNamespacesBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/api/GetMultipleNamespacesBuilder.java
@@ -28,5 +28,7 @@ import org.projectnessie.model.Namespace;
 public interface GetMultipleNamespacesBuilder
     extends OnNamespaceBuilder<GetMultipleNamespacesBuilder> {
 
+  GetMultipleNamespacesBuilder onlyDirectChildren(boolean onlyDirectChildren);
+
   GetNamespacesResponse get() throws NessieReferenceNotFoundException;
 }

--- a/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetMultipleNamespaces.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetMultipleNamespaces.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http.v1api;
 
 import org.projectnessie.api.v1.params.MultipleNamespacesParams;
+import org.projectnessie.client.api.GetMultipleNamespacesBuilder;
 import org.projectnessie.client.builder.BaseGetMultipleNamespacesBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieReferenceNotFoundException;
@@ -27,6 +28,14 @@ final class HttpGetMultipleNamespaces extends BaseGetMultipleNamespacesBuilder {
 
   HttpGetMultipleNamespaces(NessieApiClient client) {
     this.client = client;
+  }
+
+  @Override
+  public GetMultipleNamespacesBuilder onlyDirectChildren(boolean onlyDirectChildren) {
+    if (onlyDirectChildren) {
+      throw new IllegalArgumentException("'onlyDirectChildren' is not available with REST API v1");
+    }
+    return this;
   }
 
   @Override

--- a/clients/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideGetMultipleNamespaces.java
+++ b/clients/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideGetMultipleNamespaces.java
@@ -65,14 +65,13 @@ public final class ClientSideGetMultipleNamespaces extends BaseGetMultipleNamesp
       if (namespace != null && !namespace.isEmpty()) {
         String nsName = namespace.name();
         filter =
-            format(
-                "entry.encodedKey == '%s' || entry.encodedKey.startsWith('%s.')", nsName, nsName);
-        if (onlyDirectChildren) {
-          filter =
-              format(
-                  "size(entry.keyElements) == %d && (%s)",
-                  namespace.getElements().size() + 1, filter);
-        }
+            onlyDirectChildren
+                ? format(
+                    "size(entry.keyElements) == %d && entry.encodedKey.startsWith('%s.')",
+                    namespace.getElements().size() + 1, nsName)
+                : format(
+                    "entry.encodedKey == '%s' || entry.encodedKey.startsWith('%s.')",
+                    nsName, nsName);
       } else if (onlyDirectChildren) {
         filter = "size(entry.keyElements) == 1";
       }

--- a/clients/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideGetMultipleNamespaces.java
+++ b/clients/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideGetMultipleNamespaces.java
@@ -15,11 +15,14 @@
  */
 package org.projectnessie.client.util.v2api;
 
+import static java.lang.String.format;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.projectnessie.client.api.GetContentBuilder;
 import org.projectnessie.client.api.GetEntriesBuilder;
+import org.projectnessie.client.api.GetMultipleNamespacesBuilder;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.client.builder.BaseGetMultipleNamespacesBuilder;
 import org.projectnessie.error.NessieNotFoundException;
@@ -40,9 +43,16 @@ import org.projectnessie.model.Namespace;
  */
 public final class ClientSideGetMultipleNamespaces extends BaseGetMultipleNamespacesBuilder {
   private final NessieApiV2 api;
+  private boolean onlyDirectChildren;
 
   public ClientSideGetMultipleNamespaces(NessieApiV2 api) {
     this.api = api;
+  }
+
+  @Override
+  public GetMultipleNamespacesBuilder onlyDirectChildren(boolean onlyDirectChildren) {
+    this.onlyDirectChildren = onlyDirectChildren;
+    return this;
   }
 
   @Override
@@ -51,11 +61,23 @@ public final class ClientSideGetMultipleNamespaces extends BaseGetMultipleNamesp
     try {
       GetEntriesBuilder getEntries = api.getEntries().refName(refName).hashOnRef(hashOnRef);
 
+      String filter = null;
       if (namespace != null && !namespace.isEmpty()) {
         String nsName = namespace.name();
-        getEntries.filter(
-            String.format(
-                "entry.encodedKey == '%s' || entry.encodedKey.startsWith('%s.')", nsName, nsName));
+        filter =
+            format(
+                "entry.encodedKey == '%s' || entry.encodedKey.startsWith('%s.')", nsName, nsName);
+        if (onlyDirectChildren) {
+          filter =
+              format(
+                  "size(entry.keyElements) == %d && (%s)",
+                  namespace.getElements().size() + 1, filter);
+        }
+      } else if (onlyDirectChildren) {
+        filter = "size(entry.keyElements) == 1";
+      }
+      if (filter != null) {
+        getEntries.filter(filter);
       }
 
       entries =


### PR DESCRIPTION
Adds a new boolean option `onlyDirectChildren` for v2 to not return the given "root" namespace and only return direct children.