### PR TITLE
Use parameter objects for `VersionStore.merge()` + `.transplant()`

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -123,6 +123,7 @@ import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.TagName;
 import org.projectnessie.versioned.Unchanged;
 import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.VersionStore.TransplantOp;
 import org.projectnessie.versioned.WithHash;
 import org.projectnessie.versioned.paging.PaginationIterator;
 
@@ -598,25 +599,28 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       MergeResult<Commit> result =
           getStore()
               .transplant(
-                  namedRefWithHash.getValue(),
-                  targetBranch,
-                  into,
-                  transplants,
-                  commitMetaUpdate(
-                      commitMeta,
-                      numCommits ->
-                          String.format(
-                              "Transplanted %d commits from %s at %s into %s%s",
-                              numCommits,
-                              fromRefName,
-                              lastHash,
-                              branchName,
-                              into.map(h -> " at " + h.asString()).orElse(""))),
-                  Boolean.TRUE.equals(keepIndividualCommits),
-                  keyMergeBehaviors(keyMergeBehaviors),
-                  defaultMergeBehavior(defaultMergeBehavior),
-                  Boolean.TRUE.equals(dryRun),
-                  Boolean.TRUE.equals(fetchAdditionalInfo));
+                  TransplantOp.builder()
+                      .fromRef(namedRefWithHash.getValue())
+                      .toBranch(targetBranch)
+                      .expectedHash(into)
+                      .sequenceToTransplant(transplants)
+                      .updateCommitMetadata(
+                          commitMetaUpdate(
+                              commitMeta,
+                              numCommits ->
+                                  String.format(
+                                      "Transplanted %d commits from %s at %s into %s%s",
+                                      numCommits,
+                                      fromRefName,
+                                      lastHash,
+                                      branchName,
+                                      into.map(h -> " at " + h.asString()).orElse(""))))
+                      .keepIndividualCommits(Boolean.TRUE.equals(keepIndividualCommits))
+                      .mergeKeyBehaviors(keyMergeBehaviors(keyMergeBehaviors))
+                      .defaultMergeBehavior(defaultMergeBehavior(defaultMergeBehavior))
+                      .dryRun(Boolean.TRUE.equals(dryRun))
+                      .fetchAdditionalInfo(Boolean.TRUE.equals(fetchAdditionalInfo))
+                      .build());
       return createResponse(fetchAdditionalInfo, result);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
@@ -662,25 +666,28 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       MergeResult<Commit> result =
           getStore()
               .merge(
-                  namedRefWithHash.getValue(),
-                  toHash(fromRefName, fromHash),
-                  targetBranch,
-                  into,
-                  commitMetaUpdate(
-                      commitMeta,
-                      numCommits ->
-                          String.format(
-                              "Merged %d commits from %s at %s into %s%s",
-                              numCommits,
-                              fromRefName,
-                              from.asString(),
-                              branchName,
-                              into.map(h -> " at " + h.asString()).orElse(""))),
-                  Boolean.TRUE.equals(keepIndividualCommits),
-                  keyMergeBehaviors(keyMergeBehaviors),
-                  defaultMergeBehavior(defaultMergeBehavior),
-                  Boolean.TRUE.equals(dryRun),
-                  Boolean.TRUE.equals(fetchAdditionalInfo));
+                  VersionStore.MergeOp.builder()
+                      .fromRef(namedRefWithHash.getValue())
+                      .fromHash(toHash(fromRefName, fromHash))
+                      .toBranch(targetBranch)
+                      .expectedHash(into)
+                      .updateCommitMetadata(
+                          commitMetaUpdate(
+                              commitMeta,
+                              numCommits ->
+                                  String.format(
+                                      "Merged %d commits from %s at %s into %s%s",
+                                      numCommits,
+                                      fromRefName,
+                                      from.asString(),
+                                      branchName,
+                                      into.map(h -> " at " + h.asString()).orElse(""))))
+                      .keepIndividualCommits(Boolean.TRUE.equals(keepIndividualCommits))
+                      .mergeKeyBehaviors(keyMergeBehaviors(keyMergeBehaviors))
+                      .defaultMergeBehavior(defaultMergeBehavior(defaultMergeBehavior))
+                      .dryRun(Boolean.TRUE.equals(dryRun))
+                      .fetchAdditionalInfo(Boolean.TRUE.equals(fetchAdditionalInfo))
+                      .build());
       return createResponse(fetchAdditionalInfo, result);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
