### PR TITLE
Quarkus ITs: Restrict Keycloak to tests using Keycloak

### DIFF
--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/ITBearerAuthentication.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/ITBearerAuthentication.java
@@ -22,7 +22,9 @@ import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import org.projectnessie.quarkus.tests.profiles.KeycloakTestResourceLifecycleManager;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@QuarkusTestResource(
+    restrictToAnnotatedClass = true,
+    value = KeycloakTestResourceLifecycleManager.class)
 @TestProfile(value = AbstractBearerAuthentication.Profile.class)
 public class ITBearerAuthentication extends AbstractBearerAuthentication {
 

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/ITOAuth2Authentication.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/ITOAuth2Authentication.java
@@ -22,7 +22,9 @@ import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import org.projectnessie.quarkus.tests.profiles.KeycloakTestResourceLifecycleManager;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+@QuarkusTestResource(
+    restrictToAnnotatedClass = true,
+    value = KeycloakTestResourceLifecycleManager.class)
 @TestProfile(value = AbstractOAuth2Authentication.Profile.class)
 public class ITOAuth2Authentication extends AbstractOAuth2Authentication {
 


### PR DESCRIPTION
Otherwise Keycloak is run for every test, not just the annotated test classes.