### PR TITLE
Populate reference conflict details

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -321,7 +321,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     } catch (ReferenceConflictException e) {
-      throw new NessieReferenceConflictException(e.getMessage(), e);
+      throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
     }
   }
 
@@ -351,7 +351,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     } catch (ReferenceConflictException e) {
-      throw new NessieReferenceConflictException(e.getMessage(), e);
+      throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
     }
   }
 
@@ -609,9 +609,9 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
         MergeResult<Commit> mr = (MergeResult<Commit>) e.getMergeResult();
         return createResponse(fetchAdditionalInfo, mr);
       }
-      throw new NessieReferenceConflictException(e.getMessage(), e);
+      throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
     } catch (ReferenceConflictException e) {
-      throw new NessieReferenceConflictException(e.getMessage(), e);
+      throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
     }
   }
 
@@ -657,9 +657,9 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
         MergeResult<Commit> mr = (MergeResult<Commit>) e.getMergeResult();
         return createResponse(fetchAdditionalInfo, mr);
       }
-      throw new NessieReferenceConflictException(e.getMessage(), e);
+      throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
     } catch (ReferenceConflictException e) {
-      throw new NessieReferenceConflictException(e.getMessage(), e);
+      throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
     }
   }
 
@@ -912,7 +912,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     } catch (ReferenceConflictException e) {
-      throw new NessieReferenceConflictException(e.getMessage(), e);
+      throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
     }
   }
 

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/DatabaseAdapterUtil.java
@@ -15,6 +15,10 @@
  */
 package org.projectnessie.versioned.persist.adapter.spi;
 
