### PR TITLE
Do not store intermediate commits during merge/transplant

### DIFF
--- a/versioned/storage/store/build.gradle.kts
+++ b/versioned/storage/store/build.gradle.kts
@@ -28,6 +28,7 @@ description = "VersionStore implementation relying on 'Persist'."
 
 dependencies {
   implementation(project(":nessie-versioned-storage-common"))
+  implementation(project(":nessie-versioned-storage-batching"))
   implementation(project(":nessie-model"))
   implementation(project(":nessie-versioned-spi"))
   implementation(libs.agrona)

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RefMapping.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RefMapping.java
@@ -93,14 +93,14 @@ public class RefMapping {
     return new ReferenceNotFoundException(format("Commit '%s' not found", hash.asString()));
   }
 
-  public static ReferenceNotFoundException objectNotFound(ObjId hash) {
-    return new ReferenceNotFoundException(format("Commit '%s' not found", hash));
+  public static ReferenceNotFoundException objectNotFound(ObjId hash, Throwable cause) {
+    return new ReferenceNotFoundException(format("Commit '%s' not found", hash), cause);
   }
 
   public static ReferenceNotFoundException objectNotFound(ObjNotFoundException e) {
     List<ObjId> ids = e.objIds();
     if (ids.size() == 1) {
-      return objectNotFound(e.objIds().get(0));
+      return objectNotFound(e.objIds().get(0), e);
     }
 
     return new ReferenceNotFoundException(
@@ -112,7 +112,7 @@ public class RefMapping {
   public static ReferenceNotFoundException referenceNotFound(ObjNotFoundException e) {
     List<ObjId> ids = e.objIds();
     if (ids.size() == 1) {
-      return objectNotFound(e.objIds().get(0));
+      return objectNotFound(e.objIds().get(0), e);
     }
 
     return new ReferenceNotFoundException(

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.versionstore;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
+import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
+import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
+import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
+import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.Reference;
+
+public class PersistDelegate implements Persist {
+  final Persist delegate;
+
+  PersistDelegate(Persist delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public int hardObjectSizeLimit() {
+    return delegate.hardObjectSizeLimit();
+  }
+
+  @Override
+  public int effectiveIndexSegmentSizeLimit() {
+    return delegate.effectiveIndexSegmentSizeLimit();
+  }
+
+  @Override
+  public int effectiveIncrementalIndexSizeLimit() {
+    return delegate.effectiveIncrementalIndexSizeLimit();
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public String name() {
+    return delegate.name();
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public StoreConfig config() {
+    return delegate.config();
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public Reference addReference(@Nonnull @jakarta.annotation.Nonnull Reference reference)
+      throws RefAlreadyExistsException {
+    return delegate.addReference(reference);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public Reference markReferenceAsDeleted(@Nonnull @jakarta.annotation.Nonnull Reference reference)
+      throws RefNotFoundException, RefConditionFailedException {
+    return delegate.markReferenceAsDeleted(reference);
+  }
+
+  @Override
+  public void purgeReference(@Nonnull @jakarta.annotation.Nonnull Reference reference)
+      throws RefNotFoundException, RefConditionFailedException {
+    delegate.purgeReference(reference);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public Reference updateReferencePointer(
+      @Nonnull @jakarta.annotation.Nonnull Reference reference,
+      @Nonnull @jakarta.annotation.Nonnull ObjId newPointer)
+      throws RefNotFoundException, RefConditionFailedException {
+    return delegate.updateReferencePointer(reference, newPointer);
+  }
+
+  @Override
+  public Reference fetchReference(@Nonnull @jakarta.annotation.Nonnull String name) {
+    return delegate.fetchReference(name);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public Reference[] fetchReferences(@Nonnull @jakarta.annotation.Nonnull String[] names) {
+    return delegate.fetchReferences(names);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public Obj fetchObj(@Nonnull @jakarta.annotation.Nonnull ObjId id) throws ObjNotFoundException {
+    return delegate.fetchObj(id);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public <T extends Obj> T fetchTypedObj(
+      @Nonnull @jakarta.annotation.Nonnull ObjId id, ObjType type, Class<T> typeClass)
+      throws ObjNotFoundException {
+    return delegate.fetchTypedObj(id, type, typeClass);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public ObjType fetchObjType(@Nonnull @jakarta.annotation.Nonnull ObjId id)
+      throws ObjNotFoundException {
+    return delegate.fetchObjType(id);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public Obj[] fetchObjs(@Nonnull @jakarta.annotation.Nonnull ObjId[] ids)
+      throws ObjNotFoundException {
+    return delegate.fetchObjs(ids);
+  }
+
+  @Override
+  public boolean storeObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
+      throws ObjTooLargeException {
+    return delegate.storeObj(obj);
+  }
+
+  @Override
+  public boolean storeObj(
+      @Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
+      throws ObjTooLargeException {
+    return delegate.storeObj(obj, ignoreSoftSizeRestrictions);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException {
+    return delegate.storeObjs(objs);
+  }
+
+  @Override
+  public void deleteObj(@Nonnull @jakarta.annotation.Nonnull ObjId id) {
+    delegate.deleteObj(id);
+  }
+
+  @Override
+  public void deleteObjs(@Nonnull @jakarta.annotation.Nonnull ObjId[] ids) {
+    delegate.deleteObjs(ids);
+  }
+
+  @Override
+  public void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj) throws ObjTooLargeException {
+    delegate.upsertObj(obj);
+  }
+
+  @Override
+  public void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException {
+    delegate.upsertObjs(objs);
+  }
+
+  @Override
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public CloseableIterator<Obj> scanAllObjects(
+      @Nonnull @jakarta.annotation.Nonnull Set<ObjType> returnedObjTypes) {
+    return delegate.scanAllObjects(returnedObjTypes);
+  }
+
+  @Override
+  public void erase() {
+    delegate.erase();
+  }
+}

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestRefMapping.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestRefMapping.java
@@ -105,7 +105,7 @@ public class TestRefMapping {
             ReferenceNotFoundException.class,
             "Commit '1234' not found"),
         arguments(
-            objectNotFound(objIdFromString("1234")),
+            objectNotFound(objIdFromString("1234"), new RuntimeException("test")),
             ReferenceNotFoundException.class,
             "Commit '1234' not found"),
         arguments(

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreImpl.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreImpl.java
@@ -22,10 +22,11 @@ import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONF
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_COMMIT_TIMEOUT_MILLIS;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergTable;
@@ -36,16 +37,9 @@ import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.ReferenceRetryFailureException;
 import org.projectnessie.versioned.VersionStore;
-import org.projectnessie.versioned.storage.common.config.StoreConfig;
-import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
-import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
-import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
 import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
 import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
-import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
-import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
-import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 import org.projectnessie.versioned.storage.commontests.AbstractVersionStoreTests;
@@ -53,6 +47,13 @@ import org.projectnessie.versioned.storage.testextension.NessiePersist;
 import org.projectnessie.versioned.storage.testextension.NessieStoreConfig;
 
 public class TestVersionStoreImpl extends AbstractVersionStoreTests {
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Override
+  protected VersionStore store() {
+    return ValidatingVersionStoreImpl.of(soft, persist);
+  }
 
   @Test
   public void commitWithInfiniteConcurrentConflict(
@@ -158,192 +159,5 @@ public class TestVersionStoreImpl extends AbstractVersionStoreTests {
         Optional.of(branch1),
         fromMessage("commit foo"),
         singletonList(Put.of(ContentKey.of("some-key"), IcebergTable.of("meta", 42, 43, 44, 45))));
-  }
-
-  static class PersistDelegate extends BasePersistDelegate implements Persist {
-
-    PersistDelegate(Persist p) {
-      super(p);
-    }
-
-    @Override
-    public void deleteObj(@Nonnull @jakarta.annotation.Nonnull ObjId id) {
-      delegate.deleteObj(id);
-    }
-
-    @Override
-    public void deleteObjs(@Nonnull @jakarta.annotation.Nonnull ObjId[] ids) {
-      delegate.deleteObjs(ids);
-    }
-
-    @Override
-    public void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-        throws ObjTooLargeException {
-      delegate.upsertObj(obj);
-    }
-
-    @Override
-    public void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-        throws ObjTooLargeException {
-      delegate.upsertObjs(objs);
-    }
-  }
-
-  abstract static class BasePersistDelegate implements Persist {
-    final Persist delegate;
-
-    BasePersistDelegate(Persist delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public int hardObjectSizeLimit() {
-      return delegate.hardObjectSizeLimit();
-    }
-
-    @Override
-    public int effectiveIndexSegmentSizeLimit() {
-      return delegate.effectiveIndexSegmentSizeLimit();
-    }
-
-    @Override
-    public int effectiveIncrementalIndexSizeLimit() {
-      return delegate.effectiveIncrementalIndexSizeLimit();
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public String name() {
-      return delegate.name();
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public StoreConfig config() {
-      return delegate.config();
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public Reference addReference(@Nonnull @jakarta.annotation.Nonnull Reference reference)
-        throws RefAlreadyExistsException {
-      return delegate.addReference(reference);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public Reference markReferenceAsDeleted(
-        @Nonnull @jakarta.annotation.Nonnull Reference reference)
-        throws RefNotFoundException, RefConditionFailedException {
-      return delegate.markReferenceAsDeleted(reference);
-    }
-
-    @Override
-    public void purgeReference(@Nonnull @jakarta.annotation.Nonnull Reference reference)
-        throws RefNotFoundException, RefConditionFailedException {
-      delegate.purgeReference(reference);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public Reference updateReferencePointer(
-        @Nonnull @jakarta.annotation.Nonnull Reference reference,
-        @Nonnull @jakarta.annotation.Nonnull ObjId newPointer)
-        throws RefNotFoundException, RefConditionFailedException {
-      return delegate.updateReferencePointer(reference, newPointer);
-    }
-
-    @Override
-    public Reference fetchReference(@Nonnull @jakarta.annotation.Nonnull String name) {
-      return delegate.fetchReference(name);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public Reference[] fetchReferences(@Nonnull @jakarta.annotation.Nonnull String[] names) {
-      return delegate.fetchReferences(names);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public Obj fetchObj(@Nonnull @jakarta.annotation.Nonnull ObjId id) throws ObjNotFoundException {
-      return delegate.fetchObj(id);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public <T extends Obj> T fetchTypedObj(
-        @Nonnull @jakarta.annotation.Nonnull ObjId id, ObjType type, Class<T> typeClass)
-        throws ObjNotFoundException {
-      return delegate.fetchTypedObj(id, type, typeClass);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public ObjType fetchObjType(@Nonnull @jakarta.annotation.Nonnull ObjId id)
-        throws ObjNotFoundException {
-      return delegate.fetchObjType(id);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public Obj[] fetchObjs(@Nonnull @jakarta.annotation.Nonnull ObjId[] ids)
-        throws ObjNotFoundException {
-      return delegate.fetchObjs(ids);
-    }
-
-    @Override
-    public boolean storeObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-        throws ObjTooLargeException {
-      return delegate.storeObj(obj);
-    }
-
-    @Override
-    public boolean storeObj(
-        @Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
-        throws ObjTooLargeException {
-      return delegate.storeObj(obj, ignoreSoftSizeRestrictions);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-        throws ObjTooLargeException {
-      return delegate.storeObjs(objs);
-    }
-
-    @Override
-    public void deleteObj(@Nonnull @jakarta.annotation.Nonnull ObjId id) {
-      delegate.deleteObj(id);
-    }
-
-    @Override
-    public void deleteObjs(@Nonnull @jakarta.annotation.Nonnull ObjId[] ids) {
-      delegate.deleteObjs(ids);
-    }
-
-    @Override
-    @Nonnull
-    @jakarta.annotation.Nonnull
-    public CloseableIterator<Obj> scanAllObjects(
-        @Nonnull @jakarta.annotation.Nonnull Set<ObjType> returnedObjTypes) {
-      return delegate.scanAllObjects(returnedObjTypes);
-    }
-
-    @Override
-    public void erase() {
-      delegate.erase();
-    }
   }
 }

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/ValidatingVersionStoreImpl.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/ValidatingVersionStoreImpl.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.versionstore;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+import org.assertj.core.api.SoftAssertions;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
+import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
+import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
+import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.Reference;
+import org.projectnessie.versioned.tests.StorageAssertions;
+import org.projectnessie.versioned.tests.ValidatingVersionStore;
+
+public class ValidatingVersionStoreImpl extends VersionStoreImpl implements ValidatingVersionStore {
+
+  private final SoftAssertions soft;
+  private final ValidatingPersist persist;
+
+  private ValidatingVersionStoreImpl(SoftAssertions soft, ValidatingPersist persist) {
+    super(persist);
+    this.soft = soft;
+    this.persist = persist;
+  }
+
+  public static VersionStore of(SoftAssertions soft, Persist persist) {
+    return new ValidatingVersionStoreImpl(soft, new ValidatingPersist(persist));
+  }
+
+  @Override
+  public StorageAssertions storageCheckpoint() {
+    return new StorageCheckpoint();
+  }
+
+  private static class ValidatingPersist extends PersistDelegate {
+    private final AtomicInteger writeCounter = new AtomicInteger();
+    private final AtomicReference<RuntimeException> lastWrite = new AtomicReference<>();
+
+    ValidatingPersist(Persist p) {
+      super(p);
+    }
+
+    private void recordWrite() {
+      writeCounter.incrementAndGet();
+      lastWrite.set(new RuntimeException("write #" + writeCounter.incrementAndGet()));
+    }
+
+    @Nonnull
+    @jakarta.annotation.Nonnull
+    @Override
+    public Reference addReference(@Nonnull @jakarta.annotation.Nonnull Reference reference)
+        throws RefAlreadyExistsException {
+      recordWrite();
+      return super.addReference(reference);
+    }
+
+    @Nonnull
+    @jakarta.annotation.Nonnull
+    @Override
+    public Reference markReferenceAsDeleted(
+        @Nonnull @jakarta.annotation.Nonnull Reference reference)
+        throws RefNotFoundException, RefConditionFailedException {
+      recordWrite();
+      return super.markReferenceAsDeleted(reference);
+    }
+
+    @Override
+    public void purgeReference(@Nonnull @jakarta.annotation.Nonnull Reference reference)
+        throws RefNotFoundException, RefConditionFailedException {
+      recordWrite();
+      super.purgeReference(reference);
+    }
+
+    @Nonnull
+    @jakarta.annotation.Nonnull
+    @Override
+    public Reference updateReferencePointer(
+        @Nonnull @jakarta.annotation.Nonnull Reference reference,
+        @Nonnull @jakarta.annotation.Nonnull ObjId newPointer)
+        throws RefNotFoundException, RefConditionFailedException {
+      recordWrite();
+      return super.updateReferencePointer(reference, newPointer);
+    }
+
+    @Override
+    public void upsertObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
+        throws ObjTooLargeException {
+      recordWrite();
+      super.upsertObj(obj);
+    }
+
+    @Override
+    public void upsertObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+        throws ObjTooLargeException {
+      recordWrite();
+      super.upsertObjs(objs);
+    }
+
+    @Override
+    public boolean storeObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
+        throws ObjTooLargeException {
+      recordWrite();
+      return super.storeObj(obj);
+    }
+
+    @Override
+    public boolean storeObj(
+        @Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
+        throws ObjTooLargeException {
+      recordWrite();
+      return super.storeObj(obj, ignoreSoftSizeRestrictions);
+    }
+
+    @Nonnull
+    @jakarta.annotation.Nonnull
+    @Override
+    public boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+        throws ObjTooLargeException {
+      recordWrite();
+      return super.storeObjs(objs);
+    }
+  }
+
+  private class StorageCheckpoint extends StorageAssertions {
+    private final Throwable initial = persist.lastWrite.get();
+
+    @Override
+    public void assertNoWrites() {
+      RuntimeException current = persist.lastWrite.get();
+      soft.assertThatCode(
+              () -> {
+                if (current != initial) {
+                  throw current;
+                }
+              })
+          .describedAs("Expected no writes at the storage layer")
+          .doesNotThrowAnyException();
+    }
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNestedVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNestedVersionStore.java
@@ -54,6 +54,13 @@ public abstract class AbstractNestedVersionStore {
     return store;
   }
 
+  protected StorageAssertions storageCheckpoint() {
+    if (store instanceof ValidatingVersionStore) {
+      return ((ValidatingVersionStore) store).storageCheckpoint();
+    }
+    return new StorageAssertions(); // non-validating
+  }
+
   protected List<Commit> commitsList(Ref ref, boolean fetchAdditionalInfo)
       throws ReferenceNotFoundException {
     try (PaginationIterator<Commit> s = store().getCommits(ref, fetchAdditionalInfo)) {

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
@@ -241,6 +241,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
     store().create(newBranch, Optional.empty());
     commit("Another commit").put(T_1, V_1_4).toBranch(newBranch);
 
+    StorageAssertions checkpoint = storageCheckpoint();
     soft.assertThatThrownBy(
             () ->
                 store()
@@ -255,6 +256,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         dryRun,
                         false))
         .isInstanceOf(ReferenceConflictException.class);
+    checkpoint.assertNoWrites();
   }
 
   @ParameterizedTest
@@ -302,6 +304,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
   })
   protected void checkTransplantOnNonExistingBranch(boolean individualCommits, boolean dryRun) {
     final BranchName newBranch = BranchName.of("bar_5");
+    StorageAssertions checkpoint = storageCheckpoint();
     soft.assertThatThrownBy(
             () ->
                 store()
@@ -316,6 +319,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         dryRun,
                         false))
         .isInstanceOf(ReferenceNotFoundException.class);
+    checkpoint.assertNoWrites();
   }
 
   @ParameterizedTest
@@ -329,6 +333,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
       throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_6");
     store().create(newBranch, Optional.empty());
+    StorageAssertions checkpoint = storageCheckpoint();
     soft.assertThatThrownBy(
             () ->
                 store()
@@ -343,6 +348,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         dryRun,
                         false))
         .isInstanceOf(ReferenceNotFoundException.class);
+    checkpoint.assertNoWrites();
   }
 
   @ParameterizedTest
@@ -434,6 +440,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
     final BranchName newBranch = BranchName.of("bar_1");
     store().create(newBranch, Optional.empty());
 
+    StorageAssertions checkpoint = storageCheckpoint();
     soft.assertThatThrownBy(
             () ->
                 store()
@@ -448,6 +455,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         dryRun,
                         false))
         .isInstanceOf(ReferenceNotFoundException.class);
+    checkpoint.assertNoWrites();
   }
 
   @ParameterizedTest

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/StorageAssertions.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/StorageAssertions.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.tests;
+
+public class StorageAssertions {
+
+  public void assertNoWrites() {}
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/ValidatingVersionStore.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/ValidatingVersionStore.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.tests;
+
+public interface ValidatingVersionStore {
+
+  StorageAssertions storageCheckpoint();
+}


### PR DESCRIPTION
* Do not store objects during dry runs.

* Do not store objects when conflicts are detected.

Use a BatchingPersist during unsquashed merge/transplant execution and
flush only on success. This is to allow CommitLogic to 'see'
intermediate commits without writing them to storage. Batching writes in
this case is a secondary effect.

Move PersistDelegate to top level.

Add test tooling to allow validating whether any storage writes happened
since a checkpoint.

Also add a test case to make sure dry run merge/transplant operations
at the API level.

Note: exact response messages differ between old and new model in
this case, but substantial information is the same (keys from the
merge/transplant request).

Fixes #6674