### PR TITLE
Add tests to validate that API v1 responses do not have v2 attributes.

### DIFF
--- a/clients/client-testextension/src/main/java/org/projectnessie/client/ext/NessieClientResponseFactory.java
+++ b/clients/client-testextension/src/main/java/org/projectnessie/client/ext/NessieClientResponseFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.ext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.projectnessie.client.http.HttpResponseFactory;
+
+/**
+ * Annotation for JUnit5 test classes that need to run with a special HTTP response handler in
+ * Nessie REST API client.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface NessieClientResponseFactory {
+  Class<? extends HttpResponseFactory> value();
+}

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -56,6 +56,7 @@ public interface HttpClient {
     private URI baseUri;
     private ObjectMapper mapper;
     private Class<?> jsonView;
+    private HttpResponseFactory responseFactory = HttpResponse::new;
     private SSLContext sslContext;
     private SSLParameters sslParameters;
     private int readTimeoutMillis =
@@ -96,6 +97,10 @@ public interface HttpClient {
     public Builder setJsonView(Class<?> jsonView) {
       this.jsonView = jsonView;
       return this;
+    }
+
+    public void setResponseFactory(HttpResponseFactory responseFactory) {
+      this.responseFactory = responseFactory;
     }
 
     public Builder setSslContext(SSLContext sslContext) {
@@ -171,6 +176,7 @@ public interface HttpClient {
               .baseUri(baseUri)
               .mapper(mapper)
               .jsonView(jsonView)
+              .responseFactory(responseFactory)
               .readTimeoutMillis(readTimeoutMillis)
               .connectionTimeoutMillis(connectionTimeoutMillis)
               .isDisableCompression(disableCompression)

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -280,6 +280,11 @@ public class HttpClientBuilder implements NessieClientBuilder<HttpClientBuilder>
     return this;
   }
 
+  public HttpClientBuilder withResponseFactory(HttpResponseFactory responseFactory) {
+    builder.setResponseFactory(responseFactory);
+    return this;
+  }
+
   @SuppressWarnings({"unchecked"})
   @Override
   public <API extends NessieApi> API build(Class<API> apiVersion) {

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpResponse.java
@@ -23,7 +23,7 @@ import org.projectnessie.client.rest.NessieBadResponseException;
 import org.projectnessie.error.ImmutableNessieError;
 
 /** Simple holder for http response object. */
