### PR TITLE
Let AWS SDK only use the URL connection client

### DIFF
--- a/clients/client/build.gradle.kts
+++ b/clients/client/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
   compileOnly(libs.opentelemetry.semconv)
 
   compileOnly(platform(libs.awssdk.bom))
-  compileOnly(libs.awssdk.auth)
+  compileOnly(libs.awssdk.auth) { exclude("software.amazon.awssdk", "apache-client") }
 
   // javax/jakarta
   testCompileOnly(libs.jakarta.annotation.api)
@@ -74,7 +74,7 @@ dependencies {
   testImplementation(libs.opentelemetry.semconv)
   testImplementation(libs.opentelemetry.exporter.otlp)
   testImplementation(platform(libs.awssdk.bom))
-  testImplementation(libs.awssdk.auth)
+  testImplementation(libs.awssdk.auth) { exclude("software.amazon.awssdk", "apache-client") }
   testImplementation(libs.undertow.core)
   testImplementation(libs.undertow.servlet)
   testRuntimeOnly(libs.logback.classic)

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -81,7 +81,6 @@ dependencies {
 
   testImplementation(platform(libs.awssdk.bom))
   testImplementation(libs.awssdk.s3)
-  testRuntimeOnly(libs.awssdk.url.connection.client)
   // TODO those are needed, because Spark serializes some configuration stuff (Spark broadcast)
   testRuntimeOnly(libs.awssdk.dynamodb)
   testRuntimeOnly(libs.awssdk.glue)

--- a/servers/lambda/build.gradle.kts
+++ b/servers/lambda/build.gradle.kts
@@ -39,9 +39,6 @@ dependencies {
   implementation("io.quarkus:quarkus-amazon-lambda-http")
 
   implementation(platform(libs.awssdk.bom))
-  implementation(libs.awssdk.apache.client)
-  implementation(libs.awssdk.apache.client) { exclude("commons-logging", "commons-logging") }
-  implementation(libs.awssdk.netty.nio.client)
   implementation(libs.awssdk.url.connection.client)
 
   testImplementation("io.quarkus:quarkus-test-amazon-lambda")

--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
   implementation("io.quarkus:quarkus-agroal")
   implementation("io.quarkus:quarkus-jdbc-postgresql")
   implementation("io.quarkiverse.amazonservices:quarkus-amazon-dynamodb")
-  implementation(libs.awssdk.apache.client) { exclude("commons-logging", "commons-logging") }
   implementation("io.quarkus:quarkus-mongodb-client")
   implementation(platform(libs.cassandra.driver.bom))
   implementation(libs.cassandra.driver.core)

--- a/testing/s3minio/build.gradle.kts
+++ b/testing/s3minio/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
   implementation(libs.testcontainers.testcontainers)
 
   implementation(platform(libs.awssdk.bom))
-  implementation(libs.awssdk.s3)
+  implementation(libs.awssdk.s3) { exclude("software.amazon.awssdk", "apache-client") }
   implementation(libs.awssdk.url.connection.client)
 
   // hadoop-common brings Jackson in ancient versions, pulling in the Jackson BOM to avoid that

--- a/testing/s3mock/build.gradle.kts
+++ b/testing/s3mock/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
   testRuntimeOnly(libs.logback.classic)
 
   testImplementation(platform(libs.awssdk.bom))
-  testImplementation(libs.awssdk.s3)
+  testImplementation(libs.awssdk.s3) { exclude("software.amazon.awssdk", "apache-client") }
   testImplementation(libs.awssdk.url.connection.client)
 
   testCompileOnly(libs.immutables.value.annotations)

--- a/versioned/persist/dynamodb/build.gradle.kts
+++ b/versioned/persist/dynamodb/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
 
   implementation(platform(libs.awssdk.bom))
   implementation(libs.awssdk.dynamodb) { exclude("software.amazon.awssdk", "apache-client") }
-  implementation(libs.awssdk.netty.nio.client)
   implementation(libs.awssdk.url.connection.client)
 
   testImplementation(project(":nessie-versioned-tests"))

--- a/versioned/storage/dynamodb/build.gradle.kts
+++ b/versioned/storage/dynamodb/build.gradle.kts
@@ -46,7 +46,8 @@ dependencies {
   implementation(libs.protobuf.java)
   implementation(platform(libs.awssdk.bom))
   implementation(libs.awssdk.dynamodb) { exclude("software.amazon.awssdk", "apache-client") }
-  implementation(libs.awssdk.apache.client)
+  implementation(libs.awssdk.netty.nio.client)
+  implementation(libs.awssdk.url.connection.client)
 
   compileOnly(libs.testcontainers.testcontainers)
   compileOnly(libs.docker.java.api)

--- a/versioned/storage/dynamodb/build.gradle.kts
+++ b/versioned/storage/dynamodb/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
   implementation(libs.protobuf.java)
   implementation(platform(libs.awssdk.bom))
   implementation(libs.awssdk.dynamodb) { exclude("software.amazon.awssdk", "apache-client") }
-  implementation(libs.awssdk.netty.nio.client)
   implementation(libs.awssdk.url.connection.client)
 
   compileOnly(libs.testcontainers.testcontainers)

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoClientProducer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoClientProducer.java
@@ -18,7 +18,7 @@ package org.projectnessie.versioned.storage.dynamodb;
 import java.net.URI;
 import org.immutables.value.Value;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
@@ -38,7 +38,9 @@ public abstract class DynamoClientProducer {
 
   public DynamoDbClient createClient() {
     DynamoDbClientBuilder clientBuilder =
-        DynamoDbClient.builder().httpClient(ApacheHttpClient.create()).region(Region.of(region()));
+        DynamoDbClient.builder()
+            .httpClient(UrlConnectionHttpClient.create())
+            .region(Region.of(region()));
 
     AwsCredentialsProvider credentialsProvider = credentialsProvider();
     if (credentialsProvider != null) {


### PR DESCRIPTION
The (default) Apache HTTP client pulls in the (ancient) Log4J 1.x, which is not such a great idea.

ote: Nessie GC _still_ allows the Apache HTTP client for S3 via Iceberg