### PR TITLE
Gradle CI tweaks

### DIFF
--- a/.github/actions/dev-tool-java/action.yml
+++ b/.github/actions/dev-tool-java/action.yml
@@ -25,6 +25,16 @@ runs:
     - name: Setup gradle.properties
       shell: bash
       run: |
-        mkdir -p ~/.gradle
+        mkdir -p ~/.gradle/init.d
+        echo > ~/.gradle/init.d/cache-settings.gradle.kts <<!
+        beforeSettings {
+          caches {
+            releasedWrappers.setRemoveUnusedEntriesAfterDays(2)
+            snapshotWrappers.setRemoveUnusedEntriesAfterDays(1)
+            downloadedResources.setRemoveUnusedEntriesAfterDays(5)
+            createdResources.setRemoveUnusedEntriesAfterDays(2)
+          }
+        }
+        !
         echo "org.gradle.jvmargs=-Xmx1280m -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" >> ~/.gradle/gradle.properties
         echo "org.gradle.vfs.watch=false" >> ~/.gradle/gradle.properties

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Gradle / compile
       uses: gradle/gradle-build-action@v2
       with:
+        gradle-home-cache-cleanup: true
         arguments: spotlessCheck checkstyle assemble --scan
 
     - name: Gradle / unit test


### PR DESCRIPTION
Cleanup Gradle caches in CI more aggressively and cleanup the Gradle user home directory before storing the cache.