### PR TITLE
CI: Cache everything that's needed

### DIFF
--- a/.github/actions/ci-incr-build-cache-prepare/action.yml
+++ b/.github/actions/ci-incr-build-cache-prepare/action.yml
@@ -4,6 +4,9 @@ inputs:
   cache-read-only:
     description: 'Gradle cache read only'
     default: 'true'
+  memoize:
+    description: 'Memoize cache for later save'
+    default: 'false'
   java-version:
     description: 'Java version'
     default: '11'
@@ -46,15 +49,14 @@ runs:
       shell: bash
       run: |
         echo "::group::Gradle build cache / add incremental updates"
-        mkdir -p ~/.gradle/caches/build-cache-1/
-        echo "Gradle build-cache-1 contains $(ls -1 ~/.gradle/caches/build-cache-1/ | wc -l) files"
+        mkdir -p ~/.gradle/caches/
+        echo "Gradle caches/ contains $(find ~/.gradle/caches/ -type f | wc -l) files"
 
         if [[ -d ~/downloaded-artifacts/ ]] ; then
-          find ~/downloaded-artifacts/ -type f -name "ci-gradle-build-cache-*-${{ inputs.java-version }}.tar" | while read arch ; do
+          find ~/downloaded-artifacts/ -type f -name "ci-gradle-caches-*-${{ inputs.java-version }}.tar" | while read arch ; do
             echo "Adding archive content from $arch ..."
-            (cd ~/.gradle/caches/build-cache-1/ ; tar xf $arch)
+            (cd ~/.gradle/caches/ ; tar xf $arch)
           done
-
         else
           echo "No previous build cache artifacts downloaded."
         fi
@@ -62,13 +64,16 @@ runs:
 
     - name: Memoize build-cache
       shell: bash
+      if: inputs.memoize == 'true'
       run: |
-        echo "::group::Saving state of Gradle's build-cache-1 ..."
-        rm -rf ~/saved-build-cache-1/
-        mkdir -p ~/saved-build-cache-1/
+        echo "::group::Saving state of Gradle's caches/ ..."
+        rm -rf ~/saved-gradle-caches/
+        mkdir -p ~/saved-gradle-caches/
 
-        if [[ -d ~/.gradle/caches/build-cache-1/ ]] ; then
-          echo "Gradle build-cache-1 contains $(ls -1 ~/.gradle/caches/build-cache-1/ | wc -l) files"
-          (cd ~/.gradle/caches/build-cache-1/ ; cp -r . ~/saved-build-cache-1/)
+        if [[ -d ~/.gradle/caches/ ]] ; then
+          echo "Gradle caches/ contains $(find ~/.gradle/caches/ -type f | wc -l) files"
+          (cd ~/.gradle/caches/ ; cp --recursive --preserve=all . ~/saved-gradle-caches/)
+          rm ~/saved-gradle-caches/user-id*
+          find ~/saved-gradle-caches/ -name "*.lock" | xargs rm -f
         fi
         echo "::endgroup::"

--- a/.github/actions/ci-incr-build-cache-save/action.yml
+++ b/.github/actions/ci-incr-build-cache-save/action.yml
@@ -1,5 +1,5 @@
-name: 'Save incremental Gradle build cache'
-description: 'Save incremental Gradle build cache'
+name: 'Save incremental Gradle caches'
+description: 'Save incremental Gradle caches'
 inputs:
   job-name:
     description: 'job name'
@@ -9,33 +9,33 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Prepare build-cache archive
+    - name: Prepare Gradle caches archive
       shell: bash
       run: |
-        if [[ -d ~/.gradle/caches/build-cache-1/ ]] ; then
-          echo "::group::Gradle build cache / identify updated build cache items"
+        if [[ -d ~/.gradle/caches/ ]] ; then
+          echo "::group::Gradle caches / identify updated cache items"
 
-          cd ~/.gradle/caches/build-cache-1/
+          cd ~/.gradle/caches/
 
-          echo "Gradle build-cache-1 has $(ls -1 . | wc -l) files"
-          # Identify the added and changed files in build-cache-1.
+          echo "Gradle caches/ contains $(find . -type f | wc -l) files"
+          # Identify the added and changed files in caches/.
 
           echo "Identifying changed/added files..."
           # 'diff' returns 1, if files differ :(
