### PR TITLE
Remove exception mapping for `java.security.AccessControlException`

### DIFF
--- a/servers/rest-services/src/main/java/org/projectnessie/services/restjakarta/NessieExceptionMapper.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/restjakarta/NessieExceptionMapper.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
-import java.security.AccessControlException;
 import java.util.stream.Collectors;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.ErrorCode;
@@ -76,8 +75,7 @@ public class NessieExceptionMapper extends BaseExceptionMapper<Exception> {
       LOGGER.warn("Backend throttled/refused the request: {}", exception.toString());
       errorCode = ErrorCode.TOO_MANY_REQUESTS;
       message = "Backend store refused to process the request: " + exception;
-    } else if (exception instanceof AccessControlException
-        || exception instanceof AccessCheckException) {
+    } else if (exception instanceof AccessCheckException) {
       errorCode = ErrorCode.FORBIDDEN;
       message = exception.getMessage();
     } else if (exception instanceof NotSupportedException) {

--- a/servers/rest-services/src/main/java/org/projectnessie/services/restjavax/NessieExceptionMapper.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/restjavax/NessieExceptionMapper.java
@@ -18,7 +18,6 @@ package org.projectnessie.services.restjavax;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Throwables;
-import java.security.AccessControlException;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.NotSupportedException;
@@ -76,8 +75,7 @@ public class NessieExceptionMapper extends BaseExceptionMapper<Exception> {
       LOGGER.warn("Backend throttled/refused the request: {}", exception.toString());
       errorCode = ErrorCode.TOO_MANY_REQUESTS;
       message = "Backend store refused to process the request: " + exception;
-    } else if (exception instanceof AccessControlException
-        || exception instanceof AccessCheckException) {
+    } else if (exception instanceof AccessCheckException) {
       errorCode = ErrorCode.FORBIDDEN;
       message = exception.getMessage();
     } else if (exception instanceof NotSupportedException) {


### PR DESCRIPTION
`java.security.AccessControlException` has been deprecated for removal for a while, and Nessie no longer throws this exception. Handling this exception is no longer needed.