### PR TITLE
Fix nessie-perftest-simulations standalone

### DIFF
--- a/perftest/simulations/build.gradle.kts
+++ b/perftest/simulations/build.gradle.kts
@@ -62,6 +62,10 @@ nessieQuarkusApp {
   }
 }
 
+tasks.withType(GatlingRunTask::class.java).configureEach {
+  inputs.files(configurations.getByName("gatlingRuntimeClasspath"))
+}
+
 gatling {
   gatlingVersion = libs.versions.gatling.get()
   // Null is OK (io.gatling.gradle.LogbackConfigTask checks for it)


### PR DESCRIPTION
With a clean Git clone, a `./gradlew gatlingRun` does not work, because the nessie-client.jar is not available. This fix adds the jars as required task inputs.