### PR TITLE
Add an API compatibility check to Nessie clients

### DIFF
--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -80,6 +80,8 @@ dependencies {
   testFixturesApi(libs.undertow.servlet)
   testFixturesImplementation(libs.logback.classic)
 
+  testImplementation(libs.wiremock)
+
   intTestImplementation(libs.testcontainers.testcontainers)
   intTestImplementation(libs.testcontainers.junit)
   intTestImplementation(libs.testcontainers.keycloak) {

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -312,6 +312,10 @@ public final class NessieConfigConstants {
   public static final String CONF_FORCE_URL_CONNECTION_CLIENT =
       "nessie.force-url-connection-client";
 
+  /** Enables API compatibility check when creating the Nessie client. The default is {@code true}. */
+  public static final String CONF_ENABLE_API_COMPATIBILITY_CHECK =
+      "nessie.enable-api-compatibility-check";
+
   public static final int DEFAULT_READ_TIMEOUT_MILLIS = 25000;
   public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 5000;
 

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -312,7 +312,9 @@ public final class NessieConfigConstants {
   public static final String CONF_FORCE_URL_CONNECTION_CLIENT =
       "nessie.force-url-connection-client";
 
-  /** Enables API compatibility check when creating the Nessie client. The default is {@code true}. */
+  /**
+   * Enables API compatibility check when creating the Nessie client. The default is {@code true}.
+   */
   public static final String CONF_ENABLE_API_COMPATIBILITY_CHECK =
       "nessie.enable-api-compatibility-check";
 

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -324,6 +324,7 @@ public class HttpClientBuilder implements NessieClientBuilder<HttpClientBuilder>
     return this;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <API extends NessieApi> API build(Class<API> apiVersion) {
     Objects.requireNonNull(apiVersion, "API version class must be non-null");
@@ -333,31 +334,22 @@ public class HttpClientBuilder implements NessieClientBuilder<HttpClientBuilder>
       builder.addTracing();
     }
 
-    API api = buildNessieApi(apiVersion);
-
-    if (enableApiCompatibilityCheck) {
-      NessieApiCompatibility.checkApiCompatibility(api);
-    }
-
-    return api;
-  }
-
-  private <API extends NessieApi> API buildNessieApi(Class<API> apiVersion) {
-
     if (apiVersion.isAssignableFrom(HttpApiV1.class)) {
       builder.setJsonView(Views.V1.class);
       HttpClient httpClient = builder.build();
-      @SuppressWarnings("unchecked")
-      API api = (API) new HttpApiV1(new NessieHttpClient(httpClient));
-      return api;
+      if (enableApiCompatibilityCheck) {
+        NessieApiCompatibility.check(1, httpClient);
+      }
+      return (API) new HttpApiV1(new NessieHttpClient(httpClient));
     }
 
     if (apiVersion.isAssignableFrom(HttpApiV2.class)) {
       builder.setJsonView(Views.V2.class);
       HttpClient httpClient = builder.build();
-      @SuppressWarnings("unchecked")
-      API api = (API) new HttpApiV2(httpClient);
-      return api;
+      if (enableApiCompatibilityCheck) {
+        NessieApiCompatibility.check(2, httpClient);
+      }
+      return (API) new HttpApiV2(httpClient);
     }
 
     throw new IllegalArgumentException(

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -334,15 +334,6 @@ public class HttpClientBuilder implements NessieClientBuilder<HttpClientBuilder>
       builder.addTracing();
     }
 
-    if (apiVersion.isAssignableFrom(HttpApiV2.class)) {
-      builder.setJsonView(Views.V2.class);
-      HttpClient httpClient = builder.build();
-      if (enableApiCompatibilityCheck) {
-        NessieApiCompatibility.check(2, httpClient);
-      }
-      return (API) new HttpApiV2(httpClient);
-    }
-
     if (apiVersion.isAssignableFrom(HttpApiV1.class)) {
       builder.setJsonView(Views.V1.class);
       HttpClient httpClient = builder.build();
@@ -350,6 +341,15 @@ public class HttpClientBuilder implements NessieClientBuilder<HttpClientBuilder>
         NessieApiCompatibility.check(1, httpClient);
       }
       return (API) new HttpApiV1(new NessieHttpClient(httpClient));
+    }
+
+    if (apiVersion.isAssignableFrom(HttpApiV2.class)) {
+      builder.setJsonView(Views.V2.class);
+      HttpClient httpClient = builder.build();
+      if (enableApiCompatibilityCheck) {
+        NessieApiCompatibility.check(2, httpClient);
+      }
+      return (API) new HttpApiV2(httpClient);
     }
 
     throw new IllegalArgumentException(

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -334,15 +334,6 @@ public class HttpClientBuilder implements NessieClientBuilder<HttpClientBuilder>
       builder.addTracing();
     }
 
-    if (apiVersion.isAssignableFrom(HttpApiV1.class)) {
-      builder.setJsonView(Views.V1.class);
-      HttpClient httpClient = builder.build();
-      if (enableApiCompatibilityCheck) {
-        NessieApiCompatibility.check(1, httpClient);
-      }
-      return (API) new HttpApiV1(new NessieHttpClient(httpClient));
-    }
-
     if (apiVersion.isAssignableFrom(HttpApiV2.class)) {
       builder.setJsonView(Views.V2.class);
       HttpClient httpClient = builder.build();
@@ -350,6 +341,15 @@ public class HttpClientBuilder implements NessieClientBuilder<HttpClientBuilder>
         NessieApiCompatibility.check(2, httpClient);
       }
       return (API) new HttpApiV2(httpClient);
+    }
+
+    if (apiVersion.isAssignableFrom(HttpApiV1.class)) {
+      builder.setJsonView(Views.V1.class);
+      HttpClient httpClient = builder.build();
+      if (enableApiCompatibilityCheck) {
+        NessieApiCompatibility.check(1, httpClient);
+      }
+      return (API) new HttpApiV1(new NessieHttpClient(httpClient));
     }
 
     throw new IllegalArgumentException(

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibility.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibility.java
@@ -21,6 +21,7 @@ public class NessieApiCompatibility {
 
   private static final String MIN_API_VERSION = "minSupportedApiVersion";
   private static final String MAX_API_VERSION = "maxSupportedApiVersion";
+  private static final String ACTUAL_API_VERSION = "actualApiVersion";
 
   /**
    * Checks if the API version of the client is compatible with the server's.
@@ -35,12 +36,11 @@ public class NessieApiCompatibility {
     int minServerApiVersion =
         config.hasNonNull(MIN_API_VERSION) ? config.get(MIN_API_VERSION).asInt() : 1;
     int maxServerApiVersion = config.get(MAX_API_VERSION).asInt();
-    if (clientApiVersion < minServerApiVersion || clientApiVersion > maxServerApiVersion) {
-      throw new NessieApiCompatibilityException(
-          clientApiVersion, minServerApiVersion, maxServerApiVersion);
-    }
-    int actualServerApiVersion = config.hasNonNull(MIN_API_VERSION) ? 2 : 1;
-    if (clientApiVersion != actualServerApiVersion) {
+    int actualServerApiVersion =
+        config.hasNonNull(ACTUAL_API_VERSION) ? config.get(ACTUAL_API_VERSION).asInt() : 0;
+    if (clientApiVersion < minServerApiVersion
+        || clientApiVersion > maxServerApiVersion
+        || (actualServerApiVersion > 0 && clientApiVersion != actualServerApiVersion)) {
       throw new NessieApiCompatibilityException(
           clientApiVersion, minServerApiVersion, maxServerApiVersion, actualServerApiVersion);
     }

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibility.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibility.java
@@ -30,12 +30,12 @@ public class NessieApiCompatibility {
    * @throws IllegalArgumentException if the API version is not compatible
    */
   public static void checkApiCompatibility(NessieApi api) {
-    // First, check if the API version is supported by the server.
     int clientApiVersion = api instanceof NessieApiV2 ? 2 : 1;
     NessieConfiguration config = ((NessieApiV1) api).getConfig();
     int minServerApiVersion = config.getMinSupportedApiVersion();
     int maxServerApiVersion = config.getMaxSupportedApiVersion();
     String specVersion = config.getSpecVersion();
+    // First, check if the API version is supported by the server.
     if (minServerApiVersion > clientApiVersion || maxServerApiVersion < clientApiVersion) {
       throw new IllegalArgumentException(
           String.format(

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibility.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibility.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http;
+
+import org.projectnessie.client.api.NessieApi;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.model.NessieConfiguration;
+
+public class NessieApiCompatibility {
+
+  /**
+   * Checks if the API version of the client is compatible with the server's.
+   *
+   * @param api the client API to check, can be either {@link NessieApiV1} or {@link NessieApiV2}
+   *     currently.
+   * @throws IllegalArgumentException if the API version is not compatible
+   */
+  public static void checkApiCompatibility(NessieApi api) {
+    // First, check if the API version is supported by the server.
+    int clientApiVersion = api instanceof NessieApiV2 ? 2 : 1;
+    NessieConfiguration config = ((NessieApiV1) api).getConfig();
+    int minServerApiVersion = config.getMinSupportedApiVersion();
+    int maxServerApiVersion = config.getMaxSupportedApiVersion();
+    String specVersion = config.getSpecVersion();
+    if (minServerApiVersion > clientApiVersion || maxServerApiVersion < clientApiVersion) {
+      throw new IllegalArgumentException(
+          String.format(
+              "API version %s is not supported by the server. "
+                  + "The server supports API versions from %d to %d inclusive.",
+              clientApiVersion, minServerApiVersion, maxServerApiVersion));
+    }
+    // Next, if the client is a V2 API, check that the URI prefix is indeed a V2 API root.
+    // Spec version is only returned in V2+, so we can use that as a heuristic.
+    // FIXME we need a better way to detect API vs URI prefix mismatches.
+    int serverApiVersion = specVersion != null && !specVersion.isEmpty() ? 2 : 1;
+    if (clientApiVersion != serverApiVersion) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Server supports API version %d but replied with API version %d. "
+                  + "Is the client configured with the wrong URI prefix?",
+              clientApiVersion, serverApiVersion));
+    }
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityException.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityException.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http;
+
+public class NessieApiCompatibilityException extends RuntimeException {
+
+  private final int clientApiVersion;
+  private final int minServerApiVersion;
+  private final int maxServerApiVersion;
+  private final int actualServerApiVersion;
+
+  public NessieApiCompatibilityException(
+      int clientApiVersion, int minServerApiVersion, int maxServerApiVersion) {
+    this(clientApiVersion, minServerApiVersion, maxServerApiVersion, 0);
+  }
+
+  public NessieApiCompatibilityException(
+      int clientApiVersion,
+      int minServerApiVersion,
+      int maxServerApiVersion,
+      int actualServerApiVersion) {
+    super(
+        formatMessage(
+            clientApiVersion, minServerApiVersion, maxServerApiVersion, actualServerApiVersion));
+    this.clientApiVersion = clientApiVersion;
+    this.minServerApiVersion = minServerApiVersion;
+    this.maxServerApiVersion = maxServerApiVersion;
+    this.actualServerApiVersion = actualServerApiVersion;
+  }
+
+  private static String formatMessage(
+      int clientApiVersion,
+      int minServerApiVersion,
+      int maxServerApiVersion,
+      int actualServerApiVersion) {
+    if (clientApiVersion < minServerApiVersion) {
+      return String.format(
+          "API version %d is too old for server (minimum supported version is %d)",
+          clientApiVersion, minServerApiVersion);
+    }
+    if (clientApiVersion > maxServerApiVersion) {
+      return String.format(
+          "API version %d is too new for server (maximum supported version is %d)",
+          clientApiVersion, maxServerApiVersion);
+    }
+    return String.format(
+        "API version mismatch, check URI prefix (expected: %d, actual: %d)",
+        clientApiVersion, actualServerApiVersion);
+  }
+
+  public int getClientApiVersion() {
+    return clientApiVersion;
+  }
+
+  public int getMinServerApiVersion() {
+    return minServerApiVersion;
+  }
+
+  public int getMaxServerApiVersion() {
+    return maxServerApiVersion;
+  }
+
+  public int getActualServerApiVersion() {
+    return actualServerApiVersion;
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityException.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityException.java
@@ -23,11 +23,6 @@ public class NessieApiCompatibilityException extends RuntimeException {
   private final int actualServerApiVersion;
 
   public NessieApiCompatibilityException(
-      int clientApiVersion, int minServerApiVersion, int maxServerApiVersion) {
-    this(clientApiVersion, minServerApiVersion, maxServerApiVersion, 0);
-  }
-
-  public NessieApiCompatibilityException(
       int clientApiVersion,
       int minServerApiVersion,
       int maxServerApiVersion,
@@ -61,18 +56,25 @@ public class NessieApiCompatibilityException extends RuntimeException {
         clientApiVersion, actualServerApiVersion);
   }
 
+  /** The client's API version. */
   public int getClientApiVersion() {
     return clientApiVersion;
   }
 
+  /** The minimum API version supported by the server. */
   public int getMinServerApiVersion() {
     return minServerApiVersion;
   }
 
+  /** The maximum API version supported by the server. */
   public int getMaxServerApiVersion() {
     return maxServerApiVersion;
   }
 
+  /**
+   * The actual API version used by the server, or zero if the server does not report its actual API
+   * version.
+   */
   public int getActualServerApiVersion() {
     return actualServerApiVersion;
   }

--- a/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -142,7 +142,8 @@ public class TestHttpClientBuilder {
     return (req, resp) -> {
       receiver.set(req.getHeader(headerName));
       req.getInputStream().close();
-      HttpTestUtil.writeResponseBody(resp, "{\"maxSupportedApiVersion\":1}");
+      HttpTestUtil.writeResponseBody(
+          resp, "{\"maxSupportedApiVersion\":1,\"defaultBranch\":\"main\"}");
     };
   }
 }

--- a/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -142,8 +142,7 @@ public class TestHttpClientBuilder {
     return (req, resp) -> {
       receiver.set(req.getHeader(headerName));
       req.getInputStream().close();
-      HttpTestUtil.writeResponseBody(
-          resp, "{\"maxSupportedApiVersion\":1,\"defaultBranch\":\"main\"}");
+      HttpTestUtil.writeResponseBody(resp, "{\"maxSupportedApiVersion\":1}");
     };
   }
 }

--- a/api/client/src/test/java/org/projectnessie/client/http/TestNessieApiCompatibility.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestNessieApiCompatibility.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.model.ImmutableNessieConfiguration;
+import org.projectnessie.model.NessieConfiguration;
+
+@ExtendWith(MockitoExtension.class)
+class TestNessieApiCompatibility {
+
+  @Mock NessieApiV1 apiV1;
+  @Mock NessieApiV2 apiV2;
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "1, 1, 1,      ",
+        "1, 1, 2,      ",
+        "1, 1, 2, 2.0.0", // mimic v2 endpoint mistakenly called with v1 client
+        "1, 2, 2, 2.0.0",
+        "2, 1, 1,      ",
+        "2, 1, 2, 2.0.0",
+        "2, 1, 2,      ", // mimic v1 endpoint mistakenly called with v2 client
+        "2, 2, 2, 2.0.0",
+        "2, 2, 3, 3.0.0",
+        "2, 3, 3, 3.0.0"
+      })
+  void checkApiCompatibility(int client, int serverMin, int serverMax, String serverSpec) {
+    NessieApiV1 input = client == 1 ? apiV1 : apiV2;
+    NessieConfiguration config =
+        ImmutableNessieConfiguration.builder()
+            .minSupportedApiVersion(serverMin)
+            .maxSupportedApiVersion(serverMax)
+            .specVersion(serverSpec)
+            .build();
+    given(input.getConfig()).willReturn(config);
+    boolean incompatible = client < serverMin || client > serverMax;
+    boolean mismatch = client == 1 ^ serverSpec == null;
+    boolean ok = !incompatible && !mismatch;
+    if (ok) {
+      assertThatCode(() -> NessieApiCompatibility.checkApiCompatibility(input))
+          .doesNotThrowAnyException();
+    } else if (incompatible) {
+      assertThatThrownBy(() -> NessieApiCompatibility.checkApiCompatibility(input))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(
+              "API version "
+                  + client
+                  + " is not supported by the server. "
+                  + "The server supports API versions from "
+                  + serverMin
+                  + " to "
+                  + serverMax
+                  + " inclusive.");
+    } else {
+      assertThatThrownBy(() -> NessieApiCompatibility.checkApiCompatibility(input))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(
+              "Server supports API version "
+                  + client
+                  + " but replied with API version "
+                  + (client == 1 ? 2 : 1)
+                  + ". "
+                  + "Is the client configured with the wrong URI prefix?");
+    }
+  }
+}

--- a/api/client/src/test/java/org/projectnessie/client/http/TestNessieApiCompatibility.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestNessieApiCompatibility.java
@@ -43,7 +43,20 @@ class TestNessieApiCompatibility {
     OK,
     TOO_OLD,
     TOO_NEW,
-    MISMATCH
+    MISMATCH;
+
+    public String expectedErrorMessage() {
+      switch (this) {
+        case TOO_OLD:
+          return "too old";
+        case TOO_NEW:
+          return "too new";
+        case MISMATCH:
+          return "mismatch";
+        default:
+          return null;
+      }
+    }
   }
 
   @ParameterizedTest
@@ -96,10 +109,7 @@ class TestNessieApiCompatibility {
       } else {
 
         assertThatThrownBy(() -> NessieApiCompatibility.check(client, httpClient))
-            .hasMessageContaining(
-                expectation == Expectation.MISMATCH
-                    ? "mismatch"
-                    : expectation == Expectation.TOO_OLD ? "too old" : "too new")
+            .hasMessageContaining(expectation.expectedErrorMessage())
             .asInstanceOf(type(NessieApiCompatibilityException.class))
             .extracting(
                 NessieApiCompatibilityException::getClientApiVersion,

--- a/api/client/src/test/java/org/projectnessie/client/http/TestNessieApiCompatibilityException.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestNessieApiCompatibilityException.java
@@ -23,10 +23,10 @@ class TestNessieApiCompatibilityException {
 
   @Test
   void testMessages() {
-    NessieApiCompatibilityException e = new NessieApiCompatibilityException(1, 2, 3);
+    NessieApiCompatibilityException e = new NessieApiCompatibilityException(1, 2, 3, 3);
     assertThat(e.getMessage())
         .isEqualTo("API version 1 is too old for server (minimum supported version is 2)");
-    e = new NessieApiCompatibilityException(5, 3, 4);
+    e = new NessieApiCompatibilityException(5, 3, 4, 4);
     assertThat(e.getMessage())
         .isEqualTo("API version 5 is too new for server (maximum supported version is 4)");
     e = new NessieApiCompatibilityException(3, 2, 4, 2);

--- a/api/client/src/test/java/org/projectnessie/client/http/TestNessieApiCompatibilityException.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestNessieApiCompatibilityException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TestNessieApiCompatibilityException {
+
+  @Test
+  void testMessages() {
+    NessieApiCompatibilityException e = new NessieApiCompatibilityException(1, 2, 3);
+    assertThat(e.getMessage())
+        .isEqualTo("API version 1 is too old for server (minimum supported version is 2)");
+    e = new NessieApiCompatibilityException(5, 3, 4);
+    assertThat(e.getMessage())
+        .isEqualTo("API version 5 is too new for server (maximum supported version is 4)");
+    e = new NessieApiCompatibilityException(3, 2, 4, 2);
+    assertThat(e.getMessage())
+        .isEqualTo("API version mismatch, check URI prefix (expected: 3, actual: 2)");
+  }
+
+  @Test
+  void testGetters() {
+    NessieApiCompatibilityException e = new NessieApiCompatibilityException(1, 2, 4, 3);
+    assertThat(e.getClientApiVersion()).isEqualTo(1);
+    assertThat(e.getMinServerApiVersion()).isEqualTo(2);
+    assertThat(e.getMaxServerApiVersion()).isEqualTo(4);
+    assertThat(e.getActualServerApiVersion()).isEqualTo(3);
+  }
+}

--- a/api/client/src/test/java/org/projectnessie/client/http/TestNessieHttpClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestNessieHttpClient.java
@@ -16,7 +16,6 @@
 package org.projectnessie.client.http;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
@@ -28,9 +27,13 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
 import java.util.concurrent.atomic.AtomicReference;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.client.api.NessieApi;
@@ -46,7 +49,10 @@ import org.projectnessie.client.util.HttpTestUtil;
 import org.projectnessie.client.util.JaegerTestTracer;
 import org.projectnessie.model.Branch;
 
+@ExtendWith(SoftAssertionsExtension.class)
 class TestNessieHttpClient {
+
+  @InjectSoftAssertions SoftAssertions soft;
 
   static final String W3C_PROPAGATION_HEADER_NAME = "traceparent";
 
@@ -201,34 +207,44 @@ class TestNessieHttpClient {
   @Test
   void testApiCompatibility() {
     // Good cases
-    assertThatCode(() -> testConfig(NessieApiV1.class, 1, 1, 0, true)).doesNotThrowAnyException();
-    assertThatCode(() -> testConfig(NessieApiV1.class, 1, 2, 0, true)).doesNotThrowAnyException();
-    assertThatCode(() -> testConfig(NessieApiV2.class, 1, 2, 0, true)).doesNotThrowAnyException();
-    assertThatCode(() -> testConfig(NessieApiV2.class, 1, 2, 2, true)).doesNotThrowAnyException();
-    assertThatCode(() -> testConfig(NessieApiV2.class, 2, 2, 2, true)).doesNotThrowAnyException();
-    assertThatCode(() -> testConfig(NessieApiV2.class, 2, 3, 2, true)).doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV1.class, 1, 1, 0, true))
+        .doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV1.class, 1, 2, 0, true))
+        .doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV2.class, 1, 2, 0, true))
+        .doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV2.class, 1, 2, 2, true))
+        .doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV2.class, 2, 2, 2, true))
+        .doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV2.class, 2, 3, 2, true))
+        .doesNotThrowAnyException();
     // Bad cases
     // 1. v1 client called a server that doesn't support v1
-    assertThatThrownBy(() -> testConfig(NessieApiV1.class, 2, 2, 2, true))
+    soft.assertThatThrownBy(() -> testConfig(NessieApiV1.class, 2, 2, 2, true))
         .isInstanceOf(NessieApiCompatibilityException.class);
     // 2. v2 client called a server that doesn't support v2
-    assertThatThrownBy(() -> testConfig(NessieApiV2.class, 1, 1, 1, true))
+    soft.assertThatThrownBy(() -> testConfig(NessieApiV2.class, 1, 1, 1, true))
         .isInstanceOf(NessieApiCompatibilityException.class);
     // 3. v1 client called a v2 endpoint
-    assertThatThrownBy(() -> testConfig(NessieApiV1.class, 1, 2, 2, true))
+    soft.assertThatThrownBy(() -> testConfig(NessieApiV1.class, 1, 2, 2, true))
         .isInstanceOf(NessieApiCompatibilityException.class);
     // 4. v2 client called a v1 endpoint
-    assertThatThrownBy(() -> testConfig(NessieApiV2.class, 1, 2, 1, true))
+    soft.assertThatThrownBy(() -> testConfig(NessieApiV2.class, 1, 2, 1, true))
         .isInstanceOf(NessieApiCompatibilityException.class);
     // Bad cases with compatibility check disabled
     // 1. v1 client called a server that doesn't support v1
-    assertThatCode(() -> testConfig(NessieApiV1.class, 2, 2, 2, false)).doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV1.class, 2, 2, 2, false))
+        .doesNotThrowAnyException();
     // 2. v2 client called a server that doesn't support v2
