### PR TITLE
Quarkus-nit: build script cleanup

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -95,9 +95,6 @@ tasks.withType<ProcessResources>().configureEach {
 project.extra["quarkus.package.type"] =
   if (withUberJar() || project.hasProperty("native")) "uber-jar" else "fast-jar"
 
-// TODO remove the whole block
-quarkus { setFinalName("${project.name}-${project.version}") }
-
 tasks.withType<QuarkusBuild>().configureEach {
   outputs.cacheIf { false }
   inputs.property("quarkus.package.type", project.extra["quarkus.package.type"])

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -117,9 +117,6 @@ project.extra["quarkus.smallrye-openapi.additional-docs-directory"] = "$openApiS
 project.extra["quarkus.package.type"] =
   if (withUberJar()) "uber-jar" else if (project.hasProperty("native")) "native" else "fast-jar"
 
-// TODO remove the whole block
-quarkus { setFinalName("${project.name}-${project.version}") }
-
 val useDocker = project.hasProperty("docker")
 
 val pullOpenApiSpec by


### PR DESCRIPTION
... after `finalName` has a proper convention via [this commit](https://github.com/quarkusio/quarkus/commit/6424dbe216e3e0f5bdc8aa7b1453a1ece338d30e)