### PR TITLE
Enhancements to the Events API

### DIFF
--- a/events/api/src/main/java/org/projectnessie/events/api/CommitEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/CommitEvent.java
@@ -22,7 +22,7 @@ import org.immutables.value.Value;
  * persisted.
  */
 @Value.Immutable
-public interface CommitEvent extends CommittingEvent {
+public interface CommitEvent extends ReferenceEvent, WithHashBeforeEvent, WithHashAfterEvent {
 
   @Override
   @Value.Default

--- a/events/api/src/main/java/org/projectnessie/events/api/CommitMeta.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/CommitMeta.java
@@ -53,11 +53,11 @@ public interface CommitMeta {
   /** The commit message. */
   String getMessage();
 
-  /** The commit time. */
-  Instant getCommitTime();
+  /** The commit timestamp, as set by the server. */
+  Instant getCommitTimestamp();
 
-  /** Original commit time. */
-  Instant getAuthorTime();
+  /** Original commit timestamp, as provided by the user. */
+  Instant getAuthorTimestamp();
 
   /** Single-valued properties of this commit. */
   @Value.Lazy

--- a/events/api/src/main/java/org/projectnessie/events/api/ContentEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/ContentEvent.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.events.api;
 
+import java.time.Instant;
+
 /**
  * Event that is emitted when a content is stored (PUT) or removed (DELETE).
  *
@@ -25,17 +27,13 @@ package org.projectnessie.events.api;
  *   <li>{@link ContentRemovedEvent}: for DELETE operations.
  * </ul>
  */
-public interface ContentEvent extends Event {
-
-  /**
-   * The reference that the content was stored in or removed from.
-   *
-   * <p>For the time being, the reference is guaranteed to be a branch.
-   */
-  Reference getReference();
+public interface ContentEvent extends ReferenceEvent {
 
   /** The hash of the commit that the content was stored in or removed from. */
   String getHash();
+
+  /** The timestamp of the commit that the content was stored in or removed from. */
+  Instant getCommitCreationTimestamp();
 
   /** The key of the content that was stored or removed. */
   ContentKey getContentKey();

--- a/events/api/src/main/java/org/projectnessie/events/api/MergeEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/MergeEvent.java
@@ -22,7 +22,7 @@ import org.immutables.value.Value;
  * persisted.
  */
 @Value.Immutable
-public interface MergeEvent extends CommittingEvent {
+public interface MergeEvent extends MultiReferenceEvent, WithHashBeforeEvent, WithHashAfterEvent {
 
   @Override
   @Value.Default

--- a/events/api/src/main/java/org/projectnessie/events/api/MultiReferenceEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/MultiReferenceEvent.java
@@ -16,24 +16,20 @@
 package org.projectnessie.events.api;
 
 /**
- * Event that is emitted when a transaction is written to the catalog.
+ * Event that affects two references: a source and a target.
  *
- * <p>This type has 3 child interfaces:
+ * <p>This type has 2 child interfaces:
  *
  * <ul>
- *   <li>{@link CommitEvent}: for commits;
  *   <li>{@link MergeEvent}: for merges;
  *   <li>{@link TransplantEvent}: for transplants.
  * </ul>
  */
-public interface CommittingEvent extends Event {
+public interface MultiReferenceEvent extends Event {
 
   /**
-   * The source reference where the committed operations came from. This is usually a branch, but
+   * The source reference where the committed operations come from. This is usually a branch, but
    * not always (e.g. it could be a tag or a detached reference).
-   *
-   * <p>For commits, this is always the same as the {@linkplain #getTargetReference() target
-   * reference}.
    */
   Reference getSourceReference();
 
@@ -43,10 +39,4 @@ public interface CommittingEvent extends Event {
    * <p>For the time being, the target reference is guaranteed to be a branch.
    */
   Reference getTargetReference();
-
-  /** The hash on the {@linkplain #getTargetReference() target reference} before the event. */
-  String getHashBefore();
-
-  /** The hash on the {@linkplain #getTargetReference() target reference} after the event. */
-  String getHashAfter();
 }

--- a/events/api/src/main/java/org/projectnessie/events/api/ReferenceCreatedEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/ReferenceCreatedEvent.java
@@ -19,14 +19,11 @@ import org.immutables.value.Value;
 
 /** Event that is emitted after a reference is created. */
 @Value.Immutable
-public interface ReferenceCreatedEvent extends ReferenceEvent {
+public interface ReferenceCreatedEvent extends ReferenceEvent, WithHashAfterEvent {
 
   @Value.Default
   @Override
   default EventType getType() {
     return EventType.REFERENCE_CREATED;
   }
-
-  /** The hash of the reference after the creation. */
-  String getHashAfter();
 }

--- a/events/api/src/main/java/org/projectnessie/events/api/ReferenceEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/ReferenceEvent.java
@@ -16,11 +16,13 @@
 package org.projectnessie.events.api;
 
 /**
- * Event that is emitted when a reference is created, updated or deleted.
+ * Event that affects only one reference.
  *
- * <p>This type has 3 child interfaces:
+ * <p>This type has many child interfaces:
  *
  * <ul>
+ *   <li>{@link CommitEvent}: for commits;
+ *   <li>{@link ContentEvent}: for content events (PUT / DELETE operations);
  *   <li>{@link ReferenceCreatedEvent}: for reference creations;
  *   <li>{@link ReferenceUpdatedEvent}: for reference updates (reassignments);
  *   <li>{@link ReferenceDeletedEvent}: for reference deletions.

--- a/events/api/src/main/java/org/projectnessie/events/api/ReferenceUpdatedEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/ReferenceUpdatedEvent.java
@@ -19,17 +19,12 @@ import org.immutables.value.Value;
 
 /** Event that is emitted after a reference is updated. */
 @Value.Immutable
-public interface ReferenceUpdatedEvent extends ReferenceEvent {
+public interface ReferenceUpdatedEvent
+    extends ReferenceEvent, WithHashBeforeEvent, WithHashAfterEvent {
 
   @Value.Default
   @Override
   default EventType getType() {
     return EventType.REFERENCE_UPDATED;
   }
-
-  /** The hash of the reference before the update. */
-  String getHashBefore();
-
-  /** The hash of the reference after the update. */
-  String getHashAfter();
 }

--- a/events/api/src/main/java/org/projectnessie/events/api/TransplantEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/TransplantEvent.java
@@ -22,7 +22,8 @@ import org.immutables.value.Value;
  * has been persisted.
  */
 @Value.Immutable
-public interface TransplantEvent extends CommittingEvent {
+public interface TransplantEvent
+    extends MultiReferenceEvent, WithHashBeforeEvent, WithHashAfterEvent {
 
   @Override
   @Value.Default

--- a/events/api/src/main/java/org/projectnessie/events/api/WithHashAfterEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/WithHashAfterEvent.java
@@ -15,15 +15,8 @@
  */
 package org.projectnessie.events.api;
 
-import org.immutables.value.Value;
+public interface WithHashAfterEvent {
 
-/** Event that is emitted after a reference is deleted. */
-@Value.Immutable
-public interface ReferenceDeletedEvent extends ReferenceEvent, WithHashBeforeEvent {
-
-  @Value.Default
-  @Override
-  default EventType getType() {
-    return EventType.REFERENCE_DELETED;
-  }
+  /** The hash on the target reference after the event. */
+  String getHashAfter();
 }

--- a/events/api/src/main/java/org/projectnessie/events/api/WithHashBeforeEvent.java
+++ b/events/api/src/main/java/org/projectnessie/events/api/WithHashBeforeEvent.java
@@ -15,15 +15,8 @@
  */
 package org.projectnessie.events.api;
 
-import org.immutables.value.Value;
+public interface WithHashBeforeEvent {
 
-/** Event that is emitted after a reference is deleted. */
-@Value.Immutable
-public interface ReferenceDeletedEvent extends ReferenceEvent, WithHashBeforeEvent {
-
-  @Value.Default
-  @Override
-  default EventType getType() {
-    return EventType.REFERENCE_DELETED;
-  }
+  /** The hash on the target reference before the event. */
+  String getHashBefore();
 }

--- a/events/api/src/test/java/org/projectnessie/events/api/TestCommitMeta.java
+++ b/events/api/src/test/java/org/projectnessie/events/api/TestCommitMeta.java
@@ -54,7 +54,7 @@ class TestCommitMeta {
     return ImmutableCommitMeta.builder()
         .committer("committer")
         .message("message")
-        .commitTime(Instant.now())
-        .authorTime(Instant.now());
+        .commitTimestamp(Instant.now())
+        .authorTimestamp(Instant.now());
   }
 }

--- a/events/api/src/test/java/org/projectnessie/events/api/TestEventType.java
+++ b/events/api/src/test/java/org/projectnessie/events/api/TestEventType.java
@@ -41,8 +41,7 @@ class TestEventType {
   void commit() {
     CommitEvent event =
         ImmutableCommitEvent.builder()
-            .sourceReference(branch1)
-            .targetReference(branch2)
+            .reference(branch2)
             .hashBefore("hash1")
             .hashAfter("hash2")
             .id(UUID.randomUUID())
@@ -51,10 +50,10 @@ class TestEventType {
             .eventInitiator("Alice")
             .commitMeta(
                 ImmutableCommitMeta.builder()
-                    .commitTime(Instant.now())
+                    .commitTimestamp(Instant.now())
                     .committer("committer")
                     .message("message")
-                    .authorTime(Instant.now())
+                    .authorTimestamp(Instant.now())
                     .build())
             .build();
     assertThat(event.getType()).isEqualTo(EventType.COMMIT);
@@ -148,6 +147,7 @@ class TestEventType {
             .eventCreationTimestamp(Instant.now())
             .eventInitiator("Alice")
             .content(mock(Content.class))
+            .commitCreationTimestamp(Instant.now())
             .build();
     assertThat(event.getType()).isEqualTo(EventType.CONTENT_STORED);
   }
@@ -163,6 +163,7 @@ class TestEventType {
             .repositoryId("repo1")
             .eventCreationTimestamp(Instant.now())
             .eventInitiator("Alice")
+            .commitCreationTimestamp(Instant.now())
             .build();
     assertThat(event.getType()).isEqualTo(EventType.CONTENT_REMOVED);
   }

--- a/events/service/src/main/java/org/projectnessie/events/service/EventFactory.java
+++ b/events/service/src/main/java/org/projectnessie/events/service/EventFactory.java
@@ -17,6 +17,7 @@ package org.projectnessie.events.service;
 
 import jakarta.annotation.Nullable;
 import java.security.Principal;
+import java.time.Instant;
 import java.util.Objects;
 import org.projectnessie.events.api.Content;
 import org.projectnessie.events.api.ContentKey;
@@ -64,8 +65,7 @@ public class EventFactory {
             .eventCreationTimestamp(config.getClock().instant())
             .repositoryId(repositoryId)
             .properties(config.getStaticProperties())
-            .sourceReference(ReferenceMapping.map(targetBranch)) // same as target for commits
-            .targetReference(ReferenceMapping.map(targetBranch))
+            .reference(ReferenceMapping.map(targetBranch))
             .hashBefore(Objects.requireNonNull(commit.getParentHash()).asString())
             .hashAfter(commit.getHash().asString())
             .commitMeta(
@@ -74,8 +74,8 @@ public class EventFactory {
                     .authors(commitMeta.getAllAuthors())
                     .allSignedOffBy(commitMeta.getAllSignedOffBy())
                     .message(commitMeta.getMessage())
-                    .commitTime(Objects.requireNonNull(commitMeta.getCommitTime()))
-                    .authorTime(Objects.requireNonNull(commitMeta.getAuthorTime()))
+                    .commitTimestamp(Objects.requireNonNull(commitMeta.getCommitTime()))
+                    .authorTimestamp(Objects.requireNonNull(commitMeta.getAuthorTime()))
                     .allProperties(commitMeta.getAllProperties())
                     .build());
     if (user != null) {
@@ -176,6 +176,7 @@ public class EventFactory {
   protected Event newContentStoredEvent(
       BranchName branch,
       Hash hash,
+      Instant commitTimestamp,
       ContentKey contentKey,
       Content content,
       String repositoryId,
@@ -190,7 +191,8 @@ public class EventFactory {
             .reference(ReferenceMapping.map(branch))
             .hash(hash.asString())
             .contentKey(contentKey)
-            .content(content);
+            .content(content)
+            .commitCreationTimestamp(commitTimestamp);
     if (user != null) {
       builder.eventInitiator(user.getName());
     }
@@ -200,6 +202,7 @@ public class EventFactory {
   protected Event newContentRemovedEvent(
       BranchName branch,
       Hash hash,
+      Instant commitTimestamp,
       ContentKey contentKey,
       String repositoryId,
       @Nullable Principal user) {
@@ -212,7 +215,8 @@ public class EventFactory {
             .properties(config.getStaticProperties())
             .reference(ReferenceMapping.map(branch))
             .hash(hash.asString())
-            .contentKey(contentKey);
+            .contentKey(contentKey)
+            .commitCreationTimestamp(commitTimestamp);
     if (user != null) {
       builder.eventInitiator(user.getName());
     }

--- a/events/service/src/main/java/org/projectnessie/events/service/EventService.java
+++ b/events/service/src/main/java/org/projectnessie/events/service/EventService.java
@@ -17,6 +17,7 @@ package org.projectnessie.events.service;
 
 import jakarta.annotation.Nullable;
 import java.security.Principal;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -228,17 +229,19 @@ public class EventService implements AutoCloseable {
     List<Operation> operations = commit.getOperations();
     if (operations != null && !operations.isEmpty()) {
       Hash hash = Objects.requireNonNull(commit.getHash());
+      Instant commitTime = Objects.requireNonNull(commit.getCommitMeta().getCommitTime());
       for (org.projectnessie.versioned.Operation operation : operations) {
         if (operation instanceof org.projectnessie.versioned.Put) {
           ContentKey contentKey = ContentMapping.map(operation.getKey());
           Content content = ContentMapping.map(((Put) operation).getValue());
           fireEvent(
               factory.newContentStoredEvent(
-                  targetBranch, hash, contentKey, content, repositoryId, user));
+                  targetBranch, hash, commitTime, contentKey, content, repositoryId, user));
         } else if (operation instanceof org.projectnessie.versioned.Delete) {
           ContentKey contentKey = ContentMapping.map(operation.getKey());
           fireEvent(
-              factory.newContentRemovedEvent(targetBranch, hash, contentKey, repositoryId, user));
+              factory.newContentRemovedEvent(
+                  targetBranch, hash, commitTime, contentKey, repositoryId, user));
         }
       }
     }

--- a/events/service/src/test/java/org/projectnessie/events/service/TestEventFactory.java
+++ b/events/service/src/test/java/org/projectnessie/events/service/TestEventFactory.java
@@ -117,15 +117,14 @@ class TestEventFactory {
                 .putProperty("key", "value")
                 .hashBefore(Hash.of("1234").asString())
                 .hashAfter(Hash.of("5678").asString())
-                .sourceReference(branch1)
-                .targetReference(branch1)
+                .reference(branch1)
                 .commitMeta(
                     ImmutableCommitMeta.builder()
                         .message("message")
                         .addAuthor("author")
                         .committer("committer")
-                        .authorTime(now)
-                        .commitTime(now)
+                        .authorTimestamp(now)
+                        .commitTimestamp(now)
                         .build())
                 .build());
   }
@@ -273,6 +272,7 @@ class TestEventFactory {
         ef.newContentStoredEvent(
             BranchName.of("branch1"),
             Hash.of("1234"),
+            now,
             ContentKey.of("foo.bar.table1"),
             table,
             "repo1",
@@ -287,6 +287,7 @@ class TestEventFactory {
                 .putProperty("key", "value")
                 .reference(branch1)
                 .hash(Hash.of("1234").asString())
+                .commitCreationTimestamp(now)
                 .contentKey(ContentKey.of("foo.bar.table1"))
                 .content(table)
                 .build());
@@ -299,6 +300,7 @@ class TestEventFactory {
         ef.newContentRemovedEvent(
             BranchName.of("branch1"),
             Hash.of("1234"),
+            now,
             ContentKey.of("foo.bar.table1"),
             "repo1",
             () -> "alice");
@@ -312,6 +314,7 @@ class TestEventFactory {
                 .putProperty("key", "value")
                 .reference(branch1)
                 .hash(Hash.of("1234").asString())
+                .commitCreationTimestamp(now)
                 .contentKey(ContentKey.of("foo.bar.table1"))
                 .build());
   }

--- a/events/spi/src/test/java/org/projectnessie/events/spi/TestEventFilter.java
+++ b/events/spi/src/test/java/org/projectnessie/events/spi/TestEventFilter.java
@@ -31,13 +31,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.projectnessie.events.api.CommitEvent;
-import org.projectnessie.events.api.CommittingEvent;
 import org.projectnessie.events.api.ContentRemovedEvent;
 import org.projectnessie.events.api.ContentStoredEvent;
 import org.projectnessie.events.api.Event;
 import org.projectnessie.events.api.MergeEvent;
 import org.projectnessie.events.api.ReferenceCreatedEvent;
 import org.projectnessie.events.api.ReferenceDeletedEvent;
+import org.projectnessie.events.api.ReferenceEvent;
 import org.projectnessie.events.api.ReferenceUpdatedEvent;
 import org.projectnessie.events.api.TransplantEvent;
 
@@ -81,8 +81,8 @@ class TestEventFilter {
   @Test
   void and() {
     EventFilter isCommit = e -> e instanceof CommitEvent;
-    EventFilter isCommitting = e -> e instanceof CommittingEvent;
-    EventFilter filter = EventFilter.and(isCommit, isCommitting);
+    EventFilter isReference = e -> e instanceof ReferenceEvent;
+    EventFilter filter = EventFilter.and(isCommit, isReference);
     assertThat(filter.test(commitEvent)).isTrue();
     assertThat(filter.test(mergeEvent)).isFalse();
     assertThat(filter.test(transplantEvent)).isFalse();


### PR DESCRIPTION
This PR introduces two enhancements that seemed interesting to me while preparing #6943 :

1. Get rid of the awkward `CommitEvent.getSourceReference()` method by introducing a few more common interfaces.
2. Introduce a new `ContentEvent.getCommitCreationTimestamp()` that might be helpful to determine the order in which the operations were applied.