### PR TITLE
Switch to macOS 13 and re-enable Mac tests

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -76,11 +76,11 @@ jobs:
         ln -s /usr/local/bin/podman /usr/local/bin/docker
         echo "::endgroup::"
 
-        export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/qemu/podman.sock"
-        echo "DOCKER_HOST=$DOCKER_HOST" >> ${GITHUB_ENV}
+        # export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/qemu/podman.sock"
+        # echo "DOCKER_HOST=$DOCKER_HOST" >> ${GITHUB_ENV}
 
         # See https://www.testcontainers.org/supported_docker_environment/
-        echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> ${GITHUB_ENV}
+        # echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> ${GITHUB_ENV}
 
         echo "::group::Docker info"
         docker info
@@ -111,7 +111,7 @@ jobs:
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: :nessie-client:check --scan -i
+        arguments: :nessie-client:intTest -i --tests org.projectnessie.client.auth.oauth2.ITOAuth2Client
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -37,6 +37,17 @@ jobs:
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
 
+#    - name: Gradle / compile
+#      uses: gradle/gradle-build-action@v2
+#      env:
+#        # Same as for ci.yml
+#        GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-11
+#        GRADLE_BUILD_ACTION_CACHE_KEY_JOB: nessie-ci
+#        GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
+#      with:
+#        cache-read-only: true
+#        arguments: assemble --scan
+
     - name: Gradle / unit test
       uses: gradle/gradle-build-action@v2
       with:
@@ -111,6 +122,17 @@ jobs:
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
 
+#    - name: Gradle / compile
+#      uses: gradle/gradle-build-action@v2
+#      env:
+#        # Same as for ci.yml
+#        GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-11
+#        GRADLE_BUILD_ACTION_CACHE_KEY_JOB: nessie-ci
+#        GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
+#      with:
+#        cache-read-only: true
+#        arguments: assemble --scan
+
     - name: Gradle / intTest
       run: |
         echo "::group::Collect :nessie-compatibility projects"
@@ -132,16 +154,14 @@ jobs:
         export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
         echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
 
-        ./gradlew :nessie-client:intTest -i --tests org.projectnessie.client.auth.oauth2.ITOAuth2Client
-
-#        ./gradlew intTest \
-#          $(cat ../compat-prjs.txt) \
-#          $(cat ../persist-prjs.txt) \
-#          $(cat ../storage-prjs.txt) \
-#          $(cat ../spark-prjs.txt) \
-#          -x :nessie-deltalake:intTest \
-#          -x :nessie-ui:test \
-#          --scan
+        ./gradlew intTest \
+            $(cat ../compat-prjs.txt) \
+            $(cat ../persist-prjs.txt) \
+            $(cat ../storage-prjs.txt) \
+            $(cat ../spark-prjs.txt) \
+            -x :nessie-deltalake:intTest \
+            -x :nessie-ui:test \
+            --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -77,9 +77,9 @@ jobs:
         echo "::group::Update Brew"
         brew update
         echo "::endgroup::"
-        echo "::group::Brew Upgrade"
-        brew upgrade || true
-        echo "::endgroup::"
+#        echo "::group::Brew Upgrade"
+#        brew upgrade || true
+#        echo "::endgroup::"
 
     - name: Prepare Podman
       run: |
@@ -150,7 +150,7 @@ jobs:
         export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
         echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
 
-        ./gradlew :nessie-client:intTest -i --tests org.projectnessie.client.auth.oauth2.ITOAuth2Client
+#        ./gradlew :nessie-client:intTest -i --tests org.projectnessie.client.auth.oauth2.ITOAuth2Client
 
         ./gradlew intTest \
             $(cat ../compat-prjs.txt) \

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -77,14 +77,14 @@ jobs:
         echo "::group::Update Brew"
         brew update
         echo "::endgroup::"
-#        echo "::group::Brew Upgrade"
-#        brew upgrade || true
-#        echo "::endgroup::"
+        echo "::group::Brew Upgrade"
+        brew upgrade || true
+        echo "::endgroup::"
 
     - name: Prepare Podman
       run: |
         echo "::group::Install Podman"
