### PR TITLE
Add support to native arm64 build

### DIFF
--- a/buildSrc/src/main/kotlin/Utilities.kt
+++ b/buildSrc/src/main/kotlin/Utilities.kt
@@ -280,3 +280,8 @@ class SparkScalaVersions(
   val sparkVersion: String,
   val scalaVersion: String
 ) {}
+
+enum class Arch(val value: String) {
+  AMD64("amd64"),
+  ARM64("arm64")
+}

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -115,13 +115,14 @@ val pullOpenApiSpec by
 
 val openApiSpecDir = buildDir.resolve("openapi-extra")
 val useDocker = project.hasProperty("docker")
-val arch = if (project.hasProperty("arm64")) {
-  Arch.ARM64
-} else if (project.hasProperty("amd64")) {
-  Arch.AMD64
-} else {
-  Arch.AMD64
-}
+val arch =
+  if (project.hasProperty("arm64")) {
+    Arch.ARM64
+  } else if (project.hasProperty("amd64")) {
+    Arch.AMD64
+  } else {
+    Arch.AMD64
+  }
 val packageType = quarkusPackageType()
 val quarkusBuilderImage = libs.versions.quarkusBuilderImage.get()
 

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -115,6 +115,13 @@ val pullOpenApiSpec by
 
 val openApiSpecDir = buildDir.resolve("openapi-extra")
 val useDocker = project.hasProperty("docker")
+val arch = if (project.hasProperty("arm64")) {
+  Arch.ARM64
+} else if (project.hasProperty("amd64")) {
+  Arch.AMD64
+} else {
+  Arch.AMD64
+}
 val packageType = quarkusPackageType()
 val quarkusBuilderImage = libs.versions.quarkusBuilderImage.get()
 
@@ -122,6 +129,7 @@ quarkus {
   quarkusBuildProperties.put("quarkus.package.type", packageType)
   quarkusBuildProperties.put("quarkus.native.builder-image", quarkusBuilderImage)
   if (useDocker) {
+    quarkusBuildProperties.put("quarkus.jib.platforms", "linux/${arch.value}")
     quarkusBuildProperties.put("quarkus.native.container-build", "true")
     quarkusBuildProperties.put("quarkus.container-image.build", "true")
   }


### PR DESCRIPTION
PR for #6094.
I did not add any workflow change because I wasn't sure.
The arm64 build worked locally without any problem running:

`./gradlew nessie-quarkus:quarkusBuild -Pnative -Pdocker -Parm64`

Standard amd64 build works when passing -Pamd64 or even when neither `arm64` and `amd64` are defined.