### PR TITLE
Fix nullability for fields of ContentValueObj

### DIFF
--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/ContentValueObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/ContentValueObj.java
@@ -18,8 +18,6 @@ package org.projectnessie.versioned.storage.common.objtypes;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.projectnessie.versioned.storage.common.objtypes.Hashes.contentValueHash;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.immutables.value.Value;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.persist.Obj;
@@ -36,13 +34,9 @@ public interface ContentValueObj extends Obj {
 
   @Override
   @Value.Parameter(order = 1)
-  @Nullable
-  @jakarta.annotation.Nullable
   ObjId id();
 
   @Value.Parameter(order = 2)
-  @Nullable
-  @jakarta.annotation.Nullable
   String contentId();
 
   @Value.Parameter(order = 3)
@@ -51,23 +45,12 @@ public interface ContentValueObj extends Obj {
   @Value.Parameter(order = 4)
   ByteString data();
 
-  @Nonnull
-  @jakarta.annotation.Nonnull
-  static ContentValueObj contentValue(
-      @Nullable @jakarta.annotation.Nullable ObjId id,
-      @Nullable @jakarta.annotation.Nullable String contentId,
-      int payload,
-      @Nonnull @jakarta.annotation.Nonnull ByteString data) {
+  static ContentValueObj contentValue(ObjId id, String contentId, int payload, ByteString data) {
     checkArgument(payload >= 0 && payload <= 127);
     return ImmutableContentValueObj.of(id, contentId, payload, data);
   }
 
-  @Nonnull
-  @jakarta.annotation.Nonnull
-  static ContentValueObj contentValue(
-      @Nullable @jakarta.annotation.Nullable String contentId,
-      int payload,
-      @Nonnull @jakarta.annotation.Nonnull ByteString data) {
+  static ContentValueObj contentValue(String contentId, int payload, ByteString data) {
     return contentValue(contentValueHash(contentId, payload, data), contentId, payload, data);
   }
 }


### PR DESCRIPTION
This commit removes a few `@Nullable` annotations from parameters in builder methods, since they are wrong.

It also removes a few redundant `@NonNull` annotations in some return types, since return types are non-null by default.