### PR TITLE
Perftest: Fix commit-to-branch simulation

### DIFF
--- a/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
+++ b/perftest/simulations/src/gatling/scala/org/projectnessie/perftest/gatling/CommitToBranchSimulation.scala
@@ -45,7 +45,7 @@ class CommitToBranchSimulation extends Simulation {
             // Table used in the Nessie commit
             val tableName = params.makeTableName(session)
 
-            val key = ContentKey.of("name", "space", tableName)
+            val key = ContentKey.of("table-" + tableName)
 
             val existingTable =
               client.getContent.reference(branch).key(key).get().get(key)


### PR DESCRIPTION
Current code requires namespace to exists, and fails to run.