### PR TITLE
CI/main: Run CI on main sequentially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,15 @@ on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
 
+# For the main branch: let all CI runs complete, one after the other. This has a couple advantages:
+# * Site deployments happen in commit-order
+# * Saved Gradle cache are persisted in commit-order
+# * (Potentially) more GH runners available for PRs
 concurrency:
-  # PRs: 1 CI run concurrently
-  # main branch: 1 CI run per commit (so every commit is checked)
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.head_commit.id }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PRs: 1 CI run concurrently / older ones are cancelled
+  # main branch: 1 CI run concurrently / all commits / no cancellation
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   code-checks:


### PR DESCRIPTION
For the main branch: let all CI runs complete, one after the other. This has a couple advantages:
* Site deployments happen in commit-order
* Saved Gradle cache are persisted in commit-order
* (Potentially) more GH runners available for PRs