### PR TITLE
python: move safety check to separate tox env

### DIFF
--- a/python/requirements_lint.txt
+++ b/python/requirements_lint.txt
@@ -26,6 +26,5 @@ flake8-isort==6.0.0
 isort==5.12.0
 mypy==1.1.1
 pytest-mypy==0.10.3
-safety==2.3.5
 pylint==2.17.1
 pylintfileheader==0.3.2

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -15,13 +15,13 @@
 #
 
 [tox]
-envlist = py37, py38, py39, py310, format, lint, docs, docs_sync_check
+envlist = py37, py38, py39, py310, format, lint, safety, docs, docs_sync_check
 
 [gh-actions]
 python =
     3.7: py37
     # docs needs to run before docs_sync_check
-    3.8: py38, lint, docs, docs_sync_check
+    3.8: py38, lint, safety, docs, docs_sync_check
     3.9: py39
     3.10: py310
 
@@ -43,10 +43,17 @@ commands =
     # flake8 includes black check due to flake8-black
     # flake8 includes isort check which checks for import order due to flake8-isort
     flake8 pynessie tests tools
-    # ignore https://pyup.io/v/51457/f17 -> https://github.com/pytest-dev/py/issues/287
-    safety check --ignore=51457
     pylint --jobs=0 pynessie tests tools
     mypy --install-types --non-interactive -p pynessie -p tests -p tools
+
+
+[testenv:safety]
+basepython = python
+deps = safety
+commands =
+    # using separate env because of https://github.com/pyupio/safety/issues/455
+    # note that requirements_lint.txt imports all other requirement files
+    safety check --file requirements_lint.txt
 
 
 [testenv:docs]


### PR DESCRIPTION
by not installing safety alongside the other dependencies, we are not constrained by safety's overly restrictive dependency version ranges (see inline comment)

this unblocks renovate to upgrade other linting dependencies