### PR TITLE
Automatically generate Helm chart documentation

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -74,6 +74,8 @@ jobs:
         # Remove the following, once https://github.com/c4urself/bump2version/issues/30 is fixed
         # and the two workarounds below are removed.
         python3 -m pip install -r python/requirements.txt
+    - name: Setup Go
+      uses: actions/setup-go@v3
     ### END runner setup
 
     - name: Bump to release version
@@ -183,6 +185,11 @@ jobs:
         
         cp /tmp/HISTORY.rst python/HISTORY.rst
         rm /tmp/HISTORY.rst
+
+    - name: Update helm/README.md
+      run: |
+        go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+        $(go env GOPATH)/bin/helm-docs --chart-search-root=helm
 
     - name: Configure release-bot-user in git config
       run: |

--- a/helm/nessie/Chart.yaml
+++ b/helm/nessie/Chart.yaml
@@ -18,3 +18,4 @@ maintainers:
   - name: nastra
   - name: snazy
   - name: dimas-b
+  - name: adutra

--- a/helm/nessie/Chart.yaml
+++ b/helm/nessie/Chart.yaml
@@ -15,7 +15,11 @@ keywords:
   - transactional catalog
   - git-like semantics
 maintainers:
-  - name: nastra
-  - name: snazy
-  - name: dimas-b
-  - name: adutra
+  - name: Eduard Tudenhöfner
+    url: https://github.com/nastra
+  - name: Robert Stupp
+    url: https://github.com/snazy
+  - name: Dmitri Bourlatchkov
+    url: https://github.com/dimas-b
+  - name: Alexandre Dutra
+    url: https://github.com/adutra

--- a/helm/nessie/README.md
+++ b/helm/nessie/README.md
@@ -97,7 +97,6 @@ $ helm uninstall --namespace nessie-ns nessie
 | postgres.secret.username | string | `"postgres_username"` | The secret key storing the Postgres username. |
 | replicaCount | int | `1` | The number of replicas to deploy (horizontal scaling). Beware that replicas are stateless; don't set this number > 1 when using ROCKS version store type. |
 | resources | object | `{}` | Configures the resources requests and limits for nessie pods. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'resources:'. |
-| rocksdb.dbPath | string | `"/rocks-nessie"` | The path to the rocksdb database. |
 | rocksdb.selectorLabels | object | `{}` | Labels to add to the persistent volume claim spec selector; a persistent volume with matching labels must exist. Leave empty if using dynamic provisioning. |
 | rocksdb.storageClassName | string | `"standard"` | The storage class name of the persistent volume claim to create. |
 | rocksdb.storageSize | string | `"1Gi"` | The size of the persistent volume claim to create. |

--- a/helm/nessie/README.md
+++ b/helm/nessie/README.md
@@ -112,7 +112,7 @@ $ helm uninstall --namespace nessie-ns nessie
 | serviceMonitor.interval | string | `""` | The scrape interval; leave empty to let Prometheus decide. Must be a valid duration, e.g. 1d, 1h30m, 5m, 10s. |
 | serviceMonitor.labels | object | `{}` | Labels for the created ServiceMonitor so that Prometheus operator can properly pick it up. |
 | tolerations | list | `[]` | A list of tolerations to apply to nessie pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/. |
-| versionStoreAdvancedConfig | object | `{}` | Environment variables for advanced version store configuration. |
+| versionStoreAdvancedConfig | object | `{}` | Advanced version store configuration. The key-value pairs specified here will be passed to the Nessie server as environment variables. See https://projectnessie.org/try/configuration/#version-store-advanced-settings for available properties. Naming convention: to set the property nessie.version.store.advanced.repository-id, use the key: NESSIE_VERSION_STORE_ADVANCED_REPOSITORY_ID. |
 | versionStoreType | string | `"INMEMORY"` | Which type of version store to use: INMEMORY, ROCKS, DYNAMO, MONGO, TRANSACTIONAL. |
 
 ## Using secrets

--- a/helm/nessie/README.md
+++ b/helm/nessie/README.md
@@ -1,74 +1,121 @@
+<!---
+This README.md file was generated with:
+https://github.com/norwoodj/helm-docs
+Do not modify the README.md file directly, please modify README.md.gotmpl instead.
+To re-generate the README.md file, install helm-docs then run from the repo root:
+helm-docs --chart-search-root=helm
+-->
+
 # Nessie Helm chart
 
