### PR TITLE
Mongo/storage: use `replaceOne` instead of `findAndReplaceOne`

### DIFF
--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -585,14 +585,10 @@ public class MongoDBPersist implements Persist {
     checkArgument(id != null, "Obj to store must have a non-null ID");
 
     Document doc = objToDoc(obj, true);
-    Document result =
-        backend
-            .objs()
-            .findOneAndReplace(
-                and(eq(ID_PROPERTY_NAME, idObjDoc(id)), eq(COL_OBJ_TYPE, obj.type().shortName())),
-                doc);
-
-    if (result == null) {
+    UpdateResult result = backend.objs().replaceOne(eq(ID_PROPERTY_NAME, idObjDoc(id)), doc);
+    if (result.getMatchedCount() == 0L) {
+      // Testing "modified count" would be wrong here, because it represents the number of actually
+      // changed docs (which isn't the case if the obj is equal to the persisted one).
       throw new ObjNotFoundException(id);
     }
   }


### PR DESCRIPTION
Difference is to _not_ use a "find" (aka "scan") since we have the full key available.