@@ -27,8 +27,6 @@ import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
-import org.projectnessie.model.MergeBehavior;
-import org.projectnessie.model.MergeKeyBehavior;
 import org.projectnessie.versioned.paging.PaginationIterator;
 
 /**
@@ -67,30 +65,9 @@ public class EventsVersionStore implements VersionStore {
   }
 
   @Override
-  public MergeResult<Commit> transplant(
-      NamedRef sourceRef,
-      BranchName targetBranch,
-      Optional<Hash> referenceHash,
-      List<Hash> sequenceToTransplant,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      boolean keepIndividualCommits,
-      Map<ContentKey, MergeKeyBehavior> mergeKeyBehaviors,
-      MergeBehavior defaultMergeBehavior,
-      boolean dryRun,
-      boolean fetchAdditionalInfo)
+  public MergeResult<Commit> transplant(TransplantOp transplantOp)
       throws ReferenceNotFoundException, ReferenceConflictException {
-    MergeResult<Commit> result =
-        delegate.transplant(
-            sourceRef,
-            targetBranch,
-            referenceHash,
-            sequenceToTransplant,
-            updateCommitMetadata,
-            keepIndividualCommits,
-            mergeKeyBehaviors,
-            defaultMergeBehavior,
-            dryRun,
-            fetchAdditionalInfo);
+    MergeResult<Commit> result = delegate.transplant(transplantOp);
     if (result.wasApplied()) {
       resultSink.accept(result);
     }
@@ -98,30 +75,9 @@ public class EventsVersionStore implements VersionStore {
   }
 
   @Override
-  public MergeResult<Commit> merge(
-      NamedRef fromRef,
-      Hash fromHash,
-      BranchName toBranch,
-      Optional<Hash> expectedHash,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      boolean keepIndividualCommits,
-      Map<ContentKey, MergeKeyBehavior> mergeKeyBehaviors,
-      MergeBehavior defaultMergeBehavior,
-      boolean dryRun,
-      boolean fetchAdditionalInfo)
+  public MergeResult<Commit> merge(MergeOp mergeOp)
       throws ReferenceNotFoundException, ReferenceConflictException {
-    MergeResult<Commit> result =
-        delegate.merge(
-            fromRef,
-            fromHash,
-            toBranch,
-            expectedHash,
-            updateCommitMetadata,
-            keepIndividualCommits,
-            mergeKeyBehaviors,
-            defaultMergeBehavior,
-            dryRun,
-            fetchAdditionalInfo);
+    MergeResult<Commit> result = delegate.merge(mergeOp);
     if (result.wasApplied()) {
       resultSink.accept(result);
     }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetadataRewriter.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetadataRewriter.java
@@ -16,9 +16,23 @@
 package org.projectnessie.versioned;
 
 import java.util.List;
+import org.projectnessie.model.CommitMeta;
 
 public interface MetadataRewriter<T> {
   T rewriteSingle(T metadata);
 
   T squash(List<T> metadata);
+
+  MetadataRewriter<CommitMeta> NOOP_REWRITER =
+      new MetadataRewriter<CommitMeta>() {
+        @Override
+        public CommitMeta rewriteSingle(CommitMeta metadata) {
+          return metadata;
+        }
+
+        @Override
+        public CommitMeta squash(List<CommitMeta> metadata) {
+          return metadata.get(0);
+        }
+      };
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -31,8 +31,6 @@ import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
-import org.projectnessie.model.MergeBehavior;
-import org.projectnessie.model.MergeKeyBehavior;
 import org.projectnessie.versioned.paging.PaginationIterator;
 
 /** A {@link VersionStore} wrapper that publishes metrics via Micrometer. */
@@ -94,63 +92,19 @@ public final class MetricsVersionStore implements VersionStore {
   }
 
   @Override
