### PR TITLE
Ensure custom content-types work

### DIFF
--- a/api/model/build.gradle.kts
+++ b/api/model/build.gradle.kts
@@ -49,6 +49,14 @@ dependencies {
   annotationProcessor(libs.immutables.value.processor)
 
   testCompileOnly(libs.microprofile.openapi)
+  testCompileOnly(libs.immutables.value.annotations)
+  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(libs.jakarta.ws.rs.api)
+  testCompileOnly(libs.javax.ws.rs)
+  testCompileOnly(libs.jakarta.validation.api)
+  testCompileOnly(libs.javax.validation.api)
+  testCompileOnly(libs.jakarta.annotation.api)
+  testCompileOnly(libs.findbugs.jsr305)
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)

--- a/api/model/src/main/java/org/projectnessie/model/Content.java
+++ b/api/model/src/main/java/org/projectnessie/model/Content.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -34,7 +35,13 @@ import org.projectnessie.model.types.ContentTypes;
 @Schema(
     type = SchemaType.OBJECT,
     title = "Content",
-    oneOf = {IcebergTable.class, DeltaLakeTable.class, IcebergView.class, Namespace.class},
+    anyOf = {
+      IcebergTable.class,
+      DeltaLakeTable.class,
+      IcebergView.class,
+      Namespace.class,
+      Map.class
+    },
     discriminatorMapping = {
       @DiscriminatorMapping(value = "ICEBERG_TABLE", schema = IcebergTable.class),
       @DiscriminatorMapping(value = "DELTA_LAKE_TABLE", schema = DeltaLakeTable.class),

--- a/api/model/src/main/java/org/projectnessie/model/types/ContentTypeRegistry.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/ContentTypeRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,9 @@
  */
 package org.projectnessie.model.types;
 
-/**
- * Used to provide custom {@link org.projectnessie.model.Content} implementations via the Java
- * {@link java.util.ServiceLoader service loader} mechanism.
- */
-public interface ContentTypeBundle {
-  void register(ContentTypeRegistry contentTypeRegistry);
+import org.projectnessie.model.Content;
+
+/** An implementation of this interface is passed to {@link ContentTypeBundle}s. */
+public interface ContentTypeRegistry {
+  void register(Class<? extends Content> type);
 }

--- a/api/model/src/main/java/org/projectnessie/model/types/ContentTypes.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/ContentTypes.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.model.types;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,6 +52,50 @@ public final class ContentTypes {
     return Registry.forName(name);
   }
 
+  static final class RegistryHelper implements ContentTypes.Registrar {
+
+    private final List<Content.Type> list = new ArrayList<>();
+    private final Map<String, Content.Type> names = new HashMap<>();
+
+    @Override
+    public void register(String name, Class<? extends Content> type) {
+      if (name == null || name.trim().isEmpty() || !name.trim().equals(name) || type == null) {
+        throw new IllegalArgumentException(
+            String.format("Illegal content-type registration: name=%s, type=%s", name, type));
+      }
+      Content.Type contentType = new ContentTypeImpl(name, type);
+
+      JsonTypeName jsonTypeName = type.getAnnotation(JsonTypeName.class);
+      if (jsonTypeName == null) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Content-type registration: name=%s, type=%s has no @JsonTypeName annotation",
+                name, type));
+      }
+      if (!name.equals(jsonTypeName.value())) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Content-type registration: name=%s, type=%s, value of @JsonTypeName %s must be %s",
+                name, type, jsonTypeName.value(), name));
+      }
+
+      Content.Type ex = names.get(name);
+      if (ex != null) {
+        throw new IllegalStateException(
+            String.format(
+                "Duplicate content type registration for %s/%s, existing: %s/%s",
+                name, type, ex.name(), ex.type()));
+      }
+
+      add(contentType);
+    }
+
+    void add(Content.Type unknownContentType) {
+      list.add(unknownContentType);
+      names.put(unknownContentType.name(), unknownContentType);
+    }
+  }
+
   /**
    * Internal class providing the actual registry. This is a separate class to implicitly use lazy
    * initialization.
@@ -61,40 +106,18 @@ public final class ContentTypes {
     private static final Map<String, Content.Type> byName;
 
     static {
-      List<Content.Type> list = new ArrayList<>();
-      Map<String, Content.Type> names = new HashMap<>();
+      RegistryHelper registryHelper = new RegistryHelper();
 
       // Add the "DEFAULT" type.
       Content.Type unknownContentType = new DefaultContentTypeImpl();
-      list.add(unknownContentType);
-      names.put(unknownContentType.name(), unknownContentType);
+      registryHelper.add(unknownContentType);
 
       for (ContentTypeBundle bundle : ServiceLoader.load(ContentTypeBundle.class)) {
-        bundle.register(
-            (name, type) -> {
-              if (name == null
-                  || name.trim().isEmpty()
-                  || !name.trim().equals(name)
-                  || type == null) {
-                throw new IllegalArgumentException(
-                    String.format(
-                        "Illegal content-type registration: name=%s, type=%s", name, type));
-              }
-              Content.Type contentType = new ContentTypeImpl(name, type);
-              Content.Type ex = names.get(name);
-              if (ex != null) {
-                throw new IllegalStateException(
-                    String.format(
-                        "Duplicate content type registration for %s/%s, existing: %s/%s",
-                        name, type, ex.name(), ex.type()));
-              }
-              list.add(contentType);
-              names.put(name, contentType);
-            });
+        bundle.register(registryHelper);
       }
 
-      byName = Collections.unmodifiableMap(names);
-      all = list.toArray(new Content.Type[0]);
+      byName = Collections.unmodifiableMap(registryHelper.names);
+      all = registryHelper.list.toArray(new Content.Type[0]);
     }
 
     private static Content.Type[] all() {
@@ -160,11 +183,6 @@ public final class ContentTypes {
     @Override
     public int hashCode() {
       return 0;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      return obj == this;
     }
 
     @Override

--- a/api/model/src/main/java/org/projectnessie/model/types/ContentTypes.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/ContentTypes.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.model.types;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,7 +53,7 @@ public final class ContentTypes {
 
     @Override
     public void register(Class<? extends Content> type) {
-      Objects.requireNonNull(type, "Illegal content-type registration: type must not be null");
+      requireNonNull(type, "Illegal content-type registration: type must not be null");
 
       JsonTypeName jsonTypeName = type.getAnnotation(JsonTypeName.class);
       if (jsonTypeName == null) {

--- a/api/model/src/main/java/org/projectnessie/model/types/MainContentTypeBundle.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/MainContentTypeBundle.java
@@ -19,7 +19,6 @@ import org.projectnessie.model.DeltaLakeTable;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.IcebergView;
 import org.projectnessie.model.Namespace;
-import org.projectnessie.model.types.ContentTypes.Registrar;
 
 /**
  * Provides the {@link org.projectnessie.model.Content.Type content types} for Iceberg table + view,
@@ -28,10 +27,10 @@ import org.projectnessie.model.types.ContentTypes.Registrar;
 public final class MainContentTypeBundle implements ContentTypeBundle {
 
   @Override
-  public void register(Registrar registrar) {
-    registrar.register("ICEBERG_TABLE", IcebergTable.class);
-    registrar.register("DELTA_LAKE_TABLE", DeltaLakeTable.class);
-    registrar.register("ICEBERG_VIEW", IcebergView.class);
-    registrar.register("NAMESPACE", Namespace.class);
+  public void register(ContentTypeRegistry contentTypeRegistry) {
+    contentTypeRegistry.register(IcebergTable.class);
+    contentTypeRegistry.register(DeltaLakeTable.class);
+    contentTypeRegistry.register(IcebergView.class);
+    contentTypeRegistry.register(Namespace.class);
   }
 }

--- a/api/model/src/test/java/org/projectnessie/model/types/CustomTestContent.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/CustomTestContent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+import org.projectnessie.model.Content;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableCustomTestContent.class)
+@JsonDeserialize(as = ImmutableCustomTestContent.class)
+@JsonTypeName(CustomTestContent.TYPE)
+public abstract class CustomTestContent extends Content {
+  static final String TYPE = "TEST_CUSTOM_CONTENT_TYPE";
+
+  public abstract long getSomeLong();
+
+  public abstract String getSomeString();
+
+  @Override
+  public Type getType() {
+    return ContentTypes.forName(TYPE);
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/CustomTestContentTypeBundle.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/CustomTestContentTypeBundle.java
@@ -15,12 +15,10 @@
  */
 package org.projectnessie.model.types;
 
