### PR TITLE
Make dry run merge / transplant throw exceptions

### DIFF
--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -574,7 +574,7 @@ public abstract class AbstractDatabaseAdapter<
 
     mergeResult.wasSuccessful(!hasCollisions);
 
-    if (hasCollisions && !params.isDryRun()) {
+    if (hasCollisions) {
       MergeResult<CommitLogEntry> result = mergeResult.resultantTargetHash(toHead).build();
       throw new MergeConflictException(
           format(
@@ -588,7 +588,7 @@ public abstract class AbstractDatabaseAdapter<
           result);
     }
 
-    if (params.isDryRun() || hasCollisions) {
+    if (params.isDryRun()) {
       return toHead;
     }
 

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
@@ -392,14 +392,19 @@ public abstract class AbstractMergeTransplant {
 
     // Merge/transplant w/ conflict / dry run
 
-    MergeResult<CommitLogEntry> mergeResult =
-        mergeOrTransplant.apply(
-            configurer
-                .apply(commits, 2)
-                .toBranch(conflict)
-                .expectedHead(Optional.of(conflictBase))
-                .isDryRun(true));
-    assertThat(mergeResult).isEqualTo(expectedMergeResult);
+    assertThatThrownBy(
+            () ->
+                mergeOrTransplant.apply(
+                    configurer
+                        .apply(commits, 2)
+                        .toBranch(conflict)
+                        .expectedHead(Optional.of(conflictBase))
+                        .isDryRun(true)))
+        .isInstanceOf(MergeConflictException.class)
+        .hasMessage("The following keys have been changed in conflict: 'key-0', 'key-1'")
+        .asInstanceOf(InstanceOfAssertFactories.throwable(MergeConflictException.class))
+        .extracting(MergeConflictException::getMergeResult)
+        .isEqualTo(expectedMergeResult);
 
     // Merge/transplant w/ conflict
 

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -631,7 +631,7 @@ public class VersionStoreImpl implements VersionStore {
             (merge, retryState) ->
                 merge.merge(retryState, fromHash, updateCommitMetadata, mergeBehaviors, dryRun));
 
-    return mergeTransplantResponse(dryRun, mergeResult);
+    return mergeTransplantResponse(mergeResult);
   }
 
   @Override
@@ -668,12 +668,12 @@ public class VersionStoreImpl implements VersionStore {
                     mergeBehaviors,
                     dryRun));
 
-    return mergeTransplantResponse(dryRun, mergeResult);
+    return mergeTransplantResponse(mergeResult);
   }
 
-  private MergeResult<Commit> mergeTransplantResponse(
-      boolean dryRun, MergeResult<Commit> mergeResult) throws MergeConflictException {
-    if (!dryRun && !mergeResult.wasSuccessful()) {
+  private MergeResult<Commit> mergeTransplantResponse(MergeResult<Commit> mergeResult)
+      throws MergeConflictException {
+    if (!mergeResult.wasSuccessful()) {
       throw new MergeConflictException(
           String.format(
               "The following keys have been changed in conflict: %s",

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -202,52 +202,36 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
     Content c11 = store().getValue(firstCommit, ContentKey.of("t1"));
 
     for (MergeBehavior mergeBehavior : MergeBehavior.values()) {
-      if (dryRun) {
-        soft.assertThat(
-                store()
-                    .merge(
-                        thirdCommit,
-                        targetBranch,
-                        Optional.empty(),
-                        metadataRewriter,
-                        false,
-                        ImmutableMap.of(
-                            keyT3, MergeKeyBehavior.of(keyT3, mergeBehavior, c11, null)),
-                        MergeBehavior.NORMAL,
-                        dryRun,
-                        false))
-            .describedAs("MergeBehavior.%s", mergeBehavior)
-            .extracting(
-                MergeResult::wasApplied, MergeResult::wasSuccessful, r -> r.getDetails().get(keyT3))
-            .containsExactly(
-                false,
-                false,
-                KeyDetails.keyDetails(
-                    mergeBehavior,
-                    MergeResult.ConflictType.UNRESOLVABLE,
-                    Conflict.conflict(
-                        ConflictType.VALUE_DIFFERS,
-                        keyT3,
-                        "values of existing and expected content for key 't3' are different")));
-      } else {
-        soft.assertThatThrownBy(
-                () ->
-                    store()
-                        .merge(
-                            thirdCommit,
-                            targetBranch,
-                            Optional.empty(),
-                            metadataRewriter,
-                            false,
-                            ImmutableMap.of(
-                                keyT3, MergeKeyBehavior.of(keyT3, mergeBehavior, c11, null)),
-                            MergeBehavior.NORMAL,
-                            dryRun,
-                            false))
-            .describedAs("MergeBehavior.%s", mergeBehavior)
-            .isInstanceOf(MergeConflictException.class)
-            .hasMessage("The following keys have been changed in conflict: 't3'");
-      }
+      soft.assertThatThrownBy(
+              () ->
+                  store()
+                      .merge(
+                          thirdCommit,
+                          targetBranch,
+                          Optional.empty(),
+                          metadataRewriter,
+                          false,
+                          ImmutableMap.of(
+                              keyT3, MergeKeyBehavior.of(keyT3, mergeBehavior, c11, null)),
+                          MergeBehavior.NORMAL,
+                          dryRun,
+                          false))
+          .describedAs("MergeBehavior.%s", mergeBehavior)
+          .hasMessage("The following keys have been changed in conflict: 't3'")
+          .asInstanceOf(type(MergeConflictException.class))
+          .extracting(MergeConflictException::getMergeResult)
+          .extracting(
+              MergeResult::wasApplied, MergeResult::wasSuccessful, r -> r.getDetails().get(keyT3))
+          .containsExactly(
+              false,
+              false,
+              KeyDetails.keyDetails(
+                  mergeBehavior,
+                  MergeResult.ConflictType.UNRESOLVABLE,
+                  Conflict.conflict(
+                      ConflictType.VALUE_DIFFERS,
+                      keyT3,
+                      "values of existing and expected content for key 't3' are different")));
       soft.assertAll();
     }
   }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
@@ -31,6 +31,7 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
@@ -228,8 +229,13 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  protected void checkTransplantWitConflictingCommit(boolean individualCommits)
+  @CsvSource({
+    "false,false",
+    "false,true",
+    "true,false",
+    "true,true",
+  })
+  protected void checkTransplantWithConflictingCommit(boolean individualCommits, boolean dryRun)
       throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_3");
     store().create(newBranch, Optional.empty());
@@ -246,7 +252,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         individualCommits,
                         Collections.emptyMap(),
                         MergeBehavior.NORMAL,
-                        false,
+                        dryRun,
                         false))
         .isInstanceOf(ReferenceConflictException.class);
   }
@@ -288,8 +294,13 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  protected void checkTransplantOnNonExistingBranch(boolean individualCommits) {
+  @CsvSource({
+    "false,false",
+    "false,true",
+    "true,false",
+    "true,true",
+  })
+  protected void checkTransplantOnNonExistingBranch(boolean individualCommits, boolean dryRun) {
     final BranchName newBranch = BranchName.of("bar_5");
     soft.assertThatThrownBy(
             () ->
@@ -302,14 +313,19 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         individualCommits,
                         Collections.emptyMap(),
                         MergeBehavior.NORMAL,
-                        false,
+                        dryRun,
                         false))
         .isInstanceOf(ReferenceNotFoundException.class);
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  protected void checkTransplantWithNonExistingCommit(boolean individualCommits)
+  @CsvSource({
+    "false,false",
+    "false,true",
+    "true,false",
+    "true,true",
+  })
+  protected void checkTransplantWithNonExistingCommit(boolean individualCommits, boolean dryRun)
       throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_6");
     store().create(newBranch, Optional.empty());
@@ -324,7 +340,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         individualCommits,
                         Collections.emptyMap(),
                         MergeBehavior.NORMAL,
-                        false,
+                        dryRun,
                         false))
         .isInstanceOf(ReferenceNotFoundException.class);
   }
@@ -370,8 +386,13 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  protected void checkTransplantWithCommitsInWrongOrder(boolean individualCommits)
+  @CsvSource({
+    "false,false",
+    "false,true",
+    "true,false",
+    "true,true",
+  })
+  protected void checkTransplantWithCommitsInWrongOrder(boolean individualCommits, boolean dryRun)
       throws VersionStoreException {
     final BranchName newBranch = BranchName.of("bar_8");
     store().create(newBranch, Optional.empty());
@@ -388,13 +409,19 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         individualCommits,
                         Collections.emptyMap(),
                         MergeBehavior.NORMAL,
-                        false,
+                        dryRun,
                         false));
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  protected void checkInvalidBranchHash(boolean individualCommits) throws VersionStoreException {
+  @CsvSource({
+    "false,false",
+    "false,true",
+    "true,false",
+    "true,true",
+  })
+  protected void checkInvalidBranchHash(boolean individualCommits, boolean dryRun)
+      throws VersionStoreException {
     final BranchName anotherBranch = BranchName.of("bar");
     store().create(anotherBranch, Optional.empty());
     final Hash unrelatedCommit =
@@ -418,7 +445,7 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         individualCommits,
                         Collections.emptyMap(),
                         MergeBehavior.NORMAL,
-                        false,
+                        dryRun,
                         false))
         .isInstanceOf(ReferenceNotFoundException.class);
   }


### PR DESCRIPTION
The `dryRun` API parameter is different from `returnConflictAsResult`.

If a dry run is requested it should produce the same client-side effect as a normal merge / transplant.

At the `VersionStore` level this means throwing the same exception regardless of the `dryRun` parameter because `returnConflictAsResult` does not exist at that level.