-  public MergeResult<Commit> transplant(
-      NamedRef sourceRef,
-      BranchName targetBranch,
-      Optional<Hash> referenceHash,
-      List<Hash> sequenceToTransplant,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      boolean keepIndividualCommits,
-      Map<ContentKey, MergeKeyBehavior> mergeKeyBehaviors,
-      MergeBehavior defaultMergeBehavior,
-      boolean dryRun,
-      boolean fetchAdditionalInfo)
+  public MergeResult<Commit> transplant(TransplantOp transplantOp)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return this
         .<MergeResult<Commit>, ReferenceNotFoundException, ReferenceConflictException>delegate2ExR(
-            "transplant",
-            () ->
-                delegate.transplant(
-                    sourceRef,
-                    targetBranch,
-                    referenceHash,
-                    sequenceToTransplant,
-                    updateCommitMetadata,
-                    keepIndividualCommits,
-                    mergeKeyBehaviors,
-                    defaultMergeBehavior,
-                    dryRun,
-                    fetchAdditionalInfo));
+            "transplant", () -> delegate.transplant(transplantOp));
   }
 
   @Override
-  public MergeResult<Commit> merge(
-      NamedRef fromRef,
-      Hash fromHash,
-      BranchName toBranch,
-      Optional<Hash> expectedHash,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      boolean keepIndividualCommits,
-      Map<ContentKey, MergeKeyBehavior> mergeKeyBehaviors,
-      MergeBehavior defaultMergeBehavior,
-      boolean dryRun,
-      boolean fetchAdditionalInfo)
+  public MergeResult<Commit> merge(MergeOp mergeOp)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return this
         .<MergeResult<Commit>, ReferenceNotFoundException, ReferenceConflictException>delegate2ExR(
-            "merge",
-            () ->
-                delegate.merge(
-                    fromRef,
-                    fromHash,
-                    toBranch,
-                    expectedHash,
-                    updateCommitMetadata,
-                    keepIndividualCommits,
-                    mergeKeyBehaviors,
-                    defaultMergeBehavior,
-                    dryRun,
-                    fetchAdditionalInfo));
+            "merge", () -> delegate.merge(mergeOp));
   }
 
   @Override

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/Merge.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/Merge.java
@@ -16,23 +16,14 @@
 package org.projectnessie.versioned.storage.versionstore;
 
 import java.util.Optional;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.versioned.Commit;
-import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.MergeResult;
-import org.projectnessie.versioned.MetadataRewriter;
-import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.VersionStore.MergeOp;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 
 interface Merge {
-  MergeResult<Commit> merge(
-      Optional<?> retryState,
-      NamedRef fromRef,
-      Hash fromHash,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      MergeBehaviors mergeBehaviors,
-      boolean dryRun)
+  MergeResult<Commit> merge(Optional<?> retryState, MergeOp mergeOp)
       throws ReferenceNotFoundException, RetryException, ReferenceConflictException;
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/MergeIndividualImpl.java
@@ -23,17 +23,15 @@ import static org.projectnessie.versioned.storage.versionstore.TypeMapping.objId
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.MergeResult;
-import org.projectnessie.versioned.MetadataRewriter;
-import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.ResultType;
+import org.projectnessie.versioned.VersionStore.MergeOp;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
@@ -54,15 +52,9 @@ final class MergeIndividualImpl extends BaseMergeTransplantIndividual implements
   }
 
   @Override
-  public MergeResult<Commit> merge(
-      Optional<?> retryState,
-      NamedRef fromRef,
-      Hash fromHash,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      MergeBehaviors mergeBehaviors,
-      boolean dryRun)
+  public MergeResult<Commit> merge(Optional<?> retryState, MergeOp mergeOp)
       throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
-    ObjId fromId = hashToObjId(fromHash);
+    ObjId fromId = hashToObjId(mergeOp.fromHash());
     ObjId commonAncestorId = identifyCommonAncestor(fromId);
 
     CommitObj source;
@@ -75,7 +67,7 @@ final class MergeIndividualImpl extends BaseMergeTransplantIndividual implements
     ImmutableMergeResult.Builder<Commit> mergeResult =
         prepareMergeResult()
             .resultType(ResultType.MERGE)