-        brew install podman
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=true brew install podman
         echo "::endgroup::"
 
         echo "::group::Initializing Podman"

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -52,6 +52,7 @@ jobs:
         echo "::group::Initializing Podman"
         sudo podman-mac-helper install
         podman machine init
+        podman machine set --rootful
         echo "::endgroup::"
 
     - name: Start Podman
@@ -98,7 +99,7 @@ jobs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
       with:
         cache-read-only: true
-        arguments: assemble --scan
+        arguments: :nessie-client:assemble --scan
 
 #    - name: Gradle / unit test
 #      uses: gradle/gradle-build-action@v2
@@ -110,7 +111,7 @@ jobs:
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: check --scan
+        arguments: :nessie-client:check --scan -i
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -27,16 +27,16 @@ on:
 
 jobs:
 
-  java-unit:
-    name: CI Test macOS
-    runs-on: macos-13
-    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
-
-    steps:
-    - uses: actions/checkout@v3.5.2
-    - name: Setup Java, Gradle
-      uses: ./.github/actions/dev-tool-java
-
+#  java-unit:
+#    name: CI Test macOS
+#    runs-on: macos-13
+#    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+#
+#    steps:
+#    - uses: actions/checkout@v3.5.2
+#    - name: Setup Java, Gradle
+#      uses: ./.github/actions/dev-tool-java
+#
 #    - name: Gradle / compile
 #      uses: gradle/gradle-build-action@v2
 #      env:
@@ -47,21 +47,21 @@ jobs:
 #      with:
 #        cache-read-only: true
 #        arguments: assemble --scan