-public final class HttpResponse {
+public class HttpResponse {
 
   private final ResponseContext responseContext;
   private final ObjectMapper mapper;

--- a/clients/client/src/main/java/org/projectnessie/client/http/HttpResponseFactory.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/HttpResponseFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Factory interface for creating HTTP response handlers. */
+@FunctionalInterface
+public interface HttpResponseFactory {
+  HttpResponse make(ResponseContext context, ObjectMapper mapper);
+}

--- a/clients/client/src/main/java/org/projectnessie/client/http/impl/HttpRuntimeConfig.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/impl/HttpRuntimeConfig.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import org.immutables.value.Value;
+import org.projectnessie.client.http.HttpResponseFactory;
 import org.projectnessie.client.http.RequestFilter;
 import org.projectnessie.client.http.ResponseFilter;
 
@@ -50,6 +51,8 @@ public interface HttpRuntimeConfig {
   @Nullable
   @jakarta.annotation.Nullable
   Class<?> getJsonView();
+
+  HttpResponseFactory responseFactory();
 
   int getReadTimeoutMillis();
 

--- a/clients/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
@@ -129,7 +129,7 @@ final class JavaRequest extends BaseHttpRequest {
       }
 
       response = null;
-      return new org.projectnessie.client.http.HttpResponse(responseContext, config.getMapper());
+      return config.responseFactory().make(responseContext, config.getMapper());
     } finally {
       if (response != null) {
         try {

--- a/clients/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionRequest.java
+++ b/clients/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionRequest.java
@@ -85,7 +85,7 @@ final class UrlConnectionRequest extends BaseHttpRequest {
 
       config.getResponseFilters().forEach(responseFilter -> responseFilter.filter(responseContext));
 
-      return new HttpResponse(responseContext, config.getMapper());
+      return config.responseFactory().make(responseContext, config.getMapper());
     } catch (ProtocolException e) {
       throw new HttpClientException(
           String.format("Cannot perform request against '%s'. Invalid protocol %s", uri, method),

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/ValidatingApiV1ResponseFactory.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/ValidatingApiV1ResponseFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.jaxrs.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import org.projectnessie.client.http.HttpResponse;
+import org.projectnessie.client.http.HttpResponseFactory;
+import org.projectnessie.client.http.ResponseContext;
+
+public class ValidatingApiV1ResponseFactory implements HttpResponseFactory {
+
+  private static final List<String> API_V2_ATTRIBUTES =
+      ImmutableList.of(
+          // This list should include at least one v2 element from each payload type that has
+          // V2-specific API attributes, but it is not necessary to list all v2 attributes from
+          // each type. Assume that v2-specific attributes do not clash with valid v1 attributes.
+          "\"contentId\"",
+          "\"effectiveReference\"",
+          "\"authors\"",
+          "\"allSignedOffBy\"",
+          "\"addedContents\"",
+          "\"effectiveFromReference\"");
+
+  @Override
+  public HttpResponse make(ResponseContext context, ObjectMapper mapper) {
+    return new HttpResponse(context, mapper) {
+      @Override
+      public <V> V readEntity(Class<V> clazz) {
+        try {
+          JsonNode jsonNode = mapper.readValue(context.getInputStream(), JsonNode.class);
+
+          // Make sure API v2 attributes are not present. Newer/current clients would be
+          // able to parse this attribute (if preset) using the up-to-date payload
+          // class, but older clients would brake if v2 attributes were present in API
+          // v1 responses.
+          String jsonString = jsonNode.toPrettyString(); // for nicer error message
+          assertThat(jsonString).doesNotContain(API_V2_ATTRIBUTES);
+
+          return mapper.readerFor(clazz).readValue(jsonNode);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+}

--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestOlderRestApiV1ClientInMemory.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/TestOlderRestApiV1ClientInMemory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.jaxrs.tests;
+
+import static org.projectnessie.jaxrs.ext.NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.ext.NessieApiVersions;
+import org.projectnessie.client.ext.NessieClientResponseFactory;
+import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
+import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
+import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
+import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
+import org.projectnessie.versioned.persist.tests.extension.DatabaseAdapterExtension;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
+import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterName;
+import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabase;
+
+/**
+ * This tests runs the usual API v1 tests, but checks that JSON responses do not have API v2
+ * attributes.
+ */
+@ExtendWith(DatabaseAdapterExtension.class)
+@NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
+@NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
+@NessieApiVersions(versions = NessieApiVersion.V1)
+@NessieClientResponseFactory(ValidatingApiV1ResponseFactory.class)
+class TestOlderRestApiV1ClientInMemory extends BaseTestNessieApi {
+
+  @NessieDbAdapter static DatabaseAdapter databaseAdapter;
+
+  @RegisterExtension
+  static NessieJaxRsExtension server = jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
+}

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestQuarkusWithOlderRestApiV1ClientInMemory.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestQuarkusWithOlderRestApiV1ClientInMemory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.server;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.ext.NessieApiVersions;
+import org.projectnessie.client.ext.NessieClientResponseFactory;
+import org.projectnessie.jaxrs.tests.ValidatingApiV1ResponseFactory;
+import org.projectnessie.quarkus.tests.profiles.QuarkusTestProfileInmemory;
+
+/**
+ * This tests runs the usual API v1 tests, but checks that JSON responses do not have API v2
+ * attributes.
+ */
+@QuarkusTest
+@TestProfile(QuarkusTestProfileInmemory.class)
+@NessieApiVersions(versions = NessieApiVersion.V1)
+@NessieClientResponseFactory(ValidatingApiV1ResponseFactory.class)
+class TestQuarkusWithOlderRestApiV1ClientInMemory extends AbstractQuarkusRest {}


### PR DESCRIPTION
* Allow response handlers to be overwritten in the java client.

* Use the same java client-based API v1 tests to verify the absence of v2 attribute using a custom response factory.

* Both a Jersey-based test and a Quarkus-based tests are needed because Jersey and Quarkus look for JSON View annotations in different places (endpoint interface vs. resource impl. class).