-            .sourceRef(fromRef)
+            .sourceRef(mergeOp.fromRef())
             .commonAncestor(objIdToHash(commonAncestorId));
 
     // Fast-forward, if possible
@@ -84,12 +76,11 @@ final class MergeIndividualImpl extends BaseMergeTransplantIndividual implements
         //  Need to check whether the commit-metadata has changed as well.
         && source.directParent().equals(commonAncestorId)) {
 
-      return mergeSquashFastForward(dryRun, fromId, source, mergeResult, mergeBehaviors);
+      return mergeSquashFastForward(mergeOp, fromId, source, mergeResult);
     }
 
     SourceCommitsAndParent sourceCommits = loadSourceCommitsForMerge(fromId, commonAncestorId);
 
-    return individualCommits(
-        updateCommitMetadata, dryRun, mergeResult, mergeBehaviors, sourceCommits);
+    return individualCommits(mergeOp, mergeResult, sourceCommits);
   }
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/Transplant.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/Transplant.java
@@ -15,25 +15,15 @@
  */
 package org.projectnessie.versioned.storage.versionstore;
 
-import java.util.List;
 import java.util.Optional;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.versioned.Commit;
-import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.MergeResult;
-import org.projectnessie.versioned.MetadataRewriter;
-import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
+import org.projectnessie.versioned.VersionStore.TransplantOp;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 
 interface Transplant {
-  MergeResult<Commit> transplant(
-      Optional<?> retryState,
-      NamedRef sourceRef,
-      List<Hash> sequenceToTransplant,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      MergeBehaviors mergeBehaviors,
-      boolean dryRun)
+  MergeResult<Commit> transplant(Optional<?> retryState, TransplantOp transplantOp)
       throws ReferenceNotFoundException, RetryException, ReferenceConflictException;
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
@@ -15,21 +15,18 @@
  */
 package org.projectnessie.versioned.storage.versionstore;
 
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.MergeResult;
-import org.projectnessie.versioned.MetadataRewriter;
-import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.ResultType;
+import org.projectnessie.versioned.VersionStore.TransplantOp;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.persist.Persist;
@@ -48,20 +45,14 @@ final class TransplantIndividualImpl extends BaseMergeTransplantIndividual imple
   }
 
   @Override
-  public MergeResult<Commit> transplant(
-      Optional<?> retryState,
-      NamedRef sourceRef,
-      List<Hash> sequenceToTransplant,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      MergeBehaviors mergeBehaviors,
-      boolean dryRun)
+  public MergeResult<Commit> transplant(Optional<?> retryState, TransplantOp transplantOp)
       throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
-    SourceCommitsAndParent sourceCommits = loadSourceCommitsForTransplant(sequenceToTransplant);
+    SourceCommitsAndParent sourceCommits =
+        loadSourceCommitsForTransplant(transplantOp.sequenceToTransplant());
 
     ImmutableMergeResult.Builder<Commit> mergeResult =
-        prepareMergeResult().resultType(ResultType.TRANSPLANT).sourceRef(sourceRef);
+        prepareMergeResult().resultType(ResultType.TRANSPLANT).sourceRef(transplantOp.fromRef());
 
-    return individualCommits(
-        updateCommitMetadata, dryRun, mergeResult, mergeBehaviors, sourceCommits);
+    return individualCommits(transplantOp, mergeResult, sourceCommits);
   }
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantSquashImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantSquashImpl.java
@@ -15,21 +15,18 @@
  */
 package org.projectnessie.versioned.storage.versionstore;
 
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.ImmutableMergeResult;
 import org.projectnessie.versioned.MergeResult;
-import org.projectnessie.versioned.MetadataRewriter;
-import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.ResultType;
+import org.projectnessie.versioned.VersionStore.TransplantOp;
 import org.projectnessie.versioned.storage.common.logic.CommitRetry.RetryException;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.persist.Persist;
@@ -48,19 +45,14 @@ final class TransplantSquashImpl extends BaseMergeTransplantSquash implements Tr
   }
 
   @Override
