### PR TITLE
Support `@NessieServerProperty` annotations in nested tests

### DIFF
--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/ServerKey.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/ServerKey.java
@@ -49,12 +49,14 @@ final class ServerKey {
       String storageName,
       Map<String, String> defaultConfig) {
     Map<String, String> config = new HashMap<>(defaultConfig);
-    context
-        .getTestClass()
-        .ifPresent(
-            instance ->
-                findRepeatableAnnotations(instance, NessieServerProperty.class)
-                    .forEach(prop -> config.put(prop.name(), prop.value())));
+    Util.forEachContextFromRoot(
+        context,
+        c ->
+            c.getTestClass()
+                .ifPresent(
+                    instance ->
+                        findRepeatableAnnotations(instance, NessieServerProperty.class)
+                            .forEach(prop -> config.put(prop.name(), prop.value()))));
 
     String storeKindStr = config.get(STORAGE_KIND_PROPERTY);
     StorageKind kind = StorageKind.DATABASE_ADAPTER;

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.platform.engine.UniqueId;
@@ -53,6 +54,11 @@ final class Util {
       }
       c = parent.get();
     }
+  }
+
+  static void forEachContextFromRoot(ExtensionContext current, Consumer<ExtensionContext> action) {
+    current.getParent().ifPresent(p -> forEachContextFromRoot(p, action));
+    action.accept(current);
   }
 
   static <T> T withClassLoader(ClassLoader classLoader, Callable<T> callable) throws Exception {

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestUtil.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestUtil.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -87,6 +89,21 @@ class TestUtil {
         .thenReturn("[engine:my-engine]/[class:some.package.ClassName]/[test:fooBar]");
 
     soft.assertThat(Util.classContext(ctxMethod)).isSameAs(ctxClass);
+  }
+
+  @Test
+  void forEachContextFromRoot() {
+    ExtensionContext ctxEngine = mock(ExtensionContext.class);
+    ExtensionContext ctxClass = mock(ExtensionContext.class);
+    ExtensionContext ctxMethod = mock(ExtensionContext.class);
+
+    when(ctxEngine.getParent()).thenReturn(Optional.empty());
+    when(ctxClass.getParent()).thenReturn(Optional.of(ctxEngine));
+    when(ctxMethod.getParent()).thenReturn(Optional.of(ctxClass));
+
+    List<ExtensionContext> iterated = new ArrayList<>();
+    Util.forEachContextFromRoot(ctxMethod, iterated::add);
+    soft.assertThat(iterated).containsExactly(ctxEngine, ctxClass, ctxMethod);
   }
 
   @Test


### PR DESCRIPTION
* `@NessieServerProperty` annotations are processed on all test classes starting from the root context.

* Properties in inner / nested contexts take precedence over properties in outer contexts.