### PR TITLE
IntelliJ: Let IntelliJ test-runner default to CHOOSE_PER_TEST again

### DIFF
--- a/buildSrc/src/main/kotlin/Ide.kt
+++ b/buildSrc/src/main/kotlin/Ide.kt
@@ -123,7 +123,10 @@ class NessieIdePlugin : Plugin<Project> {
                 .joinToString(" ")
           }
 
-          delegateActions.testRunner = ActionDelegationConfig.TestRunner.GRADLE
+          delegateActions.testRunner =
+            ActionDelegationConfig.TestRunner.valueOf(
+              System.getProperty("nessie.intellij.test-runner", "CHOOSE_PER_TEST")
+            )
         }
       }
 


### PR DESCRIPTION
Can be overridden using the following setting in the _user's_ gradle.properties file `~/.gradle/gradle.properties` like this:
```
systemProp.nessie.intellij.test-runner=GRADLE
```