### PR TITLE
GH WF: Remove `concurrency` from PR jobs

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -25,10 +25,6 @@ on:
     - cron:  '0 4 * * 1-5'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   java:
     name: Java/Gradle macOS

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -25,10 +25,6 @@ on:
     - cron:  '0 4 * * 1-5'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   java:
     name: Java/Gradle Windows

--- a/.github/workflows/pull-request-docker.yml
+++ b/.github/workflows/pull-request-docker.yml
@@ -25,10 +25,6 @@ on:
     - cron:  '0 4 * * 1-5'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   docker-testing:
     name: Docker build and publishing

--- a/.github/workflows/pull-request-helm.yml
+++ b/.github/workflows/pull-request-helm.yml
@@ -21,10 +21,6 @@ on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   helm-testing:
     name: Lint & Test Helm chart

--- a/.github/workflows/pull-request-integ.yml
+++ b/.github/workflows/pull-request-integ.yml
@@ -19,10 +19,6 @@ on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   java:
     name: Integrations Tests

--- a/.github/workflows/pull-request-native.yml
+++ b/.github/workflows/pull-request-native.yml
@@ -21,10 +21,6 @@ on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   java:
     name: Java/Gradle Native


### PR DESCRIPTION
A couple PR runs indicated that some of the "required checks" did not run. The reason is that in fact the checks (WF/job runs) worked, but due the auto-labeler job re-triggered the WF runs, and the re-triggered runs were skipped due to the configured `concurrency` settings.

Sadly there's no way to have finer grained (label based) filters and concurrency settings. It might be worth to refactor the jobs, but that's out of scope of this PR.

At this point it's probably okay to bite the bullet and remove the concurrency setting to get proper PR checks back.

Example runs:
* https://github.com/projectnessie/nessie/actions/runs/4441749920
* https://github.com/projectnessie/nessie/actions/runs/4441750040
* https://github.com/projectnessie/nessie/actions/runs/4441750059