### PR TITLE
Fix `MergeKeyBehavior.DROP` in new storage model for merge

### DIFF
--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/DiffQuery.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/DiffQuery.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.storage.common.logic;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
@@ -71,6 +72,11 @@ public interface DiffQuery extends PageableQuery {
   @Value.Parameter(order = 6)
   boolean prefetch();
 
+  @Nullable
+  @jakarta.annotation.Nullable
+  @Value.Parameter(order = 7)
+  Predicate<StoreKey> filter();
+
   @Nonnull
   @jakarta.annotation.Nonnull
   static DiffQuery diffQuery(
@@ -79,9 +85,10 @@ public interface DiffQuery extends PageableQuery {
       @Nullable @jakarta.annotation.Nullable CommitObj toCommit,
       @Nullable @jakarta.annotation.Nullable StoreKey start,
       @Nullable @jakarta.annotation.Nullable StoreKey end,
-      boolean prefetch) {
+      boolean prefetch,
+      @Nullable @jakarta.annotation.Nullable Predicate<StoreKey> filter) {
     return ImmutableDiffQuery.of(
-        Optional.ofNullable(pagingToken), fromCommit, toCommit, start, end, prefetch);
+        Optional.ofNullable(pagingToken), fromCommit, toCommit, start, end, prefetch, filter);
   }
 
   @Nonnull
@@ -89,7 +96,8 @@ public interface DiffQuery extends PageableQuery {
   static DiffQuery diffQuery(
       @Nullable @jakarta.annotation.Nullable CommitObj fromCommit,
       @Nullable @jakarta.annotation.Nullable CommitObj toCommit,
-      boolean prefetch) {
-    return diffQuery(null, fromCommit, toCommit, null, null, prefetch);
+      boolean prefetch,
+      @Nullable @jakarta.annotation.Nullable Predicate<StoreKey> filter) {
+    return diffQuery(null, fromCommit, toCommit, null, null, prefetch, filter);
   }
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeBehaviors.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeBehaviors.java
@@ -49,12 +49,11 @@ final class MergeBehaviors {
         "Not all merge key behaviors specified in the request have been used. The following keys were not used: %s",
         remainingKeys);
     mergeKeyBehaviors.forEach(
-        (key, mergeKeyBehavior) -> {
-          checkArgument(
-              mergeKeyBehavior.getResolvedContent() == null || keysUsedForCommit.contains(key),
-              "The merge behavior for key %s has an unused resolvedContent attribute.",
-              key);
-        });
+        (key, mergeKeyBehavior) ->
+            checkArgument(
+                mergeKeyBehavior.getResolvedContent() == null || keysUsedForCommit.contains(key),
+                "The merge behavior for key %s has an unused resolvedContent attribute.",
+                key));
   }
 
   MergeBehavior mergeBehavior(ContentKey key) {

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -794,7 +794,8 @@ public class VersionStoreImpl implements VersionStore {
                 toCommit,
                 keyRanges.beginStoreKey(),
                 keyRanges.endStoreKey(),
-                true));
+                true,
+                null));
 
     ContentMapping contentMapping = new ContentMapping(persist);
 

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -206,7 +206,8 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
 
     Content c11 = store().getValue(firstCommit, ContentKey.of("t1"));
 
