### PR TITLE
Revert "Bump keykloak container image from 21.0.2 to 21.1 (#6887)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ testcontainers = "1.18.1"
 undertow = "2.2.24.Final"
 
 # Docker image tags
-keycloakContainerTag = "21.1"
+keycloakContainerTag = "21.0.2"
 postgresContainerTag = "14"
 
 [bundles]


### PR DESCRIPTION
This reverts commit db7f3b07b552b072e69450c6f68ca8e05f9413a6.

Seen "Quarkus intTest" being flaky in #6146, suspecting the included Keycloak bump to 21.1. However, all "Quarkus intTest" runs for #6887 were good, but the merge to main failed. So reverting the Keycloak bump.