### PR TITLE
Produce NessieBadRequestException when paging is not available

### DIFF
--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -352,12 +352,12 @@ public class PersistVersionStore implements VersionStore {
         namedRef -> namedRef.withUpdatedCommitMeta(commitMetaFromReference(namedRef))) {
       @Override
       protected String computeTokenForCurrent() {
-        return null;
+        throw new IllegalArgumentException("Paging not supported");
       }
 
       @Override
       public String tokenForEntry(ReferenceInfo<CommitMeta> entry) {
-        return null;
+        throw new IllegalArgumentException("Paging not supported");
       }
 
       @Override
@@ -512,12 +512,12 @@ public class PersistVersionStore implements VersionStore {
         }) {
       @Override
       protected String computeTokenForCurrent() {
-        return null;
+        throw new IllegalArgumentException("Paging not supported");
       }
 
       @Override
       public String tokenForEntry(KeyEntry entry) {
-        return null;
+        throw new IllegalArgumentException("Paging not supported");
       }
 
       @Override
@@ -579,12 +579,12 @@ public class PersistVersionStore implements VersionStore {
                                 databaseAdapter::mapToAttachment)))) {
       @Override
       protected String computeTokenForCurrent() {
-        return null;
+        throw new IllegalArgumentException("Paging not supported");
       }
 
       @Override
       public String tokenForEntry(Diff entry) {
-        return null;
+        throw new IllegalArgumentException("Paging not supported");
       }
 
       @Override


### PR DESCRIPTION
Affected APIs:
* getAllReferences()
* getEntries()
* getDiff()

Previously, if the page has to be cut short in the responses from these APIs (e.g. if `maxRecords` is set). The response would have `hasMore == true` but `pageToken == null`. This can be confusing to clients.

With this change the service with cause a `NessieBadRequestException` when it has to limit the response size, but cannot generate a paging token to clearly indicate that paging is not supported in these situations.

Clients may still observe that requests with a large `maxRecords` value succeed, but with a smaller `maxRecords` value fail. This is because the decision to limit the page size is made at the REST API level, but the token is generated at the storage level and exact behaviour depends on the available data.

Full pagination support is to be added with the new model (#5641).