### PR TITLE
Update GH WFs to publish Java images for many platforms

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,10 @@
       matchManagers: ["pip_requirements", "pip_setup"],
       "labels": ["dependencies", "python"],
     },
+    {
+      matchManagers: ["docker"],
+      "labels": ["dependencies", "docker"],
+    },
 
     // Check for updates, merge automatically
     {
@@ -58,7 +62,14 @@
         "org.glassfish.jersey:jersey-bom",
       ],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-    }
+    },
+
+    // Docker
+    {
+      matchManagers: ["docker"],
+      automerge: false,
+      platformAutomerge: false
+    },
   ],
 
   // Max 50 PRs in total, 10 per hour

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -118,22 +118,31 @@ jobs:
         MAVEN_USERNAME: ${{ secrets.OSSRH_ACCESS_ID }}
         MAVEN_OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        ARTIFACTS: ../build-artifacts
       run: |
+        rm -rf "${ARTIFACTS}"
+        mkdir -p "${ARTIFACTS}"
+        
         echo "::group::Publish to Sonatype"
         ./gradlew --no-watch-fs --no-daemon publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar
+        mv servers/quarkus-server/build/nessie-quarkus-${RELEASE_VERSION}-runner.jar "${ARTIFACTS}"
+        mv servers/quarkus-cli/build/nessie-quarkus-cli-${RELEASE_VERSION}-runner.jar "${ARTIFACTS}"
         echo "::endgroup::"
 
-        # Build the native-image, it's not released to Maven Central
-        echo "::group::Build native image"
-        ./gradlew --no-watch-fs --no-daemon :nessie-quarkus:quarkusBuild -Prelease -Pnative -Pdocker
-        echo "::endgroup::"
+        echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
+        tools/dockerbuild/build-push-images.sh \
+          -a "${ARTIFACTS}" \
+          -g ":nessie-quarkus" \
+          -p "servers/quarkus-server" \
+          -n \
+          projectnessie/nessie
 
         # Add version to the openapi file name
         cp model/build/generated/openapi/META-INF/openapi/openapi.yaml model/build/nessie-openapi-${RELEASE_VERSION}.yaml
 
-        echo "QUARKUS_NATIVE_BINARY=servers/quarkus-server/build/nessie-quarkus-${RELEASE_VERSION}-runner" >> ${GITHUB_ENV}
-        echo "QUARKUS_UBER_JAR=servers/quarkus-server/build/nessie-quarkus-${RELEASE_VERSION}-runner.jar" >> ${GITHUB_ENV}
-        echo "CLI_UBER_JAR=servers/quarkus-cli/build/nessie-quarkus-cli-${RELEASE_VERSION}-runner.jar" >> ${GITHUB_ENV}
+        echo "QUARKUS_UBER_JAR=${ARTIFACTS}/nessie-quarkus-${RELEASE_VERSION}-runner.jar" >> ${GITHUB_ENV}
+        echo "CLI_UBER_JAR=${ARTIFACTS}/nessie-quarkus-cli-${RELEASE_VERSION}-runner.jar" >> ${GITHUB_ENV}
+        echo "QUARKUS_NATIVE_BINARY=${ARTIFACTS}/nessie-quarkus-${RELEASE_VERSION}-runner" >> ${GITHUB_ENV}
         echo "GC_EXEC=gc/gc-shell/build/executable/nessie-gc" >> ${GITHUB_ENV}
         echo "NESSIE_OPENAPI=model/build/nessie-openapi-${RELEASE_VERSION}.yaml" >> ${GITHUB_ENV}
 
@@ -177,26 +186,6 @@ jobs:
     - name: pynessie info
       run: echo "## Successfully published pynessie ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
 
-    # Deploys Docker images. Build and test steps were already ran in previous workflows
-    - name: Publish Docker image for release
-      run: |
-        echo "## Docker publish ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
-
-        echo "::group::Tag Docker image"
-        docker tag projectnessie/nessie:${RELEASE_VERSION} projectnessie/nessie:latest
-        echo "Successfully tagged Docker image as \`projectnessie/nessie:${RELEASE_VERSION}\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "::endgroup::"
-
-        echo "::group::Docker Hub login"
-        echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
-        echo "::endgroup::"
-
-        echo "::group::Push Docker image"
-        docker push projectnessie/nessie:${RELEASE_VERSION} && docker push projectnessie/nessie:latest
-        echo "::endgroup::"
-        echo "Successfully pushed Docker image for ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
-
     # Prepare Nessie release notes for GitHub
     #
     # The markdown file for the release is generated using some mostly simple shell script.
