### PR TITLE
Let errorprone not check code generated by APTs

### DIFF
--- a/buildSrc/src/main/kotlin/Errorprone.kt
+++ b/buildSrc/src/main/kotlin/Errorprone.kt
@@ -73,7 +73,7 @@ class NessieErrorpronePlugin : Plugin<Project> {
             )
 
         options.errorprone.checks.putAll(checksMapProperty)
-        options.errorprone.excludedPaths.set(".*/build/generated.*")
+        options.errorprone.excludedPaths.set(".*/build/[generated|tmp].*")
       }
       plugins.withType<JavaPlugin>().configureEach {
         configure<JavaPluginExtension> {


### PR DESCRIPTION
Errorprone fails for a recent change for #6480, complaining about an unnecessary null-check in generated immutables code (something like `int x; Map.put(Objects.requireNonNull(x), ...)`). The check itself is fine, however the code is generated, so there's not much we can do.

This change just adds the temporary directory in which errorprone works.