-  public MergeResult<Commit> transplant(
-      Optional<?> retryState,
-      NamedRef sourceRef,
-      List<Hash> sequenceToTransplant,
-      MetadataRewriter<CommitMeta> updateCommitMetadata,
-      MergeBehaviors mergeBehaviors,
-      boolean dryRun)
+  public MergeResult<Commit> transplant(Optional<?> retryState, TransplantOp transplantOp)
       throws ReferenceNotFoundException, RetryException, ReferenceConflictException {
-    SourceCommitsAndParent sourceCommits = loadSourceCommitsForTransplant(sequenceToTransplant);
+    SourceCommitsAndParent sourceCommits =
+        loadSourceCommitsForTransplant(transplantOp.sequenceToTransplant());
 
     ImmutableMergeResult.Builder<Commit> mergeResult =
-        prepareMergeResult().resultType(ResultType.TRANSPLANT).sourceRef(sourceRef);
+        prepareMergeResult().resultType(ResultType.TRANSPLANT).sourceRef(transplantOp.fromRef());
 
-    return squash(dryRun, mergeResult, mergeBehaviors, updateCommitMetadata, sourceCommits, null);
+    return squash(transplantOp, mergeResult, sourceCommits, null);
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMergeKeyBehaviors.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMergeKeyBehaviors.java
@@ -22,7 +22,6 @@ import static org.projectnessie.model.CommitMeta.fromMessage;
 import static org.projectnessie.model.MergeBehavior.DROP;
 import static org.projectnessie.model.MergeBehavior.FORCE;
 import static org.projectnessie.model.MergeBehavior.NORMAL;
-import static org.projectnessie.versioned.tests.AbstractVersionStoreTestBase.METADATA_REWRITER;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
@@ -49,6 +48,7 @@ import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.MergeResult;
 import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.VersionStore.MergeOp;
 
 @ExtendWith(SoftAssertionsExtension.class)
 public abstract class AbstractMergeKeyBehaviors extends AbstractNestedVersionStore {
@@ -232,16 +232,14 @@ public abstract class AbstractMergeKeyBehaviors extends AbstractNestedVersionSto
     MergeResult<Commit> mergeResult =
         store()
             .merge(
-                sourceName,
-                source,
-                targetName,
-                Optional.of(target),
-                METADATA_REWRITER,
-                false,
-                mergeKeyBehaviors,
-                defaultMergeBehavior,
-                false,
-                false);
+                MergeOp.builder()
+                    .fromRef(sourceName)
+                    .fromHash(source)
+                    .toBranch(targetName)
+                    .expectedHash(Optional.of(target))
+                    .putAllMergeKeyBehaviors(mergeKeyBehaviors)
+                    .defaultMergeBehavior(defaultMergeBehavior)
+                    .build());
     soft.assertThat(mergeResult)
         .extracting(MergeResult::wasApplied, MergeResult::wasSuccessful)
         .containsExactly(true, true);

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNoNamespaceValidation.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNoNamespaceValidation.java
@@ -15,10 +15,7 @@
  */
 package org.projectnessie.versioned.tests;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
-import static org.projectnessie.versioned.tests.AbstractVersionStoreTestBase.METADATA_REWRITER;
 import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
 
 import java.util.Optional;
@@ -31,13 +28,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
-import org.projectnessie.model.MergeBehavior;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.CommitResult;
 import org.projectnessie.versioned.Hash;
 import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.VersionStore.MergeOp;
+import org.projectnessie.versioned.VersionStore.TransplantOp;
 
 /** Verifies that namespace validation, if disabled, is not effective. */
 @ExtendWith(SoftAssertionsExtension.class)
@@ -110,29 +108,21 @@ public abstract class AbstractNoNamespaceValidation {
               if (merge) {
                 store()
                     .merge(
-                        branch,
-                        commit2,
-                        root,
-                        Optional.empty(),
-                        METADATA_REWRITER,
-                        individual,
-                        emptyMap(),
-                        MergeBehavior.NORMAL,
-                        false,
-                        false);
+                        MergeOp.builder()
+                            .fromRef(branch)
+                            .fromHash(commit2)
+                            .toBranch(root)
+                            .keepIndividualCommits(individual)
+                            .build());
               } else {
                 store()
                     .transplant(
-                        branch,
-                        root,
-                        Optional.empty(),
-                        asList(commit1, commit2),
-                        METADATA_REWRITER,
-                        individual,
-                        emptyMap(),
-                        MergeBehavior.NORMAL,
-                        false,
-                        false);
+                        TransplantOp.builder()
+                            .fromRef(branch)
+                            .toBranch(root)
+                            .addSequenceToTransplant(commit1, commit2)
+                            .keepIndividualCommits(individual)
+                            .build());
               }
             })
         .doesNotThrowAnyException();

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractTransplant.java
@@ -22,7 +22,6 @@ import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -49,6 +48,7 @@ import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.VersionStore.TransplantOp;
 import org.projectnessie.versioned.VersionStoreException;
 import org.projectnessie.versioned.paging.PaginationIterator;
 import org.projectnessie.versioned.testworker.OnRefOnly;
