### PR TITLE
CI: Remove `CI Success` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,30 +338,24 @@ jobs:
       max-parallel: 2
       matrix:
         java-version: ['11'] # Ideally also '17', but GH concurrent job limit ... :(
-    env:
-      WF_EXEC: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'pr-native') }}
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'pr-native')
     steps:
       - uses: actions/checkout@v3.5.1
-        if: env.WF_EXEC == 'true'
       - name: Setup runner
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/setup-runner
         with:
           more-memory: 'true'
       - name: Setup Java, Gradle
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/dev-tool-java
         with:
           java-version: ${{ matrix.java-version }}
 
       - name: Prepare Gradle build cache
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/ci-incr-build-cache-prepare
         with:
           java-version: ${{ matrix.java-version }}
 
       - name: Gradle / intTest Quarkus native
-        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :nessie-quarkus:intTest -Pnative --scan
@@ -372,27 +366,20 @@ jobs:
   docker-testing:
     name: CI Docker build and publishing
     runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request'
-    env:
-      # Only run for PRs with the appropriate label
-      WF_EXEC: ${{ contains(github.event.pull_request.labels.*.name, 'pr-docker') }}
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr-docker')
     steps:
       - name: Checkout
-        if: env.WF_EXEC == 'true'
         uses: actions/checkout@v3.5.1
         with:
           fetch-depth: 0
       - name: Setup runner
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/setup-runner
         with:
           more-memory: 'true'
       - name: Setup Java, Gradle
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/dev-tool-java
 
       - name: Setup docker-registry
-        if: env.WF_EXEC == 'true'
         run: |
           sudo apt-get install -y docker-registry apache2-utils 
           cat <<! > config.yml
@@ -434,11 +421,9 @@ jobs:
           echo "DOCKER_IMAGE=localhost:5000/nessie-testing" >> ${GITHUB_ENV}
 
       - name: Prepare Gradle build cache
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/ci-incr-build-cache-prepare
 
       - name: Docker images publishing
-        if: env.WF_EXEC == 'true'
         env:
           ARTIFACTS: ../build-artifacts
         run: |
@@ -454,13 +439,11 @@ jobs:
           rm -rf "${ARTIFACTS}"
 
       - name: Cleanup buildx
-        if: env.WF_EXEC == 'true'
         run: |
           docker buildx use default
           docker buildx rm nessiebuild
 
       - name: Docker images exist test
-        if: env.WF_EXEC == 'true'
         run: |
           docker pull ${DOCKER_IMAGE}:latest
           docker pull ${DOCKER_IMAGE}:latest-java
@@ -477,7 +460,6 @@ jobs:
           !
 
       - name: Check if Docker native image works
-        if: env.WF_EXEC == 'true'
         run: |
           docker run --detach --name nessie ${DOCKER_IMAGE}:latest-native
           echo "Let native Nessie Docker image run for one minute (to make sure it starts up fine)..."
@@ -503,7 +485,6 @@ jobs:
           docker rm nessie
 
       - name: Check if Docker Java image works
-        if: env.WF_EXEC == 'true'
         run: |
           docker run --detach --name nessie ${DOCKER_IMAGE}:latest-java
           echo "Let Nessie Java Docker image run for one minute (to make sure it starts up fine)..."
@@ -531,10 +512,9 @@ jobs:
   nesqueit:
     name: CI NesQuEIT
     runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request'
+    # Only run NesQuEIT tests for PRs, if requested. This job can easily run for 30+ minutes.
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr-integrations')
     env:
-      # Only run NesQuEIT tests for PRs, if requested. This job can easily run for 30+ minutes.
-      WF_EXEC: ${{ contains(github.event.pull_request.labels.*.name, 'pr-integrations') }}
       NESSIE_DIR: included-builds/nessie
       NESSIE_PATCH_REPOSITORY: ''
       NESSIE_PATCH_BRANCH: ''
@@ -548,26 +528,22 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
       - name: Prepare Git
-        if: env.WF_EXEC == 'true'
         run: |
           git config --global user.email "integrations-testing@projectnessie.org"
           git config --global user.name "Integrations Testing [Bot]"
 
       - name: Checkout NeQuEIT repo
-        if: env.WF_EXEC == 'true'
         uses: actions/checkout@v3.5.1
         with:
           repository: ${{env.NESQUEIT_REPOSITORY}}
           ref: ${{env.NESQUEIT_BRANCH}}
 
       - name: Setup runner
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/setup-runner
         with:
           more-memory: 'true'
 
       - name: Checkout and patch Nessie PR
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/patch-git
         with:
           name: Nessie
@@ -578,7 +554,6 @@ jobs:
           work-branch: nessie-integration-patched
 
       - name: Checkout and patch Iceberg
