### PR TITLE
New storage: `Persist.updateObj()` must respect index-size limits

### DIFF
--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
@@ -488,7 +488,8 @@ public class CassandraPersist implements Persist {
     StoreObjDesc<Obj> storeObj = storeObjForObj(type);
 
     List<Object> values = new ArrayList<>();
-    storeObj.store(values::add, obj, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    storeObj.store(
+        values::add, obj, effectiveIncrementalIndexSizeLimit(), effectiveIndexSegmentSizeLimit());
     values.add(config.repositoryId());
     values.add(serializeObjId(id));
     values.add(type.name());

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
@@ -535,7 +535,7 @@ public class DynamoDBPersist implements Persist {
     ObjId id = obj.id();
     checkArgument(id != null, "Obj to store must have a non-null ID");
 
-    Map<String, AttributeValue> item = objToItem(obj, id, true);
+    Map<String, AttributeValue> item = objToItem(obj, id, false);
 
     String condition = COL_OBJ_TYPE + " = :type";
     Map<String, AttributeValue> values = singletonMap(":type", fromS(obj.type().shortName()));

--- a/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
+++ b/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
@@ -294,7 +294,9 @@ class InmemoryPersist implements Persist {
   }
 
   @Override
-  public void updateObj(@Nonnull @jakarta.annotation.Nonnull Obj obj) throws ObjNotFoundException {
+  public void updateObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
+      throws ObjNotFoundException, ObjTooLargeException {
+    verifySoftRestrictions(obj);
     Obj v =
         inmemory.objects.computeIfPresent(
             compositeKey(obj.id()), (k, ex) -> ex.type() == obj.type() ? obj : ex);
@@ -305,7 +307,7 @@ class InmemoryPersist implements Persist {
 
   @Override
   public void updateObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-      throws ObjNotFoundException {
+      throws ObjTooLargeException, ObjNotFoundException {
     List<ObjId> notFound = null;
     for (Obj obj : objs) {
       try {

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -596,7 +596,9 @@ abstract class AbstractJdbcPersist implements Persist {
     checkArgument(storeObj != null, "Cannot serialize object type %s ", type);
     try (PreparedStatement ps = conn.prepareStatement(storeObj.updateSql)) {
       //noinspection unchecked
-      int idx = storeObj.store(ps, 1, obj, Integer.MAX_VALUE, Integer.MAX_VALUE);
+      int idx =
+          storeObj.store(
+              ps, 1, obj, effectiveIncrementalIndexSizeLimit(), effectiveIndexSegmentSizeLimit());
       ps.setString(idx++, config.repositoryId());
       serializeObjId(ps, idx++, id);
       ps.setString(idx, type.name());

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -584,7 +584,7 @@ public class MongoDBPersist implements Persist {
     ObjId id = obj.id();
     checkArgument(id != null, "Obj to store must have a non-null ID");
 
-    Document doc = objToDoc(obj, true);
+    Document doc = objToDoc(obj, false);
     UpdateResult result = backend.objs().replaceOne(eq(ID_PROPERTY_NAME, idObjDoc(id)), doc);
     if (result.getMatchedCount() == 0L) {
       // Testing "modified count" would be wrong here, because it represents the number of actually

--- a/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
+++ b/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
@@ -447,7 +447,8 @@ class RocksDBPersist implements Persist {
         throw new ObjNotFoundException(id);
       }
 
-      byte[] serialized = serializeObj(obj, Integer.MAX_VALUE, Integer.MAX_VALUE);
+      byte[] serialized =
+          serializeObj(obj, effectiveIncrementalIndexSizeLimit(), effectiveIndexSegmentSizeLimit());
 
       db.put(cf, key, serialized);
     } catch (RocksDBException e) {


### PR DESCRIPTION
... otherwise the import's finalize phase, which builds the incremental and reference indexes in commits, will write only incremental indexes, which grow endlessly, effectively never writing reference indexes.