### PR TITLE
Rename jobs for mac+win GH workflows

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -99,7 +99,7 @@ jobs:
         retention-days: 3
 
   python:
-    name: Python
+    name: Python macOS
     runs-on: macos-12
     if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -109,7 +109,7 @@ jobs:
         retention-days: 3
 
   python:
-    name: Python
+    name: Python Windows
     runs-on: windows-2022
     if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:


### PR DESCRIPTION
Otherwise the names clash with the job names of the "main" CI jobs and cause confusion in the set of the "required steps".