### PR TITLE
Ability to configure PVC selector labels

### DIFF
--- a/helm/nessie/templates/storage.yaml
+++ b/helm/nessie/templates/storage.yaml
@@ -13,7 +13,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.rocksdb.storageSize }}
+{{- if .Values.rocksdb.selectorLabels }}
   selector:
     matchLabels:
-      app.projectnessie.org/file-storage-for: {{ include "nessie.fullname" . }}
+      {{- toYaml .Values.rocksdb.selectorLabels | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -17,6 +17,11 @@ rocksdb:
   storageClassName: standard
   storageSize: 1Gi
   dbPath: /rocks-nessie
+  # Labels to add to the PVC spec selector; a PV with matching labels must exist.
+  # Leave empty if using dynamic provisioning.
+  selectorLabels: {}
+    # app.kubernetes.io/name: nessie
+    # app.kubernetes.io/instance: RELEASE-NAME
 
 # this is needed when selecting DYNAMO
 dynamodb:


### PR DESCRIPTION
This commit changes the Helm chart and introduces
the ability to configure selector labels for the
RocksDB PVC that is automatically created when
versionStoreType is ROCKS.