### PR TITLE
Make nip.io usage resilient against lookup failures

### DIFF
--- a/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
+++ b/testing/s3minio/src/main/java/org/projectnessie/minio/MinioExtension.java
@@ -51,7 +51,9 @@ public class MinioExtension
     if (OS.current() == OS.LINUX) {
       return enabled("Running on Linux");
     }
-    if (OS.current() == OS.MAC && System.getenv("CI_MAC") == null) {
+    if (OS.current() == OS.MAC
+        && System.getenv("CI_MAC") == null
+        && MinioContainer.canRunOnMacOs()) {
       // Disable tests on GitHub Actions
       return enabled("Running on macOS locally");
     }


### PR DESCRIPTION
nip.io's "magic" DNS names are not always resolvable, or resolvable in every setup. This change first tries to resolve the "magic" nip.io address and falls back to the pre-#6856 behavior if the pre-check fails.