### PR TITLE
Clear in-memory database-adapter between REST-tests in Quarkus

### DIFF
--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractQuarkusRest.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractQuarkusRest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.jaxrs.tests.BaseTestNessieRest;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+
+@ExtendWith(QuarkusNessieClientResolver.class)
+public abstract class AbstractQuarkusRest extends BaseTestNessieRest {
+
+  @Inject Instance<DatabaseAdapter> databaseAdapter;
+
+  @Override
+  @AfterEach
+  public void tearDown() throws Exception {
+    try {
+      DatabaseAdapter da = databaseAdapter.select().get();
+      if (da != null) {
+        try {
+          da.eraseRepo();
+        } finally {
+          da.initializeRepo("main");
+        }
+      }
+    } finally {
+      super.tearDown();
+    }
+  }
+}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
@@ -19,13 +19,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.client.ext.NessieApiVersion;
 import org.projectnessie.client.ext.NessieApiVersions;
-import org.projectnessie.jaxrs.tests.BaseTestNessieRest;
 
-@ExtendWith(QuarkusNessieClientResolver.class)
-public abstract class AbstractQuarkusRestWithMetrics extends BaseTestNessieRest {
+public abstract class AbstractQuarkusRestWithMetrics extends AbstractQuarkusRest {
   // We need to extend the base class because all Nessie metrics are created lazily.
   // They will appear in the `/q/metrics` endpoint only when some REST actions are executed.
 


### PR DESCRIPTION
This was an attempt to fix an OOM in `:nessie-quarkus:test`. Although this change did not fix the issue, it is not a bad idea to be nice and release unused objects in Quarkus' REST tests after every test case.