### PR TITLE
Ensure parent namespace(s) for commited content objects exist

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/ContentKey.java
+++ b/api/model/src/main/java/org/projectnessie/model/ContentKey.java
@@ -96,6 +96,54 @@ public abstract class ContentKey implements Comparable<ContentKey> {
     return ContentKey.of(elements.subList(0, elements.size() - 1));
   }
 
+  /**
+   * Return the content key, truncated to the given maximum length if the number of elements is
+   * greater than {@code targetMaxLength}, otherwise returns this content key.
+   */
+  public ContentKey truncateToLength(int targetMaxLength) {
+    List<String> elements;
+    elements = getElements();
+    List<String> truncated = truncateToLengthElements(elements, targetMaxLength);
+    if (truncated == elements) {
+      return this;
+    }
+    return ContentKey.of(truncated);
+  }
+
+  private static List<String> truncateToLengthElements(List<String> elements, int targetMaxLength) {
+    int len = elements.size();
+    if (len <= targetMaxLength) {
+      return elements;
+    }
+    return elements.subList(0, targetMaxLength);
+  }
+
+  public boolean startsWith(ContentKey other) {
+    List<String> elements = getElements();
+    List<String> otherElements = other.getElements();
+    return startsWith(elements, otherElements);
+  }
+
+  public boolean startsWith(Namespace other) {
+    List<String> elements = getElements();
+    List<String> otherElements = other.getElements();
+    return startsWith(elements, otherElements);
+  }
+
+  private static boolean startsWith(List<String> elements, List<String> otherElements) {
+    int len = elements.size();
+    int otherLen = otherElements.size();
+    if (otherLen > len) {
+      return false;
+    }
+    for (int i = 0; i < otherLen; i++) {
+      if (!elements.get(i).equals(otherElements.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   public static ContentKey of(Namespace namespace, String name) {
     ImmutableContentKey.Builder b = ImmutableContentKey.builder();
     if (namespace != null && !namespace.isEmpty()) {

--- a/api/model/src/test/java/org/projectnessie/model/TestContentKey.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestContentKey.java
@@ -450,4 +450,41 @@ class TestContentKey {
   void getParent(ContentKey in, ContentKey parent) {
     assertThat(in).extracting(ContentKey::getParent).isEqualTo(parent);
   }
+
+  static Stream<Arguments> truncateToLength() {
+    return Stream.of(
+        arguments(ContentKey.of("x"), 1, ContentKey.of("x")),
+        arguments(ContentKey.of("x"), 2, ContentKey.of("x")),
+        arguments(ContentKey.of("x"), 0, ContentKey.of()),
+        arguments(ContentKey.of("x", "y", "z"), 1, ContentKey.of("x")),
+        arguments(ContentKey.of("x", "y", "z"), 2, ContentKey.of("x", "y")),
+        arguments(ContentKey.of("x", "y", "z"), 3, ContentKey.of("x", "y", "z")),
+        arguments(ContentKey.of("x", "y", "z"), 4, ContentKey.of("x", "y", "z")),
+        arguments(ContentKey.of("x", "y", "z"), 0, ContentKey.of()));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void truncateToLength(ContentKey key, int len, ContentKey expected) {
+    assertThat(key.truncateToLength(len)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> startsWith() {
+    return Stream.of(
+        arguments(ContentKey.of("x"), ContentKey.of("x", "y"), false),
+        arguments(ContentKey.of("x"), ContentKey.of("x"), true),
+        arguments(ContentKey.of("x"), ContentKey.of("y"), false),
+        arguments(ContentKey.of("x"), ContentKey.of(), true),
+        arguments(ContentKey.of("x", "y", "z"), ContentKey.of("x"), true),
+        arguments(ContentKey.of("x", "y", "z"), ContentKey.of("x", "y"), true),
+        arguments(ContentKey.of("x", "y", "z"), ContentKey.of("x", "y", "z"), true),
+        arguments(ContentKey.of("x", "y", "z"), ContentKey.of(), true));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void startsWith(ContentKey key, ContentKey other, boolean expect) {
+    assertThat(key.startsWith(other)).isEqualTo(expect);
+    assertThat(key.startsWith(Namespace.of(other))).isEqualTo(expect);
+  }
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
@@ -86,6 +86,11 @@ public interface QuarkusStoreConfig extends StoreConfig {
   @Override
   long assumedWallClockDriftMicros();
 
+  @WithName(CONFIG_NAMESPACE_VALIDATION)
+  @WithDefault("" + DEFAULT_NAMESPACE_VALIDATION)
+  @Override
+  boolean validateNamespaces();
+
   String CONFIG_CACHE_CAPACITY_MB = "cache-capacity-mb";
   int DEFAULT_CACHE_CAPACITY_MB = 0;
 

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusVersionStoreAdvancedConfig.java
@@ -40,6 +40,11 @@ import org.projectnessie.versioned.persist.tx.TxDatabaseAdapterConfig;
 public interface QuarkusVersionStoreAdvancedConfig
     extends NonTransactionalDatabaseAdapterConfig, TxDatabaseAdapterConfig {
 
+  @WithName("validate-namespaces")
+  @WithDefault("" + DEFAULT_NAMESPACE_VALIDATION)
+  @Override
+  boolean validateNamespaces();
+
   @WithName("repository-id")
   @WithDefault(DEFAULT_REPOSITORY_ID)
   // Use RepoIdConverter for the "key-prefix" property because it can be an empty string,

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/AdjustableDatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/AdjustableDatabaseAdapterConfig.java
@@ -19,6 +19,8 @@ import java.time.Clock;
 
 public interface AdjustableDatabaseAdapterConfig extends DatabaseAdapterConfig {
 
+  AdjustableDatabaseAdapterConfig withValidateNamespaces(boolean validateNamespaces);
+
   AdjustableDatabaseAdapterConfig withRepositoryId(String repositoryId);
 
   AdjustableDatabaseAdapterConfig withParentsPerCommit(int parentsPerCommit);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitParams.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/CommitParams.java
@@ -19,6 +19,7 @@ import com.google.protobuf.ByteString;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
@@ -48,7 +49,7 @@ public interface CommitParams extends ToBranchParams {
   List<ContentKey> getUnchanged();
 
   /** List of "unchanged" keys, from {@code Delete} commit operations. */
-  List<ContentKey> getDeletes();
+  Set<ContentKey> getDeletes();
 
   /** Serialized commit-metadata. */
   ByteString getCommitMetaSerialized();

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/DatabaseAdapterConfig.java
@@ -47,6 +47,20 @@ public interface DatabaseAdapterConfig {
   int DEFAULT_RETRY_MAX_SLEEP_MILLIS = 75;
   long DEFAULT_ASSUMED_WALL_CLOCK_DRIFT_MICROS = 5_000_000L;
   int DEFAULT_ATTACHMENT_KEYS_BATCH_SIZE = 100;
+  boolean DEFAULT_NAMESPACE_VALIDATION = true;
+
+  /**
+   * Committing operations by default enforce that all (parent) namespaces exist.
+   *
+   * <p>This configuration setting is only present for a few Nessie releases to work around
+   * potential migration issues and is subject to removal.
+   *
+   * @since 0.52.0
+   */
+  @Value.Default
+  default boolean validateNamespaces() {
+    return DEFAULT_NAMESPACE_VALIDATION;
+  }
 
   /**
    * A free-form string that identifies a particular Nessie storage repository.

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1560,16 +1560,6 @@ public abstract class AbstractDatabaseAdapter<
   protected Map<ContentKey, ContentAndState> fetchValues(
       OP_CONTEXT ctx, Hash refHead, Collection<ContentKey> keys, KeyFilterPredicate keyFilter)
       throws ReferenceNotFoundException {
-    return fetchValues(ctx, refHead, keys, keyFilter, x -> null);
-  }
-
-  protected Map<ContentKey, ContentAndState> fetchValues(
-      OP_CONTEXT ctx,
-      Hash refHead,
-      Collection<ContentKey> keys,
-      KeyFilterPredicate keyFilter,
-      Function<Hash, CommitLogEntry> inMemoryCommits)
-      throws ReferenceNotFoundException {
     Set<ContentKey> remainingKeys = new HashSet<>(keys);
 
     Map<ContentKey, ContentAndState> nonGlobal = new HashMap<>();
@@ -1614,7 +1604,7 @@ public abstract class AbstractDatabaseAdapter<
     // handles the 'Put` operations.
 
     AtomicBoolean keyListProcessed = new AtomicBoolean();
-    try (Stream<CommitLogEntry> baseLog = readCommitLogStream(ctx, refHead, inMemoryCommits);
+    try (Stream<CommitLogEntry> baseLog = readCommitLogStream(ctx, refHead);
         Stream<CommitLogEntry> log = takeUntilExcludeLast(baseLog, e -> remainingKeys.isEmpty())) {
       log.forEach(
           entry -> {

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1228,8 +1228,7 @@ public abstract class AbstractDatabaseAdapter<
               int keyLen = key.getElementCount();
               for (ContentKey deleted : deletes) {
                 int deletedLen = deleted.getElementCount();
-                if (keyLen > deletedLen
-                    && key.getElements().subList(0, deletedLen).equals(deleted.getElements())) {
+                if (keyLen > deletedLen && key.startsWith(deleted)) {
                   return true;
                 }
               }
@@ -1289,9 +1288,7 @@ public abstract class AbstractDatabaseAdapter<
 
         // check if element is in the current namespace, fail it is true - this means,
         // there is a live content-key in the current namespace - must not delete the namespace
-        if (!ck.equals(deleted)
-            && ckLen >= nsLen
-            && ck.getElements().subList(0, nsLen).equals(deleted.getElements())) {
+        if (ckLen > nsLen && ck.startsWith(deleted)) {
           throw new ReferenceConflictException(
               format(
                   "The namespace '%s' would be deleted, but cannot, because it has children.",

--- a/versioned/persist/testextension/src/main/java/org/projectnessie/versioned/persist/tests/SystemPropertiesConfigurer.java
+++ b/versioned/persist/testextension/src/main/java/org/projectnessie/versioned/persist/tests/SystemPropertiesConfigurer.java
@@ -90,6 +90,8 @@ public final class SystemPropertiesConfigurer {
           config = (T) m.invoke(config, Float.parseFloat(value));
         } else if (type == Double.class || type == double.class) {
           config = (T) m.invoke(config, Double.parseDouble(value));
+        } else if (type == Boolean.class || type == boolean.class) {
+          config = (T) m.invoke(config, Boolean.parseBoolean(value));
         } else {
           throw new UnsupportedOperationException("No converter from String to " + type);
         }

--- a/versioned/persist/tests/build.gradle.kts
+++ b/versioned/persist/tests/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation(project(":nessie-versioned-persist-testextension"))
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-tests"))
+  implementation(project(":nessie-server-store"))
   implementation(libs.guava)
   implementation(libs.micrometer.core)
   implementation(libs.opentracing.mock)

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterVersionStoreTest.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractDatabaseAdapterVersionStoreTest.java
@@ -24,6 +24,7 @@ import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapter;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbAdapterConfigItem;
 import org.projectnessie.versioned.persist.tests.extension.NessieDbTracer;
 import org.projectnessie.versioned.persist.tests.extension.NessieMockedTracingExtension;
+import org.projectnessie.versioned.tests.AbstractNoNamespaceValidation;
 import org.projectnessie.versioned.tests.AbstractVersionStoreTestBase;
 
 @ExtendWith(DatabaseAdapterExtension.class)
@@ -46,6 +47,20 @@ public abstract class AbstractDatabaseAdapterVersionStoreTest extends AbstractVe
   public class Tracing extends AbstractTracing {
     public Tracing() {
       super(AbstractDatabaseAdapterVersionStoreTest.store);
+    }
+  }
+
+  @Nested
+  @SuppressWarnings("ClassCanBeStatic")
+  public class NoNamespaceValidation extends AbstractNoNamespaceValidation {
+
+    @NessieDbAdapter(withTracing = true)
+    @NessieDbAdapterConfigItem(name = "validate.namespaces", value = "false")
+    VersionStore store;
+
+    @Override
+    protected VersionStore store() {
+      return store;
     }
   }
 }

--- a/versioned/storage/common-tests/build.gradle.kts
+++ b/versioned/storage/common-tests/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-testextension"))
   implementation(project(":nessie-versioned-tests"))
   implementation(project(":nessie-versioned-spi"))
+  implementation(project(":nessie-server-store"))
 
   // javax/jakarta
   compileOnly(libs.jakarta.validation.api)

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
@@ -62,6 +62,22 @@ public interface StoreConfig {
   String CONFIG_ASSUMED_WALL_CLOCK_DRIFT_MICROS = "assumed-wall-clock-drift-micros";
   long DEFAULT_ASSUMED_WALL_CLOCK_DRIFT_MICROS = 5_000_000L;
 
+  String CONFIG_NAMESPACE_VALIDATION = "namespace-validation";
+  boolean DEFAULT_NAMESPACE_VALIDATION = true;
+
+  /**
+   * Committing operations by default enforce that all (parent) namespaces exist.
+   *
+   * <p>This configuration setting is only present for a few Nessie releases to work around
+   * potential migration issues and is subject to removal.
+   *
+   * @since 0.52.0
+   */
+  @Value.Default
+  default boolean validateNamespaces() {
+    return DEFAULT_NAMESPACE_VALIDATION;
+  }
+
   /**
    * A free-form string that identifies a particular Nessie storage repository.
    *
@@ -293,6 +309,10 @@ public interface StoreConfig {
       if (v != null) {
         a = a.withAssumedWallClockDriftMicros(Integer.parseInt(v.trim()));
       }
+      v = configFunction.apply(CONFIG_NAMESPACE_VALIDATION);
+      if (v != null) {
+        a = a.withValidateNamespaces(Boolean.parseBoolean(v.trim()));
+      }
       return a;
     }
 
@@ -328,6 +348,9 @@ public interface StoreConfig {
 
     /** See {@link StoreConfig#assumedWallClockDriftMicros()}. */
     Adjustable withAssumedWallClockDriftMicros(long assumedWallClockDriftMicros);
+
+    /** See {@link StoreConfig#validateNamespaces ()} ()}. */
+    Adjustable withValidateNamespaces(boolean validateNamespaces);
 
     /** See {@link StoreConfig#clock()}. */
     Adjustable withClock(Clock clock);

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/config/TestStoreConfig.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/config/TestStoreConfig.java
@@ -24,6 +24,7 @@ import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONF
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_MAX_INCREMENTAL_INDEX_SIZE;
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_MAX_REFERENCE_STRIPES_PER_COMMIT;
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_MAX_SERIALIZED_INDEX_SIZE;
+import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_NAMESPACE_VALIDATION;
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_PARENTS_PER_COMMIT;
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_REPOSITORY_ID;
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_RETRY_INITIAL_SLEEP_MILLIS_LOWER;
@@ -110,6 +111,11 @@ public class TestStoreConfig {
             "1234567",
             (Function<Adjustable, StoreConfig>) e -> e.withAssumedWallClockDriftMicros(1234567),
             (Predicate<StoreConfig>) c -> c.assumedWallClockDriftMicros() == 1234567),
+        arguments(
+            CONFIG_NAMESPACE_VALIDATION,
+            "false",
+            (Function<Adjustable, StoreConfig>) e -> e.withValidateNamespaces(false),
+            (Predicate<StoreConfig>) c -> !c.validateNamespaces()),
         // default methods (current time in micros + hasher)
         arguments(
             "x",

--- a/versioned/storage/store/build.gradle.kts
+++ b/versioned/storage/store/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-versioned-spi"))
   implementation(libs.protobuf.java)
+  implementation(libs.agrona)
 
   // javax/jakarta
   compileOnly(libs.jakarta.validation.api)

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -269,24 +269,15 @@ class BaseCommitHelper {
             .filter(k -> k.getElementCount() > 1)
             .map(ContentKey::getParent)
             .collect(Collectors.toSet());
-    validateNamespacesExist(namespaceKeys, newContent, headIndex);
-  }
-
-  void validateNamespacesExist(
-      Set<ContentKey> namespaceKeys,
-      Map<ContentKey, Content> newContent,
-      StoreIndex<CommitOp> headIndex)
-      throws ReferenceConflictException {
     if (!persist.config().validateNamespaces()) {
       return;
     }
 
     for (ContentKey key : namespaceKeys) {
-
       Content namespaceAddedInThisCommit = newContent.get(key);
       if (namespaceAddedInThisCommit instanceof Namespace) {
-        // Namespace for the current new-content-key has been added in this commit, that
-        // namespace will be checked separately. Assume, it's okay here.
+        // Namespace for the current new-content-key has been added via the currently validated
+        // commit. Nothing to do for `Namespace`s here.
         return;
       }
 

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -282,7 +282,7 @@ class BaseCommitHelper {
       if (namespaceAddedInThisCommit instanceof Namespace) {
         // Namespace for the current new-content-key has been added via the currently validated
         // commit. Nothing to do for `Namespace`s here.
-        return;
+        continue;
       }
 
       StoreIndexElement<CommitOp> ns = headIndex.get(keyToStoreKey(key));

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -248,14 +248,21 @@ class BaseCommitHelper {
         int elLen = elContentKey.getElementCount();
         int nsLen = namespaceKey.getElementCount();
 
+        ContentKey truncatedElContentKey = elContentKey.truncateToLength(nsLen);
+
+        int cmp = truncatedElContentKey.compareTo(namespaceKey);
+
         // check if element is in the current namespace, fail it is true - this means,
         // there is a live content-key in the current namespace - must not delete the namespace
-        if (elLen >= nsLen
-            && elContentKey.getElements().subList(0, nsLen).equals(namespaceKey.getElements())) {
+        if (elLen >= nsLen && cmp == 0) {
           throw new ReferenceConflictException(
               format(
                   "The namespace '%s' would be deleted, but cannot, because it has children.",
                   namespaceKey));
+        }
+        if (cmp > 0) {
+          // iterated past the namespaceKey - break
+          break;
         }
       }
     }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
@@ -83,8 +83,9 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
     Map<ContentKey, KeyDetails> keyDetailsMap = new HashMap<>();
     for (CommitObj sourceCommit : sourceCommits.sourceCommits) {
       CreateCommit createCommit =
-          cloneCommit(
-              updateCommitMetadata, sourceCommit, sourceParentIndex, newHead, targetParentIndex);
+          cloneCommit(updateCommitMetadata, sourceCommit, sourceParentIndex, newHead);
+
+      verifyMergeTransplantCommitPolicies(targetParentIndex, sourceCommit);
 
       CommitObj newCommit =
           createMergeTransplantCommit(mergeTypeForKey, keyDetailsMap, createCommit);
@@ -116,9 +117,7 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
       MetadataRewriter<CommitMeta> updateCommitMetadata,
       CommitObj sourceCommit,
       StoreIndex<CommitOp> sourceParentIndex,
-      ObjId newHead,
-      StoreIndex<CommitOp> targetParentIndex)
-      throws ReferenceConflictException {
+      ObjId newHead) {
     CreateCommit.Builder createCommitBuilder = newCommitBuilder().parentCommitId(newHead);
 
     CommitMeta commitMeta = toCommitMeta(sourceCommit);
@@ -146,8 +145,6 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
             commitRemove(el.key(), op.payload(), requireNonNull(expectedId), op.contentId()));
       }
     }
-
-    verifyMergeTransplantCommitPolicies(targetParentIndex, sourceCommit);
 
     return createCommitBuilder.build();
   }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
@@ -41,6 +41,7 @@ import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.MergeResult.KeyDetails;
 import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
+import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
@@ -72,16 +73,18 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
       ImmutableMergeResult.Builder<Commit> mergeResult,
       Function<ContentKey, MergeType> mergeTypeForKey,
       SourceCommitsAndParent sourceCommits)
-      throws RetryException, ReferenceNotFoundException {
+      throws RetryException, ReferenceNotFoundException, ReferenceConflictException {
     IndexesLogic indexesLogic = indexesLogic(persist);
-    StoreIndex<CommitOp> parentIndex =
+    StoreIndex<CommitOp> sourceParentIndex =
         indexesLogic.buildCompleteIndexOrEmpty(sourceCommits.sourceParent);
+    StoreIndex<CommitOp> targetParentIndex = indexesLogic.buildCompleteIndexOrEmpty(head);
 
     ObjId newHead = headId();
     Map<ContentKey, KeyDetails> keyDetailsMap = new HashMap<>();
     for (CommitObj sourceCommit : sourceCommits.sourceCommits) {
       CreateCommit createCommit =
-          cloneCommit(updateCommitMetadata, parentIndex, newHead, sourceCommit);
+          cloneCommit(
+              updateCommitMetadata, sourceCommit, sourceParentIndex, newHead, targetParentIndex);
 
       CommitObj newCommit =
           createMergeTransplantCommit(mergeTypeForKey, keyDetailsMap, createCommit);
@@ -102,7 +105,8 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
         newHead = newCommit.id();
       }
 
-      parentIndex = indexesLogic.buildCompleteIndex(sourceCommit, Optional.empty());
+      sourceParentIndex = indexesLogic.buildCompleteIndex(sourceCommit, Optional.empty());
+      targetParentIndex = indexesLogic.buildCompleteIndex(newCommit, Optional.empty());
     }
 
     return mergeTransplantSuccess(mergeResult, newHead, dryRun, keyDetailsMap);
@@ -110,9 +114,11 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
 
   private CreateCommit cloneCommit(
       MetadataRewriter<CommitMeta> updateCommitMetadata,
-      StoreIndex<CommitOp> parentIndex,
+      CommitObj sourceCommit,
+      StoreIndex<CommitOp> sourceParentIndex,
       ObjId newHead,
-      CommitObj sourceCommit) {
+      StoreIndex<CommitOp> targetParentIndex)
+      throws ReferenceConflictException {
     CreateCommit.Builder createCommitBuilder = newCommitBuilder().parentCommitId(newHead);
 
     CommitMeta commitMeta = toCommitMeta(sourceCommit);
@@ -120,9 +126,8 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
     fromCommitMeta(updatedMeta, createCommitBuilder);
 
     IndexesLogic indexesLogic = indexesLogic(persist);
-
     for (StoreIndexElement<CommitOp> el : indexesLogic.commitOperations(sourceCommit)) {
-      StoreIndexElement<CommitOp> expected = parentIndex.get(el.key());
+      StoreIndexElement<CommitOp> expected = sourceParentIndex.get(el.key());
       ObjId expectedId = null;
       if (expected != null) {
         CommitOp expectedContent = expected.content();
@@ -141,6 +146,8 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
             commitRemove(el.key(), op.payload(), requireNonNull(expectedId), op.contentId()));
       }
     }
+
+    verifyMergeTransplantCommitPolicies(targetParentIndex, sourceCommit);
 
     return createCommitBuilder.build();
   }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
@@ -19,11 +19,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Sets.newHashSetWithExpectedSize;
 import static java.util.Objects.requireNonNull;
+import static org.projectnessie.versioned.storage.common.indexes.StoreIndexes.lazyStoreIndex;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Add.commitAdd;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Remove.commitRemove;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Unchanged.commitUnchanged;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.newCommitBuilder;
 import static org.projectnessie.versioned.storage.common.logic.Logics.commitLogic;
+import static org.projectnessie.versioned.storage.common.logic.Logics.indexesLogic;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.contentIdMaybe;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.EMPTY_OBJ_ID;
 import static org.projectnessie.versioned.storage.versionstore.RefMapping.referenceConflictException;
@@ -66,6 +68,7 @@ import org.projectnessie.versioned.storage.common.indexes.StoreKey;
 import org.projectnessie.versioned.storage.common.logic.CommitLogic;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 import org.projectnessie.versioned.storage.common.logic.CreateCommit;
+import org.projectnessie.versioned.storage.common.logic.IndexesLogic;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.objtypes.CommitOp;
 import org.projectnessie.versioned.storage.common.objtypes.ContentValueObj;
@@ -75,6 +78,8 @@ import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 
 class CommitImpl extends BaseCommitHelper {
+  private final StoreIndex<CommitOp> headIndex;
+  private final StoreIndex<CommitOp> expectedIndex;
 
   CommitImpl(
       @Nonnull @jakarta.annotation.Nonnull BranchName branch,
@@ -84,6 +89,29 @@ class CommitImpl extends BaseCommitHelper {
       @Nullable @jakarta.annotation.Nullable CommitObj head)
       throws ReferenceNotFoundException {
     super(branch, referenceHash, persist, reference, head);
+
+    this.headIndex =
+        lazyStoreIndex(
+            () -> {
+              IndexesLogic indexesLogic = indexesLogic(persist);
+              return indexesLogic.buildCompleteIndexOrEmpty(head);
+            });
+    this.expectedIndex =
+        expected == head
+            ? headIndex
+            : lazyStoreIndex(
+                () -> {
+                  IndexesLogic indexesLogic = indexesLogic(persist);
+                  return indexesLogic.buildCompleteIndexOrEmpty(expected);
+                });
+  }
+
+  StoreIndex<CommitOp> headIndex() {
+    return headIndex;
+  }
+
+  StoreIndex<CommitOp> expectedIndex() {
+    return expectedIndex;
   }
 
   /**
@@ -166,7 +194,7 @@ class CommitImpl extends BaseCommitHelper {
       CreateCommit.Builder commit,
       Consumer<Obj> contentToStore,
       CommitRetryState commitRetryState)
-      throws ObjNotFoundException {
+      throws ObjNotFoundException, ReferenceConflictException {
     Set<ContentKey> allKeys = new HashSet<>();
 
     Set<StoreKey> storeKeysForHead =
@@ -189,6 +217,8 @@ class CommitImpl extends BaseCommitHelper {
     }
 
     Map<UUID, StoreKey> deleted = new HashMap<>();
+    Map<ContentKey, Content> newContent = new HashMap<>();
+    Set<ContentKey> deletedNamespaces = new HashSet<>();
     for (int i = 0; i < operations.size(); i++) {
       Operation operation = operations.get(i);
       StoreKey storeKey = storeKeys.get(i);
@@ -201,13 +231,18 @@ class CommitImpl extends BaseCommitHelper {
             storeKey,
             contentToStore,
             commitRetryState,
-            deleted);
+            deleted,
+            newContent::put);
       } else if (operation instanceof Delete) {
-        commitAddDelete(expectedIndex(), commit, storeKey, deleted);
+        commitAddDelete(
+            expectedIndex(), commit, operation.getKey(), storeKey, deleted, deletedNamespaces::add);
       } else if (operation instanceof Unchanged) {
         commitAddUnchanged(headIndex(), expectedIndex(), commit, storeKey);
       }
     }
+
+    validateNamespacesExistForContentKeys(newContent, headIndex());
+    validateNamespacesHaveNoChildren(deletedNamespaces, headIndex());
   }
 
   private static void commitAddUnchanged(
@@ -248,8 +283,10 @@ class CommitImpl extends BaseCommitHelper {
   private void commitAddDelete(
       StoreIndex<CommitOp> expectedIndex,
       CreateCommit.Builder commit,
+      ContentKey contentKey,
       StoreKey storeKey,
-      Map<UUID, StoreKey> deleted) {
+      Map<UUID, StoreKey> deleted,
+      Consumer<ContentKey> deletedNamespaces) {
     StoreIndexElement<CommitOp> existingElement = expectedIndex.get(storeKey);
 
     int payload = 0;
@@ -268,6 +305,10 @@ class CommitImpl extends BaseCommitHelper {
         existingValue = content.value();
         existingContentID = content.contentId();
         deleted.put(existingContentID, storeKey);
+
+        if (payload == payloadForContent(Content.Type.NAMESPACE)) {
+          deletedNamespaces.accept(contentKey);
+        }
       }
     }
 
@@ -289,7 +330,8 @@ class CommitImpl extends BaseCommitHelper {
       StoreKey storeKey,
       Consumer<Obj> contentToStore,
       CommitRetryState commitRetryState,
-      Map<UUID, StoreKey> deleted)
+      Map<UUID, StoreKey> deleted,
+      BiConsumer<ContentKey, Content> newContent)
       throws ObjNotFoundException {
     Content putValue = put.getValue();
     ContentKey putKey = put.getKey();
@@ -356,6 +398,8 @@ class CommitImpl extends BaseCommitHelper {
           putKey);
 
       checkArgument(putValueId == null, "New value for new must not have a content iD");
+
+      newContent.accept(putKey, putValue);
 
       putValueId =
           commitRetryState.generatedContentIds.computeIfAbsent(

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/Merge.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/Merge.java
@@ -24,6 +24,7 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
+import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 
@@ -35,5 +36,5 @@ interface Merge {
       Map<ContentKey, MergeType> mergeTypes,
       MergeType defaultMergeType,
       boolean dryRun)
-      throws ReferenceNotFoundException, RetryException;
+      throws ReferenceNotFoundException, RetryException, ReferenceConflictException;
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeIndividualImpl.java
@@ -34,6 +34,7 @@ import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
+import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
@@ -62,7 +63,7 @@ final class MergeIndividualImpl extends BaseMergeTransplantIndividual implements
       Map<ContentKey, MergeType> mergeTypes,
       MergeType defaultMergeType,
       boolean dryRun)
-      throws ReferenceNotFoundException, RetryException {
+      throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
     ObjId fromId = hashToObjId(fromHash);
     ObjId commonAncestorId = identifyCommonAncestor(fromId);
 

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeSquashImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeSquashImpl.java
@@ -32,6 +32,7 @@ import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
+import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
@@ -59,7 +60,7 @@ final class MergeSquashImpl extends BaseMergeTransplantSquash implements Merge {
       Map<ContentKey, MergeType> mergeTypes,
       MergeType defaultMergeType,
       boolean dryRun)
-      throws ReferenceNotFoundException, RetryException {
+      throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
     ObjId fromId = hashToObjId(fromHash);
     ObjId commonAncestorId = identifyCommonAncestor(fromId);
 

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/Transplant.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/Transplant.java
@@ -25,6 +25,7 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
+import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 
@@ -36,5 +37,5 @@ interface Transplant {
       Map<ContentKey, MergeType> mergeTypes,
       MergeType defaultMergeType,
       boolean dryRun)
-      throws ReferenceNotFoundException, RetryException;
+      throws ReferenceNotFoundException, RetryException, ReferenceConflictException;
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
@@ -30,6 +30,7 @@ import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
+import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
@@ -56,7 +57,7 @@ final class TransplantIndividualImpl extends BaseMergeTransplantIndividual imple
       Map<ContentKey, MergeType> mergeTypes,
       MergeType defaultMergeType,
       boolean dryRun)
-      throws ReferenceNotFoundException, RetryException {
+      throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
     SourceCommitsAndParent sourceCommits = loadSourceCommitsPlusParent(sequenceToTransplant);
 
     ImmutableMergeResult.Builder<Commit> mergeResult = prepareMergeResult();

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantSquashImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantSquashImpl.java
@@ -30,6 +30,7 @@ import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.MergeType;
 import org.projectnessie.versioned.MetadataRewriter;
+import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
@@ -56,7 +57,7 @@ final class TransplantSquashImpl extends BaseMergeTransplantSquash implements Tr
       Map<ContentKey, MergeType> mergeTypes,
       MergeType defaultMergeType,
       boolean dryRun)
-      throws ReferenceNotFoundException, RetryException {
+      throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
     SourceCommitsAndParent sourceCommits = loadSourceCommitsPlusParent(sequenceToTransplant);
 
     ImmutableMergeResult.Builder<Commit> mergeResult = prepareMergeResult();

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestNoNamespaceValidation.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestNoNamespaceValidation.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.versionstore;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.testextension.NessiePersist;
+import org.projectnessie.versioned.storage.testextension.NessieStoreConfig;
+import org.projectnessie.versioned.storage.testextension.PersistExtension;
+import org.projectnessie.versioned.tests.AbstractNoNamespaceValidation;
+
+@ExtendWith(PersistExtension.class)
+public class TestNoNamespaceValidation extends AbstractNoNamespaceValidation {
+  @NessiePersist
+  @NessieStoreConfig(name = StoreConfig.CONFIG_NAMESPACE_VALIDATION, value = "false")
+  protected static Persist persist;
+
+  @Override
+  protected VersionStore store() {
+    return new VersionStoreImpl(persist);
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.tests;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.projectnessie.model.CommitMeta.fromMessage;
+import static org.projectnessie.versioned.tests.AbstractVersionStoreTestBase.METADATA_REWRITER;
+import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Namespace;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Delete;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.MergeType;
+import org.projectnessie.versioned.Put;
+import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.VersionStore;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public abstract class AbstractNamespaceValidation extends AbstractNestedVersionStore {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  protected AbstractNamespaceValidation(VersionStore store) {
+    super(store);
+  }
+
+  static Stream<ContentKey> contentKeys() {
+    return Stream.of(
+        ContentKey.of("ns", "table"),
+        ContentKey.of("ns", "table"),
+        ContentKey.of("ns2", "ns", "table"),
+        ContentKey.of("ns2", "ns", "table"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("contentKeys")
+  void commitWithNonExistingNamespace(ContentKey key) throws Exception {
+    BranchName branch = BranchName.of("commitWithNonExistingNamespace");
+    store().create(branch, Optional.empty());
+
+    soft.assertThatThrownBy(
+            () ->
+                store()
+                    .commit(
+                        branch,
+                        Optional.empty(),
+                        fromMessage("non-existing-ns"),
+                        singletonList(Put.of(key, newOnRef("value")))))
+        .isInstanceOf(ReferenceConflictException.class)
+        .hasMessage("Namespace '%s' must exist.", key.getNamespace());
+
+    store()
+        .commit(
+            branch,
+            Optional.empty(),
+            fromMessage("initial commit"),
+            singletonList(Put.of(ContentKey.of("unrelated-table"), newOnRef("value"))));
+
+    soft.assertThatThrownBy(
+            () ->
+                store()
+                    .commit(
+                        branch,
+                        Optional.empty(),
+                        fromMessage("non-existing-ns"),
+                        singletonList(Put.of(key, newOnRef("value")))))
+        .isInstanceOf(ReferenceConflictException.class)
+        .hasMessage("Namespace '%s' must exist.", key.getNamespace());
+  }
+
+  @ParameterizedTest
+  @MethodSource("contentKeys")
+  void commitWithNonNamespace(ContentKey key) throws Exception {
+    BranchName branch = BranchName.of("commitWithNonNamespace");
+    store().create(branch, Optional.empty());
+
+    // Add something else than a namespace using the content key of the namespace
+    if (key.getElementCount() == 3) {
+      store()
+          .commit(
+              branch,
+              Optional.empty(),
+              fromMessage("initial commit"),
+              singletonList(
+                  Put.of(key.getParent().getParent(), Namespace.of(key.getParent().getParent()))));
+    }
+    store()
+        .commit(
+            branch,
+            Optional.empty(),
+            fromMessage("not a namespace"),
+            singletonList(Put.of(key.getParent(), newOnRef("value"))));
+
+    soft.assertThatThrownBy(
+            () ->
+                store()
+                    .commit(
+                        branch,
+                        Optional.empty(),
+                        fromMessage("non-existing-ns"),
+                        singletonList(Put.of(key, newOnRef("value")))))
+        .isInstanceOf(ReferenceConflictException.class)
+        .hasMessage(
+            "Expecting the key '%s' to be a namespace, but is not a namespace. "
+                + "Using a content object that is not a namespace as a namespace is forbidden.",
+            key.getNamespace());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"true", "false"})
+  void preventNamespaceDeletionWithChildren(boolean childNamespace) throws Exception {
+    BranchName branch = BranchName.of("branch");
+    store().create(branch, Optional.empty());
+
+    Namespace ns = Namespace.of("ns");
+    ContentKey key = ContentKey.of(ns, "table");
+
+    store()
+        .commit(
+            branch,
+            Optional.empty(),
+            fromMessage("initial"),
+            asList(
+                Put.of(ns.toContentKey(), ns),
+                Put.of(key, childNamespace ? Namespace.of(key) : newOnRef("foo"))));
+
+    soft.assertThatThrownBy(
+            () ->
+                store.commit(
+                    branch,
+                    Optional.empty(),
+                    fromMessage("try delete ns"),
+                    singletonList(Delete.of(ns.toContentKey()))))
+        .isInstanceOf(ReferenceConflictException.class);
+  }
+
+  enum NamespaceValidationMergeTransplant {
+    MERGE_SQUASH(true, false, false, false, false),
+    MERGE_INDIVIDUAL(true, false, false, true, false),
+    MERGE_CREATE_SQUASH(true, true, false, false, false),
+    MERGE_CREATE_INDIVIDUAL(true, true, false, true, false),
+    MERGE_DELETE_SQUASH(true, false, true, false, true),
+    MERGE_DELETE_INDIVIDUAL(true, false, true, true, true),
+    TRANSPLANT_SQUASH(false, false, false, false, false),
+    TRANSPLANT_INDIVIDUAL(false, false, false, true, false),
+    TRANSPLANT_CREATE_SQUASH(true, true, false, false, false),
+    TRANSPLANT_CREATE_INDIVIDUAL(true, true, false, true, false),
+    TRANSPLANT_DELETE_SQUASH(false, false, true, false, true),
+    TRANSPLANT_DELETE_INDIVIDUAL(false, false, true, true, true),
+    ;
+
+    /** Whether to merge (or transplant, if false). */
+    final boolean merge;
+    /** Whether the namespace shall be created on the target branch. */
+    final boolean createNamespaceOnTarget;
+    /**
+     * Whether the namespace shall be deleted on the target branch to trigger an error by the
+     * namespace-exists check.
+     */
+    final boolean deleteNamespaceOnTarget;
+    /** Whether merge/transplant shall keep individual commits or "squash" those. */
+    final boolean individualCommits;
+
+    final boolean error;
+
+    NamespaceValidationMergeTransplant(
+        boolean merge,
+        boolean createNamespaceOnTarget,
+        boolean deleteNamespaceOnTarget,
+        boolean individualCommits,
+        boolean error) {
+      this.merge = merge;
+      this.createNamespaceOnTarget = createNamespaceOnTarget;
+      this.deleteNamespaceOnTarget = deleteNamespaceOnTarget;
+      this.individualCommits = individualCommits;
+      this.error = error;
+    }
+  }
+
+  /**
+   * Validate various combinations of merge/transplant scenarios, validating that the
+   * "namespace-exists checks for merged/transplanted keys" works properly.
+   *
+   * @see NamespaceValidationMergeTransplant
+   */
+  @ParameterizedTest
+  @EnumSource(NamespaceValidationMergeTransplant.class)
+  void mergeTransplantWithCommonButRemovedNamespace(NamespaceValidationMergeTransplant mode)
+      throws Exception {
+    BranchName root = BranchName.of("root");
+    store().create(root, Optional.empty());
+
+    Namespace ns = Namespace.of("ns");
+    Namespace ns2 = Namespace.of("ns2");
+    Hash rootHead =
+        store()
+            .commit(
+                root,
+                Optional.empty(),
+                fromMessage("create namespace"),
+                mode.createNamespaceOnTarget
+                    ? singletonList(Put.of(ns2.toContentKey(), ns2))
+                    : asList(Put.of(ns.toContentKey(), ns), Put.of(ns2.toContentKey(), ns2)));
+
+    BranchName branch = BranchName.of("branch");
+    store().create(branch, Optional.of(rootHead));
+
+    if (mode.createNamespaceOnTarget) {
+      store()
+          .commit(
+              branch,
+              Optional.empty(),
+              fromMessage("create namespace"),
+              singletonList(Put.of(ns.toContentKey(), ns)));
+    }
+
+    ContentKey key = ContentKey.of(ns, "foo");
+    Hash commit1 =
+        store()
+            .commit(
+                branch,
+                Optional.empty(),
+                fromMessage("create table ns.foo"),
+                singletonList(Put.of(key, newOnRef("foo"))));
+
+    Hash commit2 =
+        store()
+            .commit(
+                branch,
+                Optional.empty(),
+                fromMessage("create table ns2.bar"),
+                singletonList(Put.of(ContentKey.of(ns2, "bar"), newOnRef("bar"))));
+
+    store()
+        .commit(
+            root,
+            Optional.empty(),
+            fromMessage("unrelated"),
+            singletonList(Put.of(ContentKey.of("unrelated-table"), newOnRef("bar"))));
+
+    ThrowingCallable mergeTransplant =
+        mode.merge
+            ? () ->
+                store()
+                    .merge(
+                        store().hashOnReference(branch, Optional.empty()),
+                        root,
+                        Optional.empty(),
+                        METADATA_REWRITER,
+                        mode.individualCommits,
+                        emptyMap(),
+                        MergeType.NORMAL,
+                        false,
+                        false)
+            : () ->
+                store()
+                    .transplant(
+                        root,
+                        Optional.empty(),
+                        asList(commit1, commit2),
+                        METADATA_REWRITER,
+                        mode.individualCommits,
+                        emptyMap(),
+                        MergeType.NORMAL,
+                        false,
+                        false);
+
+    if (mode.deleteNamespaceOnTarget) {
+      store()
+          .commit(
+              root,
+              Optional.empty(),
+              fromMessage("delete namespace"),
+              singletonList(Delete.of(ns.toContentKey())));
+    }
+
+    if (mode.error) {
+      soft.assertThatThrownBy(mergeTransplant)
+          .isInstanceOf(ReferenceConflictException.class)
+          .hasMessage("Namespace '%s' must exist.", key.getNamespace());
+    } else {
+      soft.assertThatCode(mergeTransplant).doesNotThrowAnyException();
+    }
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
@@ -101,8 +101,8 @@ public abstract class AbstractNamespaceValidation extends AbstractNestedVersionS
     BranchName branch = BranchName.of("commitWithNonNamespace");
     store().create(branch, Optional.empty());
 
-    // Add something else than a namespace using the content key of the namespace
     if (key.getElementCount() == 3) {
+      // Give the non-namespace content commit a valid namespace.
       store()
           .commit(
               branch,
@@ -111,6 +111,8 @@ public abstract class AbstractNamespaceValidation extends AbstractNestedVersionS
               singletonList(
                   Put.of(key.getParent().getParent(), Namespace.of(key.getParent().getParent()))));
     }
+
+    // Add a non-namespace content using the parent key of the namespace to be checked below.
     store()
         .commit(
             branch,

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNoNamespaceValidation.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNoNamespaceValidation.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.tests;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.projectnessie.versioned.MergeType.NORMAL;
+import static org.projectnessie.versioned.tests.AbstractVersionStoreTestBase.METADATA_REWRITER;
+import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
+
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.Put;
+import org.projectnessie.versioned.VersionStore;
+
+/** Verifies that namespace validation, if disabled, is not effective. */
+@ExtendWith(SoftAssertionsExtension.class)
+public abstract class AbstractNoNamespaceValidation {
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  protected abstract VersionStore store();
+
+  @Test
+  void commit() throws Exception {
+    BranchName branch = BranchName.of("noNamespaceValidation");
+    store().create(branch, Optional.empty());
+    soft.assertThatCode(
+            () ->
+                store()
+                    .commit(
+                        branch,
+                        Optional.empty(),
+                        CommitMeta.fromMessage("commit"),
+                        singletonList(
+                            Put.of(ContentKey.of("name", "spaced", "table"), newOnRef("foo")))))
+        .doesNotThrowAnyException();
+  }
+
+  @ParameterizedTest
+  @CsvSource({"false,false", "false,true", "true,false", "true,true"})
+  void mergeTransplant(boolean merge, boolean individual) throws Exception {
+    BranchName root = BranchName.of("root");
+    BranchName branch = BranchName.of("branch");
+    store().create(root, Optional.empty());
+
+    Hash rootHead =
+        store()
+            .commit(
+                root,
+                Optional.empty(),
+                CommitMeta.fromMessage("common ancestor"),
+                singletonList(Put.of(ContentKey.of("dummy"), newOnRef("dummy"))));
+
+    store().create(branch, Optional.of(rootHead));
+
+    soft.assertThatCode(
+            () ->
+                store()
+                    .commit(
+                        branch,
+                        Optional.empty(),
+                        CommitMeta.fromMessage("commit"),
+                        singletonList(
+                            Put.of(ContentKey.of("name", "spaced", "table"), newOnRef("foo")))))
+        .doesNotThrowAnyException();
+
+    Hash commit1 = store().hashOnReference(branch, Optional.empty());
+
+    soft.assertThatCode(
+            () ->
+                store()
+                    .commit(
+                        branch,
+                        Optional.empty(),
+                        CommitMeta.fromMessage("commit"),
+                        singletonList(Put.of(ContentKey.of("another", "table"), newOnRef("bar")))))
+        .doesNotThrowAnyException();
+
+    Hash commit2 = store().hashOnReference(branch, Optional.empty());
+
+    soft.assertThatCode(
+            () -> {
+              if (merge) {
+                store()
+                    .merge(
+                        commit2,
+                        root,
+                        Optional.empty(),
+                        METADATA_REWRITER,
+                        individual,
+                        emptyMap(),
+                        NORMAL,
+                        false,
+                        false);
+              } else {
+                store()
+                    .transplant(
+                        root,
+                        Optional.empty(),
+                        asList(commit1, commit2),
+                        METADATA_REWRITER,
+                        individual,
+                        emptyMap(),
+                        NORMAL,
+                        false,
+                        false);
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractVersionStoreTestBase.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractVersionStoreTestBase.java
@@ -15,7 +15,10 @@
  */
 package org.projectnessie.versioned.tests;
 
+import java.util.List;
 import org.junit.jupiter.api.Nested;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.VersionStore;
 
 /** Base class used for integration tests against version store implementations. */
@@ -101,4 +104,25 @@ public abstract class AbstractVersionStoreTestBase {
       super(AbstractVersionStoreTestBase.this.store());
     }
   }
+
+  @Nested
+  @SuppressWarnings("ClassCanBeStatic")
+  public class NamespaceValidation extends AbstractNamespaceValidation {
+    public NamespaceValidation() {
+      super(AbstractVersionStoreTestBase.this.store());
+    }
+  }
+
+  public static final MetadataRewriter<CommitMeta> METADATA_REWRITER =
+      new MetadataRewriter<CommitMeta>() {
+        @Override
+        public CommitMeta rewriteSingle(CommitMeta metadata) {
+          return metadata;
+        }
+
+        @Override
+        public CommitMeta squash(List<CommitMeta> metadata) {
+          return metadata.get(0);
+        }
+      };
 }


### PR DESCRIPTION
Validates the following scenarios for both the new storage model and the old (database adapter) model.

* Commit operation: the namespace for a content-key must exist - either created in an older commit or created in the current commit
* Commit operation: must not delete a namespace that has children (think: non-empty folder)
* Merge/transplant individual-commits: each created individual commit must pass the two checks above
* Merge/transplant squash: the squashed commit must pass the two checks above (squash: think like applying a diff onto the target branch)

Both storage models allow to _opt-out_ of namespace validation to work around potential migration issues. The configuration setting is marked as "for removal".

A new command `create-missing-namespaces` will be added via #6280.

Fixes #6244 