### PR TITLE
Fix: `Content.Type` is a string

### DIFF
--- a/model/src/main/java/org/projectnessie/model/Content.java
+++ b/model/src/main/java/org/projectnessie/model/Content.java
@@ -48,6 +48,12 @@ public abstract class Content {
 
   @JsonDeserialize(using = Util.ContentTypeDeserializer.class)
   @JsonSerialize(using = Util.ContentTypeSerializer.class)
+  @Schema(
+      type = SchemaType.STRING,
+      description =
+          "Declares the type of a Nessie content object, which is currently one of "
+              + "ICEBERG_TABLE, DELTA_LAKE_TABLE, ICEBERG_VIEW or NAMESPACE, which are the "
+              + "discriminator mapping values of the 'Content' type.")
   public interface Type {
     Content.Type UNKNOWN = ContentTypes.forName("UNKNOWN");
     Content.Type ICEBERG_TABLE = ContentTypes.forName("ICEBERG_TABLE");


### PR DESCRIPTION
The OpenAPI spec incorrectly exposes `Content.Type` as an object, but it is a string representing the name of the content's type. It is intentionally not declared as/restricted to an enum.

Before:
```yaml
    Type_V1:
      type: object
    Type_V2:
      type: object
```

Now:
```yaml
    Type_V1:
      type: string
    Type_V2:
      type: string
```

Fixes #6199