### PR TITLE
Add test for specVersion in API v2

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -210,6 +210,13 @@ public abstract class BaseTestNessieApi {
   }
 
   @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void specVersion() {
+    NessieConfiguration config = api().getConfig();
+    soft.assertThat(config.getSpecVersion()).isNotEmpty();
+  }
+
+  @Test
   public void references() throws Exception {
     Branch main = api().getDefaultBranch();
     soft.assertThat(api().getAllReferences().get().getReferences()).containsExactly(main);


### PR DESCRIPTION
To make sure it is passed through the java client (follow-up to #6480)