### PR TITLE
Build: Fix Jackson-annotations configuration for build-plugins int-test

### DIFF
--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
   testFixturesRuntimeOnly(libs.logback.classic)
 
   testFixturesCompileOnly(platform(libs.jackson.bom))
-  testFixturesAnnotationProcessor(libs.jackson.annotations)
+  testFixturesCompileOnly(libs.jackson.annotations)
 
   testFixturesCompileOnly(libs.microprofile.openapi)
 


### PR DESCRIPTION
Fixes the failed checks for https://github.com/projectnessie/gradle-build-plugins/pull/99