### PR TITLE
Identify merge-base instead of common-ancestor

### DIFF
--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractCommitLogicTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractCommitLogicTests.java
@@ -162,15 +162,15 @@ public class AbstractCommitLogicTests {
     }
 
     for (ObjId branch : branches) {
-      soft.assertThat(commitLogic.findCommonAncestor(branch, root)).isEqualTo(root);
+      soft.assertThat(commitLogic.findCommonAncestor(branch, root).id()).isEqualTo(root);
     }
 
     for (int i = 0; i < branches.length; i++) {
       requireNonNull(branches[i]);
-      soft.assertThat(commitLogic.findCommonAncestor(branches[i], branches[i]))
+      soft.assertThat(commitLogic.findCommonAncestor(branches[i], branches[i]).id())
           .isEqualTo(branches[i]);
       for (int j = i + 1; j < branches.length; j++) {
-        soft.assertThat(commitLogic.findCommonAncestor(branches[i], branches[j]))
+        soft.assertThat(commitLogic.findCommonAncestor(branches[i], branches[j]).id())
             .isEqualTo(commonAncestor);
       }
     }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
@@ -193,7 +193,14 @@ public interface CommitLogic {
 
   @Nonnull
   @jakarta.annotation.Nonnull
-  ObjId findCommonAncestor(
+  CommitObj findCommonAncestor(
+      @Nonnull @jakarta.annotation.Nonnull ObjId headId,
+      @Nonnull @jakarta.annotation.Nonnull ObjId otherId)
+      throws NoSuchElementException;
+
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  CommitObj findMergeBase(
       @Nonnull @jakarta.annotation.Nonnull ObjId headId,
       @Nonnull @jakarta.annotation.Nonnull ObjId otherId)
       throws NoSuchElementException;

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/MergeBase.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/MergeBase.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.logic;
+
+import static org.projectnessie.versioned.storage.common.logic.CommitLogQuery.commitLogQuery;
+import static org.projectnessie.versioned.storage.common.logic.CommitLogicImpl.NO_COMMON_ANCESTOR_IN_PARENTS_OF;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.agrona.collections.ObjectHashSet;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+
+@Value.Immutable
+public abstract class MergeBase {
+  public abstract CommitLogic commitLogic();
+
+  public abstract List<ObjId> heads();
+
+  public abstract boolean respectMergeParents();
+
+  public static ImmutableMergeBase.Builder builder() {
+    return ImmutableMergeBase.builder();
+  }
+
+  @Value.NonAttribute
+  public CommitObj identifyMergeBase() {
+    List<Chain> chains = new ArrayList<>();
+    for (ObjId head : heads()) {
+      chains.add(addChain(head));
+    }
+
+    while (true) {
+      boolean allEof = true;
+      for (int i = 0; i < chains.size(); i++) {
+        Chain chain = chains.get(i);
+        CommitObj commit = chain.next();
+        if (commit != null) {
+          allEof = false;
+
+          for (int j = 0; j < chains.size(); j++) {
+            if (j != i) {
+              Chain chk = chains.get(j);
+              if (chk.commits.contains(commit.id())) {
+                return commit;
+              }
+            }
+          }
+
+          for (ObjId secondaryParent : commit.secondaryParents()) {
+            if (chains.stream().noneMatch(c -> c.commits.contains(secondaryParent))) {
+              chains.add(addChain(secondaryParent));
+            }
+          }
+        }
+      }
+      if (allEof) {
+        throw noCommonAncestor();
+      }
+    }
+  }
+
+  Chain addChain(ObjId head) {
+    Iterator<CommitObj> log = commitLogic().commitLog(commitLogQuery(head));
+    return new Chain(log);
+  }
+
+  private NoSuchElementException noCommonAncestor() {
+    StringBuilder sb = new StringBuilder(NO_COMMON_ANCESTOR_IN_PARENTS_OF);
+    for (int i = 0; i < heads().size(); i++) {
+      if (i == heads().size() - 1) {
+        sb.append(" and ");
+      } else if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append(heads().get(i));
+    }
+    return new NoSuchElementException(sb.toString());
+  }
+
+  static final class Chain {
+    final ObjectHashSet<ObjId> commits = new ObjectHashSet<>();
+    final Iterator<CommitObj> commitLog;
+
+    Chain(Iterator<CommitObj> commitLog) {
+      this.commitLog = commitLog;
+    }
+
+    CommitObj next() {
+      Iterator<CommitObj> log = commitLog;
+      if (log.hasNext()) {
+        CommitObj commit = log.next();
+        commits.add(commit.id());
+        return commit;
+      }
+      return null;
+    }
+  }
+}

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -551,15 +551,13 @@ class BaseCommitHelper {
     return mergeResult;
   }
 
-  ObjId identifyCommonAncestor(ObjId fromId) throws ReferenceNotFoundException {
+  CommitObj identifyCommonAncestor(ObjId fromId) throws ReferenceNotFoundException {
     CommitLogic commitLogic = commitLogic(persist);
-    ObjId commonAncestorId;
     try {
-      commonAncestorId = commitLogic.findCommonAncestor(headId(), fromId);
+      return commitLogic.findCommonAncestor(headId(), fromId);
     } catch (NoSuchElementException notFound) {
       throw new ReferenceNotFoundException(notFound.getMessage());
     }
-    return commonAncestorId;
   }
 
   CommitObj createMergeTransplantCommit(

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeIndividualImpl.java
@@ -63,7 +63,7 @@ final class MergeIndividualImpl extends BaseMergeTransplantIndividual implements
       boolean dryRun)
       throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
     ObjId fromId = hashToObjId(fromHash);
-    ObjId commonAncestorId = identifyCommonAncestor(fromId);
+    ObjId commonAncestorId = identifyCommonAncestor(fromId).id();
 
     CommitObj source;
     try {

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeSquashImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeSquashImpl.java
@@ -60,7 +60,7 @@ final class MergeSquashImpl extends BaseMergeTransplantSquash implements Merge {
       boolean dryRun)
       throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
     ObjId fromId = hashToObjId(fromHash);
-    ObjId commonAncestorId = identifyCommonAncestor(fromId);
+    ObjId commonAncestorId = identifyCommonAncestor(fromId).id();
 
     SourceCommitsAndParent sourceCommits = loadSourceCommitsForMerge(fromId, commonAncestorId);
 

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -403,12 +403,10 @@ public class VersionStoreImpl implements VersionStore {
         if (baseRefHead.isPresent()) {
           CommitObj baseHead = baseRefHead.get();
           try {
-            ObjId commonAncestorId = commitLogic.findCommonAncestor(baseHead.id(), head.id());
-            refInfo.commonAncestor(objIdToHash(commonAncestorId));
+            CommitObj commonAncestor = commitLogic.findCommonAncestor(baseHead.id(), head.id());
+            refInfo.commonAncestor(objIdToHash(commonAncestor.id()));
 
             if (opts.isComputeAheadBehind()) {
-              CommitObj commonAncestor =
-                  persist.fetchTypedObj(commonAncestorId, COMMIT, CommitObj.class);
               long commonAncestorSeq = commonAncestor.seq();
               refInfo.aheadBehind(
                   CommitsAheadBehind.of(


### PR DESCRIPTION
Enhances the existing logic to identify the common ancestor to respect merge parents.

Externalizes the logic into a new class `MergeBase`, which combines the logic for the common-ancestor and merge-base use cases.

Fixes #4562