### PR TITLE
Forbid special ASCII chars in content keys

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/ContentKey.java
+++ b/api/model/src/main/java/org/projectnessie/model/ContentKey.java
@@ -16,8 +16,7 @@
 package org.projectnessie.model;
 
 import static org.projectnessie.model.Util.DOT_STRING;
-import static org.projectnessie.model.Util.GROUP_SEPARATOR_STRING;
-import static org.projectnessie.model.Util.ZERO_BYTE_STRING;
+import static org.projectnessie.model.Util.FIRST_ALLOWED_KEY_CHAR;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -171,15 +170,15 @@ public abstract class ContentKey implements Comparable<ContentKey> {
         throw new IllegalArgumentException(
             String.format("Content key '%s' must not contain a null element.", elements));
       }
-      if (e.contains(ZERO_BYTE_STRING) || e.contains(GROUP_SEPARATOR_STRING)) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Content key '%s' must not contain a zero byte (\\u0000) / group separator (\\u001D).",
-                elements));
-      }
       if (e.isEmpty()) {
         throw new IllegalArgumentException(
             String.format("Content key '%s' must not contain an empty element.", elements));
+      }
+      if (e.chars().anyMatch(i -> i < FIRST_ALLOWED_KEY_CHAR)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Content key '%s' must not contain characters less than 0x%2h.",
+                elements, FIRST_ALLOWED_KEY_CHAR));
       }
     }
   }

--- a/api/model/src/main/java/org/projectnessie/model/Namespace.java
+++ b/api/model/src/main/java/org/projectnessie/model/Namespace.java
@@ -16,8 +16,7 @@
 package org.projectnessie.model;
 
 import static org.projectnessie.model.Util.DOT_STRING;
-import static org.projectnessie.model.Util.GROUP_SEPARATOR_STRING;
-import static org.projectnessie.model.Util.ZERO_BYTE_STRING;
+import static org.projectnessie.model.Util.FIRST_ALLOWED_KEY_CHAR;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -146,16 +145,16 @@ public abstract class Namespace extends Content {
             String.format(
                 "Namespace '%s' must not contain a null element.", Arrays.toString(elements)));
       }
-      if (e.contains(ZERO_BYTE_STRING) || e.contains(GROUP_SEPARATOR_STRING)) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Namespace '%s' must not contain a zero byte (\\u0000) / group separator (\\u001D).",
-                Arrays.toString(elements)));
-      }
       if (e.isEmpty()) {
         throw new IllegalArgumentException(
             String.format(
                 "Namespace '%s' must not contain an empty element.", Arrays.toString(elements)));
+      }
+      if (e.chars().anyMatch(i -> i < FIRST_ALLOWED_KEY_CHAR)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Namespace '%s' must not contain characters less than 0x%2h.",
+                Arrays.toString(elements), FIRST_ALLOWED_KEY_CHAR));
       }
     }
 

