### PR TITLE
Disable Scylla tests on macOS

### DIFF
--- a/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBBackendFactory.java
+++ b/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBBackendFactory.java
@@ -15,6 +15,13 @@
  */
 package org.projectnessie.versioned.storage.cassandra;
 
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+@DisabledOnOs(
+    value = OS.MAC,
+    disabledReason =
+        "ScyllaDB fails to start, see https://github.com/scylladb/scylladb/issues/10135")
 public class ITScyllaDBBackendFactory extends AbstractTestCassandraBackendFactory {
   @Override
   protected AbstractCassandraBackendTestFactory testFactory() {

--- a/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBPersist.java
+++ b/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBPersist.java
@@ -15,8 +15,14 @@
  */
 package org.projectnessie.versioned.storage.cassandra;
 
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.projectnessie.versioned.storage.commontests.AbstractPersistTests;
 import org.projectnessie.versioned.storage.testextension.NessieBackend;
 
+@DisabledOnOs(
+    value = OS.MAC,
+    disabledReason =
+        "ScyllaDB fails to start, see https://github.com/scylladb/scylladb/issues/10135")
 @NessieBackend(ScyllaDBBackendTestFactory.class)
 public class ITScyllaDBPersist extends AbstractPersistTests {}

--- a/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBVersionStore.java
+++ b/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/ITScyllaDBVersionStore.java
@@ -15,8 +15,14 @@
  */
 package org.projectnessie.versioned.storage.cassandra;
 
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.projectnessie.versioned.storage.commontests.AbstractVersionStoreTests;
 import org.projectnessie.versioned.storage.testextension.NessieBackend;
 
+@DisabledOnOs(
+    value = OS.MAC,
+    disabledReason =
+        "ScyllaDB fails to start, see https://github.com/scylladb/scylladb/issues/10135")
 @NessieBackend(ScyllaDBBackendTestFactory.class)
 public class ITScyllaDBVersionStore extends AbstractVersionStoreTests {}


### PR DESCRIPTION
This commit disables all Scylla tests on macOS. Details:

https://github.com/scylladb/scylladb/issues/10135

(The issue is marked closed, but I can't run tests locally and get the exact same error.)