-import org.projectnessie.model.types.ContentTypes.Registrar;
-
 public class CustomTestContentTypeBundle implements ContentTypeBundle {
 
   @Override
-  public void register(Registrar registrar) {
-    registrar.register("TEST_CUSTOM_CONTENT_TYPE", CustomTestContent.class);
+  public void register(ContentTypeRegistry contentTypeRegistry) {
+    contentTypeRegistry.register(CustomTestContent.class);
   }
 }

--- a/api/model/src/test/java/org/projectnessie/model/types/CustomTestContentTypeBundle.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/CustomTestContentTypeBundle.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import org.projectnessie.model.types.ContentTypes.Registrar;
+
+public class CustomTestContentTypeBundle implements ContentTypeBundle {
+
+  @Override
+  public void register(Registrar registrar) {
+    registrar.register("TEST_CUSTOM_CONTENT_TYPE", CustomTestContent.class);
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/TestCustomContentType.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestCustomContentType.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import static org.projectnessie.model.CommitMeta.fromMessage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ImmutableOperations;
+import org.projectnessie.model.Operation;
+import org.projectnessie.model.Operations;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestCustomContentType {
+  static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  void directSerialization() throws Exception {
+    CustomTestContent testContent =
+        ImmutableCustomTestContent.builder().someLong(42L).someString("blah").build();
+
+    String json = MAPPER.writeValueAsString(testContent);
+
+    Content deserializedAsContent = MAPPER.readValue(json, Content.class);
+    CustomTestContent deserializedAsTestContent = MAPPER.readValue(json, CustomTestContent.class);
+
+    soft.assertThat(deserializedAsContent).isEqualTo(testContent);
+    soft.assertThat(deserializedAsTestContent).isEqualTo(testContent);
+  }
+
+  @Test
+  void customContentInOperation() throws Exception {
+    CustomTestContent testContent =
+        ImmutableCustomTestContent.builder().someLong(42L).someString("blah").build();
+
+    Operations operations =
+        ImmutableOperations.builder()
+            .commitMeta(fromMessage("foo"))
+            .addOperations(Operation.Put.of(ContentKey.of("key"), testContent))
+            .build();
+
+    String json = MAPPER.writeValueAsString(operations);
+
+    Operations deserializedOperations = MAPPER.readValue(json, Operations.class);
+
+    soft.assertThat(deserializedOperations).isEqualTo(operations);
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/TestRegistryHelper.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestRegistryHelper.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.immutables.value.Value;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.types.ContentTypes.RegistryHelper;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestRegistryHelper {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  void badRegistrations() {
+    RegistryHelper registryHelper = new RegistryHelper();
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> registryHelper.register("BLAH", Content.class))
+        .withMessage(
+            "Content-type registration: name=BLAH, type=class org.projectnessie.model.Content has no @JsonTypeName annotation");
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> registryHelper.register("BLAH", RegistryHelperNoJsonTypeName.class))
+        .withMessage(
+            "Content-type registration: name=BLAH, type=class org.projectnessie.model.types.TestRegistryHelper$RegistryHelperNoJsonTypeName has no @JsonTypeName annotation");
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> registryHelper.register("BLAH", RegistryHelperNameMismatch.class))
+        .withMessage(
+            "Content-type registration: name=BLAH, type=class org.projectnessie.model.types.TestRegistryHelper$RegistryHelperNameMismatch, value of @JsonTypeName JSON_TYPE_NAME must be BLAH");
+
+    soft.assertThatCode(() -> registryHelper.register("DUPE", RegistryHelperGood.class))
+        .doesNotThrowAnyException();
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> registryHelper.register("DUPE", RegistryHelperDupe.class))
+        .withMessage(
+            "Duplicate content type registration for DUPE/class org.projectnessie.model.types.TestRegistryHelper$RegistryHelperDupe, existing: DUPE/class org.projectnessie.model.types.TestRegistryHelper$RegistryHelperGood");
+  }
+
+  @Test
+  void getUnknown() {
+    soft.assertThatNullPointerException()
+        .isThrownBy(() -> ContentTypes.forName("NO_NO_NOT_THERE"))
+        .withMessage("No content type registered for name NO_NO_NOT_THERE");
+  }
+
+  @Value.Immutable
+  public abstract static class RegistryHelperNoJsonTypeName extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName("JSON_TYPE_NAME");
+    }
+  }
+
+  @Value.Immutable
+  @JsonTypeName("JSON_TYPE_NAME")
+  public abstract static class RegistryHelperNameMismatch extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName("JSON_TYPE_NAME");
+    }
+  }
+
+  @Value.Immutable
+  @JsonTypeName("DUPE")
+  public abstract static class RegistryHelperGood extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName("DUPE");
+    }
+  }
+
+  @Value.Immutable
+  @JsonTypeName("DUPE")
+  public abstract static class RegistryHelperDupe extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName("DUPE");
+    }
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/TestRegistryHelper.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestRegistryHelper.java
@@ -34,26 +34,26 @@ public class TestRegistryHelper {
     RegistryHelper registryHelper = new RegistryHelper();
 
     soft.assertThatIllegalArgumentException()
-        .isThrownBy(() -> registryHelper.register("BLAH", Content.class))
+        .isThrownBy(() -> registryHelper.register(Content.class))
         .withMessage(
-            "Content-type registration: name=BLAH, type=class org.projectnessie.model.Content has no @JsonTypeName annotation");
+            "Content-type registration: org.projectnessie.model.Content has no @JsonTypeName annotation");
 
     soft.assertThatIllegalArgumentException()
