### PR TITLE
Bring back logback logging

### DIFF
--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
   testFixturesApi(libs.awssdk.auth)
   testFixturesApi(libs.undertow.core)
   testFixturesApi(libs.undertow.servlet)
-  testFixturesImplementation(libs.logback.classic)
+  testFixturesImplementation(libs.bundles.logback.logging)
 }
 
 jandex { skipDefaultProcessing() }

--- a/compatibility/common/build.gradle.kts
+++ b/compatibility/common/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
   implementation(platform(libs.jersey.bom))
   api(libs.slf4j.api)
-  api(libs.logback.classic)
+  api(libs.bundles.logback.logging)
   implementation("org.apache.maven:maven-core:3.9.1")
   implementation(libs.maven.resolver.provider)
   implementation(libs.maven.resolver.connector.basic)

--- a/gc/gc-base/build.gradle.kts
+++ b/gc/gc-base/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
   testImplementation(project(":nessie-versioned-persist-in-memory"))
   testImplementation(project(":nessie-versioned-persist-in-memory-test"))
 
-  testRuntimeOnly(libs.logback.classic)
+  testRuntimeOnly(libs.bundles.logback.logging)
 
   testCompileOnly(libs.microprofile.openapi)
 

--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
   testFixturesApi(nessieProject("nessie-s3mock"))
   testFixturesApi(nessieProject("nessie-s3minio"))
 
-  testFixturesRuntimeOnly(libs.logback.classic)
+  testFixturesRuntimeOnly(libs.bundles.logback.logging)
 
   testFixturesCompileOnly(platform(libs.jackson.bom))
   testFixturesCompileOnly(libs.jackson.annotations)

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -91,7 +91,7 @@ dependencies {
   intTestCompileOnly(libs.immutables.value.annotations)
   intTestAnnotationProcessor(libs.immutables.value.processor)
 
-  intTestRuntimeOnly(libs.logback.classic)
+  intTestRuntimeOnly(libs.bundles.logback.logging)
 
   // javax/jakarta
   intTestCompileOnly(libs.jakarta.validation.api)

--- a/gc/gc-iceberg-mock/build.gradle.kts
+++ b/gc/gc-iceberg-mock/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.findbugs.jsr305)
 
-  testRuntimeOnly(libs.logback.classic)
+  testRuntimeOnly(libs.bundles.logback.logging)
 
   testImplementation(libs.iceberg.core)
 

--- a/gc/gc-iceberg/build.gradle.kts
+++ b/gc/gc-iceberg/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
   compileOnly(libs.findbugs.jsr305)
 
   testImplementation(nessieProject("nessie-gc-iceberg-mock"))
-  testRuntimeOnly(libs.logback.classic)
+  testRuntimeOnly(libs.bundles.logback.logging)
 
   // hadoop-common brings Jackson in ancient versions, pulling in the Jackson BOM to avoid that
   testImplementation(platform(libs.jackson.bom))

--- a/gc/gc-repository-jdbc/build.gradle.kts
+++ b/gc/gc-repository-jdbc/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 
   testImplementation(project(":nessie-gc-base-tests"))
 
-  testRuntimeOnly(libs.logback.classic)
+  testRuntimeOnly(libs.bundles.logback.logging)
 
   testImplementation(libs.guava)
 

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
 
   runtimeOnly(libs.h2)
 
