### PR TITLE
Use nip.io domain in MinioExtension

### DIFF
--- a/testing/s3minio/src/main/java/org/projectnessie/minio/MinioContainer.java
+++ b/testing/s3minio/src/main/java/org/projectnessie/minio/MinioContainer.java
@@ -47,6 +47,7 @@ final class MinioContainer extends GenericContainer<MinioContainer>
 
   private static final String DEFAULT_STORAGE_DIRECTORY = "/data";
   private static final String HEALTH_ENDPOINT = "/minio/health/ready";
+  private static final String MINIO_DOMAIN_NIP = "minio.127-0-0-1.nip.io";
 
   private final String accessKey;
   private final String secretKey;
@@ -74,7 +75,7 @@ final class MinioContainer extends GenericContainer<MinioContainer>
     withEnv(MINIO_ACCESS_KEY, this.accessKey);
     withEnv(MINIO_SECRET_KEY, this.secretKey);
     // S3 SDK encodes bucket names in host names - need to tell Minio which domain to use
-    withEnv(MINIO_DOMAIN, "localhost");
+    withEnv(MINIO_DOMAIN, MINIO_DOMAIN_NIP);
     withCommand("server", DEFAULT_STORAGE_DIRECTORY);
     setWaitStrategy(
         new HttpWaitStrategy()
@@ -149,7 +150,7 @@ final class MinioContainer extends GenericContainer<MinioContainer>
   public void start() {
     super.start();
 
-    this.hostPort = getHost() + ":" + getMappedPort(DEFAULT_PORT);
+    this.hostPort = MINIO_DOMAIN_NIP + ":" + getMappedPort(DEFAULT_PORT);
     this.s3endpoint = String.format("http://%s/", hostPort);
     this.bucketBaseUri = URI.create(String.format("s3://%s/", bucket()));
 

--- a/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
+++ b/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
@@ -51,14 +51,10 @@ public class MinioExtension
     if (OS.current() == OS.LINUX) {
       return enabled("Running on Linux");
     }
-    if (OS.current() == OS.MAC && System.getenv("CI_MAC") == null) {
-      // Disable tests on GitHub Actions
-      return enabled("Running on macOS locally");
+    if (OS.current() == OS.MAC) {
+      return enabled("Running on macOS");
     }
-    return disabled(
-        format(
-            "Disabled on %s, because it doesn't support wildcard localhost FQDNs.",
-            OS.current().name()));
+    return disabled(format("Disabled on %s", OS.current().name()));
   }
 
   @Override

--- a/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
+++ b/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
@@ -51,8 +51,9 @@ public class MinioExtension
     if (OS.current() == OS.LINUX) {
       return enabled("Running on Linux");
     }
-    if (OS.current() == OS.MAC) {
-      return enabled("Running on macOS");
+    if (OS.current() == OS.MAC && System.getenv("CI_MAC") == null) {
+      // Disable tests on GitHub Actions
+      return enabled("Running on macOS locally");
     }
     return disabled(format("Disabled on %s", OS.current().name()));
   }


### PR DESCRIPTION
This commit also re-enables MinioExtension on macOS since the switch to nip.io fixes the localhost subdomain issue.

Note: this will have the side-effect of enabling MinIO tests on CI for macOS. If these fail, I will disable the tests, but for CI only.