-        .isThrownBy(() -> registryHelper.register("BLAH", RegistryHelperNoJsonTypeName.class))
+        .isThrownBy(() -> registryHelper.register(RegistryHelperNoJsonTypeName.class))
         .withMessage(
-            "Content-type registration: name=BLAH, type=class org.projectnessie.model.types.TestRegistryHelper$RegistryHelperNoJsonTypeName has no @JsonTypeName annotation");
+            "Content-type registration: org.projectnessie.model.types.TestRegistryHelper$RegistryHelperNoJsonTypeName has no @JsonTypeName annotation");
 
     soft.assertThatIllegalArgumentException()
-        .isThrownBy(() -> registryHelper.register("BLAH", RegistryHelperNameMismatch.class))
+        .isThrownBy(() -> registryHelper.register(RegistryHelperIllegalName.class))
         .withMessage(
-            "Content-type registration: name=BLAH, type=class org.projectnessie.model.types.TestRegistryHelper$RegistryHelperNameMismatch, value of @JsonTypeName JSON_TYPE_NAME must be BLAH");
+            "Illegal content-type registration: illegal name ' ILLEGAL ' for org.projectnessie.model.types.TestRegistryHelper$RegistryHelperIllegalName");
 
-    soft.assertThatCode(() -> registryHelper.register("DUPE", RegistryHelperGood.class))
+    soft.assertThatCode(() -> registryHelper.register(RegistryHelperGood.class))
         .doesNotThrowAnyException();
     soft.assertThatIllegalStateException()
