### PR TITLE
Use positive repo erase confirmation codes.

### DIFF
--- a/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/EraseRepository.java
+++ b/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/EraseRepository.java
@@ -125,6 +125,7 @@ public class EraseRepository extends BaseCommand {
     code = 31L * code + config.parentsPerCommit();
     code = 31L * code + config.maxIncrementalIndexSize();
     code = 31L * code + config.maxSerializedIndexSize();
+    code = Math.abs(code);
     // Format the code using MAX_RADIX to reduce the resultant string length
     return Long.toString(code, Character.MAX_RADIX);
   }


### PR DESCRIPTION
A negative code may be happen to have the "-h" prefix, which matches the help option name and breaks the --confirmation-code parameter value parsing.