@@ -167,16 +167,14 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
     MergeResult<Commit> result =
         store()
             .transplant(
-                sourceBranch,
-                newBranch,
-                Optional.of(initialHash),
-                Arrays.asList(firstCommit, secondCommit, thirdCommit),
-                commitMetaModify,
-                individualCommits,
-                Collections.emptyMap(),
-                MergeBehavior.NORMAL,
-                false,
-                false);
+                TransplantOp.builder()
+                    .fromRef(sourceBranch)
+                    .toBranch(newBranch)
+                    .expectedHash(Optional.of(initialHash))
+                    .addSequenceToTransplant(firstCommit, secondCommit, thirdCommit)
+                    .updateCommitMetadata(commitMetaModify)
+                    .keepIndividualCommits(individualCommits)
+                    .build());
 
     if (individualCommits) {
       soft.assertThat(result.getCreatedCommits()).isEmpty(); // fast-forward
@@ -219,16 +217,14 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
     MergeResult<Commit> result =
         store()
             .transplant(
-                sourceBranch,
-                newBranch,
-                Optional.of(initialHash),
-                Arrays.asList(firstCommit, secondCommit, thirdCommit),
-                createMetadataRewriter(""),
-                individualCommits,
-                Collections.emptyMap(),
-                MergeBehavior.NORMAL,
-                false,
-                false);
+                TransplantOp.builder()
+                    .fromRef(sourceBranch)
+                    .toBranch(newBranch)
+                    .expectedHash(Optional.of(initialHash))
+                    .addSequenceToTransplant(firstCommit, secondCommit, thirdCommit)
+                    .updateCommitMetadata(createMetadataRewriter(""))
+                    .keepIndividualCommits(individualCommits)
+                    .build());
 
     if (individualCommits) {
       checkRebasedCommits(targetHead, result); // no fast-forward
@@ -385,16 +381,15 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             () ->
                 store()
                     .transplant(
-                        sourceBranch,
-                        newBranch,
-                        Optional.of(initialHash),
-                        Arrays.asList(firstCommit, secondCommit, thirdCommit),
-                        createMetadataRewriter(""),
-                        individualCommits,
-                        Collections.emptyMap(),
-                        MergeBehavior.NORMAL,
-                        dryRun,
-                        false))
+                        TransplantOp.builder()
+                            .fromRef(sourceBranch)
+                            .toBranch(newBranch)
+                            .expectedHash(Optional.of(initialHash))
+                            .addSequenceToTransplant(firstCommit, secondCommit, thirdCommit)
+                            .updateCommitMetadata(createMetadataRewriter(""))
+                            .keepIndividualCommits(individualCommits)
+                            .dryRun(dryRun)
+                            .build()))
         .isInstanceOf(ReferenceConflictException.class);
     if (dryRun) {
       checkpoint.assertNoWrites();
@@ -411,16 +406,14 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
 
     store()
         .transplant(
-            sourceBranch,
-            newBranch,
-            Optional.of(initialHash),
-            Arrays.asList(firstCommit, secondCommit, thirdCommit),
-            createMetadataRewriter(""),
-            individualCommits,
-            Collections.emptyMap(),
-            MergeBehavior.NORMAL,
-            false,
-            false);
+            TransplantOp.builder()
+                .fromRef(sourceBranch)
+                .toBranch(newBranch)
+                .expectedHash(Optional.of(initialHash))
+                .addSequenceToTransplant(firstCommit, secondCommit, thirdCommit)
+                .updateCommitMetadata(createMetadataRewriter(""))
+                .keepIndividualCommits(individualCommits)
+                .build());
     soft.assertThat(
             contentsWithoutId(
                 store()
@@ -452,16 +445,15 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             () ->
                 store()
                     .transplant(
-                        sourceBranch,
-                        newBranch,
-                        Optional.of(initialHash),
-                        Arrays.asList(firstCommit, secondCommit, thirdCommit),
-                        createMetadataRewriter(""),
-                        individualCommits,
-                        Collections.emptyMap(),
-                        MergeBehavior.NORMAL,
-                        dryRun,
-                        false))
+                        TransplantOp.builder()
+                            .fromRef(sourceBranch)
+                            .toBranch(newBranch)
+                            .expectedHash(Optional.of(initialHash))
+                            .addSequenceToTransplant(firstCommit, secondCommit, thirdCommit)
+                            .updateCommitMetadata(createMetadataRewriter(""))
+                            .keepIndividualCommits(individualCommits)
+                            .dryRun(dryRun)
+                            .build()))
         .isInstanceOf(ReferenceNotFoundException.class);
     checkpoint.assertNoWrites();
   }
