### PR TITLE
Cleanup InmemoryStore after tests

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/InmemoryDatabaseAdapterBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/InmemoryDatabaseAdapterBuilder.java
@@ -30,12 +30,14 @@ import org.projectnessie.versioned.persist.nontx.NonTransactionalDatabaseAdapter
 public class InmemoryDatabaseAdapterBuilder implements DatabaseAdapterBuilder {
   @Inject NonTransactionalDatabaseAdapterConfig config;
 
+  @Inject InmemoryStore store;
+
   @Override
   public DatabaseAdapter newDatabaseAdapter() {
     return new InmemoryDatabaseAdapterFactory()
         .newBuilder()
         .withConfig(config)
-        .withConnector(new InmemoryStore())
+        .withConnector(store)
         .build();
   }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/InmemoryStoreProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/InmemoryStoreProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.providers;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Disposes;
+import javax.inject.Singleton;
+import javax.ws.rs.Produces;
+import org.projectnessie.versioned.persist.inmem.InmemoryStore;
+
+@ApplicationScoped
+public class InmemoryStoreProvider {
+
+  @Produces
+  @Singleton
+  public InmemoryStore inmemoryStore() {
+    return new InmemoryStore();
+  }
+
+  public void dispose(@Disposes InmemoryStore store) {
+    store.close();
+  }
+}

--- a/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
+++ b/versioned/persist/inmem/src/main/java/org/projectnessie/versioned/persist/inmem/InmemoryStore.java
@@ -49,7 +49,17 @@ public class InmemoryStore implements DatabaseConnectionProvider<InmemoryConfig>
   public void initialize() {}
 
   @Override
-  public void close() {}
+  public void close() {
+    globalStateLog.clear();
+    commitLog.clear();
+    keyLists.clear();
+    refLog.clear();
+    refHeads.clear();
+    refNames.clear();
+    refLogHeads.clear();
+    attachments.clear();
+    attachmentKeys.clear();
+  }
 
   void reinitializeRepo(ByteString keyPrefix) {
     Stream.of(


### PR DESCRIPTION
This was an attempt to fix an OOM in `:nessie-quarkus:test`. Although this change did not fix the issue, it is not a bad idea to be nice and release unused objects in Quarkus (triggered earliest after a test class).