### PR TITLE
Revert "Update smartbear/swaggerhub-cli action to v0.7.1 (#6519)"

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -269,7 +269,7 @@ jobs:
           "${NESSIE_HELM_CHART}"
 
     - name: Update SwaggerHub
-      uses: smartbear/swaggerhub-cli@v0.7.1
+      uses: smartbear/swaggerhub-cli@v0.6.5
       env:
         XDG_CONFIG_HOME: "/tmp"
         SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}


### PR DESCRIPTION
This reverts commit 811ace80c136d000769a350212f35bb3dd5ee123.

Reason is another issue
https://github.com/SmartBear/swaggerhub-cli/issues/293 with v0.7.1.