### PR TITLE
Build/CI: Allow renovate to update the Maven wrapper

### DIFF
--- a/build-tools-integration-tests/pom.xml
+++ b/build-tools-integration-tests/pom.xml
@@ -28,6 +28,7 @@
     <maven.compiler.release>8</maven.compiler.release>
     <versionMavenResolver>1.7.3</versionMavenResolver>
     <versionMaven>3.8.7</versionMaven>
+    <nessie.version>0.51.1</nessie.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Renovate cannot update the Maven Wrapper automatically, because the built-tools-integration-tests/pom.xml requires the `nessie.version` system property to be set. This change adds some Nessie version to let Renovate do its job.