### PR TITLE
Revert changes to Chart.yaml maintainers section

### DIFF
--- a/helm/nessie/Chart.yaml
+++ b/helm/nessie/Chart.yaml
@@ -15,11 +15,7 @@ keywords:
   - transactional catalog
   - git-like semantics
 maintainers:
-  - name: Eduard Tudenhöfner
-    url: https://github.com/nastra
-  - name: Robert Stupp
-    url: https://github.com/snazy
-  - name: Dmitri Bourlatchkov
-    url: https://github.com/dimas-b
-  - name: Alexandre Dutra
-    url: https://github.com/adutra
+  - name: nastra
+  - name: snazy
+  - name: dimas-b
+  - name: adutra

--- a/helm/nessie/README.md
+++ b/helm/nessie/README.md
@@ -15,13 +15,10 @@ A Helm chart for Nessie.
 **Homepage:** <https://projectnessie.org/>
 
 ## Maintainers
-
-| Name | Email | Url |
-| ---- | ------ | --- |
-| Eduard Tudenhöfner |  | <https://github.com/nastra> |
-| Robert Stupp |  | <https://github.com/snazy> |
-| Dmitri Bourlatchkov |  | <https://github.com/dimas-b> |
-| Alexandre Dutra |  | <https://github.com/adutra> |
+* [nastra](https://github.com/nastra)
+* [snazy](https://github.com/snazy)
+* [dimas-b](https://github.com/dimas-b)
+* [adutra](https://github.com/adutra)
 
 ## Source Code
 

--- a/helm/nessie/README.md.gotmpl
+++ b/helm/nessie/README.md.gotmpl
@@ -16,7 +16,11 @@ helm-docs --chart-search-root=helm
 
 {{ template "chart.homepageLine" . }}
 
-{{ template "chart.maintainersSection" . }}
+{{ template "chart.maintainersHeader" . }}
+
+{{- range .Maintainers }}
+* [{{ .Name }}]({{ if .Url }}{{ .Url }}{{ else }}https://github.com/{{ .Name }}{{ end }})
+{{- end }}
 
 {{ template "chart.sourcesSection" . }}
 


### PR DESCRIPTION
This commit reverts previous changes to
Charts.yaml maintainers section. These changes
were causing the chart-testing checks to fail
since there is an unspoken rule around
maintainers names that these should be valid
GitHub handles.

This commit also modifies the README template
to improve the rendering of maintainers:
instead of a table, a bullet-point list is
used instead.

See https://github.com/helm/chart-testing/issues/192
for context.