### PR TITLE
CI: Un-bump latest Java from 20 to 19 (#359)

### DIFF
--- a/.github/workflows/newer-java.yml
+++ b/.github/workflows/newer-java.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - java-version: 17
-          - java-version: 20
+          - java-version: 19
     env:
       SPARK_LOCAL_IP: localhost
 


### PR DESCRIPTION
Gradle 8.0.2 has issues with Java 20 :(

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not open cp_init generic class cache for initialization script '/home/runner/.gradle/init.d/build-result-capture.init.gradle' (/home/runner/.gradle/caches/8.0.2/scripts/81bhe3x4qmzhxltbvjll89pw1).
> BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 64
```