### PR TITLE
Remove concurrent test case execution per class

### DIFF
--- a/api/client/src/test/java/org/projectnessie/client/TestResultStreamPaginator.java
+++ b/api/client/src/test/java/org/projectnessie/client/TestResultStreamPaginator.java
@@ -27,12 +27,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.PaginatedResponse;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestResultStreamPaginator {
   @Test
   void testNotFoundException() {

--- a/api/client/src/test/java/org/projectnessie/client/auth/TestBasicAuthProvider.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/TestBasicAuthProvider.java
@@ -23,8 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mockito;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.http.HttpAuthentication;
@@ -34,7 +32,6 @@ import org.projectnessie.client.http.RequestFilter;
 import org.projectnessie.client.http.impl.HttpHeaders;
 import org.projectnessie.client.http.impl.RequestContextImpl;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestBasicAuthProvider {
   @SuppressWarnings("deprecation")
   @Test

--- a/api/client/src/test/java/org/projectnessie/client/auth/TestBearerAuthenticationProvider.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/TestBearerAuthenticationProvider.java
@@ -24,8 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mockito;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.http.HttpAuthentication;
@@ -35,7 +33,6 @@ import org.projectnessie.client.http.RequestFilter;
 import org.projectnessie.client.http.impl.HttpHeaders;
 import org.projectnessie.client.http.impl.RequestContextImpl;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestBearerAuthenticationProvider {
   private BearerAuthenticationProvider provider() {
     return new BearerAuthenticationProvider();

--- a/api/client/src/test/java/org/projectnessie/client/auth/TestNoneAuthProvider.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/TestNoneAuthProvider.java
@@ -21,11 +21,8 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.client.NessieConfigConstants;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestNoneAuthProvider {
   @Test
   void testNone() {

--- a/api/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestHttpClient.java
@@ -56,15 +56,12 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.projectnessie.client.util.HttpTestServer;
 import org.projectnessie.model.CommitMeta;
 
-@Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(SoftAssertionsExtension.class)
 public class TestHttpClient {
 

--- a/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.client.NessieConfigConstants;
@@ -38,7 +36,6 @@ import org.projectnessie.client.auth.NessieAuthentication;
 import org.projectnessie.client.util.HttpTestServer;
 import org.projectnessie.client.util.HttpTestUtil;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class TestHttpClientBuilder {
   interface IncompatibleApiInterface extends NessieApi {}
 

--- a/api/client/src/test/java/org/projectnessie/client/http/impl/TestHttpHeaders.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/TestHttpHeaders.java
@@ -26,11 +26,8 @@ import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.ArgumentCaptor;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class TestHttpHeaders {
   @Test
   public void multipleValues() {

--- a/api/client/src/test/java/org/projectnessie/client/http/impl/TestUriBuilder.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/TestUriBuilder.java
@@ -21,11 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.client.http.HttpClientException;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestUriBuilder {
 
   @Test

--- a/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -26,8 +26,6 @@ import java.net.URI;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -46,7 +44,6 @@ import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.error.NessieUnsupportedMediaTypeException;
 import software.amazon.awssdk.utils.StringInputStream;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class TestResponseFilter {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/CommitLogParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/CommitLogParamsTest.java
@@ -19,11 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.FetchOption;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class CommitLogParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/DiffParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/DiffParamsTest.java
@@ -19,12 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class DiffParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/EntriesParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/EntriesParamsTest.java
@@ -18,10 +18,7 @@ package org.projectnessie.api.v1.params;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class EntriesParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/GetReferenceParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/GetReferenceParamsTest.java
@@ -19,11 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.FetchOption;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class GetReferenceParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/MultipleNamespacesParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/MultipleNamespacesParamsTest.java
@@ -19,11 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.Namespace;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class MultipleNamespacesParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/NamespaceParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/NamespaceParamsTest.java
@@ -19,11 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.Namespace;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class NamespaceParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/RefLogParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/RefLogParamsTest.java
@@ -19,10 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class RefLogParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/ReferencesParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/ReferencesParamsTest.java
@@ -18,11 +18,8 @@ package org.projectnessie.api.v1.params;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.FetchOption;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class ReferencesParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
@@ -17,8 +17,6 @@ package org.projectnessie.api.v1.params;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.MergeBehavior;
 import org.projectnessie.model.MergeKeyBehavior;
@@ -28,7 +26,6 @@ import org.projectnessie.model.TestModelObjectsSerialization;
  * This test merely checks the JSON serialization/deserialization of API parameter classes, with an
  * intention to identify breaking cases whenever jackson version varies.
  */
-@Execution(ExecutionMode.CONCURRENT)
 public class TestParamObjectsSerialization extends TestModelObjectsSerialization {
 
   @SuppressWarnings("unused") // called by JUnit framework based on annotations in superclass

--- a/api/model/src/test/java/org/projectnessie/api/v2/params/TestParamObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/api/v2/params/TestParamObjectsSerialization.java
@@ -17,8 +17,6 @@ package org.projectnessie.api.v2.params;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.MergeBehavior;
 import org.projectnessie.model.MergeKeyBehavior;
@@ -28,7 +26,6 @@ import org.projectnessie.model.TestModelObjectsSerialization;
  * This test merely checks the JSON serialization/deserialization of API parameter classes, with an
  * intention to identify breaking cases whenever jackson version varies.
  */
-@Execution(ExecutionMode.CONCURRENT)
 public class TestParamObjectsSerialization extends TestModelObjectsSerialization {
 
   @SuppressWarnings("unused") // called by JUnit framework based on annotations in superclass

--- a/api/model/src/test/java/org/projectnessie/error/TestErrorCode.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestErrorCode.java
@@ -19,12 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestErrorCode {
 
   private Optional<Exception> ex(ErrorCode errorCode) {

--- a/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
@@ -21,10 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestNessieError {
 
   private static final ObjectMapper mapper = new ObjectMapper();

--- a/api/model/src/test/java/org/projectnessie/model/TestCommitMetaSerde.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestCommitMetaSerde.java
@@ -30,10 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestCommitMetaSerde {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.model.LogResponse.LogEntry;
@@ -36,7 +34,6 @@ import org.projectnessie.model.ser.Views;
  * This test merely checks the JSON serialization/deserialization of the model classes, with an
  * intention to identify breaking cases whenever jackson version varies.
  */
-@Execution(ExecutionMode.CONCURRENT)
 public class TestModelObjectsSerialization {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/api/model/src/test/java/org/projectnessie/model/TestTableReference.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestTableReference.java
@@ -21,13 +21,10 @@ import java.util.Arrays;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class TestTableReference {
 
   static List<Object[]> fromContentKeyTestCases() {

--- a/api/model/src/test/java/org/projectnessie/model/TestValidation.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestValidation.java
@@ -28,13 +28,10 @@ import static org.projectnessie.model.Validation.validateReferenceName;
 import static org.projectnessie.model.Validation.validateReferenceNameOrHash;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestValidation {
 
   @ParameterizedTest

--- a/servers/services/src/test/java/org/projectnessie/services/authz/TestBatchAccessChecker.java
+++ b/servers/services/src/test/java/org/projectnessie/services/authz/TestBatchAccessChecker.java
@@ -30,15 +30,12 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.services.authz.Check.CheckType;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.DetachedRef;
 import org.projectnessie.versioned.TagName;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class TestBatchAccessChecker {
 
   @Test

--- a/servers/services/src/test/java/org/projectnessie/services/impl/TestNamespaceApi.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/TestNamespaceApi.java
@@ -18,11 +18,8 @@ package org.projectnessie.services.impl;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.Namespace;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class TestNamespaceApi {
 
   @Test

--- a/servers/services/src/test/java/org/projectnessie/services/impl/TestRefUtil.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/TestRefUtil.java
@@ -21,8 +21,6 @@ import static org.projectnessie.services.impl.RefUtil.toReference;
 
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Detached;
 import org.projectnessie.model.Reference;
@@ -34,7 +32,6 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.TagName;
 
-@Execution(ExecutionMode.CONCURRENT)
 class TestRefUtil {
 
   public static final String HASH_VALUE = "deadbeeffeedcafe";

--- a/servers/services/src/test/java/org/projectnessie/services/impl/TestStreamUtil.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/TestStreamUtil.java
@@ -19,10 +19,7 @@ import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class TestStreamUtil {
 
   @Test


### PR DESCRIPTION
It was useful w/ Maven, but no longer w/ Gradle