### PR TITLE
Test: Update the validation to unblock query-engine-integration-tests

### DIFF
--- a/clients/spark-extensions-basetests/src/main/java/org/projectnessie/spark/extensions/AbstractNessieSparkSqlExtensionTest.java
+++ b/clients/spark-extensions-basetests/src/main/java/org/projectnessie/spark/extensions/AbstractNessieSparkSqlExtensionTest.java
@@ -628,7 +628,8 @@ public abstract class AbstractNessieSparkSqlExtensionTest extends SparkSqlTestBa
       throws NessieNotFoundException {
     List<Object[]> result = executeCompaction(tableName);
     // re-written files count is 2 and the added files count is 1
-    assertThat(result).hasSize(1).containsExactly(row(2, 1));
+    assertThat(result.get(0)[0]).isEqualTo(2);
+    assertThat(result.get(0)[1]).isEqualTo(1);
 
     // check for compaction commit
     LogResponse.LogEntry logEntry =


### PR DESCRIPTION
Yesterday this PR got merged (https://github.com/apache/iceberg/pull/6801) which introduces one more output value. Hence, the strict check fails.

This PR is to unblock `query-engine-integration-tests` 

Part of fixing #6114 