### PR TITLE
Expose Nessie repository information (preparation)

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
+++ b/api/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
@@ -15,15 +15,27 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.Instant;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.validation.constraints.Size;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
+import org.projectnessie.model.CommitMeta.InstantDeserializer;
+import org.projectnessie.model.CommitMeta.InstantSerializer;
 import org.projectnessie.model.ser.Views;
 
 /** configuration object to tell a client how a server is configured. */
+@Schema(
+    type = SchemaType.OBJECT,
+    title = "NessieConfiguration",
+    description = "Configuration object to tell a client how a server is configured.")
 @Value.Immutable
 @JsonSerialize(as = ImmutableNessieConfiguration.class)
 @JsonDeserialize(as = ImmutableNessieConfiguration.class)
@@ -57,10 +69,56 @@ public abstract class NessieConfiguration {
    */
   public abstract int getMaxSupportedApiVersion();
 
+  /** Semver version representing the behavior of the Nessie server. */
   @JsonView(Views.V2.class)
   @Nullable
   @jakarta.annotation.Nullable
   public abstract String getSpecVersion();
+
+  /**
+   * The so called no-ancestor-hash defines the commit-ID of the "beginning of time" in the
+   * repository. The very first commit will have the value returned by this function as its parent
+   * commit-ID. A commit with this value does never exist.
+   */
+  @JsonView(Views.V2.class)
+  @JsonInclude(Include.NON_NULL)
+  @Nullable
+  @jakarta.annotation.Nullable
+  public abstract String getNoAncestorHash();
+
+  /**
+   * Timestamp when the repository has been created.
+   *
+   * <p>The value is only returned, if the server supports this attribute.
+   */
+  @JsonView(Views.V2.class)
+  @JsonInclude(Include.NON_NULL)
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonSerialize(using = InstantSerializer.class)
+  @JsonDeserialize(using = InstantDeserializer.class)
+  public abstract Instant getRepositoryCreationTimestamp();
+
+  /**
+   * Timestamp of the oldest possible commit in the repository.
+   *
+   * <p>For new repositories, this is likely the same as {@link #getRepositoryCreationTimestamp()}.
+   * For imported repositories, this shall be the timestamp of the oldest commit.
+   *
+   * <p>The value is only returned, if the server supports this attribute.
+   */
+  @JsonView(Views.V2.class)
+  @JsonInclude(Include.NON_NULL)
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonSerialize(using = InstantSerializer.class)
+  @JsonDeserialize(using = InstantDeserializer.class)
+  public abstract Instant getOldestPossibleCommitTimestamp();
+
+  /** Additional properties, currently undefined and always empty (not present in JSON). */
+  @JsonView(Views.V2.class)
+  @JsonInclude(Include.NON_EMPTY)
+  public abstract Map<String, String> getAdditionalProperties();
 
   public static NessieConfiguration getBuiltInConfig() {
     return NessieConfigurationHolder.NESSIE_API_SPEC;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
@@ -19,18 +19,19 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ConfigApiImpl;
+import org.projectnessie.versioned.VersionStore;
 
 @ApplicationScoped
 @jakarta.enterprise.context.ApplicationScoped
 public class RestConfigService extends ConfigApiImpl {
   // Mandated by CDI 2.0
   public RestConfigService() {
-    this(null);
+    this(null, null);
   }
 
   @Inject
   @jakarta.inject.Inject
-  public RestConfigService(ServerConfig config) {
-    super(config);
+  public RestConfigService(ServerConfig config, VersionStore store) {
+    super(config, store);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
@@ -23,6 +23,7 @@ import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.ser.Views;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ConfigApiImpl;
+import org.projectnessie.versioned.VersionStore;
 
 /** REST endpoint to retrieve server settings. */
 @RequestScoped
@@ -33,13 +34,13 @@ public class RestV2ConfigResource implements HttpConfigApi {
 
   // Mandated by CDI 2.0
   public RestV2ConfigResource() {
-    this(null);
+    this(null, null);
   }
 
   @Inject
   @jakarta.inject.Inject
-  public RestV2ConfigResource(ServerConfig config) {
-    this.config = new ConfigApiImpl(config);
+  public RestV2ConfigResource(ServerConfig config, VersionStore store) {
+    this.config = new ConfigApiImpl(config, store);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
@@ -19,12 +19,15 @@ import org.projectnessie.model.ImmutableNessieConfiguration;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.spi.ConfigService;
+import org.projectnessie.versioned.VersionStore;
 
 public class ConfigApiImpl implements ConfigService {
 
+  private final VersionStore store;
   private final ServerConfig config;
 
-  public ConfigApiImpl(ServerConfig config) {
+  public ConfigApiImpl(ServerConfig config, VersionStore store) {
+    this.store = store;
     this.config = config;
   }
 

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMisc.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMisc.java
@@ -30,8 +30,22 @@ import org.projectnessie.model.ImmutableNessieConfiguration;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Operation.Unchanged;
+import org.projectnessie.versioned.RepositoryInformation;
 
 public abstract class AbstractTestMisc extends BaseTestServiceImpl {
+
+  @Test
+  public void testRepositoryInformation() {
+    RepositoryInformation info = versionStore().getRepositoryInformation();
+    soft.assertThat(info).isNotNull();
+    soft.assertThat(info.getNoAncestorHash())
+        .isNotNull()
+        .isEqualTo(versionStore().noAncestorHash().asString());
+    if (versionStore().getClass().getName().endsWith("VersionStoreImpl")) {
+      soft.assertThat(info.getRepositoryCreationTimestamp()).isNotNull();
+      soft.assertThat(info.getOldestPossibleCommitTimestamp()).isNotNull();
+    }
+  }
 
   @Test
   public void testSupportedApiVersions() {

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
@@ -113,7 +113,7 @@ public abstract class BaseTestServiceImpl {
   private Principal principal;
 
   protected final ConfigApiImpl configApi() {
-    return new ConfigApiImpl(config());
+    return new ConfigApiImpl(config(), versionStore());
   }
 
   protected final TreeApiImpl treeApi() {

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -51,6 +51,7 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ImmutableCommit;
 import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.ImmutableRefLogDetails;
+import org.projectnessie.versioned.ImmutableRepositoryInformation;
 import org.projectnessie.versioned.KeyEntry;
 import org.projectnessie.versioned.MergeConflictException;
 import org.projectnessie.versioned.MergeResult;
@@ -66,6 +67,7 @@ import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.RepositoryInformation;
 import org.projectnessie.versioned.StoreWorker;
 import org.projectnessie.versioned.Unchanged;
 import org.projectnessie.versioned.VersionStore;
@@ -97,6 +99,15 @@ public class PersistVersionStore implements VersionStore {
 
   public PersistVersionStore(DatabaseAdapter databaseAdapter) {
     this.databaseAdapter = databaseAdapter;
+  }
+
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  @Override
+  public RepositoryInformation getRepositoryInformation() {
+    return ImmutableRepositoryInformation.builder()
+        .noAncestorHash(noAncestorHash().asString())
+        .build();
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
@@ -61,6 +62,13 @@ public final class MetricsVersionStore implements VersionStore {
 
   public MetricsVersionStore(VersionStore delegate) {
     this(delegate, Metrics.globalRegistry, Clock.SYSTEM);
+  }
+
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  @Override
+  public RepositoryInformation getRepositoryInformation() {
+    return delegate("repositoryInformation", delegate::getRepositoryInformation);
   }
 
   @Override
@@ -288,6 +296,14 @@ public final class MetricsVersionStore implements VersionStore {
     } catch (RuntimeException e) {
       measure(requestName, sample, e);
       throw e;
+    }
+  }
+
+  private <R> R delegate(String requestName, Supplier<R> delegate) {
+    try {
+      return delegate2ExR(requestName, delegate::get);
+    } catch (VersionStoreException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/RepositoryInformation.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/RepositoryInformation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned;
+
+import java.time.Instant;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * Informational object to tell a client about the Nessie repository.
+ *
+ * <p>All values are optional and may or may not be present, depending on the actual server version.
+ */
+@Value.Immutable
+public interface RepositoryInformation {
+  @Nullable
+  @jakarta.annotation.Nullable
+  String getDefaultBranch();
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  String getNoAncestorHash();
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  Instant getRepositoryCreationTimestamp();
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  Instant getOldestPossibleCommitTimestamp();
+
+  Map<String, String> getAdditionalProperties();
+}

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -37,6 +37,10 @@ import org.projectnessie.versioned.paging.PaginationIterator;
  */
 public interface VersionStore {
 
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  RepositoryInformation getRepositoryInformation();
+
   /**
    * Verifies that the given {@code namedReference} exists and that {@code hashOnReference}, if
    * present, is reachable via that reference.


### PR DESCRIPTION
Enhances the REST endpoint `v2/config` with repository specific information:
* repository creation timestamp (new storage model only)
* oldest possible commit timestamp (new storage model only)
* no-ancestor-hash value
* default branch name (currently hard-wired to the configuration value)

Prepares the API changes for #4993 and #5810.

Since this changes the existing model for v2-beta, the added fields will be populated in a follow-up-PR.