### PR TITLE
Add more commit-attributes to `Merge`

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/MergeReferenceBuilder.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.api;
 import javax.validation.constraints.NotBlank;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.MergeResponse;
 import org.projectnessie.model.Reference;
 
@@ -31,13 +32,24 @@ public interface MergeReferenceBuilder extends MergeTransplantBuilder<MergeRefer
   /**
    * Sets a custom merge commit message. The message is auto-generated if not set.
    *
-   * <p>How the auto-generated message is constructed is not specified, but in general it will be
-   * based on the individual messages of the merged commits.
+   * <p>How the auto-generated message is constructed is not specified.
    *
    * @since {@link NessieApiV2}
+   * @see #commitMeta(CommitMeta)
    */
   @Override
   MergeReferenceBuilder message(String message);
+
+  /**
+   * Specify commit properties for the merge-commit, including the commit message, author(s), author
+   * timestamp, signed-off, properties.
+   *
+   * <p>If the given {@link CommitMeta} contains a non-empty message, the message specified via
+   * {@link #message(String)} will be ignored by the server.
+   *
+   * @since {@link NessieApiV2}
+   */
+  MergeReferenceBuilder commitMeta(CommitMeta commitMeta);
 
   MergeReferenceBuilder fromHash(
       @NotBlank @jakarta.validation.constraints.NotBlank String fromHash);

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.builder;
 import java.util.HashMap;
 import java.util.Map;
 import org.projectnessie.client.api.OnBranchBuilder;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.MergeBehavior;
 import org.projectnessie.model.MergeKeyBehavior;
@@ -33,10 +34,17 @@ public abstract class BaseMergeTransplantBuilder<B extends OnBranchBuilder<B>>
   protected MergeBehavior defaultMergeMode;
   protected Map<ContentKey, MergeKeyBehavior> mergeModes;
   protected String message;
