### PR TITLE
Test code cleanup / no functional change

### DIFF
--- a/api/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
@@ -15,7 +15,9 @@
  */
 package org.projectnessie.api.v1.params;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import static org.projectnessie.model.JsonUtil.arrayNode;
+import static org.projectnessie.model.JsonUtil.objectNode;
+
 import java.util.Arrays;
 import java.util.List;
 import org.projectnessie.model.ContentKey;
@@ -43,7 +45,7 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
             .jsonNode(
                 o ->
                     o.put("fromRefName", "testBranch")
-                        .set("hashesToTransplant", JsonNodeFactory.instance.arrayNode().add(HASH))),
+                        .set("hashesToTransplant", arrayNode().add(HASH))),
         new Case(Transplant.class)
             .obj(
                 ImmutableTransplant.builder()
@@ -55,7 +57,7 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
                 o ->
                     o.put("fromRefName", "testBranch")
                         .put("keepIndividualCommits", true)
-                        .set("hashesToTransplant", JsonNodeFactory.instance.arrayNode().add(HASH))),
+                        .set("hashesToTransplant", arrayNode().add(HASH))),
         new Case(Merge.class)
             .obj(ImmutableMerge.builder().fromHash(HASH).fromRefName(branchName).build())
             .jsonNode(o -> o.put("fromRefName", "testBranch").put("fromHash", HASH)),
@@ -90,36 +92,25 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
                         .put("isFetchAdditionalInfo", true)
                         .set(
                             "keyMergeModes",
-                            JsonNodeFactory.instance
-                                .arrayNode()
+                            arrayNode()
                                 .add(
-                                    JsonNodeFactory.instance
-                                        .objectNode()
+                                    objectNode()
                                         .put("mergeBehavior", "NORMAL")
                                         .set(
                                             "key",
-                                            JsonNodeFactory.instance
-                                                .objectNode()
+                                            objectNode()
                                                 .set(
                                                     "elements",
-                                                    JsonNodeFactory.instance
-                                                        .arrayNode()
-                                                        .add("merge")
-                                                        .add("me"))))
+                                                    arrayNode().add("merge").add("me"))))
                                 .add(
-                                    JsonNodeFactory.instance
-                                        .objectNode()
+                                    objectNode()
                                         .put("mergeBehavior", "DROP")
                                         .set(
                                             "key",
-                                            JsonNodeFactory.instance
-                                                .objectNode()
+                                            objectNode()
                                                 .set(
                                                     "elements",
-                                                    JsonNodeFactory.instance
-                                                        .arrayNode()
-                                                        .add("ignore")
-                                                        .add("this")))))),
+                                                    arrayNode().add("ignore").add("this")))))),
         new Case(Merge.class)
             .obj(
                 ImmutableMerge.builder()
@@ -139,36 +130,25 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
                         .put("isDryRun", false)
                         .set(
                             "keyMergeModes",
-                            JsonNodeFactory.instance
-                                .arrayNode()
+                            arrayNode()
                                 .add(
-                                    JsonNodeFactory.instance
-                                        .objectNode()
+                                    objectNode()
                                         .put("mergeBehavior", "NORMAL")
                                         .set(
                                             "key",
-                                            JsonNodeFactory.instance
-                                                .objectNode()
+                                            objectNode()
                                                 .set(
                                                     "elements",
-                                                    JsonNodeFactory.instance
-                                                        .arrayNode()
-                                                        .add("merge")
-                                                        .add("me"))))
+                                                    arrayNode().add("merge").add("me"))))
                                 .add(
-                                    JsonNodeFactory.instance
-                                        .objectNode()
+                                    objectNode()
                                         .put("mergeBehavior", "DROP")
                                         .set(
                                             "key",
-                                            JsonNodeFactory.instance
-                                                .objectNode()
+                                            objectNode()
                                                 .set(
                                                     "elements",
-                                                    JsonNodeFactory.instance
-                                                        .arrayNode()
-                                                        .add("ignore")
-                                                        .add("this")))))));
+                                                    arrayNode().add("ignore").add("this")))))));
   }
 
   @SuppressWarnings("unused") // called by JUnit framework based on annotations in superclass
@@ -178,17 +158,13 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
             .jsonNode(
                 o ->
                     o.putNull("fromRefName")
-                        .set(
-                            "hashesToTransplant",
-                            JsonNodeFactory.instance.arrayNode().add("invalidhash"))),
+                        .set("hashesToTransplant", arrayNode().add("invalidhash"))),
 
         // Invalid hash
         new Case(Transplant.class)
             .jsonNode(
                 o ->
                     o.put("fromRefName", "testBranch")
-                        .set(
-                            "hashesToTransplant",
-                            JsonNodeFactory.instance.arrayNode().add("invalidhash"))));
+                        .set("hashesToTransplant", arrayNode().add("invalidhash"))));
   }
 }

--- a/api/model/src/test/java/org/projectnessie/api/v2/params/TestParamObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/api/v2/params/TestParamObjectsSerialization.java
@@ -15,7 +15,9 @@
  */
 package org.projectnessie.api.v2.params;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import static org.projectnessie.model.JsonUtil.arrayNode;
