### PR TITLE
Enhance `NessieError` with error details

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -72,11 +72,17 @@ public interface HttpClient {
     private boolean http2Upgrade;
     private String followRedirects;
     private boolean forceUrlConnectionClient;
+    private int clientSpec = 2;
 
     private Builder() {}
 
     public URI getBaseUri() {
       return baseUri;
+    }
+
+    public Builder setClientSpec(int clientSpec) {
+      this.clientSpec = clientSpec;
+      return this;
     }
 
     public Builder setBaseUri(URI baseUri) {
@@ -187,6 +193,7 @@ public interface HttpClient {
               .isHttp11Only(!http2Upgrade)
               .followRedirects(followRedirects)
               .forceUrlConnectionClient(forceUrlConnectionClient)
+              .clientSpec(clientSpec)
               .build();
 
       return ImplSwitch.FACTORY.apply(config);

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpRequest.java
@@ -33,6 +33,11 @@ public abstract class HttpRequest
   protected HttpRequest(HttpRuntimeConfig config) {
     this.uriBuilder = new UriBuilder(config.getBaseUri());
     this.config = config;
+
+    int clientSpec = config.getClientSpec();
+    if (clientSpec > 0) {
+      headers.put("Nessie-Client-Spec", Integer.toString(clientSpec));
+    }
   }
 
   public HttpRequest contentsType(String contentType) {

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClient.java
@@ -63,7 +63,7 @@ final class NessieHttpClient extends NessieApiClient {
     if (authentication != null) {
       authentication.applyToHttpClient(clientBuilder);
     }
-    clientBuilder.addResponseFilter(new NessieHttpResponseFilter(MAPPER));
+    clientBuilder.addResponseFilter(new NessieHttpResponseFilter());
     return clientBuilder.build();
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/HttpRuntimeConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/HttpRuntimeConfig.java
@@ -93,4 +93,9 @@ public interface HttpRuntimeConfig {
   default boolean forceUrlConnectionClient() {
     return false;
   }
+
+  @Value.Default
+  default int getClientSpec() {
+    return 2;
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/rest/NessieHttpResponseFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/NessieHttpResponseFilter.java
@@ -15,23 +15,18 @@
  */
 package org.projectnessie.client.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.ResponseFilter;
 
 public class NessieHttpResponseFilter implements ResponseFilter {
 
-  private final ObjectMapper mapper;
-
-  public NessieHttpResponseFilter(ObjectMapper mapper) {
-    this.mapper = mapper;
-  }
+  public NessieHttpResponseFilter() {}
 
   @Override
   public void filter(ResponseContext con) {
     try {
-      ResponseCheckFilter.checkResponse(con, mapper);
+      ResponseCheckFilter.checkResponse(con);
     } catch (RuntimeException e) {
       throw e; // re-throw RuntimeExceptions unchanged
     } catch (Exception e) {

--- a/api/model/src/main/java/org/projectnessie/error/ErrorCodeAware.java
+++ b/api/model/src/main/java/org/projectnessie/error/ErrorCodeAware.java
@@ -15,8 +15,14 @@
  */
 package org.projectnessie.error;
 
+import org.projectnessie.model.NessieErrorDetails;
+
 /** A common interfaces for Nessie exceptions that have an associated {@link ErrorCode}. */
 public interface ErrorCodeAware {
 
   ErrorCode getErrorCode();
+
+  default NessieErrorDetails getErrorDetails() {
+    return null;
+  }
 }

--- a/api/model/src/main/java/org/projectnessie/error/NessieError.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieError.java
@@ -16,14 +16,21 @@
 package org.projectnessie.error;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
+import org.projectnessie.model.NessieErrorDetails;
 
-/** Represents Nessie-specific API error details. */
+/**
+ * Represents Nessie-specific API error details.
+ *
+ * <p>All Nessie servers respond
+ */
 @Value.Immutable
 @JsonSerialize(as = ImmutableNessieError.class)
 @JsonDeserialize(as = ImmutableNessieError.class)
@@ -46,6 +53,17 @@ public interface NessieError {
   default ErrorCode getErrorCode() {
     return ErrorCode.UNKNOWN;
   }
+
+  /**
+   * Details for this particular error.
+   *
+   * @since Nessie Client spec 2, only serialized to clients, if clients send the HTTP header {@code
+   *     Nessie-Client-Spec} with an integer value that is at least 2.
+   */
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(Include.NON_NULL)
+  NessieErrorDetails getErrorDetails();
 
   /** Server-side exception stack trace related to this error (if available). */
   @Nullable

--- a/api/model/src/main/java/org/projectnessie/error/NessieError.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieError.java
@@ -29,7 +29,10 @@ import org.projectnessie.model.NessieErrorDetails;
 /**
  * Represents Nessie-specific API error details.
  *
- * <p>All Nessie servers respond
+ * <p>All clients receive all properties that are not marked with an {@code @since} Javadoc tag.
+ * Those properties, like the {@link #getErrorDetails()} property, will only be returned to clients,
+ * if they sent the appropriate {@code Nessie-Client-Spec} header. The header value is an integer
+ * that must be greater than or equal to the version noted in the {@code @since} Javadoc tag.
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableNessieError.class)

--- a/api/model/src/main/java/org/projectnessie/error/NessieReferenceConflictException.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieReferenceConflictException.java
@@ -15,26 +15,46 @@
  */
 package org.projectnessie.error;
 
+import org.projectnessie.model.NessieErrorDetails;
+import org.projectnessie.model.ReferenceConflicts;
+
 /**
  * This exception is thrown when the expected state of a reference (e.g. the hash of the HEAD of a
  * branch) does not match the hash provided by the caller or when the requested operation could not
  * be completed within the configured time and number of retries due to concurrent operations.
  */
 public class NessieReferenceConflictException extends NessieConflictException {
-  public NessieReferenceConflictException(String message, Throwable cause) {
+  private final ReferenceConflicts referenceConflicts;
+
+  public NessieReferenceConflictException(
+      ReferenceConflicts referenceConflicts, String message, Throwable cause) {
     super(message, cause);
+    this.referenceConflicts = referenceConflicts;
+  }
+
+  public NessieReferenceConflictException(String message, Throwable cause) {
+    this(null, message, cause);
   }
 
   public NessieReferenceConflictException(String message) {
     super(message);
+    this.referenceConflicts = null;
   }
 
   public NessieReferenceConflictException(NessieError error) {
     super(error);
+    NessieErrorDetails errorDetails = error.getErrorDetails();
+    this.referenceConflicts =
+        errorDetails instanceof ReferenceConflicts ? (ReferenceConflicts) errorDetails : null;
   }
 
   @Override
   public ErrorCode getErrorCode() {
     return ErrorCode.REFERENCE_CONFLICT;
+  }
+
+  @Override
+  public ReferenceConflicts getErrorDetails() {
+    return referenceConflicts;
   }
 }

--- a/api/model/src/main/java/org/projectnessie/model/Conflict.java
+++ b/api/model/src/main/java/org/projectnessie/model/Conflict.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Locale;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+import org.projectnessie.model.Util.ConflictTypeDeserializer;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableConflict.class)
+@JsonDeserialize(as = ImmutableConflict.class)
+public interface Conflict {
+  @Value.Parameter(order = 1)
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonDeserialize(using = ConflictTypeDeserializer.class)
+  ConflictType conflictType();
+
+  @Value.Parameter(order = 2)
+  @Nullable
+  @jakarta.annotation.Nullable
+  ContentKey key();
+
+  @Value.Parameter(order = 3)
+  String message();
+
+  static Conflict conflict(
+      @Nullable @jakarta.annotation.Nullable ConflictType conflictType,
+      @Nullable @jakarta.annotation.Nullable ContentKey key,
+      String message) {
+    return ImmutableConflict.of(conflictType, key, message);
+  }
+
+  enum ConflictType {
+    /**
+     * Unknown, for situations when the server returned a conflict type that is unknown to the
+     * client.
+     */
+    UNKNOWN,
+
+    /** The key exists, but is expected to not exist. */
+    KEY_EXISTS,
+
+    /** The key does not exist, but is expected to exist. */
+    KEY_DOES_NOT_EXIST,
+
+    /** Payload of existing and expected differ. */
+    PAYLOAD_DIFFERS,
+
+    /** Content IDs of existing and expected content differs. */
+    CONTENT_ID_DIFFERS,
+
+    /** Values of existing and expected content differs. */
+    VALUE_DIFFERS,
+
+    /** The mandatory parent namespace does not exist. */
+    NAMESPACE_ABSENT,
+
+    /** The key expected to be a namespace is not a namespace. */
+    NOT_A_NAMESPACE,
+
+    /** A namespace must be empty before it can be deleted. */
+    NAMESPACE_NOT_EMPTY,
+
+    /** Reference is not at the expected hash. */
+    UNEXPECTED_HASH,
+
+    /** Generic key conflict, reported for merges and transplants. */
+    KEY_CONFLICT;
+
+    public static ConflictType parse(String conflictType) {
+      try {
+        if (conflictType != null) {
+          return ConflictType.valueOf(conflictType.toUpperCase(Locale.ROOT));
+        }
+        return null;
+      } catch (IllegalArgumentException e) {
+        return UNKNOWN;
+      }
+    }
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/NessieErrorDetails.java
+++ b/api/model/src/main/java/org/projectnessie/model/NessieErrorDetails.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(
+    type = SchemaType.OBJECT,
+    title = "NessieErrorDetails",
+    oneOf = {ReferenceConflicts.class},
+    discriminatorMapping = {
+      @DiscriminatorMapping(value = "REFERENCE_CONFLICTS", schema = ReferenceConflicts.class)
+    },
+    discriminatorProperty = "type")
+@JsonSubTypes({@JsonSubTypes.Type(ReferenceConflicts.class)})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public interface NessieErrorDetails {}

--- a/api/model/src/main/java/org/projectnessie/model/ReferenceConflicts.java
+++ b/api/model/src/main/java/org/projectnessie/model/ReferenceConflicts.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import static java.util.Collections.singletonList;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableReferenceConflicts.class)
+@JsonDeserialize(as = ImmutableReferenceConflicts.class)
+@JsonTypeName("REFERENCE_CONFLICTS")
+public interface ReferenceConflicts extends NessieErrorDetails {
+
+  @JsonInclude(Include.NON_EMPTY)
+  @Value.Parameter(order = 1)
+  List<Conflict> conflicts();
+
+  static ReferenceConflicts referenceConflicts(Conflict singleConflict) {
+    return referenceConflicts(singletonList(singleConflict));
+  }
+
+  static ReferenceConflicts referenceConflicts(List<Conflict> conflicts) {
+    return ImmutableReferenceConflicts.of(conflicts);
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/Util.java
+++ b/api/model/src/main/java/org/projectnessie/model/Util.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.projectnessie.model.Conflict.ConflictType;
 import org.projectnessie.model.types.ContentTypes;
 
 final class Util {
@@ -80,6 +81,14 @@ final class Util {
     }
 
     return builder.toString();
+  }
+
+  static final class ConflictTypeDeserializer extends JsonDeserializer<ConflictType> {
+    @Override
+    public ConflictType deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+      String name = p.readValueAs(String.class);
+      return name != null ? ConflictType.parse(name) : null;
+    }
   }
 
   static final class ContentTypeDeserializer extends JsonDeserializer<Content.Type> {

--- a/api/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.model;
 
+import static org.projectnessie.model.Conflict.ConflictType.UNEXPECTED_HASH;
+import static org.projectnessie.model.Conflict.conflict;
 import static org.projectnessie.model.JsonUtil.arrayNode;
 import static org.projectnessie.model.JsonUtil.objectNode;
 
@@ -71,6 +73,27 @@ public class TestModelObjectsSerialization {
     final String branchName = "testBranch";
 
     return Arrays.asList(
+        new Case(ReferenceConflicts.class)
+            .obj(
+                ReferenceConflicts.referenceConflicts(
+                    conflict(UNEXPECTED_HASH, ContentKey.of("foo", "bar"), "some message")))
+            .jsonNode(
+                o ->
+                    o.put("type", "REFERENCE_CONFLICTS")
+                        .set(
+                            "conflicts",
+                            arrayNode()
+                                .add(
+                                    objectNode()
+                                        .put("conflictType", "UNEXPECTED_HASH")
+                                        .put("message", "some message")
+                                        .set(
+                                            "key",
+                                            objectNode()
+                                                .set(
+                                                    "elements",
+                                                    arrayNode().add("foo").add("bar"))))))
+            .skipFinalCompare(),
         new Case(NessieConfiguration.class)
             .view(Views.V1.class)
             .obj(

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -71,7 +71,7 @@ class TestNessieError {
         HttpClient.builder()
             .setBaseUri(uri.resolve("nessieErrorTest"))
             .setObjectMapper(mapper)
-            .addResponseFilter(new NessieHttpResponseFilter(mapper))
+            .addResponseFilter(new NessieHttpResponseFilter())
             .build();
   }
 

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestCommon.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestCommon.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.rest;
+
+import com.google.common.base.Throwables;
+import java.util.function.Function;
+import org.projectnessie.error.ErrorCode;
+import org.projectnessie.error.ErrorCodeAware;
+import org.projectnessie.error.ImmutableNessieError;
+import org.projectnessie.error.NessieError;
+import org.projectnessie.model.NessieErrorDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class RestCommon {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RestCommon.class);
+
+  private RestCommon() {}
+
+  public static NessieError buildNessieError(
+      String message,
+      int statusCode,
+      String statusReason,
+      ErrorCode errorCode,
+      Exception e,
+      boolean includeExceptionStackTrace,
+      Function<String, String> requestHeader) {
+
+    if (message == null) {
+      message = "";
+    }
+
+    String stack = includeExceptionStackTrace ? Throwables.getStackTraceAsString(e) : null;
+
+    LOGGER.debug(
+        "Failure on server, propagated to client. Status: {} {}, Message: {}.",
+        statusCode,
+        statusReason,
+        message,
+        e);
+
+    NessieErrorDetails errorDetails =
+        (e instanceof ErrorCodeAware) ? ((ErrorCodeAware) e).getErrorDetails() : null;
+    if (errorDetails != null && !isNessieClientSpec2(requestHeader)) {
+      errorDetails = null;
+    }
+
+    return ImmutableNessieError.builder()
+        .message(message)
+        .status(statusCode)
+        .errorCode(errorCode)
+        .reason(statusReason)
+        .serverStackTrace(stack)
+        .errorDetails(errorDetails)
+        .build();
+  }
+
+  private static boolean isNessieClientSpec2(Function<String, String> requestHeader) {
+    String clientSpec = requestHeader.apply("Nessie-Client-Spec");
+    if (clientSpec == null) {
+      return false;
+    }
+    try {
+      int i = clientSpec.indexOf('.');
+      if (i != -1) {
+        clientSpec = clientSpec.substring(0, i);
+      }
+      return Integer.parseInt(clientSpec) >= 2;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+}

--- a/servers/rest-services/src/main/java/org/projectnessie/services/restjakarta/BaseExceptionMapper.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/restjakarta/BaseExceptionMapper.java
@@ -15,24 +15,24 @@
  */
 package org.projectnessie.services.restjakarta;
 
-import com.google.common.base.Throwables;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import java.util.function.Consumer;
 import org.projectnessie.error.ErrorCode;
-import org.projectnessie.error.ImmutableNessieError;
 import org.projectnessie.error.NessieError;
 import org.projectnessie.services.config.ServerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.projectnessie.services.rest.RestCommon;
 
 /** Code shared between concrete exception-mapper implementations. */
 public abstract class BaseExceptionMapper<T extends Throwable> implements ExceptionMapper<T> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(BaseExceptionMapper.class);
 
   private final ServerConfig serverConfig;
+
+  @Context private HttpHeaders headers;
 
   protected BaseExceptionMapper(ServerConfig serverConfig) {
     this.serverConfig = serverConfig;
@@ -54,31 +54,21 @@ public abstract class BaseExceptionMapper<T extends Throwable> implements Except
       boolean includeExceptionStackTrace,
       Consumer<ResponseBuilder> responseHandler) {
 
-    String stack = includeExceptionStackTrace ? Throwables.getStackTraceAsString(e) : null;
-
     Response.Status status = Response.Status.fromStatusCode(errorCode.httpStatus());
     if (status == null) {
       status = Response.Status.INTERNAL_SERVER_ERROR;
     }
 
-    if (message == null) {
-      message = "";
-    }
-
     NessieError error =
-        ImmutableNessieError.builder()
-            .message(message)
-            .status(status.getStatusCode())
-            .errorCode(errorCode)
-            .reason(status.getReasonPhrase())
-            .serverStackTrace(stack)
-            .build();
-    LOGGER.debug(
-        "Failure on server, propagated to client. Status: {} {}, Message: {}.",
-        status.getStatusCode(),
-        status.getReasonPhrase(),
-        message,
-        e);
+        RestCommon.buildNessieError(
+            message,
+            status.getStatusCode(),
+            status.getReasonPhrase(),
+            errorCode,
+            e,
+            includeExceptionStackTrace,
+            headers::getHeaderString);
+
     ResponseBuilder responseBuilder =
         Response.status(status).entity(error).type(MediaType.APPLICATION_JSON_TYPE);
     responseHandler.accept(responseBuilder);


### PR DESCRIPTION
Adds a new, generic property `errorDetails` to return details about a particular error to clients.

The field uses `NessieErrorDetails` as a "generic base type". Parsing of `NessieError` is now more "relaxed", unknown properties are ignored. This means, that older clients are able to safely ignore future enhancements like new error details types or added properties, which is acceptable for error information.

Clients must not assume that `errorDetails` will always be present, because older servers may not return it.

Servers must only include the new `errorDetails` property, if the client included the HTTP header `Nessie-Client-Spec` with an integer value >= 2.

This change also introduces `ReferenceConflicts` as the first use case for `errorDetails`. It contains details like the particular conflict type and related key and a mandatory message.

Fixes #4310
Part of #5645
Related to #6447