### PR TITLE
Fix typo in release notes

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -219,8 +219,8 @@ jobs:
         * ${NUM_COMMITS} commits since ${LAST_TAG#nessie-}
         * Maven Central: https://search.maven.org/search?q=g:org.projectnessie+v:${RELEASE_VERSION}
         * Docker Hub: https://hub.docker.com/r/projectnessie/nessie
-          * Multiplatform Java image (amd64, arm64, ppc64le, s390x): `projectnessie/nessie:${RELEASE_VERSION}-java\`
-          * Image with native amd64 binary: `projectnessie/nessie:${RELEASE_VERSION}-native\`
+          * Multiplatform Java image (amd64, arm64, ppc64le, s390x): \`docker pull projectnessie/nessie:${RELEASE_VERSION}-java\`
+          * Image with native amd64 binary: \`docker pull projectnessie/nessie:${RELEASE_VERSION}-native\`
             (only recommended for short running Nessie instances, amd64 only)
         * PyPI: https://pypi.org/project/pynessie/${RELEASE_VERSION}/
         * Helm Chart repo: https://charts.projectnessie.org/


### PR DESCRIPTION
A backtick needs to be escaped, otherwise it's interpreted to be a _command_ to be executed (shell script stuff).

The typo made the release notes say something wrong: "Multiplatform Java image (amd64, arm64, ppc64le, s390x): projectnessie/nessie:0.49.0-native (only recommended for short running Nessie instances, amd64 only)"