-        .isThrownBy(() -> registryHelper.register("DUPE", RegistryHelperDupe.class))
+        .isThrownBy(() -> registryHelper.register(RegistryHelperDupe.class))
         .withMessage(
-            "Duplicate content type registration for DUPE/class org.projectnessie.model.types.TestRegistryHelper$RegistryHelperDupe, existing: DUPE/class org.projectnessie.model.types.TestRegistryHelper$RegistryHelperGood");
+            "Duplicate content type registration for DUPE/org.projectnessie.model.types.TestRegistryHelper$RegistryHelperDupe, existing: DUPE/org.projectnessie.model.types.TestRegistryHelper$RegistryHelperGood");
   }
 
   @Test
@@ -68,6 +68,15 @@ public class TestRegistryHelper {
     @Override
     public Type getType() {
       return ContentTypes.forName("JSON_TYPE_NAME");
+    }
+  }
+
+  @Value.Immutable
+  @JsonTypeName(" ILLEGAL ")
+  public abstract static class RegistryHelperIllegalName extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName(" ILLEGAL ");
     }
   }
 

--- a/api/model/src/test/java/org/projectnessie/model/types/TestRegistryHelper.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestRegistryHelper.java
@@ -58,7 +58,7 @@ public class TestRegistryHelper {
 
   @Test
   void getUnknown() {
-    soft.assertThatNullPointerException()
+    soft.assertThatIllegalArgumentException()
         .isThrownBy(() -> ContentTypes.forName("NO_NO_NOT_THERE"))
         .withMessage("No content type registered for name NO_NO_NOT_THERE");
   }

--- a/api/model/src/test/resources/META-INF/services/org.projectnessie.model.types.ContentTypeBundle
+++ b/api/model/src/test/resources/META-INF/services/org.projectnessie.model.types.ContentTypeBundle
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.model.types.CustomTestContentTypeBundle

--- a/servers/store/src/main/java/org/projectnessie/server/store/MainSerializerBundle.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/MainSerializerBundle.java
@@ -15,19 +15,18 @@
  */
 package org.projectnessie.server.store;
 
-import java.util.function.Consumer;
-import org.projectnessie.versioned.store.ContentSerializer;
 import org.projectnessie.versioned.store.ContentSerializerBundle;
+import org.projectnessie.versioned.store.ContentSerializerRegistry;
 
 /** Serializer bundle for Iceberg tables+views, Delta Lake tables + namespaces. */
 public class MainSerializerBundle implements ContentSerializerBundle {
 
   @Override
-  public void register(Consumer<ContentSerializer<?>> registry) {
-    registry.accept(new UnknownSerializer());
-    registry.accept(new IcebergTableSerializer());
-    registry.accept(new DeltaLakeTableSerializer());
-    registry.accept(new IcebergViewSerializer());
-    registry.accept(new NamespaceSerializer());
+  public void register(ContentSerializerRegistry registry) {
+    registry.register(new UnknownSerializer());
+    registry.register(new IcebergTableSerializer());
+    registry.register(new DeltaLakeTableSerializer());
+    registry.register(new IcebergViewSerializer());
+    registry.register(new NamespaceSerializer());
   }
 }

--- a/site/docs/develop/_config
+++ b/site/docs/develop/_config
@@ -6,3 +6,4 @@ arrange:
   - rest.md
   - python.md
   - java.md
+  - content-types.md

--- a/site/docs/develop/content-types.md
+++ b/site/docs/develop/content-types.md
@@ -1,0 +1,67 @@
+# Nessie content types
+
+Nessie comes with built-in content types. Every content-type relates to a corresponding
+content-type ID (Java enum like string), a payload ID and an implementation of the
+`org.projectnessie.model.Content` interface.
+
+Nessie clients and servers need to know about the used content types via instances of
+`org.projectnessie.model.types.ContentTypeBundle`. Instances of this interface are loaded via
+the standard Java services mechanism.
+
+Nessie servers, and tools that directly access the Nessie repository, need the `ContentTypeBundle`
+and instances of `org.projectnessie.versioned.store.ContentSerializerBundle`, also provided via
+the Java services mechanism, that provide serialization code via instances of
+`org.projectnessie.versioned.store.ContentSerializer`.
+
+## Known and assigned content types
+
+| Payload ID | Content Type       | Model class                              | Description                                      | Implementor    |
+|------------|--------------------|------------------------------------------|--------------------------------------------------|----------------|
+| 0          | n/a                | n/a                                      | Legacy fallback value if the payload is unknown. | n/a            |
+| 1          | `ICEBERG_TABLE`    | `org.projectnessie.model.IcebergTable`   | Iceberg tables.                                  | Project Nessie |
+| 2          | `DELTA_LAKE_TABLE` | `org.projectnessie.model.DeltaLakeTable` | Delta Lake tables.                               | Project Nessie |
+| 3          | `ICEBERG_VIEW`     | `org.projectnessie.model.IcebergView`    | Iceberg views.                                   | Project Nessie |
+| 4          | `NAMESPACE`        | `org.projectnessie.model.Namespace`      | Namespaces.                                      | Project Nessie |
+
+Since the ID values for payloads and the namespace for content types must be globally unique,
+please register your Payload ID and Content Type via an
+[issue](https://github.com/projectnessie/nessie/issues/new/choose).
+
+## Implementing your own content types
+
+TBD
+
+### Content type bundle
+
+`ContentTypeBundle`s make content types available to Nessie clients and servers.
+
+Needs a resource file `META-INF/services/org.projectnessie.model.types.ContentTypeBundle`,
+which contains the class name(s) that implement the
+`org.projectnessie.model.types.ContentTypeBundle` interface.
+
+The `ContentTypeBundle.register(ContentTypes.Registrar registrar)` implementation
+must call the given `Registrar` with name of each content type and the model interface type that
+extends `org.projectnessie.model.Content`.
+
+### Serializer bundle
+
+`ContentSerializer`s provide (de)serialization functionality using a space efficient binary
+representation for Nessie servers.
+
+Needs a resource file `META-INF/services/org.projectnessie.versioned.store.ContentSerializerBundle`,
+which contains the class name(s) that implement the
+`org.projectnessie.versioned.store.ContentSerializerBundle` interface.
+
+The `ContentSerializerBundle.register(Consumer<ContentSerializer<?>> registry)` implementation
+must call the given `Consumer` with the `ContentSerializer` implementation for each content type.
+
+### Distributing content type and serializer bundles
+
+TBD
+
+* One jar for Nessie clients
+* One jar for Nessie servers/tools
+
+Open questions:
+
+* Dependencies??

--- a/site/docs/develop/content-types.md
+++ b/site/docs/develop/content-types.md
@@ -39,7 +39,7 @@ Needs a resource file `META-INF/services/org.projectnessie.model.types.ContentTy
 which contains the class name(s) that implement the
 `org.projectnessie.model.types.ContentTypeBundle` interface.
 
-The `ContentTypeBundle.register(ContentTypes.Registrar registrar)` implementation
+The `ContentTypeBundle.register(ContentTypeRegistry contentTypeRegistry)` implementation
 must call the given `Registrar` with name of each content type and the model interface type that
 extends `org.projectnessie.model.Content`.
 
@@ -52,8 +52,9 @@ Needs a resource file `META-INF/services/org.projectnessie.versioned.store.Conte
 which contains the class name(s) that implement the
 `org.projectnessie.versioned.store.ContentSerializerBundle` interface.
 
-The `ContentSerializerBundle.register(Consumer<ContentSerializer<?>> registry)` implementation
-must call the given `Consumer` with the `ContentSerializer` implementation for each content type.
+The `ContentSerializerBundle.register(ContentSerializerRegistry registry)` implementation
+must call the given `ContentTypeRegistry` with the `ContentSerializer` implementation for each
+content type serializer.
 
 ### Distributing content type and serializer bundles
 

--- a/versioned/spi/build.gradle.kts
+++ b/versioned/spi/build.gradle.kts
@@ -51,6 +51,14 @@ dependencies {
   testCompileOnly(libs.jackson.annotations)
 
   testCompileOnly(libs.microprofile.openapi)
+  testCompileOnly(libs.immutables.value.annotations)
+  testAnnotationProcessor(libs.immutables.value.processor)
+  testCompileOnly(libs.jakarta.ws.rs.api)
+  testCompileOnly(libs.javax.ws.rs)
+  testCompileOnly(libs.jakarta.validation.api)
+  testCompileOnly(libs.javax.validation.api)
+  testCompileOnly(libs.jakarta.annotation.api)
+  testCompileOnly(libs.findbugs.jsr305)
 
   // Need a few things from Quarkus, but don't leak the dependencies
   compileOnly(libs.opentracing.api)

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializer.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializer.java
@@ -23,8 +23,17 @@ import org.projectnessie.nessie.relocated.protobuf.ByteString;
  * content type.
  */
 public interface ContentSerializer<C extends Content> {
+
+  /**
+   * Content type names are assigned via the projectnessie project, see the <a
+   * href="https://projectnessie.org/develop/content-types">project website</a>.
+   */
   Content.Type contentType();
 
+  /**
+   * Payload IDs are assigned via the projectnessie project, see the <a
+   * href="https://projectnessie.org/develop/content-types">project website</a>.
+   */
   int payload();
 
   ByteString toStoreOnReferenceState(C content);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializerBundle.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializerBundle.java
@@ -15,9 +15,12 @@
  */
 package org.projectnessie.versioned.store;
 
-import java.util.function.Consumer;
-
-/** Implementations of this {@link java.util.ServiceLoader service} register content serializers. */
+/**
+ * Custom content serializers need to implement this interface and call {@link
+ * ContentSerializerRegistry#register(ContentSerializer)} for each serializer.
+ *
+ * <p>Instances of this class are loaded via Java's {@link java.util.ServiceLoader}.
+ */
 public interface ContentSerializerBundle {
-  void register(Consumer<ContentSerializer<?>> registry);
+  void register(ContentSerializerRegistry registry);
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializerRegistry.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/store/ContentSerializerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.model.types;
+package org.projectnessie.versioned.store;
 
-/**
- * Used to provide custom {@link org.projectnessie.model.Content} implementations via the Java
- * {@link java.util.ServiceLoader service loader} mechanism.
- */
-public interface ContentTypeBundle {
-  void register(ContentTypeRegistry contentTypeRegistry);
+import org.projectnessie.model.Content;
+
+public interface ContentSerializerRegistry {
+  void register(ContentSerializer<? extends Content> serializer);
 }

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContent.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.store.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.types.ContentTypes;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableCustomTestContent.class)
+@JsonDeserialize(as = ImmutableCustomTestContent.class)
+@JsonTypeName(CustomTestContent.TYPE)
+public abstract class CustomTestContent extends Content {
+  static final String TYPE = "TEST_CUSTOM_CONTENT_TYPE";
+
+  public abstract long getSomeLong();
+
+  public abstract String getSomeString();
+
+  @Override
+  public Type getType() {
+    return ContentTypes.forName(TYPE);
+  }
+}

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentSerializer.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentSerializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.store.types;
+
+import org.projectnessie.model.Content;
+import org.projectnessie.model.types.ContentTypes;
+import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.store.ContentSerializer;
+
+public class CustomTestContentSerializer implements ContentSerializer<CustomTestContent> {
+
+  static final int PAYLOAD = 42;
+
+  @Override
+  public Content.Type contentType() {
+    return ContentTypes.forName(CustomTestContent.TYPE);
+  }
+
+  @Override
+  public int payload() {
+    return PAYLOAD;
+  }
+
+  @Override
+  public ByteString toStoreOnReferenceState(CustomTestContent content) {
+    String id = content.getId();
+    return ByteString.copyFromUtf8(
+        content.getSomeString() + '|' + content.getSomeLong() + '|' + (id != null ? id : ""));
+  }
+
+  @Override
+  public CustomTestContent applyId(CustomTestContent content, String id) {
+    return ((ImmutableCustomTestContent) content).withId(id);
+  }
+
+  @Override
+  public CustomTestContent valueFromStore(ByteString onReferenceValue) {
+    String[] arr = onReferenceValue.toStringUtf8().split("\\|");
+    ImmutableCustomTestContent.Builder b =
+        ImmutableCustomTestContent.builder().someString(arr[0]).someLong(Long.parseLong(arr[1]));
+    if (arr.length >= 3 && !arr[2].isEmpty()) {
+      b.id(arr[2]);
+    }
+    return b.build();
+  }
+}

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentSerializerBundle.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentSerializerBundle.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.store.types;
+
+import java.util.function.Consumer;
+import org.projectnessie.versioned.store.ContentSerializer;
+import org.projectnessie.versioned.store.ContentSerializerBundle;
+
+public class CustomTestContentSerializerBundle implements ContentSerializerBundle {
+  @Override
+  public void register(Consumer<ContentSerializer<?>> registry) {
+    registry.accept(new CustomTestContentSerializer());
+  }
+}

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentSerializerBundle.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentSerializerBundle.java
@@ -15,13 +15,12 @@
  */
 package org.projectnessie.versioned.store.types;
 
-import java.util.function.Consumer;
-import org.projectnessie.versioned.store.ContentSerializer;
 import org.projectnessie.versioned.store.ContentSerializerBundle;
+import org.projectnessie.versioned.store.ContentSerializerRegistry;
 
 public class CustomTestContentSerializerBundle implements ContentSerializerBundle {
   @Override
-  public void register(Consumer<ContentSerializer<?>> registry) {
-    registry.accept(new CustomTestContentSerializer());
+  public void register(ContentSerializerRegistry registry) {
+    registry.register(new CustomTestContentSerializer());
   }
 }

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentTypeBundle.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentTypeBundle.java
@@ -16,12 +16,12 @@
 package org.projectnessie.versioned.store.types;
 
 import org.projectnessie.model.types.ContentTypeBundle;
-import org.projectnessie.model.types.ContentTypes.Registrar;
+import org.projectnessie.model.types.ContentTypeRegistry;
 
 public class CustomTestContentTypeBundle implements ContentTypeBundle {
 
   @Override
-  public void register(Registrar registrar) {
-    registrar.register("TEST_CUSTOM_CONTENT_TYPE", CustomTestContent.class);
+  public void register(ContentTypeRegistry contentTypeRegistry) {
+    contentTypeRegistry.register(CustomTestContent.class);
   }
 }

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentTypeBundle.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/CustomTestContentTypeBundle.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.store.types;
+
+import org.projectnessie.model.types.ContentTypeBundle;
+import org.projectnessie.model.types.ContentTypes.Registrar;
+
+public class CustomTestContentTypeBundle implements ContentTypeBundle {
+
+  @Override
+  public void register(Registrar registrar) {
+    registrar.register("TEST_CUSTOM_CONTENT_TYPE", CustomTestContent.class);
+  }
+}

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/TestCustomContentSerialization.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/store/types/TestCustomContentSerialization.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.store.types;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.Content;
+import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.store.DefaultStoreWorker;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestCustomContentSerialization {
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  void reSerialize() {
+    CustomTestContent testContent =
+        ImmutableCustomTestContent.builder().someLong(42L).someString("blah").build();
+
+    ByteString serialized = DefaultStoreWorker.instance().toStoreOnReferenceState(testContent);
+    soft.assertThat(serialized)
+        .asInstanceOf(type(ByteString.class))
+        .extracting(ByteString::toStringUtf8)
+        .isEqualTo("blah|42|");
+
+    Content deserialized =
+        DefaultStoreWorker.instance()
+            .valueFromStore(CustomTestContentSerializer.PAYLOAD, serialized);
+    soft.assertThat(deserialized).isEqualTo(testContent);
+  }
+
+  @Test
+  void reSerializeWithId() {
+    String id = randomUUID().toString();
+    CustomTestContent testContent =
+        ImmutableCustomTestContent.builder().someLong(42L).someString("blah").id(id).build();
+
+    ByteString serialized = DefaultStoreWorker.instance().toStoreOnReferenceState(testContent);
+    soft.assertThat(serialized)
+        .asInstanceOf(type(ByteString.class))
+        .extracting(ByteString::toStringUtf8)
+        .isEqualTo("blah|42|" + id);
+
+    Content deserialized =
+        DefaultStoreWorker.instance()
+            .valueFromStore(CustomTestContentSerializer.PAYLOAD, serialized);
+    soft.assertThat(deserialized).isEqualTo(testContent);
+  }
+
+  @Test
+  void applyId() {
+    String updatedId = randomUUID().toString();
+
+    CustomTestContent testContent =
+        ImmutableCustomTestContent.builder().someLong(42L).someString("blah").build();
+
+    Content otherId = DefaultStoreWorker.instance().applyId(testContent, updatedId);
+
+    soft.assertThat(otherId).isNotEqualTo(testContent);
+    soft.assertThat(otherId.getId()).isEqualTo(updatedId);
+  }
+
+  @Test
+  void changeId() {
+    String initialId = randomUUID().toString();
+    String updatedId = randomUUID().toString();
+
+    CustomTestContent testContent =
+        ImmutableCustomTestContent.builder().someLong(42L).someString("blah").id(initialId).build();
+
+    Content otherId = DefaultStoreWorker.instance().applyId(testContent, updatedId);
+
+    soft.assertThat(otherId).isNotEqualTo(testContent);
+    soft.assertThat(otherId.getId()).isEqualTo(updatedId);
+  }
+}

--- a/versioned/spi/src/test/resources/META-INF/services/org.projectnessie.model.types.ContentTypeBundle
+++ b/versioned/spi/src/test/resources/META-INF/services/org.projectnessie.model.types.ContentTypeBundle
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.versioned.store.types.CustomTestContentTypeBundle

--- a/versioned/spi/src/test/resources/META-INF/services/org.projectnessie.versioned.store.ContentSerializerBundle
+++ b/versioned/spi/src/test/resources/META-INF/services/org.projectnessie.versioned.store.ContentSerializerBundle
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2022 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.versioned.store.types.CustomTestContentSerializerBundle

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/OnRefOnly.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/OnRefOnly.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.testworker;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.immutables.value.Value;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.types.ContentTypes;
@@ -22,6 +23,7 @@ import org.projectnessie.nessie.relocated.protobuf.ByteString;
 
 /** Content with on-reference state only. */
 @Value.Immutable
+@JsonTypeName("ON_REF_ONLY")
 public abstract class OnRefOnly extends Content {
 
   public static final Content.Type ON_REF_ONLY = ContentTypes.forName("ON_REF_ONLY");

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentSerializerBundle.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentSerializerBundle.java
@@ -15,14 +15,13 @@
  */
 package org.projectnessie.versioned.testworker;
 
-import java.util.function.Consumer;
-import org.projectnessie.versioned.store.ContentSerializer;
 import org.projectnessie.versioned.store.ContentSerializerBundle;
+import org.projectnessie.versioned.store.ContentSerializerRegistry;
 
 public class TestContentSerializerBundle implements ContentSerializerBundle {
 
   @Override
-  public void register(Consumer<ContentSerializer<?>> registry) {
-    registry.accept(new OnRefOnlySerializer());
+  public void register(ContentSerializerRegistry registry) {
+    registry.register(new OnRefOnlySerializer());
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentTypeBundle.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/testworker/TestContentTypeBundle.java
@@ -16,12 +16,12 @@
 package org.projectnessie.versioned.testworker;
 
 import org.projectnessie.model.types.ContentTypeBundle;
-import org.projectnessie.model.types.ContentTypes.Registrar;
+import org.projectnessie.model.types.ContentTypeRegistry;
 
 public final class TestContentTypeBundle implements ContentTypeBundle {
 
   @Override
-  public void register(Registrar registrar) {
-    registrar.register("ON_REF_ONLY", OnRefOnly.class);
+  public void register(ContentTypeRegistry contentTypeRegistry) {
+    contentTypeRegistry.register(OnRefOnly.class);
   }
 }


### PR DESCRIPTION
* Add some more valdiations when registering content-type-bundles.
* Add a page on the project web site for registered content-types.
* Add tests in `:nessie-model` + `:nessie-versioned-spi` to verify that
  custom content-type-bundles and custom content-serializer-bundles
  work.

Fixes #6591