### PR TITLE
Reenable JVM monitoring in native images

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -160,10 +160,8 @@ quarkus.native.additional-build-args=\
   -J-Duser.language=en,\
   -J-Duser.country=US,\
   -J-Duser.variant=,\
-  -J-Dfile.encoding=UTF-8
-# Disable monitoring due to https://github.com/oracle/graal/issues/5303, reported via
-# https://github.com/projectnessie/nessie/issues/5900
-#   --enable-monitoring
+  -J-Dfile.encoding=UTF-8,\
+  --enable-monitoring
 
 ## quarkus container specific settings
 # fixed at buildtime


### PR DESCRIPTION
This change effectively reverts #5903 (#5900), since https://github.com/oracle/graal/issues/5303 is marked resolved for GraalVM 22.3.1, which is not also used for our native image builds via `quay.io/quarkus/ubi-quarkus-mandrel-builder-image@22.3` pointing to `22.3.1`.