### PR TITLE
Adjust testNotFoundUrls parameters

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRest.java
@@ -145,13 +145,7 @@ public abstract class BaseTestNessieRest extends BaseTestNessieApi {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "trees/not-there-using",
-        "contents/not-there-using",
-        "something/not-there-using",
-        ""
-      })
+  @ValueSource(strings = {"something/not-there", ""})
   public void testNotFoundUrls(String path) {
     rest().get(path).then().statusCode(404);
     rest().head(path).then().statusCode(404);


### PR DESCRIPTION
This is a follow-up to #6584

Use only truly unmapped paths for this test.

`contents/not-there-using` URLs are mapped in API v1 as requests for the key `not-there-using`.

`trees/not-there-using` URLs are mapped in API v2 as requests for the reference named `not-there-using`.

Even though the above two case do produce 404 response, they do not validate the code changed in `NessieExceptionMapper` for #6569.

Also the contents request lacks some required parameters (ref name).