### PR TITLE
Make V2 ref path-param parsing independent of `Reference`

### DIFF
--- a/model/src/main/java/org/projectnessie/api/v2/params/ParsedReference.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/ParsedReference.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.v2.params;
+
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Detached;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Reference.ReferenceType;
+import org.projectnessie.model.Tag;
+
+/**
+ * Represents the attributes that make a reference. All components are optional, except that at
+ * least one of {@link #name()} or {@link #hash()} must be supplied.
+ */
+@Value.Immutable
+public interface ParsedReference {
+  @Value.Parameter(order = 1)
+  @Nullable
+  @jakarta.annotation.Nullable
+  String name();
+
+  @Value.Parameter(order = 2)
+  @Nullable
+  @jakarta.annotation.Nullable
+  String hash();
+
+  @Value.Parameter(order = 3)
+  @Nullable
+  @jakarta.annotation.Nullable
+  ReferenceType type();
+
+  @Value.Check
+  default void check() {
+    if (hash() == null && name() == null) {
+      throw new IllegalStateException("Either name or hash or name and hash must be supplied");
+    }
+  }
+
+  static ParsedReference parsedReference(
+      @Nullable @jakarta.annotation.Nullable String name,
+      @Nullable @jakarta.annotation.Nullable String hash,
+      @Nullable @jakarta.annotation.Nullable ReferenceType type) {
+    if (hash != null && name == null) {
+      name = Detached.REF_NAME;
+    }
+    return ImmutableParsedReference.of(name, hash, type);
+  }
+
+  /**
+   * Converts to a {@link Reference}, if one of the following conditions are met, all other
+   * combinations throw an {@link IllegalArgumentException}.
+   *
+   * <ul>
+   *   <li>Returns a {@link Detached}, if {@link #hash()} is present, {@link #name()} and {@link
+   *       #type()} are {@code null}.
+   *   <li>Returns a {@link Branch}, if {@link #name()} is present, {@link #type()} == {@link
+   *       ReferenceType#BRANCH}.
+   *   <li>Returns a {@link Tag}, if {@link #name()} is present, {@link #type()} == {@link
+   *       ReferenceType#TAG}.
+   * </ul>
+   */
+  @Value.NonAttribute
+  default Reference toReference() {
+    ReferenceType t = type();
+    if (t == null) {
+      if (Detached.REF_NAME.equals(name())) {
+        return Detached.of(hash());
+      }
+      throw new IllegalArgumentException(
+          "Cannot convert a name to a typed reference without a type");
+    }
+
+    switch (t) {
+      case BRANCH:
+        return Branch.of(name(), hash());
+      case TAG:
+        return Tag.of(name(), hash());
+      default:
+        throw new IllegalArgumentException("Unsupported reference type: " + type());
+    }
+  }
+}

--- a/model/src/main/java/org/projectnessie/api/v2/params/ReferenceResolver.java
+++ b/model/src/main/java/org/projectnessie/api/v2/params/ReferenceResolver.java
@@ -15,28 +15,57 @@
  */
 package org.projectnessie.api.v2.params;
 
+import static org.projectnessie.api.v2.params.ParsedReference.parsedReference;
+import static org.projectnessie.model.Reference.ReferenceType.BRANCH;
+
 import java.util.function.Supplier;
