### PR TITLE
Allow all commit attributes for namespace operations

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/api/CreateNamespaceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/CreateNamespaceBuilder.java
@@ -25,7 +25,7 @@ import org.projectnessie.model.Namespace;
  *
  * @since {@link NessieApiV1}
  */
-public interface CreateNamespaceBuilder extends OnNamespaceBuilder<CreateNamespaceBuilder> {
+public interface CreateNamespaceBuilder extends ModifyNamespaceBuilder<CreateNamespaceBuilder> {
 
   CreateNamespaceBuilder properties(Map<String, String> properties);
 

--- a/api/client/src/main/java/org/projectnessie/client/api/DeleteNamespaceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/DeleteNamespaceBuilder.java
@@ -25,7 +25,7 @@ import org.projectnessie.model.Namespace;
  *
  * @since {@link NessieApiV1}
  */
-public interface DeleteNamespaceBuilder extends OnNamespaceBuilder<DeleteNamespaceBuilder> {
+public interface DeleteNamespaceBuilder extends ModifyNamespaceBuilder<DeleteNamespaceBuilder> {
 
   void delete()
       throws NessieNamespaceNotFoundException,

--- a/api/client/src/main/java/org/projectnessie/client/api/ModifyNamespaceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/ModifyNamespaceBuilder.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.api;
+
+import org.projectnessie.model.CommitMeta;
+
+public interface ModifyNamespaceBuilder<R extends ModifyNamespaceBuilder<R>>
+    extends OnNamespaceBuilder<R> {
+
+  R commitMeta(CommitMeta commitMeta);
+}

--- a/api/client/src/main/java/org/projectnessie/client/api/UpdateNamespaceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/UpdateNamespaceBuilder.java
@@ -26,7 +26,7 @@ import org.projectnessie.model.Namespace;
  *
  * @since {@link NessieApiV1}
  */
-public interface UpdateNamespaceBuilder extends OnNamespaceBuilder<UpdateNamespaceBuilder> {
+public interface UpdateNamespaceBuilder extends ModifyNamespaceBuilder<UpdateNamespaceBuilder> {
 
   UpdateNamespaceBuilder updateProperty(String key, String value);
 

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseCreateNamespaceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseCreateNamespaceBuilder.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.projectnessie.client.api.CreateNamespaceBuilder;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Namespace;
 
 public abstract class BaseCreateNamespaceBuilder implements CreateNamespaceBuilder {
@@ -27,6 +28,13 @@ public abstract class BaseCreateNamespaceBuilder implements CreateNamespaceBuild
   protected String refName;
   protected String hashOnRef;
   protected final Map<String, String> properties = new HashMap<>();
+  protected CommitMeta commitMeta;
+
+  @Override
+  public CreateNamespaceBuilder commitMeta(CommitMeta commitMeta) {
+    this.commitMeta = commitMeta;
+    return this;
+  }
 
   @Override
   public CreateNamespaceBuilder namespace(Namespace namespace) {

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseDeleteNamespaceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseDeleteNamespaceBuilder.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.builder;
 
 import javax.annotation.Nullable;
 import org.projectnessie.client.api.DeleteNamespaceBuilder;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Namespace;
 
 public abstract class BaseDeleteNamespaceBuilder implements DeleteNamespaceBuilder {
@@ -24,6 +25,13 @@ public abstract class BaseDeleteNamespaceBuilder implements DeleteNamespaceBuild
   protected Namespace namespace;
   protected String refName;
   protected String hashOnRef;
+  protected CommitMeta commitMeta;
+
+  @Override
+  public DeleteNamespaceBuilder commitMeta(CommitMeta commitMeta) {
+    this.commitMeta = commitMeta;
+    return this;
+  }
 
   @Override
   public DeleteNamespaceBuilder namespace(Namespace namespace) {

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseUpdateNamespaceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseUpdateNamespaceBuilder.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.projectnessie.client.api.UpdateNamespaceBuilder;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Namespace;
 
 public abstract class BaseUpdateNamespaceBuilder implements UpdateNamespaceBuilder {
@@ -30,6 +31,13 @@ public abstract class BaseUpdateNamespaceBuilder implements UpdateNamespaceBuild
   protected Namespace namespace;
   protected String refName;
   protected String hashOnRef;
+  protected CommitMeta commitMeta;
+
+  @Override
+  public UpdateNamespaceBuilder commitMeta(CommitMeta commitMeta) {
+    this.commitMeta = commitMeta;
+    return this;
+  }
 
   @Override
   public UpdateNamespaceBuilder namespace(Namespace namespace) {

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateNamespace.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpCreateNamespace.java
@@ -21,6 +21,7 @@ import org.projectnessie.client.builder.BaseCreateNamespaceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNamespaceAlreadyExistsException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Namespace;
 
 final class HttpCreateNamespace extends BaseCreateNamespaceBuilder {
@@ -50,5 +51,10 @@ final class HttpCreateNamespace extends BaseCreateNamespaceBuilder {
   public CreateNamespaceResult createWithResponse() {
     throw new UnsupportedOperationException(
         "Extended commit response data is not available in API v1");
+  }
+
+  @Override
+  public HttpCreateNamespace commitMeta(CommitMeta commitMeta) {
+    throw new UnsupportedOperationException("Commit attributes are not available in API v1");
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteNamespace.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpDeleteNamespace.java
@@ -23,6 +23,7 @@ import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNamespaceNotEmptyException;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
+import org.projectnessie.model.CommitMeta;
 
 final class HttpDeleteNamespace extends BaseDeleteNamespaceBuilder {
 
@@ -46,5 +47,10 @@ final class HttpDeleteNamespace extends BaseDeleteNamespaceBuilder {
   public DeleteNamespaceResult deleteWithResponse() {
     throw new UnsupportedOperationException(
         "Extended commit response data is not available in API v1");
+  }
+
+  @Override
+  public HttpDeleteNamespace commitMeta(CommitMeta commitMeta) {
+    throw new UnsupportedOperationException("Commit attributes are not available in API v1");
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpUpdateNamespace.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpUpdateNamespace.java
@@ -23,6 +23,7 @@ import org.projectnessie.client.builder.BaseUpdateNamespaceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
+import org.projectnessie.model.CommitMeta;
 
 final class HttpUpdateNamespace extends BaseUpdateNamespaceBuilder {
 
@@ -49,5 +50,10 @@ final class HttpUpdateNamespace extends BaseUpdateNamespaceBuilder {
   public UpdateNamespaceResult updateWithResponse() {
     throw new UnsupportedOperationException(
         "Extended commit response data is not available in API v1");
+  }
+
+  @Override
+  public HttpUpdateNamespace commitMeta(CommitMeta commitMeta) {
+    throw new UnsupportedOperationException("Commit attributes are not available in API v1");
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideCreateNamespace.java
+++ b/api/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideCreateNamespace.java
@@ -86,9 +86,16 @@ public final class ClientSideCreateNamespace extends BaseCreateNamespaceBuilder 
     try {
       Branch branch = (Branch) contentsResponse.getEffectiveReference();
 
+      CommitMeta meta = commitMeta;
+      if (meta == null) {
+        meta = CommitMeta.fromMessage("create namespace " + key);
+      } else if (meta.getMessage().isEmpty()) {
+        meta = CommitMeta.builder().from(meta).message("update namespace " + key).build();
+      }
+
       CommitResponse committed =
           api.commitMultipleOperations()
-              .commitMeta(CommitMeta.fromMessage("create namespace " + namespace.name()))
+              .commitMeta(meta)
               .branch(branch)
               .operation(Put.of(key, content))
               .commitWithResponse();

--- a/api/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideDeleteNamespace.java
+++ b/api/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideDeleteNamespace.java
@@ -100,10 +100,17 @@ public final class ClientSideDeleteNamespace extends BaseDeleteNamespaceBuilder 
     }
 
     try {
+      CommitMeta meta = commitMeta;
+      if (meta == null) {
+        meta = CommitMeta.fromMessage("delete namespace " + key);
+      } else if (meta.getMessage().isEmpty()) {
+        meta = CommitMeta.builder().from(meta).message("delete namespace " + key).build();
+      }
+
       CommitResponse commit =
           api.commitMultipleOperations()
               .branch((Branch) ref)
-              .commitMeta(CommitMeta.fromMessage("delete namespace " + key))
+              .commitMeta(meta)
               .operation(Delete.of(key))
               .commitWithResponse();
 

--- a/api/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideUpdateNamespace.java
+++ b/api/client/src/main/java/org/projectnessie/client/util/v2api/ClientSideUpdateNamespace.java
@@ -68,12 +68,19 @@ public final class ClientSideUpdateNamespace extends BaseUpdateNamespaceBuilder 
         expectedHash = api.getReference().refName(refName).get().getHash();
       }
 
+      CommitMeta meta = commitMeta;
+      if (meta == null) {
+        meta = CommitMeta.fromMessage("update namespace " + key);
+      } else if (meta.getMessage().isEmpty()) {
+        meta = CommitMeta.builder().from(meta).message("update namespace " + key).build();
+      }
+
       Namespace updatedNamespace = builder.build();
       CommitResponse commit =
           api.commitMultipleOperations()
               .branchName(refName)
               .hash(expectedHash)
-              .commitMeta(CommitMeta.fromMessage("update namespace " + key))
+              .commitMeta(meta)
               .operation(Put.of(key, updatedNamespace))
               .commitWithResponse();
 


### PR DESCRIPTION
Adds a new optional property `commitMeta` for the create/update/delete namespace client API operations. Falls back to the current behavior, if `commitMeta` is not specified. Uses the current message, if the provided `commitMeta`'s `message` is empty.

Implemented for the V2 Java client, not for the V1 client.

Fixes #5615