### PR TITLE
Empty commits should be skipped during merge/transplant

### DIFF
--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
@@ -90,6 +90,11 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
       CommitObj newCommit =
           createMergeTransplantCommit(mergeTypeForKey, keyDetailsMap, createCommit);
 
+      if (!indexesLogic.commitOperations(newCommit).iterator().hasNext()) {
+        // No operations in this commit, skip it.
+        continue;
+      }
+
       CommitLogic commitLogic = commitLogic(persist);
       boolean committed = commitLogic.storeCommit(newCommit, emptyList());
 


### PR DESCRIPTION
This commit fixes a small inconsistency between old and new storage models during merge and transplant: in the old model, if a commit has no operations (because of a merge type DROP), the commit is skipped. In the new model, the empty commit is retained. With this fix, the empty commit is not retained anymore.