### PR TITLE
Fix possible IntelliJ dependency issue

### DIFF
--- a/compatibility/common/build.gradle.kts
+++ b/compatibility/common/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
   implementation(platform(libs.jackson.bom))
   implementation("com.fasterxml.jackson.core:jackson-annotations")
 
-  implementation(platform(libs.junit.bom))
+  api(platform(libs.junit.bom))
   api("org.junit.jupiter:junit-jupiter-api")
   compileOnly("org.junit.jupiter:junit-jupiter-engine")
 

--- a/testing/multi-env-test-engine/build.gradle.kts
+++ b/testing/multi-env-test-engine/build.gradle.kts
@@ -27,7 +27,7 @@ extra["maven.name"] = "Nessie - Multi-Environment Test Engine"
 dependencies {
   api(libs.slf4j.api)
 
-  implementation(platform(libs.junit.bom))
+  api(platform(libs.junit.bom))
   api("org.junit.jupiter:junit-jupiter-api")
   compileOnly("org.junit.jupiter:junit-jupiter-engine")
   implementation("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
The updated build scripts may cause dependency resolution issues in IntelliJ, but somehow not on the command line. However, the change is reasonable.