### PR TITLE
Fix `AbstractDatabaseAdapter.removeKeyCollisionsForNamespaces`

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1891,10 +1891,7 @@ public abstract class AbstractDatabaseAdapter<
 
     if (!keyCollisions.isEmpty()) {
       removeKeyCollisionsForNamespaces(
-          ctx,
-          refHead,
-          commitsChronological.get(commitsChronological.size() - 1).getHash(),
-          keyCollisions);
+          ctx, refHead, commitsChronological.get(0).getHash(), keyCollisions);
       if (!keyCollisions.isEmpty()) {
         keyCollisions.forEach(key -> keyDetails.apply(key).conflictType(ConflictType.UNRESOLVABLE));
         return true;


### PR DESCRIPTION
The (current) database-adapter storage code has functionality that ignores merge/transplant conflicts for namespaces (#3572). The function that "removes" conflicting keys for namespaces was always called with the wrong source-commit-id, it was called with the first commit after the common ancestor of the source branch, not with the HEAD of the branch to merge.

A test will be implicitly added via #6246, which discovered this bug.