### PR TITLE
Refactor API v2 reference resolution logic into a utility class

### DIFF
--- a/model/src/main/java/org/projectnessie/api/v2/params/ReferenceResolver.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/ReferenceResolver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.v2.params;
+
+import java.util.function.Supplier;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.NessieConfiguration;
+import org.projectnessie.model.Reference;
+
+public class ReferenceResolver {
+
+  public static final String DEFAULT_REF_IN_PATH = "-";
+
+  public static Reference toReference(String refPathString, Supplier<NessieConfiguration> config) {
+    if (DEFAULT_REF_IN_PATH.equals(refPathString)) {
+      return Branch.of(config.get().getDefaultBranch(), null);
+    }
+
+    return toReference(refPathString, Reference.ReferenceType.BRANCH);
+  }
+
+  public static Reference toReference(String refPathString, Reference.ReferenceType type) {
+    return Reference.fromPathString(refPathString, type);
+  }
+}

--- a/model/src/main/java/org/projectnessie/api/v2/params/ReferenceResolver.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/ReferenceResolver.java
@@ -20,19 +20,23 @@ import org.projectnessie.model.Branch;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.Reference;
 
-public class ReferenceResolver {
+public final class ReferenceResolver {
 
   public static final String DEFAULT_REF_IN_PATH = "-";
 
-  public static Reference toReference(String refPathString, Supplier<NessieConfiguration> config) {
+  private ReferenceResolver() {}
+
+  public static Reference resolveReferencePathElement(
+      String refPathString, Supplier<NessieConfiguration> config) {
     if (DEFAULT_REF_IN_PATH.equals(refPathString)) {
       return Branch.of(config.get().getDefaultBranch(), null);
     }
 
-    return toReference(refPathString, Reference.ReferenceType.BRANCH);
+    return resolveReferencePathElement(refPathString, Reference.ReferenceType.BRANCH);
   }
 
-  public static Reference toReference(String refPathString, Reference.ReferenceType type) {
+  public static Reference resolveReferencePathElement(
+      String refPathString, Reference.ReferenceType type) {
     return Reference.fromPathString(refPathString, type);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -29,7 +29,6 @@ import org.projectnessie.api.v2.params.DiffParams;
 import org.projectnessie.api.v2.params.EntriesParams;
 import org.projectnessie.api.v2.params.GetReferenceParams;
 import org.projectnessie.api.v2.params.Merge;
-import org.projectnessie.api.v2.params.ReferenceResolver;
 import org.projectnessie.api.v2.params.ReferencesParams;
 import org.projectnessie.api.v2.params.Transplant;
 import org.projectnessie.error.NessieConflictException;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.services.rest;
 
+import static org.projectnessie.api.v2.params.ReferenceResolver.resolveReferencePathElement;
 import static org.projectnessie.services.impl.RefUtil.toReference;
 import static org.projectnessie.services.spi.TreeService.MAX_COMMIT_LOG_ENTRIES;
 
@@ -89,7 +90,7 @@ public class RestV2TreeResource implements HttpTreeApi {
   }
 
   private Reference resolveRef(String refPathString) {
-    return ReferenceResolver.toReference(refPathString, configService::getConfig);
+    return resolveReferencePathElement(refPathString, configService::getConfig);
   }
 
   private TreeService tree() {
@@ -271,7 +272,7 @@ public class RestV2TreeResource implements HttpTreeApi {
   public SingleReferenceResponse assignReference(
       Reference.ReferenceType type, String ref, Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
-    Reference reference = ReferenceResolver.toReference(ref, type);
+    Reference reference = resolveReferencePathElement(ref, type);
     Reference updated =
         tree().assignReference(type, reference.getName(), reference.getHash(), assignTo);
     return SingleReferenceResponse.builder().reference(updated).build();
@@ -281,7 +282,7 @@ public class RestV2TreeResource implements HttpTreeApi {
   @Override
   public SingleReferenceResponse deleteReference(Reference.ReferenceType type, String ref)
       throws NessieConflictException, NessieNotFoundException {
-    Reference reference = ReferenceResolver.toReference(ref, type);
+    Reference reference = resolveReferencePathElement(ref, type);
     String hash = tree().deleteReference(type, reference.getName(), reference.getHash());
     if (reference instanceof Branch) {
       reference = Branch.of(reference.getName(), hash);


### PR DESCRIPTION
Put the new utility class under `model`.

This is to keep the code that interprets ref strings in REST path elements closer to the REST interface definitions.