+import static org.projectnessie.model.JsonUtil.objectNode;
+
 import java.util.Arrays;
 import java.util.List;
 import org.projectnessie.model.ContentKey;
@@ -43,7 +45,7 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
             .jsonNode(
                 o ->
                     o.put("fromRefName", "testBranch")
-                        .set("hashesToTransplant", JsonNodeFactory.instance.arrayNode().add(HASH))),
+                        .set("hashesToTransplant", arrayNode().add(HASH))),
         new Case(Transplant.class)
             .obj(
                 ImmutableTransplant.builder()
@@ -55,7 +57,7 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
                 o ->
                     o.put("fromRefName", "testBranch")
                         .put("message", "test-msg")
-                        .set("hashesToTransplant", JsonNodeFactory.instance.arrayNode().add(HASH))),
+                        .set("hashesToTransplant", arrayNode().add(HASH))),
         new Case(Merge.class)
             .obj(ImmutableMerge.builder().fromHash(HASH).fromRefName(branchName).build())
             .jsonNode(o -> o.put("fromRefName", "testBranch").put("fromHash", HASH)),
@@ -90,36 +92,25 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
                         .put("isFetchAdditionalInfo", true)
                         .set(
                             "keyMergeModes",
-                            JsonNodeFactory.instance
-                                .arrayNode()
+                            arrayNode()
                                 .add(
-                                    JsonNodeFactory.instance
-                                        .objectNode()
+                                    objectNode()
                                         .put("mergeBehavior", "NORMAL")
                                         .set(
                                             "key",
-                                            JsonNodeFactory.instance
-                                                .objectNode()
+                                            objectNode()
                                                 .set(
                                                     "elements",
-                                                    JsonNodeFactory.instance
-                                                        .arrayNode()
-                                                        .add("merge")
-                                                        .add("me"))))
+                                                    arrayNode().add("merge").add("me"))))
                                 .add(
-                                    JsonNodeFactory.instance
-                                        .objectNode()
+                                    objectNode()
                                         .put("mergeBehavior", "DROP")
                                         .set(
                                             "key",
-                                            JsonNodeFactory.instance
-                                                .objectNode()
+                                            objectNode()
                                                 .set(
                                                     "elements",
-                                                    JsonNodeFactory.instance
-                                                        .arrayNode()
-                                                        .add("ignore")
-                                                        .add("this")))))),
+                                                    arrayNode().add("ignore").add("this")))))),
         new Case(Merge.class)
             .obj(
                 ImmutableMerge.builder()
@@ -139,36 +130,25 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
                         .put("isDryRun", false)
                         .set(
                             "keyMergeModes",
-                            JsonNodeFactory.instance
-                                .arrayNode()
+                            arrayNode()
                                 .add(
-                                    JsonNodeFactory.instance
-                                        .objectNode()
+                                    objectNode()
                                         .put("mergeBehavior", "NORMAL")
                                         .set(
                                             "key",
-                                            JsonNodeFactory.instance
-                                                .objectNode()
+                                            objectNode()
                                                 .set(
                                                     "elements",
-                                                    JsonNodeFactory.instance
-                                                        .arrayNode()
-                                                        .add("merge")
-                                                        .add("me"))))
+                                                    arrayNode().add("merge").add("me"))))
                                 .add(
-                                    JsonNodeFactory.instance
-                                        .objectNode()
+                                    objectNode()
                                         .put("mergeBehavior", "DROP")
                                         .set(
                                             "key",
-                                            JsonNodeFactory.instance
-                                                .objectNode()
+                                            objectNode()
                                                 .set(
                                                     "elements",
-                                                    JsonNodeFactory.instance
-                                                        .arrayNode()
-                                                        .add("ignore")
-                                                        .add("this")))))));
+                                                    arrayNode().add("ignore").add("this")))))));
   }
 
   @SuppressWarnings("unused") // called by JUnit framework based on annotations in superclass
@@ -178,17 +158,13 @@ public class TestParamObjectsSerialization extends TestModelObjectsSerialization
             .jsonNode(
                 o ->
                     o.putNull("fromRefName")
-                        .set(
-                            "hashesToTransplant",
-                            JsonNodeFactory.instance.arrayNode().add("invalidhash"))),
+                        .set("hashesToTransplant", arrayNode().add("invalidhash"))),
 
         // Invalid hash
         new Case(Transplant.class)
             .jsonNode(
                 o ->
                     o.put("fromRefName", "testBranch")
-                        .set(
-                            "hashesToTransplant",
-                            JsonNodeFactory.instance.arrayNode().add("invalidhash"))));
+                        .set("hashesToTransplant", arrayNode().add("invalidhash"))));
   }
 }

