### PR TITLE
New storage: add "batch write" facade

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     api(project(":nessie-versioned-persist-transactional"))
     api(project(":nessie-versioned-persist-transactional-test"))
     api(project(":nessie-versioned-spi"))
+    api(project(":nessie-versioned-storage-batching"))
     api(project(":nessie-versioned-storage-cache"))
     api(project(":nessie-versioned-storage-cassandra"))
     api(project(":nessie-versioned-storage-common"))

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -48,6 +48,7 @@ nessie-versioned-persist-tests=versioned/persist/tests
 nessie-versioned-persist-transactional=versioned/persist/tx
 nessie-versioned-persist-transactional-test=versioned/persist/tx-test
 nessie-versioned-spi=versioned/spi
+nessie-versioned-storage-batching=versioned/storage/batching
 nessie-versioned-storage-cache=versioned/storage/cache
 nessie-versioned-storage-cassandra=versioned/storage/cassandra
 nessie-versioned-storage-common=versioned/storage/common

--- a/versioned/storage/batching/build.gradle.kts
+++ b/versioned/storage/batching/build.gradle.kts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  `java-library`
+  jacoco
+  `maven-publish`
+  signing
+  `nessie-conventions`
+}
+
+extra["maven.name"] = "Nessie - Storage - Batching Persist"
+
+description = "Storage implementation using in-memory maps, not persisting."
+
+dependencies {
+  implementation(project(":nessie-versioned-storage-common"))
+
+  // javax/jakarta
+  compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.javax.validation.api)
+  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.findbugs.jsr305)
+
+  compileOnly(libs.errorprone.annotations)
+  implementation(libs.guava)
+
+  compileOnly(project(":nessie-versioned-storage-testextension"))
+
+  compileOnly(libs.immutables.builder)
+  compileOnly(libs.immutables.value.annotations)
+  annotationProcessor(libs.immutables.value.processor)
+
+  testImplementation(project(":nessie-versioned-storage-common-tests"))
+  testImplementation(project(":nessie-versioned-storage-inmemory"))
+  testImplementation(project(path = ":nessie-protobuf-relocated", configuration = "shadow"))
+  testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.bundles.junit.testing)
+}

--- a/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersist.java
+++ b/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersist.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.batching;
+
+import org.projectnessie.versioned.storage.common.persist.Persist;
+
+public interface BatchingPersist extends Persist {
+
+  void flush();
+}

