### PR TITLE
GH workflow to smoke test Docker images

### DIFF
--- a/.github/workflows/pull-request-docker.yml
+++ b/.github/workflows/pull-request-docker.yml
@@ -1,0 +1,181 @@
+# Copyright (C) 2020 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Projectnessie GitHub Pull-Request / Docker build and publishing
+
+name: Docker images test
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+  schedule:
+    # Run daily on week days
+    - cron:  '0 4 * * 1-5'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-testing:
+    name: Docker build and publishing
+    runs-on: ubuntu-22.04
+    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-docker')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+      - name: Setup runner
+        uses: ./.github/actions/setup-runner
+        with:
+          more-memory: 'true'
+      - name: Setup Java, Gradle
+        uses: ./.github/actions/dev-tool-java
+
+      - name: Setup docker-registry
+        run: |
+          sudo apt-get install -y docker-registry apache2-utils 
+          cat <<! > config.yml
+          version: 0.1
+          log:
+            fields:
+              service: registry
+          storage:
+            cache:
+              blobdescriptor: inmemory
+            filesystem:
+              rootdirectory: /var/lib/docker-registry
+            delete:
+              enabled: true
+          http:
+            addr: 127.0.0.1:5000
+            headers:
+              X-Content-Type-Options: [nosniff]
+          auth:
+            htpasswd:
+              realm: basic-realm
+              path: /etc/docker/registry/htpasswd
+          health:
+            storagedriver:
+              enabled: true
+              interval: 10s
+              threshold: 3
+          !
+          sudo mv config.yml /etc/docker/registry/config.yml
+          sudo htpasswd -cBb /etc/docker/registry/htpasswd micky mouse 
+          
+          sudo service docker-registry restart
+          
+          echo mouse | docker login -u micky --password-stdin localhost:5000
+
+          VERSION="$(cat version.txt)"
+          DOCKER_VERSION="${VERSION%-SNAPSHOT}"
+          echo "DOCKER_VERSION=${DOCKER_VERSION}" >> ${GITHUB_ENV}
+          echo "DOCKER_IMAGE=localhost:5000/nessie-testing" >> ${GITHUB_ENV}
+
+      - name: Gradle / prepare
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
+          # Just fetch cache, defer build to "later"
+          arguments: projects
+
+      - name: Docker images publishing
+        env:
+          ARTIFACTS: ../build-artifacts
+        run: |
+          rm -rf "${ARTIFACTS}"
+          mkdir -p "${ARTIFACTS}"
+
+          tools/dockerbuild/build-push-images.sh \
+            -a "${ARTIFACTS}" \
+            -g ":nessie-quarkus" \
+            -p "servers/quarkus-server" \
+            -n \
+            ${DOCKER_IMAGE}
+          rm -rf "${ARTIFACTS}"
+
+      - name: Cleanup buildx
+        run: |
+          docker buildx use default
+          docker buildx rm nessiebuild
+
+      - name: Docker images exist test
+        run: |
+          docker pull ${DOCKER_IMAGE}:latest
+          docker pull ${DOCKER_IMAGE}:latest-java
+          docker pull ${DOCKER_IMAGE}:latest-native
+          docker pull ${DOCKER_IMAGE}:${DOCKER_VERSION}
+          docker pull ${DOCKER_IMAGE}:${DOCKER_VERSION}-native
+          docker pull ${DOCKER_IMAGE}:${DOCKER_VERSION}-java
+          cat <<! >> $GITHUB_STEP_SUMMARY
+          ## Docker images
+          
+          \`\`\`
+          $(docker images)
+          \`\`\`
+          !
+
+      - name: Check if Docker native image works
+        run: |
+          docker run --detach --name nessie ${DOCKER_IMAGE}:latest-native
+          echo "Let native Nessie Docker image run for one minute (to make sure it starts up fine)..."
+          for i in {1..60}; do
+            STATUS="$(docker container inspect nessie | jq -r '.[0].State.Status')"
+            if [[ ${STATUS} != "running" ]] ; then
+              echo "Nessie native Docker image stopped on its own ... a bug?" > /dev/stderr
+              docker logs nessie
+              cat <<! >> $GITHUB_STEP_SUMMARY
+              ## Nessie native Docker image FAILED
+
+              \`\`\`
+              $(docker logs nessie)
+              \`\`\`
+          !
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "## Nessie native Docker image smoke test: PASSED" >> $GITHUB_STEP_SUMMARY  
+          echo "Nessie native Docker image smoke test: PASSED"
+          docker stop nessie
+          docker rm nessie
+
+      - name: Check if Docker Java image works
+        run: |
+          docker run --detach --name nessie ${DOCKER_IMAGE}:latest-java
+          echo "Let Nessie Java Docker image run for one minute (to make sure it starts up fine)..."
+          for i in {1..60}; do
+            STATUS="$(docker container inspect nessie | jq -r '.[0].State.Status')"
+            if [[ ${STATUS} != "running" ]] ; then
+              echo "Nessie Java Docker image stopped on its own ... a bug?" > /dev/stderr
+              docker logs nessie
+              cat <<! >> $GITHUB_STEP_SUMMARY
+              ## Nessie Java Docker image FAILED
+
+              \`\`\`
+              $(docker logs nessie)
+              \`\`\`
+          !
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "## Nessie Java Docker image smoke test: PASSED" >> $GITHUB_STEP_SUMMARY  
+          echo "Nessie Java Docker image smoke test: PASSED"
+          docker stop nessie
+          docker rm nessie

--- a/tools/dockerbuild/README.md
+++ b/tools/dockerbuild/README.md
@@ -30,7 +30,7 @@ Hint: The images are pushed to the local registry, those will **not** show up in
 
 ## Updating your local Docker registry
 
-There's a `docker-regsitry` Debian/Ubuntu package. The registry configuration might need some tweaks
+There's a `docker-registry` Debian/Ubuntu package. The registry configuration might need some tweaks
 like this. You can also use
 the [official Docker registry](https://docs.docker.com/registry/deploying/).
 

--- a/tools/dockerbuild/build-push-images.sh
+++ b/tools/dockerbuild/build-push-images.sh
@@ -173,7 +173,7 @@ if [[ ${NATIVE} == 1 ]] ; then
     # Note: '--output type=registry' is needed to be able to push to a local registry (e.g. localhost:5000)
   gh_summary "## Native image tags, built for ${NATIVE_PLATFORM}"
   gh_summary "* \`docker pull ${IMAGE_NAME}:latest-native\`"
-  gh_summary "* \`docker pull ${IMAGE_NAME}:native\`"
+  gh_summary "* \`docker pull ${IMAGE_NAME}:${IMAGE_TAG_BASE}-native\`"
   gh_endgroup
 fi
 


### PR DESCRIPTION
Exercises Docker image build and push and lets both the native and Java image run for 1 minute to validate those start up fine.