### PR TITLE
Cleanup V2 MergeResponse

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/MergeResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/MergeResponse.java
@@ -73,12 +73,14 @@ public interface MergeResponse {
 
   @Deprecated // for removal and replaced with something else
   @Schema(deprecated = true, hidden = true)
+  @JsonView(Views.V1.class)
   List<LogEntry> getSourceCommits();
 
   @Nullable
   @jakarta.annotation.Nullable
   @Deprecated // for removal and replaced with something else
   @Schema(deprecated = true, hidden = true)
+  @JsonView(Views.V1.class)
   List<LogEntry> getTargetCommits();
 
   /** Details of all keys encountered during the merge or transplant operation. */
@@ -93,18 +95,23 @@ public interface MergeResponse {
 
     MergeBehavior getMergeBehavior();
 
+    @Deprecated // for removal, #getConflict() is a proper replacement
     @Value.Default
     @JsonDeserialize(using = ContentKeyConflict.Deserializer.class)
+    @Schema(deprecated = true, hidden = true)
+    @JsonView(Views.V1.class)
     default ContentKeyConflict getConflictType() {
       return ContentKeyConflict.NONE;
     }
 
     @Deprecated // for removal and replaced with something else
     @Schema(deprecated = true, hidden = true)
+    @JsonView(Views.V1.class)
     List<String> getSourceCommits();
 
     @Deprecated // for removal and replaced with something else
     @Schema(deprecated = true, hidden = true)
+    @JsonView(Views.V1.class)
     List<String> getTargetCommits();
 
     /** {@link Conflict} details, if available. */
@@ -115,6 +122,7 @@ public interface MergeResponse {
     Conflict getConflict();
   }
 
+  @Deprecated // for removal
   enum ContentKeyConflict {
     NONE,
     UNRESOLVABLE;

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -2046,7 +2046,12 @@ public abstract class AbstractDatabaseAdapter<
       removeKeyCollisionsForNamespaces(
           ctx, refHead, commitsChronological.get(0).getHash(), keyCollisions);
       if (!keyCollisions.isEmpty()) {
-        keyCollisions.forEach(key -> keyDetails.apply(key).conflictType(ConflictType.UNRESOLVABLE));
+        keyCollisions.forEach(
+            key ->
+                keyDetails
+                    .apply(key)
+                    .conflict(Conflict.conflict(Conflict.ConflictType.UNKNOWN, key, "UNRESOLVABLE"))
+                    .conflictType(ConflictType.UNRESOLVABLE));
         return true;
       }
     }

--- a/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
+++ b/versioned/persist/tests/src/main/java/org/projectnessie/versioned/persist/tests/AbstractMergeTransplant.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.projectnessie.model.Conflict;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.MergeBehavior;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
@@ -458,7 +459,10 @@ public abstract class AbstractMergeTransplant {
                       .collect(Collectors.toList()));
 
       if (k < 2) {
-        details.conflictType(ConflictType.UNRESOLVABLE).addTargetCommits(conflictHead);
+        details
+            .conflict(Conflict.conflict(Conflict.ConflictType.UNKNOWN, key, "UNRESOLVABLE"))
+            .conflictType(ConflictType.UNRESOLVABLE)
+            .addTargetCommits(conflictHead);
       }
 
       expectedMergeResult.putDetails(key, details.build());

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeConflictException.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeConflictException.java
@@ -44,8 +44,7 @@ public class MergeConflictException extends ReferenceConflictException {
               Conflict conflict = keyDetails.getConflict();
               return conflict != null
                   ? conflict
-                  : Conflict.conflict(
-                      ConflictType.KEY_CONFLICT, e.getKey(), e.getValue().getConflictType().name());
+                  : Conflict.conflict(ConflictType.KEY_CONFLICT, e.getKey(), "UNKNOWN");
             })
         .collect(Collectors.toList());
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MergeResult.java
@@ -80,6 +80,7 @@ public interface MergeResult<COMMIT> {
     @Value.Parameter(order = 1)
     MergeBehavior getMergeBehavior();
 
+    @Deprecated // for removal, #getConflict() is a proper replacement
     @Value.Default
     @Value.Parameter(order = 2)
     default ConflictType getConflictType() {
@@ -102,16 +103,15 @@ public interface MergeResult<COMMIT> {
       return ImmutableKeyDetails.builder();
     }
 
-    static KeyDetails keyDetails(MergeBehavior mergeBehavior, ConflictType conflictType) {
-      return keyDetails(mergeBehavior, conflictType, null);
-    }
-
-    static KeyDetails keyDetails(
-        MergeBehavior mergeBehavior, ConflictType conflictType, Conflict conflict) {
-      return ImmutableKeyDetails.of(mergeBehavior, conflictType, conflict);
+    static KeyDetails keyDetails(MergeBehavior mergeBehavior, Conflict conflict) {
+      return ImmutableKeyDetails.of(
+          mergeBehavior,
+          conflict != null ? ConflictType.UNRESOLVABLE : ConflictType.NONE,
+          conflict);
     }
   }
 
+  @Deprecated // for removal
   enum ConflictType {
     NONE,
     UNRESOLVABLE

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -81,7 +81,6 @@ import org.projectnessie.versioned.ImmutableRepositoryInformation;
 import org.projectnessie.versioned.KeyEntry;
 import org.projectnessie.versioned.MergeConflictException;
 import org.projectnessie.versioned.MergeResult;
-import org.projectnessie.versioned.MergeResult.ConflictType;
 import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.Operation;
@@ -687,7 +686,7 @@ public class VersionStoreImpl implements VersionStore {
           String.format(
               "The following keys have been changed in conflict: %s",
               mergeResult.getDetails().entrySet().stream()
-                  .filter(e -> e.getValue().getConflictType() != ConflictType.NONE)
+                  .filter(e -> e.getValue().getConflict() != null)
                   .map(Map.Entry::getKey)
                   .sorted()
                   .map(key -> String.format("'%s'", key))

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -228,7 +228,6 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
               false,
               KeyDetails.keyDetails(
                   mergeBehavior,
-                  MergeResult.ConflictType.UNRESOLVABLE,
                   Conflict.conflict(
                       ConflictType.VALUE_DIFFERS,
                       keyT3,


### PR DESCRIPTION
Ensure that all non-V2 attributes in `MergeResponse` (those that are present for V1, but deprecated) are properly annotated with `@JsonView(Views.V1.class)`.

On top of the already deprecated attributes,
`MergeResponse.ContentKeyDetails.getConflictType()` is deprecated and V1-only now as well. It already has a better replacement with `MergeResponse.getConflictType.getConflict()`. The corresponding enum is also deprecated now.

Fixes #5689