+import static java.lang.String.format;
+import static org.projectnessie.model.Conflict.ConflictType.UNEXPECTED_HASH;
+import static org.projectnessie.model.Conflict.conflict;
+
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import java.nio.charset.StandardCharsets;
@@ -66,12 +70,11 @@ public final class DatabaseAdapterUtil {
   /** Builds a {@link ReferenceNotFoundException} exception with a human-readable message. */
   public static ReferenceNotFoundException hashNotFound(NamedRef ref, Hash hash) {
     return new ReferenceNotFoundException(
-        String.format(
-            "Could not find commit '%s' in reference '%s'.", hash.asString(), ref.getName()));
+        format("Could not find commit '%s' in reference '%s'.", hash.asString(), ref.getName()));
   }
 
   public static ReferenceNotFoundException referenceNotFound(String ref) {
-    return new ReferenceNotFoundException(String.format("Named reference '%s' not found", ref));
+    return new ReferenceNotFoundException(format("Named reference '%s' not found", ref));
   }
 
   public static ReferenceNotFoundException referenceNotFound(NamedRef ref) {
@@ -79,16 +82,16 @@ public final class DatabaseAdapterUtil {
   }
 
   public static ReferenceNotFoundException referenceNotFound(Hash hash) {
-    return new ReferenceNotFoundException(String.format("Commit '%s' not found", hash.asString()));
+    return new ReferenceNotFoundException(format("Commit '%s' not found", hash.asString()));
   }
 
   public static ReferenceAlreadyExistsException referenceAlreadyExists(NamedRef ref) {
     return new ReferenceAlreadyExistsException(
-        String.format("Named reference '%s' already exists.", ref.getName()));
+        format("Named reference '%s' already exists.", ref.getName()));
   }
 
   public static String mergeConflictMessage(String err, MergeParams mergeParams) {
-    return String.format(
+    return format(
         "%s during merge of '%s' into '%s%s' requiring a common ancestor",
         err,
         mergeParams.getMergeFromHash().asString(),
@@ -97,7 +100,7 @@ public final class DatabaseAdapterUtil {
   }
 
   public static String transplantConflictMessage(String err, TransplantParams transplantParams) {
-    return String.format(
+    return format(
         "%s during transplant of %d commits into '%s%s'",
         err,
         transplantParams.getSequenceToTransplant().size(),
@@ -107,26 +110,26 @@ public final class DatabaseAdapterUtil {
 
   public static String commitConflictMessage(
       String err, BranchName commitTo, Optional<Hash> expectedHead) {
-    return String.format(
+    return format(
         "%s during commit against '%s%s'",
         err, commitTo.getName(), expectedHead.map(h -> "@" + h.asString()).orElse(""));
   }
 
   public static String createConflictMessage(String err, NamedRef ref, Hash target) {
-    return String.format(
+    return format(
         "%s during create of reference '%s' at '%s'", err, ref.getName(), target.asString());
   }
 
   public static String deleteConflictMessage(
       String err, NamedRef reference, Optional<Hash> expectedHead) {
-    return String.format(
+    return format(
         "%s during delete of reference '%s%s'",
         err, reference.getName(), expectedHead.map(h -> "@" + h.asString()).orElse(""));
   }
 
   public static String assignConflictMessage(
       String err, NamedRef assignee, Optional<Hash> expectedHead, Hash assignTo) {
-    return String.format(
+    return format(
         "%s during reassign of reference %s%s to '%s'",
         err,
         assignee.getName(),
@@ -135,11 +138,11 @@ public final class DatabaseAdapterUtil {
   }
 
   public static String maintenanceConflictMessage(String err, String msg) {
-    return String.format("%s during %s", err, msg);
+    return format("%s during %s", err, msg);
   }
 
   public static String repoDescUpdateConflictMessage(String err) {
-    return String.format("%s during update of the repository description", err);
+    return format("%s during update of the repository description", err);
   }
 
   /**
@@ -151,9 +154,14 @@ public final class DatabaseAdapterUtil {
       throws ReferenceConflictException {
     if (expectedHead.isPresent() && !referenceCurrentHead.equals(expectedHead.get())) {
       throw new ReferenceConflictException(
-          String.format(
-              "Named-reference '%s' is not at expected hash '%s', but at '%s'.",
-              reference.getName(), expectedHead.get().asString(), referenceCurrentHead.asString()));
+          conflict(
+              UNEXPECTED_HASH,
+              null,
+              format(
+                  "named-reference '%s' is not at expected hash '%s', but at '%s'",
+                  reference.getName(),
+                  expectedHead.get().asString(),
+                  referenceCurrentHead.asString())));
     }
   }
 

--- a/versioned/persist/inmem/build.gradle.kts
+++ b/versioned/persist/inmem/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   implementation(project(":nessie-versioned-persist-non-transactional"))
   implementation(project(":nessie-versioned-persist-serialize"))
   implementation(project(":nessie-versioned-spi"))
+  implementation(project(":nessie-model"))
   implementation(libs.guava)
   compileOnly(libs.immutables.value.annotations)
   annotationProcessor(libs.immutables.value.processor)

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeConflictException.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeConflictException.java
@@ -15,6 +15,13 @@
  */
 package org.projectnessie.versioned;
 
+import static org.projectnessie.model.ReferenceConflicts.referenceConflicts;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.projectnessie.model.Conflict;
+import org.projectnessie.model.Conflict.ConflictType;
+
 /**
  * Special case of a {@link ReferenceConflictException} indicating that a non-dry-run merge or
  * transplant operation could not be completed due to conflicts.
@@ -24,8 +31,17 @@ public class MergeConflictException extends ReferenceConflictException {
   private final MergeResult<?> mergeResult;
 
   public MergeConflictException(String message, MergeResult<?> mergeResult) {
-    super(message);
+    super(referenceConflicts(asReferenceConflicts(mergeResult)), message);
     this.mergeResult = mergeResult;
+  }
+
+  private static List<Conflict> asReferenceConflicts(MergeResult<?> mergeResult) {
+    return mergeResult.getDetails().entrySet().stream()
+        .map(
+            e ->
+                Conflict.conflict(
+                    ConflictType.KEY_CONFLICT, e.getKey(), e.getValue().getConflictType().name()))
+        .collect(Collectors.toList());
   }
 
   public MergeResult<?> getMergeResult() {

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
@@ -250,8 +250,7 @@ class CommitImpl extends BaseCommitHelper {
       }
     }
 
-    validateNamespacesExistForContentKeys(newContent, headIndex());
-    validateNamespacesToDeleteHaveNoChildren(deletedKeysAndPayload, headIndex());
+    validateNamespaces(newContent, deletedKeysAndPayload, headIndex());
   }
 
   private static void commitAddUnchanged(

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestRefMapping.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestRefMapping.java
@@ -135,13 +135,13 @@ public class TestRefMapping {
                             KEY_DOES_NOT_EXIST,
                             null)))),
             ReferenceConflictException.class,
-            "There are conflicts that prevent committing the provided operations: key 'aaa.foo' does not exist."),
+            "Key 'aaa.foo' does not exist."),
         arguments(
             referenceConflictException(
                 new CommitConflictException(
                     singletonList(commitConflict(key("aaa", "foo"), KEY_DOES_NOT_EXIST, null)))),
             ReferenceConflictException.class,
-            "There are conflicts that prevent committing the provided operations: store-key 'aaa/foo' does not exist."),
+            "Store-key 'aaa/foo' does not exist."),
         arguments(
             referenceConflictException(
                 new CommitConflictException(
@@ -152,7 +152,7 @@ public class TestRefMapping {
                         commitConflict(key("ddd", "foo"), CONTENT_ID_DIFFERS, null),
                         commitConflict(key("eee", "foo"), VALUE_DIFFERS, null)))),
             ReferenceConflictException.class,
-            "There are conflicts that prevent committing the provided operations: "
+            "There are multiple conflicts that prevent committing the provided operations: "
                 + "store-key 'aaa/foo' already exists, "
                 + "store-key 'bbb/foo' does not exist, "
                 + "payload of existing and expected content for store-key 'ccc/foo' are different, "
@@ -173,7 +173,7 @@ public class TestRefMapping {
                         commitConflict(
                             keyToStoreKey(ContentKey.of("eee", "foo")), VALUE_DIFFERS, null)))),
             ReferenceConflictException.class,
-            "There are conflicts that prevent committing the provided operations: "
+            "There are multiple conflicts that prevent committing the provided operations: "
                 + "key 'aaa.foo' already exists, "
                 + "key 'bbb.foo' does not exist, "
                 + "payload of existing and expected content for key 'ccc.foo' are different, "


### PR DESCRIPTION
Adds the storage layer code to populate the `ReferenceConflicts` in `NessieReferenceConflictException`, based on the code from #6492