-  intTestRuntimeOnly(libs.logback.classic)
+  intTestRuntimeOnly(libs.bundles.logback.logging)
 
   intTestImplementation(
     nessieProject("nessie-spark-extensions-basetests_${sparkScala.scalaMajorVersion}")

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
   annotationProcessor(libs.picocli.codegen)
 
   implementation(libs.slf4j.api)
-  runtimeOnly(libs.logback.classic)
+  runtimeOnly(libs.bundles.logback.logging)
 
   compileOnly(libs.microprofile.openapi)
   compileOnly(libs.jackson.annotations)
@@ -86,7 +86,7 @@ dependencies {
   testImplementation(nessieProject("nessie-versioned-persist-in-memory"))
   testImplementation(nessieProject("nessie-versioned-persist-in-memory-test"))
 
-  testRuntimeOnly(libs.logback.classic)
+  testRuntimeOnly(libs.bundles.logback.logging)
 
   testCompileOnly(libs.immutables.value.annotations)
   testAnnotationProcessor(libs.immutables.value.processor)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ managed-testcontainers = ["testcontainers-cockroachdb", "testcontainers-mongodb"
   "testcontainers-postgresql", "testcontainers-testcontainers"]
 
 junit-testing = ["assertj-core", "mockito-core", "junit-jupiter-api", "junit-jupiter-params"]
+logback-logging = ["logback-classic", "slf4j-simple"]
 
 [libraries]
 agroal-pool = { module = "io.agroal:agroal-pool", version = "2.1" }
@@ -202,6 +203,7 @@ scala-library-v213 = { module = "org.scala-lang:scala-library", version = { stri
 slf4j-api = {  module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-jcl-over-slf4j = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }
 slf4j-log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
+slf4j-simple = {  module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 smallrye-openapi-plugin = { module = "io.smallrye:smallrye-open-api-gradle-plugin", version = "3.3.2" }
 spark-sql-v31-v212 = { module = "org.apache.spark:spark-sql_2_12", version = { strictly = "[3.1, 3.2[", prefer = "3.1.3"}}
 spark-sql-v32-v212 = { module = "org.apache.spark:spark-sql_2_12", version = { strictly = "[3.2, 3.3[", prefer = "3.2.3"}}

--- a/integrations/deltalake/build.gradle.kts
+++ b/integrations/deltalake/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
   testFixturesImplementation(platform(libs.jackson.bom))
   testFixturesImplementation(libs.jackson.databind)
   testFixturesApi(libs.microprofile.openapi)
-  testFixturesImplementation(libs.logback.classic)
+  testFixturesImplementation(libs.bundles.logback.logging)
   testFixturesImplementation(libs.slf4j.log4j.over.slf4j)
   testFixturesCompileOnly(libs.errorprone.annotations)
 

--- a/integrations/spark-extensions/build.gradle.kts
+++ b/integrations/spark-extensions/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
   testFixturesImplementation("org.apache.iceberg:iceberg-spark-extensions-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}:$versionIceberg")
   testFixturesImplementation("org.apache.iceberg:iceberg-hive-metastore:$versionIceberg")
 
-  testFixturesRuntimeOnly(libs.logback.classic)
+  testFixturesRuntimeOnly(libs.bundles.logback.logging)
   testFixturesImplementation(libs.slf4j.log4j.over.slf4j)
   testFixturesImplementation("org.apache.spark:spark-sql_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }
   testFixturesImplementation("org.apache.spark:spark-core_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }

--- a/testing/s3minio/build.gradle.kts
+++ b/testing/s3minio/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
   intTestImplementation(libs.bundles.junit.testing)
   intTestImplementation(libs.hadoop.common) { withSparkExcludes() }
 
-  intTestRuntimeOnly(libs.logback.classic)
+  intTestRuntimeOnly(libs.bundles.logback.logging)
 }
 
 tasks.withType(Test::class.java).configureEach { systemProperty("aws.region", "us-east-1") }

--- a/testing/s3mock/build.gradle.kts
+++ b/testing/s3mock/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
 
   implementation(libs.slf4j.api)
 
-  testRuntimeOnly(libs.logback.classic)
+  testRuntimeOnly(libs.bundles.logback.logging)
 
   testImplementation(platform(libs.awssdk.bom))
   testImplementation(libs.awssdk.s3)

--- a/versioned/persist/dynamodb/build.gradle.kts
+++ b/versioned/persist/dynamodb/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
   intTestImplementation(project(":nessie-versioned-persist-tests"))
   intTestImplementation(project(":nessie-versioned-persist-non-transactional-test"))
   intTestImplementation(project(":nessie-versioned-persist-dynamodb-test"))
-  intTestImplementation(libs.logback.classic)
+  intTestImplementation(libs.bundles.logback.logging)
 
   intTestImplementation(platform(libs.junit.bom))
   intTestImplementation(libs.bundles.junit.testing)

--- a/versioned/persist/mongodb/build.gradle.kts
+++ b/versioned/persist/mongodb/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
   intTestImplementation(project(":nessie-versioned-persist-tests"))
   intTestImplementation(project(":nessie-versioned-persist-non-transactional-test"))
   intTestImplementation(project(":nessie-versioned-persist-mongodb-test"))
-  intTestImplementation(libs.logback.classic)
+  intTestImplementation(libs.bundles.logback.logging)
 
   intTestImplementation(platform(libs.junit.bom))
   intTestImplementation(libs.bundles.junit.testing)

--- a/versioned/persist/rocks/build.gradle.kts
+++ b/versioned/persist/rocks/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   intTestImplementation(project(":nessie-versioned-persist-tests"))
   intTestImplementation(project(":nessie-versioned-persist-non-transactional-test"))
   intTestImplementation(project(":nessie-versioned-persist-rocks-test"))
-  intTestImplementation(libs.logback.classic)
+  intTestImplementation(libs.bundles.logback.logging)
 
   intTestImplementation(platform(libs.junit.bom))
   intTestImplementation(libs.bundles.junit.testing)

--- a/versioned/persist/tx/build.gradle.kts
+++ b/versioned/persist/tx/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
   testFixturesApi(project(":nessie-versioned-persist-testextension"))
   testFixturesApi(project(":nessie-versioned-persist-tests"))
   testFixturesApi(project(":nessie-versioned-persist-transactional-test"))
-  testFixturesImplementation(libs.logback.classic)
+  testFixturesImplementation(libs.bundles.logback.logging)
   testRuntimeOnly(libs.h2)
   intTestRuntimeOnly(libs.postgresql)
 

--- a/versioned/storage/common-tests/build.gradle.kts
+++ b/versioned/storage/common-tests/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
   compileOnly(libs.errorprone.annotations)
   implementation(libs.guava)
 
-  implementation(libs.logback.classic)
+  implementation(libs.bundles.logback.logging)
 
   compileOnly(libs.immutables.builder)
   compileOnly(libs.immutables.value.annotations)


### PR DESCRIPTION
After the bump to SLF4J v2, logging via the "old" logback-classic no longer worked due to https://www.slf4j.org/codes.html#ignoredBindings. This change adds the recommended slf4j-simple dependency to re-enable the "old" logback-classic.