-    assertThatCode(() -> testConfig(NessieApiV2.class, 1, 1, 1, false)).doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV2.class, 1, 1, 1, false))
+        .doesNotThrowAnyException();
     // 3. v1 client called a v2 endpoint
-    assertThatCode(() -> testConfig(NessieApiV1.class, 1, 2, 2, false)).doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV1.class, 1, 2, 2, false))
+        .doesNotThrowAnyException();
     // 4. v2 client called a v1 endpoint
-    assertThatCode(() -> testConfig(NessieApiV2.class, 1, 2, 1, false)).doesNotThrowAnyException();
+    soft.assertThatCode(() -> testConfig(NessieApiV2.class, 1, 2, 1, false))
+        .doesNotThrowAnyException();
   }
 
   @SuppressWarnings("EmptyTryBlock")

--- a/api/client/src/test/java/org/projectnessie/client/http/TestNessieHttpClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestNessieHttpClient.java
@@ -275,8 +275,7 @@ class TestNessieHttpClient {
       receiver.set(req.getHeader(headerName));
       req.getInputStream().close();
       resp.addHeader("Content-Type", "application/json");
-      HttpTestUtil.writeResponseBody(
-          resp, "{\"maxSupportedApiVersion\":1,\"defaultBranch\":\"main\"}");
+      HttpTestUtil.writeResponseBody(resp, "{\"maxSupportedApiVersion\":1}");
     };
   }
 

