### PR TITLE
Don't retain a squashed PUT-DELETE sequence

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -2091,8 +2091,9 @@ public abstract class AbstractDatabaseAdapter<
       CommitLogEntry source = commitsToMergeChronological.get(i);
       for (ContentKey delete : source.getDeletes()) {
         if (includeKeyPredicate.test(delete)) {
-          deletes.add(delete);
-          puts.remove(delete);
+          if (puts.remove(delete) == null) {
+            deletes.add(delete);
+          }
         }
       }
       for (KeyWithBytes put : source.getPuts()) {

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -937,7 +937,7 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
             false,
             false);
 
-    // Expected operation in the squashed commit: PUT t2=v2.2, PUT t4=v3.1 (rename t3 => t4)
+    // Expected operations in the squashed commit: PUT t2=v2.2, PUT t4=v3.1 (rename t3 => t4)
     try (PaginationIterator<Commit> commits = store().getCommits(target, true)) {
       Commit squashed = commits.next();
       soft.assertThat(squashed.getOperations())


### PR DESCRIPTION
This commit fixes a small inconsistency between old and new storage models during merge and transplant: in the old model, if the commits to squash contained a PUT followed by a DELETE for the same key, the squashed commit would mistakenly retain the DELETE operation.

The tests included in this PR do not pass for the old model, without the fix.