### PR TITLE
python: upgrade flake8 to v6.0.0

### DIFF
--- a/python/requirements_basedev.txt
+++ b/python/requirements_basedev.txt
@@ -20,7 +20,6 @@ assertpy==1.1
 bump2version==1.0.1
 codecov==2.1.12
 coverage==7.1.0
-flake8==5.0.4
 pip==23.0
 pytest==7.2.1
 pytest-cov==4.0.0

--- a/python/requirements_lint.txt
+++ b/python/requirements_lint.txt
@@ -16,6 +16,7 @@
 -r requirements_dev.txt
 bandit==1.7.4
 black==22.12.0
+flake8==6.0.0
 flake8-annotations==3.0.0
 flake8-bandit==4.1.1
 flake8-black==0.3.6


### PR DESCRIPTION
replaces https://github.com/projectnessie/nessie/pull/6031

flake8 6.0.0 Requires-Python >=3.8.1

so we move it to the lint config, which we only run on 3.8 anyway:
https://github.com/projectnessie/nessie/blob/80997890e19072ad5d69634729e201a29ed7fc21/python/tox.ini#L20-L25