-
-    - name: Gradle / unit test
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: test --scan
-
-    - name: Capture Test Reports
-      uses: actions/upload-artifact@v3
-      if: ${{ failure() }}
-      with:
-        name: ci-test-reports-macos
-        path: |
-          **/build/reports/*
-          **/build/test-results/*
-        retention-days: 3
+#
+#    - name: Gradle / unit test
+#      uses: gradle/gradle-build-action@v2
+#      with:
+#        arguments: test --scan
+#
+#    - name: Capture Test Reports
+#      uses: actions/upload-artifact@v3
+#      if: ${{ failure() }}
+#      with:
+#        name: ci-test-reports-macos
+#        path: |
+#          **/build/reports/*
+#          **/build/test-results/*
+#        retention-days: 3
 
   java-intTest:
     name: CI intTest macOS
@@ -147,20 +147,15 @@ jobs:
         ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-storage- --output ../storage-prjs.txt --exclude
         echo "::endgroup::"
 
-        echo "::group::Collect :nessie-spark-extensions projects"
-        ./gradlew :listProjectsWithPrefix --prefix :nessie-spark-ext --output ../spark-prjs.txt --exclude
-        echo "::endgroup::"
-
         export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
         echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
+
+        ./gradlew :nessie-client:intTest -i --tests org.projectnessie.client.auth.oauth2.ITOAuth2Client
 
         ./gradlew intTest \
             $(cat ../compat-prjs.txt) \
             $(cat ../persist-prjs.txt) \
             $(cat ../storage-prjs.txt) \
-            $(cat ../spark-prjs.txt) \
-            -x :nessie-deltalake:intTest \
-            -x :nessie-ui:test \
             --scan
 
     - name: Capture Test Reports

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -122,17 +122,6 @@ jobs:
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
 
-#    - name: Gradle / compile
-#      uses: gradle/gradle-build-action@v2
-#      env:
-#        # Same as for ci.yml
-#        GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-11
-#        GRADLE_BUILD_ACTION_CACHE_KEY_JOB: nessie-ci
-#        GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
-#      with:
-#        cache-read-only: true
-#        arguments: assemble --scan
-
     - name: Gradle / intTest
       run: |
         echo "::group::Collect :nessie-compatibility projects"
@@ -149,8 +138,6 @@ jobs:
 
         export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
         echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
-
-#        ./gradlew :nessie-client:intTest -i --tests org.projectnessie.client.auth.oauth2.ITOAuth2Client
 
         ./gradlew intTest \
             $(cat ../compat-prjs.txt) \

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -26,8 +26,34 @@ on:
   workflow_dispatch:
 
 jobs:
-  java:
-    name: Java/Gradle macOS
+
+  java-unit:
+    name: CI Test macOS
+    runs-on: macos-13
+    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+
+    steps:
+    - uses: actions/checkout@v3.5.2
+    - name: Setup Java, Gradle
+      uses: ./.github/actions/dev-tool-java
+
+    - name: Gradle / unit test
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: test --scan
+
+    - name: Capture Test Reports
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: ci-test-reports-macos
+        path: |
+          **/build/reports/*
+          **/build/test-results/*
+        retention-days: 3
+
+  java-intTest:
+    name: CI intTest macOS
     runs-on: macos-13
     if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
@@ -85,32 +111,40 @@ jobs:
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
 
-    - name: Gradle / compile
-      uses: gradle/gradle-build-action@v2
-      env:
-        # Same as for ci.yml
-        GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-11
-        GRADLE_BUILD_ACTION_CACHE_KEY_JOB: nessie-ci
-        GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
-      with:
-        cache-read-only: true
-        arguments: assemble --scan
+    - name: Gradle / intTest
+      run: |
+        echo "::group::Collect :nessie-compatibility projects"
+        ./gradlew :listProjectsWithPrefix --prefix :nessie-compatibility- --output ../compat-prjs.txt --exclude
+        echo "::endgroup::"
 
-    - name: Gradle / unit test
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: test --scan
+        echo "::group::Collect :nessie-versioned-storage projects"
+        ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-persist- --output ../persist-prjs.txt --exclude
+        echo "::endgroup::"
 
-    - name: Gradle / check incl. integ-test
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: check --scan
+        echo "::group::Collect :nessie-versioned-persist projects"
+        ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-storage- --output ../storage-prjs.txt --exclude
+        echo "::endgroup::"
+
+        echo "::group::Collect :nessie-spark-extensions projects"
+        ./gradlew :listProjectsWithPrefix --prefix :nessie-spark-ext --output ../spark-prjs.txt --exclude
+        echo "::endgroup::"
+
+        export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
+        echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
+
+        ./gradlew intTest \
+          $(cat ../compat-prjs.txt) \
+          $(cat ../persist-prjs.txt) \
+          $(cat ../storage-prjs.txt) \
+          $(cat ../spark-prjs.txt) \
+          -x :nessie-deltalake:intTest \
+          --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
-        name: test-results
+        name: ci-inttest-reports-macos
         path: |
           **/build/reports/*
           **/build/test-results/*
@@ -118,7 +152,7 @@ jobs:
 
   python:
     name: Python macOS
-    runs-on: macos-12
+    runs-on: macos-13
     if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
       working-directory: ./python

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -27,41 +27,39 @@ on:
 
 jobs:
 
-#  java-unit:
-#    name: CI Test macOS
-#    runs-on: macos-13
-#    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
-#
-#    steps:
-#    - uses: actions/checkout@v3.5.2
-#    - name: Setup Java, Gradle
-#      uses: ./.github/actions/dev-tool-java
-#
-#    - name: Gradle / compile
-#      uses: gradle/gradle-build-action@v2
-#      env:
-#        # Same as for ci.yml
-#        GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-11
-#        GRADLE_BUILD_ACTION_CACHE_KEY_JOB: nessie-ci
-#        GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
-#      with:
-#        cache-read-only: true
-#        arguments: assemble --scan
-#
-#    - name: Gradle / unit test
-#      uses: gradle/gradle-build-action@v2
-#      with:
-#        arguments: test --scan
-#
-#    - name: Capture Test Reports
-#      uses: actions/upload-artifact@v3
-#      if: ${{ failure() }}
-#      with:
-#        name: ci-test-reports-macos
-#        path: |
-#          **/build/reports/*
-#          **/build/test-results/*
-#        retention-days: 3
+  java-unit:
+    name: CI Test macOS
+    runs-on: macos-13
+    if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3.5.2
+
+    - name: Setup Java, Gradle
+      uses: ./.github/actions/dev-tool-java
+
+    - name: Prepare Gradle build cache
+      uses: ./.github/actions/ci-incr-build-cache-prepare
+      with:
+        cache-read-only: true
+        java-version: "11"
+        job-id: "nessie-ci"
+        job-instance: "ci"
+
+    - name: Gradle / test
+      run: |
+        ./gradlew test --scan
+
+    - name: Capture Test Reports
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: ci-test-reports-macos
+        path: |
+          **/build/reports/*
+          **/build/test-results/*
+        retention-days: 3
 
   java-intTest:
     name: CI intTest macOS
@@ -69,6 +67,7 @@ jobs:
     if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
       TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED: "true"
+      TESTCONTAINERS_PULL_PAUSE_TIMEOUT: "60"
       SPARK_LOCAL_IP: localhost
 
     steps:
@@ -84,7 +83,7 @@ jobs:
     - name: Prepare Podman
       run: |
         echo "::group::Install Podman"
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=true brew install podman
+        brew install podman
         echo "::endgroup::"
 
         echo "::group::Initializing Podman"
@@ -118,9 +117,19 @@ jobs:
         docker info
         echo "::endgroup::"
 
-    - uses: actions/checkout@v3.5.2
+    - name: Checkout code
+      uses: actions/checkout@v3.5.2
+
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
+
+    - name: Prepare Gradle build cache
+      uses: ./.github/actions/ci-incr-build-cache-prepare
+      with:
+        cache-read-only: true
+        java-version: "11"
+        job-id: "nessie-ci"
+        job-instance: "ci"
 
     - name: Gradle / intTest
       run: |
@@ -135,12 +144,6 @@ jobs:
         echo "::group::Collect :nessie-versioned-persist projects"
         ./gradlew :listProjectsWithPrefix --prefix :nessie-versioned-storage- --output ../storage-prjs.txt --exclude
         echo "::endgroup::"
-
-        export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
-        echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
-        
-        export TESTCONTAINERS_PULL_PAUSE_TIMEOUT=60
-        echo "TESTCONTAINERS_PULL_PAUSE_TIMEOUT=60" >> ${GITHUB_ENV}
 
         ./gradlew intTest \
             $(cat ../compat-prjs.txt) \

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -132,13 +132,16 @@ jobs:
         export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
         echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
 
-        ./gradlew intTest \
-          $(cat ../compat-prjs.txt) \
-          $(cat ../persist-prjs.txt) \
-          $(cat ../storage-prjs.txt) \
-          $(cat ../spark-prjs.txt) \
-          -x :nessie-deltalake:intTest \
-          --scan
+        ./gradlew :nessie-client:intTest -i --tests org.projectnessie.client.auth.oauth2.ITOAuth2Client
+
+#        ./gradlew intTest \
+#          $(cat ../compat-prjs.txt) \
+#          $(cat ../persist-prjs.txt) \
+#          $(cat ../storage-prjs.txt) \
+#          $(cat ../spark-prjs.txt) \
+#          -x :nessie-deltalake:intTest \
+#          -x :nessie-ui:test \
+#          --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: macos-13
     if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
+      TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED: "true"
       SPARK_LOCAL_IP: localhost
 
     steps:
@@ -76,15 +77,6 @@ jobs:
         ln -s /usr/local/bin/podman /usr/local/bin/docker
         echo "::endgroup::"
 
-        # export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/qemu/podman.sock"
-        # echo "DOCKER_HOST=$DOCKER_HOST" >> ${GITHUB_ENV}
-
-        # See https://www.testcontainers.org/supported_docker_environment/
-        # echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> ${GITHUB_ENV}
-        
-        export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
-        echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
-
         echo "::group::Docker info"
         docker info
         echo "::endgroup::"
@@ -102,19 +94,17 @@ jobs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
       with:
         cache-read-only: true
-        arguments: :nessie-client:assemble --scan
+        arguments: assemble --scan
 
-#    - name: Gradle / unit test
-#      uses: gradle/gradle-build-action@v2
-#      env:
-#        SPARK_LOCAL_IP: localhost
-#      with:
-#        arguments: test --scan
+    - name: Gradle / unit test
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: test --scan
 
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: :nessie-client:intTest -i --tests org.projectnessie.client.auth.oauth2.ITOAuth2Client
+        arguments: check --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -138,6 +138,9 @@ jobs:
 
         export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
         echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
+        
+        export TESTCONTAINERS_PULL_PAUSE_TIMEOUT=60
+        echo "TESTCONTAINERS_PULL_PAUSE_TIMEOUT=60" >> ${GITHUB_ENV}
 
         ./gradlew intTest \
             $(cat ../compat-prjs.txt) \

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -81,6 +81,9 @@ jobs:
 
         # See https://www.testcontainers.org/supported_docker_environment/
         # echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> ${GITHUB_ENV}
+        
+        export TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true
+        echo "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true" >> ${GITHUB_ENV}
 
         echo "::group::Docker info"
         docker info

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -28,11 +28,10 @@ on:
 jobs:
   java:
     name: Java/Gradle macOS
-    runs-on: macos-12
+    runs-on: macos-13
     if: (github.repository == 'projectnessie/nessie' && github.event_name != 'pull_request') || contains(github.event.pull_request.labels.*.name, 'pr-macos-win')
     env:
       SPARK_LOCAL_IP: localhost
-      CI_MAC: "true"
 
     steps:
     - name: Brew update & upgrade

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -50,6 +50,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Initializing Podman"
+        sudo podman-mac-helper install
         podman machine init
         echo "::endgroup::"
 
@@ -74,7 +75,7 @@ jobs:
         ln -s /usr/local/bin/podman /usr/local/bin/docker
         echo "::endgroup::"
 
-        export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/podman-machine-default/podman.sock"
+        export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/qemu/podman.sock"
         echo "DOCKER_HOST=$DOCKER_HOST" >> ${GITHUB_ENV}
 
         # See https://www.testcontainers.org/supported_docker_environment/
@@ -99,12 +100,12 @@ jobs:
         cache-read-only: true
         arguments: assemble --scan
 
-    - name: Gradle / unit test
-      uses: gradle/gradle-build-action@v2
-      env:
-        SPARK_LOCAL_IP: localhost
-      with:
-        arguments: test --scan
+#    - name: Gradle / unit test
+#      uses: gradle/gradle-build-action@v2
+#      env:
+#        SPARK_LOCAL_IP: localhost
+#      with:
+#        arguments: test --scan
 
     - name: Gradle / check incl. integ-test
       uses: gradle/gradle-build-action@v2

--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -179,6 +179,6 @@ annotationStripper {
 }
 
 // Issue w/ testcontainers/podman in GH workflows :(
-if ((Os.isFamily(Os.FAMILY_MAC) || Os.isFamily(Os.FAMILY_WINDOWS)) && System.getenv("CI") != null) {
+if (Os.isFamily(Os.FAMILY_WINDOWS) && System.getenv("CI") != null) {
   tasks.named<Test>("intTest") { this.enabled = false }
 }

--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
@@ -60,7 +60,10 @@ public class ITOAuth2Client {
 
   @Container
   private static final KeycloakContainer KEYCLOAK =
-      new KeycloakContainer().withFeaturesEnabled("preview", "token-exchange");
+      new KeycloakContainer()
+          .withFeaturesEnabled("preview", "token-exchange")
+          .withStartupTimeout(Duration.ofMinutes(5)) // for CI
+      ;
 
   private static RealmResource master;
   private static URI tokenEndpoint;

--- a/api/client/src/test/resources/logback-test.xml
+++ b/api/client/src/test/resources/logback-test.xml
@@ -24,7 +24,7 @@
     </encoder>
   </appender>
   <root>
-    <level value="${test.log.level:-INFO}"/>
+    <level value="${test.log.level:-DEBUG}"/>
     <appender-ref ref="console"/>
   </root>
 </configuration>

--- a/api/client/src/test/resources/logback-test.xml
+++ b/api/client/src/test/resources/logback-test.xml
@@ -24,7 +24,7 @@
     </encoder>
   </appender>
   <root>
-    <level value="${test.log.level:-DEBUG}"/>
+    <level value="${test.log.level:-INFO}"/>
     <appender-ref ref="console"/>
   </root>
 </configuration>

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.tools.compatibility.internal;
 
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.projectnessie.tools.compatibility.internal.AbstractNessieApiHolder.apiInstanceForField;
 import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieApiFields;
 import static org.projectnessie.tools.compatibility.internal.GlobalForClass.globalForClass;
@@ -46,8 +47,7 @@ public class NessieUpgradesExtension extends AbstractMultiVersionExtension {
   @Override
   public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
     if (OS.MAC.isCurrentOs()) {
-      return ConditionEvaluationResult.disabled(
-          "Disabled on macOS due to SIGSEV issues with RocksDB");
+      return disabled("Disabled on macOS due to SIGSEGV issues with RocksDB");
     }
     return super.evaluateExecutionCondition(context);
   }

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.projectnessie.tools.compatibility.api.TargetVersion;
 import org.projectnessie.tools.compatibility.api.Version;
@@ -40,6 +42,15 @@ import org.projectnessie.tools.compatibility.api.Version;
  * proxies, model classes are re-serialized.
  */
 public class NessieUpgradesExtension extends AbstractMultiVersionExtension {
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (OS.MAC.isCurrentOs()) {
+      return ConditionEvaluationResult.disabled(
+          "Disabled on macOS due to SIGSEV issues with RocksDB");
+    }
+    return super.evaluateExecutionCondition(context);
+  }
 
   @Override
   public void beforeAll(ExtensionContext context) {

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieApiHolder.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieApiHolder.java
@@ -73,7 +73,6 @@ class TestNessieApiHolder {
   }
 
   @Test
-  @DisabledOnOs(OS.MAC)
   void oldVersionServer() {
     ExtensionValuesStore valuesStore = new ExtensionValuesStore(null);
     try {

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieApiHolder.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieApiHolder.java
@@ -26,8 +26,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -141,8 +141,8 @@ class TestNessieCompatibilityExtensions {
 
   @Test
   @DisabledOnOs(
-    value = OS.MAC,
-    disabledReason = "Uses NessieUpgradesExtension, which is not compatible with macOS")
+      value = OS.MAC,
+      disabledReason = "Uses NessieUpgradesExtension, which is not compatible with macOS")
   void upgrade() {
     EngineTestKit.engine(MultiEnvTestEngine.ENGINE_ID)
         .configurationParameter("nessie.versions", "0.42.0,current")

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -27,8 +27,6 @@ import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -44,7 +44,6 @@ import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.api.VersionCondition;
 
 @ExtendWith(SoftAssertionsExtension.class)
-@DisabledOnOs(OS.MAC)
 class TestNessieCompatibilityExtensions {
   @InjectSoftAssertions protected SoftAssertions soft;
 

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -27,6 +27,8 @@ import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
@@ -60,6 +62,9 @@ class TestNessieCompatibilityExtensions {
   }
 
   @Test
+  @DisabledOnOs(
+      value = OS.MAC,
+      disabledReason = "Uses NessieUpgradesExtension, which is not compatible with macOS")
   void tooManyExtensions() {
     soft.assertThat(
             Stream.of(
@@ -135,6 +140,9 @@ class TestNessieCompatibilityExtensions {
   }
 
   @Test
+  @DisabledOnOs(
+    value = OS.MAC,
+    disabledReason = "Uses NessieUpgradesExtension, which is not compatible with macOS")
   void upgrade() {
     EngineTestKit.engine(MultiEnvTestEngine.ENGINE_ID)
         .configurationParameter("nessie.versions", "0.42.0,current")

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieServer.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieServer.java
@@ -79,7 +79,6 @@ class TestNessieServer {
 
   @ParameterizedTest
   @ValueSource(strings = {"0.42.0"})
-  @DisabledOnOs(OS.MAC)
   void oldNessieVersionServer(String nessieVersion) {
     ExtensionValuesStore valuesStore = new ExtensionValuesStore(null);
     NessieServer server;

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieServer.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieServer.java
@@ -25,8 +25,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;

--- a/compatibility/compatibility-tests/build.gradle.kts
+++ b/compatibility/compatibility-tests/build.gradle.kts
@@ -51,10 +51,7 @@ tasks.withType<Test>().configureEach {
   systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
 }
 
-// Compatibility tests fail on macOS with the following message: `libc++abi: terminating
-// with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument`
-//
 // Compatibility tests fail, because Windows not supported by testcontainers (logged message)
-if (Os.isFamily(Os.FAMILY_MAC) || Os.isFamily(Os.FAMILY_WINDOWS)) {
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.withType<Test>().configureEach { this.enabled = false }
 }

--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -139,8 +139,3 @@ listOf("checkstyleTest", "compileTestJava").forEach { name ->
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.named<Test>("intTest") { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -197,8 +197,3 @@ listOf("checkstyleTest", "compileTestJava").forEach { name ->
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.named<Test>("intTest") { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/servers/services/build.gradle.kts
+++ b/servers/services/build.gradle.kts
@@ -109,11 +109,6 @@ dependencies {
   testCompileOnly(libs.jackson.annotations)
 }
 
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.withType<Test>().configureEach { this.enabled = false }
-}
-
 annotationStripper {
   registerDefault().configure {
     annotationsToDrop("^jakarta[.].+".toRegex())

--- a/servers/services/build.gradle.kts
+++ b/servers/services/build.gradle.kts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import org.apache.tools.ant.taskdefs.condition.Os
-
 plugins {
   `java-library`
   jacoco

--- a/testing/s3minio/src/main/java/org/projectnessie/minio/MinioContainer.java
+++ b/testing/s3minio/src/main/java/org/projectnessie/minio/MinioContainer.java
@@ -47,6 +47,7 @@ final class MinioContainer extends GenericContainer<MinioContainer>
 
   private static final String DEFAULT_STORAGE_DIRECTORY = "/data";
   private static final String HEALTH_ENDPOINT = "/minio/health/ready";
+  private static final String MINIO_DOMAIN_NIP = "minio.127-0-0-1.nip.io";
 
   private final String accessKey;
   private final String secretKey;
@@ -74,7 +75,7 @@ final class MinioContainer extends GenericContainer<MinioContainer>
     withEnv(MINIO_ACCESS_KEY, this.accessKey);
     withEnv(MINIO_SECRET_KEY, this.secretKey);
     // S3 SDK encodes bucket names in host names - need to tell Minio which domain to use
-    withEnv(MINIO_DOMAIN, "localhost");
+    withEnv(MINIO_DOMAIN, MINIO_DOMAIN_NIP);
     withCommand("server", DEFAULT_STORAGE_DIRECTORY);
     setWaitStrategy(
         new HttpWaitStrategy()
@@ -149,7 +150,7 @@ final class MinioContainer extends GenericContainer<MinioContainer>
   public void start() {
     super.start();
 
-    this.hostPort = getHost() + ":" + getMappedPort(DEFAULT_PORT);
+    this.hostPort = MINIO_DOMAIN_NIP + ":" + getMappedPort(DEFAULT_PORT);
     this.s3endpoint = String.format("http://%s/", hostPort);
     this.bucketBaseUri = URI.create(String.format("s3://%s/", bucket()));
 

--- a/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
+++ b/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
@@ -54,10 +54,7 @@ public class MinioExtension
     if (OS.current() == OS.MAC) {
       return enabled("Running on macOS");
     }
-    return disabled(
-        format(
-            "Disabled on %s, because it doesn't support wildcard localhost FQDNs.",
-            OS.current().name()));
+    return disabled(format("Disabled on %s", OS.current().name()));
   }
 
   @Override

--- a/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
+++ b/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
@@ -51,10 +51,6 @@ public class MinioExtension
     if (OS.current() == OS.LINUX) {
       return enabled("Running on Linux");
     }
-    if (OS.current() == OS.MAC && System.getenv("CI_MAC") == null) {
-      // Disable tests on GitHub Actions
-      return enabled("Running on macOS locally");
-    }
     return disabled(
         format(
             "Disabled on %s, because it doesn't support wildcard localhost FQDNs.",

--- a/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
+++ b/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
@@ -51,6 +51,9 @@ public class MinioExtension
     if (OS.current() == OS.LINUX) {
       return enabled("Running on Linux");
     }
+    if (OS.current() == OS.MAC) {
+      return enabled("Running on macOS");
+    }
     return disabled(
         format(
             "Disabled on %s, because it doesn't support wildcard localhost FQDNs.",

--- a/versioned/persist/dynamodb/build.gradle.kts
+++ b/versioned/persist/dynamodb/build.gradle.kts
@@ -60,8 +60,3 @@ dependencies {
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.named<Test>("intTest") { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/versioned/persist/mongodb/build.gradle.kts
+++ b/versioned/persist/mongodb/build.gradle.kts
@@ -55,8 +55,3 @@ dependencies {
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.named<Test>("intTest") { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/versioned/persist/tx/build.gradle.kts
+++ b/versioned/persist/tx/build.gradle.kts
@@ -74,8 +74,3 @@ tasks.named<Test>("intTest") {
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.named<Test>("intTest") { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/versioned/storage/cassandra/build.gradle.kts
+++ b/versioned/storage/cassandra/build.gradle.kts
@@ -70,8 +70,3 @@ dependencies {
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.withType<Test>().configureEach { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBBackendFactory.java
+++ b/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBBackendFactory.java
@@ -15,6 +15,13 @@
  */
 package org.projectnessie.versioned.storage.cassandra;
 
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+@DisabledOnOs(
+    value = OS.MAC,
+    disabledReason =
+        "ScyllaDB fails to start, see https://github.com/scylladb/scylladb/issues/10135")
 public class ITScyllaDBBackendFactory extends AbstractTestCassandraBackendFactory {
   @Override
   protected AbstractCassandraBackendTestFactory testFactory() {

--- a/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBPersist.java
+++ b/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBPersist.java
@@ -15,8 +15,14 @@
  */
 package org.projectnessie.versioned.storage.cassandra;
 
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.projectnessie.versioned.storage.commontests.AbstractPersistTests;
 import org.projectnessie.versioned.storage.testextension.NessieBackend;
 
+@DisabledOnOs(
+    value = OS.MAC,
+    disabledReason =
+        "ScyllaDB fails to start, see https://github.com/scylladb/scylladb/issues/10135")
 @NessieBackend(ScyllaDBBackendTestFactory.class)
 public class ITScyllaDBPersist extends AbstractPersistTests {}

--- a/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBVersionStore.java
+++ b/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBVersionStore.java
@@ -15,8 +15,14 @@
  */
 package org.projectnessie.versioned.storage.cassandra;
 
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.projectnessie.versioned.storage.commontests.AbstractVersionStoreTests;
 import org.projectnessie.versioned.storage.testextension.NessieBackend;
 
+@DisabledOnOs(
+    value = OS.MAC,
+    disabledReason =
+        "ScyllaDB fails to start, see https://github.com/scylladb/scylladb/issues/10135")
 @NessieBackend(ScyllaDBBackendTestFactory.class)
 public class ITScyllaDBVersionStore extends AbstractVersionStoreTests {}

--- a/versioned/storage/dynamodb/build.gradle.kts
+++ b/versioned/storage/dynamodb/build.gradle.kts
@@ -70,8 +70,3 @@ dependencies {
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.withType<Test>().configureEach { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/versioned/storage/jdbc/build.gradle.kts
+++ b/versioned/storage/jdbc/build.gradle.kts
@@ -74,8 +74,3 @@ dependencies {
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.named<Test>("intTest").configure { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/versioned/storage/mongodb/build.gradle.kts
+++ b/versioned/storage/mongodb/build.gradle.kts
@@ -65,8 +65,3 @@ dependencies {
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   tasks.withType<Test>().configureEach { this.enabled = false }
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}

--- a/versioned/transfer/build.gradle.kts
+++ b/versioned/transfer/build.gradle.kts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import org.apache.tools.ant.taskdefs.condition.Os
-
 plugins {
   `java-library`
   jacoco

--- a/versioned/transfer/build.gradle.kts
+++ b/versioned/transfer/build.gradle.kts
@@ -94,8 +94,3 @@ dependencies {
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)
 }
-
-// Issue w/ testcontainers/podman in GH workflows :(
-if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
-  tasks.named<Test>("intTest") { this.enabled = false }
-}


### PR DESCRIPTION
Not to be merged as is, I'm just trying to figure out which tests can be run on macOS 13, both locally and on GHA. But I'm aware that it might not be desirable to actually run all the Mac tests as part of regular CI.