### PR TITLE
V2 REST declares wrong response types in OpenAPI spec

### DIFF
--- a/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
+++ b/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
@@ -128,8 +128,8 @@ public interface HttpTreeApi extends TreeApi {
         content = {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
-              examples = {@ExampleObject(ref = "refObjNew")},
-              schema = @Schema(implementation = Reference.class))
+              examples = {@ExampleObject(ref = "singleReferenceResponse")},
+              schema = @Schema(implementation = SingleReferenceResponse.class))
         }),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
     @APIResponse(responseCode = "403", description = "Not allowed to create reference"),
@@ -176,8 +176,11 @@ public interface HttpTreeApi extends TreeApi {
         content = {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
-              examples = {@ExampleObject(ref = "refObj")},
-              schema = @Schema(implementation = Reference.class))
+              examples = {
+                @ExampleObject(ref = "singleReferenceResponse"),
+                @ExampleObject(ref = "singleReferenceResponseWithMetadata")
+              },
+              schema = @Schema(implementation = SingleReferenceResponse.class))
         }),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
@@ -217,7 +220,7 @@ public interface HttpTreeApi extends TreeApi {
         content = {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
-              examples = {@ExampleObject(ref = "entriesResponse")},
+              examples = {@ExampleObject(ref = "entriesResponseV2")},
               schema = @Schema(implementation = EntriesResponse.class))
         }),
     @APIResponse(responseCode = "200", description = "Returned successfully."),
@@ -345,7 +348,7 @@ public interface HttpTreeApi extends TreeApi {
             @Content(
                 mediaType = MediaType.APPLICATION_JSON,
                 examples = {
-                  @ExampleObject(ref = "diffResponse"),
+                  @ExampleObject(ref = "diffResponseWithRef"),
                 },
                 schema = @Schema(implementation = DiffResponse.class))),
     @APIResponse(responseCode = "400", description = "Invalid input, fromRef/toRef name not valid"),
