### PR TITLE
Mark REST API v2 as GA

### DIFF
--- a/api/model/src/main/java/org/projectnessie/api/v2/http/HttpConfigApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/http/HttpConfigApi.java
@@ -33,7 +33,7 @@ import org.projectnessie.model.ser.Views;
 
 @Path("v2/config")
 @jakarta.ws.rs.Path("v2/config")
-@Tag(name = "v2-beta")
+@Tag(name = "v2")
 public interface HttpConfigApi extends ConfigApi {
 
   @Override

--- a/api/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
@@ -77,7 +77,7 @@ import org.projectnessie.model.ser.Views;
 @jakarta.ws.rs.Consumes(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
 @Path("v2/trees")
 @jakarta.ws.rs.Path("v2/trees")
-@Tag(name = "v2-beta")
+@Tag(name = "v2")
 public interface HttpTreeApi extends TreeApi {
 
   @Override

--- a/api/model/src/main/resources/META-INF/openapi.yaml
+++ b/api/model/src/main/resources/META-INF/openapi.yaml
@@ -30,8 +30,8 @@ info:
 
 tags:
   - name: v1
-    description: End points from the legacy v1 API
-  - name: v2-beta
+    description: End points from the legacy v1 API, deprecated
+  - name: v2
     description: End points from the Nessie v2 API
 
 paths: {} # inferred from java annotations
@@ -48,7 +48,7 @@ components:
         defaultBranch: main
         minSupportedApiVersion: 1
         maxSupportedApiVersion: 2
-        specVersion: "2.0"
+        specVersion: "2.0.0"
 
     namespace:
       value: "a.b.c"

--- a/api/model/src/main/resources/org/projectnessie/model/NessieConfiguration.json
+++ b/api/model/src/main/resources/org/projectnessie/model/NessieConfiguration.json
@@ -1,5 +1,5 @@
 {
   "minSupportedApiVersion": 1,
   "maxSupportedApiVersion": 2,
-  "specVersion": "2.0.0-beta.1"
+  "specVersion": "2.0.0"
 }


### PR DESCRIPTION
* Bump spec-version from 2.0.0-beta.1 to 2.0.0
* Update OpenAPI tag from v2-beta to v2