--- a/api/model/src/test/java/org/projectnessie/model/JsonUtil.java
+++ b/api/model/src/test/java/org/projectnessie/model/JsonUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public final class JsonUtil {
+  private JsonUtil() {}
+
+  public static ObjectNode objectNode() {
+    return JsonNodeFactory.instance.objectNode();
+  }
+
+  public static ArrayNode arrayNode() {
+    return JsonNodeFactory.instance.arrayNode();
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -15,10 +15,12 @@
  */
 package org.projectnessie.model;
 
+import static org.projectnessie.model.JsonUtil.arrayNode;
+import static org.projectnessie.model.JsonUtil.objectNode;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.time.Instant;
@@ -123,20 +125,14 @@ public class TestModelObjectsSerialization {
                         .putNull("effectiveReference")
                         .putArray("entries")
                         .add(
-                            JsonNodeFactory.instance
-                                .objectNode()
+                            objectNode()
                                 .put("type", "ICEBERG_TABLE")
                                 .putNull("contentId")
                                 .putNull("content")
                                 .set(
                                     "name",
-                                    JsonNodeFactory.instance
-                                        .objectNode()
-                                        .set(
-                                            "elements",
-                                            JsonNodeFactory.instance
-                                                .arrayNode()
-                                                .add("/tmp/testpath"))))),
+                                    objectNode()
+                                        .set("elements", arrayNode().add("/tmp/testpath"))))),
         new Case(CommitMeta.class)
             .obj(
                 CommitMeta.builder()
@@ -159,26 +155,16 @@ public class TestModelObjectsSerialization {
                 o -> {
                   o.put("hash", HASH)
                       .put("committer", "c1")
-                      .set("authors", JsonNodeFactory.instance.arrayNode().add("a1").add("a2"));
-                  o.set("allSignedOffBy", JsonNodeFactory.instance.arrayNode().add("s1").add("s2"));
+                      .set("authors", arrayNode().add("a1").add("a2"));
+                  o.set("allSignedOffBy", arrayNode().add("s1").add("s2"));
                   o.put("message", "msg")
                       .put("commitTime", "1970-01-01T00:00:02Z")
                       .put("authorTime", "1970-01-01T00:00:01Z")
                       .set(
                           "allProperties",
-                          ((ObjectNode)
-                                  JsonNodeFactory.instance
-                                      .objectNode()
-                                      .set(
-                                          "p1",
-                                          JsonNodeFactory.instance
-                                              .arrayNode()
-                                              .add("v1a")
-                                              .add("v1b")))
-                              .set("p2", JsonNodeFactory.instance.arrayNode().add("v2")));
-                  o.set(
-                      "parentCommitHashes",
-                      JsonNodeFactory.instance.arrayNode().add("p1").add("p2"));
+                          ((ObjectNode) objectNode().set("p1", arrayNode().add("v1a").add("v1b")))
+                              .set("p2", arrayNode().add("v2")));
+                  o.set("parentCommitHashes", arrayNode().add("p1").add("p2"));
                 }),
         new Case(LogResponse.class)
             .obj(
@@ -203,38 +189,26 @@ public class TestModelObjectsSerialization {
             .jsonNode(
                 o -> {
                   ObjectNode meta =
-                      JsonNodeFactory.instance
-                          .objectNode()
+                      objectNode()
                           .put("hash", HASH)
                           .put("committer", "committer@example.com")
                           .put("author", "author@example.com")
-                          .set(
-                              "authors",
-                              JsonNodeFactory.instance.arrayNode().add("author@example.com"));
+                          .set("authors", arrayNode().add("author@example.com"));
                   meta.put("signedOffBy", "signer@example.com")
-                      .set(
-                          "allSignedOffBy",
-                          JsonNodeFactory.instance.arrayNode().add("signer@example.com"));
+                      .set("allSignedOffBy", arrayNode().add("signer@example.com"));
                   meta.put("message", "test commit")
                       .put("commitTime", now.toString())
                       .put("authorTime", now.toString())
-                      .set(
-                          "properties", JsonNodeFactory.instance.objectNode().put("prop1", "val1"));
-                  meta.set(
-                      "allProperties",
-                      JsonNodeFactory.instance
-                          .objectNode()
-                          .set("prop1", JsonNodeFactory.instance.arrayNode().add("val1")));
+                      .set("properties", objectNode().put("prop1", "val1"));
+                  meta.set("allProperties", objectNode().set("prop1", arrayNode().add("val1")));
 
                   o.put("token", HASH)
                       .put("hasMore", true)
                       .set(
                           "logEntries",
-                          JsonNodeFactory.instance
-                              .arrayNode()
+                          arrayNode()
                               .add(
-                                  JsonNodeFactory.instance
-                                      .objectNode()
+                                  objectNode()
                                       .putNull("parentCommitHash")
                                       .putNull("operations")
                                       .set("commitMeta", meta)));
@@ -264,7 +238,7 @@ public class TestModelObjectsSerialization {
     Object obj;
     Class<?> serializationView;
     final Class<?> deserializeAs;
-    ObjectNode deserializedJson = JsonNodeFactory.instance.objectNode();
+    ObjectNode deserializedJson = objectNode();
     boolean skipFinalCompare;
 
     public Case(Class<?> deserializeAs) {


### PR DESCRIPTION
Plain replace of the boilerplate `JsonNodeFactory.instance.arrayNode()`/`objectNode()` with static helper functions.