### PR TITLE
Nit: Suppress a bunch of unchecked and deprecated warnings

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/GetRefLogBuilder.java
@@ -28,6 +28,7 @@ import org.projectnessie.model.Validation;
  *
  * @since {@link NessieApiV1}
  */
+@Deprecated
 public interface GetRefLogBuilder
     extends PagingBuilder<GetRefLogBuilder, RefLogResponse, RefLogResponse.RefLogResponseEntry>,
         QueryBuilder<GetRefLogBuilder> {

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseGetRefLogBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseGetRefLogBuilder.java
@@ -23,6 +23,7 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.model.RefLogResponse.RefLogResponseEntry;
 
+@Deprecated
 public abstract class BaseGetRefLogBuilder<PARAMS> implements GetRefLogBuilder {
 
   private final BiFunction<PARAMS, String, PARAMS> paramsForPage;

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
@@ -34,41 +34,49 @@ public abstract class BaseMergeTransplantBuilder<B extends OnBranchBuilder<B>>
   protected Map<ContentKey, MergeKeyBehavior> mergeModes;
   protected String message;
 
+  @SuppressWarnings("unchecked")
   public B message(String message) {
     this.message = message;
     return (B) this;
   }
 
+  @SuppressWarnings("unchecked")
   public B fromRefName(String fromRefName) {
     this.fromRefName = fromRefName;
     return (B) this;
   }
 
+  @SuppressWarnings("unchecked")
   public B keepIndividualCommits(boolean keepIndividualCommits) {
     this.keepIndividualCommits = keepIndividualCommits;
     return (B) this;
   }
 
+  @SuppressWarnings("unchecked")
   public B dryRun(boolean dryRun) {
     this.dryRun = dryRun;
     return (B) this;
   }
 
+  @SuppressWarnings("unchecked")
   public B fetchAdditionalInfo(boolean fetchAdditionalInfo) {
     this.fetchAdditionalInfo = fetchAdditionalInfo;
     return (B) this;
   }
 
+  @SuppressWarnings("unchecked")
   public B returnConflictAsResult(boolean returnConflictAsResult) {
     this.returnConflictAsResult = returnConflictAsResult;
     return (B) this;
   }
 
+  @SuppressWarnings("unchecked")
   public B defaultMergeMode(MergeBehavior mergeBehavior) {
     defaultMergeMode = mergeBehavior;
     return (B) this;
   }
 
+  @SuppressWarnings("unchecked")
   public B mergeMode(ContentKey key, MergeBehavior mergeBehavior) {
     if (mergeModes == null) {
       mergeModes = new HashMap<>();

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseOnBranchBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseOnBranchBuilder.java
@@ -22,12 +22,14 @@ public abstract class BaseOnBranchBuilder<R extends OnBranchBuilder<R>>
   protected String branchName;
   protected String hash;
 
+  @SuppressWarnings("unchecked")
   @Override
   public R branchName(String branchName) {
     this.branchName = branchName;
     return (R) this;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public R hash(String hash) {
     this.hash = hash;

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseOnReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseOnReferenceBuilder.java
@@ -22,12 +22,14 @@ abstract class BaseOnReferenceBuilder<R extends OnReferenceBuilder<R>>
   protected String refName;
   protected String hashOnRef;
 
+  @SuppressWarnings("unchecked")
   @Override
   public R refName(String refName) {
     this.refName = refName;
     return (R) this;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public R hashOnRef(String hashOnRef) {
     this.hashOnRef = hashOnRef;

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseOnTagBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseOnTagBuilder.java
@@ -21,12 +21,14 @@ public abstract class BaseOnTagBuilder<R extends OnTagBuilder<R>> implements OnT
   protected String tagName;
   protected String hash;
 
+  @SuppressWarnings("unchecked")
   @Override
   public R tagName(String tagName) {
     this.tagName = tagName;
     return (R) this;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public R hash(String hash) {
     this.hash = hash;

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpRefLogClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpRefLogClient.java
@@ -21,6 +21,7 @@ import org.projectnessie.api.v1.params.RefLogParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 
+@Deprecated
 class HttpRefLogClient implements HttpRefLogApi {
 
   private final HttpClient client;

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
@@ -67,6 +67,7 @@ final class NessieHttpClient extends NessieApiClient {
     return clientBuilder.build();
   }
 
+  @SuppressWarnings("deprecation")
   private NessieHttpClient(HttpClient client) {
     super(
         wrap(HttpConfigApi.class, new HttpConfigClient(client)),

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpApiV1.java
@@ -135,6 +135,7 @@ public final class HttpApiV1 implements NessieApiV1 {
   }
 
   @Override
+  @Deprecated
   public GetRefLogBuilder getRefLog() {
     return new HttpGetRefLog(client);
   }

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetRefLog.java
@@ -21,6 +21,7 @@ import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 
+@Deprecated
 final class HttpGetRefLog extends BaseGetRefLogBuilder<RefLogParams> {
 
   private final NessieApiClient client;

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpOnReferenceRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpOnReferenceRequest.java
@@ -27,12 +27,14 @@ abstract class BaseHttpOnReferenceRequest<R extends OnReferenceBuilder<R>> exten
     super(client);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public R refName(String refName) {
     this.refName = refName;
     return (R) this;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public R hashOnRef(String hashOnRef) {
     this.hashOnRef = hashOnRef;

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpApiV2.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpApiV2.java
@@ -147,6 +147,7 @@ public class HttpApiV2 implements NessieApiV2 {
   }
 
   @Override
+  @Deprecated
   public GetRefLogBuilder getRefLog() {
     throw new UnsupportedOperationException("Reflog is not supported in API v2");
   }

--- a/api/client/src/test/java/org/projectnessie/client/auth/TestBasicAuthProvider.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/TestBasicAuthProvider.java
@@ -18,8 +18,6 @@ package org.projectnessie.client.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_PASSWORD;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_USERNAME;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
@@ -38,6 +36,7 @@ import org.projectnessie.client.http.impl.RequestContextImpl;
 
 @Execution(ExecutionMode.CONCURRENT)
 class TestBasicAuthProvider {
+  @SuppressWarnings("deprecation")
   @Test
   void testNullParams() {
     assertAll(
@@ -45,13 +44,17 @@ class TestBasicAuthProvider {
             assertThatThrownBy(
                     () ->
                         new BasicAuthenticationProvider()
-                            .build(ImmutableMap.of(CONF_NESSIE_PASSWORD, "pass")::get))
+                            .build(
+                                ImmutableMap.of(NessieConfigConstants.CONF_NESSIE_PASSWORD, "pass")
+                                    ::get))
                 .isInstanceOf(NullPointerException.class),
         () ->
             assertThatThrownBy(
                     () ->
                         new BasicAuthenticationProvider()
-                            .build(ImmutableMap.of(CONF_NESSIE_USERNAME, "user")::get))
+                            .build(
+                                ImmutableMap.of(NessieConfigConstants.CONF_NESSIE_USERNAME, "user")
+                                    ::get))
                 .isInstanceOf(NullPointerException.class),
         () ->
             assertThatThrownBy(() -> new BasicAuthenticationProvider().build(s -> null))
@@ -69,13 +72,14 @@ class TestBasicAuthProvider {
 
   @Test
   void testFromConfig() {
+    @SuppressWarnings("deprecation")
     Map<String, String> authCfg =
         ImmutableMap.of(
             NessieConfigConstants.CONF_NESSIE_AUTH_TYPE,
             BasicAuthenticationProvider.AUTH_TYPE_VALUE,
-            CONF_NESSIE_USERNAME,
+            NessieConfigConstants.CONF_NESSIE_USERNAME,
             "Aladdin",
-            CONF_NESSIE_PASSWORD,
+            NessieConfigConstants.CONF_NESSIE_PASSWORD,
             "OpenSesame");
 
     NessieAuthentication authentication = NessieAuthenticationProvider.fromConfig(authCfg::get);

--- a/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -93,6 +93,7 @@ public class TestHttpClientBuilder {
             "Cannot start http client. file:///foo/bar/baz must be a valid http or https address");
   }
 
+  @SuppressWarnings("deprecation")
   static List<Function<HttpClientBuilder, HttpClientBuilder>> basicAuthConfigs() {
     return Arrays.asList(
         cfg ->

--- a/api/model/src/main/java/org/projectnessie/api/v1/RefLogApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v1/RefLogApi.java
@@ -21,6 +21,7 @@ import org.projectnessie.api.v1.params.RefLogParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 
+@Deprecated
 public interface RefLogApi {
 
   // Note: When substantial changes in Nessie API (this and related interfaces) are made

--- a/api/model/src/main/java/org/projectnessie/api/v1/http/HttpRefLogApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v1/http/HttpRefLogApi.java
@@ -32,6 +32,7 @@ import org.projectnessie.api.v1.params.RefLogParams;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.RefLogResponse;
 
+@SuppressWarnings("deprecation")
 @Tag(name = "v1")
 @Consumes(MediaType.APPLICATION_JSON)
 @jakarta.ws.rs.Consumes(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)

--- a/api/model/src/main/java/org/projectnessie/model/RefLogResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/RefLogResponse.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 
+@SuppressWarnings("all")
 @Value.Immutable
 @Schema(type = SchemaType.OBJECT, title = "RefLogResponse", deprecated = true, hidden = true)
 @JsonSerialize(as = ImmutableRefLogResponse.class)
@@ -34,6 +35,7 @@ public interface RefLogResponse extends PaginatedResponse {
   @jakarta.validation.constraints.NotNull
   List<RefLogResponseEntry> getLogEntries();
 
+  @SuppressWarnings("all")
   @Value.Immutable
   @Schema(type = SchemaType.OBJECT, title = "RefLogResponseEntry", deprecated = true, hidden = true)
   @JsonSerialize(as = ImmutableRefLogResponseEntry.class)

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/TranslatingVersionNessieApi.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/TranslatingVersionNessieApi.java
@@ -446,21 +446,23 @@ final class TranslatingVersionNessieApi implements AutoCloseable {
 
   static <T extends NessieApi> T unsupportedApiInterfaceProxy(
       Class<T> declaredType, Version runtimeVersion) {
-    //noinspection unchecked
-    return (T)
-        Proxy.newProxyInstance(
-            declaredType.getClassLoader(),
-            getAllInterfaces(declaredType),
-            (proxyInstance, method, args) -> {
-              // Ignore close() calls - they are made by the test framework (normally)
-              if ("close".equals(method.getName())) {
-                return null;
-              }
+    @SuppressWarnings("unchecked")
+    T r =
+        (T)
+            Proxy.newProxyInstance(
+                declaredType.getClassLoader(),
+                getAllInterfaces(declaredType),
+                (proxyInstance, method, args) -> {
+                  // Ignore close() calls - they are made by the test framework (normally)
+                  if ("close".equals(method.getName())) {
+                    return null;
+                  }
 
-              throw new UnsupportedOperationException(
-                  String.format(
-                      "Nessie API %s is not supported in version %s",
-                      declaredType.getSimpleName(), runtimeVersion));
-            });
+                  throw new UnsupportedOperationException(
+                      String.format(
+                          "Nessie API %s is not supported in version %s",
+                          declaredType.getSimpleName(), runtimeVersion));
+                });
+    return r;
   }
 }

--- a/integrations/iceberg-views/src/main/java/org/apache/iceberg/view/HadoopViewOperations.java
+++ b/integrations/iceberg-views/src/main/java/org/apache/iceberg/view/HadoopViewOperations.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 
 /** The Views implementation Based on FileIO. */
+@SuppressWarnings("deprecation")
 public class HadoopViewOperations implements ViewOperations {
   private final Configuration conf;
   private final Path location;

--- a/integrations/iceberg-views/src/main/java/org/apache/iceberg/view/VersionParser.java
+++ b/integrations/iceberg-views/src/main/java/org/apache/iceberg/view/VersionParser.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.util.JsonUtil;
 
+@SuppressWarnings("deprecation")
 public class VersionParser {
 
   private static final String VERSION_ID = "version-id";

--- a/integrations/iceberg-views/src/main/java/org/apache/iceberg/view/ViewVersionMetadataParser.java
+++ b/integrations/iceberg-views/src/main/java/org/apache/iceberg/view/ViewVersionMetadataParser.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.JsonUtil;
 
+@SuppressWarnings("deprecation")
 public class ViewVersionMetadataParser {
 
   private ViewVersionMetadataParser() {}

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
@@ -227,6 +227,7 @@ public class NessieJaxRsExtension extends NessieClientResolver
       this.accessChecker = accessChecker;
     }
 
+    @SuppressWarnings("resource")
     public EnvHolder(Extension versionStoreExtension) throws Exception {
       weld = new Weld();
       // Let Weld scan all the resources to discover injection points and dependencies
@@ -251,7 +252,9 @@ public class NessieJaxRsExtension extends NessieClientResolver
               config.register(RestContentResource.class);
               config.register(RestDiffResource.class);
               config.register(RestNamespaceResource.class);
-              config.register(RestRefLogResource.class);
+              @SuppressWarnings("deprecation")
+              Class<?> refLogResource = RestRefLogResource.class;
+              config.register(refLogResource);
               config.register(ConfigApiImpl.class);
               config.register(ContentKeyParamConverterProvider.class);
               config.register(NamespaceParamConverterProvider.class);

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestAuthorizationRules.java
@@ -205,16 +205,16 @@ class TestAuthorizationRules extends BaseClientAuthTest {
   @Test
   @TestSecurity(user = "admin_user")
   @NessieApiVersions(versions = NessieApiVersion.V1) // Reflog is not supported in API v2
+  @SuppressWarnings("deprecation")
   void testRefLogAllowed() throws Exception {
-    //noinspection deprecation
     assertThat(api().getRefLog().stream()).isNotNull();
   }
 
   @Test
   @TestSecurity(user = "disallowed_user")
   @NessieApiVersions(versions = NessieApiVersion.V1) // Reflog is not supported in API v2
+  @SuppressWarnings("deprecation")
   void testRefLogDisallowed() {
-    //noinspection deprecation
     assertThatThrownBy(() -> api().getRefLog().stream())
         .isInstanceOf(NessieForbiddenException.class)
         .hasMessageContaining(

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogResource.java
@@ -26,6 +26,7 @@ import org.projectnessie.services.spi.RefLogService;
 /** REST endpoint for the reflog-API. */
 @RequestScoped
 @jakarta.enterprise.context.RequestScoped
+@Deprecated
 public class RestRefLogResource implements HttpRefLogApi {
 
   private final RefLogService refLogService;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestRefLogService.java
@@ -31,6 +31,7 @@ import org.projectnessie.versioned.VersionStore;
 @ValidateOnExecution(type = ExecutableType.ALL)
 @jakarta.validation.executable.ValidateOnExecution(
     type = jakarta.validation.executable.ExecutableType.ALL)
+@Deprecated
 public class RestRefLogService extends RefLogApiImpl {
   // Mandated by CDI 2.0
   public RestRefLogService() {

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -80,6 +80,7 @@ public final class CELUtil {
   public static final List<Object> COMMIT_LOG_TYPES =
       ImmutableList.of(CommitMeta.class, OperationForCel.class, ContentKey.class, Namespace.class);
 
+  @SuppressWarnings("deprecation")
   public static final List<Object> REFLOG_TYPES =
       ImmutableList.of(RefLogResponse.RefLogResponseEntry.class);
 
@@ -92,6 +93,7 @@ public final class CELUtil {
   public static final ReferenceMetadata EMPTY_REFERENCE_METADATA =
       ImmutableReferenceMetadata.builder().commitMetaOfHEAD(EMPTY_COMMIT_META).build();
 
+  @SuppressWarnings("deprecation")
   public static final List<Decl> REFLOG_DECLARATIONS =
       ImmutableList.of(
           Decls.newVar(

--- a/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/RefLogApiImpl.java
@@ -45,6 +45,7 @@ import org.projectnessie.versioned.RefLogDetails;
 import org.projectnessie.versioned.RefLogNotFoundException;
 import org.projectnessie.versioned.VersionStore;
 
+@Deprecated
 public class RefLogApiImpl extends BaseApiImpl implements RefLogService {
 
   private static final int MAX_REF_LOG_ENTRIES = 250;

--- a/servers/services/src/main/java/org/projectnessie/services/spi/RefLogService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/RefLogService.java
@@ -27,6 +27,7 @@ import org.projectnessie.model.Validation;
  * <p>Refer to the javadoc of corresponding client-facing interfaces in the {@code model} module for
  * the meaning of various methods and their parameters.
  */
+@Deprecated
 public interface RefLogService {
   RefLogResponse getRefLog(
       @Nullable

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestContents.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestContents.java
@@ -215,8 +215,7 @@ public abstract class AbstractTestContents extends BaseTestServiceImpl {
                         c.operation.getKey(), ((Put) c.operation).getContent());
                   }
                   if (c.operation instanceof Unchanged) {
-                    return Maps.immutableEntry(
-                        c.operation.getKey(), ((Put) c.prepare).getContent());
+                    return Maps.immutableEntry(c.operation.getKey(), c.prepare.getContent());
                   }
                   return null;
                 })

--- a/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/EmptyConfigurationParameters.java
+++ b/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/EmptyConfigurationParameters.java
@@ -22,6 +22,8 @@ import org.junit.platform.engine.ConfigurationParameters;
 
 public class EmptyConfigurationParameters implements ConfigurationParameters {
   @Override
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public int size() {
     return 0;
   }

--- a/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/MultiEnvExtensionRegistry.java
+++ b/testing/multi-env-test-engine/src/main/java/org/projectnessie/junit/engine/MultiEnvExtensionRegistry.java
@@ -57,11 +57,13 @@ public class MultiEnvExtensionRegistry {
       annotations.addAll(AnnotationUtils.findRepeatableAnnotations(cl, ExtendWith.class));
     }
 
-    //noinspection unchecked
-    return (Stream<? extends MultiEnvTestExtension>)
-        annotations.stream()
-            .flatMap(e -> Arrays.stream(e.value()))
-            .filter(MultiEnvTestExtension.class::isAssignableFrom)
-            .flatMap(registry::stream);
+    @SuppressWarnings("unchecked")
+    Stream<? extends MultiEnvTestExtension> r =
+        (Stream<? extends MultiEnvTestExtension>)
+            annotations.stream()
+                .flatMap(e -> Arrays.stream(e.value()))
+                .filter(MultiEnvTestExtension.class::isAssignableFrom)
+                .flatMap(registry::stream);
+    return r;
   }
 }

--- a/testing/s3mock/src/main/java/org/projectnessie/s3mock/data/ListBucketResultBase.java
+++ b/testing/s3mock/src/main/java/org/projectnessie/s3mock/data/ListBucketResultBase.java
@@ -21,7 +21,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 public interface ListBucketResultBase {
-  interface Builder<B extends Builder> {
+  interface Builder<B extends Builder<B>> {
     B name(String name);
 
     B prefix(String prefix);

--- a/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestIcebergS3MockServer.java
+++ b/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestIcebergS3MockServer.java
@@ -132,6 +132,7 @@ public class TestIcebergS3MockServer extends AbstractIcebergS3MockServer {
     return ((HttpURLConnection) conn).getResponseCode();
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T doGet(URI uri, Class<T> type, Map<String, String> headers) throws Exception {
     URLConnection conn = uri.toURL().openConnection();
     headers.forEach(conn::addRequestProperty);
@@ -160,9 +161,7 @@ public class TestIcebergS3MockServer extends AbstractIcebergS3MockServer {
       return JSON_MAPPER.readValue(out.toByteArray(), type);
     }
     if (type.isAssignableFrom(String.class)) {
-      @SuppressWarnings("unchecked")
-      T r = (T) out.toString("UTF-8");
-      return r;
+      return (T) out.toString("UTF-8");
     }
     return (T) out.toByteArray();
   }

--- a/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestIcebergS3MockServer.java
+++ b/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestIcebergS3MockServer.java
@@ -51,12 +51,14 @@ public class TestIcebergS3MockServer extends AbstractIcebergS3MockServer {
 
   @Test
   public void smoke() throws Exception {
+    @SuppressWarnings("resource")
     JsonNode node = doGet(createServer(b -> {}).getBaseUri().resolve("ready"), JsonNode.class);
     soft.assertThat(node.get("ready")).isEqualTo(BooleanNode.TRUE);
   }
 
   @Test
   public void listBuckets() throws Exception {
+    @SuppressWarnings("resource")
     S3MockServer server =
         createServer(
             b ->
@@ -80,6 +82,7 @@ public class TestIcebergS3MockServer extends AbstractIcebergS3MockServer {
 
   @Test
   public void headObject() throws Exception {
+    @SuppressWarnings("resource")
     S3MockServer server = createServer(b -> b.putBuckets(BUCKET, S3Bucket.builder().build()));
 
     soft.assertThat(doHead(server.getBaseUri().resolve(BUCKET + "/" + MY_OBJECT_NAME)))
@@ -92,6 +95,7 @@ public class TestIcebergS3MockServer extends AbstractIcebergS3MockServer {
   public void getObject() throws Exception {
     Map<String, MockObject> objects = new HashMap<>();
 
+    @SuppressWarnings("resource")
     S3MockServer server =
         createServer(
             b ->

--- a/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestFetchValuesUsingOpenAddressing.java
+++ b/versioned/persist/adapter/src/test/java/org/projectnessie/versioned/persist/adapter/spi/TestFetchValuesUsingOpenAddressing.java
@@ -84,6 +84,7 @@ public class TestFetchValuesUsingOpenAddressing {
     assertEquals(ImmutableList.of(Hash.of("01")), fetch.entityIdsToFetch(2, 0, singleton));
     assertEquals(ImmutableList.of(Hash.of("02")), fetch.entityIdsToFetch(3, 0, singleton));
 
+    @SuppressWarnings("unchecked")
     Consumer<KeyListEntry> keyHits = mock(Consumer.class);
     fetch.entityLoaded(getKeyListEntity(6, 3, 2, KeyWithSpecificHash::withMaxIntHash));
     fetch.checkForKeys(0, singleton, keyHits);

--- a/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
+++ b/versioned/persist/bench/src/main/java/org/projectnessie/versioned/persist/benchmarks/CommitBench.java
@@ -181,6 +181,7 @@ public class CommitBench {
     Map<ContentKey, String> contentIds;
 
     @Setup
+    @SuppressWarnings("deprecation") // Thread.getId() deprecated since 19
     public void createBranch(BenchmarkParam bp) throws Exception {
       branch = BranchName.of("thread-" + Thread.currentThread().getId());
 

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -609,6 +609,7 @@ public class PersistVersionStore implements VersionStore {
 
   @Override
   @MustBeClosed
+  @Deprecated
   public Stream<RefLogDetails> getRefLog(Hash refLogId) throws RefLogNotFoundException {
     return databaseAdapter
         .refLog(refLogId)

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -212,6 +212,7 @@ public final class MetricsVersionStore implements VersionStore {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public Stream<RefLogDetails> getRefLog(Hash refLogId) throws RefLogNotFoundException {
     return delegateStream1Ex("getreflog", () -> delegate.getRefLog(refLogId));
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -212,7 +212,7 @@ public final class MetricsVersionStore implements VersionStore {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
+  @Deprecated
   public Stream<RefLogDetails> getRefLog(Hash refLogId) throws RefLogNotFoundException {
     return delegateStream1Ex("getreflog", () -> delegate.getRefLog(refLogId));
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -272,6 +272,7 @@ public class TracingVersionStore implements VersionStore {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public Stream<RefLogDetails> getRefLog(Hash refLogId) throws RefLogNotFoundException {
     return delegate.getRefLog(refLogId);
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -272,7 +272,7 @@ public class TracingVersionStore implements VersionStore {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
+  @Deprecated
   public Stream<RefLogDetails> getRefLog(Hash refLogId) throws RefLogNotFoundException {
     return delegate.getRefLog(refLogId);
   }

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -207,10 +207,14 @@ class TestMetricsVersionStore {
                 stringStringDummyEnumVersionStore ->
                     stringStringDummyEnumVersionStore.getNamedRefs(
                         GetNamedRefsParams.DEFAULT, null),
-                () ->
-                    PaginationIterator.of(
-                        WithHash.of(Hash.of("cafebabe"), BranchName.of("foo")),
-                        WithHash.of(Hash.of("deadbeef"), BranchName.of("cow"))),
+                () -> {
+                  @SuppressWarnings("unchecked")
+                  PaginationIterator<WithHash<BranchName>> r =
+                      PaginationIterator.of(
+                          WithHash.of(Hash.of("cafebabe"), BranchName.of("foo")),
+                          WithHash.of(Hash.of("deadbeef"), BranchName.of("cow")));
+                  return r;
+                },
                 runtimeThrows),
             new VersionStoreInvocation<>(
                 "getvalue",

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -104,6 +104,7 @@ class TestTracingVersionStore {
 
     // "Declare" test-invocations for all VersionStore functions with their respective outcomes
     // and exceptions.
+    @SuppressWarnings("unchecked")
     Stream<TestedTraceingStoreInvocation<VersionStore>> versionStoreFunctions =
         Stream.of(
             new TestedTraceingStoreInvocation<VersionStore>("GetNamedRef", refNotFoundThrows)
@@ -257,6 +258,7 @@ class TestTracingVersionStore {
             && !(expectedThrow instanceof IllegalArgumentException);
     String opNameTag = "nessie.version-store.operation";
 
+    @SuppressWarnings("resource")
     TestTracer tracer = new TestTracer();
     tracer.registerForCurrentTest();
 

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
@@ -604,6 +604,7 @@ public class DynamoDBPersist implements Persist {
     return ObjType.fromShortName(shortType);
   }
 
+  @SuppressWarnings("unchecked")
   private Obj decomposeObj(Map<String, AttributeValue> item) {
     ObjId id = objIdFromString(item.get(KEY_NAME).s().substring(keyPrefix.length()));
     ObjType type = objTypeFromItem(item);
@@ -611,10 +612,10 @@ public class DynamoDBPersist implements Persist {
     StoreObjDesc storeObj = STORE_OBJ_TYPE.get(type);
     checkState(storeObj != null, "Cannot deserialize object type %s", type);
     Map<String, AttributeValue> inner = item.get(storeObj.typeName).m();
-    //noinspection unchecked
     return storeObj.fromMap(id, inner);
   }
 
+  @SuppressWarnings("unchecked")
   @Nonnull
   @jakarta.annotation.Nonnull
   private Map<String, AttributeValue> objToItem(
@@ -633,7 +634,6 @@ public class DynamoDBPersist implements Persist {
         ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIncrementalIndexSizeLimit();
     int indexSizeLimit =
         ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIndexSegmentSizeLimit();
-    //noinspection unchecked
     storeObj.toMap(obj, inner, incrementalIndexSizeLimit, indexSizeLimit);
     item.put(storeObj.typeName, fromM(inner));
     return item;

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -458,6 +458,7 @@ abstract class AbstractJdbcPersist implements Persist {
     return null;
   }
 
+  @SuppressWarnings("unchecked")
   @Nonnull
   @jakarta.annotation.Nonnull
   private boolean[] upsertObjs(
@@ -518,7 +519,6 @@ abstract class AbstractJdbcPersist implements Persist {
           if (e.getKey() == type) {
             @SuppressWarnings("rawtypes")
             StoreObjDesc storeType = e.getValue();
-            //noinspection unchecked
             idx = storeType.store(ps, idx, obj, incrementalIndexSizeLimit, indexSizeLimit);
           } else {
             idx = e.getValue().storeNone(ps, idx);

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -652,6 +652,7 @@ public class MongoDBPersist implements Persist {
     return storeObj.docToObj(id, inner);
   }
 
+  @SuppressWarnings("unchecked")
   private Document objToDoc(
       @Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
       throws ObjTooLargeException {
@@ -671,7 +672,6 @@ public class MongoDBPersist implements Persist {
         ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIncrementalIndexSizeLimit();
     int indexSizeLimit =
         ignoreSoftSizeRestrictions ? Integer.MAX_VALUE : effectiveIndexSegmentSizeLimit();
-    //noinspection unchecked
     storeObj.objToDoc(obj, inner, incrementalIndexSizeLimit, indexSizeLimit);
     doc.put(storeObj.typeName, inner);
     return doc;

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -729,6 +729,7 @@ public class VersionStoreImpl implements VersionStore {
   }
 
   @Override
+  @Deprecated
   public Stream<RefLogDetails> getRefLog(Hash refLogId) {
     throw new UnsupportedOperationException();
   }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -194,6 +194,7 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                 ContentKey.of("t4"), V_4_1));
   }
 
+  @SuppressWarnings({"deprecation", "DataFlowIssue"})
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   void compareDryAndEffectiveMergeResults(boolean individualCommits) throws VersionStoreException {
@@ -373,6 +374,7 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   protected void mergeIntoNonConflictingBranch(boolean individualCommits)


### PR DESCRIPTION
but leaving the warnings for deprecated Nessie API _member_ attributes (like source-commits) - while suppressing all for ref-log.