### PR TITLE
CI: finally the correct artifacts

### DIFF
--- a/.github/actions/ci-incr-build-cache-prepare/action.yml
+++ b/.github/actions/ci-incr-build-cache-prepare/action.yml
@@ -4,9 +4,6 @@ inputs:
   cache-read-only:
     description: 'Gradle cache read only'
     default: 'true'
-  memoize:
-    description: 'Memoize cache for later save'
-    default: 'false'
   java-version:
     description: 'Java version'
     default: '11'
@@ -50,7 +47,6 @@ runs:
       run: |
         echo "::group::Gradle build cache / add incremental updates"
         mkdir -p ~/.gradle/caches/
-        echo "Gradle caches/ contains $(find ~/.gradle/caches/ -type f | wc -l) files"
 
         if [[ -d ~/downloaded-artifacts/ ]] ; then
           find ~/downloaded-artifacts/ -type f -name "ci-gradle-caches-*-${{ inputs.java-version }}.tar" | while read arch ; do
@@ -60,20 +56,7 @@ runs:
         else
           echo "No previous build cache artifacts downloaded."
         fi
-        echo "::endgroup::"
+        
+        date +%s > ~/caches-prepared-at-epoch
 
-    - name: Memoize build-cache
-      shell: bash
-      if: inputs.memoize == 'true'
-      run: |
-        echo "::group::Saving state of Gradle's caches/ ..."
-        rm -rf ~/saved-gradle-caches/
-        mkdir -p ~/saved-gradle-caches/
-
-        if [[ -d ~/.gradle/caches/ ]] ; then
-          echo "Gradle caches/ contains $(find ~/.gradle/caches/ -type f | wc -l) files"
-          (cd ~/.gradle/caches/ ; cp --recursive --preserve=all . ~/saved-gradle-caches/)
-          rm ~/saved-gradle-caches/user-id*
-          find ~/saved-gradle-caches/ -name "*.lock" | xargs rm -f
-        fi
         echo "::endgroup::"

--- a/.github/actions/ci-incr-build-cache-save/action.yml
+++ b/.github/actions/ci-incr-build-cache-save/action.yml
@@ -21,15 +21,28 @@ runs:
           # Identify the added and changed files in caches/.
 
           echo "Identifying changed/added files..."
-          # 'diff' returns 1, if files differ :(
-          (diff --brief --recursive --new-file --no-dereference ~/saved-gradle-caches/ . || true) | \
-            cut -d\  -f4 > ~/ci-gradle-caches-diff
+          AGE_SECS=$(($(date +%s) - $(cat ~/caches-prepared-at-epoch)))
+          echo "Build started ~ $AGE_SECS seconds ago"
+          AGE_MINS=$(($AGE_SECS / 60 + 1))
+          echo " ... assuming that is ~ $AGE_MINS minutes"
+          # This lists all relevant files that have been created or modified during by the Gradle
+          # runs of the current job.
+          find . -mmin -$AGE_MINS -type f '(' \
+            -path './[0-9]*/kotlin-dsl/*' -or \
+            -path './jars-*/*' -or \
+            -path './modules-*/files-*/*' -or \
+            -path './modules-*/files-*/*' -or \
+            -path './build-cache-*/*' \
+            ')' | grep -v '[.]lock$'  > ~/ci-gradle-caches-diff
           echo "Identified $(wc -l < ~/ci-gradle-caches-diff) changed/added files in caches/"
 
           # Only call 'tar', if there is some difference
           # Note: actions/upload-artifact takes care of compressing the artifact, no need to bug the CPU here
           echo "Creating artifact (if necessary)..."
-          [[ -s ~/ci-gradle-caches-diff ]] && tar cf ~/ci-gradle-caches-${{ inputs.job-name }}-${{ inputs.java-version }}.tar -T ~/ci-gradle-caches-diff
+          if [[ -s ~/ci-gradle-caches-diff ]] ; then
+            tar --create --ignore-failed-read --file ~/ci-gradle-caches-${{ inputs.job-name }}-${{ inputs.java-version }}.tar -T ~/ci-gradle-caches-diff
+            ls -al ~/ci-gradle-caches-${{ inputs.job-name }}-${{ inputs.java-version }}.tar
+          fi
           echo "::endgroup::"
         fi
     - name: Archive code-checks incremental

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
-          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / Code Checks
         uses: gradle/gradle-build-action@v2
@@ -133,7 +132,6 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
-          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / test
         uses: gradle/gradle-build-action@v2
@@ -167,7 +165,6 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
-          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / Test Quarkus
         uses: gradle/gradle-build-action@v2
@@ -201,14 +198,21 @@ jobs:
 
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
-        with:
-          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / intTest
         run: |
+          echo "::group::Collect :nessie-versioned-storage projects"
           ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-persist- --output ../persist-prjs.txt --exclude
+          echo "::endgroup::"
+
+          echo "::group::Collect :nessie-versioned-persist projects"
           ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-storage- --output ../storage-prjs.txt --exclude
+          echo "::endgroup::"
+
+          echo "::group::Collect :nessie-spark-extensions projects"
           ./gradlew :listProjectsWithPrefix --prefix :nessie-spark-ext --output ../spark-prjs.txt --exclude
+          echo "::endgroup::"
+
           ./gradlew intTest \
             -x :nessie-quarkus:intTest \
             -x :nessie-quarkus-cli:intTest \
@@ -245,12 +249,17 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
-          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / intTest versioned/stores
         run: |
+          echo "::group::Collect :nessie-versioned-storage projects"
           ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-storage- --output ../storage-prjs.txt
+          echo "::endgroup::"
+
+          echo "::group::Collect :nessie-versioned-persist projects"
           ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-persist- --output ../persist-prjs.txt
+          echo "::endgroup::"
+
           ./gradlew $(cat ../persist-prjs.txt) $(cat ../storage-prjs.txt) --scan
 
       - name: Save partial Gradle build cache
@@ -274,12 +283,13 @@ jobs:
 
       - name: Prepare Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-prepare
-        with:
-          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / intTest integrations
         run: |
+          echo "::group::Collect :nessie-spark-extensions projects"
           ./gradlew :listProjectsWithPrefix --prefix :nessie-spark-ext --output ../spark-prjs.txt
+          echo "::endgroup::"
+
           ./gradlew :nessie-deltalake:intTest $(cat ../spark-prjs.txt) --scan
 
       - name: Save partial Gradle build cache
@@ -308,7 +318,6 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
-          memoize: ${{ github.event_name == 'push' }}
 
       - name: Gradle / intTest Quarkus
         uses: gradle/gradle-build-action@v2
@@ -350,7 +359,6 @@ jobs:
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
-          memoize: false
 
       - name: Gradle / intTest Quarkus native
         if: env.WF_EXEC == 'true'
@@ -428,8 +436,6 @@ jobs:
       - name: Prepare Gradle build cache
         if: env.WF_EXEC == 'true'
         uses: ./.github/actions/ci-incr-build-cache-prepare
-        with:
-          memoize: false
 
       - name: Docker images publishing
         if: env.WF_EXEC == 'true'
@@ -782,7 +788,6 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           cache-read-only: false
-          memoize: false
 
       - name: Trigger Gradle home cleanup
         run: ./gradlew --no-daemon :showVersion


### PR DESCRIPTION
Only add the really needed files to the per-job-cache-diff artifacts.

Gradle cache content is finally correct and cacheable/cached data is properly used and speeds up the builds significantly.