### PR TITLE
Ignore jEnv .java-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ __pycache__/
 
 # Site
 site/site
+
+#jEnv, see https://github.com/jenv/jenv
+.java-version


### PR DESCRIPTION
This commit adds one entry to the .gitignore file: .java-version.

This file is created by the Java version manager jEnv:

https://github.com/jenv/jenv

The file is produced when we force a different "local" Java version than the configured global one, e.g. with the following command:

jenv local 11

This is useful when a project needs a special Java version.

**Note: Iceberg has decided to commit this file, see https://github.com/apache/iceberg/pull/3651. I'd prefer to leave it untracked.**