--- a/api/model/src/main/java/org/projectnessie/model/Util.java
+++ b/api/model/src/main/java/org/projectnessie/model/Util.java
@@ -33,13 +33,12 @@ final class Util {
 
   private Util() {}
 
+  public static final int FIRST_ALLOWED_KEY_CHAR = 0x20;
   public static final char ZERO_BYTE = '\u0000';
   public static final char DOT = '.';
   public static final char GROUP_SEPARATOR = '\u001D';
   public static final char URL_PATH_SEPARATOR = '/';
   public static final String DOT_STRING = ".";
-  public static final String ZERO_BYTE_STRING = Character.toString(ZERO_BYTE);
-  public static final String GROUP_SEPARATOR_STRING = Character.toString(GROUP_SEPARATOR);
 
   /**
    * Convert from path encoded string to normal string.

--- a/api/model/src/test/java/org/projectnessie/model/TestContentKey.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestContentKey.java
@@ -326,12 +326,12 @@ class TestContentKey {
     assertThatThrownBy(() -> ContentKey.of("a", "b", "\u0000", "c", "d"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "Content key '[a, b, \u0000, c, d]' must not contain a zero byte (\\u0000) / group separator (\\u001D).");
+            "Content key '[a, b, \u0000, c, d]' must not contain characters less than 0x20.");
 
     assertThatThrownBy(() -> ContentKey.of("a", "b", "\u001D", "c", "d"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "Content key '[a, b, \u001D, c, d]' must not contain a zero byte (\\u0000) / group separator (\\u001D).");
+            "Content key '[a, b, \u001D, c, d]' must not contain characters less than 0x20.");
   }
 
   @Test
@@ -358,9 +358,14 @@ class TestContentKey {
     assertRoundTrip("/%国", "国.国");
   }
 
+  static Stream<Arguments> invalidChars() {
+    return IntStream.range(0, 0x20)
+        .mapToObj(asciiCode -> arguments("invalid-char-" + asciiCode + ((char) asciiCode)));
+  }
+
   @ParameterizedTest
-  @ValueSource(strings = {"\u0000", "\u001D"})
-  void blockZeroByteUsage(String s) {
+  @MethodSource("invalidChars")
+  void blockSpecialBytesUsage(String s) {
     assertThrows(IllegalArgumentException.class, () -> ContentKey.of(s));
   }
 

--- a/api/model/src/test/java/org/projectnessie/model/TestNamespace.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestNamespace.java
@@ -119,7 +119,6 @@ public class TestNamespace {
     assertThat(namespace.isSameOrSubElementOf(Namespace.parse("a.b\u001Dc.namespace"))).isTrue();
     assertThat(namespace.isSameOrSubElementOf(Namespace.parse("a.b\u0000c.namespace"))).isTrue();
 
-    assertThat(namespace.isSameOrSubElementOf(Namespace.of("a", "\u0012b"))).isFalse();
     assertThat(namespace.isSameOrSubElementOf(Namespace.of("x"))).isFalse();
     assertThat(namespace.isSameOrSubElementOf(Namespace.of("a", "b", "c"))).isFalse();
 
@@ -204,7 +203,7 @@ public class TestNamespace {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             String.format(
-                "Namespace '%s' must not contain a zero byte (\\u0000) / group separator (\\u001D).",
+                "Namespace '%s' must not contain characters less than 0x20.",
                 singletonList(identifier)));
   }
 

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TypeMapping.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TypeMapping.java
@@ -125,6 +125,9 @@ public final class TypeMapping {
   @Nonnull
   @jakarta.annotation.Nonnull
   public static StoreKey keyToStoreKey(@Nonnull @jakarta.annotation.Nonnull ContentKey key) {
+    // Note: the relative values of outer and inner (key elements) separators affect the correctness
+    // of StoreKey comparisons WRT to ContentKey comparisons. The inner separator must be greater
+    // than the outer separator because longer ContentKeys are greater than shorter ContentKeys.
     StringBuilder sb = new StringBuilder();
     sb.append(MAIN_UNIVERSE);
     List<String> elements = key.getElements();

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestTypeMapping.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestTypeMapping.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.storage.versionstore;
 
+import static java.lang.Integer.signum;
 import static java.util.TimeZone.getTimeZone;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -194,6 +195,24 @@ public class TestTypeMapping {
       soft.assertThat(keyToStoreKey(key)).isEqualTo(storeKey);
     }
     soft.assertThat(storeKeyToKey(storeKey)).isEqualTo(key);
+  }
+
+  static Stream<Arguments> keyComparisons() {
+    return Stream.of(
+        arguments(ContentKey.of("a", "b", "c"), ContentKey.of("a", "b", "c")),
+        arguments(ContentKey.of("a", "b", "c"), ContentKey.of("a", "b", "d")),
+        arguments(ContentKey.of("a", "b", "c"), ContentKey.of("a", "b", "cc")),
+        arguments(ContentKey.of("a", "b", "c"), ContentKey.of("a", "aaa")),
+        arguments(ContentKey.of("a", "b", "c"), ContentKey.of("a", "a")),
+        arguments(ContentKey.of("a", "b", "c"), ContentKey.of()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("keyComparisons")
+  public void keyComparisons(ContentKey k1, ContentKey k2) {
+    int cmp = signum(k1.compareTo(k2));
+    soft.assertThat(signum(keyToStoreKey(k1).compareTo(keyToStoreKey(k2)))).isEqualTo(cmp);
+    soft.assertThat(signum(keyToStoreKey(k2).compareTo(keyToStoreKey(k1)))).isEqualTo(-cmp);
   }
 
   static Stream<Arguments> headers() {


### PR DESCRIPTION
This is to ensure correctness with conversion to/from StoreKey.

Fixes #6311