### PR TITLE
Bump jaxb-impl from hadoop-common

### DIFF
--- a/gc/gc-iceberg-files/build.gradle.kts
+++ b/gc/gc-iceberg-files/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
     exclude("org.eclipse.jetty")
     exclude("org.apache.zookeeper")
   }
+  // Bump the jabx-impl version 2.2.3-1 via hadoop-common to make it work with Java 17+
+  implementation(libs.jaxb.impl)
+
   implementation(libs.iceberg.core)
   implementation(libs.iceberg.aws)
 

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
     exclude("org.apache.hadoop")
     exclude("org.apache.zookeeper")
   }
+  // Bump the jabx-impl version 2.2.3-1 via hadoop-common to make it work with Java 17+
+  implementation(libs.jaxb.impl)
 
   implementation(libs.slf4j.api)
 

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
     exclude("org.apache.hadoop")
     exclude("org.apache.zookeeper")
   }
+  // Bump the jabx-impl version 2.2.3-1 via hadoop-common to make it work with Java 17+
+  implementation(libs.jaxb.impl)
 
   implementation(platform(libs.awssdk.bom))
   runtimeOnly(libs.awssdk.s3)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -159,6 +159,7 @@ javax-servlet = { module = "javax.servlet:javax.servlet-api", version = "4.0.1" 
 javax-validation-api = { module = "javax.validation:validation-api", version = "2.0.1.Final"}
 javax-ws-rs = { module = "javax.ws.rs:javax.ws.rs-api", version = "2.1.1" }
 javax-ws-rs21 = { module = "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec", version = "2.0.2.Final" }
+jaxb-impl = { module = "com.sun.xml.bind:jaxb-impl", version = "2.3.8" }
 jersey-bom = { module = "org.glassfish.jersey:jersey-bom", version = "2.39.1" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.0.1" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }


### PR DESCRIPTION
Fixes this error:
```
java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @19e4653c
...
    at com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1.run(Injector.java:177)
```