### PR TITLE
IntelliJ: Always use Gradle to run tests

### DIFF
--- a/buildSrc/src/main/kotlin/Ide.kt
+++ b/buildSrc/src/main/kotlin/Ide.kt
@@ -123,7 +123,7 @@ class NessieIdePlugin : Plugin<Project> {
                 .joinToString(" ")
           }
 
-          delegateActions.testRunner = ActionDelegationConfig.TestRunner.CHOOSE_PER_TEST
+          delegateActions.testRunner = ActionDelegationConfig.TestRunner.GRADLE
         }
       }
 


### PR DESCRIPTION
IJ sometimes gets configurations and classpathes for tests wrong from the Gradle configuration, so better let IJ always run tests via Gradle, which will always work.