### PR TITLE
GH workflows: prevent running a bunch of stuff on forks

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -44,6 +44,7 @@ jobs:
   create-release:
     name: Bump version
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'projectnessie'
     env:
       BUMP_ON_BRANCH: ${{ github.event.inputs.bumpBranch }}
       BUMP_TYPE: ${{ github.event.inputs.bumpType }}

--- a/.github/workflows/check-results-upload.yml
+++ b/.github/workflows/check-results-upload.yml
@@ -30,7 +30,7 @@ jobs:
   report-upload:
     name: Report Upload
     runs-on: ubuntu-20.04
-    if: ${{ github.repository == 'projectnessie/nessie' }}
+    if: github.repository_owner == 'projectnessie'
 
     env:
       WEB_DIR: ${{ github.event.workflow_run.event }}/${{ github.event.workflow_run.head_branch }}/${{ github.event.workflow_run.head_sha }}/gatling

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -33,7 +33,7 @@ jobs:
   java:
     name: Java/Gradle macOS
     runs-on: macos-12
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
       SPARK_LOCAL_IP: localhost
 
@@ -100,7 +100,7 @@ jobs:
   python:
     name: Python
     runs-on: macos-12
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
       working-directory: ./python
     strategy:

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -33,7 +33,7 @@ jobs:
   java:
     name: Java/Gradle Windows
     runs-on: windows-2022
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
       SPARK_LOCAL_IP: localhost
 
@@ -110,7 +110,7 @@ jobs:
   python:
     name: Python
     runs-on: windows-2022
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
       working-directory: ./python
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,21 +40,25 @@ jobs:
 
     - name: Gradle / unit test
       uses: gradle/gradle-build-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         arguments: test --scan
 
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         arguments: check codeCoverageReport -x test --scan
 
     - name: Gradle / Gatling simulations
       uses: gradle/gradle-build-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         arguments: gatlingRun
 
     - name: Gradle / assemble + publish local
       uses: gradle/gradle-build-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         arguments: |
           assemble
@@ -64,6 +68,7 @@ jobs:
 
     - name: Gradle / build tools integration tests
       uses: gradle/gradle-build-action@v2
+      if: github.repository_owner == 'projectnessie'
       with:
         arguments: buildToolsIntegrationTest
 
@@ -82,6 +87,7 @@ jobs:
   native:
     name: Java/Gradle/Native
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'projectnessie'
 
     steps:
       - uses: actions/checkout@v3.3.0
@@ -116,6 +122,7 @@ jobs:
   python:
     name: Python
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'projectnessie'
     env:
       working-directory: ./python
     strategy:

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -49,6 +49,7 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'projectnessie'
     env:
       RELEASE_FROM: ${{ github.event.inputs.releaseFromBranch }}
       BUMP_TYPE: ${{ github.event.inputs.bumpType }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -45,7 +45,7 @@ jobs:
   publish-release:
     name: Publish release
     runs-on: ubuntu-20.04
-
+    if: github.repository_owner == 'projectnessie'
     # Runs in the `release` environment, which has the necessary secrets and defines the reviewers.
     # See https://docs.github.com/en/actions/reference/environments
     environment: release

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,7 +10,7 @@ jobs:
   site:
     name: Build & Deploy Website
     runs-on: ubuntu-20.04
-    if: ${{ github.repository == 'projectnessie/nessie' }}
+    if: github.repository_owner == 'projectnessie'
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Setup Python


### PR DESCRIPTION
There's usually no need to run all the CI stuff that happens on `projectnessie/nessie`'s `main` branch on forks.