### PR TITLE
New DynamoDB storage - do not pull in the Apache HTTP client

### DIFF
--- a/versioned/storage/dynamodb/build.gradle.kts
+++ b/versioned/storage/dynamodb/build.gradle.kts
@@ -46,7 +46,8 @@ dependencies {
   implementation(libs.protobuf.java)
   implementation(platform(libs.awssdk.bom))
   implementation(libs.awssdk.dynamodb) { exclude("software.amazon.awssdk", "apache-client") }
-  implementation(libs.awssdk.apache.client)
+  implementation(libs.awssdk.netty.nio.client)
+  implementation(libs.awssdk.url.connection.client)
 
   compileOnly(libs.testcontainers.testcontainers)
   compileOnly(libs.docker.java.api)

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoClientProducer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoClientProducer.java
@@ -18,7 +18,7 @@ package org.projectnessie.versioned.storage.dynamodb;
 import java.net.URI;
 import org.immutables.value.Value;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
@@ -38,7 +38,9 @@ public abstract class DynamoClientProducer {
 
   public DynamoDbClient createClient() {
     DynamoDbClientBuilder clientBuilder =
-        DynamoDbClient.builder().httpClient(ApacheHttpClient.create()).region(Region.of(region()));
+        DynamoDbClient.builder()
+            .httpClient(UrlConnectionHttpClient.create())
+            .region(Region.of(region()));
 
     AwsCredentialsProvider credentialsProvider = credentialsProvider();
     if (credentialsProvider != null) {


### PR DESCRIPTION
The Apache HTTP client pulls in the (very old) commons-logging:commons-logging and log4j:log4j dependencies, which we do not want. Compare: dependencies of `nessie-versioned-persist-dynamodb`.

Otherwise the native image build w/ Quarkus 3 fails with `Caused by: java.lang.ClassNotFoundException: org.apache.log4j.Priority`
