### PR TITLE
Revert "Update smartbear/swaggerhub-cli action to v0.7.0 (#6478)"

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -264,7 +264,7 @@ jobs:
           "${NESSIE_HELM_CHART}"
 
     - name: Update SwaggerHub
-      uses: smartbear/swaggerhub-cli@v0.7.0
+      uses: smartbear/swaggerhub-cli@v0.6.5
       env:
         XDG_CONFIG_HOME: "/tmp"
         SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}


### PR DESCRIPTION
This reverts commit 7d5648e2c46472f1c19f15c213a2cf2fdf93bbc7.

Posted an [issue for swaggerhub-cli](https://github.com/SmartBear/swaggerhub-cli/issues/290).

The 0.7.0 version broke the OpenAPI publication for the latest Nessie 0.55.0 release.