### PR TITLE
Persist: replace `updateObj()` with `upsertObj()`

### DIFF
--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
@@ -157,20 +157,19 @@ class CachingPersistImpl implements Persist {
   }
 
   @Override
-  public void updateObj(@jakarta.annotation.Nonnull @Nonnull Obj obj)
-      throws ObjTooLargeException, ObjNotFoundException {
+  public void upsertObj(@jakarta.annotation.Nonnull @Nonnull Obj obj) throws ObjTooLargeException {
     try {
-      persist.updateObj(obj);
+      persist.upsertObj(obj);
     } finally {
       cache.remove(obj.id());
     }
   }
 
   @Override
-  public void updateObjs(@jakarta.annotation.Nonnull @Nonnull Obj[] objs)
-      throws ObjTooLargeException, ObjNotFoundException {
+  public void upsertObjs(@jakarta.annotation.Nonnull @Nonnull Obj[] objs)
+      throws ObjTooLargeException {
     try {
-      persist.updateObjs(objs);
+      persist.upsertObjs(objs);
     } finally {
       for (Obj obj : objs) {
         if (obj != null) {

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
@@ -41,11 +41,7 @@ final class CassandraConstants {
   static final String COLS_STRING =
       "s_content_type, s_compression, s_filename, s_predecessors, s_text";
 
-  static final String UPDATE_OBJ_PREFIX = "UPDATE %s." + TABLE_OBJS + " SET ";
-  static final String UPDATE_OBJ_SUFFIX =
-      " WHERE " + COL_REPO_ID + "=?" + " AND " + COL_OBJ_ID + "=? IF " + COL_OBJ_TYPE + "=?";
-
-  static final String STORE_OBJ_PREFIX =
+  static final String INSERT_OBJ_PREFIX =
       "INSERT INTO %s."
           + TABLE_OBJS
           + " ("
@@ -56,20 +52,17 @@ final class CassandraConstants {
           + COL_OBJ_TYPE
           + ", ";
   static final String STORE_OBJ_SUFFIX = " IF NOT EXISTS";
-  static final String STORE_OBJ_STRING =
-      STORE_OBJ_PREFIX + COLS_STRING + ") VALUES (?,?,?, ?,?,?,?,?)" + STORE_OBJ_SUFFIX;
-  static final String STORE_OBJ_TAG =
-      STORE_OBJ_PREFIX + COLS_TAG + ") VALUES (?,?,?, ?,?,?,?)" + STORE_OBJ_SUFFIX;
-  static final String STORE_OBJ_INDEX =
-      STORE_OBJ_PREFIX + COLS_INDEX + ") VALUES (?,?,?, ?)" + STORE_OBJ_SUFFIX;
-  static final String STORE_OBJ_SEGMENTS =
-      STORE_OBJ_PREFIX + COLS_SEGMENTS + ") VALUES (?,?,?, ?)" + STORE_OBJ_SUFFIX;
-  static final String STORE_OBJ_VALUE =
-      STORE_OBJ_PREFIX + COLS_VALUE + ") VALUES (?,?,?, ?,?,?)" + STORE_OBJ_SUFFIX;
-  static final String STORE_OBJ_REF =
-      STORE_OBJ_PREFIX + COLS_REF + ") VALUES (?,?,?, ?,?,?)" + STORE_OBJ_SUFFIX;
-  static final String STORE_OBJ_COMMIT =
-      STORE_OBJ_PREFIX + COLS_COMMIT + ") VALUES (?,?,?, ?,?,?,?,?,?,?,?,?,?,?)" + STORE_OBJ_SUFFIX;
+  static final String INSERT_OBJ_STRING =
+      INSERT_OBJ_PREFIX + COLS_STRING + ") VALUES (?,?,?, ?,?,?,?,?)";
+  static final String INSERT_OBJ_TAG = INSERT_OBJ_PREFIX + COLS_TAG + ") VALUES (?,?,?, ?,?,?,?)";
+  static final String INSERT_OBJ_INDEX = INSERT_OBJ_PREFIX + COLS_INDEX + ") VALUES (?,?,?, ?)";
+  static final String INSERT_OBJ_SEGMENTS =
+      INSERT_OBJ_PREFIX + COLS_SEGMENTS + ") VALUES (?,?,?, ?)";
+  static final String INSERT_OBJ_VALUE = INSERT_OBJ_PREFIX + COLS_VALUE + ") VALUES (?,?,?, ?,?,?)";
+  static final String INSERT_OBJ_REF = INSERT_OBJ_PREFIX + COLS_REF + ") VALUES (?,?,?, ?,?,?)";
+  static final String INSERT_OBJ_COMMIT =
+      INSERT_OBJ_PREFIX + COLS_COMMIT + ") VALUES (?,?,?, ?,?,?,?,?,?,?,?,?,?,?)";
+
   static final String CREATE_TABLE_OBJS =
       "CREATE TABLE %s."
           + TABLE_OBJS

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
@@ -137,8 +137,7 @@ public interface CommitLogic {
    * @param commit the commit to update
    * @return the persisted commit, containing the updated incremental and reference indexes
    */
-  CommitObj updateCommit(@Nonnull @jakarta.annotation.Nonnull CommitObj commit)
-      throws ObjNotFoundException;
+  CommitObj updateCommit(@Nonnull @jakarta.annotation.Nonnull CommitObj commit);
 
   /**
    * Similar to {@link #doCommit(CreateCommit, List)}, but does not persist the {@link CommitObj}

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
@@ -320,17 +320,16 @@ final class CommitLogicImpl implements CommitLogic {
   }
 
   @Override
-  public CommitObj updateCommit(@Nonnull @jakarta.annotation.Nonnull CommitObj commit)
-      throws ObjNotFoundException {
+  public CommitObj updateCommit(@Nonnull @jakarta.annotation.Nonnull CommitObj commit) {
     try {
-      persist.updateObj(commit);
+      persist.upsertObj(commit);
     } catch (ObjTooLargeException e) {
       // The incremental index became too big - need to spill out the INCREMENTAL_* operations to
       // the reference index.
 
       commit = indexTooBigStoreUpdate(commit);
       try {
-        persist.updateObj(commit);
+        persist.upsertObj(commit);
       } catch (ObjTooLargeException ex) {
         // Hit the "Hard database object size limit"
         throw new RuntimeException(ex);

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
@@ -286,32 +286,25 @@ public interface Persist {
   void deleteObjs(@Nonnull @jakarta.annotation.Nonnull ObjId[] ids);
 
   /**
-   * Updates an existing object, used only for maintenance operations, never for production code.
-   * The "user facing semantics" of an object <em>must not</em> change.
+   * Updates an existing object or inserts it as a new object, used only for maintenance operations,
+   * never for production code. The "user facing semantics" of an object <em>must not</em> change.
    *
-   * <p>Unlike {@link #storeObj(Obj)}, {@code updateObj} always ignores soft size limits from {@link
-   * #config()}.
-   *
-   * @see #updateObjs(Obj[])
+   * @see #upsertObjs (Obj[])
    * @throws ObjTooLargeException thrown when a hard database row/item size limit has been hit
    */
-  void updateObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-      throws ObjTooLargeException, ObjNotFoundException;
+  void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj) throws ObjTooLargeException;
 
   /**
-   * Updates an existing object, used only for maintenance operations, never for production code.
-   * The "user facing semantics" of an object <em>must not</em> change.
-   *
-   * <p>Unlike {@link #storeObj(Obj)}, {@code updateObj} always ignores soft size limits from {@link
-   * #config()}.
+   * Updates existing objects or inserts those as a new objects, used only for maintenance
+   * operations, never for production code. The "user facing semantics" of an object <em>must
+   * not</em> change.
    *
    * <p>In case an object failed to be updated, it is undefined whether other objects have been
    * updated or not.
    *
-   * @see #updateObj(Obj)
+   * @see #upsertObj( Obj)
    */
-  void updateObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-      throws ObjTooLargeException, ObjNotFoundException;
+  void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs) throws ObjTooLargeException;
 
   /**
    * Returns an iterator over all objects that match the given predicate.

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestCommitConflicts.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestCommitConflicts.java
@@ -464,8 +464,6 @@ public class TestCommitConflicts {
         .containsEntry(fooKey, fooAddId)
         .containsEntry(barKey, barAddId);
 
-    soft.assertThatThrownBy(() -> commitLogic.updateCommit(firstCommit))
-        .isInstanceOf(ObjNotFoundException.class);
     soft.assertThat(commitLogic.storeCommit(firstCommit, emptyList())).isTrue();
     ObjId firstCommitId = firstCommit.id();
 
@@ -488,8 +486,6 @@ public class TestCommitConflicts {
         .containsEntry(fooKey, null)
         .containsEntry(barKey, barUpdateId);
 
-    soft.assertThatThrownBy(() -> commitLogic.updateCommit(secondCommit))
-        .isInstanceOf(ObjNotFoundException.class);
     soft.assertThat(commitLogic.storeCommit(secondCommit, emptyList())).isTrue();
     ObjId secondCommitId = secondCommit.id();
     CommitObj secondCommitLoaded = requireNonNull(commitLogic.fetchCommit(secondCommitId));

--- a/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
+++ b/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
@@ -294,33 +294,16 @@ class InmemoryPersist implements Persist {
   }
 
   @Override
-  public void updateObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-      throws ObjNotFoundException, ObjTooLargeException {
+  public void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj) throws ObjTooLargeException {
     verifySoftRestrictions(obj);
-    Obj v =
-        inmemory.objects.computeIfPresent(
-            compositeKey(obj.id()), (k, ex) -> ex.type() == obj.type() ? obj : ex);
-    if (!obj.equals(v)) {
-      throw new ObjNotFoundException(obj.id());
-    }
+    inmemory.objects.put(compositeKey(obj.id()), obj);
   }
 
   @Override
-  public void updateObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-      throws ObjTooLargeException, ObjNotFoundException {
-    List<ObjId> notFound = null;
+  public void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException {
     for (Obj obj : objs) {
-      try {
-        updateObj(obj);
-      } catch (ObjNotFoundException nf) {
-        if (notFound == null) {
-          notFound = new ArrayList<>();
-        }
-        notFound.add(obj.id());
-      }
-    }
-    if (notFound != null) {
-      throw new ObjNotFoundException(notFound);
+      upsertObj(obj);
     }
   }
 

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
@@ -247,19 +247,14 @@ class JdbcPersist extends AbstractJdbcPersist {
   }
 
   @Override
-  public void updateObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-      throws ObjTooLargeException, ObjNotFoundException {
-    withConnectionExceptions(
-        (SQLRunnableExceptions<Void, ObjTooLargeException, ObjNotFoundException>)
-            conn -> super.updateObj(conn, obj));
+  public void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj) throws ObjTooLargeException {
+    withConnectionException(false, conn -> super.updateObj(conn, obj));
   }
 
   @Override
-  public void updateObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-      throws ObjTooLargeException, ObjNotFoundException {
-    withConnectionExceptions(
-        (SQLRunnableExceptions<Void, ObjTooLargeException, ObjNotFoundException>)
-            conn -> super.updateObjs(conn, objs));
+  public void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException {
+    withConnectionException(false, conn -> super.updateObjs(conn, objs));
   }
 
   @Override

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
@@ -39,10 +39,6 @@ final class SqlConstants {
   static final String COLS_STRING =
       "s_content_type, s_compression, s_filename, s_predecessors, s_text";
 
-  static final String UPDATE_OBJ_PREFIX = "UPDATE " + TABLE_OBJS + " SET ";
-  static final String UPDATE_OBJ_SUFFIX =
-      " WHERE " + COL_REPO_ID + "=?" + " AND " + COL_OBJ_ID + "=? AND " + COL_OBJ_TYPE + "=?";
-
   static final String STORE_OBJ =
       "INSERT INTO "
           + TABLE_OBJS

--- a/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
+++ b/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
@@ -430,8 +430,7 @@ class RocksDBPersist implements Persist {
   }
 
   @Override
-  public void updateObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-      throws ObjTooLargeException, ObjNotFoundException {
+  public void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj) throws ObjTooLargeException {
     ObjId id = obj.id();
     checkArgument(id != null, "Obj to store must have a non-null ID");
 
@@ -441,11 +440,6 @@ class RocksDBPersist implements Persist {
       TransactionDB db = b.db();
       ColumnFamilyHandle cf = b.objs();
       byte[] key = dbKey(id);
-
-      byte[] existing = db.get(cf, key);
-      if (existing == null || deserializeObj(id, existing).type() != obj.type()) {
-        throw new ObjNotFoundException(id);
-      }
 
       byte[] serialized =
           serializeObj(obj, effectiveIncrementalIndexSizeLimit(), effectiveIndexSegmentSizeLimit());
@@ -459,10 +453,10 @@ class RocksDBPersist implements Persist {
   }
 
   @Override
-  public void updateObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-      throws ObjTooLargeException, ObjNotFoundException {
+  public void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException {
     for (Obj obj : objs) {
-      updateObj(obj);
+      upsertObj(obj);
     }
   }
 

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreImpl.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreImpl.java
@@ -177,15 +177,15 @@ public class TestVersionStoreImpl extends AbstractVersionStoreTests {
     }
 
     @Override
-    public void updateObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-        throws ObjTooLargeException, ObjNotFoundException {
-      delegate.updateObj(obj);
+    public void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
+        throws ObjTooLargeException {
+      delegate.upsertObj(obj);
     }
 
     @Override
-    public void updateObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-        throws ObjTooLargeException, ObjNotFoundException {
-      delegate.updateObjs(objs);
+    public void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+        throws ObjTooLargeException {
+      delegate.upsertObjs(objs);
     }
   }
 

--- a/versioned/storage/telemetry/src/main/java/org/projectnessie/versioned/storage/telemetry/TelemetryPersist.java
+++ b/versioned/storage/telemetry/src/main/java/org/projectnessie/versioned/storage/telemetry/TelemetryPersist.java
@@ -300,11 +300,10 @@ final class TelemetryPersist implements Persist {
   }
 
   @Override
-  public void updateObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-      throws ObjTooLargeException, ObjNotFoundException {
-    try (Traced trace = traced("updateObj")) {
+  public void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj) throws ObjTooLargeException {
+    try (Traced trace = traced("upsertObj")) {
       try {
-        persist.updateObj(obj);
+        persist.upsertObj(obj);
       } catch (RuntimeException e) {
         throw trace.unhandledError(e);
       }
@@ -312,11 +311,11 @@ final class TelemetryPersist implements Persist {
   }
 
   @Override
-  public void updateObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-      throws ObjTooLargeException, ObjNotFoundException {
-    try (Traced trace = traced("updateObjs")) {
+  public void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException {
+    try (Traced trace = traced("upsertObjs")) {
       try {
-        persist.updateObjs(objs);
+        persist.upsertObjs(objs);
       } catch (RuntimeException e) {
         throw trace.unhandledError(e);
       }


### PR DESCRIPTION
The only purpose of `updateObj()` is to allow the Nessie repository import to enhance the freshly imported `CommitObj`s, which are marked with `incompleteIndex==true`, with properly populated incremental and reference indexes.

During the import operation, we do not really care, whether the object to be updated (the commit) does not exist, because that will not be the case, because the import already stored all the commits. TL;DR the behavior to check whether the `Obj` passed to `updateObj()` already exists is rather meaningless.

Using "upsert" semantics has the big benefit that those can be batched, which is not only nice but a big performance improvement during import.