-import org.projectnessie.model.Branch;
-import org.projectnessie.model.NessieConfiguration;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.projectnessie.model.Reference;
 
 public final class ReferenceResolver {
 
   public static final String DEFAULT_REF_IN_PATH = "-";
+  public static final char REF_HASH_SEPARATOR = '@';
 
   private ReferenceResolver() {}
 
-  public static Reference resolveReferencePathElement(
-      String refPathString, Supplier<NessieConfiguration> config) {
-    if (DEFAULT_REF_IN_PATH.equals(refPathString)) {
-      return Branch.of(config.get().getDefaultBranch(), null);
+  public static ParsedReference resolveReferencePathElement(
+      @Nonnull @jakarta.annotation.Nonnull String value,
+      @Nullable @jakarta.annotation.Nullable Reference.ReferenceType namedRefType) {
+    String name = null;
+    String hash = null;
+    int hashIdx = value.indexOf(REF_HASH_SEPARATOR);
+
+    if (hashIdx > 0) {
+      name = value.substring(0, hashIdx);
     }
 
-    return resolveReferencePathElement(refPathString, Reference.ReferenceType.BRANCH);
+    if (hashIdx < 0) {
+      name = value;
+    }
+
+    if (hashIdx >= 0) {
+      hash = value.substring(hashIdx + 1);
+      if (hash.isEmpty()) {
+        hash = null;
+      }
+    }
+
+    if (name != null) {
+      return parsedReference(name, hash, namedRefType);
+    }
+    // detached
+    return parsedReference(null, hash, null);
   }
 
-  public static Reference resolveReferencePathElement(
-      String refPathString, Reference.ReferenceType type) {
-    return Reference.fromPathString(refPathString, type);
+  public static ParsedReference resolveReferencePathElementWithDefaultBranch(
+      @Nonnull @jakarta.annotation.Nonnull String refPathString,
+      @Nonnull @jakarta.annotation.Nonnull Supplier<String> defaultBranchSupplier) {
+    if (!DEFAULT_REF_IN_PATH.equals(refPathString)) {
+      return resolveReferencePathElement(refPathString, null);
+    }
+
+    return parsedReference(defaultBranchSupplier.get(), null, BRANCH);
   }
 }

--- a/model/src/main/java/org/projectnessie/model/Reference.java
+++ b/model/src/main/java/org/projectnessie/model/Reference.java
@@ -105,10 +105,6 @@ public interface Reference extends Base {
     return Util.toPathStringRef(name, hash);
   }
 
-  static Reference fromPathString(String value, ReferenceType parseAsType) {
-    return Util.fromPathStringRef(value, parseAsType);
-  }
-
   /** The reference type as an enum. */
   @Schema(enumeration = {"branch", "tag"}) // Required to have lower-case values in OpenAPI
   enum ReferenceType {

--- a/model/src/main/java/org/projectnessie/model/Util.java
+++ b/model/src/main/java/org/projectnessie/model/Util.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.model;
 
+import static org.projectnessie.api.v2.params.ReferenceResolver.REF_HASH_SEPARATOR;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -25,7 +27,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.projectnessie.model.types.ContentTypes;
 
 final class Util {
@@ -35,7 +36,6 @@ final class Util {
   public static final char ZERO_BYTE = '\u0000';
   public static final char DOT = '.';
   public static final char GROUP_SEPARATOR = '\u001D';
-  public static final char REF_HASH_SEPARATOR = '@';
   public static final char URL_PATH_SEPARATOR = '/';
   public static final String DOT_STRING = ".";
   public static final String ZERO_BYTE_STRING = Character.toString(ZERO_BYTE);
@@ -81,42 +81,6 @@ final class Util {
     }
 
     return builder.toString();
-  }
-
-  public static Reference fromPathStringRef(
-      @Nonnull @jakarta.annotation.Nonnull String value,
-      @Nonnull @jakarta.annotation.Nonnull Reference.ReferenceType namedRefType) {
-    String name = null;
-    String hash = null;
-    int hashIdx = value.indexOf(REF_HASH_SEPARATOR);
-
-    if (hashIdx > 0) {
-      name = value.substring(0, hashIdx);
-    }
-
-    if (hashIdx < 0) {
-      name = value;
-    }
-
-    if (hashIdx >= 0) {
-      hash = value.substring(hashIdx + 1);
-      if (hash.isEmpty()) {
-        hash = null;
-      }
-    }
-
-    if (name == null) {
-      return Detached.of(hash);
-    } else {
-      switch (namedRefType) {
-        case TAG:
-          return Tag.of(name, hash);
-        case BRANCH:
-          return Branch.of(name, hash);
-        default:
-          throw new IllegalArgumentException("Unsupported reference type: " + namedRefType);
-      }
-    }
   }
 
   static final class ContentTypeDeserializer extends JsonDeserializer<Content.Type> {

--- a/model/src/test/java/org/projectnessie/api/v2/params/TestParsedReference.java
+++ b/model/src/test/java/org/projectnessie/api/v2/params/TestParsedReference.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.v2.params;
+
+import static org.projectnessie.api.v2.params.ReferenceResolver.resolveReferencePathElement;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.projectnessie.model.Detached;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Reference.ReferenceType;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestParsedReference {
+  @InjectSoftAssertions private SoftAssertions soft;
+
+  @ParameterizedTest
+  @CsvSource({
+    "a@11223344,a,11223344",
+    "a,a,",
+    "a/b,a/b,",
+    "a/b@11223344,a/b,11223344",
+    "a@,a,",
+    "a/b@,a/b,",
+  })
+  void fromPathString(String pathParameter, String expectedName, String expectedHash) {
+    for (ReferenceType type : ReferenceType.values()) {
+      soft.assertThat(resolveReferencePathElement(pathParameter, type))
+          .extracting(ParsedReference::type, ParsedReference::name, ParsedReference::hash)
+          .containsExactly(type, expectedName, expectedHash);
+
+      soft.assertThat(resolveReferencePathElement(pathParameter, type))
+          .extracting(ParsedReference::toReference)
+          .extracting(Reference::getType, Reference::getName, Reference::getHash)
+          .containsExactly(type, expectedName, expectedHash);
+    }
+
+    soft.assertThat(resolveReferencePathElement(pathParameter, null))
+        .extracting(ParsedReference::type, ParsedReference::name, ParsedReference::hash)
+        .containsExactly(null, expectedName, expectedHash);
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> resolveReferencePathElement(pathParameter, null).toReference())
+        .withMessage("Cannot convert a name to a typed reference without a type");
+  }
+
+  @Test
+  void fromPathStringDetached() {
+    soft.assertThat(resolveReferencePathElement("@11223344", ReferenceType.BRANCH))
+        .extracting(ParsedReference::hash)
+        .isEqualTo("11223344");
+
+    soft.assertThat(resolveReferencePathElement("@11223344", ReferenceType.BRANCH))
+        .extracting(ParsedReference::toReference)
+        .isInstanceOf(Detached.class)
+        .extracting(Reference::getHash)
+        .isEqualTo("11223344");
+
+    soft.assertThat(resolveReferencePathElement("@11223344", null))
+        .extracting(ParsedReference::hash)
+        .isEqualTo("11223344");
+
+    soft.assertThat(resolveReferencePathElement("@11223344", null))
+        .extracting(ParsedReference::toReference)
+        .isInstanceOf(Detached.class)
+        .extracting(Reference::getHash)
+        .isEqualTo("11223344");
+  }
+}

--- a/model/src/test/java/org/projectnessie/model/TestReference.java
+++ b/model/src/test/java/org/projectnessie/model/TestReference.java
@@ -17,10 +17,8 @@ package org.projectnessie.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.projectnessie.model.Reference.ReferenceType;
 
 class TestReference {
 
@@ -34,30 +32,5 @@ class TestReference {
   })
   void toPathString(String name, String hash, String expectedResult) {
     assertThat(Reference.toPathString(name, hash)).isEqualTo(expectedResult);
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-    "a@11223344,a,11223344",
-    "a,a,",
-    "a/b,a/b,",
-    "a/b@11223344,a/b,11223344",
-    "a@,a,",
-    "a/b@,a/b,",
-  })
-  void fromPathString(String pathParameter, String expectedName, String expectedHash) {
-    for (ReferenceType type : ReferenceType.values()) {
-      assertThat(Reference.fromPathString(pathParameter, type))
-          .extracting(Reference::getType, Reference::getName, Reference::getHash)
-          .containsExactly(type, expectedName, expectedHash);
-    }
-  }
-
-  @Test
-  void fromPathStringDetached() {
-    assertThat(Reference.fromPathString("@11223344", ReferenceType.BRANCH))
-        .isInstanceOf(Detached.class)
-        .extracting(Reference::getHash)
-        .isEqualTo("11223344");
   }
 }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -92,8 +92,9 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   }
 
   @Test
-  @TestSecurity(user = "disallowed_user")
-  void testDeleteBranchDisallowed() {
+  @TestSecurity(user = "delete_branch_disallowed_user")
+  void testDeleteBranchDisallowed() throws BaseNessieClientServerException {
+    api().createReference().reference(Branch.of("testDeleteBranchDisallowed", null)).create();
     assertThatThrownBy(
             () ->
                 api()
@@ -105,7 +106,7 @@ class TestAuthorizationRules extends BaseClientAuthTest {
         .hasMessageContaining(
             String.format(
                 "'DELETE_REFERENCE' is not allowed for role '%s' on reference '%s'",
-                "disallowed_user", "testDeleteBranchDisallowed"));
+                "delete_branch_disallowed_user", "testDeleteBranchDisallowed"));
   }
 
   @Test

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
@@ -59,6 +59,9 @@ public class NessieAuthorizationTestProfile extends AuthenticationEnabledProfile
               "nessie.server.authorization.rules.allow_view_merge_delete_user1",
               "op in ['VIEW_REFERENCE', 'ASSIGN_REFERENCE_TO_HASH', 'COMMIT_CHANGE_AGAINST_REFERENCE', 'DELETE_REFERENCE'] "
                   + "&& role=='user1' && (ref.startsWith('allowedBranch') || ref == 'main')")
+          .put(
+              "nessie.server.authorization.rules.delete_branch_disallowed",
+              "op in ['VIEW_REFERENCE', 'CREATE_REFERENCE'] && role=='delete_branch_disallowed_user' && ref in ['testDeleteBranchDisallowed', 'main']")
           .build();
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefUtil.java
@@ -16,9 +16,11 @@
 package org.projectnessie.services.impl;
 
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Detached;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.Reference.ReferenceType;
 import org.projectnessie.model.Tag;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.DetachedRef;
@@ -30,7 +32,7 @@ import org.projectnessie.versioned.WithHash;
 public final class RefUtil {
   private RefUtil() {}
 
-  public static NamedRef toNamedRef(Reference reference) {
+  public static NamedRef toNamedRef(@Nonnull @jakarta.annotation.Nonnull Reference reference) {
     Objects.requireNonNull(reference, "reference must not be null");
     if (reference instanceof Branch) {
       return BranchName.of(reference.getName());
@@ -44,7 +46,9 @@ public final class RefUtil {
     throw new IllegalArgumentException(String.format("Unsupported reference '%s'", reference));
   }
 
-  public static NamedRef toNamedRef(Reference.ReferenceType referenceType, String referenceName) {
+  public static NamedRef toNamedRef(
+      @Nonnull @jakarta.annotation.Nonnull Reference.ReferenceType referenceType,
+      @Nonnull @jakarta.annotation.Nonnull String referenceName) {
     Objects.requireNonNull(referenceType, "referenceType must not be null");
     switch (referenceType) {
       case BRANCH:
@@ -57,12 +61,14 @@ public final class RefUtil {
     }
   }
 
-  public static Reference toReference(NamedRef namedRef, Hash hash) {
+  public static Reference toReference(
+      @Nonnull @jakarta.annotation.Nonnull NamedRef namedRef, Hash hash) {
     Objects.requireNonNull(namedRef, "namedRef must not be null");
     return toReference(namedRef, hash != null ? hash.asString() : null);
   }
 
-  public static Reference toReference(NamedRef namedRef, String hash) {
+  public static Reference toReference(
+      @Nonnull @jakarta.annotation.Nonnull NamedRef namedRef, String hash) {
     Objects.requireNonNull(namedRef, "namedRef must not be null");
     if (namedRef instanceof BranchName) {
       return Branch.of(namedRef.getName(), hash);
@@ -77,7 +83,19 @@ public final class RefUtil {
     throw new IllegalArgumentException(String.format("Unsupported named reference '%s'", namedRef));
   }
 
-  public static Reference toReference(WithHash<NamedRef> hashWitRef) {
+  public static Reference toReference(
+      @Nonnull @jakarta.annotation.Nonnull WithHash<NamedRef> hashWitRef) {
     return toReference(hashWitRef.getValue(), hashWitRef.getHash());
+  }
+
+  public static ReferenceType referenceType(
+      @Nonnull @jakarta.annotation.Nonnull NamedRef namedRef) {
+    if (namedRef instanceof BranchName) {
+      return ReferenceType.BRANCH;
+    }
+    if (namedRef instanceof TagName) {
+      return ReferenceType.TAG;
+    }
+    throw new IllegalArgumentException(String.format("Not a branch or tag: " + namedRef));
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -119,7 +119,7 @@ public interface TreeService {
       @Valid @jakarta.validation.Valid Reference assignTo)
       throws NessieNotFoundException, NessieConflictException;
 
-  String deleteReference(
+  Reference deleteReference(
       ReferenceType referenceType,
       @Valid
           @jakarta.validation.Valid

--- a/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestReferences.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/AbstractTestReferences.java
@@ -193,14 +193,13 @@ public abstract class AbstractTestReferences extends BaseTestServiceImpl {
   public void getAndDeleteBranch() throws Exception {
     Branch branch = createBranch("testBranch");
     assertThat(treeApi().deleteReference(BRANCH, branch.getName(), branch.getHash()))
-        .isEqualTo(branch.getHash());
+        .isEqualTo(branch);
   }
 
   @Test
   public void getAndDeleteTag() throws Exception {
     Tag tag = createTag("testTag", treeApi().getDefaultBranch());
-    assertThat(treeApi().deleteReference(TAG, tag.getName(), tag.getHash()))
-        .isEqualTo(tag.getHash());
+    assertThat(treeApi().deleteReference(TAG, tag.getName(), tag.getHash())).isEqualTo(tag);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
`Reference` is strongly types, it can only be exactly one of the types `Branch`, `Tag` or `Detached`. When parsing the path parameter in V2 API, the actual reference type (branch or tag or detached) is usually unknown, it _can_ be typed by the called by passing the _optional_ reference type.

This change introduces a new V2-internal tuple `ParsedReference` to allow parsing a reference path parameter without knowing the reference type. The backend service interface (`TreeService`) and implementation (`TreeApiImpl`) already allows the reference-type to be optional. A follow-up ticket might refactor the `TreeService` functions to use the new `ParsedReference` type, possibly renaming it and handling the various validation rules.

Updates `TestAuthorizationRules` and adopts the authz check for delete-reference to work like the other functions, which prefer throwing a NessieReferenceNotFoundException over NessieForbiddenException. This behavior (not-found over forbidden) is undefined though - we might change it in the future, but it would require updating the authz check interface and contract as well, because the reference-type would become optional).

Fixes #6223