### PR TITLE
Improve NessieError message

### DIFF
--- a/api/model/src/main/java/org/projectnessie/error/NessieError.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieError.java
@@ -99,14 +99,21 @@ public interface NessieError {
     StringBuilder sb = new StringBuilder();
     sb.append(getReason()).append(" (HTTP/").append(getStatus()).append(')');
     sb.append(": ");
-    sb.append(getMessage());
+    String serverMessage = getMessage();
+    if (serverMessage == null) {
+      serverMessage = "[no error message found in HTTP response]";
+    }
+    sb.append(serverMessage);
 
     if (getServerStackTrace() != null) {
       sb.append("\n").append(getServerStackTrace());
     }
 
     if (getClientProcessingException() != null) {
-      StringWriter sw = new StringWriter();
+      StringWriter sw =
+          new StringWriter()
+              .append(
+                  "\nAdditionally, the client-side exception below was caught while decoding the HTTP response:\n");
       getClientProcessingException().printStackTrace(new PrintWriter(sw));
       sb.append("\n").append(sw);
     }

--- a/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
@@ -121,6 +121,7 @@ class TestNessieError {
                     + "[)]: message\\R"
                     + "foo.bar.InternalServerError\\R"
                     + "\tat some.other.Class\\R"
+                    + "\\RAdditionally, the client-side exception below was caught while decoding the HTTP response:\\R"
                     + "java.lang.Exception: processingException\\R"
                     + "\tat (all//)?org.projectnessie.error.TestNessieError.fullMessage[(]TestNessieError.java:"
                     + ".*",


### PR DESCRIPTION
This commit clarifies the message especially
when there is no server-side information
available, other than the HTTP status code,
but a client-side exception happens to be
present.

This was an idea initially suggested in Zulip:
https://project-nessie.zulipchat.com/#narrow/stream/371193-dev/topic/strange.20error.20msg/near/350785761