### PR TITLE
REST V2: Key ranges for entries + diff

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/api/GetDiffBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/GetDiffBuilder.java
@@ -25,7 +25,9 @@ import org.projectnessie.model.Reference;
  * @since {@link NessieApiV1}
  */
 public interface GetDiffBuilder
-    extends PagingBuilder<GetDiffBuilder, DiffResponse, DiffResponse.DiffEntry> {
+    extends PagingBuilder<GetDiffBuilder, DiffResponse, DiffResponse.DiffEntry>,
+        QueryBuilder<GetDiffBuilder>,
+        KeyRangeBuilder<GetDiffBuilder> {
 
   GetDiffBuilder fromRefName(String fromRefName);
 

--- a/api/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/GetEntriesBuilder.java
@@ -25,6 +25,7 @@ import org.projectnessie.model.EntriesResponse;
  */
 public interface GetEntriesBuilder
     extends QueryBuilder<GetEntriesBuilder>,
+        KeyRangeBuilder<GetEntriesBuilder>,
         PagingBuilder<GetEntriesBuilder, EntriesResponse, EntriesResponse.Entry>,
         OnReferenceBuilder<GetEntriesBuilder> {
 

--- a/api/client/src/main/java/org/projectnessie/client/api/KeyRangeBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/KeyRangeBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.api;
+
+import java.util.Collection;
+import org.projectnessie.model.ContentKey;
+
+public interface KeyRangeBuilder<R extends KeyRangeBuilder<R>> {
+
+  R minKey(ContentKey key);
+
+  R maxKey(ContentKey key);
+
+  R prefixKey(ContentKey key);
+
+  R key(ContentKey key);
+
+  R keys(Collection<ContentKey> keys);
+}

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseGetDiffBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseGetDiffBuilder.java
@@ -15,11 +15,15 @@
  */
 package org.projectnessie.client.builder;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.projectnessie.client.StreamingUtil;
 import org.projectnessie.client.api.GetDiffBuilder;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.DiffResponse;
 
 public abstract class BaseGetDiffBuilder<PARAMS> implements GetDiffBuilder {
@@ -32,6 +36,11 @@ public abstract class BaseGetDiffBuilder<PARAMS> implements GetDiffBuilder {
   protected String fromHashOnRef;
   protected String toRefName;
   protected String toHashOnRef;
+  protected final List<ContentKey> keys = new ArrayList<>();
+  protected ContentKey minKey;
+  protected ContentKey maxKey;
+  protected ContentKey prefixKey;
+  protected String filter;
 
   protected BaseGetDiffBuilder(BiFunction<PARAMS, String, PARAMS> paramsForPage) {
     this.paramsForPage = paramsForPage;
@@ -70,6 +79,42 @@ public abstract class BaseGetDiffBuilder<PARAMS> implements GetDiffBuilder {
   @Override
   public GetDiffBuilder pageToken(String pageToken) {
     this.pageToken = pageToken;
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder key(ContentKey key) {
+    this.keys.add(key);
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder keys(Collection<ContentKey> keys) {
+    this.keys.addAll(keys);
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder minKey(ContentKey minKey) {
+    this.minKey = minKey;
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder maxKey(ContentKey maxKey) {
+    this.maxKey = maxKey;
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder prefixKey(ContentKey prefixKey) {
+    this.prefixKey = prefixKey;
+    return this;
+  }
+
+  @Override
+  public GetDiffBuilder filter(String filter) {
+    this.filter = filter;
     return this;
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseGetEntriesBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseGetEntriesBuilder.java
@@ -15,11 +15,15 @@
  */
 package org.projectnessie.client.builder;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.projectnessie.client.StreamingUtil;
 import org.projectnessie.client.api.GetEntriesBuilder;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.EntriesResponse.Entry;
 
@@ -30,6 +34,10 @@ public abstract class BaseGetEntriesBuilder<PARAMS>
   private String pageToken;
 
   protected Integer maxRecords;
+  protected final List<ContentKey> keys = new ArrayList<>();
+  protected ContentKey minKey;
+  protected ContentKey maxKey;
+  protected ContentKey prefixKey;
   protected String filter;
   protected Integer namespaceDepth;
   protected boolean withContent;
@@ -47,6 +55,36 @@ public abstract class BaseGetEntriesBuilder<PARAMS>
   @Override
   public GetEntriesBuilder pageToken(String pageToken) {
     this.pageToken = pageToken;
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder key(ContentKey key) {
+    this.keys.add(key);
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder keys(Collection<ContentKey> keys) {
+    this.keys.addAll(keys);
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder minKey(ContentKey minKey) {
+    this.minKey = minKey;
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder maxKey(ContentKey maxKey) {
+    this.maxKey = maxKey;
+    return this;
+  }
+
+  @Override
+  public GetEntriesBuilder prefixKey(ContentKey prefixKey) {
+    this.prefixKey = prefixKey;
     return this;
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetDiff.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetDiff.java
@@ -15,12 +15,14 @@
  */
 package org.projectnessie.client.http.v1api;
 
+import java.util.Collection;
 import org.projectnessie.api.v1.params.DiffParams;
 import org.projectnessie.api.v1.params.DiffParamsBuilder;
 import org.projectnessie.client.api.GetDiffBuilder;
 import org.projectnessie.client.builder.BaseGetDiffBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.DiffResponse;
 
 final class HttpGetDiff extends BaseGetDiffBuilder<DiffParams> {
@@ -44,6 +46,38 @@ final class HttpGetDiff extends BaseGetDiffBuilder<DiffParams> {
   @Override
   public GetDiffBuilder maxRecords(int maxRecords) {
     throw new UnsupportedOperationException(PAGINATION_ERROR_MESSAGE);
+  }
+
+  @Override
+  public GetDiffBuilder key(ContentKey key) {
+    throw new UnsupportedOperationException(
+        "Requesting individual keys is not supported in API v1.");
+  }
+
+  @Override
+  public GetDiffBuilder keys(Collection<ContentKey> keys) {
+    throw new UnsupportedOperationException(
+        "Requesting individual keys is not supported in API v1.");
+  }
+
+  @Override
+  public GetDiffBuilder minKey(ContentKey minKey) {
+    throw new UnsupportedOperationException("Requesting key ranges is not supported in API v1.");
+  }
+
+  @Override
+  public GetDiffBuilder maxKey(ContentKey maxKey) {
+    throw new UnsupportedOperationException("Requesting key ranges is not supported in API v1.");
+  }
+
+  @Override
+  public GetDiffBuilder prefixKey(ContentKey prefixKey) {
+    throw new UnsupportedOperationException("Requesting key prefix is not supported in API v1.");
+  }
+
+  @Override
+  public GetDiffBuilder filter(String filter) {
+    throw new UnsupportedOperationException("CEL key filter is not supported in API v1.");
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpGetEntries.java
@@ -15,10 +15,13 @@
  */
 package org.projectnessie.client.http.v1api;
 
+import java.util.Collection;
 import org.projectnessie.api.v1.params.EntriesParams;
+import org.projectnessie.client.api.GetEntriesBuilder;
 import org.projectnessie.client.builder.BaseGetEntriesBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.EntriesResponse;
 
 final class HttpGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
@@ -38,6 +41,33 @@ final class HttpGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
         .maxRecords(maxRecords)
         .hashOnRef(hashOnRef)
         .build();
+  }
+
+  @Override
+  public HttpGetEntries key(ContentKey key) {
+    throw new UnsupportedOperationException(
+        "Requesting individual keys is not supported in API v1.");
+  }
+
+  @Override
+  public HttpGetEntries keys(Collection<ContentKey> keys) {
+    throw new UnsupportedOperationException(
+        "Requesting individual keys is not supported in API v1.");
+  }
+
+  @Override
+  public HttpGetEntries minKey(ContentKey minKey) {
+    throw new UnsupportedOperationException("Requesting key ranges is not supported in API v1.");
+  }
+
+  @Override
+  public HttpGetEntries maxKey(ContentKey maxKey) {
+    throw new UnsupportedOperationException("Requesting key ranges is not supported in API v1.");
+  }
+
+  @Override
+  public GetEntriesBuilder prefixKey(ContentKey prefixKey) {
+    throw new UnsupportedOperationException("Requesting key ranges is not supported in API v1.");
   }
 
   @Override

--- a/api/model/src/main/java/org/projectnessie/api/v2/doc/ApiDoc.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/doc/ApiDoc.java
@@ -112,11 +112,36 @@ public interface ApiDoc {
           + "'type' parameter may be used to ensure the operation is performed on the same object that the user "
           + "expects.\n";
 
-  String KEY_PARAMETER_DESCRIPTION =
-      "The key to a content object.\n"
-          + "\n"
-          + "Key components (namespaces) are separated by the dot ('.') character. Dot ('.') characters that are not "
+  String KEY_ELEMENTS_DESCRIPTION =
+      "Key components (namespaces) are separated by the dot ('.') character. Dot ('.') characters that are not "
           + "Nessie namespace separators must be encoded as the 'group separator' ASCII character (0x1D).\n";
+
+  String KEY_PARAMETER_DESCRIPTION = "The key to a content object.\n\n" + KEY_ELEMENTS_DESCRIPTION;
+
+  String REQUESTED_KEY_PARAMETER_DESCRIPTION =
+      "Restrict the result to one or more keys.\n\n"
+          + "Can be combined with min/max-key and prefix-key parameters, however both predicates must match. "
+          + "This means that keys specified via this parameter that do not match a given min/max-key or prefix-key will not be returned.\n\n"
+          + KEY_ELEMENTS_DESCRIPTION;
+
+  String KEY_MIN_PARAMETER_DESCRIPTION =
+      "The lower bound of the content key range to retrieve (inclusive). "
+          + "The content keys of all returned entries will be greater than or equal to the min-value. "
+          + "Content-keys are compared as a 'whole', unlike prefix-keys.\n\n"
+          + KEY_ELEMENTS_DESCRIPTION;
+
+  String KEY_MAX_PARAMETER_DESCRIPTION =
+      "The upper bound of the content key range to retrieve (inclusive). "
+          + "The content keys of all returned entries will be less than or equal to the max-value. "
+          + "Content-keys are compared as a 'whole', unlike prefix-keys.\n\n"
+          + KEY_ELEMENTS_DESCRIPTION;
+
+  String KEY_PREFIX_PARAMETER_DESCRIPTION =
+      "The content key prefix to retrieve (inclusive). "
+          + "A content key matches a given prefix, a content key's elements starts with all elements of the prefix-key. "
+          + "Key prefixes exactly match key-element boundaries.\n\n"
+          + "Must not be combined with min/max-key parameters.\n\n"
+          + KEY_ELEMENTS_DESCRIPTION;
 
   String DEFAULT_KEY_MERGE_MODE_DESCRIPTION =
       "The default merge mode. If not set, `NORMAL` is assumed.\n"

--- a/api/model/src/main/java/org/projectnessie/api/v2/params/AbstractParams.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/params/AbstractParams.java
@@ -40,7 +40,7 @@ public abstract class AbstractParams<IMPL extends AbstractParams<IMPL>> {
 
   protected AbstractParams() {}
 
-  protected AbstractParams(Integer maxRecords, String pageToken) {
+  protected AbstractParams(@Nullable Integer maxRecords, @Nullable String pageToken) {
     this.maxRecords = maxRecords;
     this.pageToken = pageToken;
   }

--- a/api/model/src/main/java/org/projectnessie/api/v2/params/DiffParams.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/params/DiffParams.java
@@ -16,14 +16,18 @@
 package org.projectnessie.api.v2.params;
 
 import static org.projectnessie.api.v2.doc.ApiDoc.REF_PARAMETER_DESCRIPTION;
+import static org.projectnessie.api.v2.doc.ApiDoc.REQUESTED_KEY_PARAMETER_DESCRIPTION;
 
+import java.util.List;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.immutables.builder.Builder.Constructor;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Validation;
 
 /**
@@ -33,7 +37,7 @@ import org.projectnessie.model.Validation;
  * intention is to allow clients to request a diff on a sub-set of keys (e.g. in one particular
  * namespace) or just for one particular key.
  */
-public class DiffParams extends AbstractParams<DiffParams> {
+public class DiffParams extends KeyRangeParams<DiffParams> {
 
   @NotNull
   @jakarta.validation.constraints.NotNull
@@ -66,6 +70,20 @@ public class DiffParams extends AbstractParams<DiffParams> {
   @jakarta.ws.rs.PathParam("to-ref")
   private String toRef;
 
+  @Parameter(description = REQUESTED_KEY_PARAMETER_DESCRIPTION)
+  @QueryParam("key")
+  @jakarta.ws.rs.QueryParam("key")
+  private List<ContentKey> requestedKeys;
+
+  @Parameter(
+      description =
+          "A Common Expression Language (CEL) expression. An intro to CEL can be found at https://github.com/google/cel-spec/blob/master/doc/intro.md.\n\n"
+              + "Usable variables within the expression are:\n\n"
+              + "- 'key' (string, namespace + table name), 'keyElements' (list of strings), 'namespace' (string), 'namespaceElements' (list of strings) and 'name' (string, the \"simple\" table name)")
+  @QueryParam("filter")
+  @jakarta.ws.rs.QueryParam("filter")
+  private String filter;
+
   public DiffParams() {}
 
   @Constructor
@@ -73,10 +91,17 @@ public class DiffParams extends AbstractParams<DiffParams> {
       @NotNull @jakarta.validation.constraints.NotNull String fromRef,
       @NotNull @jakarta.validation.constraints.NotNull String toRef,
       @Nullable @jakarta.annotation.Nullable Integer maxRecords,
-      @Nullable @jakarta.annotation.Nullable String pageToken) {
-    super(maxRecords, pageToken);
+      @Nullable @jakarta.annotation.Nullable String pageToken,
+      @Nullable @jakarta.annotation.Nullable ContentKey minKey,
+      @Nullable @jakarta.annotation.Nullable ContentKey maxKey,
+      @Nullable @jakarta.annotation.Nullable ContentKey prefixKey,
+      @Nullable @jakarta.annotation.Nullable List<ContentKey> requestedKeys,
+      @Nullable @jakarta.annotation.Nullable String filter) {
+    super(maxRecords, pageToken, minKey, maxKey, prefixKey);
     this.fromRef = fromRef;
     this.toRef = toRef;
+    this.requestedKeys = requestedKeys;
+    this.filter = filter;
   }
 
   public String getFromRef() {
@@ -87,12 +112,29 @@ public class DiffParams extends AbstractParams<DiffParams> {
     return toRef;
   }
 
+  public List<ContentKey> getRequestedKeys() {
+    return requestedKeys;
+  }
+
+  public String getFilter() {
+    return filter;
+  }
+
   public static DiffParamsBuilder builder() {
     return new DiffParamsBuilder();
   }
 
   @Override
   public DiffParams forNextPage(String pageToken) {
-    return new DiffParams(fromRef, toRef, maxRecords(), pageToken);
+    return new DiffParams(
+        fromRef,
+        toRef,
+        maxRecords(),
+        pageToken,
+        minKey(),
+        maxKey(),
+        prefixKey(),
+        requestedKeys,
+        filter);
   }
 }

--- a/api/model/src/main/java/org/projectnessie/api/v2/params/EntriesParams.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/params/EntriesParams.java
@@ -15,11 +15,15 @@
  */
 package org.projectnessie.api.v2.params;
 
+import static org.projectnessie.api.v2.doc.ApiDoc.REQUESTED_KEY_PARAMETER_DESCRIPTION;
+
+import java.util.List;
 import javax.annotation.Nullable;
 import javax.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.immutables.builder.Builder.Constructor;
+import org.projectnessie.model.ContentKey;
 
 /**
  * The purpose of this class is to include optional parameters that can be passed to {@code
@@ -28,7 +32,12 @@ import org.immutables.builder.Builder.Constructor;
  * <p>For easier usage of this class, there is {@link EntriesParams#builder()}, which allows
  * configuring/setting the different parameters.
  */
-public class EntriesParams extends AbstractParams<EntriesParams> {
+public class EntriesParams extends KeyRangeParams<EntriesParams> {
+
+  @Parameter(description = REQUESTED_KEY_PARAMETER_DESCRIPTION)
+  @QueryParam("key")
+  @jakarta.ws.rs.QueryParam("key")
+  private List<ContentKey> requestedKeys;
 
   @Nullable
   @jakarta.annotation.Nullable
@@ -58,11 +67,16 @@ public class EntriesParams extends AbstractParams<EntriesParams> {
   EntriesParams(
       @Nullable @jakarta.annotation.Nullable Integer maxRecords,
       @Nullable @jakarta.annotation.Nullable String pageToken,
+      @Nullable @jakarta.annotation.Nullable ContentKey minKey,
+      @Nullable @jakarta.annotation.Nullable ContentKey maxKey,
+      @Nullable @jakarta.annotation.Nullable ContentKey prefixKey,
+      @Nullable @jakarta.annotation.Nullable List<ContentKey> requestedKeys,
       @Nullable @jakarta.annotation.Nullable String filter,
       @Nullable @jakarta.annotation.Nullable Boolean withContent) {
-    super(maxRecords, pageToken);
+    super(maxRecords, pageToken, minKey, maxKey, prefixKey);
     this.filter = filter;
     this.withContent = withContent;
+    this.requestedKeys = requestedKeys;
   }
 
   public static EntriesParamsBuilder builder() {
@@ -71,6 +85,10 @@ public class EntriesParams extends AbstractParams<EntriesParams> {
 
   public static EntriesParams empty() {
     return builder().build();
+  }
+
+  public List<ContentKey> getRequestedKeys() {
+    return requestedKeys;
   }
 
   @Nullable
@@ -85,6 +103,14 @@ public class EntriesParams extends AbstractParams<EntriesParams> {
 
   @Override
   public EntriesParams forNextPage(String pageToken) {
-    return new EntriesParams(maxRecords(), pageToken, filter, withContent);
+    return new EntriesParams(
+        maxRecords(),
+        pageToken,
+        minKey(),
+        maxKey(),
+        prefixKey(),
+        requestedKeys,
+        filter,
+        withContent);
   }
 }

--- a/api/model/src/main/java/org/projectnessie/api/v2/params/KeyRangeParams.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/params/KeyRangeParams.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.api.v2.params;
+
+import static org.projectnessie.api.v2.doc.ApiDoc.KEY_MAX_PARAMETER_DESCRIPTION;
+import static org.projectnessie.api.v2.doc.ApiDoc.KEY_MIN_PARAMETER_DESCRIPTION;
+import static org.projectnessie.api.v2.doc.ApiDoc.KEY_PREFIX_PARAMETER_DESCRIPTION;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.QueryParam;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.projectnessie.model.ContentKey;
+
+public abstract class KeyRangeParams<IMPL extends KeyRangeParams<IMPL>>
+    extends AbstractParams<IMPL> {
+
+  @Parameter(
+      description = KEY_MIN_PARAMETER_DESCRIPTION,
+      examples = @ExampleObject(ref = "ContentKeyGet"))
+  @QueryParam("min-key")
+  @Nullable
+  @jakarta.annotation.Nullable
+  private ContentKey minKey;
+
+  @Parameter(
+      description = KEY_MAX_PARAMETER_DESCRIPTION,
+      examples = @ExampleObject(ref = "ContentKeyGet"))
+  @QueryParam("max-key")
+  @Nullable
+  @jakarta.annotation.Nullable
+  private ContentKey maxKey;
+
+  @Parameter(
+      description = KEY_PREFIX_PARAMETER_DESCRIPTION,
+      examples = @ExampleObject(ref = "ContentKeyGet"))
+  @QueryParam("prefix-key")
+  @Nullable
+  @jakarta.annotation.Nullable
+  private ContentKey prefixKey;
+
+  protected KeyRangeParams() {}
+
+  public KeyRangeParams(
+      @Nullable @jakarta.annotation.Nullable Integer maxRecords,
+      @Nullable @jakarta.annotation.Nullable String pageToken,
+      @Nullable @jakarta.annotation.Nullable ContentKey minKey,
+      @Nullable @jakarta.annotation.Nullable ContentKey maxKey,
+      @Nullable @jakarta.annotation.Nullable ContentKey prefixKey) {
+    super(maxRecords, pageToken);
+    this.minKey = minKey;
+    this.maxKey = maxKey;
+    this.prefixKey = prefixKey;
+  }
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  public ContentKey minKey() {
+    return minKey;
+  }
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  public ContentKey maxKey() {
+    return maxKey;
+  }
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  public ContentKey prefixKey() {
+    return prefixKey;
+  }
+}

--- a/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImportPersist.java
+++ b/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImportPersist.java
@@ -305,7 +305,7 @@ public class ITExportImportPersist {
       throws ReferenceNotFoundException {
     VersionStoreImpl store = new VersionStoreImpl(persist);
     ReferenceInfo<CommitMeta> main = store.getNamedRef(ref, GetNamedRefsParams.DEFAULT);
-    soft.assertThat(store.getKeys(main.getHash(), null, true))
+    soft.assertThat(store.getKeys(main.getHash(), null, false, null, null, null, null))
         .toIterable()
         .extracting(KeyEntry::getKey, KeyEntry::getContent)
         .containsExactly(tuple(key, value));

--- a/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImportPersist.java
+++ b/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImportPersist.java
@@ -305,7 +305,7 @@ public class ITExportImportPersist {
       throws ReferenceNotFoundException {
     VersionStoreImpl store = new VersionStoreImpl(persist);
     ReferenceInfo<CommitMeta> main = store.getNamedRef(ref, GetNamedRefsParams.DEFAULT);
-    soft.assertThat(store.getKeys(main.getHash(), null, false, null, null, null, null))
+    soft.assertThat(store.getKeys(main.getHash(), null, true, null, null, null, null))
         .toIterable()
         .extracting(KeyEntry::getKey, KeyEntry::getContent)
         .containsExactly(tuple(key, value));

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
@@ -86,6 +86,11 @@ public class RestDiffResource implements HttpDiffApi {
               }
             },
             h -> builder.effectiveFromReference(toReference(h)),
-            h -> builder.effectiveToReference(toReference(h)));
+            h -> builder.effectiveToReference(toReference(h)),
+            null,
+            null,
+            null,
+            null,
+            null);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -154,7 +154,11 @@ public class RestTreeResource implements HttpTreeApi {
                 builder.isHasMore(true).token(pagingToken);
               }
             },
-            h -> builder.effectiveReference(toReference(h)));
+            h -> builder.effectiveReference(toReference(h)),
+            null,
+            null,
+            null,
+            null);
   }
 
   @JsonView(Views.V1.class)

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -197,7 +197,11 @@ public class RestV2TreeResource implements HttpTreeApi {
                 builder.isHasMore(true).token(pagingToken);
               }
             },
-            h -> builder.effectiveReference(toReference(h)));
+            h -> builder.effectiveReference(toReference(h)),
+            params.minKey(),
+            params.maxKey(),
+            params.prefixKey(),
+            params.getRequestedKeys());
   }
 
   @JsonView(Views.V2.class)
@@ -268,7 +272,12 @@ public class RestV2TreeResource implements HttpTreeApi {
               }
             },
             h -> builder.effectiveFromReference(toReference(h)),
-            h -> builder.effectiveToReference(toReference(h)));
+            h -> builder.effectiveToReference(toReference(h)),
+            params.minKey(),
+            params.maxKey(),
+            params.prefixKey(),
+            params.getRequestedKeys(),
+            params.getFilter());
   }
 
   @JsonView(Views.V2.class)

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -133,7 +133,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
       Callable<Void> validator =
           () -> {
             try (PaginationIterator<KeyEntry> keys =
-                getStore().getKeys(refWithHash.getHash(), null, false)) {
+                getStore().getKeys(refWithHash.getHash(), null, false, null, null, null, null)) {
               while (keys.hasNext()) {
                 KeyEntry k = keys.next();
                 if (Namespace.of(k.getKey().getElements()).isSameOrSubElementOf(namespaceToDelete)
@@ -285,7 +285,8 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
       Hash hash,
       Predicate<KeyEntry> earlyFilterPredicate)
       throws ReferenceNotFoundException {
-    PaginationIterator<KeyEntry> iter = getStore().getKeys(hash, null, false);
+    PaginationIterator<KeyEntry> iter =
+        getStore().getKeys(hash, null, false, null, null, null, null);
     return stream(spliteratorUnknownSize(iter, 0), false)
         .onClose(iter::close)
         .filter(earlyFilterPredicate)

--- a/servers/services/src/main/java/org/projectnessie/services/spi/DiffService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/DiffService.java
@@ -17,11 +17,13 @@ package org.projectnessie.services.spi;
 
 import static org.projectnessie.api.v1.params.DiffParams.HASH_OPTIONAL_REGEX;
 
+import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.DiffResponse.DiffEntry;
 import org.projectnessie.model.Validation;
 import org.projectnessie.versioned.NamedRef;
@@ -66,6 +68,11 @@ public interface DiffService {
       @Nullable @jakarta.annotation.Nullable String pagingToken,
       PagedResponseHandler<R, DiffEntry> pagedResponseHandler,
       Consumer<WithHash<NamedRef>> fromReference,
-      Consumer<WithHash<NamedRef>> toReference)
+      Consumer<WithHash<NamedRef>> toReference,
+      @Nullable @jakarta.annotation.Nullable ContentKey minKey,
+      @Nullable @jakarta.annotation.Nullable ContentKey maxKey,
+      ContentKey prefixKey,
+      @Nullable @jakarta.annotation.Nullable List<ContentKey> requestedKeys,
+      @Nullable @jakarta.annotation.Nullable String filter)
       throws NessieNotFoundException;
 }

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -28,6 +28,7 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.CommitResponse;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.EntriesResponse.Entry;
 import org.projectnessie.model.FetchOption;
 import org.projectnessie.model.LogResponse.LogEntry;
@@ -281,7 +282,11 @@ public interface TreeService {
       @Nullable @jakarta.annotation.Nullable String pagingToken,
       boolean withContent,
       PagedResponseHandler<R, Entry> pagedResponseHandler,
-      Consumer<WithHash<NamedRef>> effectiveReference)
+      Consumer<WithHash<NamedRef>> effectiveReference,
+      @Nullable @jakarta.annotation.Nullable ContentKey minKey,
+      @Nullable @jakarta.annotation.Nullable ContentKey maxKey,
+      ContentKey prefixKey,
+      List<ContentKey> requestedKeys)
       throws NessieNotFoundException;
 
   CommitResponse commitMultipleOperations(

--- a/servers/services/src/test/java/org/projectnessie/services/impl/TestCelFilters.java
+++ b/servers/services/src/test/java/org/projectnessie/services/impl/TestCelFilters.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.services.impl;
+
+import static java.util.Collections.emptySet;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.model.ContentKey;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestCelFilters {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  static Stream<Arguments> filterOnContentKey() {
+    return Stream.of(
+        arguments("false", emptySet(), ImmutableSet.of(ContentKey.of("foo"), ContentKey.of("bar"))),
+        arguments("true", ImmutableSet.of(ContentKey.of("foo"), ContentKey.of("bar")), emptySet()),
+        arguments(
+            "key.name=='table'",
+            ImmutableSet.of(ContentKey.of("foo", "table"), ContentKey.of("bar", "table")),
+            ImmutableSet.of(
+                ContentKey.of("foo", "udf"),
+                ContentKey.of("bar", "view"),
+                ContentKey.of("foo"),
+                ContentKey.of("bar"))),
+        arguments(
+            "key.namespace=='foo'",
+            ImmutableSet.of(ContentKey.of("foo", "table"), ContentKey.of("foo", "foo")),
+            ImmutableSet.of(
+                ContentKey.of("foo", "bar", "udf"),
+                ContentKey.of("bar", "view"),
+                ContentKey.of("foo"),
+                ContentKey.of("bar"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void filterOnContentKey(String filter, Set<ContentKey> mustMatch, Set<ContentKey> mustNotMatch) {
+    Predicate<ContentKey> predicate = BaseApiImpl.filterOnContentKey(filter);
+    soft.assertThat(mustMatch).allMatch(predicate);
+    soft.assertThat(mustNotMatch).noneMatch(predicate);
+  }
+}

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestDiff.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestDiff.java
@@ -71,7 +71,12 @@ public abstract class AbstractTestDiff extends BaseTestServiceImpl {
               "666f6f",
               new UnlimitedListResponseHandler<>(),
               h -> {},
-              h -> {});
+              h -> {},
+              null,
+              null,
+              null,
+              null,
+              null);
     } catch (IllegalArgumentException e) {
       if (!e.getMessage().contains("Paging not supported")) {
         throw e;

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestEntries.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestEntries.java
@@ -69,7 +69,11 @@ public abstract class AbstractTestEntries extends BaseTestServiceImpl {
               "666f6f",
               false,
               new UnlimitedListResponseHandler<>(),
-              h -> {});
+              h -> {},
+              null,
+              null,
+              null,
+              null);
     } catch (IllegalArgumentException e) {
       if (!e.getMessage().contains("Paging not supported")) {
         throw e;

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
@@ -259,7 +259,11 @@ public abstract class BaseTestServiceImpl {
             null,
             withContent,
             new UnlimitedListResponseHandler<>(),
-            h -> {});
+            h -> {},
+            null,
+            null,
+            null,
+            null);
   }
 
   protected List<DiffEntry> diff(Reference fromRef, Reference toRef)
@@ -278,7 +282,12 @@ public abstract class BaseTestServiceImpl {
             null,
             new UnlimitedListResponseHandler<>(),
             h -> {},
-            h -> {});
+            h -> {},
+            null,
+            null,
+            null,
+            null,
+            null);
   }
 
   protected List<LogEntry> pagedCommitLog(
@@ -360,7 +369,11 @@ public abstract class BaseTestServiceImpl {
                   token,
                   withContent,
                   new DirectPagedCountingResponseHandler<>(pageSize, nextToken::set),
-                  h -> effectiveReference.accept(toReference(h)));
+                  h -> effectiveReference.accept(toReference(h)),
+                  null,
+                  null,
+                  null,
+                  null);
       completeLog.addAll(page);
       if (nextToken.get() == null) {
         break;
@@ -396,7 +409,12 @@ public abstract class BaseTestServiceImpl {
                   token,
                   new DirectPagedCountingResponseHandler<>(pageSize, nextToken::set),
                   h -> effectiveFrom.accept(toReference(h)),
-                  h -> effectiveTo.accept(toReference(h)));
+                  h -> effectiveTo.accept(toReference(h)),
+                  null,
+                  null,
+                  null,
+                  null,
+                  null);
       completeLog.addAll(page);
       if (nextToken.get() == null) {
         break;

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
@@ -192,9 +193,17 @@ public class EventsVersionStore implements VersionStore {
   }
 
   @Override
-  public PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken, boolean withContent)
+  public PaginationIterator<KeyEntry> getKeys(
+      Ref ref,
+      String pagingToken,
+      boolean withContent,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
       throws ReferenceNotFoundException {
-    return delegate.getKeys(ref, pagingToken, withContent);
+    return delegate.getKeys(
+        ref, pagingToken, withContent, minKey, maxKey, prefixKey, contentKeyPredicate);
   }
 
   @Override
@@ -209,9 +218,16 @@ public class EventsVersionStore implements VersionStore {
   }
 
   @Override
-  public PaginationIterator<Diff> getDiffs(Ref from, Ref to, String pagingToken)
+  public PaginationIterator<Diff> getDiffs(
+      Ref from,
+      Ref to,
+      String pagingToken,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
       throws ReferenceNotFoundException {
-    return delegate.getDiffs(from, to, pagingToken);
+    return delegate.getDiffs(from, to, pagingToken, minKey, maxKey, prefixKey, contentKeyPredicate);
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -207,10 +208,20 @@ public final class MetricsVersionStore implements VersionStore {
   }
 
   @Override
-  public PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken, boolean withContent)
+  public PaginationIterator<KeyEntry> getKeys(
+      Ref ref,
+      String pagingToken,
+      boolean withContent,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
       throws ReferenceNotFoundException {
     return delegatePaginationIterator(
-        "getkeys", () -> delegate.getKeys(ref, pagingToken, withContent));
+        "getkeys",
+        () ->
+            delegate.getKeys(
+                ref, pagingToken, withContent, minKey, maxKey, prefixKey, contentKeyPredicate));
   }
 
   @Override
@@ -225,9 +236,20 @@ public final class MetricsVersionStore implements VersionStore {
   }
 
   @Override
-  public PaginationIterator<Diff> getDiffs(Ref from, Ref to, String pagingToken)
+  public PaginationIterator<Diff> getDiffs(
+      Ref from,
+      Ref to,
+      String pagingToken,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
       throws ReferenceNotFoundException {
-    return delegatePaginationIterator("getdiffs", () -> delegate.getDiffs(from, to, pagingToken));
+    return delegatePaginationIterator(
+        "getdiffs",
+        () ->
+            delegate.getDiffs(
+                from, to, pagingToken, minKey, maxKey, prefixKey, contentKeyPredicate));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -277,13 +278,22 @@ public class TracingVersionStore implements VersionStore {
   }
 
   @Override
-  public PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken, boolean withContent)
+  public PaginationIterator<KeyEntry> getKeys(
+      Ref ref,
+      String pagingToken,
+      boolean withContent,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
       throws ReferenceNotFoundException {
     return callPaginationIterator(
         tracer,
         "GetKeys",
         b -> b.setAttribute(TAG_REF, safeToString(ref)),
-        () -> delegate.getKeys(ref, pagingToken, withContent));
+        () ->
+            delegate.getKeys(
+                ref, pagingToken, withContent, minKey, maxKey, prefixKey, contentKeyPredicate));
   }
 
   @Override
@@ -306,13 +316,22 @@ public class TracingVersionStore implements VersionStore {
   }
 
   @Override
-  public PaginationIterator<Diff> getDiffs(Ref from, Ref to, String pagingToken)
+  public PaginationIterator<Diff> getDiffs(
+      Ref from,
+      Ref to,
+      String pagingToken,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
       throws ReferenceNotFoundException {
     return callPaginationIterator(
         tracer,
         "GetDiffs",
         b -> b.setAttribute(TAG_FROM, safeToString(from)).setAttribute(TAG_TO, safeToString(to)),
-        () -> delegate.getDiffs(from, to, pagingToken));
+        () ->
+            delegate.getDiffs(
+                from, to, pagingToken, minKey, maxKey, prefixKey, contentKeyPredicate));
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
@@ -293,10 +294,21 @@ public interface VersionStore {
    * @param ref The ref to get keys for.
    * @param pagingToken paging token to start at
    * @param withContent whether to populate {@link KeyEntry#getContent()}
+   * @param minKey optional, if not {@code null}: the minimum key to return
+   * @param maxKey optional, if not {@code null}: the maximum key to return
+   * @param prefixKey optional, if not {@code null}: the prefix of the keys to return
+   * @param contentKeyPredicate filter predicate, can be {@code null}
    * @return The stream of keys available for this ref.
    * @throws ReferenceNotFoundException if {@code ref} is not present in the store
    */
-  PaginationIterator<KeyEntry> getKeys(Ref ref, String pagingToken, boolean withContent)
+  PaginationIterator<KeyEntry> getKeys(
+      Ref ref,
+      String pagingToken,
+      boolean withContent,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
       throws ReferenceNotFoundException;
 
   /**
@@ -326,9 +338,20 @@ public interface VersionStore {
    * @param from The from part of the diff.
    * @param to The to part of the diff.
    * @param pagingToken paging token to start at
+   * @param minKey optional, if not {@code null}: the minimum key to return
+   * @param maxKey optional, if not {@code null}: the maximum key to return
+   * @param prefixKey optional, if not {@code null}: the prefix of the keys to return
+   * @param contentKeyPredicate filter predicate, can be {@code null}
    * @return A stream of values that are different.
    */
-  PaginationIterator<Diff> getDiffs(Ref from, Ref to, String pagingToken)
+  PaginationIterator<Diff> getDiffs(
+      Ref from,
+      Ref to,
+      String pagingToken,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
       throws ReferenceNotFoundException;
 
   /**

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/paging/FilteringPaginationIterator.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/paging/FilteringPaginationIterator.java
@@ -28,6 +28,7 @@ public abstract class FilteringPaginationIterator<S, T> extends AbstractIterator
   private final Function<S, T> mapper;
 
   private final Predicate<S> sourcePredicate;
+  private final Predicate<S> stopPredicate;
   private S current;
 
   public FilteringPaginationIterator(Iterator<S> base, Function<S, T> mapper) {
@@ -36,9 +37,18 @@ public abstract class FilteringPaginationIterator<S, T> extends AbstractIterator
 
   public FilteringPaginationIterator(
       Iterator<S> base, Function<S, T> mapper, Predicate<S> sourcePredicate) {
+    this(base, mapper, sourcePredicate, x -> false);
+  }
+
+  public FilteringPaginationIterator(
+      Iterator<S> base,
+      Function<S, T> mapper,
+      Predicate<S> sourcePredicate,
+      Predicate<S> stopPredicate) {
     this.base = base;
     this.mapper = mapper;
     this.sourcePredicate = sourcePredicate;
+    this.stopPredicate = stopPredicate;
   }
 
   @Override
@@ -50,6 +60,10 @@ public abstract class FilteringPaginationIterator<S, T> extends AbstractIterator
         return null;
       }
       S source = base.next();
+      if (stopPredicate.test(source)) {
+        endOfData();
+        return null;
+      }
       if (!sourcePredicate.test(source)) {
         continue;
       }

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestEventsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestEventsVersionStore.java
@@ -586,9 +586,11 @@ class TestEventsVersionStore {
 
   @Test
   void testGetKeys() throws Exception {
-    when(delegate.getKeys(branch1, "token1", false)).thenReturn(iteratorKeyEntries);
+    when(delegate.getKeys(branch1, "token1", false, null, null, null, null))
+        .thenReturn(iteratorKeyEntries);
     EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);
-    PaginationIterator<KeyEntry> result = versionStore.getKeys(branch1, "token1", false);
+    PaginationIterator<KeyEntry> result =
+        versionStore.getKeys(branch1, "token1", false, null, null, null, null);
     assertThat(result).isSameAs(iteratorKeyEntries);
     verifyNoMoreInteractions(delegate);
     verifyNoInteractions(sink);
@@ -617,9 +619,11 @@ class TestEventsVersionStore {
 
   @Test
   void testGetDiffs() throws Exception {
-    when(delegate.getDiffs(hash1, hash2, "token1")).thenReturn(iteratorDiffs);
+    when(delegate.getDiffs(hash1, hash2, "token1", null, null, null, null))
+        .thenReturn(iteratorDiffs);
     EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);
-    PaginationIterator<Diff> result = versionStore.getDiffs(hash1, hash2, "token1");
+    PaginationIterator<Diff> result =
+        versionStore.getDiffs(hash1, hash2, "token1", null, null, null, null);
     assertThat(result).isSameAs(iteratorDiffs);
     verifyNoMoreInteractions(delegate);
     verifyNoInteractions(sink);

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -242,7 +242,7 @@ class TestMetricsVersionStore {
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "getkeys",
-                vs -> vs.getKeys(Hash.of("cafe4242"), null, false),
+                vs -> vs.getKeys(Hash.of("cafe4242"), null, false, null, null, null, null),
                 () -> PaginationIterator.of(ContentKey.of("hello", "world")),
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
@@ -274,7 +274,15 @@ class TestMetricsVersionStore {
                 refNotFoundThrows),
             new VersionStoreInvocation<>(
                 "getdiffs",
-                vs -> vs.getDiffs(BranchName.of("mock-branch"), BranchName.of("foo-branch"), null),
+                vs ->
+                    vs.getDiffs(
+                        BranchName.of("mock-branch"),
+                        BranchName.of("foo-branch"),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
                 PaginationIterator::empty,
                 refNotFoundThrows));
 

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestTracingVersionStore.java
@@ -254,7 +254,7 @@ class TestTracingVersionStore {
             new TestedTracingStoreInvocation<VersionStore>("GetKeys.stream", refNotFoundThrows)
                 .tag("nessie.version-store.ref", "Hash cafe4242")
                 .function(
-                    vs -> vs.getKeys(Hash.of("cafe4242"), null, false),
+                    vs -> vs.getKeys(Hash.of("cafe4242"), null, false, null, null, null, null),
                     () -> PaginationIterator.of(ContentKey.of("hello", "world"))),
             new TestedTracingStoreInvocation<VersionStore>("GetNamedRefs.stream", runtimeThrows)
                 .function(
@@ -286,7 +286,13 @@ class TestTracingVersionStore {
                 .function(
                     vs ->
                         vs.getDiffs(
-                            BranchName.of("mock-branch"), BranchName.of("foo-branch"), null),
+                            BranchName.of("mock-branch"),
+                            BranchName.of("foo-branch"),
+                            null,
+                            null,
+                            null,
+                            null,
+                            null),
                     PaginationIterator::empty));
 
     return TestedTracingStoreInvocation.toArguments(versionStoreFunctions);

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/StoreKey.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/StoreKey.java
@@ -24,6 +24,7 @@ import static java.lang.Character.toCodePoint;
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -241,5 +242,33 @@ public final class StoreKey implements Comparable<StoreKey> {
 
   public boolean startsWith(StoreKey prefix) {
     return key.startsWith(prefix.key);
+  }
+
+  public boolean startsWithElementsOrParts(StoreKey prefix) {
+    int m = CharBuffer.wrap(key).mismatch(CharBuffer.wrap(prefix.key));
+    if (m == -1) {
+      // equal
+      return true;
+    }
+    if (m < prefix.key.length()) {
+      // prefix does not match at all
+      return false;
+    }
+    // check for element or part border
+    char c = key.charAt(m);
+    return c == (char) 0 || c == (char) 1;
+  }
+
+  /** Tests whether this store key ends with the given element. */
+  public boolean endsWithElement(String element) {
+    int elLen = element.length();
+    int len = key.length();
+    if (len < elLen + 1) {
+      if (len == elLen) {
+        return key.equals(element);
+      }
+      return false;
+    }
+    return key.charAt(len - elLen - 1) == (char) 0 && key.endsWith(element);
   }
 }

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/indexes/TestStoreIndexImpl.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/indexes/TestStoreIndexImpl.java
@@ -149,7 +149,7 @@ public class TestStoreIndexImpl {
     Function<StoreIndex<ObjId>, StoreIndex<ObjId>> reSerialize =
         seg -> deserializeStoreIndex(seg.serialize(), OBJ_ID_SERIALIZER);
 
-    soft.assertThat(asHex(segment.serialize())).isEqualTo("01");
+    soft.assertThat(asHex(segment.serialize())).isEqualTo(serializationFormatVersion);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList()).isEmpty();
     soft.assertThat(segment.elementCount()).isEqualTo(0);

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/KeyRanges.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/KeyRanges.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.versionstore;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.projectnessie.versioned.storage.common.indexes.StoreKey.keyFromString;
+import static org.projectnessie.versioned.storage.common.logic.PagingToken.fromString;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.keyToStoreKeyMax;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.keyToStoreKeyMin;
+
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.versioned.storage.common.indexes.StoreKey;
+import org.projectnessie.versioned.storage.common.logic.PagingToken;
+
+@Value.Immutable
+abstract class KeyRanges {
+  static KeyRanges keyRanges(
+      String pagingToken, ContentKey minKey, ContentKey maxKey, ContentKey prefixKey) {
+    return ImmutableKeyRanges.of(pagingToken, minKey, maxKey, prefixKey);
+  }
+
+  @Value.Parameter(order = 1)
+  @Nullable
+  @jakarta.annotation.Nullable
+  abstract String pagingToken();
+
+  @Value.Parameter(order = 2)
+  @Nullable
+  @jakarta.annotation.Nullable
+  abstract ContentKey minKey();
+
+  @Value.Parameter(order = 3)
+  @Nullable
+  @jakarta.annotation.Nullable
+  abstract ContentKey maxKey();
+
+  @Value.Parameter(order = 4)
+  @Nullable
+  @jakarta.annotation.Nullable
+  abstract ContentKey prefixKey();
+
+  @Value.NonAttribute
+  StoreKey beginStoreKey() {
+    String paging = pagingToken();
+    if (paging != null && !paging.isEmpty()) {
+      return keyFromString(fromString(paging).token().toStringUtf8());
+    }
+    ContentKey prefix = prefixKey();
+    ContentKey min = (prefix != null) ? prefix : minKey();
+    return min != null ? keyToStoreKeyMin(min) : null;
+  }
+
+  @Value.NonAttribute
+  PagingToken pagingTokenObj() {
+    String paging = pagingToken();
+    return paging != null ? fromString(paging) : null;
+  }
+
+  @Value.NonAttribute
+  StoreKey endStoreKey() {
+    ContentKey max = maxKey();
+    return max != null ? keyToStoreKeyMax(max) : null;
+  }
+
+  @Value.Check
+  void validate() {
+    if (prefixKey() != null) {
+      checkArgument(
+          minKey() == null && maxKey() == null,
+          "Combining prefixKey with either minKey or maxKey is not supported.");
+    }
+  }
+}

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestKeyRanges.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestKeyRanges.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.versionstore;
+
+import static org.projectnessie.nessie.relocated.protobuf.ByteString.copyFromUtf8;
+import static org.projectnessie.versioned.storage.common.indexes.StoreKey.keyFromString;
+import static org.projectnessie.versioned.storage.common.logic.PagingToken.pagingToken;
+import static org.projectnessie.versioned.storage.versionstore.KeyRanges.keyRanges;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.MAIN_UNIVERSE;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.keyToStoreKey;
+import static org.projectnessie.versioned.storage.versionstore.TypeMapping.keyToStoreKeyVariant;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.ContentKey;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestKeyRanges {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  public void entriesWrongParameters() {
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> keyRanges(null, ContentKey.of("foo"), ContentKey.of("foo"), ContentKey.of("foo")))
+        .withMessageContaining(
+            "Combining prefixKey with either minKey or maxKey is not supported.");
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> keyRanges(null, null, ContentKey.of("foo"), ContentKey.of("foo")))
+        .withMessageContaining(
+            "Combining prefixKey with either minKey or maxKey is not supported.");
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> keyRanges(null, ContentKey.of("foo"), null, ContentKey.of("foo")))
+        .withMessageContaining(
+            "Combining prefixKey with either minKey or maxKey is not supported.");
+  }
+
+  @Test
+  public void pagingTokenSupersedesMinKey() {
+    String token =
+        pagingToken(copyFromUtf8(keyToStoreKey(ContentKey.of("foo")).rawString())).asString();
+
+    soft.assertThat(keyRanges(token, ContentKey.of("bar"), null, null))
+        .extracting(KeyRanges::beginStoreKey)
+        .isEqualTo(keyToStoreKey(ContentKey.of("foo")));
+
+    soft.assertThat(keyRanges(token, null, null, ContentKey.of("bar")))
+        .extracting(KeyRanges::beginStoreKey)
+        .isEqualTo(keyToStoreKey(ContentKey.of("foo")));
+  }
+
+  @Test
+  public void max() {
+    ContentKey bar = ContentKey.of("bar");
+    KeyRanges keyRange = keyRanges(null, null, bar, null);
+
+    soft.assertThat(keyRange.endStoreKey()).isGreaterThan(keyToStoreKey(bar));
+    soft.assertThat(keyRange.endStoreKey()).isGreaterThan(keyToStoreKeyVariant(bar, "Z"));
+    soft.assertThat(keyRange.endStoreKey()).isGreaterThan(keyToStoreKeyVariant(bar, "A"));
+
+    soft.assertThat(keyRange.endStoreKey()).isLessThan(keyToStoreKey(ContentKey.of("bar", "baz")));
+    soft.assertThat(keyRange.endStoreKey()).isLessThan(keyToStoreKey(ContentKey.of("bar", "0")));
+    soft.assertThat(keyRange.endStoreKey()).isLessThan(keyToStoreKey(ContentKey.of("barbaz")));
+    soft.assertThat(keyRange.endStoreKey())
+        .isLessThan(keyToStoreKey(ContentKey.of("barπ"))); //  UNICODE CHAR
+    soft.assertThat(keyRange.endStoreKey()).isLessThan(keyToStoreKey(ContentKey.of("bar0")));
+
+    soft.assertThat(keyRange.endStoreKey()).isLessThan(keyToStoreKey(ContentKey.of("bar0")));
+
+    String storeKeyRawPrefix = MAIN_UNIVERSE + (char) 0 + "bar";
+
+    soft.assertThat(keyRange.endStoreKey()).isGreaterThan(keyFromString(storeKeyRawPrefix));
+    soft.assertThat(keyRange.endStoreKey())
+        .isLessThan(keyFromString(storeKeyRawPrefix + (char) 1 + "baz"));
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
@@ -154,6 +154,11 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
   public void commitSomeOperations() throws Exception {
     BranchName branch = BranchName.of("foo");
 
+    ContentKey keyT1 = ContentKey.of("t1");
+    ContentKey keyT2 = ContentKey.of("t2");
+    ContentKey keyT3 = ContentKey.of("t3");
+    ContentKey keyT4 = ContentKey.of("t4");
+
     Hash base = store().create(branch, Optional.empty()).getHash();
 
     Hash initialCommit =
@@ -162,7 +167,7 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             .put("t2", V_2_1)
             .put("t3", V_3_1)
             .toBranch(branch);
-    Content t1 = store().getValue(branch, ContentKey.of("t1"));
+    Content t1 = store().getValue(branch, keyT1);
 
     Hash secondCommit =
         commit("Second Commit")
@@ -180,72 +185,51 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             commit(secondCommit, "Second Commit", initialCommit),
             commit(initialCommit, "Initial Commit", base));
 
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(branch, null, false)) {
+    try (PaginationIterator<KeyEntry> keys =
+        store().getKeys(branch, null, false, null, null, null, null)) {
       soft.assertThat(stream(keys).map(KeyEntry::getKey))
-          .containsExactlyInAnyOrder(ContentKey.of("t1"), ContentKey.of("t2"), ContentKey.of("t4"));
+          .containsExactlyInAnyOrder(keyT1, keyT2, keyT4);
     }
 
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(secondCommit, null, false)) {
-      soft.assertThat(stream(keys).map(KeyEntry::getKey))
-          .containsExactlyInAnyOrder(ContentKey.of("t1"), ContentKey.of("t4"));
+    try (PaginationIterator<KeyEntry> keys =
+        store().getKeys(secondCommit, null, false, null, null, null, null)) {
+      soft.assertThat(stream(keys).map(KeyEntry::getKey)).containsExactlyInAnyOrder(keyT1, keyT4);
     }
 
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(initialCommit, null, false)) {
+    try (PaginationIterator<KeyEntry> keys =
+        store().getKeys(initialCommit, null, false, null, null, null, null)) {
       soft.assertThat(stream(keys).map(KeyEntry::getKey))
-          .containsExactlyInAnyOrder(ContentKey.of("t1"), ContentKey.of("t2"), ContentKey.of("t3"));
+          .containsExactlyInAnyOrder(keyT1, keyT2, keyT3);
     }
 
     soft.assertThat(
             contentsWithoutId(
-                store()
-                    .getValues(
-                        secondCommit,
-                        Arrays.asList(
-                            ContentKey.of("t1"),
-                            ContentKey.of("t2"),
-                            ContentKey.of("t3"),
-                            ContentKey.of("t4")))))
-        .containsExactlyInAnyOrderEntriesOf(
-            ImmutableMap.of(ContentKey.of("t1"), V_1_2, ContentKey.of("t4"), V_4_1));
+                store().getValues(secondCommit, Arrays.asList(keyT1, keyT2, keyT3, keyT4))))
+        .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(keyT1, V_1_2, keyT4, V_4_1));
 
     soft.assertThat(
             contentsWithoutId(
-                store()
-                    .getValues(
-                        initialCommit,
-                        Arrays.asList(
-                            ContentKey.of("t1"),
-                            ContentKey.of("t2"),
-                            ContentKey.of("t3"),
-                            ContentKey.of("t4")))))
+                store().getValues(initialCommit, Arrays.asList(keyT1, keyT2, keyT3, keyT4))))
         .containsExactlyInAnyOrderEntriesOf(
             ImmutableMap.of(
-                ContentKey.of("t1"), V_1_1,
-                ContentKey.of("t2"), V_2_1,
-                ContentKey.of("t3"), V_3_1));
+                keyT1, V_1_1,
+                keyT2, V_2_1,
+                keyT3, V_3_1));
 
-    soft.assertThat(contentWithoutId(store().getValue(branch, ContentKey.of("t1"))))
-        .isEqualTo(V_1_2);
-    soft.assertThat(contentWithoutId(store().getValue(branch, ContentKey.of("t2"))))
-        .isEqualTo(V_2_2);
-    soft.assertThat(store().getValue(branch, ContentKey.of("t3"))).isNull();
-    soft.assertThat(contentWithoutId(store().getValue(branch, ContentKey.of("t4"))))
-        .isEqualTo(V_4_1);
+    soft.assertThat(contentWithoutId(store().getValue(branch, keyT1))).isEqualTo(V_1_2);
+    soft.assertThat(contentWithoutId(store().getValue(branch, keyT2))).isEqualTo(V_2_2);
+    soft.assertThat(store().getValue(branch, keyT3)).isNull();
+    soft.assertThat(contentWithoutId(store().getValue(branch, keyT4))).isEqualTo(V_4_1);
 
-    soft.assertThat(contentWithoutId(store().getValue(secondCommit, ContentKey.of("t1"))))
-        .isEqualTo(V_1_2);
-    soft.assertThat(store().getValue(secondCommit, ContentKey.of("t2"))).isNull();
-    soft.assertThat(store().getValue(secondCommit, ContentKey.of("t3"))).isNull();
-    soft.assertThat(contentWithoutId(store().getValue(secondCommit, ContentKey.of("t4"))))
-        .isEqualTo(V_4_1);
+    soft.assertThat(contentWithoutId(store().getValue(secondCommit, keyT1))).isEqualTo(V_1_2);
+    soft.assertThat(store().getValue(secondCommit, keyT2)).isNull();
+    soft.assertThat(store().getValue(secondCommit, keyT3)).isNull();
+    soft.assertThat(contentWithoutId(store().getValue(secondCommit, keyT4))).isEqualTo(V_4_1);
 
-    soft.assertThat(contentWithoutId(store().getValue(initialCommit, ContentKey.of("t1"))))
-        .isEqualTo(V_1_1);
-    soft.assertThat(contentWithoutId(store().getValue(initialCommit, ContentKey.of("t2"))))
-        .isEqualTo(V_2_1);
-    soft.assertThat(contentWithoutId(store().getValue(initialCommit, ContentKey.of("t3"))))
-        .isEqualTo(V_3_1);
-    soft.assertThat(store().getValue(initialCommit, ContentKey.of("t4"))).isNull();
+    soft.assertThat(contentWithoutId(store().getValue(initialCommit, keyT1))).isEqualTo(V_1_1);
+    soft.assertThat(contentWithoutId(store().getValue(initialCommit, keyT2))).isEqualTo(V_2_1);
+    soft.assertThat(contentWithoutId(store().getValue(initialCommit, keyT3))).isEqualTo(V_3_1);
+    soft.assertThat(store().getValue(initialCommit, keyT4)).isNull();
   }
 
   /*
@@ -302,7 +286,8 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             commit(t1Commit, "T1 Commit", initialCommit),
             commit(initialCommit, "Initial Commit", base));
 
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(branch, null, false)) {
+    try (PaginationIterator<KeyEntry> keys =
+        store().getKeys(branch, null, false, null, null, null, null)) {
       soft.assertThat(stream(keys).map(KeyEntry::getKey))
           .containsExactlyInAnyOrder(ContentKey.of("t1"), ContentKey.of("t2"), ContentKey.of("t3"));
     }
@@ -839,7 +824,7 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
                       try {
                         assertThat(store().getValue(branch, key)).isNull();
                         try (PaginationIterator<KeyEntry> ignore =
-                            store().getKeys(branch, null, false)) {}
+                            store().getKeys(branch, null, false, null, null, null, null)) {}
                       } catch (ReferenceNotFoundException e) {
                         throw new RuntimeException(e);
                       }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractDiff.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractDiff.java
@@ -20,6 +20,7 @@ import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -56,11 +57,16 @@ public abstract class AbstractDiff extends AbstractNestedVersionStore {
     store().create(branch, Optional.empty());
     Hash initial = store().hashOnReference(branch, Optional.empty());
 
+    ContentKey k1 = ContentKey.of("k1");
+    ContentKey k2 = ContentKey.of("k2");
+    ContentKey k3 = ContentKey.of("k3");
+    ContentKey k1a = ContentKey.of("k1a");
+
     Hash firstCommit = commit("First Commit").put("k1", V_1).put("k2", V_2).toBranch(branch);
-    Content k2 = store().getValue(branch, ContentKey.of("k2"));
+    Content k2content = store().getValue(branch, k2);
     Hash secondCommit =
         commit("Second Commit")
-            .put("k2", V_2_A.withId(k2))
+            .put("k2", V_2_A.withId(k2content))
             .put("k3", V_3)
             .put("k1a", V_1_A)
             .toBranch(branch);
@@ -68,39 +74,98 @@ public abstract class AbstractDiff extends AbstractNestedVersionStore {
     List<Diff> startToSecond = diffAsList(initial, secondCommit);
     soft.assertThat(diffsWithoutContentId(startToSecond))
         .containsExactlyInAnyOrder(
-            Diff.of(ContentKey.of("k1"), Optional.empty(), Optional.of(V_1)),
-            Diff.of(ContentKey.of("k2"), Optional.empty(), Optional.of(V_2_A)),
-            Diff.of(ContentKey.of("k3"), Optional.empty(), Optional.of(V_3)),
-            Diff.of(ContentKey.of("k1a"), Optional.empty(), Optional.of(V_1_A)));
+            Diff.of(k1, Optional.empty(), Optional.of(V_1)),
+            Diff.of(k2, Optional.empty(), Optional.of(V_2_A)),
+            Diff.of(k3, Optional.empty(), Optional.of(V_3)),
+            Diff.of(k1a, Optional.empty(), Optional.of(V_1_A)));
 
     List<Diff> secondToStart = diffAsList(secondCommit, initial);
     soft.assertThat(diffsWithoutContentId(secondToStart))
         .containsExactlyInAnyOrder(
-            Diff.of(ContentKey.of("k1"), Optional.of(V_1), Optional.empty()),
-            Diff.of(ContentKey.of("k2"), Optional.of(V_2_A), Optional.empty()),
-            Diff.of(ContentKey.of("k3"), Optional.of(V_3), Optional.empty()),
-            Diff.of(ContentKey.of("k1a"), Optional.of(V_1_A), Optional.empty()));
+            Diff.of(k1, Optional.of(V_1), Optional.empty()),
+            Diff.of(k2, Optional.of(V_2_A), Optional.empty()),
+            Diff.of(k3, Optional.of(V_3), Optional.empty()),
+            Diff.of(k1a, Optional.of(V_1_A), Optional.empty()));
 
     List<Diff> firstToSecond = diffAsList(firstCommit, secondCommit);
     soft.assertThat(diffsWithoutContentId(firstToSecond))
         .containsExactlyInAnyOrder(
-            Diff.of(ContentKey.of("k1a"), Optional.empty(), Optional.of(V_1_A)),
-            Diff.of(ContentKey.of("k2"), Optional.of(V_2), Optional.of(V_2_A)),
-            Diff.of(ContentKey.of("k3"), Optional.empty(), Optional.of(V_3)));
+            Diff.of(k1a, Optional.empty(), Optional.of(V_1_A)),
+            Diff.of(k2, Optional.of(V_2), Optional.of(V_2_A)),
+            Diff.of(k3, Optional.empty(), Optional.of(V_3)));
 
     List<Diff> secondToFirst = diffAsList(secondCommit, firstCommit);
     soft.assertThat(diffsWithoutContentId(secondToFirst))
         .containsExactlyInAnyOrder(
-            Diff.of(ContentKey.of("k1a"), Optional.of(V_1_A), Optional.empty()),
-            Diff.of(ContentKey.of("k2"), Optional.of(V_2_A), Optional.of(V_2)),
-            Diff.of(ContentKey.of("k3"), Optional.of(V_3), Optional.empty()));
+            Diff.of(k1a, Optional.of(V_1_A), Optional.empty()),
+            Diff.of(k2, Optional.of(V_2_A), Optional.of(V_2)),
+            Diff.of(k3, Optional.of(V_3), Optional.empty()));
 
-    List<Diff> firstToFirst = diffAsList(firstCommit, firstCommit);
-    soft.assertThat(firstToFirst).isEmpty();
+    soft.assertThat(diffAsList(firstCommit, firstCommit)).isEmpty();
+
+    // Key restrictions
+    if (store().getClass().getName().endsWith("VersionStoreImpl")) {
+      soft.assertThat(
+              diffAsList(initial, secondCommit, ContentKey.of("k"), ContentKey.of("l"), null, null))
+          .extracting(Diff::getKey)
+          .containsExactlyInAnyOrder(k1, k2, k3, k1a);
+
+      soft.assertThat(diffAsList(initial, secondCommit, ContentKey.of("k"), null, null, null))
+          .extracting(Diff::getKey)
+          .containsExactlyInAnyOrder(k1, k2, k3, k1a);
+
+      soft.assertThat(diffAsList(initial, secondCommit, null, k2, null, null))
+          .extracting(Diff::getKey)
+          .containsExactlyInAnyOrder(k1, k2, k1a);
+
+      soft.assertThat(diffAsList(initial, secondCommit, k1a, k2, null, null))
+          .extracting(Diff::getKey)
+          .containsExactlyInAnyOrder(k1a, k2);
+
+      soft.assertThat(diffAsList(initial, secondCommit, k2, k2, null, null))
+          .extracting(Diff::getKey)
+          .containsExactlyInAnyOrder(k2);
+
+      soft.assertThat(
+              diffAsList(
+                  initial, secondCommit, ContentKey.of("k4"), ContentKey.of("l"), null, null))
+          .isEmpty();
+
+      // prefix
+
+      soft.assertThat(diffAsList(initial, secondCommit, null, null, ContentKey.of("k1"), null))
+          .extracting(Diff::getKey)
+          .containsExactlyInAnyOrder(k1);
+
+      soft.assertThat(diffAsList(initial, secondCommit, null, null, ContentKey.of("k"), null))
+          .extracting(Diff::getKey)
+          .isEmpty();
+
+      soft.assertThat(diffAsList(initial, secondCommit, null, null, ContentKey.of("x"), null))
+          .isEmpty();
+    }
+    soft.assertThat(
+            diffAsList(initial, secondCommit, null, null, null, k -> k1.equals(k) || k3.equals(k)))
+        .extracting(Diff::getKey)
+        .containsExactlyInAnyOrder(k1, k3);
+
+    soft.assertThat(diffAsList(initial, secondCommit, null, null, null, k -> false)).isEmpty();
   }
 
   private List<Diff> diffAsList(Hash initial, Hash secondCommit) throws ReferenceNotFoundException {
-    try (PaginationIterator<Diff> diffStream = store().getDiffs(initial, secondCommit, null)) {
+    return diffAsList(initial, secondCommit, null, null, null, null);
+  }
+
+  private List<Diff> diffAsList(
+      Hash initial,
+      Hash secondCommit,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> keyPredicate)
+      throws ReferenceNotFoundException {
+    try (PaginationIterator<Diff> diffStream =
+        store().getDiffs(initial, secondCommit, null, minKey, maxKey, prefixKey, keyPredicate)) {
       List<Diff> r = new ArrayList<>();
       diffStream.forEachRemaining(r::add);
       return r;

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractEntries.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractEntries.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.tests;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Namespace;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.KeyEntry;
+import org.projectnessie.versioned.Ref;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.paging.PaginationIterator;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public abstract class AbstractEntries extends AbstractNestedVersionStore {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  protected AbstractEntries(VersionStore store) {
+    super(store);
+  }
+
+  @Test
+  public void entriesWrongParameters() {
+    assumeThat(store().getClass().getName()).endsWith("VersionStoreImpl");
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                keysAsList(
+                    store().noAncestorHash(),
+                    ContentKey.of("foo"),
+                    ContentKey.of("foo"),
+                    ContentKey.of("foo"),
+                    null))
+        .withMessageContaining(
+            "Combining prefixKey with either minKey or maxKey is not supported.");
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                keysAsList(
+                    store().noAncestorHash(),
+                    null,
+                    ContentKey.of("foo"),
+                    ContentKey.of("foo"),
+                    null))
+        .withMessageContaining(
+            "Combining prefixKey with either minKey or maxKey is not supported.");
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                keysAsList(
+                    store().noAncestorHash(),
+                    ContentKey.of("foo"),
+                    null,
+                    ContentKey.of("foo"),
+                    null))
+        .withMessageContaining(
+            "Combining prefixKey with either minKey or maxKey is not supported.");
+  }
+
+  @Test
+  public void entriesRanges() throws Exception {
+    assumeThat(store().getClass().getName()).endsWith("VersionStoreImpl");
+
+    BranchName branch = BranchName.of("foo");
+    ContentKey key1 = ContentKey.of("k1");
+    ContentKey key2 = ContentKey.of("k2");
+    ContentKey key2a = ContentKey.of("k2", "a");
+    ContentKey key2b = ContentKey.of("k2", "aπ"); // UNICODE CHAR
+    ContentKey key2c = ContentKey.of("k2", "πa"); // UNICODE CHAR, This is GREATER than k2.k3 !
+    ContentKey key2d = ContentKey.of("k2", "aa");
+    ContentKey key23 = ContentKey.of("k2", "k3");
+    ContentKey key23a = ContentKey.of("k2", "k3", "a");
+    ContentKey key23b = ContentKey.of("k2", "k3", "b");
+    ContentKey key3 = ContentKey.of("k3");
+    store().create(branch, Optional.empty()).getHash();
+    Hash initialCommit =
+        commit("Initial Commit")
+            .put(key1, newOnRef("v1"))
+            .put(key2, Namespace.of(key2))
+            .put(key23, Namespace.of(key23))
+            .put(key2a, newOnRef("v2a"))
+            .put(key2b, newOnRef("v2b"))
+            .put(key2c, newOnRef("v2c"))
+            .put(key2d, newOnRef("v2d"))
+            .put(key23a, newOnRef("v23a"))
+            .put(key23b, newOnRef("v23b"))
+            .put(key3, newOnRef("v3"))
+            .toBranch(branch);
+
+    soft.assertThat(keysAsList(initialCommit, null, null, null, null))
+        .map(KeyEntry::getKey)
+        .containsExactlyInAnyOrder(
+            key1, key2, key2a, key2b, key2c, key2d, key23, key23a, key23b, key3);
+    soft.assertThat(keysAsList(initialCommit, key23, null, null, null))
+        .map(KeyEntry::getKey)
+        .containsExactlyInAnyOrder(key23, key23a, key23b, key3, key2c);
+    soft.assertThat(keysAsList(initialCommit, null, null, key23, null))
+        .map(KeyEntry::getKey)
+        .containsExactlyInAnyOrder(key23, key23a, key23b);
+    soft.assertThat(keysAsList(initialCommit, null, key23, null, null))
+        .map(KeyEntry::getKey)
+        .containsExactlyInAnyOrder(key1, key2, key2a, key2b, key2d, key23);
+    soft.assertThat(keysAsList(initialCommit, key23, key23a, null, null))
+        .map(KeyEntry::getKey)
+        .containsExactlyInAnyOrder(key23, key23a);
+    soft.assertThat(keysAsList(initialCommit, null, null, ContentKey.of("k"), null))
+        .map(KeyEntry::getKey)
+        .isEmpty();
+    soft.assertThat(keysAsList(initialCommit, null, ContentKey.of("k"), null, null))
+        .map(KeyEntry::getKey)
+        .isEmpty();
+    soft.assertThat(keysAsList(initialCommit, null, null, ContentKey.of("x"), null))
+        .map(KeyEntry::getKey)
+        .isEmpty();
+    soft.assertThat(
+            keysAsList(
+                initialCommit,
+                null,
+                null,
+                null,
+                k -> k.toPathString().startsWith(key2.toPathString())))
+        .map(KeyEntry::getKey)
+        .containsExactlyInAnyOrder(key2, key2a, key2b, key2c, key2d, key23, key23a, key23b);
+  }
+
+  List<KeyEntry> keysAsList(
+      Ref ref,
+      ContentKey minKey,
+      ContentKey maxKey,
+      ContentKey prefixKey,
+      Predicate<ContentKey> contentKeyPredicate)
+      throws Exception {
+    try (PaginationIterator<KeyEntry> keys =
+        store().getKeys(ref, null, false, minKey, maxKey, prefixKey, contentKeyPredicate)) {
+      return newArrayList(keys);
+    }
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
@@ -139,16 +139,40 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
         // getKeys()
         new ReferenceNotFoundFunction("getKeys/branch")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.getKeys(BranchName.of("this-one-should-not-exist"), null, false)),
+            .function(
+                s ->
+                    s.getKeys(
+                        BranchName.of("this-one-should-not-exist"),
+                        null,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null)),
         new ReferenceNotFoundFunction("getKeys/tag")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.getKeys(TagName.of("this-one-should-not-exist"), null, false)),
+            .function(
+                s ->
+                    s.getKeys(
+                        TagName.of("this-one-should-not-exist"),
+                        null,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null)),
         new ReferenceNotFoundFunction("getKeys/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
             .function(
                 s ->
                     s.getKeys(
-                        Hash.of("12341234123412341234123412341234123412341234"), null, false)),
+                        Hash.of("12341234123412341234123412341234123412341234"),
+                        null,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null)),
         // assign()
         new ReferenceNotFoundFunction("assign/branch/ok")
             .msg("Named reference 'this-one-should-not-exist' not found")
@@ -256,13 +280,23 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                     s.getDiffs(
                         Hash.of("12341234123412341234123412341234123412341234"),
                         BranchName.of("main"),
+                        null,
+                        null,
+                        null,
+                        null,
                         null)),
         new ReferenceNotFoundFunction("diff/to-branch")
             .msg("Named reference 'this-one-should-not-exist' not found")
             .function(
                 s ->
                     s.getDiffs(
-                        BranchName.of("main"), BranchName.of("this-one-should-not-exist"), null)),
+                        BranchName.of("main"),
+                        BranchName.of("this-one-should-not-exist"),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)),
         new ReferenceNotFoundFunction("diff/from-hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
             .function(
@@ -270,13 +304,23 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                     s.getDiffs(
                         Hash.of("12341234123412341234123412341234123412341234"),
                         BranchName.of("main"),
+                        null,
+                        null,
+                        null,
+                        null,
                         null)),
         new ReferenceNotFoundFunction("diff/from-branch")
             .msg("Named reference 'this-one-should-not-exist' not found")
             .function(
                 s ->
                     s.getDiffs(
-                        BranchName.of("this-one-should-not-exist"), BranchName.of("main"), null)),
+                        BranchName.of("this-one-should-not-exist"),
+                        BranchName.of("main"),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)),
         // merge()
         new ReferenceNotFoundFunction("merge/hash/empty")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractVersionStoreTestBase.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractVersionStoreTestBase.java
@@ -83,6 +83,13 @@ public abstract class AbstractVersionStoreTestBase {
   }
 
   @Nested
+  protected class Entries extends AbstractEntries {
+    public Entries() {
+      super(AbstractVersionStoreTestBase.this.store());
+    }
+  }
+
+  @Nested
   public class ReferenceNotFound extends AbstractReferenceNotFound {
     public ReferenceNotFound() {
       super(AbstractVersionStoreTestBase.this.store());

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportContents.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportContents.java
@@ -89,7 +89,8 @@ final class ExportContents extends ExportCommon {
     long startMicors = TimeUnit.MILLISECONDS.toMicros(currentTimestampMillis());
 
     long seq = 0;
-    try (PaginationIterator<KeyEntry> entries = store.getKeys(ref.getNamedRef(), null, false)) {
+    try (PaginationIterator<KeyEntry> entries =
+        store.getKeys(ref.getNamedRef(), null, false, null, null, null, null)) {
       while (true) {
         List<KeyEntry> batch = take(exporter.contentsBatchSize(), entries);
         if (batch.isEmpty()) {

--- a/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/BaseExportImport.java
+++ b/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/BaseExportImport.java
@@ -350,7 +350,8 @@ public abstract class BaseExportImport {
   }
 
   List<KeyEntry> keys(VersionStore versionStore, Hash hash) {
-    try (PaginationIterator<KeyEntry> keys = versionStore.getKeys(hash, null, false)) {
+    try (PaginationIterator<KeyEntry> keys =
+        versionStore.getKeys(hash, null, false, null, null, null, null)) {
       return newArrayList(keys);
     } catch (ReferenceNotFoundException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Builds upon the work in #5656.

However, the "get range of contents" has been removed, because it's tricky to add it to the current Nessie Java API and since it's probably not a very useful functionality. It would also require adding paging and min/max-keys to the `GetMultipleContentRequest`/`Response` types to leverage the existing paging infrastructure and/or add `ContentsParams` parameter object - neither works well with the existing code.

Adds the necessary `VersionStore` changes, which are pretty straight forward.

Fixes #3957
Fixes #5591 