### PR TITLE
Bump slf4j to 1.7.36/2.0.12 + logback to 1.3.14/1.5.6

### DIFF
--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
   compileOnly(libs.httpclient5)
 
-  implementation(libs.slf4j.api)
+  implementation(libs.slf4j.api) { version { require(libs.versions.slf4j.compat.get()) } }
   compileOnly(libs.errorprone.annotations)
 
   compileOnly(project(":nessie-doc-generator-annotations"))
@@ -78,7 +78,11 @@ dependencies {
   testFixturesApi(libs.undertow.core)
   testFixturesApi(libs.undertow.servlet)
   testFixturesApi(libs.httpclient5)
-  testFixturesImplementation(libs.logback.classic)
+  testFixturesImplementation(libs.logback.classic) {
+    version { require(libs.versions.logback.compat.get()) }
+    // Logback 1.3 brings Slf4j 2.0, which doesn't work with Spark up to 3.3
+    exclude("org.slf4j", "slf4j-api")
+  }
 
   testImplementation(libs.wiremock)
 

--- a/events/service/build.gradle.kts
+++ b/events/service/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
   testImplementation(libs.guava)
-  testImplementation(libs.logback.classic)
+  testRuntimeOnly(libs.logback.classic)
 
   testCompileOnly(libs.microprofile.openapi)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ jandex = "3.1.8"
 jmh = "1.37"
 junit = "5.10.2"
 keycloak = "24.0.4"
+logback = "1.5.6"
 mavenResolver = "1.9.20"
 mockito="4.11.0"
 nessieClientVersion = "0.77.1" # Must be in sync with Nessie version in the Iceberg release.
@@ -26,9 +27,13 @@ picocli = "4.7.6"
 protobuf = "3.25.3"
 quarkusPlatform = "3.10.0"
 quarkusPlugin = "3.10.0"
-slf4j = "1.7.36"
+slf4j = "2.0.12"
 smallryeConfig = "3.8.1"
 undertow = "2.2.28.Final"
+
+# Backwards compatibility versions. Not referenced in this file to not let Renovate bump those versions.
+logback_compat = "1.3.14" # For Java 8
+slf4j_compat = "1.7.36" # Spark up to 3.3 has a hard reference to org.slf4j.impl.StaticLoggerBinder
 
 [bundles]
 junit-testing = ["assertj-core", "mockito-core", "mockito-junit-jupiter", "junit-jupiter-api", "junit-jupiter-params", "junit-platform-reporting"]
@@ -96,7 +101,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-reporting = { module = "org.junit.platform:junit-platform-reporting" }
-logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.2.13" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version.ref = "keycloak" }
 maven-resolver-supplier = { module = "org.apache.maven.resolver:maven-resolver-supplier", version.ref = "mavenResolver" }
 micrometer-core = { module = "io.micrometer:micrometer-core", version = "1.12.5" }

--- a/integrations/spark-extensions/build.gradle.kts
+++ b/integrations/spark-extensions/build.gradle.kts
@@ -49,8 +49,14 @@ dependencies {
   testFixturesImplementation("org.apache.iceberg:iceberg-spark-extensions-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}:$versionIceberg")
   testFixturesImplementation("org.apache.iceberg:iceberg-hive-metastore:$versionIceberg")
 
-  testFixturesRuntimeOnly(libs.logback.classic)
-  testFixturesImplementation(libs.slf4j.log4j.over.slf4j)
+  testFixturesRuntimeOnly(libs.logback.classic) {
+    version { strictly(libs.versions.logback.compat.get()) }
+    // Logback 1.3 brings Slf4j 2.0, which doesn't work with Spark up to 3.3
+    exclude("org.slf4j", "slf4j-api")
+  }
+  testFixturesImplementation(libs.slf4j.log4j.over.slf4j) {
+    version { require(libs.versions.slf4j.compat.get()) }
+  }
   testFixturesImplementation("org.apache.spark:spark-sql_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }
   testFixturesImplementation("org.apache.spark:spark-core_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }
   testFixturesImplementation("org.apache.spark:spark-hive_${sparkScala.scalaMajorVersion}") { forSpark(sparkScala.sparkVersion) }

--- a/servers/services/build.gradle.kts
+++ b/servers/services/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   implementation(project(":nessie-model"))
   implementation(project(":nessie-services-config"))
   implementation(project(":nessie-versioned-spi"))
-  implementation(libs.slf4j.api)
+  implementation(libs.slf4j.api) { version { require(libs.versions.slf4j.compat.get()) } }
 
   implementation(platform(libs.cel.bom))
   implementation("org.projectnessie.cel:cel-standalone")


### PR DESCRIPTION
* For nessie-client: slf4j 1.7 + logback 1.3
* For Spark related: slf4j 1.7 + logback 1.3
* Other modules: slf4j 2.0 + logback 1.5

Fixes #5216