### PR TITLE
Symlink gradle-wrapper.jar, unignore gradle-wrapper.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ out/
 # gradle
 .gradle/
 build/
-gradle/wrapper/gradle-wrapper.jar
+!gradle-wrapper.jar
 
 # Python
 venv/

--- a/build-tools-integration-tests/gradle/wrapper/gradle-wrapper.jar
+++ b/build-tools-integration-tests/gradle/wrapper/gradle-wrapper.jar
@@ -1,0 +1,1 @@
+../../../gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
Since gradle-wrapper.jar is in Git, it should be actively tracked as well