### PR TITLE
Nit: rename build utility function to `buildForJava11`

### DIFF
--- a/buildSrc/src/main/kotlin/Utilities.kt
+++ b/buildSrc/src/main/kotlin/Utilities.kt
@@ -50,7 +50,7 @@ import org.gradle.kotlin.dsl.withType
  * Configures the `JavaPluginExtension` to use Java 11, or a newer Java version explicitly
  * configured for testing.
  */
-fun Project.preferJava11() {
+fun Project.buildForJava11() {
   extensions.findByType<JavaPluginExtension>()!!.run {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/servers/lambda/build.gradle.kts
+++ b/servers/lambda/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
-preferJava11()
+buildForJava11()
 
 val useDocker = project.hasProperty("docker")
 val packageType = quarkusPackageType()

--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -82,7 +82,7 @@ dependencies {
   jacocoRuntime(libs.jacoco.ant)
 }
 
-preferJava11()
+buildForJava11()
 
 tasks.withType<ProcessResources>().configureEach {
   from("src/main/resources") {

--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -59,4 +59,4 @@ dependencies {
   compileOnly(libs.microprofile.openapi)
 }
 
-preferJava11()
+buildForJava11()

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -105,7 +105,7 @@ dependencies {
   jacocoRuntime(libs.jacoco.ant)
 }
 
-preferJava11()
+buildForJava11()
 
 val pullOpenApiSpec by
   tasks.registering(Sync::class) {

--- a/servers/quarkus-tests/build.gradle.kts
+++ b/servers/quarkus-tests/build.gradle.kts
@@ -50,4 +50,4 @@ dependencies {
   implementation("io.quarkiverse.amazonservices:quarkus-amazon-dynamodb")
 }
 
-preferJava11()
+buildForJava11()


### PR DESCRIPTION
from `preferJava11`, to reflect what it really does