### PR TITLE
Fix console log level setting in Helm charts

### DIFF
--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -45,10 +45,14 @@ spec:
             {{- if .Values.logLevel }}
             - name: QUARKUS_LOG_LEVEL
               value: {{ .Values.logLevel }}
-            - name: QUARKUS_CONSOLE_LOG_LEVEL
+            - name: QUARKUS_LOG_CONSOLE_LEVEL
               value: {{ .Values.logLevel }}
             - name: QUARKUS_LOG_FILE_LEVEL
               value: {{ .Values.logLevel }}
+            {{- if or (eq .Values.logLevel "DEBUG") (eq .Values.logLevel "TRACE") }}
+            - name: QUARKUS_LOG_MIN_LEVEL
+              value: {{ .Values.logLevel }}
+            {{- end }}
             {{- end }}
 
             {{- if eq .Values.versionStoreType "DYNAMO" }}


### PR DESCRIPTION
This commit fixes the handling of the log level for the console, since it was using previously a wrong environment variable: `QUARKUS_CONSOLE_LOG_LEVEL` instead of `QUARKUS_LOG_CONSOLE_LEVEL`.

It also introduces the usage of the `QUARKUS_LOG_MIN_LEVEL` environment variable, when the requested log level is `DEBUG` or `TRACE`. This is required so that the requested log level can actually be achieved, since by default, Quarkus does not allow any log messages with level below `INFO`.