### PR TITLE
Allow all GH WFs to become "required checks"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,7 +33,7 @@
 
     // Check for updates, merge automatically
     {
-      matchManagers: ["maven", "gradle", "gradle-wrapper", "npm", "pip_requirements", "pip_setup"],
+      matchManagers: ["maven", "gradle", "gradle-wrapper", "npm", "pip_requirements", "pip_setup", "dockerfile"],
       matchUpdateTypes: ["minor", "patch"],
       automerge: true,
       platformAutomerge: true,
@@ -62,13 +62,6 @@
         "org.glassfish.jersey:jersey-bom",
       ],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-    },
-
-    // Docker
-    {
-      matchManagers: ["dockerfile"],
-      automerge: false,
-      platformAutomerge: false
     },
   ],
 

--- a/.github/workflows/pull-request-docker.yml
+++ b/.github/workflows/pull-request-docker.yml
@@ -33,20 +33,25 @@ jobs:
   docker-testing:
     name: Docker build and publishing
     runs-on: ubuntu-22.04
-    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-docker')
+    env:
+      WF_EXEC: ${{ (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-docker') }}
     steps:
       - name: Checkout
+        if: env.WF_EXEC == 'true'
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
       - name: Setup runner
+        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/setup-runner
         with:
           more-memory: 'true'
       - name: Setup Java, Gradle
+        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/dev-tool-java
 
       - name: Setup docker-registry
+        if: env.WF_EXEC == 'true'
         run: |
           sudo apt-get install -y docker-registry apache2-utils 
           cat <<! > config.yml
@@ -88,6 +93,7 @@ jobs:
           echo "DOCKER_IMAGE=localhost:5000/nessie-testing" >> ${GITHUB_ENV}
 
       - name: Gradle / prepare
+        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: true
@@ -95,6 +101,7 @@ jobs:
           arguments: projects
 
       - name: Docker images publishing
+        if: env.WF_EXEC == 'true'
         env:
           ARTIFACTS: ../build-artifacts
         run: |
@@ -110,11 +117,13 @@ jobs:
           rm -rf "${ARTIFACTS}"
 
       - name: Cleanup buildx
+        if: env.WF_EXEC == 'true'
         run: |
           docker buildx use default
           docker buildx rm nessiebuild
 
       - name: Docker images exist test
+        if: env.WF_EXEC == 'true'
         run: |
           docker pull ${DOCKER_IMAGE}:latest
           docker pull ${DOCKER_IMAGE}:latest-java
@@ -131,6 +140,7 @@ jobs:
           !
 
       - name: Check if Docker native image works
+        if: env.WF_EXEC == 'true'
         run: |
           docker run --detach --name nessie ${DOCKER_IMAGE}:latest-native
           echo "Let native Nessie Docker image run for one minute (to make sure it starts up fine)..."
@@ -156,6 +166,7 @@ jobs:
           docker rm nessie
 
       - name: Check if Docker Java image works
+        if: env.WF_EXEC == 'true'
         run: |
           docker run --detach --name nessie ${DOCKER_IMAGE}:latest-java
           echo "Let Nessie Java Docker image run for one minute (to make sure it starts up fine)..."

--- a/.github/workflows/pull-request-helm.yml
+++ b/.github/workflows/pull-request-helm.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Projectnessie GitHub Pull-Request / Default CI
+# Projectnessie GitHub Pull-Request / Helm
 
 name: PR Helm
 
@@ -29,37 +29,47 @@ jobs:
   helm-testing:
     name: Lint & Test Helm chart
     runs-on: ubuntu-20.04
-    if: contains(github.event.pull_request.labels.*.name, 'pr-helm')
+    env:
+      WF_EXEC: ${{ contains(github.event.pull_request.labels.*.name, 'pr-helm') }}
     steps:
       - name: Checkout
+        if: env.WF_EXEC == 'true'
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
       - name: Set up Helm
+        if: env.WF_EXEC == 'true'
         uses: azure/setup-helm@v3
         with:
           version: v3.8.1
       - uses: actions/setup-python@v4
+        if: env.WF_EXEC == 'true'
         with:
           python-version: '3.8'
       - name: Set up chart-testing
+        if: env.WF_EXEC == 'true'
         uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (list-changed)
+        if: env.WF_EXEC == 'true'
         id: list-changed
         run: |
           ct list-changed --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Run chart-testing (lint)
+        if: env.WF_EXEC == 'true'
         run: ct lint --debug --charts ./helm/nessie
 
       - name: Set up & Start Minikube
+        if: env.WF_EXEC == 'true'
         uses: medyagh/setup-minikube@v0.0.11
         with:
           cache: false
 
       - name: Show pods
+        if: env.WF_EXEC == 'true'
         run: kubectl get pods -A
 
       - name: Run chart-testing (install)
+        if: env.WF_EXEC == 'true'
         run: ct install --debug --charts ./helm/nessie

--- a/.github/workflows/pull-request-integ.yml
+++ b/.github/workflows/pull-request-integ.yml
@@ -27,8 +27,8 @@ jobs:
   java:
     name: Integrations Tests
     runs-on: ubuntu-20.04
-    if: contains(github.event.pull_request.labels.*.name, 'pr-integrations')
     env:
+      WF_EXEC: ${{ contains(github.event.pull_request.labels.*.name, 'pr-integrations') }}
       NESSIE_DIR: included-builds/nessie
       NESSIE_PATCH_REPOSITORY: ''
       NESSIE_PATCH_BRANCH: ''
@@ -41,17 +41,20 @@ jobs:
 
     steps:
       - name: Prepare Git
+        if: env.WF_EXEC == 'true'
         run: |
           git config --global user.email "integrations-testing@projectnessie.org"
           git config --global user.name "Integrations Testing [Bot]"
 
       - name: Checkout nqeit repo
+        if: env.WF_EXEC == 'true'
         uses: actions/checkout@v3.3.0
         with:
           repository: projectnessie/query-engine-integration-tests
           ref: main
 
       - name: Checkout and patch Nessie PR
+        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/patch-git
         with:
           name: Nessie
@@ -62,6 +65,7 @@ jobs:
           work-branch: nessie-integration-patched
 
       - name: Checkout and patch Iceberg
+        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/patch-git
         with:
           name: Nessie
@@ -74,49 +78,58 @@ jobs:
 
       # Setup Gradle properties, heap requirements are for the "Integration test w/ Nessie".
       - name: Setup gradle.properties
+        if: env.WF_EXEC == 'true'
         run: |
           mkdir -p ~/.gradle
           echo "org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" >> ~/.gradle/gradle.properties
           echo "org.gradle.vfs.watch=false" >> ~/.gradle/gradle.properties
 
       - name: Set up JDK ${{ matrix.java-version }}
+        if: env.WF_EXEC == 'true'
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: Iceberg Nessie test
+        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: true
           arguments: :iceberg:iceberg-nessie:test --scan
 
       - name: Nessie Spark 3.1 Extensions test
+        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :nessie-iceberg:nessie-spark-extensions-3.1_2.12:test :nessie-iceberg:nessie-spark-extensions-3.1_2.12:intTest --scan
 
       - name: Nessie Spark 3.2 / 2.12 Extensions test
+        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest --scan
 
       - name: Nessie Spark 3.3 / 2.12 Extensions test
+        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest --scan
 
       - name: Stop Gradle daemon
+        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: --stop
 
       - name: Publish Nessie + Iceberg to local Maven repo
+        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: publishLocal --scan
 
       - name: Gather locally published versions
+        if: env.WF_EXEC == 'true'
         run: |
           NESSIE_VERSION="$(cat included-builds/nessie/version.txt)"
           ICEBERG_VERSION="$(cat included-builds/iceberg/build/iceberg-build.properties | grep '^git.build.version=' | cut -d= -f2)"
@@ -130,6 +143,7 @@ jobs:
           !
 
       - name: Tools & Integrations tests
+        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: intTest

--- a/.github/workflows/pull-request-native.yml
+++ b/.github/workflows/pull-request-native.yml
@@ -29,34 +29,39 @@ jobs:
   java:
     name: Java/Gradle Native
     runs-on: ubuntu-20.04
-    if: contains(github.event.pull_request.labels.*.name, 'pr-native')
+    env:
+      WF_EXEC: ${{ contains(github.event.pull_request.labels.*.name, 'pr-native') }}
     steps:
-    - uses: actions/checkout@v3.3.0
-    - name: Setup runner
-      uses: ./.github/actions/setup-runner
-      with:
-        more-memory: 'true'
-    - name: Setup Java, Gradle
-      uses: ./.github/actions/dev-tool-java
+      - uses: actions/checkout@v3.3.0
+        if: env.WF_EXEC == 'true'
+      - name: Setup runner
+        if: env.WF_EXEC == 'true'
+        uses: ./.github/actions/setup-runner
+        with:
+          more-memory: 'true'
+      - name: Setup Java, Gradle
+        if: env.WF_EXEC == 'true'
+        uses: ./.github/actions/dev-tool-java
 
-    - name: Gradle / integration test native
-      uses: gradle/gradle-build-action@v2
-      with:
-        cache-read-only: true
-        arguments: |
-          --no-watch-fs
-          :nessie-quarkus:quarkusBuild
-          :nessie-quarkus:intTest
-          -Pnative
-          -Pdocker
-          --scan
+      - name: Gradle / integration test native
+        if: env.WF_EXEC == 'true'
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
+          arguments: |
+            --no-watch-fs
+            :nessie-quarkus:quarkusBuild
+            :nessie-quarkus:intTest
+            -Pnative
+            -Pdocker
+            --scan
 
-    - name: Capture Test Reports
-      uses: actions/upload-artifact@v3
-      if: ${{ failure() }}
-      with:
-        name: test-results-native
-        path: |
-          **/build/reports/*
-          **/build/test-results/*
-        retention-days: 3
+      - name: Capture Test Reports
+        uses: actions/upload-artifact@v3
+        if: env.WF_EXEC == 'true' && failure()
+        with:
+          name: test-results-native
+          path: |
+            **/build/reports/*
+            **/build/test-results/*
+          retention-days: 3


### PR DESCRIPTION
A couple of PR workflows are "optional", but if those are enabled, those should succeed, especially for automatically merged PRs like those opened by renovate.

A PR WF that's not run is marked as "Skipped". For the "required checks" a skipped check means "failed". The [workaround described here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) recommends adding another WF with the same WF and step names as the "skipped one", see the description in the link for details.

The proposed workaround is not really nice, WFs/checks appear twice in the list of PR checks and WFs _appear_ as exact duplicates in the list of workflows (in the repository's "Actions" tab).

This change refactors the "global" `if:` of the four workflows to become an environment variable, which is checked for every step. Although that adds some boilerplate to the WF definition, the overall appearance is much nicer.

This change allows making the jobs in these four WFs to become "required status checks".