-          (diff --brief --recursive --new-file --no-dereference ~/saved-build-cache-1/ . || true) | \
-            cut -d\  -f4 > ~/ci-gradle-build-cache-diff
-          echo "Identified $(wc -l < ~/ci-gradle-build-cache-diff) changed/added files in build-cache-1"
+          (diff --brief --recursive --new-file --no-dereference ~/saved-gradle-caches/ . || true) | \
+            cut -d\  -f4 > ~/ci-gradle-caches-diff
+          echo "Identified $(wc -l < ~/ci-gradle-caches-diff) changed/added files in caches/"
 
           # Only call 'tar', if there is some difference
           # Note: actions/upload-artifact takes care of compressing the artifact, no need to bug the CPU here
           echo "Creating artifact (if necessary)..."
-          [[ -s ~/ci-gradle-build-cache-diff ]] && tar cf ~/ci-gradle-build-cache-${{ inputs.job-name }}-${{ inputs.java-version }}.tar -T ~/ci-gradle-build-cache-diff
+          [[ -s ~/ci-gradle-caches-diff ]] && tar cf ~/ci-gradle-caches-${{ inputs.job-name }}-${{ inputs.java-version }}.tar -T ~/ci-gradle-caches-diff
           echo "::endgroup::"
         fi
     - name: Archive code-checks incremental
       uses: actions/upload-artifact@v3
       with:
-        name: ci-gradle-build-cache-${{ inputs.job-name }}-${{ inputs.java-version }}
-        path: ~/ci-gradle-build-cache-${{ inputs.job-name }}-${{ inputs.java-version }}.tar
+        name: ci-gradle-caches-${{ inputs.job-name }}-${{ inputs.java-version }}
+        path: ~/ci-gradle-caches-${{ inputs.job-name }}-${{ inputs.java-version }}.tar
         if-no-files-found: ignore
         retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
+          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / Code Checks
         uses: gradle/gradle-build-action@v2
@@ -107,6 +108,7 @@ jobs:
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push'
         with:
           job-name: 'code-checks'
           java-version: ${{ matrix.java-version }}
@@ -131,6 +133,7 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
+          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / test
         uses: gradle/gradle-build-action@v2
@@ -139,6 +142,7 @@ jobs:
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push'
         with:
           job-name: 'test'
           java-version: ${{ matrix.java-version }}
@@ -163,6 +167,7 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
+          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / Test Quarkus
         uses: gradle/gradle-build-action@v2
@@ -171,6 +176,7 @@ jobs:
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push'
         with:
           job-name: 'test-quarkus'
           java-version: ${{ matrix.java-version }}
@@ -195,6 +201,8 @@ jobs:
 
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
+        with:
+          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / intTest
         run: |
@@ -212,6 +220,7 @@ jobs:
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push'
         with:
           job-name: 'int-test'
           java-version: ${{ matrix.java-version }}
@@ -236,6 +245,7 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
+          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / intTest versioned/stores
         run: |
@@ -245,6 +255,7 @@ jobs:
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push'
         with:
           job-name: 'int-test-stores'
           java-version: ${{ matrix.java-version }}
@@ -263,6 +274,8 @@ jobs:
 
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
+        with:
+          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / intTest integrations
         run: |
@@ -271,6 +284,7 @@ jobs:
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push'
         with:
           job-name: 'int-test-integrations'
 
@@ -294,6 +308,7 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
+          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / intTest Quarkus
         uses: gradle/gradle-build-action@v2
@@ -302,6 +317,7 @@ jobs:
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
+        if: github.event_name == 'push'
         with:
           job-name: 'int-test-quarkus'
           java-version: ${{ matrix.java-version }}
@@ -334,6 +350,7 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
+          memoize: false
 
       - name: Gradle / intTest Quarkus native
         if: env.WF_EXEC == 'true'
@@ -411,6 +428,8 @@ jobs:
       - name: Prepare Gradle build cache
         if: env.WF_EXEC == 'true'
         uses: ./.github/actions/ci-incr-build-cache-prepare
+        with:
+          memoize: false
 
       - name: Docker images publishing
         if: env.WF_EXEC == 'true'
@@ -763,6 +782,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           cache-read-only: false
+          memoize: false
 
       - name: Trigger Gradle home cleanup
         run: ./gradlew --no-daemon :showVersion


### PR DESCRIPTION
The new CI workflow accidentally does not cache dependencies, generated jars and more, only the build-cache was saved.

Not having the dependencies available leads to unnecessary network traffic and sporadic build issues (dependencies not downloaded).