+  protected CommitMeta commitMeta;
 
   @SuppressWarnings("unchecked")
   public B message(String message) {
     this.message = message;
+    return (B) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public B commitMeta(CommitMeta commitMeta) {
+    this.commitMeta = commitMeta;
     return (B) this;
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpMergeReference.java
@@ -21,6 +21,7 @@ import org.projectnessie.client.builder.BaseMergeReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.MergeResponse;
 
 final class HttpMergeReference extends BaseMergeReferenceBuilder {
@@ -34,6 +35,12 @@ final class HttpMergeReference extends BaseMergeReferenceBuilder {
   @Override
   public MergeReferenceBuilder message(String message) {
     throw new UnsupportedOperationException("Merge message overrides are not supported in API v1.");
+  }
+
+  @Override
+  public MergeReferenceBuilder commitMeta(CommitMeta commitMeta) {
+    throw new UnsupportedOperationException(
+        "Merge commit-meta overrides are not supported in API v1.");
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpMergeReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpMergeReference.java
@@ -46,6 +46,7 @@ final class HttpMergeReference extends BaseMergeReferenceBuilder {
             .fromHash(fromHash)
             .fromRefName(fromRefName)
             .message(message)
+            .commitMeta(commitMeta)
             .isDryRun(dryRun)
             .isFetchAdditionalInfo(fetchAdditionalInfo)
             .isReturnConflictAsResult(returnConflictAsResult);

--- a/api/model/src/main/java/org/projectnessie/api/v2/params/Merge.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/params/Merge.java
@@ -23,6 +23,8 @@ import static org.projectnessie.api.v2.doc.ApiDoc.KEY_MERGE_MODES_DESCRIPTION;
 import static org.projectnessie.api.v2.doc.ApiDoc.RETURN_CONFLICTS_AS_RESULT_DESCRIPTION;
 import static org.projectnessie.model.Validation.validateHash;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Nullable;
@@ -32,6 +34,7 @@ import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.media.SchemaProperty;
 import org.immutables.value.Value;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Validation;
 
 @Schema(
@@ -73,7 +76,17 @@ public interface Merge extends BaseMergeTransplant {
   @jakarta.annotation.Nullable
   @Size
   @jakarta.validation.constraints.Size(min = 1)
+  @Deprecated
   String getMessage();
+
+  /**
+   * Optional: additional merge-commit attributes. If a commit message is specified in this
+   * attribute, {@link #getMessage()} will be ignored.
+   */
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(Include.NON_NULL)
+  CommitMeta getCommitMeta();
 
   @NotBlank
   @jakarta.validation.constraints.NotBlank

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -31,6 +31,7 @@ import org.projectnessie.api.v1.params.Transplant;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.ImmutableEntriesResponse;
 import org.projectnessie.model.ImmutableLogResponse;
@@ -219,7 +220,7 @@ public class RestTreeResource implements HttpTreeApi {
         .transplantCommitsIntoBranch(
             branchName,
             expectedHash,
-            message,
+            message != null ? CommitMeta.fromMessage(message) : null,
             transplant.getHashesToTransplant(),
             transplant.getFromRefName(),
             transplant.keepIndividualCommits(),

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -325,7 +325,7 @@ public class RestV2TreeResource implements HttpTreeApi {
     ParsedReference ref = resolveRef(branch);
 
     String msg = transplant.getMessage();
-    CommitMeta meta = CommitMeta.builder().message(msg == null ? "" : msg).build();
+    CommitMeta meta = CommitMeta.fromMessage(msg == null ? "" : msg);
 
     return tree()
         .transplantCommitsIntoBranch(
@@ -348,6 +348,7 @@ public class RestV2TreeResource implements HttpTreeApi {
       throws NessieNotFoundException, NessieConflictException {
     ParsedReference ref = resolveRef(branch);
 
+    @SuppressWarnings("deprecation")
     String msg = merge.getMessage();
 
     ImmutableCommitMeta.Builder meta = CommitMeta.builder();

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -15,7 +15,6 @@
  */
 package org.projectnessie.services.rest;
 
-import static java.util.Collections.emptyList;
 import static org.projectnessie.api.v2.params.ReferenceResolver.resolveReferencePathElement;
 import static org.projectnessie.api.v2.params.ReferenceResolver.resolveReferencePathElementWithDefaultBranch;
 import static org.projectnessie.services.impl.RefUtil.toReference;
@@ -354,7 +353,7 @@ public class RestV2TreeResource implements HttpTreeApi {
     ImmutableCommitMeta.Builder meta = CommitMeta.builder();
     CommitMeta commitMeta = merge.getCommitMeta();
     if (commitMeta != null) {
-      meta.from(commitMeta).committer(null).commitTime(null).parentCommitHashes(emptyList());
+      meta.from(commitMeta);
       if (commitMeta.getMessage().isEmpty() && msg != null) {
         meta.message(msg);
       }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.services.impl;
 
+import static java.util.Collections.singletonList;
+
 import java.security.Principal;
 import java.time.Instant;
 import java.util.HashMap;
@@ -133,7 +135,7 @@ public abstract class BaseApiImpl {
   }
 
   protected MetadataRewriter<CommitMeta> commitMetaUpdate(
-      @Nullable @jakarta.annotation.Nullable String messageOverride) {
+      @Nullable @jakarta.annotation.Nullable CommitMeta commitMeta) {
     return new MetadataRewriter<CommitMeta>() {
       // Used for setting contextual commit properties during new and merge/transplant commits.
       // WARNING: ONLY SET PROPERTIES, WHICH APPLY COMMONLY TO ALL COMMIT TYPES.
@@ -141,20 +143,43 @@ public abstract class BaseApiImpl {
       private final String committer = principal == null ? "" : principal.getName();
       private final Instant now = Instant.now();
 
-      @Override
-      public CommitMeta rewriteSingle(CommitMeta metadata) {
-        ImmutableCommitMeta.Builder builder =
-            metadata.toBuilder()
-                .committer(committer)
-                .commitTime(now)
-                .author(metadata.getAuthor() == null ? committer : metadata.getAuthor())
-                .authorTime(metadata.getAuthorTime() == null ? now : metadata.getAuthorTime());
+      private CommitMeta buildCommitMeta(
+          ImmutableCommitMeta.Builder metadata, Supplier<String> defaultMessage) {
 
-        if (messageOverride != null) {
-          builder.message(messageOverride);
+        ImmutableCommitMeta pre = metadata.message("").build();
+
+        if (commitMeta != null && !commitMeta.getAllAuthors().isEmpty()) {
+          metadata.allAuthors(commitMeta.getAllAuthors());
+        } else if (pre.getAllAuthors().isEmpty()) {
+          metadata.allAuthors(singletonList(committer));
         }
 
-        return builder.build();
+        if (commitMeta != null && !commitMeta.getAllSignedOffBy().isEmpty()) {
+          metadata.allSignedOffBy(commitMeta.getAllSignedOffBy());
+        }
+
+        if (commitMeta != null && commitMeta.getAuthorTime() != null) {
+          metadata.authorTime(commitMeta.getAuthorTime());
+        } else if (pre.getAuthorTime() == null) {
+          metadata.authorTime(now);
+        }
+
+        if (commitMeta != null && !commitMeta.getAllProperties().isEmpty()) {
+          metadata.allProperties(commitMeta.getAllProperties());
+        }
+
+        if (commitMeta != null && !commitMeta.getMessage().isEmpty()) {
+          metadata.message(commitMeta.getMessage());
+        } else {
+          metadata.message(defaultMessage.get());
+        }
+
+        return metadata.committer(committer).commitTime(now).build();
+      }
+
+      @Override
+      public CommitMeta rewriteSingle(CommitMeta metadata) {
+        return buildCommitMeta(CommitMeta.builder().from(metadata), metadata::getMessage);
       }
 
       @Override
@@ -163,30 +188,23 @@ public abstract class BaseApiImpl {
           return rewriteSingle(metadata.get(0));
         }
 
-        ImmutableCommitMeta.Builder newMeta =
-            CommitMeta.builder()
-                .committer(committer)
-                .commitTime(now)
-                .author(committer)
-                .authorTime(now);
-        StringBuilder newMessage = new StringBuilder();
-
-        if (messageOverride != null) {
-          newMessage.append(messageOverride);
-        }
-
         Map<String, String> newProperties = new HashMap<>();
         for (CommitMeta commitMeta : metadata) {
           newProperties.putAll(commitMeta.getProperties());
-
-          if (messageOverride == null) {
-            if (newMessage.length() > 0) {
-              newMessage.append("\n---------------------------------------------\n");
-            }
-            newMessage.append(commitMeta.getMessage());
-          }
         }
-        return newMeta.putAllProperties(newProperties).message(newMessage.toString()).build();
+
+        return buildCommitMeta(
+            CommitMeta.builder().properties(newProperties),
+            () -> {
+              StringBuilder newMessage = new StringBuilder();
+              for (CommitMeta commitMeta : metadata) {
+                if (newMessage.length() > 0) {
+                  newMessage.append("\n---------------------------------------------\n");
+                }
+                newMessage.append(commitMeta.getMessage());
+              }
+              return newMessage.toString();
+            });
       }
     };
   }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -553,7 +553,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
   public MergeResponse transplantCommitsIntoBranch(
       String branchName,
       String expectedHash,
-      String message,
+      @Nullable @jakarta.annotation.Nullable CommitMeta commitMeta,
       List<String> hashesToTransplant,
       String fromRefName,
       Boolean keepIndividualCommits,
@@ -583,7 +583,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       if (Boolean.TRUE.equals(keepIndividualCommits) && transplants.size() > 1) {
         // Message overrides are not meaningful when transplanting more than one commit.
         // This matches old behaviour where `message` was ignored in all cases.
-        message = null;
+        commitMeta = null;
       }
 
       MergeResult<Commit> result =
@@ -592,7 +592,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
                   targetBranch,
                   toHash(expectedHash, true),
                   transplants,
-                  commitMetaUpdate(message),
+                  commitMetaUpdate(commitMeta),
                   Boolean.TRUE.equals(keepIndividualCommits),
                   keyMergeBehaviors(keyMergeBehaviors),
                   defaultMergeBehavior(defaultMergeBehavior),
@@ -620,7 +620,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       String fromRefName,
       String fromHash,
       Boolean keepIndividualCommits,
-      @Nullable @jakarta.annotation.Nullable String message,
+      @Nullable @jakarta.annotation.Nullable CommitMeta commitMeta,
       Collection<MergeKeyBehavior> keyMergeBehaviors,
       MergeBehavior defaultMergeBehavior,
       Boolean dryRun,
@@ -640,7 +640,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
                   toHash(fromRefName, fromHash),
                   targetBranch,
                   toHash(expectedHash, true),
-                  commitMetaUpdate(message),
+                  commitMetaUpdate(commitMeta),
                   Boolean.TRUE.equals(keepIndividualCommits),
                   keyMergeBehaviors(keyMergeBehaviors),
                   defaultMergeBehavior(defaultMergeBehavior),

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -565,6 +565,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       throws NessieNotFoundException, NessieConflictException {
     try {
       checkArgument(!hashesToTransplant.isEmpty(), "No hashes given to transplant.");
+      validateCommitMeta(commitMeta);
 
       BranchName targetBranch = BranchName.of(branchName);
       startAccessCheck()
@@ -628,6 +629,8 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       Boolean returnConflictAsResult)
       throws NessieNotFoundException, NessieConflictException {
     try {
+      validateCommitMeta(commitMeta);
+
       BranchName targetBranch = BranchName.of(branchName);
       startAccessCheck()
           .canViewReference(namedRefWithHashOrThrow(fromRefName, fromHash).getValue())
@@ -658,6 +661,24 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
     } catch (ReferenceConflictException e) {
       throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
+    }
+  }
+
+  private static void validateCommitMeta(CommitMeta commitMeta) {
+    if (commitMeta != null) {
+      checkArgument(
+          commitMeta.getCommitter() == null,
+          "Cannot set the committer on the client side. It is set by the server.");
+      checkArgument(
+          commitMeta.getCommitTime() == null,
+          "Cannot set the commit time on the client side. It is set by the server.");
+      checkArgument(
+          commitMeta.getHash() == null,
+          "Cannot set the commit hash on the client side. It is set by the server.");
+      checkArgument(
+          commitMeta.getParentCommitHashes() == null
+              || commitMeta.getParentCommitHashes().isEmpty(),
+          "Cannot set the parent commit hashes on the client side. It is set by the server.");
     }
   }
 
@@ -868,6 +889,9 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
   public CommitResponse commitMultipleOperations(
       String branch, String expectedHash, Operations operations)
       throws NessieNotFoundException, NessieConflictException {
+    CommitMeta commitMeta = operations.getCommitMeta();
+    validateCommitMeta(commitMeta);
+
     BranchName branchName = BranchName.of(branch);
     BatchAccessChecker check = startAccessCheck().canCommitChangeAgainstReference(branchName);
     operations
@@ -891,12 +915,6 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
         operations.getOperations().stream()
             .map(TreeApiImpl::toOp)
             .collect(ImmutableList.toImmutableList());
-
-    CommitMeta commitMeta = operations.getCommitMeta();
-    if (commitMeta.getCommitter() != null) {
-      throw new IllegalArgumentException(
-          "Cannot set the committer on the client side. It is set by the server.");
-    }
 
     try {
       ImmutableCommitResponse.Builder commitResponse = ImmutableCommitResponse.builder();

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Pattern;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.CommitResponse;
 import org.projectnessie.model.EntriesResponse.Entry;
 import org.projectnessie.model.FetchOption;
@@ -189,7 +190,7 @@ public interface TreeService {
               regexp = Validation.HASH_REGEX,
               message = Validation.HASH_MESSAGE)
           String expectedHash,
-      String message,
+      @Nullable @jakarta.annotation.Nullable CommitMeta commitMeta,
       List<String> hashesToTransplant,
       @Valid
           @jakarta.validation.Valid
@@ -248,7 +249,7 @@ public interface TreeService {
               message = Validation.HASH_MESSAGE)
           String fromHash,
       @Nullable @jakarta.annotation.Nullable Boolean keepIndividualCommits,
-      @Nullable @jakarta.annotation.Nullable String message,
+      @Nullable @jakarta.annotation.Nullable CommitMeta commitMeta,
       Collection<MergeKeyBehavior> keyMergeBehaviors,
       MergeBehavior defaultMergeType,
       @Nullable @jakarta.annotation.Nullable Boolean dryRun,

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
@@ -373,7 +373,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
                     source.getName(),
                     source.getHash(),
                     false,
-                    "test-message-override-123",
+                    CommitMeta.fromMessage("test-message-override-123"),
                     emptyList(),
                     NORMAL,
                     false,
@@ -411,7 +411,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
                 .transplantCommitsIntoBranch(
                     target.getName(),
                     target.getHash(),
-                    "test-message-override-123",
+                    CommitMeta.fromMessage("test-message-override-123"),
                     ImmutableList.of(
                         requireNonNull(committed1.getHash()), requireNonNull(committed2.getHash())),
                     source.getName(),
@@ -432,7 +432,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
                 .transplantCommitsIntoBranch(
                     target.getName(),
                     target.getHash(),
-                    "test-message-override-123",
+                    CommitMeta.fromMessage("test-message-override-123"),
                     ImmutableList.of(requireNonNull(committed1.getHash())),
                     source.getName(),
                     false,
@@ -452,7 +452,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
                 .transplantCommitsIntoBranch(
                     target.getName(),
                     target.getHash(),
-                    "ignored-message-override",
+                    CommitMeta.fromMessage("ignored-message-override"),
                     ImmutableList.of(
                         requireNonNull(committed1.getHash()), requireNonNull(committed2.getHash())),
                     source.getName(),

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestNamespace.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestNamespace.java
@@ -276,7 +276,7 @@ public abstract class AbstractTestNamespace extends BaseTestServiceImpl {
                         finalBranch.getName(),
                         finalBranch.getHash(),
                         false,
-                        "foo",
+                        CommitMeta.fromMessage("foo"),
                         emptyList(),
                         NORMAL,
                         false,


### PR DESCRIPTION
The new property `Merge.getCommitMeta()` allows specifying more commit attributes than just the message:
* message
* authors
* author-time
* signed-off-by
* properties

Fixes #5995