### PR TITLE
Add Jakarta's `@Nonnull` to `javax.annotation.Nonnull`

### DIFF
--- a/clients/client-testextension/src/main/java/org/projectnessie/client/ext/NessieClientFactory.java
+++ b/clients/client-testextension/src/main/java/org/projectnessie/client/ext/NessieClientFactory.java
@@ -30,10 +30,12 @@ public interface NessieClientFactory {
   NessieApiVersion apiVersion();
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   default NessieApiV1 make() {
     return make((builder, version) -> builder);
   }
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   NessieApiV1 make(NessieClientCustomizer customizer);
 }

--- a/clients/client-testextension/src/main/java/org/projectnessie/client/ext/NessieClientResolver.java
+++ b/clients/client-testextension/src/main/java/org/projectnessie/client/ext/NessieClientResolver.java
@@ -79,6 +79,7 @@ public abstract class NessieClientResolver implements ParameterResolver {
       NessieClientCustomizer testCustomizer = (NessieClientCustomizer) testInstance;
       return new ClientFactory(uri, apiVersion) {
         @Nonnull
+        @jakarta.annotation.Nonnull
         @Override // Note: this object is not serializable
         public NessieApiV1 make(NessieClientCustomizer customizer) {
           return super.make(
@@ -108,6 +109,7 @@ public abstract class NessieClientResolver implements ParameterResolver {
     }
 
     @Nonnull
+    @jakarta.annotation.Nonnull
     @Override
     public NessieApiV1 make(NessieClientCustomizer customizer) {
       URI uri = apiVersion.resolve(baseUri);

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/CutoffPolicy.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/CutoffPolicy.java
@@ -37,9 +37,9 @@ public interface CutoffPolicy {
     return NO_TIMESTAMP;
   }
 
-  boolean isCutoff(@Nonnull Instant commitTime, int numCommits);
+  boolean isCutoff(@Nonnull @jakarta.annotation.Nonnull Instant commitTime, int numCommits);
 
-  static CutoffPolicy atTimestamp(@Nonnull Instant cutoffTimestamp) {
+  static CutoffPolicy atTimestamp(@Nonnull @jakarta.annotation.Nonnull Instant cutoffTimestamp) {
     return new TimestampCutoffPolicy(cutoffTimestamp);
   }
 

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/DefaultVisitedDeduplicator.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/DefaultVisitedDeduplicator.java
@@ -47,7 +47,8 @@ public final class DefaultVisitedDeduplicator implements VisitedDeduplicator {
 
   @Override
   public synchronized boolean alreadyVisited(
-      @Nonnull Instant cutoffTimestamp, @Nonnull String commitId) {
+      @Nonnull @jakarta.annotation.Nonnull Instant cutoffTimestamp,
+      @Nonnull @jakarta.annotation.Nonnull String commitId) {
     if (cutoffTimestamp.equals(NO_TIMESTAMP)) {
       return false;
     }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/NoneCutoffPolicy.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/NoneCutoffPolicy.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 final class NoneCutoffPolicy implements CutoffPolicy {
 
   @Override
-  public boolean isCutoff(@Nonnull Instant commitTime, int numCommits) {
+  public boolean isCutoff(@Nonnull @jakarta.annotation.Nonnull Instant commitTime, int numCommits) {
     return false;
   }
 

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/NumCommitsCutoffPolicy.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/NumCommitsCutoffPolicy.java
@@ -28,7 +28,7 @@ final class NumCommitsCutoffPolicy implements CutoffPolicy {
   }
 
   @Override
-  public boolean isCutoff(@Nonnull Instant commitTime, int numCommits) {
+  public boolean isCutoff(@Nonnull @jakarta.annotation.Nonnull Instant commitTime, int numCommits) {
     return numCommits >= commits;
   }
 

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/TimestampCutoffPolicy.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/TimestampCutoffPolicy.java
@@ -28,7 +28,7 @@ final class TimestampCutoffPolicy implements CutoffPolicy {
   }
 
   @Override
-  public boolean isCutoff(@Nonnull Instant commitTime, int numCommits) {
+  public boolean isCutoff(@Nonnull @jakarta.annotation.Nonnull Instant commitTime, int numCommits) {
     return commitTime.compareTo(cutoffTimestamp) < 0L;
   }
 

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/VisitedDeduplicator.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/VisitedDeduplicator.java
@@ -22,5 +22,7 @@ import javax.annotation.Nonnull;
 public interface VisitedDeduplicator {
   VisitedDeduplicator NOOP = (cutOffTimestamp, commitId) -> false;
 
-  boolean alreadyVisited(@Nonnull Instant cutOffTimestamp, @Nonnull String commitId);
+  boolean alreadyVisited(
+      @Nonnull @jakarta.annotation.Nonnull Instant cutOffTimestamp,
+      @Nonnull @jakarta.annotation.Nonnull String commitId);
 }

--- a/gc/gc-iceberg-mock/src/main/java/org/projectnessie/gc/iceberg/mocks/MockManifestFile.java
+++ b/gc/gc-iceberg-mock/src/main/java/org/projectnessie/gc/iceberg/mocks/MockManifestFile.java
@@ -46,6 +46,7 @@ import org.immutables.value.Value;
 public abstract class MockManifestFile implements IndexedRecord {
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   public abstract String path();
 
   @Value.Default

--- a/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/IcebergContentToFiles.java
+++ b/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/IcebergContentToFiles.java
@@ -237,13 +237,16 @@ public abstract class IcebergContentToFiles implements ContentToFiles {
   }
 
   static URI baseUri(
-      @Nonnull TableMetadata tableMetadata, @Nonnull ContentReference contentReference) {
+      @Nonnull @jakarta.annotation.Nonnull TableMetadata tableMetadata,
+      @Nonnull @jakarta.annotation.Nonnull ContentReference contentReference) {
     String location = tableMetadata.location();
     URI uri = URI.create(location.endsWith("/") ? location : (location + "/"));
     return checkUri("location", uri, contentReference);
   }
 
-  static URI manifestFileUri(@Nonnull ManifestFile mf, @Nonnull ContentReference contentReference) {
+  static URI manifestFileUri(
+      @Nonnull @jakarta.annotation.Nonnull ManifestFile mf,
+      @Nonnull @jakarta.annotation.Nonnull ContentReference contentReference) {
     String manifestFilePath =
         Preconditions.checkNotNull(
             mf.path(),
@@ -254,7 +257,9 @@ public abstract class IcebergContentToFiles implements ContentToFiles {
     return checkUri("manifest file", manifestFile, contentReference);
   }
 
-  static URI dataFileUri(@Nonnull String dataFilePath, @Nonnull ContentReference contentReference) {
+  static URI dataFileUri(
+      @Nonnull @jakarta.annotation.Nonnull String dataFilePath,
+      @Nonnull @jakarta.annotation.Nonnull ContentReference contentReference) {
     URI uri = URI.create(dataFilePath);
     return checkUri("data file", uri, contentReference);
   }

--- a/model/src/main/java/org/projectnessie/model/Util.java
+++ b/model/src/main/java/org/projectnessie/model/Util.java
@@ -84,7 +84,8 @@ final class Util {
   }
 
   public static Reference fromPathStringRef(
-      @Nonnull String value, @Nonnull Reference.ReferenceType namedRefType) {
+      @Nonnull @jakarta.annotation.Nonnull String value,
+      @Nonnull @jakarta.annotation.Nonnull Reference.ReferenceType namedRefType) {
     String name = null;
     String hash = null;
     int hashIdx = value.indexOf(REF_HASH_SEPARATOR);

--- a/servers/services/src/test/java/org/projectnessie/services/impl/TestRefUtil.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/TestRefUtil.java
@@ -142,6 +142,7 @@ class TestRefUtil {
                     new NamedRef() {
                       @Override
                       @Nonnull
+                      @jakarta.annotation.Nonnull
                       public String getName() {
                         return REF_NAME;
                       }
@@ -173,6 +174,7 @@ class TestRefUtil {
                     new NamedRef() {
                       @Override
                       @Nonnull
+                      @jakarta.annotation.Nonnull
                       public String getName() {
                         return REF_NAME;
                       }

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/KeyGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/keygen/KeyGenerator.java
@@ -37,15 +37,16 @@ public class KeyGenerator {
     void apply(Random random, StringBuilder target);
   }
 
-  public static KeyGenerator newKeyGenerator(@Nonnull String pattern) {
+  public static KeyGenerator newKeyGenerator(@Nonnull @jakarta.annotation.Nonnull String pattern) {
     return newKeyGenerator(ImmutableParams.builder().pattern(pattern).build());
   }
 
-  public static KeyGenerator newKeyGenerator(long seed, @Nonnull String pattern) {
+  public static KeyGenerator newKeyGenerator(
+      long seed, @Nonnull @jakarta.annotation.Nonnull String pattern) {
     return newKeyGenerator(ImmutableParams.builder().seed(seed).pattern(pattern).build());
   }
 
-  public static KeyGenerator newKeyGenerator(@Nonnull Params params) {
+  public static KeyGenerator newKeyGenerator(@Nonnull @jakarta.annotation.Nonnull Params params) {
     PatternParser parser = new PatternParser(params.pattern());
     List<Func> generators = parser.parse();
     return new KeyGenerator(params, generators);
@@ -55,7 +56,9 @@ public class KeyGenerator {
   private final Random random;
   private final List<Func> generators;
 
-  private KeyGenerator(@Nonnull Params params, @Nonnull List<Func> generators) {
+  private KeyGenerator(
+      @Nonnull @jakarta.annotation.Nonnull Params params,
+      @Nonnull @jakarta.annotation.Nonnull List<Func> generators) {
     this.params = params;
     this.random = new Random(params.seed());
     this.generators = generators;

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ContentAndState.java
@@ -32,6 +32,7 @@ public interface ContentAndState {
    * partition-spec-ID, default-sort-order-ID.
    */
   @Nonnull
+  @jakarta.annotation.Nonnull
   @Value.Parameter(order = 2)
   ByteString getRefState();
 
@@ -41,13 +42,18 @@ public interface ContentAndState {
   ByteString getGlobalState();
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   static ContentAndState of(
-      byte payload, @Nonnull ByteString refState, @Nullable ByteString globalState) {
+      byte payload,
+      @Nonnull @jakarta.annotation.Nonnull ByteString refState,
+      @Nullable ByteString globalState) {
     return ImmutableContentAndState.of(payload, refState, globalState);
   }
 
   @Nonnull
-  static ContentAndState of(byte payload, @Nonnull ByteString refState) {
+  @jakarta.annotation.Nonnull
+  static ContentAndState of(
+      byte payload, @Nonnull @jakarta.annotation.Nonnull ByteString refState) {
     return ImmutableContentAndState.of(payload, refState, null);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapter.java
@@ -405,6 +405,7 @@ public interface DatabaseAdapter {
    *     not been persisted.
    */
   CommitLogEntry rebuildKeyList(
-      CommitLogEntry entry, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
+      CommitLogEntry entry,
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException;
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -210,7 +210,8 @@ public abstract class AbstractDatabaseAdapter<
 
   @Override
   public CommitLogEntry rebuildKeyList(
-      CommitLogEntry entry, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
+      CommitLogEntry entry,
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
     try (OP_CONTEXT ctx = borrowConnection()) {
       return buildKeyList(ctx, entry, h -> {}, inMemoryCommits);
@@ -952,7 +953,9 @@ public abstract class AbstractDatabaseAdapter<
    * returned as {@code null}.
    */
   private List<CommitLogEntry> fetchMultipleFromCommitLog(
-      OP_CONTEXT ctx, List<Hash> hashes, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits) {
+      OP_CONTEXT ctx,
+      List<Hash> hashes,
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits) {
     List<CommitLogEntry> result = new ArrayList<>(hashes.size());
     BitSet remainingHashes = null;
 
@@ -1015,14 +1018,18 @@ public abstract class AbstractDatabaseAdapter<
 
   @MustBeClosed
   protected Stream<CommitLogEntry> readCommitLogStream(
-      OP_CONTEXT ctx, Hash initialHash, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
+      OP_CONTEXT ctx,
+      Hash initialHash,
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
     Spliterator<CommitLogEntry> split = readCommitLog(ctx, initialHash, inMemoryCommits);
     return StreamSupport.stream(split, false);
   }
 
   protected Spliterator<CommitLogEntry> readCommitLog(
-      OP_CONTEXT ctx, Hash initialHash, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
+      OP_CONTEXT ctx,
+      Hash initialHash,
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
     Preconditions.checkNotNull(inMemoryCommits, "in-memory commits cannot be null");
 
@@ -1150,7 +1157,7 @@ public abstract class AbstractDatabaseAdapter<
       Iterable<Key> deletes,
       int currentKeyListDistance,
       Consumer<Hash> newKeyLists,
-      @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits,
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits,
       Iterable<Hash> additionalParents)
       throws ReferenceNotFoundException {
     Hash commitHash = individualCommitHash(parentHashes, commitMeta, puts, deletes);
@@ -1222,7 +1229,7 @@ public abstract class AbstractDatabaseAdapter<
       OP_CONTEXT ctx,
       CommitLogEntry unwrittenEntry,
       Consumer<Hash> newKeyLists,
-      @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
     // Read commit-log until the previous persisted key-list
 
@@ -1363,7 +1370,7 @@ public abstract class AbstractDatabaseAdapter<
       OP_CONTEXT ctx,
       Hash hash,
       KeyFilterPredicate keyFilter,
-      @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
     // walk the commit-logs in reverse order - starting with the last persisted key-list
 
@@ -2184,7 +2191,8 @@ public abstract class AbstractDatabaseAdapter<
   protected abstract Spliterator<RefLog> readRefLog(OP_CONTEXT ctx, Hash initialHash)
       throws RefLogNotFoundException;
 
-  protected void tryLoopStateCompletion(@Nonnull Boolean success, TryLoopState state) {
+  protected void tryLoopStateCompletion(
+      @Nonnull @jakarta.annotation.Nonnull Boolean success, TryLoopState state) {
     tryLoopFinished(
         success ? "success" : "fail", state.getRetries(), state.getDuration(NANOSECONDS));
   }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterMetrics.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterMetrics.java
@@ -26,25 +26,26 @@ public final class DatabaseAdapterMetrics {
 
   private DatabaseAdapterMetrics() {}
 
-  static void tryLoopFinished(@Nonnull String result, int retries, long durationNanos) {
+  static void tryLoopFinished(
+      @Nonnull @jakarta.annotation.Nonnull String result, int retries, long durationNanos) {
     tryLoopCounts(result).increment();
     tryLoopRetries(result).increment(retries);
     tryLoopDuration(result).record(durationNanos, NANOSECONDS);
   }
 
-  public static Timer tryLoopDuration(@Nonnull String result) {
+  public static Timer tryLoopDuration(@Nonnull @jakarta.annotation.Nonnull String result) {
     return Timer.builder("nessie.databaseadapter.tryloop.duration")
         .tag("result", result)
         .register(Metrics.globalRegistry);
   }
 
-  public static Counter tryLoopRetries(@Nonnull String result) {
+  public static Counter tryLoopRetries(@Nonnull @jakarta.annotation.Nonnull String result) {
     return Counter.builder("nessie.databaseadapter.tryloop.retries")
         .tag("result", result)
         .register(Metrics.globalRegistry);
   }
 
-  public static Counter tryLoopCounts(@Nonnull String result) {
+  public static Counter tryLoopCounts(@Nonnull @jakarta.annotation.Nonnull String result) {
     return Counter.builder("nessie.databaseadapter.tryloop.count")
         .tag("result", result)
         .register(Metrics.globalRegistry);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/TracingDatabaseAdapter.java
@@ -316,7 +316,8 @@ public final class TracingDatabaseAdapter implements DatabaseAdapter {
 
   @Override
   public CommitLogEntry rebuildKeyList(
-      CommitLogEntry entry, @Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
+      CommitLogEntry entry,
+      @Nonnull @jakarta.annotation.Nonnull Function<Hash, CommitLogEntry> inMemoryCommits)
       throws ReferenceNotFoundException {
     try (Traced ignore = trace("rebuildKeyList").tag(TAG_HASH, entry.getHash().asString())) {
       return delegate.rebuildKeyList(entry, inMemoryCommits);

--- a/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
+++ b/versioned/persist/dynamodb/src/main/java/org/projectnessie/versioned/persist/dynamodb/DynamoDatabaseAdapter.java
@@ -131,6 +131,7 @@ public class DynamoDatabaseAdapter
 
   // TODO find a way to wrap those DynamoDB-exceptions everywhere - even when returning Stream's
   @Nonnull
+  @jakarta.annotation.Nonnull
   @VisibleForTesting
   static RuntimeException unhandledException(String operation, RuntimeException e) {
     if (e instanceof RequestLimitExceededException) {

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -104,6 +104,7 @@ public class PersistVersionStore implements VersionStore {
   }
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   @Override
   public Hash noAncestorHash() {
     return databaseAdapter.noAncestorHash();
@@ -111,11 +112,11 @@ public class PersistVersionStore implements VersionStore {
 
   @Override
   public Hash commit(
-      @Nonnull BranchName branch,
-      @Nonnull Optional<Hash> expectedHead,
-      @Nonnull CommitMeta metadata,
-      @Nonnull List<Operation> operations,
-      @Nonnull Callable<Void> validator,
+      @Nonnull @jakarta.annotation.Nonnull BranchName branch,
+      @Nonnull @jakarta.annotation.Nonnull Optional<Hash> expectedHead,
+      @Nonnull @jakarta.annotation.Nonnull CommitMeta metadata,
+      @Nonnull @jakarta.annotation.Nonnull List<Operation> operations,
+      @Nonnull @jakarta.annotation.Nonnull Callable<Void> validator,
       BiConsumer<Key, String> addedContents)
       throws ReferenceNotFoundException, ReferenceConflictException {
 
@@ -332,8 +333,10 @@ public class PersistVersionStore implements VersionStore {
   }
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   @Override
-  public ReferenceInfo<CommitMeta> getNamedRef(@Nonnull String ref, GetNamedRefsParams params)
+  public ReferenceInfo<CommitMeta> getNamedRef(
+      @Nonnull @jakarta.annotation.Nonnull String ref, GetNamedRefsParams params)
       throws ReferenceNotFoundException {
     ReferenceInfo<ByteString> namedRef = databaseAdapter.namedRef(ref, params);
     return namedRef.withUpdatedCommitMeta(commitMetaFromReference(namedRef));

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/BranchName.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/BranchName.java
@@ -29,7 +29,8 @@ public interface BranchName extends NamedRef {
    * @return an instance of {@code BranchName} for the provided name
    */
   @Nonnull
-  static BranchName of(@Nonnull String name) {
+  @jakarta.annotation.Nonnull
+  static BranchName of(@Nonnull @jakarta.annotation.Nonnull String name) {
     return ImmutableBranchName.builder().name(name).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Delete.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Delete.java
@@ -29,7 +29,8 @@ public interface Delete extends Operation {
    * @return a delete operation for the key
    */
   @Nonnull
-  static Delete of(@Nonnull Key key) {
+  @jakarta.annotation.Nonnull
+  static Delete of(@Nonnull @jakarta.annotation.Nonnull Key key) {
     return ImmutableDelete.builder().key(key).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/DetachedRef.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/DetachedRef.java
@@ -27,6 +27,7 @@ public interface DetachedRef extends NamedRef {
   DetachedRef INSTANCE = ImmutableDetachedRef.builder().build();
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   @Override
   @Value.Redacted
   default String getName() {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Hash.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Hash.java
@@ -63,7 +63,7 @@ public abstract class Hash implements Ref {
    * @throws IllegalArgumentException if {@code hash} is not a valid representation of a hash
    * @throws NullPointerException if {@code hash} is {@code null}
    */
-  public static Hash of(@Nonnull String hash) {
+  public static Hash of(@Nonnull @jakarta.annotation.Nonnull String hash) {
     requireNonNull(hash);
     int len = hash.length();
     checkArgument(
@@ -84,7 +84,7 @@ public abstract class Hash implements Ref {
    * @return a {@code Hash} instance
    * @throws NullPointerException if {@code hash} is {@code null}
    */
-  public static Hash of(@Nonnull ByteString bytes) {
+  public static Hash of(@Nonnull @jakarta.annotation.Nonnull ByteString bytes) {
     switch (bytes.size()) {
       case 32:
         return new Hash256(bytes);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -68,6 +68,7 @@ public final class MetricsVersionStore implements VersionStore {
   }
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   @Override
   public Hash noAncestorHash() {
     return delegate.noAncestorHash();
@@ -75,12 +76,12 @@ public final class MetricsVersionStore implements VersionStore {
 
   @Override
   public Hash commit(
-      @Nonnull BranchName branch,
-      @Nonnull Optional<Hash> referenceHash,
-      @Nonnull CommitMeta metadata,
-      @Nonnull List<Operation> operations,
-      @Nonnull Callable<Void> validator,
-      @Nonnull BiConsumer<Key, String> addedContents)
+      @Nonnull @jakarta.annotation.Nonnull BranchName branch,
+      @Nonnull @jakarta.annotation.Nonnull Optional<Hash> referenceHash,
+      @Nonnull @jakarta.annotation.Nonnull CommitMeta metadata,
+      @Nonnull @jakarta.annotation.Nonnull List<Operation> operations,
+      @Nonnull @jakarta.annotation.Nonnull Callable<Void> validator,
+      @Nonnull @jakarta.annotation.Nonnull BiConsumer<Key, String> addedContents)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return this.<Hash, ReferenceNotFoundException, ReferenceConflictException>delegate2ExR(
         "commit",

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/NamedRef.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/NamedRef.java
@@ -26,5 +26,6 @@ public interface NamedRef extends Ref {
    * @return the reference name
    */
   @Nonnull
+  @jakarta.annotation.Nonnull
   String getName();
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Put.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Put.java
@@ -46,7 +46,10 @@ public interface Put extends Operation {
    * @return a put operation for the key and value
    */
   @Nonnull
-  static Put of(@Nonnull Key key, @Nonnull Content value) {
+  @jakarta.annotation.Nonnull
+  static Put of(
+      @Nonnull @jakarta.annotation.Nonnull Key key,
+      @Nonnull @jakarta.annotation.Nonnull Content value) {
     return ImmutablePut.builder().key(key).value(value).build();
   }
 
@@ -64,7 +67,11 @@ public interface Put extends Operation {
    * @return a put operation for the key and value
    */
   @Nonnull
-  static Put of(@Nonnull Key key, @Nonnull Content value, @Nonnull Content expectedValue) {
+  @jakarta.annotation.Nonnull
+  static Put of(
+      @Nonnull @jakarta.annotation.Nonnull Key key,
+      @Nonnull @jakarta.annotation.Nonnull Content value,
+      @Nonnull @jakarta.annotation.Nonnull Content expectedValue) {
     return ImmutablePut.builder().key(key).value(value).expectedValue(expectedValue).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/RefLogNotFoundException.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/RefLogNotFoundException.java
@@ -40,7 +40,9 @@ public class RefLogNotFoundException extends VersionStoreException {
    * @throws NullPointerException if {@code refLogId} is {@code null}.
    */
   @Nonnull
-  public static RefLogNotFoundException forRefLogId(@Nonnull String refLogId) {
+  @jakarta.annotation.Nonnull
+  public static RefLogNotFoundException forRefLogId(
+      @Nonnull @jakarta.annotation.Nonnull String refLogId) {
     requireNonNull(refLogId);
     return new RefLogNotFoundException(format("RefLog entry for '%s' does not exist", refLogId));
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TagName.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TagName.java
@@ -29,7 +29,8 @@ public interface TagName extends NamedRef {
    * @return an instance of {@code TagName} for the provided name
    */
   @Nonnull
-  static TagName of(@Nonnull String name) {
+  @jakarta.annotation.Nonnull
+  static TagName of(@Nonnull @jakarta.annotation.Nonnull String name) {
     return ImmutableTagName.builder().name(name).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -84,6 +84,7 @@ public class TracingVersionStore implements VersionStore {
   }
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   @Override
   public Hash noAncestorHash() {
     return delegate.noAncestorHash();
@@ -91,12 +92,12 @@ public class TracingVersionStore implements VersionStore {
 
   @Override
   public Hash commit(
-      @Nonnull BranchName branch,
-      @Nonnull Optional<Hash> referenceHash,
-      @Nonnull CommitMeta metadata,
-      @Nonnull List<Operation> operations,
-      @Nonnull Callable<Void> validator,
-      @Nonnull BiConsumer<Key, String> addedContents)
+      @Nonnull @jakarta.annotation.Nonnull BranchName branch,
+      @Nonnull @jakarta.annotation.Nonnull Optional<Hash> referenceHash,
+      @Nonnull @jakarta.annotation.Nonnull CommitMeta metadata,
+      @Nonnull @jakarta.annotation.Nonnull List<Operation> operations,
+      @Nonnull @jakarta.annotation.Nonnull Callable<Void> validator,
+      @Nonnull @jakarta.annotation.Nonnull BiConsumer<Key, String> addedContents)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return TracingVersionStore
         .<Hash, ReferenceNotFoundException, ReferenceConflictException>callWithTwoExceptions(

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Unchanged.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Unchanged.java
@@ -39,7 +39,8 @@ public interface Unchanged extends Operation {
    * @return a unchanged operation for the key
    */
   @Nonnull
-  static Unchanged of(@Nonnull Key key) {
+  @jakarta.annotation.Nonnull
+  static Unchanged of(@Nonnull @jakarta.annotation.Nonnull Key key) {
     return ImmutableUnchanged.builder().key(key).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -59,6 +59,7 @@ public interface VersionStore {
    * for different backends and even for different instances of the same backend.
    */
   @Nonnull
+  @jakarta.annotation.Nonnull
   Hash noAncestorHash();
 
   /**
@@ -82,19 +83,19 @@ public interface VersionStore {
    * @throws NullPointerException if one of the argument is {@code null}
    */
   Hash commit(
-      @Nonnull BranchName branch,
-      @Nonnull Optional<Hash> referenceHash,
-      @Nonnull CommitMeta metadata,
-      @Nonnull List<Operation> operations,
-      @Nonnull Callable<Void> validator,
-      @Nonnull BiConsumer<Key, String> addedContents)
+      @Nonnull @jakarta.annotation.Nonnull BranchName branch,
+      @Nonnull @jakarta.annotation.Nonnull Optional<Hash> referenceHash,
+      @Nonnull @jakarta.annotation.Nonnull CommitMeta metadata,
+      @Nonnull @jakarta.annotation.Nonnull List<Operation> operations,
+      @Nonnull @jakarta.annotation.Nonnull Callable<Void> validator,
+      @Nonnull @jakarta.annotation.Nonnull BiConsumer<Key, String> addedContents)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   default Hash commit(
-      @Nonnull BranchName branch,
-      @Nonnull Optional<Hash> referenceHash,
-      @Nonnull CommitMeta metadata,
-      @Nonnull List<Operation> operations)
+      @Nonnull @jakarta.annotation.Nonnull BranchName branch,
+      @Nonnull @jakarta.annotation.Nonnull Optional<Hash> referenceHash,
+      @Nonnull @jakarta.annotation.Nonnull CommitMeta metadata,
+      @Nonnull @jakarta.annotation.Nonnull List<Operation> operations)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return commit(branch, referenceHash, metadata, operations, () -> null, (k, c) -> {});
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/store/DefaultStoreWorker.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/store/DefaultStoreWorker.java
@@ -103,12 +103,13 @@ public class DefaultStoreWorker implements StoreWorker {
     }
   }
 
-  private static @Nonnull <C extends Content> ContentSerializer<C> serializer(C content) {
+  private static @Nonnull @jakarta.annotation.Nonnull <C extends Content>
+      ContentSerializer<C> serializer(C content) {
     return serializer(content.getType());
   }
 
-  private static @Nonnull <C extends Content> ContentSerializer<C> serializer(
-      Content.Type contentType) {
+  private static @Nonnull @jakarta.annotation.Nonnull <C extends Content>
+      ContentSerializer<C> serializer(Content.Type contentType) {
     @SuppressWarnings("unchecked")
     ContentSerializer<C> serializer = (ContentSerializer<C>) Registry.BY_TYPE.get(contentType);
     if (serializer == null) {
@@ -117,7 +118,8 @@ public class DefaultStoreWorker implements StoreWorker {
     return serializer;
   }
 
-  private static @Nonnull <C extends Content> ContentSerializer<C> serializer(byte payload) {
+  private static @Nonnull @jakarta.annotation.Nonnull <C extends Content>
+      ContentSerializer<C> serializer(byte payload) {
     @SuppressWarnings("unchecked")
     ContentSerializer<C> serializer =
         payload >= 0 && payload < Registry.BY_PAYLOAD.length

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ProgressListener.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ProgressListener.java
@@ -21,7 +21,7 @@ import org.projectnessie.versioned.transfer.serialize.TransferTypes.ExportMeta;
 
 @FunctionalInterface
 public interface ProgressListener {
-  default void progress(@Nonnull ProgressEvent type) {
+  default void progress(@Nonnull @jakarta.annotation.Nonnull ProgressEvent type) {
     progress(type, null);
   }
 
@@ -29,5 +29,6 @@ public interface ProgressListener {
    * Reports a progress event. The {@code exportMeta} parameter is only valid for {@link
    * ProgressEvent#END_META}.
    */
-  void progress(@Nonnull ProgressEvent type, @Nullable ExportMeta exportMeta);
+  void progress(
+      @Nonnull @jakarta.annotation.Nonnull ProgressEvent type, @Nullable ExportMeta exportMeta);
 }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ExportFileSupplier.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ExportFileSupplier.java
@@ -23,10 +23,13 @@ import javax.annotation.Nonnull;
 public interface ExportFileSupplier extends AutoCloseable {
 
   @Nonnull
+  @jakarta.annotation.Nonnull
   Path getTargetPath();
 
   void preValidate() throws IOException;
 
   @Nonnull
-  OutputStream newFileOutput(@Nonnull String fileName) throws IOException;
+  @jakarta.annotation.Nonnull
+  OutputStream newFileOutput(@Nonnull @jakarta.annotation.Nonnull String fileName)
+      throws IOException;
 }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/FileExporter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/FileExporter.java
@@ -49,6 +49,7 @@ public abstract class FileExporter implements ExportFileSupplier {
 
   @Override
   @Nonnull
+  @jakarta.annotation.Nonnull
   public Path getTargetPath() {
     return targetDirectory();
   }
@@ -69,7 +70,9 @@ public abstract class FileExporter implements ExportFileSupplier {
 
   @Override
   @Nonnull
-  public OutputStream newFileOutput(@Nonnull String fileName) throws IOException {
+  @jakarta.annotation.Nonnull
+  public OutputStream newFileOutput(@Nonnull @jakarta.annotation.Nonnull String fileName)
+      throws IOException {
     checkArgument(
         fileName.indexOf('/') == -1 && fileName.indexOf('\\') == -1, "Directories not supported");
     Path f = Paths.get(fileName);

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/FileImporter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/FileImporter.java
@@ -54,7 +54,9 @@ public abstract class FileImporter implements ImportFileSupplier {
 
   @Override
   @Nonnull
-  public InputStream newFileInput(@Nonnull String fileName) throws IOException {
+  @jakarta.annotation.Nonnull
+  public InputStream newFileInput(@Nonnull @jakarta.annotation.Nonnull String fileName)
+      throws IOException {
     return new BufferedInputStream(
         newInputStream(sourceDirectory().resolve(fileName)), inputBufferSize());
   }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ImportFileSupplier.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ImportFileSupplier.java
@@ -21,5 +21,6 @@ import javax.annotation.Nonnull;
 
 public interface ImportFileSupplier extends AutoCloseable {
   @Nonnull
-  InputStream newFileInput(@Nonnull String fileName) throws IOException;
+  @jakarta.annotation.Nonnull
+  InputStream newFileInput(@Nonnull @jakarta.annotation.Nonnull String fileName) throws IOException;
 }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ZipArchiveExporter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ZipArchiveExporter.java
@@ -56,13 +56,16 @@ public abstract class ZipArchiveExporter implements ExportFileSupplier {
 
   @Override
   @Nonnull
+  @jakarta.annotation.Nonnull
   public Path getTargetPath() {
     return outputFile();
   }
 
   @Override
   @Nonnull
-  public OutputStream newFileOutput(@Nonnull String fileName) throws IOException {
+  @jakarta.annotation.Nonnull
+  public OutputStream newFileOutput(@Nonnull @jakarta.annotation.Nonnull String fileName)
+      throws IOException {
     checkArgument(
         fileName.indexOf('/') == -1 && fileName.indexOf('\\') == -1, "Directories not supported");
     checkArgument(!fileName.isEmpty(), "Invalid file name argument");

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ZipArchiveImporter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ZipArchiveImporter.java
@@ -49,7 +49,9 @@ public abstract class ZipArchiveImporter implements ImportFileSupplier {
 
   @Override
   @Nonnull
-  public InputStream newFileInput(@Nonnull String fileName) throws IOException {
+  @jakarta.annotation.Nonnull
+  public InputStream newFileInput(@Nonnull @jakarta.annotation.Nonnull String fileName)
+      throws IOException {
     @SuppressWarnings("resource")
     ZipFile zip = zipFile();
     ZipEntry entry = zip.getEntry(fileName);

--- a/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestSizeLimitedOutput.java
+++ b/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestSizeLimitedOutput.java
@@ -57,6 +57,7 @@ public class TestSizeLimitedOutput {
     ExportFileSupplier exportFiles =
         new ExportFileSupplier() {
           @Nonnull
+          @jakarta.annotation.Nonnull
           @Override
           public Path getTargetPath() {
             throw new UnsupportedOperationException();
@@ -66,8 +67,9 @@ public class TestSizeLimitedOutput {
           public void preValidate() {}
 
           @Nonnull
+          @jakarta.annotation.Nonnull
           @Override
-          public OutputStream newFileOutput(@Nonnull String fileName) {
+          public OutputStream newFileOutput(@Nonnull @jakarta.annotation.Nonnull String fileName) {
             return outputSupplier.apply(fileName);
           }
 


### PR DESCRIPTION
A "boring" change that duplicates `@javax.annotation.Nonnull` with `@jakarta.annotation.Nonnull`, which is backwards compatible safe.

This is the first of a series of PRs to add the `jakarta.*` annotations, a preparation for Quarkus 3.

Duplicating annotations, although quite boilerplate, feels much safer than effectively duplicating a lot of Java types.