### PR TITLE
Remove rocksdb.dbPath from Helm chart values

### DIFF
--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           {{- if eq .Values.versionStoreType "ROCKS" }}
           volumeMounts:
             - name: rocks-storage
-              mountPath: {{ .Values.rocksdb.dbPath }}
+              mountPath: /rocks-nessie
           {{- end }}
           env:
             - name: NESSIE_VERSION_STORE_TYPE
@@ -69,10 +69,8 @@ spec:
             {{- end }}
 
             {{- if eq .Values.versionStoreType "ROCKS" }}
-            {{- if .Values.rocksdb.dbPath }}
             - name: NESSIE_VERSION_STORE_ROCKS_DB_PATH
-              value: {{ .Values.rocksdb.dbPath }}
-            {{- end }}
+              value: /rocks-nessie
             {{- end }}
 
             {{- if eq .Values.versionStoreType "MONGO" }}

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -22,9 +22,6 @@ rocksdb:
   storageClassName: standard
   # -- The size of the persistent volume claim to create.
   storageSize: 1Gi
-  # Deprecated value; it will be removed in a future release.
-  # @ignore
-  dbPath: /rocks-nessie
   # -- Labels to add to the persistent volume claim spec selector; a persistent volume with matching labels must exist.
   # Leave empty if using dynamic provisioning.
   selectorLabels:

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -38,7 +38,7 @@ When setting `nessie.version.store.type=TRANSACTIONAL` which enables transaction
 
 #### RocksDB Version Store Settings
 
-When setting `nessie.version.store.type=ROCKS` which enables RockDB as the version store used by the Nessie server, the following configurations are applicable in combination with `nessie.version.store.type`:
+When setting `nessie.version.store.type=ROCKS` which enables RocksDB as the version store used by the Nessie server, the following configurations are applicable in combination with `nessie.version.store.type`:
 
 | Property                             | Default values        | Type     | Description                                          |
 |--------------------------------------|-----------------------|----------|------------------------------------------------------|


### PR DESCRIPTION
This commit removes the rocksdb.dbPath setting from the values.yaml file of Nessie's chart.

While this setting is exposed to users running Nessie outside of Kubernetes, id doesn't make a lot of sense in the Kubernetes world. What really needs to be exposed to Kubernetes users is the persistent volume claim, not the mount path on the Nessie container.