### PR TITLE
compatiblity-tests: Extracted test changes for namespace-validation

### DIFF
--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
@@ -24,6 +24,8 @@ import java.util.Objects;
  */
 public class Version implements Comparable<Version> {
 
+  public static final Version CLIENT_RESULTS_NATIVE_STREAM = Version.parseVersion("0.31.0");
+  public static final Version HAS_MERGE_RESPONSE = Version.parseVersion("0.31.0");
   public static final Version VERSIONED_REST_URI_START = Version.parseVersion("0.46.0");
   public static final Version REFLOG_FOR_COMMIT_REMOVED = Version.parseVersion("0.44.0");
   // OPENTRACING_VERSION_MISMATCH_* is the version range where Nessie declared dependencies on

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieApiHolder.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieApiHolder.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.tools.compatibility.internal;
 
+import static java.util.Collections.singletonList;
 import static org.projectnessie.tools.compatibility.internal.OldNessie.oldNessieClassLoader;
 import static org.projectnessie.tools.compatibility.internal.Util.extensionStore;
 
@@ -36,6 +37,7 @@ final class OldNessieApiHolder extends AbstractNessieApiHolder {
     ClassLoader oldVersionClassLoader = nessieVersionClassLoader(extensionContext);
     this.translatingApiInstance =
         new TranslatingVersionNessieApi(
+            clientKey.getVersion(),
             createNessieClient(oldVersionClassLoader, clientKey),
             clientKey.getType(),
             oldVersionClassLoader);
@@ -70,7 +72,7 @@ final class OldNessieApiHolder extends AbstractNessieApiHolder {
     }
 
     try {
-      return oldNessieClassLoader(clientKey.getVersion(), "nessie-client");
+      return oldNessieClassLoader(clientKey.getVersion(), singletonList("nessie-client"));
     } catch (DependencyResolutionException e) {
       throw new RuntimeException(
           "Failed to resolve dependencies for Nessie client version " + clientKey.getVersion(), e);

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieServer.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.tools.compatibility.internal;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.projectnessie.tools.compatibility.api.Version.COMPAT_COMMON_DEPENDENCIES_START;
 import static org.projectnessie.tools.compatibility.api.Version.VERSIONED_REST_URI_START;
 import static org.projectnessie.tools.compatibility.internal.OldNessie.oldNessieClassLoader;
@@ -22,6 +24,7 @@ import static org.projectnessie.tools.compatibility.internal.Util.extensionStore
 import static org.projectnessie.tools.compatibility.internal.Util.withClassLoader;
 
 import java.net.URI;
+import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.eclipse.aether.resolution.DependencyResolutionException;
@@ -91,13 +94,16 @@ final class OldNessieServer implements NessieServer {
     // The 'nessie-jaxrs' has all the necessary dependencies to the DatabaseAdapter
     // implementations, REST services, Version store implementation, etc. in older versions.
     // Newer versions declare what is required as runtime dependencies of
-    // `nessie-compatibility-common`
-    String artifactId =
+    // `nessie-compatibility-common`, except mongodb
+    List<String> artifactIds =
         version.isGreaterThanOrEqual(COMPAT_COMMON_DEPENDENCIES_START)
-            ? "nessie-compatibility-common"
-            : "nessie-jaxrs";
+            ? asList(
+                "nessie-compatibility-common",
+                "nessie-versioned-persist-mongodb",
+                "nessie-versioned-persist-mongodb-test")
+            : singletonList("nessie-jaxrs");
     try {
-      return oldNessieClassLoader(version, artifactId);
+      return oldNessieClassLoader(version, artifactIds);
     } catch (DependencyResolutionException e) {
       throw new RuntimeException(
           "Failed to resolve dependencies for Nessie server version " + version, e);

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestTranslatingVersionNessieApi.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestTranslatingVersionNessieApi.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.tools.compatibility.internal;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.projectnessie.tools.compatibility.internal.Util.withClassLoader;
 
@@ -63,7 +64,8 @@ class TestTranslatingVersionNessieApi {
   @BeforeAll
   static void init() throws Exception {
     oldVersionClassLoader =
-        OldNessie.oldNessieClassLoader(Version.parseVersion("0.19.0"), "nessie-client");
+        OldNessie.oldNessieClassLoader(
+            Version.parseVersion("0.19.0"), singletonList("nessie-client"));
   }
 
   @Test
@@ -99,7 +101,10 @@ class TestTranslatingVersionNessieApi {
 
     try (TranslatingVersionNessieApi translating =
         new TranslatingVersionNessieApi(
-            createOldVersionNessieAPi(), NessieApiV1.class, oldVersionClassLoader)) {
+            Version.CURRENT,
+            createOldVersionNessieAPi(),
+            NessieApiV1.class,
+            oldVersionClassLoader)) {
 
       soft.assertThat(translating.translateObject(null, oldVersionClassLoader, contextClassLoader))
           .isNull();
@@ -123,7 +128,7 @@ class TestTranslatingVersionNessieApi {
               new Object[] {
                 null,
                 modelObj,
-                Collections.singletonList(modelObj),
+                singletonList(modelObj),
                 Collections.singleton(modelObj),
                 Collections.singletonMap("key", modelObj)
               },
@@ -171,7 +176,10 @@ class TestTranslatingVersionNessieApi {
 
     try (TranslatingVersionNessieApi translating =
         new TranslatingVersionNessieApi(
-            createOldVersionNessieAPi(), NessieApiV1.class, oldVersionClassLoader)) {
+            Version.CURRENT,
+            createOldVersionNessieAPi(),
+            NessieApiV1.class,
+            oldVersionClassLoader)) {
 
       Object translatedObject =
           translating.translateObject(modelObj, oldVersionClassLoader, contextClassLoader);
@@ -205,7 +213,10 @@ class TestTranslatingVersionNessieApi {
 
     try (TranslatingVersionNessieApi translating =
         new TranslatingVersionNessieApi(
-            createOldVersionNessieAPi(), NessieApiV1.class, oldVersionClassLoader)) {
+            Version.CURRENT,
+            createOldVersionNessieAPi(),
+            NessieApiV1.class,
+            oldVersionClassLoader)) {
 
       Class<?> contextClass = contextClassLoader.loadClass(className);
 
@@ -373,7 +384,10 @@ class TestTranslatingVersionNessieApi {
       throws Exception {
     try (TranslatingVersionNessieApi translating =
         new TranslatingVersionNessieApi(
-            createOldVersionNessieAPi(), NessieApiV1.class, oldVersionClassLoader)) {
+            Version.CURRENT,
+            createOldVersionNessieAPi(),
+            NessieApiV1.class,
+            oldVersionClassLoader)) {
       Class<?> nessieErrorClass =
           oldVersionClassLoader.loadClass("org.projectnessie.error.NessieError");
 

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgradeScenario.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgradeScenario.java
@@ -98,7 +98,7 @@ public class ITRollingUpgradeScenario {
   Branch commit(NessieApiV1 api, String suffix, Branch head) throws Exception {
     ThreadLocalRandom tlr = ThreadLocalRandom.current();
 
-    ContentKey key = ContentKey.of("key-" + suffix, "v" + version.toString());
+    ContentKey key = ContentKey.of("key-" + suffix + "-v" + version.toString());
     IcebergTable table =
         IcebergTable.of(
             "metadata-" + version,

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgrades.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgrades.java
@@ -137,7 +137,7 @@ public class ITRollingUpgrades {
   void commitDataInOld() throws Exception {
     ThreadLocalRandom tlr = ThreadLocalRandom.current();
 
-    ContentKey key = ContentKey.of("key", "v" + version.toString());
+    ContentKey key = ContentKey.of("key-v" + version.toString());
     IcebergTable table =
         IcebergTable.of(
             "metadata-" + version,
@@ -165,7 +165,7 @@ public class ITRollingUpgrades {
 
     Branch branch = apiCurrent.getDefaultBranch();
 
-    ContentKey key = ContentKey.of("keyCurrent", "v" + version.toString());
+    ContentKey key = ContentKey.of("keyCurrent-v" + version.toString());
     IcebergTable table =
         IcebergTable.of(
             "metadataCurrent-" + version,

--- a/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
+++ b/compatibility/compatibility-tests/src/test/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
@@ -174,7 +174,7 @@ public class ITUpgradePath {
   @Test
   @Order(103)
   void commit() throws Exception {
-    ContentKey key = ContentKey.of("my", "tables", "table_name");
+    ContentKey key = ContentKey.of("my-tables-table_name");
     IcebergTable content =
         IcebergTable.of("metadata-location", 42L, 43, 44, 45, "content-id-" + version);
     String commitMessage = "hello world " + version;
@@ -228,7 +228,7 @@ public class ITUpgradePath {
         .allSatisfy(
             ref -> {
               String versionFromRef = ref.getName().substring(VERSION_BRANCH_PREFIX.length());
-              ContentKey key = ContentKey.of("my", "tables", "table_name");
+              ContentKey key = ContentKey.of("my-tables-table_name");
               IcebergTable content =
                   IcebergTable.of(
                       "metadata-location", 42L, 43, 44, 45, "content-id-" + versionFromRef);
@@ -339,7 +339,7 @@ public class ITUpgradePath {
     // The number of keys equals the number of commits per version.
     List<ContentKey> keys =
         IntStream.range(0, keysUpgradeCommitsPerVersion)
-            .mapToObj(i -> ContentKey.of(EXPLICIT_KEYS_ELEMENT, "upgrade", "table" + i))
+            .mapToObj(i -> ContentKey.of(EXPLICIT_KEYS_ELEMENT + "-upgrade-table-" + i))
             .collect(Collectors.toList());
     for (Entry<String, Map<ContentKey, IcebergTable>> hashToKeyValues :
         keysUpgradeAtHash.entrySet()) {
@@ -395,7 +395,7 @@ public class ITUpgradePath {
         keysUpgradeAtHash.getOrDefault(keysUpgradeBranch.getHash(), Collections.emptyMap());
 
     for (int i = 0; i < keysUpgradeCommitsPerVersion; i++) {
-      ContentKey key = ContentKey.of(EXPLICIT_KEYS_ELEMENT, "upgrade", "table" + i);
+      ContentKey key = ContentKey.of(EXPLICIT_KEYS_ELEMENT + "-upgrade-table-" + i);
       if ((i % 10) == 9) {
         keysUpgradeBranch =
             commitMaybeRetry(

--- a/compatibility/compatibility-tests/src/test/resources/META-INF/nessie-compatibility.properties
+++ b/compatibility/compatibility-tests/src/test/resources/META-INF/nessie-compatibility.properties
@@ -31,4 +31,10 @@
 # 0.40.0:
 #   - changed references data model
 #   - introduced open-addressing key-list
-nessie.versions=0.15.0,0.18.0,0.26.0,0.30.0,0.40.3,0.41.0,0.47.0,current
+# 0.51.1:
+#   - moved to new Maven group ID (with relocation poms for the old group ID)
+#
+# MINIMUM VERSION is 0.23.1 !!!
+#
+# Untested (for CI duration): 0.23.1,0.26.0,0.30.0,0.40.3
+nessie.versions=0.41.0,0.47.0,0.48.2,0.51.1,current


### PR DESCRIPTION
* Adds namespace-validation related test changes (from/for #6246)
* Adds 0.48.2 and 0.51.1 including required code for dependency changes
* Removes 0.15.0, 0.18.0, 0.26.0, 0.30.0, 0.40.3 (versions w/o namespace support, latter to speed up testing)