### PR TITLE
Enables the extended information in `NessieConfiguration`

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -213,6 +213,10 @@ public abstract class BaseTestNessieApi {
             NessieConfiguration::getDefaultBranch, NessieConfiguration::getMaxSupportedApiVersion)
         .containsExactly("main", 2);
 
+    if (isV2()) {
+      soft.assertThat(config.getNoAncestorHash()).isNotNull();
+    }
+
     soft.assertThat(api().getDefaultBranch())
         .extracting(Branch::getName, Branch::getHash)
         .containsExactly(config.getDefaultBranch(), EMPTY);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
@@ -19,6 +19,7 @@ import org.projectnessie.model.ImmutableNessieConfiguration;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.spi.ConfigService;
+import org.projectnessie.versioned.RepositoryInformation;
 import org.projectnessie.versioned.VersionStore;
 
 public class ConfigApiImpl implements ConfigService {
@@ -35,10 +36,19 @@ public class ConfigApiImpl implements ConfigService {
 
   @Override
   public NessieConfiguration getConfig() {
+    RepositoryInformation info = store.getRepositoryInformation();
+    String defaultBranch = info.getDefaultBranch();
+    if (defaultBranch == null) {
+      defaultBranch = this.config.getDefaultBranch();
+    }
     return ImmutableNessieConfiguration.builder()
         .from(NessieConfiguration.getBuiltInConfig())
         .defaultBranch(this.config.getDefaultBranch())
         .actualApiVersion(actualApiVersion)
+        .noAncestorHash(info.getNoAncestorHash())
+        .repositoryCreationTimestamp(info.getRepositoryCreationTimestamp())
+        .oldestPossibleCommitTimestamp(info.getOldestPossibleCommitTimestamp())
+        .additionalProperties(info.getAdditionalProperties())
         .build();
   }
 }

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMisc.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMisc.java
@@ -26,7 +26,6 @@ import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergTable;
-import org.projectnessie.model.ImmutableNessieConfiguration;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Operation.Unchanged;
@@ -50,13 +49,18 @@ public abstract class AbstractTestMisc extends BaseTestServiceImpl {
   @Test
   public void testSupportedApiVersions() {
     NessieConfiguration serverConfig = configApi().getConfig();
-    NessieConfiguration expectedConfig =
-        ImmutableNessieConfiguration.builder()
-            .from(NessieConfiguration.getBuiltInConfig())
-            .defaultBranch(serverConfig.getDefaultBranch())
-            .actualApiVersion(2)
-            .build();
-    assertThat(serverConfig).isEqualTo(expectedConfig);
+    NessieConfiguration builtInConfig = NessieConfiguration.getBuiltInConfig();
+    assertThat(serverConfig)
+        .extracting(
+            NessieConfiguration::getMinSupportedApiVersion,
+            NessieConfiguration::getMaxSupportedApiVersion,
+            NessieConfiguration::getSpecVersion,
+            NessieConfiguration::getActualApiVersion)
+        .containsExactly(
+            builtInConfig.getMinSupportedApiVersion(),
+            builtInConfig.getMaxSupportedApiVersion(),
+            builtInConfig.getSpecVersion(),
+            2);
   }
 
   @Test


### PR DESCRIPTION
Builds on the API changes from #6635

Fixes #4993
Fixes #5810