@@ -229,7 +218,10 @@ jobs:
 
         * ${NUM_COMMITS} commits since ${LAST_TAG#nessie-}
         * Maven Central: https://search.maven.org/search?q=g:org.projectnessie+v:${RELEASE_VERSION}
-        * Docker Hub: https://hub.docker.com/r/projectnessie/nessie \`docker pull projectnessie/nessie:${RELEASE_VERSION}\`
+        * Docker Hub: https://hub.docker.com/r/projectnessie/nessie
+          * Multiplatform Java image (amd64, arm64, ppc64le, s390x): `projectnessie/nessie:${RELEASE_VERSION}-java\`
+          * Image with native amd64 binary: `projectnessie/nessie:${RELEASE_VERSION}-native\`
+            (only recommended for short running Nessie instances, amd64 only)
         * PyPI: https://pypi.org/project/pynessie/${RELEASE_VERSION}/
         * Helm Chart repo: https://charts.projectnessie.org/
 

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -38,22 +38,18 @@ jobs:
             publishToSonatype closeAndReleaseSonatypeStagingRepository
             -Prelease -Puber-jar
 
-      - name: Gradle / build Docker container
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: |
-            --no-daemon
-            :nessie-quarkus:quarkusBuild
-            -Pnative
-            -Pdocker
-
-      - name: Push Docker images
+      - name: Docker images publishing
         env:
-          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+          ARTIFACTS: ../build-artifacts
         run: |
+          rm -rf "${ARTIFACTS}"
+          mkdir -p "${ARTIFACTS}"
+
           echo '${{ secrets.DOCKER_TOKEN }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
-          docker images --filter 'reference=projectnessie/nessie' --format '{{.ID}}\t{{.Tag}}' |
-          while read IMAGE_ID IMAGE_TAG; do
-            docker tag "$IMAGE_ID" "projectnessie/nessie-unstable:${IMAGE_TAG%-snapshot}"
-            docker push "projectnessie/nessie-unstable:${IMAGE_TAG%-snapshot}"
-          done
+          tools/dockerbuild/build-push-images.sh \
+            -a "${ARTIFACTS}" \
+            -g ":nessie-quarkus" \
+            -p "servers/quarkus-server" \
+            -n \
+            projectnessie/nessie-unstable
+          rm -rf "${ARTIFACTS}"

--- a/servers/lambda/build.gradle.kts
+++ b/servers/lambda/build.gradle.kts
@@ -54,19 +54,7 @@ dependencies {
 
 buildForJava11()
 
-val useDocker = project.hasProperty("docker")
 val useNative = project.hasProperty("native")
-var jibPlatforms: String = System.getProperty("quarkus.jib.platforms", "linux/amd64")
-
-if (useNative && jibPlatforms.contains(',')) {
-  val single = jibPlatforms.substring(0, jibPlatforms.indexOf(','))
-  logger.warn(
-    "ONLY building for plaform '{}' instead of '{}', because native image build is enabled.",
-    single,
-    jibPlatforms
-  )
-  jibPlatforms = single
-}
 
 quarkus {
   quarkusBuildProperties.put("quarkus.package.type", quarkusPackageType())
@@ -75,12 +63,6 @@ quarkus {
     libs.versions.quarkusNativeBuilderImage.get()
   )
   quarkusBuildProperties.put("quarkus.native.container-build", useNative.toString())
-  quarkusBuildProperties.put("quarkus.container-image.build", useDocker.toString())
-  quarkusBuildProperties.put(
-    "quarkus.jib.base-jvm-image",
-    libs.versions.quarkusJibBaseJvmImage.get()
-  )
-  quarkusBuildProperties.put("quarkus.jib.platforms", jibPlatforms)
 }
 
 val quarkusBuild by
@@ -98,7 +80,6 @@ tasks.withType<Test>().configureEach {
   systemProperty("quarkus.log.console.level", testLogLevel())
   systemProperty("http.access.log.level", testLogLevel())
   systemProperty("native.image.path", quarkusBuild.nativeRunner)
-  systemProperty("quarkus.container-image.build", useDocker)
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
 
   val testHeapSize: String? by project

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
   implementation("io.quarkus:quarkus-micrometer")
   implementation("io.quarkus:quarkus-core-deployment")
   implementation(libs.quarkus.opentelemetry)
-  implementation("io.quarkus:quarkus-container-image-jib")
   implementation(libs.quarkus.logging.sentry)
   implementation("io.smallrye:smallrye-open-api-jaxrs")
   implementation("io.micrometer:micrometer-registry-prometheus")
@@ -114,19 +113,7 @@ val pullOpenApiSpec by
   }
 
 val openApiSpecDir = buildDir.resolve("openapi-extra")
-val useDocker = project.hasProperty("docker")
 val useNative = project.hasProperty("native")
-var jibPlatforms: String = System.getProperty("quarkus.jib.platforms", "linux/amd64")
-
-if (useNative && jibPlatforms.contains(',')) {
-  val single = jibPlatforms.substring(0, jibPlatforms.indexOf(','))
-  logger.warn(
-    "ONLY building for plaform '{}' instead of '{}', because native image build is enabled.",
-    single,
-    jibPlatforms
-  )
-  jibPlatforms = single
-}
 
 quarkus {
   quarkusBuildProperties.put("quarkus.package.type", quarkusPackageType())
@@ -134,14 +121,6 @@ quarkus {
     "quarkus.native.builder-image",
     libs.versions.quarkusNativeBuilderImage.get()
   )
-  quarkusBuildProperties.put("quarkus.native.container-build", useNative.toString())
-  quarkusBuildProperties.put("quarkus.container-image.build", useDocker.toString())
-  quarkusBuildProperties.put("quarkus.container-image.builder", "jib")
-  quarkusBuildProperties.put(
-    "quarkus.jib.base-jvm-image",
-    libs.versions.quarkusJibBaseJvmImage.get()
-  )
-  quarkusBuildProperties.put("quarkus.jib.platforms", jibPlatforms)
   quarkusBuildProperties.put(
     "quarkus.smallrye-openapi.store-schema-directory",
     buildDir.resolve("openapi").toString()
@@ -202,7 +181,6 @@ tasks.withType<Test>().configureEach {
   if (project.hasProperty("native")) {
     systemProperty("native.image.path", quarkusBuild.get().nativeRunner)
   }
-  systemProperty("quarkus.container-image.build", useDocker)
   systemProperty("quarkus.smallrye.jwt.enabled", "true")
   systemProperty(
     "it.nessie.container.postgres.tag",

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -163,11 +163,6 @@ quarkus.native.additional-build-args=\
   -J-Dfile.encoding=UTF-8,\
   --enable-monitoring
 
-## quarkus container specific settings
-# fixed at buildtime
-quarkus.container-image.group=projectnessie
-quarkus.container-image.name=nessie
-
 # Metrics collection settings
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -1,14 +1,14 @@
 # Configuration
 
-The Nessie server is configurable via properties as listed in the [application.properties](https://github.com/projectnessie/nessie/blob/main/servers/quarkus-server/src/main/resources/application.properties) file.
-These properties can be set when starting up the docker image by adding them to the Docker invocation prefixed with `-D`.  For example, if you want to 
-set Nessie to use the INMEMORY version store running on port 8080, you would run the 
-following:
+The Nessie server is configurable via properties as listed in
+the [application.properties](https://github.com/projectnessie/nessie/blob/main/servers/quarkus-server/src/main/resources/application.properties)
+file. These properties can be set when starting up the docker image by adding them via the
+`JAVA_OPTS_APPEND` options to the Docker invocation prefixed with `-D`. For example, if you want to
+set Nessie to use the INMEMORY version store running on port 8080, you would run the following. For
+more information, see [Docker image options](#docker-image-options) below.
 
 ```bash
-docker run -p 8080:8080 projectnessie/nessie \
-  -Dnessie.version.store.type=INMEMORY \
-  -Dquarkus.http.port=8080
+docker run -p 8080:19120 -e JAVA_OPTS_APPEND="-Dnessie.version.store.type=INMEMORY" projectnessie/nessie
 ```
 
 ## Core Nessie Configuration Settings
@@ -132,3 +132,65 @@ Metrics are published using prometheus and can be collected via standard methods
 ### Swagger UI
 The Swagger UI allows for testing the REST API and reading the API docs. It is available 
 via [localhost:19120/q/swagger-ui](http://localhost:19120/q/swagger-ui/)
+
+# Docker image options
+
+Nessie (Quarkus) opens a HTTP server on port 19120 by default. To expose the HTTP port on 8080
+instead of 19120, use the following command.
+
+```bash
+docker run -p 8080:19120 \
+  -e JAVA_OPTS_APPEND="-Dnessie.version.store.type=INMEMORY" \
+  projectnessie/nessie
+```
+
+Java VM options are passed via the `JAVA_OPTS_APPEND` environment variable.
+
+Quarkus specific settings are passed using the standard Java `-D` option to set system properties.
+
+## Nessie Docker image types
+
+Nessie publishes a Java based multiplatform (for amd64, arm64, ppc64le, s390x) image running on
+OpenJDK 17 and a native binary image (amd64 only). The native binary image should only be used when
+the Nessie server is run for a very short time, when the longer startup time of a Java application
+is a real issue (Lambda-ish architectures with nearly no keep-alive time). Otherwise, always prefer
+the Java images.
+
+## Advanced Docker image tuning (Java images only)
+
+There are a bunch of environment variables to configure the Docker image. If in doubt, leave
+everything at its default. You can configure the behavior using the following environment
+properties. These settings come from the base image
+[ubi8/openjdk-17](https://catalog.redhat.com/software/containers/ubi8/openjdk-17/618bdbf34ae3739687568813).
+
+### Examples
+
+| Example                                    | `docker run` option                                                                                                |
+|--------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| Using another GC                           | `-e GC_CONTAINER_OPTIONS="-XX:+UseShenandoahGC"` lets Nessie use Shenandoah GC instead of the default parallel GC. |
+| Set the Java heap size to a _fixed_ amount | `-e JAVA_OPTS_APPEND="-Xms8g -Xmx8g"` lets Nessie use a Java heap of 8g.                                           | 
+
+### Reference
+
+| Environment variable             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `JAVA_OPTS`                      | JVM options passed to the `java` command (example: "-verbose:class")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `JAVA_OPTS_APPEND`               | User specified Java options to be appended to generated options in JAVA_OPTS (example: "-Dsome.property=foo")                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `JAVA_MAX_MEM_RATIO`             | Is used when no `-Xmx` option is given in JAVA_OPTS. This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option is added. |
+| `JAVA_INITIAL_MEM_RATIO`         | Is used when no `-Xms` option is given in JAVA_OPTS. This is used to calculate a default initial heap memory based on the maximum heap memory. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xms` is set to a ratio of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx` is used as the initial heap size. You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added (example: "25")      |
+| `JAVA_MAX_INITIAL_MEM`           | Is used when no `-Xms` option is given in JAVA_OPTS. This is used to calculate the maximum value of the initial heap memory. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xms` is limited to the value set here. The default is 4096MB which means the calculated value of `-Xms` never will be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")                                                                           |
+| `JAVA_DIAGNOSTICS`               | Set this to get some diagnostics information to standard output when things are happening. This option, if set to true, will set `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").                                                                                                                                                                                                                                                                                                                                                        |
+| `JAVA_DEBUG`                     | If set remote debugging will be switched on. Disabled by default (example: true").                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `JAVA_DEBUG_PORT`                | Port used for remote debugging. Defaults to 5005 (example: "8787").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `CONTAINER_CORE_LIMIT`           | A calculated core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `CONTAINER_MAX_MEMORY`           | Memory limit given to the container (example: "1024").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `GC_MIN_HEAP_FREE_RATIO`         | Minimum percentage of heap free after GC to avoid expansion.(example: "20")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `GC_MAX_HEAP_FREE_RATIO`         | Maximum percentage of heap free after GC to avoid shrinking.(example: "40")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `GC_TIME_RATIO`                  | Specifies the ratio of the time spent outside the garbage collection.(example: "4")                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `GC_ADAPTIVE_SIZE_POLICY_WEIGHT` | The weighting given to the current GC time versus previous GC times. (example: "90")                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `GC_METASPACE_SIZE`              | The initial metaspace size. (example: "20")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `GC_MAX_METASPACE_SIZE`          | The maximum metaspace size. (example: "100")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `GC_CONTAINER_OPTIONS`           | Specify Java GC to use. The value of this variable should contain the necessary JRE command-line options to specify the required GC, which will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).                                                                                                                                                                                                                                                                                                                                            |
+| `HTTPS_PROXY`                    | The location of the https proxy. (example: "myuser@127.0.0.1:8080")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `HTTP_PROXY`                     | The location of the http proxy. (example: "myuser@127.0.0.1:8080")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `NO_PROXY`                       | A comma separated lists of hosts, IP addresses or domains that can be accessed directly. (example: "foo.example.com,bar.example.com")                                                                                                                                                                                                                                                                                                                                                                                                                            |

--- a/tools/dockerbuild/README.md
+++ b/tools/dockerbuild/README.md
@@ -1,0 +1,43 @@
+# Multiplatform Docker build support scripts
+
+The `build-push-images.sh` script is meant to build Java and optionally native images. Usage is not
+restricted to (or specialized for) `:nessie-quarkus`, but can be used with basically any Quarkus
+application.
+
+Minimal options (use `./build-push-images.sh -h` for an up-to-date listing) are:
+
+* `-g <gradle-project-name>` in the `:my-project-name` syntax
+* `-p <gradle-project-directory>` like `servers/quarkus-server`
+* the image name as an argument, for example `projectnessie/nessie`
+
+The image name also defines where the built images are pushed to. By (Docker) default, it's Docker
+Hub.
+
+## Push to a local Docker registry (`localhost:5000`)
+
+To push to a locally running Docker registry, prefix the image name with `localhost:5000/`. For
+example (see local Docker registry notes below):
+
+```bash
+tools/dockerbuild/build-push-images.sh \
+  -g :nessie-quarkus \
+  -p servers/quarkus-server \
+  -n \
+  localhost:5000/projectnessie/nessie-local
+```
+
+Hint: The images are pushed to the local registry, those will **not** show up in `docker images`.
+
+## Updating your local Docker registry
+
+There's a `docker-regsitry` Debian/Ubuntu package. The registry configuration might need some tweaks
+like this. You can also use
+the [official Docker registry](https://docs.docker.com/registry/deploying/).
+
+* `http.addr` may default to `::1`, which is TCP6, and the Docker tools might not be able to connect
+  to it.
+  Change `http.addr` to `127.0.0.1:5000`.
+* Change `auth.htpasswd.path` to `/etc/docker/registry/htpasswd`
+* Create the htpasswd file - for example: `htpasswd -B $(id -un)`,
+  if `/etc/docker/registry/htpasswd` doesn't yet exist, add the `-c` option.
+* Login to your local registry using `docker login -u $(id -un) localhost:5000`

--- a/tools/dockerbuild/build-push-images.sh
+++ b/tools/dockerbuild/build-push-images.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2023 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Helper script to generate all Docker images for a release (and snapshot publishing).
+# The produced Docker images are:
+#   native linux/amd64
+#     with tags: <version>-native, latest-native
+#   Java (Quarkus fast-jar) multiplatform
+#     with tags: <version>-java, <version>, latest-java, latest
+# The list if generated images is placed into the file passed in via the -i option.
+# The generated native binary is placed into the directory passed in via the -r option.
+#
+
+set -e
+
+IMAGE_NAME=""
+GITHUB=0
+NATIVE=0
+ARTIFACTS=""
+GRADLE_PROJECT=""
+PROJECT_DIR=""
+
+if [[ -n ${GITHUB_ENV} ]]; then
+  GITHUB=1
+fi
+
+function usage() {
+  cat << ! > /dev/stderr
+  Usage: $0 [options] <docker-image-base-name>
+
+      -g | --gradle-project <project>   Gradle project name, for example
+      -p | --project-dir <dir>          Directory of the Gradle project
+      -gh | --github                    GitHub actions mode
+      -i | --images-file <file>         text file receiving the Docker image names to push
+      -a | --artifacts-dir <dir>        directory to place native binaries and uber-jars in
+
+  GitHub mode is automatically enabled, when GITHUB_ENV is present. -i and -r are mandatory in GitHub mode.
+
+  Example: $0 -g :nessie-server -p servers/quarkus-server nessie-unstable
+!
+}
+
+function gh_group() {
+  [ ${GITHUB} == 1 ] && echo "::group::$*" || (echo "" ; echo "** $*" ; echo "")
+}
+
+function gh_endgroup() {
+  [ ${GITHUB} == 1 ] && echo "::endgroup::" || echo ""
+}
+
+function gh_summary() {
+  [ ${GITHUB} == 1 ] && echo "$*" >> "${GITHUB_STEP_SUMMARY}" || echo "$*"
+}
+
+while [[ $# -gt 0 ]]; do
+  arg="$1"
+  case "$arg" in
+  -g | --gradle-project)
+    GRADLE_PROJECT="$2"
+    shift
+    ;;
+  -p | --project-dir)
+    PROJECT_DIR="$2"
+    shift
+    ;;
+  -a | --artifacts-dir)
+    ARTIFACTS="$2"
+    shift
+    ;;
+  -n | --native)
+    NATIVE=1
+    ;;
+  -gh | --github)
+    GITHUB=1
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  -*)
+    usage
+    exit 1
+    ;;
+  *)
+    IMAGE_NAME="$arg"
+    ;;
+  esac
+  shift
+done
+
+if [[ ${GITHUB} == 1 ]] ; then
+  if [[ -z $ARTIFACTS ]] ; then
+    usage
+    exit 1
+  fi
+fi
+if [[ -z $IMAGE_NAME || -z $GRADLE_PROJECT || -z $PROJECT_DIR || ! -d $PROJECT_DIR ]] ; then
+  usage
+  exit 1
+fi
+
+BASE_DIR="$(cd "$(dirname "$0")/../.." ; pwd)"
+cd "$BASE_DIR"
+
+if [[ -z ${ARTIFACTS} ]]; then
+  mkdir -p "$BASE_DIR/build"
+  ARTIFACTS="$(mktemp -p "$BASE_DIR/build" -d dockerbuild-artifacts-XXXXX)"
+fi
+
+#
+# Prepare
+#
+
+gh_group "Prepare Docker image name and tag base"
+IMAGE_TAG="$(cat version.txt)"
+IMAGE_TAG_BASE="${IMAGE_TAG%-SNAPSHOT}"
+echo "Image name: ${IMAGE_NAME}"
+echo "Tag base: ${IMAGE_TAG_BASE}"
+echo "Placing binaries in: ${ARTIFACTS}"
+mkdir -p "${ARTIFACTS}"
+gh_endgroup
+
+gh_group "Prepare buildx"
+docker buildx use default
+docker buildx create \
+  --platform linux/amd64,linux/arm64 \
+  --use \
+  --name nessiebuild \
+  --driver-opt network=host || docker buildx use nessiebuild
+# Note: '--driver-opt network=host' is needed to be able to push to a local registry (e.g. localhost:5000)
+gh_endgroup
+
+gh_group "Docker buildx info"
+docker buildx inspect
+gh_endgroup
+
+#
+# Native amd64 image
+#
+
+if [[ ${NATIVE} == 1 ]] ; then
+  gh_group "Build native image"
+  ./gradlew "${GRADLE_PROJECT}:clean" "${GRADLE_PROJECT}:quarkusBuild" -Pnative
+  # Save the native runner binary in case we're publishing it
+  cp "${PROJECT_DIR}"/build/*-runner "${ARTIFACTS}"
+  gh_endgroup
+
+  gh_group "Docker buildx build"
+  NATIVE_PLATFORM="linux/amd64"
+  docker buildx build \
+    -f "${BASE_DIR}/tools/dockerbuild/docker/Dockerfile-native" \
+    --platform "${NATIVE_PLATFORM}" \
+    -t "${IMAGE_NAME}:latest-native" \
+    -t "${IMAGE_NAME}:${IMAGE_TAG_BASE}-native" \
+    "${BASE_DIR}/${PROJECT_DIR}" \
+    --push \
+    --output type=registry
+    # Note: '--output type=registry' is needed to be able to push to a local registry (e.g. localhost:5000)
+  gh_summary "## Native image tags, built for ${NATIVE_PLATFORM}"
+  gh_summary "* \`docker pull ${IMAGE_NAME}:latest-native\`"
+  gh_summary "* \`docker pull ${IMAGE_NAME}:native\`"
+  gh_endgroup
+fi
+
+#
+# Java multiplatform image
+#
+
+gh_group "Build Java linux/amd64"
+./gradlew "${GRADLE_PROJECT}:clean" "${GRADLE_PROJECT}:quarkusBuild"
+gh_endgroup
+
+gh_group "Docker buildx build"
+# All the platforms that are available
+PLATFORMS="linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x"
+docker buildx build \
+  -f "${BASE_DIR}/tools/dockerbuild/docker/Dockerfile-jvm" \
+  --platform "${PLATFORMS}" \
+  -t "${IMAGE_NAME}:latest" \
+  -t "${IMAGE_NAME}:latest-java" \
+  -t "${IMAGE_NAME}:${IMAGE_TAG_BASE}" \
+  -t "${IMAGE_NAME}:${IMAGE_TAG_BASE}-java" \
+  "${BASE_DIR}/${PROJECT_DIR}" \
+  --push \
+  --output type=registry
+  # Note: '--output type=registry' is needed to be able to push to a local registry (e.g. localhost:5000)
+  gh_summary "## Java image tags, built for ${PLATFORMS}"
+  gh_summary "* \`docker pull ${IMAGE_NAME}:latest\`"
+  gh_summary "* \`docker pull ${IMAGE_NAME}:latest-java\`"
+  gh_summary "* \`docker pull ${IMAGE_NAME}:${IMAGE_TAG_BASE}\`"
+  gh_summary "* \`docker pull ${IMAGE_NAME}:${IMAGE_TAG_BASE}-java\`"
+gh_endgroup

--- a/tools/dockerbuild/docker/Dockerfile-jvm
+++ b/tools/dockerbuild/docker/Dockerfile-jvm
@@ -1,0 +1,38 @@
+####
+#
+# This Dockerfile is used in order to build a container that runs a Quarkus application in JVM mode.
+#
+# Before building the container image, build the Quarkus application using the "fast-jar" packaging,
+# which is the default packaging type. For example:
+#    ./gradlew :nessie-quarkus:quarkusBuild
+#
+#
+# FOLLOWING DESCRIPTION AND CONTENT "BORROWED" FROM QUARKUS SOURCE.
+# source file: https://github.com/quarkusio/quarkus/blob/main/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/docker/Dockerfile.jvm
+#
+#
+#
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+#
+# (See site/docs/try/configuration.md)
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+# NOTE: Do **NOT** bump ubi8 to ubi9 - that will break all the options above!
+
+ENV LANGUAGE='en_US:en'
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=185 build/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 build/quarkus-app/*.jar /deployments/
+COPY --chown=185 build/quarkus-app/app/ /deployments/app/
+COPY --chown=185 build/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 19120
+USER 185
+ENV AB_JOLOKIA_OFF=""
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/tools/dockerbuild/docker/Dockerfile-native
+++ b/tools/dockerbuild/docker/Dockerfile-native
@@ -1,0 +1,22 @@
+####
+#
+# This Dockerfile is used in order to build a container that runs a Quarkus application in native mode.
+#
+# Before building the container image, build the Quarkus application using the "native" packaging.
+# For example:
+#    ./gradlew :nessie-quarkus:quarkusBuild -Pnative
+#
+#
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root build/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
Release and snapshot publishing produces 2 different Docker images:
* Java multi-platform / amd64, arm64, ppc64le, s390x (all those are available for OpenJDK 17)
* Native / amd64 only

The multiplatform Docker images are created via a new shell script using `docker buildx`.

This change removes all Docker related settings and dependencies from the Quarkus builds.

See notes in `tools/dockerbuild/README.md`

Fixes #6099