### PR TITLE
Do not let Weld register a shutdown hook

### DIFF
--- a/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/JerseyServer.java
+++ b/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/JerseyServer.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.tools.compatibility.jersey;
 
+import static org.jboss.weld.environment.se.Weld.SHUTDOWN_HOOK_SYSTEM_PROPERTY;
+
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.function.Consumer;
@@ -60,6 +62,7 @@ public class JerseyServer implements AutoCloseable {
     weld.addExtension(new ServerConfigExtension());
     weld.addExtension(PersistVersionStoreExtension.forDatabaseAdapter(databaseAdapterSupplier));
     weld.addExtension(authzExtension());
+    weld.property(SHUTDOWN_HOOK_SYSTEM_PROPERTY, "false");
     weld.initialize();
 
     jerseyTest =

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/NessieJaxRsExtension.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.jaxrs.ext;
 
+import static org.jboss.weld.environment.se.Weld.SHUTDOWN_HOOK_SYSTEM_PROPERTY;
 import static org.projectnessie.services.config.ServerConfigExtension.SERVER_CONFIG;
 import static org.projectnessie.versioned.storage.common.logic.Logics.repositoryLogic;
 
@@ -238,6 +239,7 @@ public class NessieJaxRsExtension extends NessieClientResolver
       weld.addExtension(new ServerConfigExtension());
       weld.addExtension(versionStoreExtension);
       weld.addExtension(new AuthorizerExtension().setAccessCheckerSupplier(this::createNewChecker));
+      weld.property(SHUTDOWN_HOOK_SYSTEM_PROPERTY, "false");
       weld.initialize();
 
       jerseyTest =


### PR DESCRIPTION
Shutdown hooks are a nice feature, but registered shutdown hooks can easily lead to out-of-memory errors, especially when used from "re-generated" class loaders or, in situations like the one in our compatibility tests.