### PR TITLE
Add API v2 test for commit parents

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -23,6 +23,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.projectnessie.model.CommitMeta.fromMessage;
 import static org.projectnessie.model.FetchOption.ALL;
 
@@ -456,6 +457,35 @@ public abstract class BaseTestNessieApi {
                 .refName(main.getName())
                 .get())
         .containsKeys(ContentKey.of("a", "a"), ContentKey.of("b", "a"), ContentKey.of("b", "b"));
+  }
+
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void commitParents() throws Exception {
+    Branch main = api().getDefaultBranch();
+
+    Branch initialCommit = prepCommit(main, "common ancestor", dummyPut("initial")).commit();
+    main = prepCommit(main, "common ancestor", dummyPut("test1")).commit();
+
+    assertThat(api().getCommitLog().refName(main.getName()).maxRecords(1).get().getLogEntries())
+        .map(logEntry -> logEntry.getCommitMeta().getParentCommitHashes())
+        .first()
+        .asInstanceOf(list(String.class))
+        .containsExactly(initialCommit.getHash());
+
+    Branch branch = createReference(Branch.of("branch", main.getHash()), main.getName());
+
+    branch = prepCommit(branch, "one", dummyPut("a", "a")).commit();
+    Reference mainParent = api().getReference().refName(main.getName()).get();
+
+    api().mergeRefIntoBranch().fromRef(branch).branch(main).merge();
+
+    assertThat(api().getCommitLog().refName(main.getName()).maxRecords(1).get().getLogEntries())
+        .map(logEntry -> logEntry.getCommitMeta().getParentCommitHashes())
+        .first()
+        .asInstanceOf(list(String.class))
+        .containsExactly(
+            mainParent.getHash(), branch.getHash()); // branch lineage parent, then merge parent
   }
 
   @Test

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -467,7 +467,8 @@ public abstract class BaseTestNessieApi {
     Branch initialCommit = prepCommit(main, "common ancestor", dummyPut("initial")).commit();
     main = prepCommit(main, "common ancestor", dummyPut("test1")).commit();
 
-    assertThat(api().getCommitLog().refName(main.getName()).maxRecords(1).get().getLogEntries())
+    soft.assertThat(
+            api().getCommitLog().refName(main.getName()).maxRecords(1).get().getLogEntries())
         .map(logEntry -> logEntry.getCommitMeta().getParentCommitHashes())
         .first()
         .asInstanceOf(list(String.class))
@@ -480,7 +481,8 @@ public abstract class BaseTestNessieApi {
 
     api().mergeRefIntoBranch().fromRef(branch).branch(main).merge();
 
-    assertThat(api().getCommitLog().refName(main.getName()).maxRecords(1).get().getLogEntries())
+    soft.assertThat(
+            api().getCommitLog().refName(main.getName()).maxRecords(1).get().getLogEntries())
         .map(logEntry -> logEntry.getCommitMeta().getParentCommitHashes())
         .first()
         .asInstanceOf(list(String.class))


### PR DESCRIPTION
This is to make sure backend data (whose validation was added in #6001) is property propagated to the API layer.