### PR TITLE
Nit: fix IntelliJ import warning for nessie-perftest-simulations

### DIFF
--- a/perftest/simulations/build.gradle.kts
+++ b/perftest/simulations/build.gradle.kts
@@ -28,6 +28,10 @@ plugins {
 extra["maven.name"] = "Nessie - Perf Test - Simulations"
 
 dependencies {
+  if (System.getProperty("idea.sync.active").toBoolean()) {
+    // IJ complains about Scala-library not present (it's there for the 'gatling' source set).
+    compileOnly("org.scala-lang:scala-library:${scalaDependencyVersion("2.13")}")
+  }
   gatling(project(":nessie-model"))
   gatling(project(":nessie-client"))
   gatling(project(":nessie-perftest-gatling"))


### PR DESCRIPTION
IJ complains about Scala-library not present (it's there for the 'gatling' source set).