### PR TITLE
Null out references to java.net.http.HttpClient

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClient.java
@@ -35,7 +35,7 @@ import org.projectnessie.client.http.impl.HttpRuntimeConfig;
 @SuppressWarnings("Since15") // IntelliJ warns about new APIs. 15 is misleading, it means 11
 public final class JavaHttpClient implements org.projectnessie.client.http.HttpClient {
   final HttpRuntimeConfig config;
-  final HttpClient client;
+  HttpClient client;
 
   public JavaHttpClient(HttpRuntimeConfig config) {
     this.config = config;
@@ -75,6 +75,7 @@ public final class JavaHttpClient implements org.projectnessie.client.http.HttpC
 
   @Override
   public void close() {
+    client = null;
     config.close();
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClient.java
@@ -35,7 +35,7 @@ import org.projectnessie.client.http.impl.HttpRuntimeConfig;
 @SuppressWarnings("Since15") // IntelliJ warns about new APIs. 15 is misleading, it means 11
 public final class JavaHttpClient implements org.projectnessie.client.http.HttpClient {
   final HttpRuntimeConfig config;
-  HttpClient client;
+  private HttpClient client;
 
   public JavaHttpClient(HttpRuntimeConfig config) {
     this.config = config;
@@ -65,7 +65,7 @@ public final class JavaHttpClient implements org.projectnessie.client.http.HttpC
 
   @Override
   public HttpRequest newRequest() {
-    return new JavaRequest(this);
+    return new JavaRequest(this.config, (req, handler) -> client.send(req, handler));
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
@@ -55,7 +55,7 @@ final class JavaRequest extends BaseHttpRequest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JavaRequest.class);
 
-  private final HttpClient client;
+  private HttpClient client;
 
   JavaRequest(JavaHttpClient client) {
     super(client.config);
@@ -131,6 +131,7 @@ final class JavaRequest extends BaseHttpRequest {
       response = null;
       return config.responseFactory().make(responseContext, config.getMapper());
     } finally {
+      client = null;
       if (response != null) {
         try {
           LOGGER.debug(

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
@@ -62,6 +62,10 @@ final class JavaRequest extends BaseHttpRequest {
   interface HttpExchange<T> {
 
     /**
+     * Sends the given request using the underlying client, blocking if necessary to get the
+     * response. The returned {@link HttpResponse}{@code <T>} contains the response status, headers,
+     * and body (as handled by given response body handler).
+     *
      * @see HttpClient#send(HttpRequest, HttpResponse.BodyHandler)
      */
     HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
@@ -45,6 +45,7 @@ import org.projectnessie.client.http.RequestContext;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.impl.BaseHttpRequest;
 import org.projectnessie.client.http.impl.HttpHeaders.HttpHeader;
+import org.projectnessie.client.http.impl.HttpRuntimeConfig;
 import org.projectnessie.client.http.impl.RequestContextImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,13 +54,27 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("Since15") // IntelliJ warns about new APIs. 15 is misleading, it means 11
 final class JavaRequest extends BaseHttpRequest {
 
+  /**
+   * A functional interface that is used to send an {@link HttpRequest} and return an {@link
+   * HttpResponse} without leaking the {@link HttpClient} instance.
+   */
+  @FunctionalInterface
+  interface HttpExchange<T> {
+
+    /**
+     * @see HttpClient#send(HttpRequest, HttpResponse.BodyHandler)
+     */
+    HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+        throws IOException, InterruptedException;
+  }
+
   private static final Logger LOGGER = LoggerFactory.getLogger(JavaRequest.class);
 
-  private HttpClient client;
+  private final HttpExchange<InputStream> exchange;
 
-  JavaRequest(JavaHttpClient client) {
-    super(client.config);
-    this.client = client.client;
+  JavaRequest(HttpRuntimeConfig config, HttpExchange<InputStream> exchange) {
+    super(config);
+    this.exchange = exchange;
   }
 
   @Override
@@ -88,7 +103,7 @@ final class JavaRequest extends BaseHttpRequest {
     try {
       try {
         LOGGER.debug("Sending {} request to {} ...", method, uri);
-        response = client.send(request.build(), BodyHandlers.ofInputStream());
+        response = exchange.send(request.build(), BodyHandlers.ofInputStream());
       } catch (HttpConnectTimeoutException e) {
         throw new HttpClientException(
             String.format(
@@ -131,7 +146,6 @@ final class JavaRequest extends BaseHttpRequest {
       response = null;
       return config.responseFactory().make(responseContext, config.getMapper());
     } finally {
-      client = null;
       if (response != null) {
         try {
           LOGGER.debug(

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusSmoke.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusSmoke.java
@@ -100,6 +100,7 @@ public abstract class AbstractQuarkusSmoke {
                 }
               });
       api().close();
+      api = null;
     }
   }
 


### PR DESCRIPTION
HttpClient maintains a thread pool and a single
selector thread. These resources cannot be freed
if a strong reference to the HttpClient instance
exists.