### PR TITLE
Expand iceberg-views version-ID to 64 bit

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/IcebergView.java
+++ b/api/model/src/main/java/org/projectnessie/model/IcebergView.java
@@ -42,7 +42,7 @@ public abstract class IcebergView extends IcebergContent {
   public abstract String getMetadataLocation();
 
   /** Corresponds to Iceberg's {@code currentVersionId}. */
-  public abstract int getVersionId();
+  public abstract long getVersionId();
 
   public abstract int getSchemaId();
 
@@ -72,7 +72,7 @@ public abstract class IcebergView extends IcebergContent {
   }
 
   public static IcebergView of(
-      String metadataLocation, int versionId, int schemaId, String dialect, String sqlText) {
+      String metadataLocation, long versionId, int schemaId, String dialect, String sqlText) {
     return builder()
         .metadataLocation(metadataLocation)
         .versionId(versionId)
@@ -85,7 +85,7 @@ public abstract class IcebergView extends IcebergContent {
   public static IcebergView of(
       String id,
       String metadataLocation,
-      int versionId,
+      long versionId,
       int schemaId,
       String dialect,
       String sqlText) {

--- a/integrations/iceberg-views/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
+++ b/integrations/iceberg-views/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
@@ -125,8 +125,9 @@ public class NessieViewOperations extends BaseMetastoreViewOperations {
           new BaseVersion(
               v.versionId(), v.parentId(), v.timestampMillis(), v.summary(), v.viewDefinition());
 
-      List<Version> versions = getVersionsUntil(metadata, icebergView.getVersionId());
-      List<HistoryEntry> history = getHistoryEntriesUntil(metadata, icebergView.getVersionId());
+      List<Version> versions = getVersionsUntil(metadata, (int) icebergView.getVersionId());
+      List<HistoryEntry> history =
+          getHistoryEntriesUntil(metadata, (int) icebergView.getVersionId());
       metadata =
           ViewVersionMetadata.newViewVersionMetadata(
               baseVersion,

--- a/servers/store-proto/src/main/proto/org/projectnessie/server/store/proto/table.proto
+++ b/servers/store-proto/src/main/proto/org/projectnessie/server/store/proto/table.proto
@@ -97,7 +97,7 @@ message IcebergRefState {
 }
 
 message IcebergViewState {
-  int32 version_id = 1;
+  int64 version_id = 1;
   int32 schema_id = 2;
   string sql_text = 3;
   string dialect = 4;

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -188,7 +188,7 @@ class TestStoreWorker {
         .isInstanceOf(IcebergView.class)
         .asInstanceOf(InstanceOfAssertFactories.type(IcebergView.class))
         .extracting(IcebergView::getMetadataLocation, IcebergView::getVersionId)
-        .containsExactly("metadata-location", 42);
+        .containsExactly("metadata-location", 42L);
   }
 
   static Stream<Arguments> requiresGlobalStateModelType() {
@@ -297,7 +297,7 @@ class TestStoreWorker {
         .isInstanceOf(IcebergView.class)
         .asInstanceOf(InstanceOfAssertFactories.type(IcebergView.class))
         .extracting(IcebergView::getMetadataLocation, IcebergView::getVersionId)
-        .containsExactly("metadata-location", 42);
+        .containsExactly("metadata-location", 42L);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Should be safe to do this now, since Iceberg Views are not "in production" yet.