-        if: env.WF_EXEC == 'true'
         uses: ./.github/actions/patch-git
         with:
           name: Nessie
@@ -591,52 +566,44 @@ jobs:
 
       # Setup Gradle properties, heap requirements are for the "Integration test w/ Nessie".
       - name: Setup gradle.properties
-        if: env.WF_EXEC == 'true'
         run: |
           mkdir -p ~/.gradle
           echo "org.gradle.jvmargs=-Xms2g -Xmx4g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" >> ~/.gradle/gradle.properties
           echo "org.gradle.vfs.watch=false" >> ~/.gradle/gradle.properties
 
       - name: Set up JDK ${{ matrix.java-version }}
-        if: env.WF_EXEC == 'true'
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: Iceberg Nessie test
-        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: true
           arguments: :iceberg:iceberg-nessie:test --scan
 
       - name: Nessie Spark 3.1 Extensions test
-        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.1_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.1_2.12:intTest --scan
 
       - name: Nessie Spark 3.2 / 2.12 Extensions test
-        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest --scan
 
       - name: Nessie Spark 3.3 / 2.12 Extensions test
-        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest --scan
 
       #- name: Publish Nessie + Iceberg to local Maven repo
-      #  if: env.WF_EXEC == 'true'
       #  uses: gradle/gradle-build-action@v2
       #  with:
       #    arguments: publishLocal --scan
       #
       #- name: Gather locally published versions
-      #  if: env.WF_EXEC == 'true'
       #  run: |
       #    NESSIE_VERSION="$(cat included-builds/nessie/version.txt)"
       #    ICEBERG_VERSION="$(cat included-builds/iceberg/build/iceberg-build.properties | grep '^git.build.version=' | cut -d= -f2)"
@@ -650,7 +617,6 @@ jobs:
       #    !
 
       - name: Tools & Integrations tests
-        if: env.WF_EXEC == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: intTest --scan
@@ -658,18 +624,15 @@ jobs:
   helm-testing:
     name: CI Lint & Test Helm chart
     runs-on: ubuntu-22.04
-    env:
-      WF_EXEC: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'pr-helm') }}
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'pr-helm')
     steps:
       - name: Checkout
-        if: env.WF_EXEC == 'true'
         uses: actions/checkout@v3.5.1
         with:
           fetch-depth: 0
 
       # Skip remaining steps, if version is not available
       - name: Precheck
-        if: env.WF_EXEC == 'true'
         run: |
           EXPECT_VERSION="$(cat helm/nessie/Chart.yaml | grep -E '^version: ')"
           curl https://charts.projectnessie.org/index.yaml 2>/dev/null | grep -q "${EXPECT_VERSION}" || (
@@ -678,40 +641,40 @@ jobs:
           )
 
       - name: Set up Helm
-        if: env.WF_EXEC == 'true'
+        if: env.WF_EXEC != 'false'
         uses: azure/setup-helm@v3
         with:
           version: v3.8.1
       - uses: actions/setup-python@v4
-        if: env.WF_EXEC == 'true'
+        if: env.WF_EXEC != 'false'
         with:
           python-version: '3.8'
       - name: Set up chart-testing
-        if: env.WF_EXEC == 'true'
+        if: env.WF_EXEC != 'false'
         uses: helm/chart-testing-action@v2.4.0
 
       - name: Run chart-testing (list-changed)
-        if: env.WF_EXEC == 'true'
+        if: env.WF_EXEC != 'false'
         id: list-changed
         run: |
           ct list-changed --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Run chart-testing (lint)
-        if: env.WF_EXEC == 'true'
+        if: env.WF_EXEC != 'false'
         run: ct lint --debug --charts ./helm/nessie
 
       - name: Set up & Start Minikube
-        if: env.WF_EXEC == 'true'
+        if: env.WF_EXEC != 'false'
         uses: medyagh/setup-minikube@v0.0.13
         with:
           cache: false
 
       - name: Show pods
-        if: env.WF_EXEC == 'true'
+        if: env.WF_EXEC != 'false'
         run: kubectl get pods -A
 
       - name: Run chart-testing (install)
-        if: env.WF_EXEC == 'true'
+        if: env.WF_EXEC != 'false'
         run: ct install --debug --charts ./helm/nessie
 
   python:


### PR DESCRIPTION
The idea for the `CI Success` job was to have only one required status check, without the need to configure each individual job in `ci.yml`. But sadly, a _skipped_ job counts as _passed_ for required checks. This is different from `needs: [jobs]` for a job, which requires all _needed_ jobs to run and succeed, so a skipped job in `neeeds:` counts as "failed".