### PR TITLE
Enable compatibility tests on macOS

### DIFF
--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/NessieUpgradesExtension.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.tools.compatibility.internal;
 
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.projectnessie.tools.compatibility.internal.AbstractNessieApiHolder.apiInstanceForField;
 import static org.projectnessie.tools.compatibility.internal.AnnotatedFields.populateNessieApiFields;
 import static org.projectnessie.tools.compatibility.internal.GlobalForClass.globalForClass;
@@ -27,6 +28,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.projectnessie.tools.compatibility.api.TargetVersion;
 import org.projectnessie.tools.compatibility.api.Version;
@@ -40,6 +43,14 @@ import org.projectnessie.tools.compatibility.api.Version;
  * proxies, model classes are re-serialized.
  */
 public class NessieUpgradesExtension extends AbstractMultiVersionExtension {
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (OS.MAC.isCurrentOs()) {
+      return disabled("Disabled on macOS due to SIGSEGV issues with RocksDB");
+    }
+    return super.evaluateExecutionCondition(context);
+  }
 
   @Override
   public void beforeAll(ExtensionContext context) {

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieApiHolder.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieApiHolder.java
@@ -26,8 +26,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
@@ -75,7 +73,6 @@ class TestNessieApiHolder {
   }
 
   @Test
-  @DisabledOnOs(OS.MAC)
   void oldVersionServer() {
     ExtensionValuesStore valuesStore = new ExtensionValuesStore(null);
     try {

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -44,7 +44,6 @@ import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.api.VersionCondition;
 
 @ExtendWith(SoftAssertionsExtension.class)
-@DisabledOnOs(OS.MAC)
 class TestNessieCompatibilityExtensions {
   @InjectSoftAssertions protected SoftAssertions soft;
 
@@ -63,6 +62,9 @@ class TestNessieCompatibilityExtensions {
   }
 
   @Test
+  @DisabledOnOs(
+      value = OS.MAC,
+      disabledReason = "Uses NessieUpgradesExtension, which is not compatible with macOS")
   void tooManyExtensions() {
     soft.assertThat(
             Stream.of(
@@ -138,6 +140,9 @@ class TestNessieCompatibilityExtensions {
   }
 
   @Test
+  @DisabledOnOs(
+      value = OS.MAC,
+      disabledReason = "Uses NessieUpgradesExtension, which is not compatible with macOS")
   void upgrade() {
     EngineTestKit.engine(MultiEnvTestEngine.ENGINE_ID)
         .configurationParameter("nessie.versions", "0.42.0,current")

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieServer.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieServer.java
@@ -25,8 +25,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
@@ -79,7 +77,6 @@ class TestNessieServer {
 
   @ParameterizedTest
   @ValueSource(strings = {"0.42.0"})
-  @DisabledOnOs(OS.MAC)
   void oldNessieVersionServer(String nessieVersion) {
     ExtensionValuesStore valuesStore = new ExtensionValuesStore(null);
     NessieServer server;

--- a/compatibility/compatibility-tests/build.gradle.kts
+++ b/compatibility/compatibility-tests/build.gradle.kts
@@ -51,10 +51,7 @@ tasks.withType<Test>().configureEach {
   systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
 }
 
-// Compatibility tests fail on macOS with the following message: `libc++abi: terminating
-// with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument`
-//
 // Compatibility tests fail, because Windows not supported by testcontainers (logged message)
-if ((Os.isFamily(Os.FAMILY_MAC) || Os.isFamily(Os.FAMILY_WINDOWS)) && System.getenv("CI") != null) {
+if (Os.isFamily(Os.FAMILY_WINDOWS) && System.getenv("CI") != null) {
   tasks.withType<Test>().configureEach { this.enabled = false }
 }

--- a/compatibility/compatibility-tests/build.gradle.kts
+++ b/compatibility/compatibility-tests/build.gradle.kts
@@ -51,7 +51,10 @@ tasks.withType<Test>().configureEach {
   systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
 }
 
+// Compatibility tests fail on macOS with the following message: `libc++abi: terminating
+// with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument`
+//
 // Compatibility tests fail, because Windows not supported by testcontainers (logged message)
-if (Os.isFamily(Os.FAMILY_WINDOWS) && System.getenv("CI") != null) {
+if ((Os.isFamily(Os.FAMILY_MAC) || Os.isFamily(Os.FAMILY_WINDOWS)) && System.getenv("CI") != null) {
   tasks.withType<Test>().configureEach { this.enabled = false }
 }


### PR DESCRIPTION
This commit enables all the compatibility tests that are currently doable on macOS, namely, all tests except the ones relying on RocksDB.

Compatibility tests with RocksDB fail consistently with SIGSEGV on macOS.