-    for (MergeBehavior mergeBehavior : MergeBehavior.values()) {
+    for (MergeBehavior mergeBehavior :
+        new MergeBehavior[] {MergeBehavior.NORMAL, MergeBehavior.FORCE}) {
       StorageAssertions checkpoint = storageCheckpoint();
       soft.assertThatThrownBy(
               () ->

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMergeKeyBehaviors.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMergeKeyBehaviors.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.tests;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.projectnessie.model.CommitMeta.fromMessage;
+import static org.projectnessie.model.MergeBehavior.DROP;
+import static org.projectnessie.model.MergeBehavior.FORCE;
+import static org.projectnessie.model.MergeBehavior.NORMAL;
+import static org.projectnessie.versioned.tests.AbstractVersionStoreTestBase.METADATA_REWRITER;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.ImmutableIcebergTable;
+import org.projectnessie.model.MergeBehavior;
+import org.projectnessie.model.MergeKeyBehavior;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Commit;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.MergeResult;
+import org.projectnessie.versioned.Put;
+import org.projectnessie.versioned.VersionStore;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public abstract class AbstractMergeKeyBehaviors extends AbstractNestedVersionStore {
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  static ContentKey keyInitial = ContentKey.of("initial");
+  static ContentKey keyTarget1 = ContentKey.of("target1");
+  static ContentKey keySource1 = ContentKey.of("source1");
+  static ContentKey keyCommon1 = ContentKey.of("common1");
+  static ContentKey keyCommon2 = ContentKey.of("common2");
+  static IcebergTable initialTable = IcebergTable.of("initial", 1, 2, 3, 4);
+  static IcebergTable targetTable1 = IcebergTable.of("target1", 1, 2, 3, 4);
+  static IcebergTable sourceTable1 = IcebergTable.of("source1", 1, 2, 3, 4);
+  static IcebergTable commonTable1onTarget = IcebergTable.of("common1onTarget", 1, 2, 3, 4);
+  static IcebergTable commonTable2onTarget = IcebergTable.of("common2onTarget", 1, 2, 3, 4);
+  static IcebergTable commonTable1onSource = IcebergTable.of("common1onSource", 1, 2, 3, 4);
+  static IcebergTable commonTable2onSource = IcebergTable.of("common2onSource", 1, 2, 3, 4);
+
+  protected AbstractMergeKeyBehaviors(VersionStore store) {
+    super(store);
+  }
+
+  static Stream<Arguments> mergeKeyBehavior() {
+    return Stream.of(
+        // 1
+        arguments(
+            ImmutableMap.of(
+                keyCommon1, MergeKeyBehavior.of(keyCommon1, DROP),
+                keyCommon2, MergeKeyBehavior.of(keyCommon2, DROP)),
+            NORMAL,
+            ImmutableMap.of(
+                keyInitial, initialTable,
+                keyTarget1, targetTable1,
+                keySource1, sourceTable1,
+                keyCommon1, commonTable1onTarget,
+                keyCommon2, commonTable2onTarget)),
+        // 2
+        arguments(
+            ImmutableMap.of(
+                keyCommon1, MergeKeyBehavior.of(keyCommon1, FORCE),
+                keyCommon2, MergeKeyBehavior.of(keyCommon2, FORCE)),
+            NORMAL,
+            ImmutableMap.of(
+                keyInitial, initialTable,
+                keyTarget1, targetTable1,
+                keySource1, sourceTable1,
+                keyCommon1, commonTable1onSource,
+                keyCommon2, commonTable2onSource)),
+        // 3
+        arguments(
+            ImmutableMap.of(
+                keyCommon1, MergeKeyBehavior.of(keyCommon1, DROP),
+                keyCommon2, MergeKeyBehavior.of(keyCommon2, FORCE)),
+            NORMAL,
+            ImmutableMap.of(
+                keyInitial, initialTable,
+                keyTarget1, targetTable1,
+                keySource1, sourceTable1,
+                keyCommon1, commonTable1onTarget,
+                keyCommon2, commonTable2onSource)),
+        // 4
+        arguments(
+            ImmutableMap.of(
+                keyCommon1, MergeKeyBehavior.of(keyCommon1, DROP),
+                keyCommon2, MergeKeyBehavior.of(keyCommon2, DROP)),
+            NORMAL,
+            ImmutableMap.of(
+                keyInitial, initialTable,
+                keyTarget1, targetTable1,
+                keySource1, sourceTable1,
+                keyCommon1, commonTable1onTarget,
+                keyCommon2, commonTable2onTarget)),
+        // 5
+        arguments(
+            ImmutableMap.of(
+                keyCommon1, MergeKeyBehavior.of(keyCommon1, FORCE),
+                keyCommon2, MergeKeyBehavior.of(keyCommon2, FORCE)),
+            NORMAL,
+            ImmutableMap.of(
+                keyInitial, initialTable,
+                keyTarget1, targetTable1,
+                keySource1, sourceTable1,
+                keyCommon1, commonTable1onSource,
+                keyCommon2, commonTable2onSource)),
+        // 6
+        arguments(
+            ImmutableMap.of(
+                keyCommon1, MergeKeyBehavior.of(keyCommon1, DROP),
+                keyCommon2, MergeKeyBehavior.of(keyCommon2, FORCE),
+                keySource1, MergeKeyBehavior.of(keySource1, DROP)),
+            NORMAL,
+            ImmutableMap.of(
+                keyInitial, initialTable,
+                keyTarget1, targetTable1,
+                keyCommon1, commonTable1onTarget,
+                keyCommon2, commonTable2onSource)),
+        // 7
+        arguments(
+            ImmutableMap.of(
+                keyCommon1, MergeKeyBehavior.of(keyCommon1, DROP),
+                keyCommon2, MergeKeyBehavior.of(keyCommon2, FORCE)),
+            DROP,
+            ImmutableMap.of(
+                keyInitial, initialTable,
+                keyTarget1, targetTable1,
+                keyCommon1, commonTable1onTarget,
+                keyCommon2, commonTable2onSource)),
+        // 8
+        arguments(
+            ImmutableMap.of(),
+            FORCE,
+            ImmutableMap.of(
+                keyInitial, initialTable,
+                keyTarget1, targetTable1,
+                keySource1, sourceTable1,
+                keyCommon1, commonTable1onSource,
+                keyCommon2, commonTable2onSource)),
+        // 9
+        arguments(
+            ImmutableMap.of(keySource1, MergeKeyBehavior.of(keySource1, DROP)),
+            FORCE,
+            ImmutableMap.of(
+                keyInitial,
+                initialTable,
+                keyTarget1,
+                targetTable1,
+                keyCommon1,
+                commonTable1onSource,
+                keyCommon2,
+                commonTable2onSource)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("mergeKeyBehavior")
+  void mergeKeyBehavior(
+      Map<ContentKey, MergeKeyBehavior> mergeKeyBehaviors,
+      MergeBehavior defaultMergeBehavior,
+      Map<ContentKey, Content> expectedContentsAfter)
+      throws Exception {
+    BranchName targetName = BranchName.of("target");
+    Hash target = store().create(targetName, Optional.empty()).getHash();
+
+    List<ContentKey> allKeys = asList(keyInitial, keyTarget1, keySource1, keyCommon1, keyCommon2);
+
+    target =
+        store()
+            .commit(
+                targetName,
+                Optional.of(target),
+                fromMessage("initial"),
+                singletonList(Put.of(keyInitial, initialTable)))
+            .getCommitHash();
+
+    BranchName sourceName = BranchName.of("source");
+    Hash source = store().create(sourceName, Optional.of(target)).getHash();
+
+    target =
+        store()
+            .commit(
+                targetName,
+                Optional.of(target),
+                fromMessage("target 2"),
+                asList(
+                    Put.of(keyTarget1, targetTable1),
+                    Put.of(keyCommon1, commonTable1onTarget),
+                    Put.of(keyCommon2, commonTable2onTarget)))
+            .getCommitHash();
+    source =
+        store()
+            .commit(
+                sourceName,
+                Optional.of(source),
+                fromMessage("source 2"),
+                asList(
+                    Put.of(keySource1, sourceTable1),
+                    Put.of(keyCommon1, commonTable1onSource),
+                    Put.of(keyCommon2, commonTable2onSource)))
+            .getCommitHash();
+
+    MergeResult<Commit> mergeResult =
+        store()
+            .merge(
+                sourceName,
+                source,
+                targetName,
+                Optional.of(target),
+                METADATA_REWRITER,
+                false,
+                mergeKeyBehaviors,
+                defaultMergeBehavior,
+                false,
+                false);
+    soft.assertThat(mergeResult)
+        .extracting(MergeResult::wasApplied, MergeResult::wasSuccessful)
+        .containsExactly(true, true);
+    soft.assertThat(mergeResult.getResultantTargetHash()).isNotEqualTo(target);
+    target = mergeResult.getResultantTargetHash();
+    Map<ContentKey, Content> contentsOnTargetAfter =
+        store().getValues(target, allKeys).entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey, e -> ((ImmutableIcebergTable) e.getValue()).withId(null)));
+    soft.assertThat(contentsOnTargetAfter)
+        .containsExactlyInAnyOrderEntriesOf(expectedContentsAfter);
+  }
+}

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractVersionStoreTestBase.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractVersionStoreTestBase.java
@@ -76,6 +76,13 @@ public abstract class AbstractVersionStoreTestBase {
   }
 
   @Nested
+  protected class MergeKeyBehaviors extends AbstractMergeKeyBehaviors {
+    public MergeKeyBehaviors() {
+      super(AbstractVersionStoreTestBase.this.store());
+    }
+  }
+
+  @Nested
   protected class Diff extends AbstractDiff {
     public Diff() {
       super(AbstractVersionStoreTestBase.this.store());


### PR DESCRIPTION
The (legacy) behavior of `MergeKeyBehavior.DROP` is to completely ignore such content keys from the source branch to be merged. The implementation in the new model wrongly implemented it to ignore the value from the source branch, but only in case of a conflict. It must also ignore such content-keys without a conflict.

This was discovered while porting the compatibility-tests to the new storage model.

This PR adds test cases to validate the behavior (and updates an existing test).