### PR TITLE
Reserve usage of BatchingPersist to dry-run mode only

### DIFF
--- a/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/WriteBatching.java
+++ b/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/WriteBatching.java
@@ -29,6 +29,13 @@ public interface WriteBatching {
 
   Persist persist();
 
+  /**
+   * The maximum number of objects to be stored in a single batch.
+   *
+   * <p>A value of {@code 0} or fewer means "infinite batching" and effectively disables flushes,
+   * preventing all writes from being persisted. This can be useful for testing in dry-run mode, but
+   * should not be used in production.
+   */
   @Value.Default
   default int batchSize() {
     return DEFAULT_BATCH_SIZE;
@@ -41,7 +48,7 @@ public interface WriteBatching {
    * thing.
    *
    * <p><em>IMPORTANT NOTE:</em> there is currently no implementation that supports strict checks
-   * that would provide the same guarantees are live-production {@code Persist} implementations.
+   * that would provide the same guarantees as live-production {@code Persist} implementations.
    */
   @Value.Default
   default boolean optimistic() {

--- a/versioned/storage/batching/src/test/java/org/projectnessie/versioned/storage/batching/TestBatchingPersist.java
+++ b/versioned/storage/batching/src/test/java/org/projectnessie/versioned/storage/batching/TestBatchingPersist.java
@@ -204,6 +204,19 @@ public class TestBatchingPersist {
         .isInstanceOf(ObjTooLargeException.class);
   }
 
+  @ParameterizedTest
+  @MethodSource("allObjectTypeSamples")
+  void noFlush(Obj obj) throws Exception {
+    BatchingPersistImpl persist =
+        (BatchingPersistImpl) WriteBatching.builder().persist(base).batchSize(0).build().create();
+    persist.storeObj(obj);
+    Obj updated = updateObjChange(obj);
+    persist.upsertObj(updated);
+    persist.flush();
+    soft.assertThat(persist.pendingStores()).containsExactly(entry(obj.id(), obj));
+    soft.assertThat(persist.pendingUpserts()).containsExactly(entry(obj.id(), updated));
+  }
+
   private Persist base() {
     InmemoryBackendFactory factory = new InmemoryBackendFactory();
     @SuppressWarnings("resource")

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
@@ -42,8 +42,6 @@ import org.projectnessie.versioned.MergeResult.KeyDetails;
 import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
-import org.projectnessie.versioned.storage.batching.BatchingPersist;
-import org.projectnessie.versioned.storage.batching.WriteBatching;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
 import org.projectnessie.versioned.storage.common.logic.CommitLogic;
@@ -59,8 +57,6 @@ import org.projectnessie.versioned.storage.common.persist.Reference;
 
 class BaseMergeTransplantIndividual extends BaseCommitHelper {
 
-  final BatchingPersist persist;
-
   BaseMergeTransplantIndividual(
       @Nonnull @jakarta.annotation.Nonnull BranchName branch,
       @Nonnull @jakarta.annotation.Nonnull Optional<Hash> referenceHash,
@@ -68,22 +64,7 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
       @Nonnull @jakarta.annotation.Nonnull Reference reference,
       @Nullable @jakarta.annotation.Nullable CommitObj head)
       throws ReferenceNotFoundException {
-    this(branch, referenceHash, batching(persist), reference, head);
-  }
-
-  private BaseMergeTransplantIndividual(
-      @Nonnull @jakarta.annotation.Nonnull BranchName branch,
-      @Nonnull @jakarta.annotation.Nonnull Optional<Hash> referenceHash,
-      @Nonnull @jakarta.annotation.Nonnull BatchingPersist persist,
-      @Nonnull @jakarta.annotation.Nonnull Reference reference,
-      @Nullable @jakarta.annotation.Nullable CommitObj head)
-      throws ReferenceNotFoundException {
     super(branch, referenceHash, persist, reference, head);
-    this.persist = persist;
-  }
-
-  private static BatchingPersist batching(Persist persist) {
-    return WriteBatching.builder().persist(persist).batchSize(Integer.MAX_VALUE).build().create();
   }
 
   MergeResult<Commit> individualCommits(
@@ -129,10 +110,6 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
     }
 
     boolean hasConflicts = recordKeyDetailsAndCheckConflicts(mergeResult, keyDetailsMap);
-
-    if (!dryRun && !hasConflicts) {
-      persist.flush();
-    }
 
     return finishMergeTransplant(empty, mergeResult, newHead, dryRun, hasConflicts);
   }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -33,6 +33,7 @@ import static org.projectnessie.versioned.storage.common.persist.ObjId.EMPTY_OBJ
 import static org.projectnessie.versioned.storage.common.persist.ObjType.COMMIT;
 import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
 import static org.projectnessie.versioned.storage.versionstore.BaseCommitHelper.committingOperation;
+import static org.projectnessie.versioned.storage.versionstore.BaseCommitHelper.dryRunCommitterSupplier;
 import static org.projectnessie.versioned.storage.versionstore.RefMapping.NO_ANCESTOR;
 import static org.projectnessie.versioned.storage.versionstore.RefMapping.asBranchName;
 import static org.projectnessie.versioned.storage.versionstore.RefMapping.asTagName;
@@ -618,6 +619,10 @@ public class VersionStoreImpl implements VersionStore {
     CommitterSupplier<Merge> supplier =
         keepIndividualCommits ? MergeIndividualImpl::new : MergeSquashImpl::new;
 
+    if (dryRun) {
+      supplier = dryRunCommitterSupplier(supplier);
+    }
+
     MergeBehaviors mergeBehaviors =
         new MergeBehaviors(keepIndividualCommits, mergeKeyBehaviors, defaultMergeBehavior);
 
@@ -649,6 +654,10 @@ public class VersionStoreImpl implements VersionStore {
 
     CommitterSupplier<Transplant> supplier =
         keepIndividualCommits ? TransplantIndividualImpl::new : TransplantSquashImpl::new;
+
+    if (dryRun) {
+      supplier = dryRunCommitterSupplier(supplier);
+    }
 
     MergeBehaviors mergeBehaviors =
         new MergeBehaviors(keepIndividualCommits, mergeKeyBehaviors, defaultMergeBehavior);

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -258,7 +258,6 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
             .toBranch(sourceBranch);
     contentT2 = store().getValue(MAIN_BRANCH, key2);
 
-    StorageAssertions checkpoint = storageCheckpoint();
     soft.assertThatThrownBy(
             () ->
                 store()
@@ -273,7 +272,6 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                         false,
                         false))
         .isInstanceOf(MergeConflictException.class);
-    checkpoint.assertNoWrites();
 
     Content resolvedContent = onRef("resolved", contentT2.getId());
     Content wrongExpectedContent = onRef("wrong", contentT2.getId());
@@ -301,7 +299,6 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                           false))
           .withMessage(
               "MergeKeyBehavior.resolvedContent and MergeKeyBehavior.expectedTargetContent are not supported for this storage model");
-      checkpoint.assertNoWrites();
       return;
     }
 
@@ -328,7 +325,6 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                           false))
           .withMessage(
               "MergeKeyBehavior.expectedTargetContent and MergeKeyBehavior.resolvedContent are only supported for squashing merge/transplant operations.");
-      checkpoint.assertNoWrites();
       return;
     }
 
