### PR TITLE
Fail test discovery in MultiEnvTestEngine if no environments are defined

### DIFF
--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -47,13 +47,16 @@ class TestNessieCompatibilityExtensions {
 
   @Test
   void noVersions() {
-    soft.assertThat(
-            EngineTestKit.engine(MultiEnvTestEngine.ENGINE_ID)
-                .selectors(selectClass(OldClientsSample.class))
-                .execute()
-                .testEvents()
-                .list())
-        .isEmpty();
+    soft.assertThatThrownBy(
+            () ->
+                EngineTestKit.engine(MultiEnvTestEngine.ENGINE_ID)
+                    .selectors(selectClass(OldClientsSample.class))
+                    .execute())
+        .hasMessageContaining("TestEngine with ID 'nessie-multi-env' failed to discover tests")
+        .cause()
+        .hasMessageContaining(
+            "MultiEnvTestEngine was enabled, but test extensions did not discover any environment IDs")
+        .hasMessageContaining("OlderNessieClientsExtension");
   }
 
   @Test


### PR DESCRIPTION
This is to prevent silently ignoring tests in case of configuration mistakes like forgetting to set the `nessie.versions` system property or a `META-INF/nessie-compatibility.properties` file.

The default is to fail during test discovery. The failure can be suppressed, when necessary, by setting the java system property `org.projectnessie.junit.engine.ignore-empty-environments` to "true".