### PR TITLE
Quarkus-tests: Update test resources to use new storage test code

### DIFF
--- a/servers/quarkus-tests/build.gradle.kts
+++ b/servers/quarkus-tests/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
   implementation(project(":nessie-versioned-persist-transactional"))
   implementation(project(":nessie-versioned-persist-transactional-test"))
   implementation(project(":nessie-versioned-storage-cassandra"))
+  implementation(project(":nessie-versioned-storage-dynamodb"))
+  implementation(project(":nessie-versioned-storage-mongodb"))
   implementation(project(":nessie-versioned-storage-testextension"))
 
   implementation(enforcedPlatform(libs.quarkus.bom))

--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/DynamoTestResourceLifecycleManager.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/DynamoTestResourceLifecycleManager.java
@@ -20,12 +20,12 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import org.projectnessie.versioned.persist.dynamodb.LocalDynamoTestConnectionProviderSource;
+import org.projectnessie.versioned.storage.dynamodb.DynamoDBBackendTestFactory;
 
 public class DynamoTestResourceLifecycleManager
     implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
 
-  private LocalDynamoTestConnectionProviderSource dynamo;
+  private DynamoDBBackendTestFactory dynamo;
 
   private Optional<String> containerNetworkId = Optional.empty();
 
@@ -36,12 +36,11 @@ public class DynamoTestResourceLifecycleManager
 
   @Override
   public Map<String, String> start() {
-    dynamo = new LocalDynamoTestConnectionProviderSource();
+    dynamo = new DynamoDBBackendTestFactory();
 
     try {
-      // Only start the Docker container (local Dynamo-compatible). The DynamoDatabaseClient will
-      // be configured via Quarkus -> Quarkus-Dynamo / DynamoVersionStoreFactory.
-      dynamo.startDynamo(containerNetworkId, true);
+      // Only start the Docker container (local Dynamo-compatible).
+      dynamo.startDynamo(containerNetworkId);
     } catch (Exception e) {
       e.printStackTrace();
       throw new RuntimeException(e);

--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/MongoTestResourceLifecycleManager.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/MongoTestResourceLifecycleManager.java
@@ -15,17 +15,16 @@
  */
 package org.projectnessie.quarkus.tests.profiles;
 
-import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.util.Map;
 import java.util.Optional;
-import org.projectnessie.versioned.persist.mongodb.LocalMongoTestConnectionProviderSource;
+import org.projectnessie.versioned.storage.mongodb.MongoDBBackendTestFactory;
 
 public class MongoTestResourceLifecycleManager
     implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
 
-  private LocalMongoTestConnectionProviderSource mongo;
+  private MongoDBBackendTestFactory mongo;
 
   private Optional<String> containerNetworkId;
 
@@ -36,19 +35,15 @@ public class MongoTestResourceLifecycleManager
 
   @Override
   public Map<String, String> start() {
-    mongo = new LocalMongoTestConnectionProviderSource();
+    mongo = new MongoDBBackendTestFactory();
 
     try {
-      mongo.startMongo(containerNetworkId, true);
+      mongo.startMongo(containerNetworkId);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
 
-    return ImmutableMap.of(
-        "quarkus.mongodb.connection-string",
-        mongo.getConnectionString(),
-        "quarkus.mongodb.database",
-        mongo.getDatabaseName());
+    return mongo.getQuarkusConfig();
   }
 
   @Override

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBBackendTestFactory.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBBackendTestFactory.java
@@ -52,7 +52,7 @@ public class DynamoDBBackendTestFactory implements BackendTestFactory {
   }
 
   @SuppressWarnings("resource")
-  private void startDynamo(Optional<String> containerNetworkId) {
+  public void startDynamo(Optional<String> containerNetworkId) {
     if (container != null) {
       throw new IllegalStateException("Already started");
     }
@@ -105,5 +105,9 @@ public class DynamoDBBackendTestFactory implements BackendTestFactory {
     } finally {
       container = null;
     }
+  }
+
+  public String getEndpointURI() {
+    return endpointURI;
   }
 }


### PR DESCRIPTION
These lifecycle-managers relied on database-adapter test support code.