### PR TITLE
Quarkus: make `QuarkusBuild` not caching

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import io.quarkus.gradle.tasks.QuarkusBuild
-import io.quarkus.gradle.tasks.QuarkusGenerateCode
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
@@ -100,6 +99,7 @@ project.extra["quarkus.package.type"] =
 quarkus { setFinalName("${project.name}-${project.version}") }
 
 tasks.withType<QuarkusBuild>().configureEach {
+  outputs.cacheIf { false }
   inputs.property("quarkus.package.type", project.extra["quarkus.package.type"])
   inputs.property("final.name", quarkus.finalName())
   val quarkusBuilderImage = libs.versions.quarkusBuilderImage.get()
@@ -110,8 +110,6 @@ tasks.withType<QuarkusBuild>().configureEach {
     System.setProperty("quarkus.native.builder-image", quarkusBuilderImage)
   }
 }
-
-tasks.withType<QuarkusGenerateCode>().configureEach { outputs.cacheIf { true } }
 
 val prepareJacocoReport by
   tasks.registering {

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import io.quarkus.gradle.tasks.QuarkusBuild
-import io.quarkus.gradle.tasks.QuarkusGenerateCode
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
@@ -131,6 +130,7 @@ val pullOpenApiSpec by
 
 val quarkusBuild =
   tasks.named<QuarkusBuild>("quarkusBuild") {
+    outputs.cacheIf { false }
     dependsOn(pullOpenApiSpec)
     inputs.property("quarkus.package.type", project.extra["quarkus.package.type"])
     inputs.property("final.name", quarkus.finalName())
@@ -152,8 +152,6 @@ val quarkusBuild =
       }
     }
   }
-
-tasks.withType<QuarkusGenerateCode>().configureEach { outputs.cacheIf { true } }
 
 val prepareJacocoReport by
   tasks.registering {


### PR DESCRIPTION
See [Quarkus issue 30852](https://github.com/quarkusio/quarkus/issues/30852), both the actual bug and the fact that the cached output of the `GradleBuild` task is huge.