@@ -482,16 +474,15 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             () ->
                 store()
                     .transplant(
-                        sourceBranch,
-                        newBranch,
-                        Optional.of(initialHash),
-                        Collections.singletonList(Hash.of("1234567890abcdef")),
-                        createMetadataRewriter(""),
-                        individualCommits,
-                        Collections.emptyMap(),
-                        MergeBehavior.NORMAL,
-                        dryRun,
-                        false))
+                        TransplantOp.builder()
+                            .fromRef(sourceBranch)
+                            .toBranch(newBranch)
+                            .expectedHash(Optional.of(initialHash))
+                            .addSequenceToTransplant(Hash.of("1234567890abcdef"))
+                            .updateCommitMetadata(createMetadataRewriter(""))
+                            .keepIndividualCommits(individualCommits)
+                            .dryRun(dryRun)
+                            .build()))
         .isInstanceOf(ReferenceNotFoundException.class);
     checkpoint.assertNoWrites();
   }
@@ -508,16 +499,13 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
 
     store()
         .transplant(
-            sourceBranch,
-            newBranch,
-            Optional.empty(),
-            Arrays.asList(firstCommit, secondCommit, thirdCommit),
-            createMetadataRewriter(""),
-            individualCommits,
-            Collections.emptyMap(),
-            MergeBehavior.NORMAL,
-            false,
-            false);
+            TransplantOp.builder()
+                .fromRef(sourceBranch)
+                .toBranch(newBranch)
+                .addSequenceToTransplant(firstCommit, secondCommit, thirdCommit)
+                .updateCommitMetadata(createMetadataRewriter(""))
+                .keepIndividualCommits(individualCommits)
+                .build());
     soft.assertThat(
             contentsWithoutId(
                 store()
@@ -554,16 +542,14 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             () ->
                 store()
                     .transplant(
-                        sourceBranch,
-                        newBranch,
-                        Optional.empty(),
-                        Arrays.asList(secondCommit, firstCommit, thirdCommit),
-                        createMetadataRewriter(""),
-                        individualCommits,
-                        Collections.emptyMap(),
-                        MergeBehavior.NORMAL,
-                        dryRun,
-                        false));
+                        TransplantOp.builder()
+                            .fromRef(sourceBranch)
+                            .toBranch(newBranch)
+                            .addSequenceToTransplant(secondCommit, firstCommit, thirdCommit)
+                            .updateCommitMetadata(createMetadataRewriter(""))
+                            .keepIndividualCommits(individualCommits)
+                            .dryRun(dryRun)
+                            .build()));
   }
 
   @ParameterizedTest
