### PR TITLE
CI: Prevent OOM/GCLocker-issue in tests / disable Micrometer JVM-Metrics for tests

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -214,3 +214,13 @@ quarkus.micrometer.binder.http-server.match-patterns=\
 %test.quarkus.devservices.enabled=false
 %test.quarkus.jacoco.report=false
 %test.quarkus.jacoco.reuse-data-file=true
+
+# Disable Micrometer JVM-Metrics for tests.
+#
+# TL;DR Quarkus restarts (due to profile/configuration changes) causes memory leaks with
+# Micrometer's JVM GC Metrics.
+#
+# See https://github.com/quarkusio/quarkus/issues/24210#issuecomment-1064833013 why OOMs, or worse,
+# endless 'Retried waiting for GCLocker too often allocating * words' messages instead of a
+# "proper OutOfMemoryException" happen.
+%test.quarkus.micrometer.binder.jvm=false

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
@@ -47,7 +47,9 @@ public abstract class AbstractQuarkusRestWithMetrics extends BaseTestNessieRest 
   @Test
   void smokeTestMetrics() {
     String body = getMetrics();
-    assertThat(body).contains("jvm_threads_live_threads");
+    // Do not query JVM metrics in tests, see
+    // https://github.com/quarkusio/quarkus/issues/24210#issuecomment-1064833013
+    assertThat(body).contains("process_cpu_usage");
     assertThat(body).contains("nessie_versionstore_request_seconds_max");
     assertThat(body).contains("nessie_versionstore_request_seconds_bucket");
     assertThat(body).contains("nessie_versionstore_request_seconds_count");


### PR DESCRIPTION
TL;DR Quarkus restarts (due to profile/configuration changes) causes memory leaks with Micrometer's JVM GC Metrics.

See https://github.com/quarkusio/quarkus/issues/24210#issuecomment-1064833013 why OOMs, or worse, endless 'Retried waiting for GCLocker too often allocating * words' messages instead of a "proper OutOfMemoryException" happen.

This does _not_ affect production systems.