--- a/api/client/src/test/java/org/projectnessie/client/http/TestNessieHttpClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestNessieHttpClient.java
@@ -241,17 +241,13 @@ class TestNessieHttpClient {
 
   @SuppressWarnings("EmptyTryBlock")
   private void testConfig(
-      Class<? extends NessieApi> apiClass,
-      int min,
-      int max,
-      String spec,
-      boolean enableApiCompatCheck)
+      Class<? extends NessieApi> apiClass, int min, int max, String spec, boolean check)
       throws Exception {
     try (HttpTestServer server = forConfig(min, max, spec);
         NessieApi ignored =
             HttpClientBuilder.builder()
                 .withUri(server.getUri())
-                .withEnableApiCompatibilityCheck(enableApiCompatCheck)
+                .withEnableApiCompatibilityCheck(check)
                 .build(apiClass)) {
       // no-op
     }

--- a/api/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
+++ b/api/model/src/main/java/org/projectnessie/model/NessieConfiguration.java
@@ -69,6 +69,19 @@ public abstract class NessieConfiguration {
    */
   public abstract int getMaxSupportedApiVersion();
 
+  /**
+   * The actual API version that was used to handle the REST request to the configuration endpoint.
+   *
+   * <p>If this value is 0, then the server does not support returning the actual API version.
+   * Otherwise, this value is guaranteed to be between {@link #getMinSupportedApiVersion()} and
+   * {@link #getMaxSupportedApiVersion()} (inclusive).
+   */
+  @JsonView(Views.V2.class)
+  @Value.Default
+  public int getActualApiVersion() {
+    return 0;
+  }
+
   /** Semver version representing the behavior of the Nessie server. */
   @JsonView(Views.V2.class)
   @Nullable

--- a/api/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestModelObjectsSerialization.java
@@ -114,6 +114,7 @@ public class TestModelObjectsSerialization {
                     .defaultBranch("default-branch")
                     .minSupportedApiVersion(11)
                     .maxSupportedApiVersion(42)
+                    .actualApiVersion(42)
                     .specVersion("42.1.2")
                     .build())
             .jsonNode(
@@ -121,6 +122,7 @@ public class TestModelObjectsSerialization {
                     o.put("defaultBranch", "default-branch")
                         .put("minSupportedApiVersion", 11)
                         .put("maxSupportedApiVersion", 42)
+                        .put("actualApiVersion", 42)
                         .put("specVersion", "42.1.2")),
         new Case(Branch.class)
             .obj(Branch.of(branchName, HASH))

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
@@ -35,11 +35,15 @@ public class Version implements Comparable<Version> {
   // CLIENT_LOG4J_UNDECLARED_* is the version range where :nessie-client uses log4j without
   // declaring an explicit dependency in its POM.
   public static final Version CLIENT_LOG4J_UNDECLARED_LOW = Version.parseVersion("0.46.0");
+  public static final Version API_V2 = Version.parseVersion("0.46.0");
   public static final Version CLIENT_LOG4J_UNDECLARED_HIGH = Version.parseVersion("0.47.1");
   // COMPAT_COMMON_DEPENDENCIES_START is the version where dependency declarations for
   // "compatibility" tests moved to :nessie-compatibility-common
   public static final Version COMPAT_COMMON_DEPENDENCIES_START = Version.parseVersion("0.48.2");
   public static final Version OLD_GROUP_IDS = Version.parseVersion("0.50.0");
+  public static final Version SPEC_VERSION_IN_CONFIG_V2 = Version.parseVersion("0.55.0");
+  public static final Version SPEC_VERSION_IN_CONFIG_V2_SEMVER = Version.parseVersion("0.57.0");
+  public static final Version ACTUAL_VERSION_IN_CONFIG_V2 = Version.parseVersion("0.59.0");
 
   public static final String CURRENT_STRING = "current";
   public static final String NOT_CURRENT_STRING = "not-current";

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieApiHolder.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieApiHolder.java
@@ -20,8 +20,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Proxy;
-import java.util.Collections;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -57,7 +57,9 @@ class TestNessieApiHolder {
                   Version.CURRENT,
                   "org.projectnessie.client.http.HttpClientBuilder",
                   NessieApiV1.class,
-                  Collections.singletonMap("nessie.uri", "http://127.42.42.42:19120")));
+                  ImmutableMap.of(
+                      "nessie.uri", "http://127.42.42.42:19120",
+                      "nessie.enable-api-compatibility-check", "false")));
       try {
         soft.assertThat(apiHolder)
             .extracting(AbstractNessieApiHolder::getApiInstance)
@@ -90,7 +92,9 @@ class TestNessieApiHolder {
                   Version.parseVersion("0.42.0"),
                   "org.projectnessie.client.http.HttpClientBuilder",
                   NessieApiV1.class,
-                  Collections.singletonMap("nessie.uri", "http://127.42.42.42:19120")));
+                  ImmutableMap.of(
+                      "nessie.uri", "http://127.42.42.42:19120",
+                      "nessie.enable-api-compatibility-check", "false")));
       try {
         soft.assertThat(apiHolder)
             .satisfies(

--- a/compatibility/compatibility-tests/build.gradle.kts
+++ b/compatibility/compatibility-tests/build.gradle.kts
@@ -55,6 +55,6 @@ tasks.withType<Test>().configureEach {
 // with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument`
 //
 // Compatibility tests fail, because Windows not supported by testcontainers (logged message)
-if (Os.isFamily(Os.FAMILY_MAC) || Os.isFamily(Os.FAMILY_WINDOWS)) {
+if ((Os.isFamily(Os.FAMILY_MAC) || Os.isFamily(Os.FAMILY_WINDOWS)) && System.getenv("CI") != null) {
   tasks.withType<Test>().configureEach { this.enabled = false }
 }

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -50,7 +50,6 @@ import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Reference;
 import org.projectnessie.tools.compatibility.api.NessieAPI;
-import org.projectnessie.tools.compatibility.api.NessieApiBuilderProperty;
 import org.projectnessie.tools.compatibility.api.NessieVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.api.VersionCondition;
@@ -58,14 +57,8 @@ import org.projectnessie.tools.compatibility.api.VersionCondition;
 @VersionCondition(maxVersion = Version.NOT_CURRENT_STRING)
 public abstract class AbstractCompatibilityTests {
 
-  @NessieAPI
-  @NessieApiBuilderProperty(name = "nessie.enable-api-compatibility-check", value = "false")
-  protected NessieApiV1 api;
-
-  @NessieAPI
-  @NessieApiBuilderProperty(name = "nessie.enable-api-compatibility-check", value = "false")
-  protected NessieApiV2 apiV2;
-
+  @NessieAPI protected NessieApiV1 api;
+  @NessieAPI protected NessieApiV2 apiV2;
   @NessieVersion Version version;
 
   abstract Version getClientVersion();

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -54,7 +54,7 @@ import org.projectnessie.tools.compatibility.api.NessieVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.api.VersionCondition;
 
-@VersionCondition(maxVersion = Version.NOT_CURRENT_STRING)
+// @VersionCondition(maxVersion = Version.NOT_CURRENT_STRING)
 public abstract class AbstractCompatibilityTests {
 
   @NessieAPI protected NessieApiV1 api;
@@ -115,9 +115,73 @@ public abstract class AbstractCompatibilityTests {
   }
 
   @Test
-  void getConfig() {
+  @VersionCondition(maxVersion = "0.45.0")
+  void getConfigV1WithoutV2Support() {
     NessieConfiguration config = api.getConfig();
-    assertThat(config).extracting(NessieConfiguration::getDefaultBranch).isEqualTo("main");
+    assertThat(config)
+        .extracting(
+            NessieConfiguration::getDefaultBranch,
+            NessieConfiguration::getMinSupportedApiVersion,
+            NessieConfiguration::getMaxSupportedApiVersion,
+            NessieConfiguration::getActualApiVersion,
+            NessieConfiguration::getSpecVersion)
+        .containsExactly("main", 1, 1, 0, null);
+  }
+
+  @Test
+  @VersionCondition(minVersion = "0.47.0")
+  void getConfigV1WithV2Support() {
+    NessieConfiguration config = api.getConfig();
+    assertThat(config)
+        .extracting(
+            NessieConfiguration::getDefaultBranch,
+            NessieConfiguration::getMinSupportedApiVersion,
+            NessieConfiguration::getMaxSupportedApiVersion,
+            NessieConfiguration::getActualApiVersion,
+            NessieConfiguration::getSpecVersion)
+        .containsExactly("main", 1, 2, 0, null);
+  }
+
+  @Test
+  @VersionCondition(minVersion = "0.47.0", maxVersion = "0.51.1")
+  void getConfigV2WithoutSpecWithoutActualVersion() {
+    NessieConfiguration config = apiV2.getConfig();
+    assertThat(config)
+        .extracting(
+            NessieConfiguration::getDefaultBranch,
+            NessieConfiguration::getMinSupportedApiVersion,
+            NessieConfiguration::getMaxSupportedApiVersion,
+            NessieConfiguration::getActualApiVersion,
+            NessieConfiguration::getSpecVersion)
+        .containsExactly("main", 1, 2, 0, null);
+  }
+
+  @Test
+  @VersionCondition(minVersion = "0.52.3", maxVersion = "0.57.0")
+  void getConfigV2WithSpecWithoutActualVersion() {
+    NessieConfiguration config = apiV2.getConfig();
+    assertThat(config)
+        .extracting(
+            NessieConfiguration::getDefaultBranch,
+            NessieConfiguration::getMinSupportedApiVersion,
+            NessieConfiguration::getMaxSupportedApiVersion,
+            NessieConfiguration::getActualApiVersion,
+            NessieConfiguration::getSpecVersion)
+        .containsExactly("main", 1, 2, 0, "2.0-beta.1");
+  }
+
+  @Test
+  @VersionCondition(minVersion = "0.59.0")
+  void getConfigV2WithSpecWithActualVersion() {
+    NessieConfiguration config = apiV2.getConfig();
+    assertThat(config)
+        .extracting(
+            NessieConfiguration::getDefaultBranch,
+            NessieConfiguration::getMinSupportedApiVersion,
+            NessieConfiguration::getMaxSupportedApiVersion,
+            NessieConfiguration::getActualApiVersion,
+            NessieConfiguration::getSpecVersion)
+        .containsExactly("main", 1, 2, 2, "2.0.0-beta.1");
   }
 
   @Test

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -113,7 +113,7 @@ public abstract class AbstractCompatibilityTests {
   }
 
   @Test
-  void getConfig() {
+  void getConfigV1() {
     NessieConfiguration config = api.getConfig();
     assertThat(config.getDefaultBranch()).isEqualTo("main");
     assertThat(config.getMinSupportedApiVersion()).isEqualTo(1);

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -50,6 +50,7 @@ import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Reference;
 import org.projectnessie.tools.compatibility.api.NessieAPI;
+import org.projectnessie.tools.compatibility.api.NessieApiBuilderProperty;
 import org.projectnessie.tools.compatibility.api.NessieVersion;
 import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.api.VersionCondition;
@@ -57,8 +58,14 @@ import org.projectnessie.tools.compatibility.api.VersionCondition;
 @VersionCondition(maxVersion = Version.NOT_CURRENT_STRING)
 public abstract class AbstractCompatibilityTests {
 
-  @NessieAPI protected NessieApiV1 api;
-  @NessieAPI protected NessieApiV2 apiV2;
+  @NessieAPI
+  @NessieApiBuilderProperty(name = "nessie.enable-api-compatibility-check", value = "false")
+  protected NessieApiV1 api;
+
+  @NessieAPI
+  @NessieApiBuilderProperty(name = "nessie.enable-api-compatibility-check", value = "false")
+  protected NessieApiV2 apiV2;
+
   @NessieVersion Version version;
 
   abstract Version getClientVersion();

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
@@ -15,9 +15,7 @@
  */
 package org.projectnessie.tools.compatibility.tests;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.internal.OlderNessieServersExtension;
 
@@ -27,11 +25,5 @@ public class ITOlderServers extends AbstractCompatibilityTests {
   @Override
   Version getClientVersion() {
     return Version.CURRENT;
-  }
-
-  @Override
-  @Test
-  public void mergeBehavior() throws BaseNessieClientServerException {
-    super.mergeBehavior();
   }
 }

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
@@ -34,7 +34,7 @@ public class ITOlderServers extends AbstractCompatibilityTests {
 
   @Test
   @Override
-  void getConfig() {
+  void getConfigV1() {
     NessieConfiguration config = api.getConfig();
     assertThat(config.getDefaultBranch()).isEqualTo("main");
     assertThat(config.getMinSupportedApiVersion()).isEqualTo(1);

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
@@ -15,8 +15,13 @@
  */
 package org.projectnessie.tools.compatibility.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.tools.compatibility.api.Version;
+import org.projectnessie.tools.compatibility.api.VersionCondition;
 import org.projectnessie.tools.compatibility.internal.OlderNessieServersExtension;
 
 @ExtendWith(OlderNessieServersExtension.class)
@@ -25,5 +30,42 @@ public class ITOlderServers extends AbstractCompatibilityTests {
   @Override
   Version getClientVersion() {
     return Version.CURRENT;
+  }
+
+  @Test
+  @Override
+  void getConfig() {
+    NessieConfiguration config = api.getConfig();
+    assertThat(config.getDefaultBranch()).isEqualTo("main");
+    assertThat(config.getMinSupportedApiVersion()).isEqualTo(1);
+    if (version.isLessThan(Version.API_V2)) {
+      assertThat(config.getMaxSupportedApiVersion()).isEqualTo(1);
+    } else {
+      assertThat(config.getMaxSupportedApiVersion()).isEqualTo(2);
+    }
+    assertThat(config.getActualApiVersion()).isEqualTo(0);
+    assertThat(config.getSpecVersion()).isNull();
+  }
+
+  @Test
+  @VersionCondition(minVersion = "0.47.0")
+  @Override
+  void getConfigV2() {
+    NessieConfiguration config = apiV2.getConfig();
+    assertThat(config.getDefaultBranch()).isEqualTo("main");
+    assertThat(config.getMinSupportedApiVersion()).isEqualTo(1);
+    assertThat(config.getMaxSupportedApiVersion()).isEqualTo(2);
+    if (version.isLessThan(Version.ACTUAL_VERSION_IN_CONFIG_V2)) {
+      assertThat(config.getActualApiVersion()).isEqualTo(0);
+    } else {
+      assertThat(config.getActualApiVersion()).isEqualTo(2);
+    }
+    if (version.isLessThan(Version.SPEC_VERSION_IN_CONFIG_V2)) {
+      assertThat(config.getSpecVersion()).isNull();
+    } else if (version.isLessThan(Version.SPEC_VERSION_IN_CONFIG_V2_SEMVER)) {
+      assertThat(config.getSpecVersion()).isEqualTo("2.0-beta.1");
+    } else {
+      assertThat(config.getSpecVersion()).isEqualTo("2.0.0-beta.1");
+    }
   }
 }

--- a/compatibility/compatibility-tests/src/intTest/resources/META-INF/nessie-compatibility.properties
+++ b/compatibility/compatibility-tests/src/intTest/resources/META-INF/nessie-compatibility.properties
@@ -33,8 +33,10 @@
 #   - introduced open-addressing key-list
 # 0.51.1:
 #   - moved to new Maven group ID (with relocation poms for the old group ID)
+# 0.55.0
+#   - introduced minSupportedApiVersion and specVersion in NessieConfiguration
 #
 # MINIMUM VERSION is 0.23.1 !!!
 #
 # Untested (for CI duration): 0.23.1,0.26.0,0.30.0,0.40.3
-nessie.versions=0.42.0,0.47.0,0.48.2,0.51.1,current
+nessie.versions=0.42.0,0.47.0,0.48.2,0.51.1,0.55.0,current

--- a/compatibility/compatibility-tests/src/intTest/resources/META-INF/nessie-compatibility.properties
+++ b/compatibility/compatibility-tests/src/intTest/resources/META-INF/nessie-compatibility.properties
@@ -35,8 +35,10 @@
 #   - moved to new Maven group ID (with relocation poms for the old group ID)
 # 0.55.0
 #   - introduced minSupportedApiVersion and specVersion in NessieConfiguration
+# 0.57.0
+#   - specVersion in NessieConfiguration changed to semver syntax
 #
 # MINIMUM VERSION is 0.23.1 !!!
 #
 # Untested (for CI duration): 0.23.1,0.26.0,0.30.0,0.40.3
-nessie.versions=0.42.0,0.47.0,0.48.2,0.51.1,0.55.0,current
+nessie.versions=0.42.0,0.47.0,0.48.2,0.51.1,0.55.0,0.57.0,current

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/NessieOptions.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/NessieOptions.java
@@ -39,8 +39,8 @@ public class NessieOptions {
   @CommandLine.Option(
       names = {"-u", "--uri"},
       scope = CommandLine.ScopeType.INHERIT,
-      description = "Nessie API endpoint URI, defaults to http://localhost:19120/api/v2.")
-  URI nessieUri = URI.create("http://localhost:19120/api/v2");
+      description = "Nessie API endpoint URI, defaults to http://localhost:19120/api/v1.")
+  URI nessieUri = URI.create("http://localhost:19120/api/v1");
 
   @CommandLine.Option(
       names = "--nessie-option",

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/NessieOptions.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/NessieOptions.java
@@ -39,8 +39,8 @@ public class NessieOptions {
   @CommandLine.Option(
       names = {"-u", "--uri"},
       scope = CommandLine.ScopeType.INHERIT,
-      description = "Nessie API endpoint URI, defaults to http://localhost:19120/api/v1.")
-  URI nessieUri = URI.create("http://localhost:19120/api/v1");
+      description = "Nessie API endpoint URI, defaults to http://localhost:19120/api/v2.")
+  URI nessieUri = URI.create("http://localhost:19120/api/v2");
 
   @CommandLine.Option(
       names = "--nessie-option",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ rocksdb = "8.1.1.1"
 slf4j = "1.7.36"
 testcontainers = "1.18.1"
 undertow = "2.2.19.Final"
+wiremock = "2.35.0"
 
 [bundles]
 # Bundles serve two purposes:
@@ -225,6 +226,7 @@ threeten-extra = { module = "org.threeten:threeten-extra", version = "1.7.2" }
 undertow-core = { module = "io.undertow:undertow-core", version.ref = "undertow" }
 undertow-servlet = { module = "io.undertow:undertow-servlet", version.ref = "undertow" }
 weld-se-core = { module = "org.jboss.weld.se:weld-se-core", version = "3.1.9.Final" }
+wiremock = { module = "com.github.tomakehurst:wiremock-jre8-standalone", version.ref = "wiremock" }
 
 [plugins]
 annotations-stripper = { id = "org.projectnessie.annotation-stripper", version = "0.1.2" }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
@@ -32,6 +32,6 @@ public class RestConfigService extends ConfigApiImpl {
   @Inject
   @jakarta.inject.Inject
   public RestConfigService(ServerConfig config, VersionStore store) {
-    super(config, store);
+    super(config, store, 1);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
@@ -40,7 +40,7 @@ public class RestV2ConfigResource implements HttpConfigApi {
   @Inject
   @jakarta.inject.Inject
   public RestV2ConfigResource(ServerConfig config, VersionStore store) {
-    this.config = new ConfigApiImpl(config, store);
+    this.config = new ConfigApiImpl(config, store, 2);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
@@ -25,10 +25,12 @@ public class ConfigApiImpl implements ConfigService {
 
   private final VersionStore store;
   private final ServerConfig config;
+  private final int actualApiVersion;
 
-  public ConfigApiImpl(ServerConfig config, VersionStore store) {
+  public ConfigApiImpl(ServerConfig config, VersionStore store, int actualApiVersion) {
     this.store = store;
     this.config = config;
+    this.actualApiVersion = actualApiVersion;
   }
 
   @Override
@@ -36,6 +38,7 @@ public class ConfigApiImpl implements ConfigService {
     return ImmutableNessieConfiguration.builder()
         .from(NessieConfiguration.getBuiltInConfig())
         .defaultBranch(this.config.getDefaultBranch())
+        .actualApiVersion(actualApiVersion)
         .build();
   }
 }

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMisc.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMisc.java
@@ -54,6 +54,7 @@ public abstract class AbstractTestMisc extends BaseTestServiceImpl {
         ImmutableNessieConfiguration.builder()
             .from(NessieConfiguration.getBuiltInConfig())
             .defaultBranch(serverConfig.getDefaultBranch())
+            .actualApiVersion(2)
             .build();
     assertThat(serverConfig).isEqualTo(expectedConfig);
   }

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
@@ -114,7 +114,7 @@ public abstract class BaseTestServiceImpl {
   private Principal principal;
 
   protected final ConfigApiImpl configApi() {
-    return new ConfigApiImpl(config(), versionStore(), 1);
+    return new ConfigApiImpl(config(), versionStore(), 2);
   }
 
   protected final TreeApiImpl treeApi() {

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
@@ -114,7 +114,7 @@ public abstract class BaseTestServiceImpl {
   private Principal principal;
 
   protected final ConfigApiImpl configApi() {
-    return new ConfigApiImpl(config(), versionStore());
+    return new ConfigApiImpl(config(), versionStore(), 1);
   }
 
   protected final TreeApiImpl treeApi() {


### PR DESCRIPTION
... and change default URI of GC tool to a v2 URI.

Fixes #6805.