@@ -592,16 +578,15 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
             () ->
                 store()
                     .transplant(
-                        sourceBranch,
-                        newBranch,
-                        Optional.of(unrelatedCommit),
-                        Arrays.asList(firstCommit, secondCommit, thirdCommit),
-                        createMetadataRewriter(""),
-                        individualCommits,
-                        Collections.emptyMap(),
-                        MergeBehavior.NORMAL,
-                        dryRun,
-                        false))
+                        TransplantOp.builder()
+                            .fromRef(sourceBranch)
+                            .toBranch(newBranch)
+                            .expectedHash(Optional.of(unrelatedCommit))
+                            .addSequenceToTransplant(firstCommit, secondCommit, thirdCommit)
+                            .updateCommitMetadata(createMetadataRewriter(""))
+                            .keepIndividualCommits(individualCommits)
+                            .dryRun(dryRun)
+                            .build()))
         .isInstanceOf(ReferenceNotFoundException.class);
     checkpoint.assertNoWrites();
   }
@@ -616,16 +601,14 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
     MergeResult<Commit> result =
         store()
             .transplant(
-                sourceBranch,
-                newBranch,
-                Optional.of(initialHash),
-                Arrays.asList(firstCommit, secondCommit),
-                createMetadataRewriter(""),
-                individualCommits,
-                Collections.emptyMap(),
-                MergeBehavior.NORMAL,
-                false,
-                false);
+                TransplantOp.builder()
+                    .fromRef(sourceBranch)
+                    .toBranch(newBranch)
+                    .expectedHash(Optional.of(initialHash))
+                    .addSequenceToTransplant(firstCommit, secondCommit)
+                    .updateCommitMetadata(createMetadataRewriter(""))
+                    .keepIndividualCommits(individualCommits)
+                    .build());
 
     if (individualCommits) {
       soft.assertThat(result.getCreatedCommits())
@@ -719,20 +702,16 @@ public abstract class AbstractTransplant extends AbstractNestedVersionStore {
 
     store()
         .transplant(
-            source,
-            target,
-            Optional.of(targetHead),
-            Arrays.asList(source1, source2),
-            createMetadataRewriter(", merge-drop"),
-            individualCommits,
-            ImmutableMap.of(
-                key1,
-                MergeKeyBehavior.of(key1, MergeBehavior.DROP),
-                key2,
-                MergeKeyBehavior.of(key2, MergeBehavior.DROP)),
-            MergeBehavior.NORMAL,
-            false,
-            false);
+            TransplantOp.builder()
+                .fromRef(source)
+                .toBranch(target)
+                .expectedHash(Optional.of(targetHead))
+                .addSequenceToTransplant(source1, source2)
+                .updateCommitMetadata(createMetadataRewriter(", merge-drop"))
+                .keepIndividualCommits(individualCommits)
+                .putMergeKeyBehaviors(key1, MergeKeyBehavior.of(key1, MergeBehavior.DROP))
+                .putMergeKeyBehaviors(key2, MergeKeyBehavior.of(key2, MergeBehavior.DROP))
+                .build());
 
     // No new commit should have been created in the target branch
     try (PaginationIterator<Commit> iterator = store().getCommits(target, true)) {

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractVersionStoreTestBase.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractVersionStoreTestBase.java
@@ -15,10 +15,7 @@
  */
 package org.projectnessie.versioned.tests;
 
-import java.util.List;
 import org.junit.jupiter.api.Nested;
-import org.projectnessie.model.CommitMeta;
-import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.VersionStore;
 
 /** Base class used for integration tests against version store implementations. */
@@ -123,17 +120,4 @@ public abstract class AbstractVersionStoreTestBase {
       super(AbstractVersionStoreTestBase.this.store());
     }
   }
-
-  public static final MetadataRewriter<CommitMeta> METADATA_REWRITER =
-      new MetadataRewriter<CommitMeta>() {
-        @Override
-        public CommitMeta rewriteSingle(CommitMeta metadata) {
-          return metadata;
-        }
-
-        @Override
-        public CommitMeta squash(List<CommitMeta> metadata) {
-          return metadata.get(0);
-        }
-      };
 }


### PR DESCRIPTION
No functional change, replacing the many arguments for `VersionStore.merge()` + `.transplant()`