### PR TITLE
Disable intTest using containers/podman for macOS CI

### DIFF
--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -179,5 +179,10 @@ listOf("checkstyleTest", "compileTestJava").forEach { name ->
 
 // Testcontainers is not supported on Windows :(
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-  tasks.withType<Test>().configureEach { this.enabled = false }
+  tasks.named<Test>("intTest") { this.enabled = false }
+}
+
+// Issue w/ testcontainers/podman in GH workflows :(
+if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
+  tasks.named<Test>("intTest") { this.enabled = false }
 }

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -230,5 +230,10 @@ listOf("checkstyleTest", "compileTestJava").forEach { name ->
 
 // Testcontainers is not supported on Windows :(
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-  tasks.withType<Test>().configureEach { this.enabled = false }
+  tasks.named<Test>("intTest") { this.enabled = false }
+}
+
+// Issue w/ testcontainers/podman in GH workflows :(
+if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
+  tasks.named<Test>("intTest") { this.enabled = false }
 }

--- a/servers/services/build.gradle.kts
+++ b/servers/services/build.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 plugins {
   `java-library`
   jacoco
@@ -86,4 +88,9 @@ dependencies {
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
   testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+// Issue w/ testcontainers/podman in GH workflows :(
+if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
+  tasks.withType<Test>().configureEach { this.enabled = false }
 }

--- a/versioned/persist/dynamodb/build.gradle.kts
+++ b/versioned/persist/dynamodb/build.gradle.kts
@@ -58,5 +58,10 @@ dependencies {
 
 // Testcontainers is not supported on Windows :(
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-  tasks.withType<Test>().configureEach { this.enabled = false }
+  tasks.named<Test>("intTest") { this.enabled = false }
+}
+
+// Issue w/ testcontainers/podman in GH workflows :(
+if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
+  tasks.named<Test>("intTest") { this.enabled = false }
 }

--- a/versioned/persist/mongodb/build.gradle.kts
+++ b/versioned/persist/mongodb/build.gradle.kts
@@ -54,5 +54,10 @@ dependencies {
 
 // Testcontainers is not supported on Windows :(
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-  tasks.withType<Test>().configureEach { this.enabled = false }
+  tasks.named<Test>("intTest") { this.enabled = false }
+}
+
+// Issue w/ testcontainers/podman in GH workflows :(
+if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
+  tasks.named<Test>("intTest") { this.enabled = false }
 }

--- a/versioned/persist/tx/build.gradle.kts
+++ b/versioned/persist/tx/build.gradle.kts
@@ -68,5 +68,10 @@ tasks.named<Test>("intTest") {
 
 // Testcontainers is not supported on Windows :(
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-  tasks.withType<Test>().configureEach { this.enabled = false }
+  tasks.named<Test>("intTest") { this.enabled = false }
+}
+
+// Issue w/ testcontainers/podman in GH workflows :(
+if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
+  tasks.named<Test>("intTest") { this.enabled = false }
 }


### PR DESCRIPTION
there are issues "pulling" the images - but that's likely more an issue in GH workflows, likely memory issues