-## Installation from local directory
-```bash
-$ helm install --namespace nessie-ns nessie helm/nessie
-```
+![Version: 0.48.2](https://img.shields.io/badge/Version-0.48.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-## Installation from Helm repo
+A Helm chart for Nessie.
+
+**Homepage:** <https://projectnessie.org/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| nastra |  |  |
+| snazy |  |  |
+| dimas-b |  |  |
+| adutra |  |  |
+
+## Source Code
+
+* <https://github.com/projectnessie/nessie>
+
+## Installation
+
+### From Helm repo
 ```bash
 $ helm repo add nessie-helm https://charts.projectnessie.org
 $ helm repo update
 $ helm install --namespace nessie-ns nessie nessie-helm/nessie
 ```
 
-## Uninstalling the Chart
+### From local directory (for development purposes)
+
+From Nessie repo root:
+
+```bash
+$ helm install --namespace nessie-ns nessie helm/nessie
+```
+
+### Uninstalling the chart
 
 ```bash
 $ helm uninstall --namespace nessie-ns nessie
 ```
 
-## Configuration
-### Nessie Configuration Parameters
-The following table lists the configurable parameters of the Nessie chart and their default values.
+## Values
 
-| Parameter  | Description | Default |
-| -----------| ----------- | ------- |
-| replicaCount | The number of replicas to run | `1` |
-| image | Nessie Image settings | |
-| image.repository | The nessie image to use | `projectnessie/nessie` |
-| image.pullPolicy | Image pull policy, such as `IfNotPresent` / `Always` / `Never` | `IfNotPresent` |
-| image.tag | Overrides the image tag whose default is the chart version | `version` from `Chart.yaml` |
-| logLevel | The default logging level to be used | `INFO` |
-| versionStoreType | Version store to use: `INMEMORY` / `ROCKS` / `DYNAMO` / `MONGO` / `TRANSACTIONAL` | `INMEMORY` |
-| rocksdb | Configuration specific to `versionStoreType: ROCKS` | |
-| rocks.dbPath | Sets RocksDB storage path | `/tmp/rocks-nessie` |
-| dynamodb | Configuration specific to `versionStoreType: DYNAMO` | |
-| dynamodb.region | The region to configure for Dynamo | `us-west-2` |
-| dynamodb.secret.name | The name of the secret where credentials are stored | `awscreds` |
-| dynamodb.secret.awsAccessKeyId | The AWS access key id in the secret | `aws_access_key_id` |
-| dynamodb.secret.awsSecretAccessKey | The AWS secret access key | `aws_secret_access_key` |
-| mongodb | Configuration specific to `versionStoreType: MONGO` | |
-| mongodb.name | The database name | `nessie` |
-| mongodb.connectionString | The database connection string | `mongodb://localhost:27017` |
-| mongodb.secret.name | The name of the secret where database credentials are stored | `mongodb-creds` |
-| mongodb.secret.username | The name of the username key inside the secret | `mongodb_username` |
-| mongodb.secret.password | The name of the password key inside the secret | `mongodb_password` |
-| postgres | Configuration specific to `versionStoreType: TRANSACTIONAL` | |
-| postgres.jdbcUrl | The database connection URL | `jdbc:postgresql://localhost:5432/my_database` |
-| postgres.secret.name | The name of the secret where database credentials are stored | `postgres-creds` |
-| postgres.secret.username | The name of the username key inside the secret | `postgres_username` |
-| postgres.secret.password | The name of the password key inside the secret | `postgres_password` |
-| versionStoreAdvancedConfig | Key:value pairs of environment variables for advancend version store configuration | |
-| authentication | Authentication settings | |
-| authentication.enabled | Configures whether authentication is enabled | `false` |
-| authentication.oidcAuthServerUrl | Sets the base URL of the OpenID Connect (OIDC) server. Needs to be overridden with `authentication.enabled=true` | `http://127.255.0.0:0/auth/realms/unset/` |
-| authentication.oidcClientId | Set the OIDC client ID when `authentication.enabled=true`. Each application has a client ID that is used to identify the application | `nessie` |
-| authorization | Authorization settings | |
-| authorization.enabled | Configures whether authorization is enabled | `false` |
-| authorization.rules | The authorization rules when `authorization.enabled=true`. Example rules can be found [here](https://projectnessie.org/features/metadata_authorization/#authorization-rules) | |
-| jaegerTracing | Jaeger Tracing configuration | |
-| jaegerTracing.enabled | Determines whether Jaeger Tracing for Nessie is enabled or not via `true` / `false` | `false` |
-| jaegerTracing.endpoint | The traces endpoint, in case the client should connect directly to the Collector, such as `http://jaeger-collector:14268/api/traces` | None |
-| jaegerTracing.serviceName | The Jaeger service name | `nessie` |
-| jaegerTracing.publishMetrics | Determines whether metrics should be published or not via `true` / `false` | `true` |
-| jaegerTracing.samplerType | The sampler type (`const`, `probabilistic`, `ratelimiting` or `remote`) | `ratelimiting` |
-| jaegerTracing.samplerParam | 1=Sample all requests. Set `samplerParam` to somewhere between 0 and 1, e.g. 0.50, if you do not wish to sample all requests | `1` |
-| serviceMonitor | Configuration specific to a `ServiceMonitor` for the Prometheus Operator | |
-| serviceMonitor.enabled | Specifies whether a `ServiceMonitor` for Prometheus operator should be created | `true` |
-| serviceMonitor.interval | Interval at which metrics should be scraped | `30s` |
-| serviceMonitor.labels | Additional labels to add to the created `ServiceMonitor` so that Prometheus can properly pick it up | None |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity and anti-affinity for nessie pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity. |
+| authentication.enabled | bool | `false` | Specifies whether authentication for the nessie server should be enabled. |
+| authentication.oidcAuthServerUrl | string | `"http://127.255.0.0:0/auth/realms/unset/"` | Sets the base URL of the OpenID Connect (OIDC) server. Needs to be overridden with authentication.enabled=true |
+| authentication.oidcClientId | string | `"nessie"` | Set the OIDC client ID when authentication.enabled=true. Each application has a client ID that is used to identify the application |
+| authorization.enabled | bool | `false` | Specifies whether authorization for the nessie server should be enabled. |
+| authorization.rules | object | `{}` | The authorization rules when authorization.enabled=true. Example rules can be found at https://projectnessie.org/features/metadata_authorization/#authorization-rules |
+| autoscaling.enabled | bool | `false` | Specifies whether automatic horizontal scaling should be enabled. Do not enable this when using ROCKS version store type. |
+| autoscaling.maxReplicas | int | `3` | The maximum number of replicas to maintain. |
+| autoscaling.minReplicas | int | `1` | The minimum number of replicas to maintain. |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Optional; set to zero or empty to disable. |
+| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Optional; set to zero or empty to disable. |
+| dynamodb.region | string | `"us-west-2"` | The AWS region to use. |
+| dynamodb.secret.awsAccessKeyId | string | `"aws_access_key_id"` | The secret key storing the AWS secret key id. |
+| dynamodb.secret.awsSecretAccessKey | string | `"aws_secret_access_key"` | The secret key storing the AWS secret access key. |
+| dynamodb.secret.name | string | `"awscreds"` | The secret name to pull AWS credentials from. |
+| image.pullPolicy | string | `"IfNotPresent"` | The image pull policy. |
+| image.repository | string | `"projectnessie/nessie"` | The image repository to pull from. |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart version. |
+| ingress.annotations | object | `{}` | Annotations to add to the ingress. |
+| ingress.enabled | bool | `false` | Specifies whether an ingress should be created. |
+| ingress.hosts | list | `[{"host":"chart-example.local","paths":[]}]` | A list of host paths used to configure the ingress. |
+| ingress.tls | list | `[]` | A list of TLS certificates; each entry has a list of hosts in the certificate, along with the secret name used to terminate TLS traffic on port 443. |
+| jaegerTracing.enabled | bool | `false` | Specifies whether jaeger tracing for the nessie server should be enabled. |
+| jaegerTracing.endpoint | string | `""` | The traces endpoint, in case the client should connect directly to the Collector, e.g. http://jaeger-collector:14268/api/traces |
+| jaegerTracing.publishMetrics | bool | `true` | Whether metrics are published if tracing is enabled. |
+| jaegerTracing.samplerParam | int | `1` | The request sampling probability. 1=Sample all requests. Set samplerParam to somewhere between 0 and 1, e.g. 0.50, if you do not wish to sample all requests. |
+| jaegerTracing.samplerType | string | `"ratelimiting"` | The sampler type (const, probabilistic, ratelimiting or remote). |
+| jaegerTracing.serviceName | string | `"nessie"` | The Jaeger service name. |
+| logLevel | string | `"INFO"` | The default logging level for the nessie server. |
+| mongodb.connectionString | string | `"mongodb://localhost:27017"` | The MongoDB connection string. |
+| mongodb.name | string | `"nessie"` | The MongoDB database name. |
+| mongodb.secret.name | string | `"mongodb-creds"` | The secret name to pull MongoDB credentials from. |
+| mongodb.secret.password | string | `"mongodb_password"` | The secret key storing the MongoDB password. |
+| mongodb.secret.username | string | `"mongodb_username"` | The secret key storing the MongoDB username. |
+| nodeSelector | object | `{}` | Node labels which must match for the nessie pod to be scheduled on that node. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector. |
+| podAnnotations | object | `{}` | Annotations to apply to nessie pods. |
+| podSecurityContext | object | `{}` | Security context for the nessie pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
+| postgres.jdbcUrl | string | `"jdbc:postgresql://localhost:5432/my_database"` | The Postgres JDBC connection string. |
+| postgres.secret.name | string | `"postgres-creds"` | The secret name to pull Postgres credentials from. |
+| postgres.secret.password | string | `"postgres_password"` | The secret key storing the Postgres password. |
+| postgres.secret.username | string | `"postgres_username"` | The secret key storing the Postgres username. |
+| replicaCount | int | `1` | The number of replicas to deploy (horizontal scaling). Beware that replicas are stateless; don't set this number > 1 when using ROCKS version store type. |
+| resources | object | `{}` | Configures the resources requests and limits for nessie pods. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'resources:'. |
+| rocksdb.dbPath | string | `"/rocks-nessie"` | The path to the rocksdb database. |
+| rocksdb.selectorLabels | object | `{}` | Labels to add to the persistent volume claim spec selector; a persistent volume with matching labels must exist. Leave empty if using dynamic provisioning. |
+| rocksdb.storageClassName | string | `"standard"` | The storage class name of the persistent volume claim to create. |
+| rocksdb.storageSize | string | `"1Gi"` | The size of the persistent volume claim to create. |
+| securityContext | object | `{}` | Security context for the nessie container. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
+| service.annotations | object | `{}` | Annotations to add to the service. |
+| service.port | int | `19120` | The port on which the service should listen. |
+| service.type | string | `"ClusterIP"` | The type of service to create. |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
+| serviceMonitor.enabled | bool | `true` | Specifies whether a ServiceMonitor for Prometheus operator should be created. |
+| serviceMonitor.interval | string | `""` | The scrape interval; leave empty to let Prometheus decide. Must be a valid duration, e.g. 1d, 1h30m, 5m, 10s. |
+| serviceMonitor.labels | object | `{}` | Labels for the created ServiceMonitor so that Prometheus operator can properly pick it up. |
+| tolerations | list | `[]` | A list of tolerations to apply to nessie pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/. |
+| versionStoreAdvancedConfig | object | `{}` | Environment variables for advanced version store configuration. |
+| versionStoreType | string | `"INMEMORY"` | Which type of version store to use: INMEMORY, ROCKS, DYNAMO, MONGO, TRANSACTIONAL. |
 
+## Using secrets
 
 ### Providing secrets for Dynamo Version Store
 
@@ -83,7 +130,6 @@ aws_secret_access_key=YOURSECRETKEYDATA
   `kubectl create secret generic awscreds --from-env-file="$PWD/awscreds"`
 
 * Now you can use `DYNAMO` as the version store when installing Nessie via `helm install -n nessie-ns nessie helm/nessie --set versionStoreType=DYNAMO`.
-
 
 ### Providing secrets for MongoDB
 
@@ -100,7 +146,6 @@ mongodb_password=YOUR_PASSWORD
 
 * The `mongodb-creds` secret will now be picked up when you use `MONGO` as the version store when installing Nessie via `helm install -n nessie-ns nessie helm/nessie --set versionStoreType=MONGO`.
 
-
 ### Providing secrets for Transactional Version Store
 
 * Make sure you have a Secret in the following form:
@@ -115,11 +160,10 @@ postgres_password=YOUR_PASSWORD
 
 * Now you can use `TRANSACTIONAL` as the version store when installing Nessie via `helm install -n nessie-ns nessie helm/nessie --set versionStoreType=TRANSACTIONAL`.
 
-
 ## Dev installation
 
 * Install Minikube as described in https://minikube.sigs.k8s.io/docs/start/
-* Install Helm as described in https://helm.sh/docs/intro/install/ 
+* Install Helm as described in https://helm.sh/docs/intro/install/
 * Start Minikube cluster: `minikube start`
 * Create K8s Namespace: `kubectl create namespace nessie-ns`
 * Install Nessie Helm chart: `helm install nessie -n nessie-ns helm/nessie`
@@ -132,7 +176,7 @@ This is broadly following the example from https://kubernetes.io/docs/tasks/acce
 * Enable NGINX Ingress controller: `minikube addons enable ingress`
 * Verify Ingress controller is running: `kubectl get pods -n ingress-nginx`
 * Create K8s Namespace: `kubectl create namespace nessie-ns`
-* Install Nessie Helm chart with Ingress enabled: 
+* Install Nessie Helm chart with Ingress enabled:
   ```bash
   helm install nessie -n nessie-ns helm/nessie \
     --set ingress.enabled=true \

--- a/helm/nessie/README.md
+++ b/helm/nessie/README.md
@@ -18,10 +18,10 @@ A Helm chart for Nessie.
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| nastra |  |  |
-| snazy |  |  |
-| dimas-b |  |  |
-| adutra |  |  |
+| Eduard Tudenhöfner |  | <https://github.com/nastra> |
+| Robert Stupp |  | <https://github.com/snazy> |
+| Dmitri Bourlatchkov |  | <https://github.com/dimas-b> |
+| Alexandre Dutra |  | <https://github.com/adutra> |
 
 ## Source Code
 

--- a/helm/nessie/README.md.gotmpl
+++ b/helm/nessie/README.md.gotmpl
@@ -1,0 +1,133 @@
+<!---
+This README.md file was generated with:
+https://github.com/norwoodj/helm-docs
+Do not modify the README.md file directly, please modify README.md.gotmpl instead.
+To re-generate the README.md file, install helm-docs then run from the repo root:
+helm-docs --chart-search-root=helm
+-->
+
+# Nessie Helm chart
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}.
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installation
+
+### From Helm repo
+```bash
+$ helm repo add nessie-helm https://charts.projectnessie.org
+$ helm repo update
+$ helm install --namespace nessie-ns nessie nessie-helm/nessie
+```
+
+### From local directory (for development purposes)
+
+From Nessie repo root:
+
+```bash
+$ helm install --namespace nessie-ns nessie helm/nessie
+```
+
+### Uninstalling the chart
+
+```bash
+$ helm uninstall --namespace nessie-ns nessie
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Using secrets
+
+### Providing secrets for Dynamo Version Store
+
+* Make sure you have a Secret in the following form:
+```
+> cat $PWD/awscreds
+aws_access_key_id=YOURACCESSKEYDATA
+aws_secret_access_key=YOURSECRETKEYDATA
+```
+
+* Create the secret from the given file
+  `kubectl create secret generic awscreds --from-env-file="$PWD/awscreds"`
+
+* Now you can use `DYNAMO` as the version store when installing Nessie via `helm install -n nessie-ns nessie helm/nessie --set versionStoreType=DYNAMO`.
+
+### Providing secrets for MongoDB
+
+* Providing secrets for MongoDB is strongly recommended, but not enforced.
+* Make sure you have a Secret in the following form:
+```
+> cat $PWD/mongodb-creds
+mongodb_username=YOUR_USERNAME
+mongodb_password=YOUR_PASSWORD
+```
+
+* Create the secret from the given file
+  `kubectl create secret generic mongodb-creds --from-env-file="$PWD/mongodb-creds"`
+
+* The `mongodb-creds` secret will now be picked up when you use `MONGO` as the version store when installing Nessie via `helm install -n nessie-ns nessie helm/nessie --set versionStoreType=MONGO`.
+
+### Providing secrets for Transactional Version Store
+
+* Make sure you have a Secret in the following form:
+```
+> cat $PWD/postgres-creds
+postgres_username=YOUR_USERNAME
+postgres_password=YOUR_PASSWORD
+```
+
+* Create the secret from the given file
+  `kubectl create secret generic postgres-creds --from-env-file="$PWD/postgres-creds"`
+
+* Now you can use `TRANSACTIONAL` as the version store when installing Nessie via `helm install -n nessie-ns nessie helm/nessie --set versionStoreType=TRANSACTIONAL`.
+
+## Dev installation
+
+* Install Minikube as described in https://minikube.sigs.k8s.io/docs/start/
+* Install Helm as described in https://helm.sh/docs/intro/install/
+* Start Minikube cluster: `minikube start`
+* Create K8s Namespace: `kubectl create namespace nessie-ns`
+* Install Nessie Helm chart: `helm install nessie -n nessie-ns helm/nessie`
+
+### Ingress with Minikube
+
+This is broadly following the example from https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/
+
+* Start Minikube cluster: `minikube start`
+* Enable NGINX Ingress controller: `minikube addons enable ingress`
+* Verify Ingress controller is running: `kubectl get pods -n ingress-nginx`
+* Create K8s Namespace: `kubectl create namespace nessie-ns`
+* Install Nessie Helm chart with Ingress enabled:
+  ```bash
+  helm install nessie -n nessie-ns helm/nessie \
+    --set ingress.enabled=true \
+    --set ingress.hosts[0].host='chart-example.local' \
+    --set ingress.hosts[0].paths[0]='/'
+  ```
+
+* Verify that the IP address is set:
+  ```bash
+  kubectl get ingress -n nessie-ns
+  NAME     CLASS   HOSTS   ADDRESS        PORTS   AGE
+  nessie   nginx   *       192.168.49.2   80      4m35s
+  ```
+* Use the IP from the above output and add it to `/etc/hosts` via `echo "192.168.49.2 chart-example.local" | sudo tee /etc/hosts`
+* Verify that `curl chart-example.local` works
+
+### Stop/Uninstall everything in Dev
+
+```sh
+helm uninstall --namespace nessie-ns nessie
+minikube delete
+```

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -1,112 +1,141 @@
+# -- The number of replicas to deploy (horizontal scaling).
+# Beware that replicas are stateless; don't set this number > 1 when using ROCKS version store type.
 replicaCount: 1
 
 image:
+  # -- The image repository to pull from.
   repository: projectnessie/nessie
+  # -- The image pull policy.
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart version.
+  # -- Overrides the image tag whose default is the chart version.
   tag: ""
 
-# The default logging level for the nessie server
+# -- The default logging level for the nessie server.
 logLevel: INFO
 
-# which type of version store to use: INMEMORY, ROCKS, DYNAMO, MONGO, TRANSACTIONAL
+# -- Which type of version store to use: INMEMORY, ROCKS, DYNAMO, MONGO, TRANSACTIONAL.
 versionStoreType: INMEMORY
 
-# this is needed when selecting ROCKS
+# RocksDB settings. Only required when using ROCKS version store type; ignored otherwise.
 rocksdb:
+  # -- The storage class name of the persistent volume claim to create.
   storageClassName: standard
+  # -- The size of the persistent volume claim to create.
   storageSize: 1Gi
+  # -- The path to the rocksdb database.
   dbPath: /rocks-nessie
-  # Labels to add to the PVC spec selector; a PV with matching labels must exist.
+  # -- Labels to add to the persistent volume claim spec selector; a persistent volume with matching labels must exist.
   # Leave empty if using dynamic provisioning.
-  selectorLabels: {}
+  selectorLabels:
+    {}
     # app.kubernetes.io/name: nessie
     # app.kubernetes.io/instance: RELEASE-NAME
 
-# this is needed when selecting DYNAMO
+# DynamoDB settings. Only required when using DYNAMO version store type; ignored otherwise.
 dynamodb:
+  # -- The AWS region to use.
   region: us-west-2
   secret:
+    # -- The secret name to pull AWS credentials from.
     name: awscreds
+    # -- The secret key storing the AWS secret key id.
     awsAccessKeyId: aws_access_key_id
+    # -- The secret key storing the AWS secret access key.
     awsSecretAccessKey: aws_secret_access_key
 
-# this is needed when selecting MONGO
+## Mongo DB settings. Only required when using MONGO version store type; ignored otherwise.
 mongodb:
+  # -- The MongoDB database name.
   name: nessie
+  # -- The MongoDB connection string.
   connectionString: mongodb://localhost:27017
   secret:
+    # -- The secret name to pull MongoDB credentials from.
     name: mongodb-creds
+    # -- The secret key storing the MongoDB username.
     username: mongodb_username
+    # -- The secret key storing the MongoDB password.
     password: mongodb_password
 
-# this is needed when selecting TRANSACTIONAL
+# Postgres settings. Only required when using TRANSACTIONAL version store type; ignored otherwise.
 postgres:
+  # -- The Postgres JDBC connection string.
   jdbcUrl: jdbc:postgresql://localhost:5432/my_database
   secret:
+    # -- The secret name to pull Postgres credentials from.
     name: postgres-creds
+    # -- The secret key storing the Postgres username.
     username: postgres_username
+    # -- The secret key storing the Postgres password.
     password: postgres_password
 
-# environment variables for advanced version store configuration
-# versionStoreAdvancedConfig:
-#   - key: QUARKUS_DATASOURCE_JDBC_POOLING_ENABLED
-#     value: true
+# -- Environment variables for advanced version store configuration.
+versionStoreAdvancedConfig:
+  {}
+  # - key: QUARKUS_DATASOURCE_JDBC_POOLING_ENABLED
+  #   value: true
 
-# configures authentication for the nessie server
 authentication:
+  # -- Specifies whether authentication for the nessie server should be enabled.
   enabled: false
-  # Sets the base URL of the OpenID Connect (OIDC) server. Needs to be overridden with authentication.enabled=true
+  # -- Sets the base URL of the OpenID Connect (OIDC) server. Needs to be overridden with authentication.enabled=true
   oidcAuthServerUrl: http://127.255.0.0:0/auth/realms/unset/
-  # Set the OIDC client ID when authentication.enabled=true. Each application has a client ID that is used to identify the application
+  # -- Set the OIDC client ID when authentication.enabled=true. Each application has a client ID that is used to identify the application
   oidcClientId: nessie
 
-# configures authorization for the nessie server
 authorization:
+  # -- Specifies whether authorization for the nessie server should be enabled.
   enabled: false
-  # the authorization rules when authorization.enabled=true. Example rules can be found at https://projectnessie.org/features/metadata_authorization/#authorization-rules
-  # rules:
-  #  allowViewingBranch: op=='VIEW_REFERENCE' && role.startsWith('test_user') && ref.startsWith('allowedBranch')
-  #  allowCommits: op=='COMMIT_CHANGE_AGAINST_REFERENCE' && role.startsWith('test_user') && ref.startsWith('allowedBranch')
+  # -- The authorization rules when authorization.enabled=true. Example rules can be found at https://projectnessie.org/features/metadata_authorization/#authorization-rules
+  rules:
+    {}
+    # allowViewingBranch: op=='VIEW_REFERENCE' && role.startsWith('test_user') && ref.startsWith('allowedBranch')
+    # allowCommits: op=='COMMIT_CHANGE_AGAINST_REFERENCE' && role.startsWith('test_user') && ref.startsWith('allowedBranch')
 
-# configure jaeger tracing for the nessie server
 jaegerTracing:
+  # -- Specifies whether jaeger tracing for the nessie server should be enabled.
   enabled: false
-  # The traces endpoint, in case the client should connect directly to the Collector, like http://jaeger-collector:14268/api/traces
-  # endpoint: http://localhost:14268/api/traces
-  # the Jaeger service name
+  # -- The traces endpoint, in case the client should connect directly to the Collector, e.g. http://jaeger-collector:14268/api/traces
+  endpoint: ""
+  # -- The Jaeger service name.
   serviceName: nessie
-  # whether or not metrics are published if tracing is enabled
+  # -- Whether metrics are published if tracing is enabled.
   publishMetrics: true
-  # the sampler type (const, probabilistic, ratelimiting or remote)
+  # -- The sampler type (const, probabilistic, ratelimiting or remote).
   samplerType: ratelimiting
-  # 1=Sample all requests. Set samplerParam to somewhere between 0 and 1, e.g. 0.50, if you do not wish to sample all requests
+  # -- The request sampling probability. 1=Sample all requests. Set samplerParam to somewhere between 0 and 1, e.g. 0.50, if you do not wish to sample all requests.
   samplerParam: 1
 
 serviceMonitor:
-  # Specifies whether ServiceMonitor for Prometheus operator should be created
+  # -- Specifies whether a ServiceMonitor for Prometheus operator should be created.
   enabled: true
-    # interval: 30s
-  # labels for the created ServiceMonitor so that Prometheus operator can properly pick it up
-  # labels:
+  # -- The scrape interval; leave empty to let Prometheus decide. Must be a valid duration, e.g. 1d, 1h30m, 5m, 10s.
+  interval: ""
+  # -- Labels for the created ServiceMonitor so that Prometheus operator can properly pick it up.
+  labels:
+    {}
     # release: prometheus
 
-
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created.
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account.
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
   name: ""
 
+# -- Annotations to apply to nessie pods.
 podAnnotations: {}
 
-podSecurityContext: {}
+# -- Security context for the nessie pod. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+# -- Security context for the nessie container. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -114,25 +143,39 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# Nessie service settings.
 service:
+  # -- The type of service to create.
   type: ClusterIP
+  # -- The port on which the service should listen.
   port: 19120
-  # Annotations to add to the service
+  # -- Annotations to add to the service.
   annotations: {}
 
 ingress:
+  # -- Specifies whether an ingress should be created.
   enabled: false
+  # -- Annotations to add to the ingress.
   annotations: {}
+  # -- A list of host paths used to configure the ingress.
   hosts:
     - host: chart-example.local
       paths: []
+  # -- A list of TLS certificates; each entry has a list of hosts in the certificate,
+  # along with the secret name used to terminate TLS traffic on port 443.
   tls: []
+#    - hosts:
+#        - chart-example1.local
+#        - chart-example2.local
+#      secretName: secret1
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# -- Configures the resources requests and limits for nessie pods.
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -141,14 +184,39 @@ resources: {}
   #   memory: 128Mi
 
 autoscaling:
+  # -- Specifies whether automatic horizontal scaling should be enabled.
+  # Do not enable this when using ROCKS version store type.
   enabled: false
+  # -- The minimum number of replicas to maintain.
   minReplicas: 1
+  # -- The maximum number of replicas to maintain.
   maxReplicas: 3
+  # -- Optional; set to zero or empty to disable.
   targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
+  # -- Optional; set to zero or empty to disable.
+  targetMemoryUtilizationPercentage:
 
-nodeSelector: {}
+# -- Node labels which must match for the nessie pod to be scheduled on that node. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+nodeSelector:
+  {}
+  # kubernetes.io/os: linux
 
+# -- A list of tolerations to apply to nessie pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.
 tolerations: []
+#  - key: "node-role.kubernetes.io/control-plane"
+#    operator: "Exists"
+#    effect: "NoSchedule"
 
+# -- Affinity and anti-affinity for nessie pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.
 affinity: {}
+#  podAffinity:
+#    preferredDuringSchedulingIgnoredDuringExecution:
+#      - weight: 100
+#        podAffinityTerm:
+#          topologyKey: kubernetes.io/hostname
+#          labelSelector:
+#            matchExpressions:
+#              - key: app.kubernetes.io/name
+#                operator: In
+#                values:
+#                  - nessie

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -22,7 +22,8 @@ rocksdb:
   storageClassName: standard
   # -- The size of the persistent volume claim to create.
   storageSize: 1Gi
-  # -- The path to the rocksdb database.
+  # Deprecated value; it will be removed in a future release.
+  # @ignore
   dbPath: /rocks-nessie
   # -- Labels to add to the persistent volume claim spec selector; a persistent volume with matching labels must exist.
   # Leave empty if using dynamic provisioning.

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -69,11 +69,15 @@ postgres:
     # -- The secret key storing the Postgres password.
     password: postgres_password
 
-# -- Environment variables for advanced version store configuration.
+# -- Advanced version store configuration.
+# The key-value pairs specified here will be passed to the Nessie server as environment variables.
+# See https://projectnessie.org/try/configuration/#version-store-advanced-settings for available properties.
+# Naming convention: to set the property nessie.version.store.advanced.repository-id,
+# use the key: NESSIE_VERSION_STORE_ADVANCED_REPOSITORY_ID.
 versionStoreAdvancedConfig:
   {}
-  # - key: QUARKUS_DATASOURCE_JDBC_POOLING_ENABLED
-  #   value: true
+  # - key: NESSIE_VERSION_STORE_ADVANCED_REPOSITORY_ID
+  #   value: my-tenant
 
 authentication:
   # -- Specifies whether authentication for the nessie server should be enabled.


### PR DESCRIPTION
This commit introduces the usage of
https://github.com/norwoodj/helm-docs
to generate documentation for the Nessie
Helm chart.

It also modifies the release workflow
so that it executes helm-docs on the updated
chart.