@@ -376,7 +379,15 @@ public interface HttpTreeApi extends TreeApi {
               + "define the new HEAD of the reference being reassigned. Detached hashes may be used in the payload.",
       operationId = "assignReferenceV2")
   @APIResponses({
-    @APIResponse(responseCode = "204", description = "Assigned successfully"),
+    @APIResponse(
+        responseCode = "200",
+        description = "Assigned successfully.",
+        content = {
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              examples = {@ExampleObject(ref = "singleReferenceResponse")},
+              schema = @Schema(implementation = SingleReferenceResponse.class))
+        }),
     @APIResponse(responseCode = "400", description = "Invalid input, ref specification not valid"),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
     @APIResponse(responseCode = "403", description = "Not allowed to view or assign reference"),
@@ -428,7 +439,15 @@ public interface HttpTreeApi extends TreeApi {
               + "Only branches and tags can be deleted. However, deleting the default branch may be restricted.",
       operationId = "deleteReferenceV2")
   @APIResponses({
-    @APIResponse(responseCode = "204", description = "Deleted successfully."),
+    @APIResponse(
+        responseCode = "200",
+        description = "Deleted successfully.",
+        content = {
+          @Content(
+              mediaType = MediaType.APPLICATION_JSON,
+              examples = {@ExampleObject(ref = "singleReferenceResponse")},
+              schema = @Schema(implementation = SingleReferenceResponse.class))
+        }),
     @APIResponse(responseCode = "400", description = "Invalid input, ref/hash name not valid"),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
     @APIResponse(responseCode = "403", description = "Not allowed to view or delete reference"),
@@ -472,8 +491,8 @@ public interface HttpTreeApi extends TreeApi {
         content =
             @Content(
                 mediaType = MediaType.APPLICATION_JSON,
-                examples = {@ExampleObject(ref = "iceberg")},
-                schema = @Schema(implementation = org.projectnessie.model.Content.class))),
+                examples = {@ExampleObject(ref = "contentResponseIceberg")},
+                schema = @Schema(implementation = ContentResponse.class))),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
     @APIResponse(
@@ -525,7 +544,7 @@ public interface HttpTreeApi extends TreeApi {
         content =
             @Content(
                 mediaType = MediaType.APPLICATION_JSON,
-                examples = @ExampleObject(ref = "multiGetResponse"),
+                examples = @ExampleObject(ref = "multipleContentsResponse"),
                 schema = @Schema(implementation = GetMultipleContentsResponse.class))),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
@@ -574,7 +593,7 @@ public interface HttpTreeApi extends TreeApi {
         content =
             @Content(
                 mediaType = MediaType.APPLICATION_JSON,
-                examples = @ExampleObject(ref = "multiGetResponse"),
+                examples = @ExampleObject(ref = "multipleContentsResponse"),
                 schema = @Schema(implementation = GetMultipleContentsResponse.class))),
     @APIResponse(responseCode = "400", description = "Invalid input, ref name not valid"),
     @APIResponse(responseCode = "401", description = "Invalid credentials provided"),
@@ -754,7 +773,7 @@ public interface HttpTreeApi extends TreeApi {
         content = {
           @Content(
               mediaType = MediaType.APPLICATION_JSON,
-              examples = {@ExampleObject(ref = "refObj")},
+              examples = {@ExampleObject(ref = "commitResponse")},
               schema = @Schema(implementation = CommitResponse.class))
         }),
     @APIResponse(responseCode = "400", description = "Invalid input, ref/hash name not valid"),

--- a/model/src/main/java/org/projectnessie/model/SingleReferenceResponse.java
+++ b/model/src/main/java/org/projectnessie/model/SingleReferenceResponse.java
@@ -18,8 +18,11 @@ package org.projectnessie.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 
+@Schema(type = SchemaType.OBJECT, title = "SingleReferenceResponse")
 @Value.Immutable
 @JsonSerialize(as = ImmutableSingleReferenceResponse.class)
 @JsonDeserialize(as = ImmutableSingleReferenceResponse.class)

--- a/model/src/main/resources/META-INF/openapi.yaml
+++ b/model/src/main/resources/META-INF/openapi.yaml
@@ -189,20 +189,38 @@ components:
 
     entriesResponse:
       value:
-        token: "xxx"
+        token: null
+        hasMore: false
         entries:
           - name:
               elements:
                 - example
                 - key
             type: ICEBERG_TABLE
-        prefixes:
-          - elements:
-              - example
-              - a
-          - elements:
-              - example
-              - b
+
+    entriesResponseV2:
+      value:
+        token: "xxx"
+        hasMore: false
+        effectiveReference:
+          type: BRANCH
+          hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+          name: "exampleBranch"
+        entries:
+          - name:
+              elements:
+                - example
+                - key
+            type: ICEBERG_TABLE
+            contentId: "f350b391-f492-41eb-9959-730a8c49f01e"
+            content:
+              type: ICEBERG_TABLE
+              id: "f350b391-f492-41eb-9959-730a8c49f01e"
+              metadataLocation: "/path/to/metadata/"
+              snapshotId: 23
+              schemaId: 15
+              specId: 15
+              sortOrderId: 15
 
     types:
       value:
@@ -248,48 +266,6 @@ components:
         targetBranch: "main"
         effectiveTargetHash: "e9058b675c519b3542cd8155aed42ecf1ddb4e55874e3eb241b30b96f861566a"
         expectedHash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
-        sourceCommits:
-          - commitMeta:
-              author: "authorName <authorName@example.com>"
-              authorTime: "2021-04-07T14:42:25.534748Z"
-              hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
-              message: "Example Commit Message"
-            operations:
-              - type: PUT
-                key:
-                  elements:
-                    - example
-                    - key
-                content:
-                  type: ICEBERG_TABLE
-                  id: b874b5d5-f926-4eed-9be7-b2380d9810c0
-                  metadataLocation: "/path/to/metadata/"
-                  snapshotId: 1
-                  schemaId: 2
-                  specId: 3
-                  sortOrderId: 4
-            parentCommitHash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
-        targetCommits:
-          - commitMeta:
-              author: "authorName <authorName@example.com>"
-              authorTime: "2021-04-07T14:42:25.534748Z"
-              hash: "e9058b675c519b3542cd8155aed42ecf1ddb4e55874e3eb241b30b96f861566a"
-              message: "Example Commit Message"
-            operations:
-              - type: PUT
-                key:
-                  elements:
-                    - example
-                    - key
-                content:
-                  type: ICEBERG_TABLE
-                  id: b874b5d5-f926-4eed-9be7-b2380d9810c0
-                  metadataLocation: "/path/to/metadata/"
-                  snapshotId: 1
-                  schemaId: 2
-                  specId: 3
-                  sortOrderId: 4
-            parentCommitHash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
         details:
           - key:
               elements:
@@ -297,9 +273,6 @@ components:
                 - key
             mergeBehavior: "NORMAL"
             conflictType: "NONE"
-            sourceCommits:
-            targetCommits:
-              - "e9058b675c519b3542cd8155aed42ecf1ddb4e55874e3eb241b30b96f861566a"
 
     mergeResponseFail:
       value:
@@ -310,48 +283,6 @@ components:
         targetBranch: "main"
         effectiveTargetHash: "8a2f19888eb620c25b0d2cbcddfdf56fb2d3e9dd443c6d29e37c567493fc5d3b"
         expectedHash: "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
-        sourceCommits:
-          - commitMeta:
-              author: "authorName <authorName@example.com>"
-              authorTime: "2021-04-07T14:42:25.534748Z"
-              hash: "88012047ce424686ca55e8bb228ae9d9cbd6f7bbfc800d830a53a6edf2d55ffb"
-              message: "Example Commit Message"
-            operations:
-              - type: PUT
-                key:
-                  elements:
-                    - example
-                    - key
-                content:
-                  type: ICEBERG_TABLE
-                  id: b874b5d5-f926-4eed-9be7-b2380d9810c0
-                  metadataLocation: "/path/to/metadata/"
-                  snapshotId: 1
-                  schemaId: 2
-                  specId: 3
-                  sortOrderId: 4
-            parentCommitHash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
-        targetCommits:
-          - commitMeta:
-              author: "authorName <authorName@example.com>"
-              authorTime: "2021-04-07T14:42:25.534748Z"
-              hash: "54388c80e6387b8cfa4cf3e7c7909073ffc761f9c7f0d6154ec0d5c5829a4503"
-              message: "Example Commit Message"
-            operations:
-              - type: PUT
-                key:
-                  elements:
-                    - example
-                    - key
-                content:
-                  type: ICEBERG_TABLE
-                  id: b874b5d5-f926-4eed-9be7-b2380d9810c0
-                  metadataLocation: "/path/to/metadata/"
-                  snapshotId: 1
-                  schemaId: 2
-                  specId: 3
-                  sortOrderId: 4
-            parentCommitHash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
         details:
           - key:
               elements:
@@ -359,10 +290,6 @@ components:
                 - key
             mergeBehavior: "NORMAL"
             conflictType: "UNRESOLVABLE"
-            sourceCommits:
-              - "88012047ce424686ca55e8bb228ae9d9cbd6f7bbfc800d830a53a6edf2d55ffb"
-            targetCommits:
-              - "54388c80e6387b8cfa4cf3e7c7909073ffc761f9c7f0d6154ec0d5c5829a4503"
 
     operations:
       value:
@@ -394,6 +321,7 @@ components:
     logResponseAdditionalInfo:
       value:
         token: "xxx"
+        hasMore: false
         logEntries:
           - commitMeta:
               author: "authorName <authorName@example.com>"
@@ -430,6 +358,7 @@ components:
     logResponseSimple:
       value:
         token: "xxx"
+        hasMore: false
         logEntries:
           - commitMeta:
               author: "authorName <authorName@example.com>"
@@ -443,6 +372,78 @@ components:
                 additionalProp2: "yyy"
                 additionalProp3: "zzz"
               signedOffBy: "signedOffByName <signedOffBy@example.com>"
+
+    multipleContentsResponse:
+      value:
+        contents:
+          - content:
+              type: ICEBERG_TABLE
+              id: "b874b5d5-f926-4eed-9be7-b2380d9810c0"
+              metadataLocation: "/path/to/metadata/"
+              snapshotId: 1
+              schemaId: 2
+              specId: 3
+              sortOrderId: 4
+            key:
+              elements:
+                - example
+                - key
+        effectiveReference:
+          type: BRANCH
+          hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+          name: "exampleBranch"
+
+    commitResponse:
+      value:
+        targetBranch:
+          type: BRANCH
+          hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+          name: "exampleBranch"
+        addedContents:
+          - contentId: "7fe924d9-45af-574e-9bbc-51b48077017e"
+            key:
+              elements:
+                - example
+                - key
+
+    contentResponseIceberg:
+      value:
+        content:
+          type: ICEBERG_TABLE
+          id: b874b5d5-f926-4eed-9be7-b2380d9810c0
+          metadataLocation: "/path/to/metadata/"
+          snapshotId: 1
+          schemaId: 2
+          specId: 3
+          sortOrderId: 4
+        effectiveReference:
+          type: BRANCH
+          hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+          name: "exampleBranch"
+
+    singleReferenceResponse:
+      value:
+        reference:
+          type: BRANCH
+          hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+          name: "exampleBranch"
+
+    singleReferenceResponseWithMetadata:
+      value:
+        reference:
+          type: BRANCH
+          hash: "84c57a20c5e956af4af40f3cc34ecc8a9028b9586da135c79011b1867aa3191d"
+          name: "main"
+          metadata:
+            commitMetaOfHEAD:
+              hash: "84c57a20c5e956af4af40f3cc34ecc8a9028b9586da135c79011b1867aa3191d"
+              committer: ""
+              author: "nessie-author"
+              signedOffBy: null
+              message: "update table"
+              commitTime: "2021-11-26T08:01:13.855974Z"
+              authorTime: "2021-11-26T08:01:13.852826Z"
+              properties: {}
 
     referencesResponse:
       value:
@@ -559,3 +560,37 @@ components:
               schemaId: 16
               specId: 16
               sortOrderId: 16
+
+    diffResponseWithRef:
+      value:
+        hasMore: false
+        token: null
+        diffs:
+          - key:
+              elements:
+                - example
+                - key
+            from:
+              type: ICEBERG_TABLE
+              id: "f350b391-f492-41eb-9959-730a8c49f01e"
+              metadataLocation: "/path/to/metadata/"
+              snapshotId: 23
+              schemaId: 15
+              specId: 15
+              sortOrderId: 15
+            to:
+              type: ICEBERG_TABLE
+              id: "dec31d0a-7d4b-4534-8c24-24f08eda33b2"
+              metadataLocation: "/path/to/metadata/"
+              snapshotId: 24
+              schemaId: 16
+              specId: 16
+              sortOrderId: 16
+        effectiveFromReference:
+          type: BRANCH
+          hash: "da086850076827d2989c8ee1d7fd22f152f525d46a0441f2b22ad8119c0bbbe5"
+          name: "dev"
+        effectiveToReference:
+          type: BRANCH
+          hash: "abcdef4242424242424242424242beef00dead42112233445566778899001122"
+          name: "exampleBranch"


### PR DESCRIPTION
A couple of response types in the V2 HttpTreeApi were incorrectly declared in the corresponding `@APIResponse`. Especialy `SingleReferenceResponse` was missing, also a few places where V2 now returns HTTP/200 (assign+delete) with the assigned/deleted reference.

Fixes #6210