### PR TITLE
Remove top-level condition from the `CI Website` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -901,7 +901,6 @@ jobs:
   site:
     name: CI Website
     runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v3.5.2
       - name: Setup Python


### PR DESCRIPTION
This will make the job run on commits to `main` as well as PRs.

Keep the condition on the `Deploy Static Site to GitHub` step to allow deployment only from commits in the main Nessie repo.