### PR TITLE
Support annotation-based configuration in "old server" tests

### DIFF
--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/NessieServerProperties.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/NessieServerProperties.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.compatibility.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Container annotation for {@link NessieServerProperty}. */
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface NessieServerProperties {
+  NessieServerProperty[] value();
+}

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/NessieServerProperty.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/NessieServerProperty.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.compatibility.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Configuration properties for Nessie servers started for "older server" tests. */
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(NessieServerProperties.class)
+@Inherited
+public @interface NessieServerProperty {
+  String name();
+
+  String value();
+}

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
@@ -91,7 +91,10 @@ final class CurrentNessieServer implements NessieServer {
           createDatabaseConnectionProvider(
               serverKey.getDatabaseAdapterName(), serverKey.getDatabaseAdapterConfig());
       this.databaseAdapter =
-          createDatabaseAdapter(serverKey.getDatabaseAdapterName(), connectionProvider);
+          createDatabaseAdapter(
+              serverKey.getDatabaseAdapterName(),
+              connectionProvider,
+              serverKey.getDatabaseAdapterConfig());
 
       if (initializeRepository.getAsBoolean()) {
         databaseAdapter.eraseRepo();

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
@@ -83,7 +83,7 @@ public class NessieUpgradesExtension extends AbstractMultiVersionExtension {
     Map<String, String> configuration =
         Collections.singletonMap("nessie.store.db.path", tempDir.resolve("persist").toString());
 
-    return new ServerKey(version, databaseAdapterName, configuration);
+    return ServerKey.forContext(context, version, databaseAdapterName, configuration);
   }
 
   private BooleanSupplier initializeRepositorySupplier(

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieClientsExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieClientsExtension.java
@@ -52,7 +52,8 @@ public class OlderNessieClientsExtension extends AbstractMultiVersionExtension {
       return;
     }
 
-    ServerKey serverKey = new ServerKey(Version.CURRENT, "In-Memory", Collections.emptyMap());
+    ServerKey serverKey =
+        ServerKey.forContext(context, Version.CURRENT, "In-Memory", Collections.emptyMap());
     BooleanSupplier initializeRepository = () -> true;
 
     populateNessieApiFields(

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieServersExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OlderNessieServersExtension.java
@@ -55,7 +55,8 @@ public class OlderNessieServersExtension extends AbstractMultiVersionExtension {
     }
 
     BooleanSupplier initializeRepository = () -> true;
-    ServerKey serverKey = new ServerKey(version, "In-Memory", Collections.emptyMap());
+    ServerKey serverKey =
+        ServerKey.forContext(context, version, "In-Memory", Collections.emptyMap());
     NessieServer nessieServer =
         nessieServer(classContext(context), serverKey, initializeRepository);
 

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/RollingUpgradesExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/RollingUpgradesExtension.java
@@ -97,7 +97,7 @@ public class RollingUpgradesExtension extends AbstractMultiVersionExtension {
             "nessie.store.database.name",
             mongo.getDatabaseName());
 
-    return new ServerKey(version, databaseAdapterName, configuration);
+    return ServerKey.forContext(context, version, databaseAdapterName, configuration);
   }
 
   private void populateNessieApiFields(

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITImplicitNamespaces.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITImplicitNamespaces.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.compatibility.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Operation.Put;
+import org.projectnessie.tools.compatibility.api.NessieAPI;
+import org.projectnessie.tools.compatibility.api.NessieServerProperty;
+import org.projectnessie.tools.compatibility.api.NessieVersion;
+import org.projectnessie.tools.compatibility.api.Version;
+import org.projectnessie.tools.compatibility.internal.NessieUpgradesExtension;
+
+@ExtendWith(NessieUpgradesExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@NessieServerProperty(name = "nessie.store.validate.namespaces", value = "false")
+public class ITImplicitNamespaces {
+
+  @NessieVersion Version version;
+  @NessieAPI NessieApiV1 api;
+
+  @Test
+  @Order(101)
+  void createTableWithImplicitNamespaceReference() throws Exception {
+    Branch main = api.getDefaultBranch();
+    Branch versionBranch = Branch.of("version-implicit-ns-" + version, main.getHash());
+    api.createReference().sourceRefName(main.getName()).reference(versionBranch).create();
+
+    // Check that keys with a non-existent namespace can be used in Put operations.
+    // Note the server config annotations at the class level.
+    Branch branchNew =
+        api.commitMultipleOperations()
+            .commitMeta(CommitMeta.fromMessage("test implicit namespace in " + version))
+            .operation(
+                Put.of(
+                    ContentKey.of("test-implicit-namespace-" + version, "table_name123"),
+                    IcebergTable.of("metadata-location", 42L, 43, 44, 45, "content-id-" + version)))
+            .branch(versionBranch)
+            .commit();
+    assertThat(branchNew)
+        .isNotEqualTo(versionBranch)
+        .extracting(Branch::getName)
+        .isEqualTo(versionBranch.getName());
+  }
+}

--- a/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/DatabaseAdapters.java
+++ b/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/DatabaseAdapters.java
@@ -93,7 +93,8 @@ public final class DatabaseAdapters {
 
   public static DatabaseAdapter createDatabaseAdapter(
       String databaseAdapterName,
-      DatabaseConnectionProvider<DatabaseConnectionConfig> connectionProvider) {
+      DatabaseConnectionProvider<DatabaseConnectionConfig> connectionProvider,
+      Map<String, String> configuration) {
     DatabaseAdapterFactory<
             DatabaseAdapter,
             DatabaseAdapterConfig,
@@ -105,6 +106,8 @@ public final class DatabaseAdapters {
         .newBuilder()
         .withConnector(connectionProvider)
         .configure(SystemPropertiesConfigurer::configureAdapterFromSystemProperties)
+        .configure(
+            c -> SystemPropertiesConfigurer.configureAdapterFromProperties(c, configuration::get))
         .build();
   }
 }


### PR DESCRIPTION
Also add ITImplicitNamespaces to make sure that namespace validation can be suppressed with a configuration property.