@@ -357,7 +353,6 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                 ConflictType.VALUE_DIFFERS,
                 key2,
                 "values of existing and expected content for key 't2' are different"));
-    checkpoint.assertNoWrites();
 
     soft.assertThatIllegalArgumentException()
         .isThrownBy(
@@ -377,7 +372,6 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                         false))
         .withMessage(
             "MergeKeyBehavior.resolvedContent requires setting MergeKeyBehavior.expectedTarget as well for key t2");
-    checkpoint.assertNoWrites();
 
     MergeResult<Commit> result =
         store()
@@ -943,7 +937,9 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
         .hasMessageContaining("The following keys have been changed in conflict:")
         .hasMessageContaining(conflictingKey1.toString())
         .hasMessageContaining(conflictingKey2.toString());
-    checkpoint.assertNoWrites();
+    if (dryRun) {
+      checkpoint.assertNoWrites();
+    }
 
     // default to MergeBehavior.NORMAL, but ignore conflictingKey1
     soft.assertThatThrownBy(
@@ -965,7 +961,9 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
         .hasMessageContaining("The following keys have been changed in conflict:")
         .hasMessageContaining(conflictingKey1.toString())
         .hasMessageNotContaining(conflictingKey2.toString());
-    checkpoint.assertNoWrites();
+    if (dryRun) {
+      checkpoint.assertNoWrites();
+    }
 
     // default to MergeBehavior.DROP (don't merge keys by default), but include conflictingKey1
     soft.assertThatThrownBy(
@@ -987,7 +985,9 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
         .hasMessageContaining("The following keys have been changed in conflict:")
         .hasMessageContaining(conflictingKey1.toString())
         .hasMessageNotContaining(conflictingKey2.toString());
-    checkpoint.assertNoWrites();
+    if (dryRun) {
+      checkpoint.assertNoWrites();
+    }
 
     // default to MergeBehavior.NORMAL, but include conflictingKey1
     soft.assertThatThrownBy(
@@ -1009,7 +1009,9 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
         .hasMessageContaining("The following keys have been changed in conflict:")
         .hasMessageNotContaining(conflictingKey1.toString())
         .hasMessageContaining(conflictingKey2.toString());
-    checkpoint.assertNoWrites();
+    if (dryRun) {
+      checkpoint.assertNoWrites();
+    }
 
     Supplier<Hash> mergeIntoHeadSupplier =
         () -> {
@@ -1102,7 +1104,9 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                         dryRun,
                         false))
         .isInstanceOf(ReferenceConflictException.class);
-    checkpoint.assertNoWrites();
+    if (dryRun) {
+      checkpoint.assertNoWrites();
+    }
   }
 
   @ParameterizedTest

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
@@ -256,7 +256,9 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
                         dryRun,
                         false))
         .isInstanceOf(ReferenceConflictException.class);
-    checkpoint.assertNoWrites();
+    if (dryRun) {
+      checkpoint.assertNoWrites();
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
This commit changes the behavior of merges and transplants to only use BatchingPersist in dry-run mode.