### PR TITLE
Gatling simulation for a mixed workload

### DIFF
--- a/perftest/simulations/build.gradle.kts
+++ b/perftest/simulations/build.gradle.kts
@@ -65,9 +65,11 @@ gatling {
   jvmArgs =
     System.getProperties()
       .map { e -> Maps.immutableEntry(e.key.toString(), e.value.toString()) }
-      .filter { e -> e.key.startsWith("nessie.") || e.key.startsWith("gatling.") }
+      .filter { e ->
+        e.key.startsWith("nessie.") || e.key.startsWith("gatling.") || e.key.startsWith("sim.")
+      }
       .map { e ->
-        if (e.key.startsWith("nessie.")) {
+        if (e.key.startsWith("nessie.") || e.key.startsWith("sim.")) {
           "-D${e.key}=${e.value}"
         } else if (e.key.startsWith("gatling.jvmArg")) {
           e.value

--- a/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/MixedWorkloadsParams.scala
+++ b/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/MixedWorkloadsParams.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.perftest.gatling
+
+import io.gatling.core.session.Session
+import java.lang.Integer.getInteger
+import java.lang.System.getProperty
+import java.util.concurrent.ThreadLocalRandom
+import org.projectnessie.model.{ContentKey, Namespace}
+import scala.concurrent.duration.{Duration, FiniteDuration, HOURS, NANOSECONDS}
+
+case class SessionsAndRate(
+    users: Int,
+    opRate: Double
+) {
+  def rateToDuration(): FiniteDuration = {
+    val oneHour = FiniteDuration(1, HOURS)
+    val nanosPerIteration = oneHour.toNanos / (opRate * oneHour.toSeconds)
+    FiniteDuration(nanosPerIteration.toLong, NANOSECONDS)
+  }
+
+  override def toString: String = s"$users users at rate $opRate"
+}
+
+object SessionsAndRate {
+  def fromSystemProperties(
+      prefix: String,
+      usersDefault: Int = 1,
+      opRateDefault: Double = 10
+  ): SessionsAndRate = {
+    val users: Int = getInteger(s"$prefix.users", usersDefault)
+    val rate: Double = getProperty(s"$prefix.rate", s"$opRateDefault").toDouble
+    SessionsAndRate(users, rate)
+  }
+}
+
+case class MixedWorkloadsTables(
+    namespaceStr: String,
+    totalTables: Int,
+    activeTables: Int,
+    suffix: String = ""
+) {
+  def contentKey(t: Int, session: Session): ContentKey = {
+    val namespace = session("namespace").as[Namespace]
+    ContentKey.of(namespace, s"table-${t}$suffix")
+  }
+
+  def randomActiveTable(): Int = {
+    ThreadLocalRandom.current().nextInt(activeTables)
+  }
+
+  def namespace: Namespace = Namespace.fromPathString(namespaceStr)
+
+  override def toString: String =
+    s"$totalTables total tables, $activeTables active, in namespace '$namespaceStr', table name suffix '$suffix'"
+}
+
+object MixedWorkloadsTables {
+  def fromSystemProperties(): MixedWorkloadsTables = {
+    val namespace: String = getProperty("sim.namespace", "")
+    val totalTables: Int = getInteger("sim.totalTables", 10)
+    val activeTables: Int = getInteger("sim.activeTables", 1)
+
+    MixedWorkloadsTables(namespace, totalTables, activeTables)
+  }
+}
+
+case class MixedWorkloadsBranches(
+    branch: String,
+    numBranches: Int = 1
+) {
+  def branchOf(num: Int): String = {
+    if (num == 0) branch else s"$branch-$num"
+  }
+
+  def randomBranch: String = {
+    val num =
+      if (numBranches == 1) 0
+      else ThreadLocalRandom.current().nextInt(numBranches)
+    branchOf(num)
+  }
+
+  override def toString: String =
+    s"branch prefix '$branch', $numBranches branches"
+}
+
+object MixedWorkloadsBranches {
+
+  def fromSystemProperties(): MixedWorkloadsBranches = {
+    val defaultPre = s"mixed-${System.currentTimeMillis()}"
+    val branch: String = getProperty("sim.branch", defaultPre)
+    val numBranches: Int = getInteger("sim.numBranches", 1)
+
+    MixedWorkloadsBranches(branch, numBranches)
+  }
+}
+
+case class MixedWorkloadsParams(
+    tablePrefix: String,
+    branches: MixedWorkloadsBranches,
+    duration: Duration,
+    tables: MixedWorkloadsTables,
+    tablesPerCommit: Int,
+    readNumTables: Int,
+    allowConflicts: Boolean,
+    writers: SessionsAndRate,
+    readers: SessionsAndRate,
+    uiUsers: SessionsAndRate
+)
+
+object MixedWorkloadsParams {
+  def fromSystemProperties(): MixedWorkloadsParams = {
+
+    val tablePrefix: String = getProperty("sim.tablePrefix", "table")
+    val allowConflicts: Boolean =
+      getProperty("sim.allowConflicts", "true").toBoolean
+    val duration: Duration = Duration.create(getProperty("sim.duration", "20s"))
+
+    val writers: SessionsAndRate =
+      SessionsAndRate.fromSystemProperties("sim.writers")
+    val readers: SessionsAndRate =
+      SessionsAndRate.fromSystemProperties("sim.readers")
+    val uiUsers: SessionsAndRate =
+      SessionsAndRate.fromSystemProperties("sim.uiUsers")
+
+    val tablesPerCommit: Int = getInteger("sim.tablesPerCommit", 20)
+    val readNumTables: Int = getInteger("sim.readNumTables", 1)
+
+    val tables = MixedWorkloadsTables.fromSystemProperties()
+    val branches = MixedWorkloadsBranches.fromSystemProperties()
+
+    MixedWorkloadsParams(
+      tablePrefix,
+      branches,
+      duration,
+      tables,
+      tablesPerCommit,
+      readNumTables,
+      allowConflicts,
+      writers,
+      readers,
+      uiUsers
+    )
+  }
+}

--- a/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/MixedWorkloadsSimulation.scala
+++ b/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/MixedWorkloadsSimulation.scala
@@ -1,0 +1,379 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.perftest.gatling
+
+import io.gatling.core.Predef._
+import io.gatling.core.scenario.Simulation
+import io.gatling.core.structure.{
+  ChainBuilder,
+  PopulationBuilder,
+  ScenarioBuilder
+}
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.locks.{Lock, ReentrantReadWriteLock}
+import org.projectnessie.client.api.CommitMultipleOperationsBuilder
+import org.projectnessie.error.NessieConflictException
+import org.projectnessie.model.CommitMeta.fromMessage
+import org.projectnessie.model.{Branch, ContentKey, IcebergTable, Operation}
+import org.projectnessie.perftest.gatling.Predef.nessie
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration.{FiniteDuration, NANOSECONDS}
+import scala.jdk.CollectionConverters.SeqHasAsJava
+
+/** Gatling simulation with three parallel scenarios.
+  *
+  * Preparation: populate the target branch with tables
+  *
+  *   1. writers - updates tables - each iteration: get-HEAD, get-content,
+  *      commit, for each table
+  *   1. readers - only read from tables - each iteration: get-content, for each
+  *      table
+  *   1. ui users - list & read tables - each iteration: get-HEAD, get-keys,
+  *      get-content
+  *
+  * It has a bunch of configurables, see [[MixedWorkloadsParams]]
+  */
+class MixedWorkloadsSimulation extends Simulation {
+
+  private val params: MixedWorkloadsParams =
+    MixedWorkloadsParams.fromSystemProperties()
+  private val branchTables: mutable.Map[(String, Int), Lock] =
+    mutable.HashMap[(String, Int), Lock]()
+
+  private def prepareScenario(): ScenarioBuilder = {
+    scenario("Initialize")
+      .exec(session => {
+        for (b <- 0 until params.branches.numBranches) {
+          for (t <- 0 until params.tables.activeTables) {
+            val branch = params.branches.branchOf(b)
+            branchTables
+              .put((branch, t), new ReentrantReadWriteLock().writeLock())
+          }
+        }
+        session
+          .set("namespace", params.tables.namespace)
+          .set("branchesCreated", 0)
+          .set("tablesCreated", 0)
+      })
+      .exitHereIfFailed
+      .exec(prepareInitialReference)
+      .exitHereIfFailed
+      .exec(
+        doWhile(
+          session =>
+            session("tablesCreated").as[Int] < params.tables.totalTables,
+          "tableNum"
+        ) {
+          exec(prepareTables)
+        }
+      )
+      .exitHereIfFailed
+      .exec(
+        doWhile(
+          session =>
+            session("branchesCreated").as[Int] < params.branches.numBranches,
+          "branchNum"
+        ) {
+          exec(prepareAdditionalReference)
+        }
+      )
+      .exitHereIfFailed
+  }
+
+  private def prepareTables: NessieActionBuilder = {
+    nessie(s"prepare - Create tables ...")
+      .execute { (client, session) =>
+        val tablesCreated: Int =
+          session("tablesCreated").asOption[Int].getOrElse(0)
+        val tables: Int = params.tablesPerCommit
+        val head = session("branch").as[Branch]
+        val batchNum = session("tableNum").as[Int]
+
+        val commit: CommitMultipleOperationsBuilder = client
+          .commitMultipleOperations()
+          .branch(head)
+          .commitMeta(
+            fromMessage(
+              s"Create table batch $batchNum for tables $tablesCreated .. ${tablesCreated + tables - 1}"
+            )
+          )
+        for (t <- tablesCreated until tablesCreated + tables) {
+          commit.operation(
+            Operation.Put.of(
+              params.tables.contentKey(t, session),
+              IcebergTable.of("meta-0", 1, 2, 3, 4)
+            )
+          )
+        }
+        val updatedHead = commit.commit()
+
+        session
+          .set("tablesCreated", tablesCreated + tables)
+          .set("branch", updatedHead)
+      }
+  }
+
+  private def prepareInitialReference: NessieActionBuilder =
+    nessie(s"prepare - Create initial branch")
+      .execute { (client, session) =>
+        // create the branch (errors will be ignored)
+        val branch = client
+          .createReference()
+          .reference(Branch.of(params.branches.branchOf(0), null))
+          .create()
+        System.err.println(s"Created initial $branch")
+        session.set("branchesCreated", 1).set("branch", branch)
+      }
+
+  private def prepareAdditionalReference: NessieActionBuilder =
+    nessie(s"prepare - Create additional branch")
+      .execute { (client, session) =>
+        val branchesCreated: Int =
+          session("branchesCreated").asOption[Int].getOrElse(0)
+
+        val initialBranch: Branch = session("branch").as[Branch]
+
+        // create the branch (errors will be ignored)
+        val branch = client.createReference
+          .sourceRefName(initialBranch.getName)
+          .reference(
+            Branch.of(
+              params.branches.branchOf(branchesCreated),
+              initialBranch.getHash
+            )
+          )
+          .create()
+        System.err.println(s"Created branch $branch from $initialBranch")
+
+        session
+          .set("branchesCreated", branchesCreated + 1)
+      }
+
+  private def writersScenario(): ScenarioBuilder = {
+    scenario("writers")
+      .exec(session => session.set("namespace", params.tables.namespace))
+      .exec(
+        nessie("writers - precheck")
+          .execute { (client, session) =>
+            client.getDefaultBranch
+            session
+          }
+          .dontLog()
+      )
+      .exitHereIfFailed
+      .exec(
+        forever("iteration") {
+          pace(params.writers.rateToDuration())
+            .exitBlockOnFail(
+              exec(session =>
+                session.set("branch", params.branches.randomBranch)
+              )
+                .exec(performUpdate("writers"))
+            )
+        }
+      )
+  }
+
+  private def readersScenario(): ScenarioBuilder = {
+    val chain = exec(
+      nessie(s"readers - Read ${params.readNumTables} table(s)").execute {
+        (client, session) =>
+          val tables = mutable.HashSet[ContentKey]()
+          while (tables.size < params.readNumTables) {
+            val tableId: Int = params.tables.randomActiveTable()
+            tables.add(params.tables.contentKey(tableId, session))
+          }
+          client.getContent
+            .refName(params.branches.randomBranch)
+            .keys(tables.toSeq.asJava)
+            .get()
+          session
+      }
+    )
+
+    scenario("readers")
+      .exec(session => session.set("namespace", params.tables.namespace))
+      .exec(
+        nessie("readers - precheck")
+          .execute { (client, session) =>
+            client.getDefaultBranch
+            session
+          }
+          .dontLog()
+      )
+      .exitHereIfFailed
+      .exec(
+        forever("iteration") {
+          pace(params.readers.rateToDuration()).exitBlockOnFail(chain)
+        }
+      )
+  }
+
+  private def uiUsersScenario(): ScenarioBuilder = {
+    val chain =
+      exec(session => session.set("branch", params.branches.randomBranch))
+        .exec(
+          nessie("ui-users - Get all entries").execute { (client, session) =>
+            val branch: String = session("branch").as[String]
+            // Consume all entries
+            client.getEntries.refName(branch).stream().forEach(_ => {})
+            session
+          }
+        )
+        .exec(performUpdate("ui-users"))
+
+    scenario("ui-users")
+      .exec(session => session.set("namespace", params.tables.namespace))
+      .exec(
+        nessie("ui-users - precheck")
+          .execute { (client, session) =>
+            client.getDefaultBranch
+            session
+          }
+          .dontLog()
+      )
+      .exitHereIfFailed
+      .exec(
+        forever("iteration") {
+          pace(params.uiUsers.rateToDuration()).exitBlockOnFail(chain)
+        }
+      )
+  }
+
+  private def borrowTable(
+      branch: String,
+      session: Session
+  ): (ContentKey, Option[Lock]) = {
+    var tableLock: Option[Lock] = None
+    var tableId: Int = 0
+    if (!params.allowConflicts) {
+      while (tableLock.isEmpty) {
+        tableId = params.tables.randomActiveTable()
+        val lock: Lock = branchTables((branch, tableId))
+        if (lock.tryLock()) {
+          tableLock = Some(lock)
+        }
+      }
+    } else {
+      tableId = params.tables.randomActiveTable()
+    }
+    (params.tables.contentKey(tableId, session), tableLock)
+  }
+
+  private def performUpdate(parent: String): ChainBuilder = {
+    exec(session => session.set("updated", false))
+      .doWhile(s => !s("updated").as[Boolean], "retries") {
+        exec(session => {
+          val branch: String = session("branch").as[String]
+          val tableAndLock: (ContentKey, Option[Lock]) =
+            borrowTable(branch, session)
+          session.set("table", tableAndLock)
+        })
+          .exec(
+            nessie(s"$parent - Update table / get content").execute {
+              (client, session) =>
+                val branch: String = session("branch").as[String]
+                val tableAndLock: (ContentKey, Option[Lock]) =
+                  session("table").as[(ContentKey, Option[Lock])]
+                val content = client.getContent
+                  .refName(branch)
+                  .getSingle(tableAndLock._1)
+
+                session
+                  .set("content", content.getContent)
+                  .set("ref", content.getEffectiveReference)
+            }
+          )
+          .exec(
+            nessie(s"$parent - Update table / commit").execute {
+              (client, session) =>
+                val tableAndLock: (ContentKey, Option[Lock]) =
+                  session("table").as[(ContentKey, Option[Lock])]
+                val ref: Branch = session("ref").as[Branch]
+
+                // Consume all entries
+                val currentTable = session("content").as[IcebergTable]
+                val updatedTable = IcebergTable
+                  .builder()
+                  .from(currentTable)
+                  .snapshotId(
+                    ThreadLocalRandom.current().nextLong(1, Long.MaxValue)
+                  )
+                  .build()
+
+                try {
+                  client
+                    .commitMultipleOperations()
+                    .branch(ref)
+                    .commitMeta(fromMessage(s"Update table ${tableAndLock._1}"))
+                    .operation(
+                      Operation.Put
+                        .of(tableAndLock._1, updatedTable, currentTable)
+                    )
+                    .commit()
+                  session.set("updated", true)
+                } catch {
+                  case _: NessieConflictException => session
+                } finally {
+                  tableAndLock._2.foreach(l => l.unlock())
+                }
+            }
+          )
+      }
+  }
+
+  /** Sets up the simulation. Implemented as a function to respect the optional
+    * maximum-duration.
+    */
+  private def doSetUp(): SetUp = {
+    val nessieProtocol: NessieProtocol = nessie().clientFromSystemProperties()
+
+    System.err.println(
+      s"Setting up ${params.tables}, ${params.branches}"
+    )
+    val prepare: PopulationBuilder =
+      prepareScenario().inject(atOnceUsers(1))
+
+    val popBuilders: ListBuffer[PopulationBuilder] = ListBuffer()
+    if (params.writers.users > 0) {
+      System.err.println(s"Simulating writers: ${params.writers}")
+      popBuilders.addOne(
+        writersScenario().inject(atOnceUsers(params.writers.users))
+      )
+    }
+    if (params.readers.users > 0) {
+      System.err.println(s"Simulating readers: ${params.readers}")
+      popBuilders.addOne(
+        readersScenario().inject(atOnceUsers(params.readers.users))
+      )
+    }
+    if (params.uiUsers.users > 0) {
+      System.err.println(s"Simulating ui-users: ${params.uiUsers}")
+      popBuilders.addOne(
+        uiUsersScenario().inject(atOnceUsers(params.uiUsers.users))
+      )
+    }
+
+    System.err.println(s"Will run for ${params.duration}")
+    setUp(prepare.andThen(popBuilders))
+      .maxDuration(FiniteDuration(params.duration.toNanos, NANOSECONDS))
+      .protocols(nessieProtocol)
+  }
+
+  // This is where everything starts, doSetUp() returns the `SetUp` ...
+  doSetUp()
+}


### PR DESCRIPTION
Current Gatling simulations target only one specific use case and are always focued on "commit rate".

The simulation in this PR supports a mixed workload.

"Workflow" of the whole simulation
1. Setup phase:
    1. Create a starting branch with many Iceberg tables, allows creating multiple tables in a single commit to reduce the setup time.
    2. Create additional branches, if more than one branch is configured, based on the HEAD of the branch from step 1.1.
2. "Mixed workload" phase with three use cases. All can be tweaked with the number of simulated users and the rate per second for each of the simulated users.
    1. UI user: 1. List all tables 2. Get current content of one tables 3. Update that table (Nessie commit)
    2. "Readers" (read from N tables at some fixed rate):
        1. Get current content of one or more tables
    2. "Writer" (think: a scheduled job committing at some fixed rate): 1. Get current content of one tables 1. Update that table (Nessie commit)

The "global" set of tables consists of a "pool" of tables and a subset of that "pool" as "active" tables to simulate the (probably common) scenario that people have many 10000s tables, but only actively use a fraction of those.