### PR TITLE
New storage: allow deletion of multiple repositories

### DIFF
--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
@@ -253,20 +253,24 @@ final class CassandraConstants {
 
   static final String ERASE_OBJS_SCAN =
       "SELECT "
+          + COL_REPO_ID
+          + ", "
           + COL_OBJ_ID
           + " FROM %s."
           + TABLE_OBJS
           + " WHERE "
           + COL_REPO_ID
-          + "=? ALLOW FILTERING";
+          + " IN ? ALLOW FILTERING";
   static final String ERASE_REFS_SCAN =
       "SELECT "
+          + COL_REPO_ID
+          + ", "
           + COL_REFS_NAME
           + " FROM %s."
           + TABLE_REFS
           + " WHERE "
           + COL_REPO_ID
-          + "=? ALLOW FILTERING";
+          + " IN ? ALLOW FILTERING";
 
   static final String ERASE_OBJ = DELETE_OBJ;
   static final String ERASE_REF =

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBackendRepositoryTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBackendRepositoryTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.commontests;
+
+import static org.projectnessie.versioned.storage.common.logic.Logics.repositoryLogic;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.logic.RepositoryLogic;
+import org.projectnessie.versioned.storage.common.persist.Backend;
+import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.PersistFactory;
+import org.projectnessie.versioned.storage.testextension.NessiePersist;
+import org.projectnessie.versioned.storage.testextension.PersistExtension;
+
+/** Basic {@link Persist} tests to be run by every implementation. */
+@ExtendWith({PersistExtension.class, SoftAssertionsExtension.class})
+public class AbstractBackendRepositoryTests {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @NessiePersist protected Backend backend;
+  @NessiePersist protected PersistFactory persistFactory;
+
+  @Test
+  public void createEraseRepoViaPersist() {
+    Persist repo1 = newRepo();
+
+    RepositoryLogic repositoryLogic = repositoryLogic(repo1);
+    repositoryLogic.initialize("foo-main");
+    soft.assertThat(repositoryLogic.repositoryExists()).isTrue();
+    repo1.erase();
+    soft.assertThat(repositoryLogic.repositoryExists()).isFalse();
+    try (CloseableIterator<Obj> scan = repo1.scanAllObjects(EnumSet.allOf(ObjType.class))) {
+      soft.assertThat(scan).isExhausted();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 3, 10})
+  public void createEraseManyRepos(int numRepos) {
+    List<Persist> repos =
+        IntStream.range(0, numRepos).mapToObj(x -> newRepo()).collect(Collectors.toList());
+
+    repos.forEach(r -> repositoryLogic(r).initialize("foo-meep"));
+    soft.assertThat(repos).allMatch(r -> repositoryLogic(r).repositoryExists());
+    backend.eraseRepositories(
+        repos.stream().map(r -> r.config().repositoryId()).collect(Collectors.toSet()));
+    soft.assertThat(repos).noneMatch(r -> repositoryLogic(r).repositoryExists());
+    soft.assertThat(repos)
+        .noneMatch(
+            r -> {
+              try (CloseableIterator<Obj> scan = r.scanAllObjects(EnumSet.allOf(ObjType.class))) {
+                return scan.hasNext();
+              }
+            });
+  }
+
+  private Persist newRepo() {
+    return persistFactory.newPersist(
+        StoreConfig.Adjustable.empty().withRepositoryId("repo-" + UUID.randomUUID()));
+  }
+}

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractPersistTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractPersistTests.java
@@ -38,4 +38,8 @@ public abstract class AbstractPersistTests {
   @Nested
   @SuppressWarnings("ClassCanBeStatic")
   public class RepositoryLogicTests extends AbstractRepositoryLogicTests {}
+
+  @Nested
+  @SuppressWarnings("ClassCanBeStatic")
+  public class BackendRepositoryTests extends AbstractBackendRepositoryTests {}
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Backend.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Backend.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned.storage.common.persist;
 
+import java.util.Set;
 import javax.annotation.Nonnull;
 
 public interface Backend extends AutoCloseable {
@@ -26,4 +27,6 @@ public interface Backend extends AutoCloseable {
   PersistFactory createFactory();
 
   String configInfo();
+
+  void eraseRepositories(Set<String> repositoryIds);
 }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/BatchWrite.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/BatchWrite.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.dynamodb;
+
+import static java.util.Collections.singletonMap;
+import static org.projectnessie.versioned.storage.dynamodb.DynamoDBConstants.BATCH_WRITE_MAX_REQUESTS;
+import static org.projectnessie.versioned.storage.dynamodb.DynamoDBConstants.KEY_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
+
+final class BatchWrite implements AutoCloseable {
+  private final DynamoDBBackend backend;
+  private final String tableName;
+  private final List<WriteRequest> requestItems = new ArrayList<>();
+
+  BatchWrite(DynamoDBBackend backend, String tableName) {
+    this.backend = backend;
+    this.tableName = tableName;
+  }
+
+  private void addRequest(WriteRequest.Builder request) {
+    requestItems.add(request.build());
+    if (requestItems.size() == BATCH_WRITE_MAX_REQUESTS) {
+      flush();
+    }
+  }
+
+  void addDelete(AttributeValue key) {
+    addRequest(WriteRequest.builder().deleteRequest(b -> b.key(singletonMap(KEY_NAME, key))));
+  }
+
+  public void addPut(Map<String, AttributeValue> item) {
+    addRequest(WriteRequest.builder().putRequest(b -> b.item(item)));
+  }
+
+  // close() is actually a flush, implementing AutoCloseable for easier use of BatchDelete using
+  // try-with-resources.
+  @Override
+  public void close() {
+    if (!requestItems.isEmpty()) {
+      flush();
+    }
+  }
+
+  private void flush() {
+    backend.client().batchWriteItem(b -> b.requestItems(singletonMap(tableName, requestItems)));
+    requestItems.clear();
+  }
+}

--- a/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
+++ b/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.storage.inmemory;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Collections.singleton;
 import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
 
 import com.google.common.collect.AbstractIterator;
@@ -24,7 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
@@ -51,7 +51,7 @@ class InmemoryPersist implements ValidatingPersist {
   }
 
   private String compositeKeyRepo() {
-    return config.repositoryId() + ':';
+    return InmemoryBackend.compositeKeyRepo(config.repositoryId());
   }
 
   private String compositeKey(String id) {
@@ -306,12 +306,7 @@ class InmemoryPersist implements ValidatingPersist {
 
   @Override
   public void erase() {
-    String prefix = compositeKeyRepo();
-
-    Consumer<Map<String, ?>> cleaner = m -> m.keySet().removeIf(k -> k.startsWith(prefix));
-
-    cleaner.accept(inmemory.references);
-    cleaner.accept(inmemory.objects);
+    inmemory.eraseRepositories(singleton(config().repositoryId()));
   }
 
   @Nonnull

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.versioned.storage.jdbc;
 
+import static java.util.Collections.singleton;
+import static org.projectnessie.versioned.storage.jdbc.JdbcBackend.unhandledSQLException;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Set;
@@ -259,7 +262,7 @@ class JdbcPersist extends AbstractJdbcPersist {
 
   @Override
   public void erase() {
-    withConnectionVoid(super::erase);
+    backend.eraseRepositories(singleton(config().repositoryId()));
   }
 
   @Nonnull

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
@@ -22,8 +22,10 @@ final class SqlConstants {
   static final String TABLE_REFS = "refs";
   static final String TABLE_OBJS = "objs";
   static final String COL_REPO_ID = "repo";
-  static final String ERASE_OBJS = "DELETE FROM " + TABLE_OBJS + " WHERE " + COL_REPO_ID + " = ?";
-  static final String ERASE_REFS = "DELETE FROM " + TABLE_REFS + " WHERE " + COL_REPO_ID + " = ?";
+  static final String ERASE_OBJS =
+      "DELETE FROM " + TABLE_OBJS + " WHERE " + COL_REPO_ID + " IN (?)";
+  static final String ERASE_REFS =
+      "DELETE FROM " + TABLE_REFS + " WHERE " + COL_REPO_ID + " IN (?)";
   static final String COL_OBJ_ID = "obj_id";
   static final String DELETE_OBJ =
       "DELETE FROM " + TABLE_OBJS + " WHERE " + COL_REPO_ID + "=? AND " + COL_OBJ_ID + "=?";

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -23,6 +23,7 @@ import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Updates.set;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 import static org.projectnessie.nessie.relocated.protobuf.UnsafeByteOperations.unsafeWrap;
 import static org.projectnessie.versioned.storage.common.indexes.StoreKey.keyFromString;
@@ -109,7 +110,6 @@ import javax.annotation.Nonnull;
 import org.agrona.collections.Hashing;
 import org.agrona.collections.Object2IntHashMap;
 import org.bson.Document;
-import org.bson.conversions.Bson;
 import org.bson.types.Binary;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
@@ -637,8 +637,7 @@ public class MongoDBPersist implements Persist {
 
   @Override
   public void erase() {
-    Bson repoIdFilter = eq(ID_REPO_PATH, config.repositoryId());
-    Stream.of(backend.refs(), backend.objs()).forEach(coll -> coll.deleteMany(repoIdFilter));
+    backend.eraseRepositories(singleton(config.repositoryId()));
   }
 
   private Obj docToObj(Document doc) {

--- a/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
+++ b/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
@@ -35,6 +35,7 @@ final class ClassPersistInstances {
 
   private final List<Persist> persistInstances = new ArrayList<>();
   private final CacheBackend cacheBackend;
+  private final Backend backend;
   private final PersistFactory persistFactory;
 
   ClassPersistInstances(ExtensionContext context) {
@@ -48,12 +49,19 @@ final class ClassPersistInstances {
     cacheBackend =
         nessiePersistCache != null ? PersistCaches.newBackend(nessiePersistCache.capacity()) : null;
 
-    @SuppressWarnings("resource")
-    Backend backend = reusableTestBackend.backend(context);
+    backend = reusableTestBackend.backend(context);
 
     backend.setupSchema();
 
     persistFactory = backend.createFactory();
+  }
+
+  PersistFactory persistFactory() {
+    return persistFactory;
+  }
+
+  Backend backend() {
+    return backend;
   }
 
   void registerPersist(Persist persist) {


### PR DESCRIPTION
This change only moves the logic from the `Persist.erase()` implementations to their `Backend.eraseRepositories(Set)` counterparts and makes the implementations delete multiple repos in one shot. No other changes, just moving some already existing code around.