### PR TITLE
mac-CI: Workaround for brew-upgrade issue

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -44,7 +44,7 @@ jobs:
         brew update
         echo "::endgroup::"
         echo "::group::Brew Upgrade"
-        brew upgrade
+        brew upgrade || true
         echo "::endgroup::"
 
     - name: Prepare Podman


### PR DESCRIPTION
The `brew upgrade` works, but returns a non-0 exit code. Currently it complains about a tcl-tk symlink-issue. There's not much we can do about `brew upgrade`, but just accept it.

Current tcl-gk error (harmless for us):
```
  ==> Pouring tcl-tk--8.6.13_1.monterey.bottle.tar.gz
  Error: The `brew link` step did not complete successfully
  The formula built, but is not symlinked into /usr/local
  Could not symlink lib/libtcl8.6.dylib
  Target /usr/local/lib/libtcl8.6.dylib
  is a symlink belonging to tcl-tk. You can unlink it:
    brew unlink tcl-tk

  To force the link and overwrite all conflicting files:
    brew link --overwrite tcl-tk

  To list all files that would be deleted:
    brew link --overwrite --dry-run tcl-tk

  Possible conflicting files are:
  /usr/local/lib/libtcl8.6.dylib -> /usr/local/Cellar/tcl-tk/8.6.13/lib/libtcl8.6.dylib
  /usr/local/lib/libtk8.6.dylib -> /usr/local/Cellar/tcl-tk/8.6.13/lib/libtk8.6.dylib
  ==> Caveats
  The sqlite3_analyzer binary is in the `sqlite-analyzer` formula.
  ==> Summary
  🍺  /usr/local/Cellar/tcl-tk/8.6.13_1: 3,070 files, 52.8MB
  ==> Running `brew cleanup tcl-tk`...
  Removing: /usr/local/Cellar/tcl-tk/8.6.13... (3,070 files, 52.8MB)
```