### PR TITLE
Bugfix: include ROCKSDB in selector to create PVC in both cases.

### DIFF
--- a/helm/nessie/templates/storage.yaml
+++ b/helm/nessie/templates/storage.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.versionStoreType "ROCKS" }}
+{{- if or (eq .Values.versionStoreType "ROCKS") (eq .Values.versionStoreType "ROCKSDB") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
This PR slightly modifies `helm/nessie/templates/storage.yaml` to include both "ROCKS" and "ROCKSDB" set as versionStoreType.

Once "ROCKS" is fully deprecated, this can be updated again to only include "ROCKSDB".

Tested with `helm template . --set versionStoreType=ROCKSDB` & `helm template . --set versionStoreType=ROCKS`
Generates:

```
# Source: nessie/templates/storage.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: release-name-nessie
  labels:
    helm.sh/chart: nessie-0.59.0
    app.kubernetes.io/name: nessie
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.59.0"
    app.kubernetes.io/managed-by: Helm
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  storageClassName: standard
  resources:
    requests:
      storage: 1Gi
```

fixes #6876