### PR TITLE
Configure MeterRegistry and MeterFilter globally

### DIFF
--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
   implementation("com.datastax.oss.quarkus:cassandra-quarkus-client")
   implementation("org.jboss.slf4j:slf4j-jboss-logmanager")
   implementation("io.opentelemetry:opentelemetry-api")
+  implementation("io.micrometer:micrometer-core")
 
   // javax/jakarta
   compileOnly(libs.jakarta.validation.api)

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/MeterFilterProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/MeterFilterProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.providers;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.config.MeterFilter;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+public class MeterFilterProvider {
+
+  public static final String APPLICATION_TAG_NAME = "application";
+  public static final String APPLICATION_TAG_VALUE = "Nessie";
+
+  @Produces
+  @Singleton
+  public MeterFilter produceGlobalMeterFilter() {
+    return MeterFilter.commonTags(Tags.of(APPLICATION_TAG_NAME, APPLICATION_TAG_VALUE));
+  }
+}

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
@@ -47,7 +47,9 @@ public abstract class AbstractQuarkusRestWithMetrics extends AbstractQuarkusRest
     // Do not query JVM metrics in tests, see
     // https://github.com/quarkusio/quarkus/issues/24210#issuecomment-1064833013
     assertThat(body).contains("process_cpu_usage");
-    assertThat(body).contains("nessie_versionstore_request_seconds_max");
+    assertThat(body)
+        // also assert that VersionStore metrics have the global tag application="Nessie"
+        .containsPattern("nessie_versionstore_request_seconds_max\\{.*application=\"Nessie\".*}");
     assertThat(body).contains("nessie_versionstore_request_seconds_bucket");
     assertThat(body).contains("nessie_versionstore_request_seconds_count");
     assertThat(body).contains("nessie_versionstore_request_seconds_sum");

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -17,9 +17,6 @@ package org.projectnessie.versioned;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Sample;
 import java.util.Collection;
@@ -45,7 +42,6 @@ public final class MetricsVersionStore implements VersionStore {
   private final VersionStore delegate;
   private final MeterRegistry registry;
   private final Clock clock;
-  private final Iterable<Tag> commonTags;
 
   /**
    * Constructor taking the delegate version-store and the metrics-registry.
@@ -53,15 +49,10 @@ public final class MetricsVersionStore implements VersionStore {
    * @param delegate delegate version-store
    * @param registry metrics-registry
    */
-  MetricsVersionStore(VersionStore delegate, MeterRegistry registry, Clock clock) {
+  public MetricsVersionStore(VersionStore delegate, MeterRegistry registry, Clock clock) {
     this.delegate = delegate;
     this.registry = registry;
     this.clock = clock;
-    this.commonTags = Tags.of("application", "Nessie");
-  }
-
-  public MetricsVersionStore(VersionStore delegate) {
-    this(delegate, Metrics.globalRegistry, Clock.SYSTEM);
   }
 
   @Nonnull
@@ -266,7 +257,6 @@ public final class MetricsVersionStore implements VersionStore {
   private void measure(String requestName, Sample sample, Exception failure) {
     Timer timer =
         Timer.builder("nessie.versionstore.request")
-            .tags(commonTags)
             .tag("request", requestName)
             .tag("error", Boolean.toString(failure != null))
             .publishPercentileHistogram()

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestMetricsVersionStore.java
@@ -427,13 +427,7 @@ class TestMetricsVersionStore {
 
     return new Meter.Id(
         "nessie.versionstore.request",
-        Tags.of(
-            "error",
-            Boolean.toString(isErrorException),
-            "request",
-            opName,
-            "application",
-            "Nessie"),
+        Tags.of("error", Boolean.toString(isErrorException), "request", opName),
         "nanoseconds",
         null,
         Meter.Type.TIMER);


### PR DESCRIPTION
This commit changes the way MetricsVersionStore is created in a Quarkus application. Instead of relying on Metrics.globalRegistry, a MeterRegistry bean is injected.

Also, a global MeterFilter bean is now available and is used to inject global tags in all registries.