### PR TITLE
mac-os/win CI - add retry for steps that regularly timeout/hang

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -38,8 +38,16 @@ jobs:
       SPARK_LOCAL_IP: localhost
 
     steps:
-    - name: Setup Colima
-      timeout-minutes: 30
+    - name: Brew update & upgrade
+      run: |
+        echo "::group::Update Brew"
+        brew update
+        echo "::endgroup::"
+        echo "::group::Brew Upgrade"
+        brew upgrade
+        echo "::endgroup::"
+
+    - name: Prepare Podman
       run: |
         echo "::group::Install Podman"
         brew install podman
@@ -49,10 +57,23 @@ jobs:
         podman machine init
         echo "::endgroup::"
 
-        echo "::group::Starting Podman"
-        podman machine start
-        echo "::endgroup::"
+    - name: Start Podman
+      uses: nick-fields/retry@v2
+      with:
+        max_attempts: 10
+        timeout_minutes: 5
+        retry_wait_seconds: 3
+        command: |
+          echo "::group::Starting Podman"
+          podman machine start
+          echo "::endgroup::"
+        on_retry_command: |
+          echo "::group::Stopping Podman"
+          podman machine stop
+          echo "::endgroup::"
 
+    - name: Configure Podman
+      run: |
         echo "::group::Aliasing Podman"
         ln -s /usr/local/bin/podman /usr/local/bin/docker
         echo "::endgroup::"

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -51,20 +51,23 @@ jobs:
         path: hadoop-winutils
         ref: d018bd9c919dee1448b95519351cc591a6338a00
 
-    - name: Setup Hadoop
+    - name: Pull Hadoop
       # A local Hadoop setup is required on Windows, very sad...
-      timeout-minutes: 30
       run: |
         cd $HOME
-        Invoke-WebRequest -Uri https://archive.apache.org/dist/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz -OutFile hadoop-3.3.2.tar.gz
+        Invoke-WebRequest -Uri https://dlcdn.apache.org/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz -TimeoutSec 60 -MaximumRetryCount 10 -OutFile hadoop-3.3.2.tar.gz
 
+    - name: Setup Hadoop
+      # A local Hadoop setup is required on Windows, very sad...
+      run: |
         echo "::group::Extract hadoop-3.3.2.tar.gz"
+        cd $HOME
         mkdir hadoop-3.3.2
         cd hadoop-3.3.2
         7z e ..\hadoop-3.3.2.tar.gz
         echo "::endgroup::"
-
         echo "HADOOP_HOME=$HOME\hadoop-3.3.2" >> $env:GITHUB_ENV
+
     - name: Add Hadoop winutils
       run: |
         cd hadoop-winutils\hadoop-3.2.2\bin


### PR DESCRIPTION
* macOS CI: `podman machine start`
* win CI: pulling the Hadoop tarball

Add a GH retry action with a timeout of 5 minutes + 10 attempts