### PR TITLE
Fix renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,7 @@
       "labels": ["dependencies", "python"],
     },
     {
-      matchManagers: ["docker"],
+      matchManagers: ["dockerfile"],
       "labels": ["dependencies", "docker"],
     },
 
@@ -66,7 +66,7 @@
 
     // Docker
     {
-      matchManagers: ["docker"],
+      matchManagers: ["dockerfile"],
       automerge: false,
       platformAutomerge: false
     },


### PR DESCRIPTION
broken by #6110

Renovate error message:
_packageRules: You have included an unsupported manager in a package rule. Your list: `docker`. Supported managers are: (..., `dockerfile`, ...)._

Fixes #5488