--- a/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
+++ b/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.batching;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.annotations.VisibleForTesting;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
+import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
+import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
+import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
+import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.Reference;
+import org.projectnessie.versioned.storage.common.persist.ValidatingPersist;
+
+final class BatchingPersistImpl implements BatchingPersist, ValidatingPersist {
+  private final WriteBatching batching;
+
+  private final Map<ObjId, Obj> pendingUpserts = new HashMap<>();
+  private final Map<ObjId, Obj> pendingStores = new HashMap<>();
+
+  private final ReentrantReadWriteLock lock;
+
+  BatchingPersistImpl(WriteBatching batching) {
+    checkArgument(batching.optimistic(), "Non-optimistic mode is not supported");
+    this.batching = batching;
+    this.lock = new ReentrantReadWriteLock();
+  }
+
+  @VisibleForTesting
+  Map<ObjId, Obj> pendingUpserts() {
+    return pendingUpserts;
+  }
+
+  @VisibleForTesting
+  Map<ObjId, Obj> pendingStores() {
+    return pendingStores;
+  }
+
+  @Override
+  public void flush() {
+    writeLock();
+    try {
+      if (!pendingStores.isEmpty()) {
+        delegate().storeObjs(pendingStores.values().toArray(new Obj[0]));
+        pendingStores.clear();
+      }
+      if (!pendingUpserts.isEmpty()) {
+        delegate().upsertObjs(pendingUpserts.values().toArray(new Obj[0]));
+        pendingUpserts.clear();
+      }
+    } catch (ObjTooLargeException e) {
+      throw new RuntimeException(e);
+    } finally {
+      writeUnlock();
+    }
+  }
+
+  private Persist delegate() {
+    return batching.persist();
+  }
+
+  private void readLock() {
+    lock.readLock().lock();
+  }
+
+  private void readUnlock() {
+    lock.readLock().unlock();
+  }
+
+  private void writeUnlock() {
+    lock.writeLock().unlock();
+  }
+
+  private void writeLock() {
+    lock.writeLock().lock();
+  }
+
+  private void maybeFlush() {
+    if (pendingStores.size() > batching.batchSize()
+        || pendingUpserts.size() > batching.batchSize()) {
+      flush();
+    }
+  }
+
+  @Override
+  public boolean storeObj(
+      @Nonnull @javax.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
+      throws ObjTooLargeException {
+    if (!ignoreSoftSizeRestrictions) {
+      verifySoftRestrictions(obj);
+    }
+    writeLock();
+    try {
+      pendingStores.putIfAbsent(obj.id(), obj);
+      maybeFlush();
+    } finally {
+      writeUnlock();
+    }
+    return true;
+  }
+
+  @Override
+  public void upsertObj(@Nonnull @javax.annotation.Nonnull Obj obj) throws ObjTooLargeException {
+    verifySoftRestrictions(obj);
+    writeLock();
+    try {
+      pendingUpserts.put(obj.id(), obj);
+      maybeFlush();
+    } finally {
+      writeUnlock();
+    }
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public boolean[] storeObjs(@Nonnull @javax.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException {
+    writeLock();
+    try {
+      for (Obj obj : objs) {
+        if (obj != null) {
+          storeObj(obj);
+        }
+      }
+    } finally {
+      writeUnlock();
+    }
+    boolean[] r = new boolean[objs.length];
+    Arrays.fill(r, true);
+    return r;
+  }
+
+  @Override
+  public void upsertObjs(@Nonnull @javax.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException {
+    writeLock();
+    try {
+      for (Obj obj : objs) {
+        if (obj != null) {
+          upsertObj(obj);
+        }
+      }
+    } finally {
+      writeUnlock();
+    }
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public Obj fetchObj(@Nonnull @javax.annotation.Nonnull ObjId id) throws ObjNotFoundException {
+    readLock();
+    try {
+      Obj r = pendingObj(id);
+      if (r != null) {
+        return r;
+      }
+    } finally {
+      readUnlock();
+    }
+
+    return delegate().fetchObj(id);
+  }
+
+  private Obj pendingObj(ObjId id) {
+    Obj r = pendingUpserts.get(id);
+    if (r == null) {
+      r = pendingStores.get(id);
+    }
+    return r;
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public <T extends Obj> T fetchTypedObj(
+      @Nonnull @javax.annotation.Nonnull ObjId id, ObjType type, Class<T> typeClass)
+      throws ObjNotFoundException {
+    readLock();
+    try {
+      Obj r = pendingObj(id);
+      if (r != null) {
+        if (r.type() != type) {
+          throw new ObjNotFoundException(id);
+        }
+        @SuppressWarnings("unchecked")
+        T o = (T) r;
+        return o;
+      }
+    } finally {
+      readUnlock();
+    }
+    return delegate().fetchTypedObj(id, type, typeClass);
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public ObjType fetchObjType(@Nonnull @javax.annotation.Nonnull ObjId id)
+      throws ObjNotFoundException {
+    readLock();
+    try {
+      Obj r = pendingObj(id);
+      if (r != null) {
+        return r.type();
+      }
+    } finally {
+      readUnlock();
+    }
+    return delegate().fetchObjType(id);
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public Obj[] fetchObjs(@Nonnull @javax.annotation.Nonnull ObjId[] ids)
+      throws ObjNotFoundException {
+
+    ObjId[] backendIds = null;
+    Obj[] r = new Obj[ids.length];
+
+    readLock();
+    try {
+      for (int i = 0; i < ids.length; i++) {
+        ObjId id = ids[i];
+        if (id == null) {
+          continue;
+        }
+        Obj o = pendingObj(id);
+        if (o != null) {
+          r[i] = o;
+        } else {
+          if (backendIds == null) {
+            backendIds = new ObjId[ids.length];
+          }
+          backendIds[i] = id;
+        }
+      }
+    } finally {
+      readUnlock();
+    }
+
+    if (backendIds == null) {
+      return r;
+    }
+
+    Obj[] backendResult = delegate().fetchObjs(backendIds);
+    for (int i = 0; i < backendResult.length; i++) {
+      Obj o = backendResult[i];
+      if (o != null) {
+        r[i] = o;
+      }
+    }
+    return r;
+  }
+
+  @Override
+  public void deleteObj(@Nonnull @javax.annotation.Nonnull ObjId id) {
+    writeLock();
+    try {
+      delegate().deleteObj(id);
+      pendingStores.remove(id);
+      pendingUpserts.remove(id);
+    } finally {
+      writeUnlock();
+    }
+  }
+
+  @Override
+  public void deleteObjs(@Nonnull @javax.annotation.Nonnull ObjId[] ids) {
+    writeLock();
+    try {
+      for (ObjId id : ids) {
+        if (id != null) {
+          deleteObj(id);
+        }
+      }
+    } finally {
+      writeUnlock();
+    }
+  }
+
+  @Override
+  public void erase() {
+    writeLock();
+    try {
+      pendingStores.clear();
+      pendingUpserts.clear();
+      delegate().erase();
+    } finally {
+      writeUnlock();
+    }
+  }
+
+  @Override
+  public int hardObjectSizeLimit() {
+    return delegate().hardObjectSizeLimit();
+  }
+
+  @Override
+  public int effectiveIndexSegmentSizeLimit() {
+    return delegate().effectiveIndexSegmentSizeLimit();
+  }
+
+  @Override
+  public int effectiveIncrementalIndexSizeLimit() {
+    return delegate().effectiveIncrementalIndexSizeLimit();
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public String name() {
+    return delegate().name();
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public StoreConfig config() {
+    return delegate().config();
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public Reference addReference(@Nonnull @javax.annotation.Nonnull Reference reference)
+      throws RefAlreadyExistsException {
+    return delegate().addReference(reference);
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public Reference markReferenceAsDeleted(@Nonnull @javax.annotation.Nonnull Reference reference)
+      throws RefNotFoundException, RefConditionFailedException {
+    return delegate().markReferenceAsDeleted(reference);
+  }
+
+  @Override
+  public void purgeReference(@Nonnull @javax.annotation.Nonnull Reference reference)
+      throws RefNotFoundException, RefConditionFailedException {
+    delegate().purgeReference(reference);
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public Reference updateReferencePointer(
+      @Nonnull @javax.annotation.Nonnull Reference reference,
+      @Nonnull @javax.annotation.Nonnull ObjId newPointer)
+      throws RefNotFoundException, RefConditionFailedException {
+    return delegate().updateReferencePointer(reference, newPointer);
+  }
+
+  @Override
+  @Nullable
+  @javax.annotation.Nullable
+  public Reference fetchReference(@Nonnull @javax.annotation.Nonnull String name) {
+    return delegate().fetchReference(name);
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public Reference[] fetchReferences(@Nonnull @javax.annotation.Nonnull String[] names) {
+    return delegate().fetchReferences(names);
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public CloseableIterator<Obj> scanAllObjects(
+      @Nonnull @javax.annotation.Nonnull Set<ObjType> returnedObjTypes) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/WriteBatching.java
+++ b/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/WriteBatching.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.batching;
+
+import org.immutables.value.Value;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+
+@Value.Immutable
+public interface WriteBatching {
+  int DEFAULT_BATCH_SIZE = 100;
+  boolean DEFAULT_OPTIMISTIC = true;
+
+  static ImmutableWriteBatching.Builder builder() {
+    return ImmutableWriteBatching.builder();
+  }
+
+  Persist persist();
+
+  @Value.Default
+  default int batchSize() {
+    return DEFAULT_BATCH_SIZE;
+  }
+
+  /**
+   * Optimistic batching means, that the {@link BatchingPersist batching} implementation assumes
+   * that objects to be stored do not already exist, all row-level checks are not in effect, the
+   * {@link BatchingPersist batching} implementation effectively "trusts" the called to do the right
+   * thing.
+   *
+   * <p><em>IMPORTANT NOTE:</em> there is currently no implementation that supports strict checks
+   * that would provide the same guarantees are live-production {@code Persist} implementations.
+   */
+  @Value.Default
+  default boolean optimistic() {
+    return DEFAULT_OPTIMISTIC;
+  }
+
+  default BatchingPersist create() {
+    return new BatchingPersistImpl(this);
+  }
+}

--- a/versioned/storage/batching/src/test/java/org/projectnessie/versioned/storage/batching/TestBatchingPersist.java
+++ b/versioned/storage/batching/src/test/java/org/projectnessie/versioned/storage/batching/TestBatchingPersist.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.batching;
+
+import static java.util.Arrays.stream;
+import static org.assertj.core.api.AssertionsForClassTypes.entry;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
+import static org.projectnessie.versioned.storage.commontests.AbstractBasePersistTests.updateObjChange;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
+import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
+import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
+import org.projectnessie.versioned.storage.common.objtypes.IndexObj;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.commontests.AbstractBasePersistTests;
+import org.projectnessie.versioned.storage.inmemory.InmemoryBackend;
+import org.projectnessie.versioned.storage.inmemory.InmemoryBackendFactory;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestBatchingPersist {
+  @InjectSoftAssertions protected SoftAssertions soft;
+  private Persist base;
+  private BatchingPersistImpl batching;
+
+  @BeforeEach
+  void setup() {
+    base = base();
+    batching = batching(base);
+  }
+
+  @ParameterizedTest
+  @MethodSource("allObjectTypeSamples")
+  void singleObj(Obj obj) throws Exception {
+    // Obj that exists in "base"
+    base.storeObj(obj);
+    soft.assertThat(batching.fetchObj(obj.id())).isEqualTo(obj);
+    base.deleteObj(obj.id());
+    soft.assertThatThrownBy(() -> batching.fetchObj(obj.id()))
+        .isInstanceOf(ObjNotFoundException.class);
+    soft.assertThatThrownBy(() -> batching.fetchObjs(new ObjId[] {obj.id()}))
+        .isInstanceOf(ObjNotFoundException.class);
+
+    // Obj stored via "batching"
+    batching.storeObj(obj);
+    soft.assertThat(batching.pendingStores()).containsExactly(entry(obj.id(), obj));
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+    soft.assertThatThrownBy(() -> base.fetchObj(obj.id())).isInstanceOf(ObjNotFoundException.class);
+    soft.assertThatThrownBy(() -> base.fetchObjs(new ObjId[] {obj.id()}))
+        .isInstanceOf(ObjNotFoundException.class);
+    soft.assertThat(batching.fetchObj(obj.id())).isEqualTo(obj);
+    soft.assertThat(batching.fetchObjs(new ObjId[] {obj.id()})).containsExactly(obj);
+    batching.flush();
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+    soft.assertThat(base.fetchObj(obj.id())).isEqualTo(obj);
+    soft.assertThat(base.fetchObjs(new ObjId[] {obj.id()})).containsExactly(obj);
+    soft.assertThat(batching.fetchObj(obj.id())).isEqualTo(obj);
+    soft.assertThat(batching.fetchObjs(new ObjId[] {obj.id()})).containsExactly(obj);
+
+    // Obj updated via "batching"
+    Obj updated = updateObjChange(obj);
+    batching.upsertObj(updated);
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).containsExactly(entry(obj.id(), updated));
+    soft.assertThat(base.fetchObj(obj.id())).isEqualTo(obj);
+    soft.assertThat(base.fetchObjs(new ObjId[] {obj.id()})).containsExactly(obj);
+    soft.assertThat(batching.fetchObj(obj.id())).isEqualTo(updated);
+    soft.assertThat(batching.fetchObjs(new ObjId[] {obj.id()})).containsExactly(updated);
+    batching.flush();
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+    soft.assertThat(base.fetchObj(obj.id())).isEqualTo(updated);
+    soft.assertThat(base.fetchObjs(new ObjId[] {obj.id()})).containsExactly(updated);
+    soft.assertThat(batching.fetchObj(obj.id())).isEqualTo(updated);
+    soft.assertThat(batching.fetchObjs(new ObjId[] {obj.id()})).containsExactly(updated);
+  }
+
+  @Test
+  void multipleObjs() throws Exception {
+    Obj[] objs = allObjectTypeSamples().toArray(Obj[]::new);
+    ObjId[] ids = stream(objs).map(Obj::id).toArray(ObjId[]::new);
+    Map<ObjId, Obj> objsMap = stream(objs).collect(Collectors.toMap(Obj::id, o -> o));
+
+    // Obj that exists in "base"
+    base.storeObjs(objs);
+    soft.assertThat(batching.fetchObjs(ids)).containsExactly(objs);
+    base.deleteObjs(ids);
+    soft.assertThatThrownBy(() -> batching.fetchObjs(ids))
+        .isInstanceOf(ObjNotFoundException.class)
+        .asInstanceOf(type(ObjNotFoundException.class))
+        .extracting(ObjNotFoundException::objIds)
+        .asInstanceOf(list(ObjId.class))
+        .containsExactly(ids);
+
+    // Obj stored via "batching"
+    batching.storeObjs(objs);
+    soft.assertThat(batching.pendingStores()).isEqualTo(objsMap);
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+    soft.assertThatThrownBy(() -> base.fetchObjs(ids))
+        .isInstanceOf(ObjNotFoundException.class)
+        .asInstanceOf(type(ObjNotFoundException.class))
+        .extracting(ObjNotFoundException::objIds)
+        .asInstanceOf(list(ObjId.class))
+        .containsExactly(ids);
+    soft.assertThat(batching.fetchObjs(ids)).containsExactly(objs);
+    batching.flush();
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+    soft.assertThat(base.fetchObjs(ids)).containsExactly(objs);
+    soft.assertThat(batching.fetchObjs(ids)).containsExactly(objs);
+
+    // Obj updated via "batching"
+    Obj[] updated = stream(objs).map(AbstractBasePersistTests::updateObjChange).toArray(Obj[]::new);
+    Map<ObjId, Obj> updatedMap = stream(updated).collect(Collectors.toMap(Obj::id, o -> o));
+    batching.upsertObjs(updated);
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).isEqualTo(updatedMap);
+    soft.assertThat(base.fetchObjs(ids)).containsExactly(objs);
+    soft.assertThat(batching.fetchObjs(ids)).containsExactly(updated);
+    batching.flush();
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+    soft.assertThat(base.fetchObjs(ids)).containsExactly(updated);
+    soft.assertThat(batching.fetchObjs(ids)).containsExactly(updated);
+  }
+
+  @Test
+  void erase() throws Exception {
+    Obj[] objs = allObjectTypeSamples().toArray(Obj[]::new);
+
+    batching.storeObjs(objs);
+    soft.assertThat(batching.pendingStores()).hasSize(objs.length);
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+    batching.erase();
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+
+    Obj[] updated = stream(objs).map(AbstractBasePersistTests::updateObjChange).toArray(Obj[]::new);
+    batching.upsertObjs(updated);
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).hasSize(objs.length);
+    batching.erase();
+    soft.assertThat(batching.pendingStores()).isEmpty();
+    soft.assertThat(batching.pendingUpserts()).isEmpty();
+  }
+
+  @Test
+  void tooLarge() {
+    CommitObj o =
+        CommitObj.commitBuilder()
+            .id(randomObjId())
+            .created(0L)
+            .seq(0L)
+            .headers(CommitHeaders.EMPTY_COMMIT_HEADERS)
+            .message("")
+            .incrementalIndex(
+                ByteString.copyFrom(new byte[base.effectiveIncrementalIndexSizeLimit() + 1]))
+            .build();
+    soft.assertThatThrownBy(() -> batching.storeObj(o)).isInstanceOf(ObjTooLargeException.class);
+    soft.assertThatThrownBy(() -> batching.storeObjs(new Obj[] {o}))
+        .isInstanceOf(ObjTooLargeException.class);
+    soft.assertThatThrownBy(() -> batching.upsertObj(o)).isInstanceOf(ObjTooLargeException.class);
+    soft.assertThatThrownBy(() -> batching.upsertObjs(new Obj[] {o}))
+        .isInstanceOf(ObjTooLargeException.class);
+
+    IndexObj s =
+        IndexObj.index(ByteString.copyFrom(new byte[base.effectiveIndexSegmentSizeLimit() + 1]));
+    soft.assertThatThrownBy(() -> batching.storeObj(s)).isInstanceOf(ObjTooLargeException.class);
+    soft.assertThatThrownBy(() -> batching.storeObjs(new Obj[] {s}))
+        .isInstanceOf(ObjTooLargeException.class);
+    soft.assertThatThrownBy(() -> batching.upsertObj(s)).isInstanceOf(ObjTooLargeException.class);
+    soft.assertThatThrownBy(() -> batching.upsertObjs(new Obj[] {s}))
+        .isInstanceOf(ObjTooLargeException.class);
+  }
+
+  private Persist base() {
+    InmemoryBackendFactory factory = new InmemoryBackendFactory();
+    @SuppressWarnings("resource")
+    InmemoryBackend backend = factory.buildBackend(factory.newConfigInstance());
+    return backend.createFactory().newPersist(StoreConfig.Adjustable.empty());
+  }
+
+  private BatchingPersistImpl batching(Persist base) {
+    return (BatchingPersistImpl)
+        WriteBatching.builder().persist(base).batchSize(20).build().create();
+  }
+
+  static Stream<Obj> allObjectTypeSamples() {
+    return AbstractBasePersistTests.allObjectTypeSamples();
+  }
+
+  // plain delegates are untested (delegation code generated by IntelliJ)
+}

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
@@ -252,7 +252,7 @@ public class AbstractBasePersistTests {
     soft.assertThat(persist.fetchReferences(new String[205])).hasSize(205).containsOnlyNulls();
   }
 
-  static Stream<Obj> allObjectTypeSamples() {
+  public static Stream<Obj> allObjectTypeSamples() {
     String nonAscii = "äöüß^€éèêµ";
     byte[] someFooBar = "Some foo bar baz".getBytes(UTF_8);
     ByteString fooBar = ByteString.copyFrom(someFooBar);
@@ -754,7 +754,7 @@ public class AbstractBasePersistTests {
   @Test
   public void updateMultipleObjects() throws Exception {
     Obj[] objs = allObjectTypeSamples().toArray(Obj[]::new);
-    Obj[] newObjs = stream(objs).map(this::updateObjChange).toArray(Obj[]::new);
+    Obj[] newObjs = stream(objs).map(AbstractBasePersistTests::updateObjChange).toArray(Obj[]::new);
 
     for (int i = 0; i < objs.length; i++) {
       soft.assertThat(newObjs[i]).isNotEqualTo(objs[i]);
@@ -769,7 +769,7 @@ public class AbstractBasePersistTests {
         .containsExactly(newObjs);
   }
 
-  private Obj updateObjChange(Obj obj) {
+  public static Obj updateObjChange(Obj obj) {
     Obj newObj;
     switch (obj.type()) {
       case COMMIT:
@@ -822,8 +822,7 @@ public class AbstractBasePersistTests {
                 ByteString.copyFrom(new byte[123]));
         break;
       default:
-        soft.fail("Unknown object type %s", obj.type());
-        return null;
+        throw new UnsupportedOperationException("Unknown object type " + obj.type());
     }
     return newObj;
   }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ValidatingPersist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ValidatingPersist.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.persist;
+
+import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
+import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
+import org.projectnessie.versioned.storage.common.objtypes.IndexObj;
+
+public interface ValidatingPersist extends Persist {
+
+  default void verifySoftRestrictions(Obj obj) throws ObjTooLargeException {
+    if (obj instanceof CommitObj) {
+      CommitObj c = (CommitObj) obj;
+      ByteString serializedIndex = c.incrementalIndex();
+      if (serializedIndex.size() > effectiveIncrementalIndexSizeLimit()) {
+        throw new ObjTooLargeException(
+            serializedIndex.size(), effectiveIncrementalIndexSizeLimit());
+      }
+    } else if (obj instanceof IndexObj) {
+      IndexObj s = (IndexObj) obj;
+      ByteString index = s.index();
+      if (index.size() > effectiveIndexSegmentSizeLimit()) {
+        throw new ObjTooLargeException(index.size(), effectiveIndexSegmentSizeLimit());
+      }
+    }
+  }
+}

--- a/versioned/transfer/build.gradle.kts
+++ b/versioned/transfer/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-persist-adapter"))
   implementation(project(":nessie-versioned-transfer-proto"))
+  implementation(project(":nessie-versioned-storage-batching"))
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-versioned-storage-store"))
 

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/BatchWriter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/BatchWriter.java
@@ -23,9 +23,6 @@ import java.util.function.Consumer;
 import org.projectnessie.versioned.ContentAttachment;
 import org.projectnessie.versioned.persist.adapter.CommitLogEntry;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
-import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
-import org.projectnessie.versioned.storage.common.persist.Obj;
-import org.projectnessie.versioned.storage.common.persist.Persist;
 
 /**
  * Buffers a configurable amount of objects and passes those as batches to a consumer, should be
@@ -55,18 +52,6 @@ final class BatchWriter<T> implements AutoCloseable {
       int batchSize, DatabaseAdapter databaseAdapter) {
     return new BatchWriter<>(
         batchSize, attachments -> databaseAdapter.putAttachments(attachments.stream()));
-  }
-
-  static BatchWriter<Obj> objWriter(int batchSize, Persist persist) {
-    return new BatchWriter<>(
-        batchSize,
-        objs -> {
-          try {
-            persist.storeObjs(objs.toArray(new Obj[0]));
-          } catch (ObjTooLargeException e) {
-            throw new RuntimeException(e);
-          }
-        });
   }
 
   BatchWriter(int capacity, Consumer<List<T>> flush) {


### PR DESCRIPTION
Adds a `Persist` implementation that batches "store" and "update" operations.

This change leverages the "upsert" capability introduced by #6384 for "Nessie's repository import" to perform bulk writes, replaces the previous `Obj` bulk write and introduces bulk-updates for the new storage model's finalization phase. This change, in combination with a "large-ish" value (e.g. 500) for the import's `--commit-batch-size` parameter, brings a extremely huge improvement. For a local test case, the duration to "finalize" 1000 commits was ~5.2 seconds, with this change down to <0.2 seconds per 1000 commits.