### PR TITLE
Python: `codecov` not found

### DIFF
--- a/python/requirements_basedev.txt
+++ b/python/requirements_basedev.txt
@@ -18,7 +18,6 @@
 -r requirements.txt
 assertpy==1.1
 bump2version==1.0.1
-codecov==2.1.12
 coverage==7.2.3
 pip==23.0.1
 pytest==7.3.0


### PR DESCRIPTION
Python CI started to fail with:
```
.pkg: _exit> python /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
ERROR: Could not find a version that satisfies the requirement codecov==2.1.12 (from versions: none)
ERROR: No matching distribution found for codecov==2.1.12
ERROR: Could not find a version that satisfies the requirement codecov==2.1.12 (from versions: none)
ERROR: No matching distribution found for codecov==2.1.12
ERROR: Could not find a version that satisfies the requirement codecov==2.1.12 (from versions: none)
ERROR: No matching distribution found for codecov==2.1.12
ERROR: Could not find a version that satisfies the requirement codecov==2.1.12 (from versions: none)
ERROR: No matching distribution found for codecov==2.1.12
```

Removing the `codecov` dependency.