### PR TITLE
Build/CI: pass `test.log.level` via `CommandLineArgumentProvider` and populate Quarkus console log level

### DIFF
--- a/buildSrc/src/main/kotlin/Testing.kt
+++ b/buildSrc/src/main/kotlin/Testing.kt
@@ -112,8 +112,8 @@ class NessieTestingPlugin : Plugin<Project> {
           jvmArgumentProviders.add(
             CommandLineArgumentProvider {
               listOf(
-                "-Dquarkus.log.level=${testLogLevel()}",
-                "-Dquarkus.log.console.level=${testLogLevel()}",
+                "-Dquarkus.log.level=${testLogLevel("INFO")}",
+                "-Dquarkus.log.console.level=${testLogLevel("INFO")}",
                 "-Dhttp.access.log.level=${testLogLevel()}"
               )
             }

--- a/buildSrc/src/main/kotlin/Testing.kt
+++ b/buildSrc/src/main/kotlin/Testing.kt
@@ -33,6 +33,7 @@ import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
+import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.testing.base.TestingExtension
 
 class NessieTestingPlugin : Plugin<Project> {
@@ -100,15 +101,23 @@ class NessieTestingPlugin : Plugin<Project> {
         systemProperty("user.language", "en")
         systemProperty("user.country", "US")
         systemProperty("user.variant", "")
-        systemProperty("test.log.level", testLogLevel())
+        jvmArgumentProviders.add(
+          CommandLineArgumentProvider { listOf("-Dtest.log.level=${testLogLevel()}") }
+        )
         environment("TESTCONTAINERS_REUSE_ENABLE", "true")
 
         if (plugins.hasPlugin("io.quarkus")) {
           jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
           // Log-levels are required to be able to parse the HTTP listen URL
-          systemProperty("quarkus.log.level", "INFO")
-          systemProperty("quarkus.log.console.level", "INFO")
-          systemProperty("http.access.log.level", testLogLevel())
+          jvmArgumentProviders.add(
+            CommandLineArgumentProvider {
+              listOf(
+                "-Dquarkus.log.level=${testLogLevel()}",
+                "-Dquarkus.log.console.level=${testLogLevel()}",
+                "-Dhttp.access.log.level=${testLogLevel()}"
+              )
+            }
+          )
 
           minHeapSize = if (testHeapSize != null) testHeapSize as String else "512m"
           maxHeapSize = if (testHeapSize != null) testHeapSize as String else "1536m"

--- a/buildSrc/src/main/kotlin/Utilities.kt
+++ b/buildSrc/src/main/kotlin/Utilities.kt
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
@@ -114,6 +115,15 @@ fun Project.libsRequiredVersion(name: String): String {
 }
 
 fun testLogLevel(): String = System.getProperty("test.log.level", "WARN")
+
+fun testLogLevel(minVerbose: String): String {
+  val requested = LogLevel.valueOf(testLogLevel().uppercase())
+  val minimum = LogLevel.valueOf(minVerbose.uppercase())
+  if (requested.ordinal > minimum.ordinal) {
+    return minimum.name
+  }
+  return requested.name
+}
 
 /** Check whether the current build is run in the context of integrations-testing. */
 fun isIntegrationsTestingEnabled() =


### PR DESCRIPTION
Allows passing for example `-Dtest.log.level=DEBUG` on the Gradle command line and all relevant logging configs use this value as well.

Using a `CommandLineArgumentProvider` prevents the log-level setting from influencing the Gradle cache.