### PR TITLE
Fix codecov-n-builds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,9 +17,9 @@
 # https://docs.codecov.com/docs/codecovyml-reference
 codecov:
   notify:
-    after_n_builds: 5
+    after_n_builds: 6
 comment:
-  after_n_builds: 5
+  after_n_builds: 6
 # https://docs.codecov.com/docs/commit-status
 coverage:
   status:


### PR DESCRIPTION
Current config mentions "5 builds", but it's actually 6:
* 4 x python
* ui-module
* all JVM