### PR TITLE
Emit access-checks for merge and transplant

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -370,10 +370,16 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
                   .operations()
                   .forEach(
                       op -> {
-                        if (op.operation() instanceof org.projectnessie.versioned.Put) {
-                          check.canUpdateEntity(branch, op.identifiedKey());
-                        } else {
-                          check.canDeleteEntity(branch, op.identifiedKey());
+                        switch (op.operation()) {
+                          case PUT:
+                            check.canUpdateEntity(branch, op.identifiedKey());
+                            break;
+                          case DELETE:
+                            check.canDeleteEntity(branch, op.identifiedKey());
+                            break;
+                          default:
+                            throw new UnsupportedOperationException(
+                                "Unknown operation type " + op.operation());
                         }
                       });
               check.checkAndThrow();

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -182,13 +182,13 @@ public class PersistVersionStore implements VersionStore {
             CommitValidation.CommitOperation.commitOperation(
                 identifiedContentKeyFromContent(
                     op.getKey(), contentTypeForPayload(payload), contentId.getId(), x -> null),
-                operation));
+                operation.getType()));
       } else if (operation instanceof Delete) {
         commitAttempt.addDeletes(operation.getKey());
         commitValidation.addOperations(
             CommitValidation.CommitOperation.commitOperation(
                 identifiedContentKeyFromContent(operation.getKey(), null, null, x -> null),
-                operation));
+                operation.getType()));
       } else if (operation instanceof Unchanged) {
         commitAttempt.addUnchanged(operation.getKey());
       } else {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/CommitValidation.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/CommitValidation.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned;
 import java.util.List;
 import org.immutables.value.Value;
 import org.projectnessie.model.IdentifiedContentKey;
+import org.projectnessie.versioned.Operation.OperationType;
 
 @Value.Immutable
 public interface CommitValidation {
@@ -33,10 +34,10 @@ public interface CommitValidation {
     IdentifiedContentKey identifiedKey();
 
     @Value.Parameter(order = 2)
-    Operation operation();
+    OperationType operation();
 
     static CommitOperation commitOperation(
-        IdentifiedContentKey identifiedKey, Operation operation) {
+        IdentifiedContentKey identifiedKey, OperationType operation) {
       return ImmutableCommitOperation.of(identifiedKey, operation);
     }
   }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Delete.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Delete.java
@@ -23,6 +23,11 @@ import org.projectnessie.model.ContentKey;
 @Value.Immutable
 public interface Delete extends Operation {
 
+  @Override
+  default OperationType getType() {
+    return OperationType.DELETE;
+  }
+
   /**
    * Creates a delete operation for the given key.
    *

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Operation.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Operation.java
@@ -32,4 +32,12 @@ public interface Operation {
 
   /** The key for this operation. */
   ContentKey getKey();
+
+  OperationType getType();
+
+  enum OperationType {
+    PUT,
+    DELETE,
+    UNCHANGED
+  }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Put.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Put.java
@@ -40,6 +40,11 @@ public abstract class Put implements Operation {
     return getValueSupplier().get();
   }
 
+  @Override
+  public OperationType getType() {
+    return OperationType.PUT;
+  }
+
   protected abstract Supplier<Content> getValueSupplier();
 
   /**

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/Unchanged.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/Unchanged.java
@@ -27,6 +27,10 @@ import org.projectnessie.model.ContentKey;
  */
 @Value.Immutable
 public interface Unchanged extends Operation {
+  @Override
+  default OperationType getType() {
+    return OperationType.UNCHANGED;
+  }
 
   @Override
   default boolean shouldMatchHash() {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -163,6 +163,11 @@ public interface VersionStore {
     default boolean fetchAdditionalInfo() {
       return false;
     }
+
+    @Value.Default
+    default CommitValidator validator() {
+      return commitValidation -> {};
+    }
   }
 
   @Value.Immutable

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantIndividual.java
@@ -92,6 +92,9 @@ class BaseMergeTransplantIndividual extends BaseCommitHelper {
               sourceParentIndex,
               newHead);
 
+      validateMergeTransplantCommit(
+          createCommit, mergeTransplantOpBase.validator(), targetParentIndex);
+
       verifyMergeTransplantCommitPolicies(targetParentIndex, sourceCommit);
 
       List<Obj> objsToStore = new ArrayList<>();

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantSquash.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantSquash.java
@@ -97,6 +97,9 @@ class BaseMergeTransplantSquash extends BaseCommitHelper {
     // It's okay to do the fetchCommit() here and not complicate the surrounding logic (think:
     // local cache)
     StoreIndex<CommitOp> headIndex = indexesLogic(persist).buildCompleteIndexOrEmpty(head);
+
+    validateMergeTransplantCommit(createCommit, mergeTransplantOpBase.validator(), headIndex);
+
     verifyMergeTransplantCommitPolicies(headIndex, mergeCommit);
 
     mergeBehaviors.postValidate();


### PR DESCRIPTION
Adds `CommitValidator` to `VersionStore`'s merge and tranplant functions, so those can (indirectly) emit access checks for merged/transplanted content.

Replaces the `Content` property of the internal `CommitValidation` value object with the operation type, because otherwise merge+transplant would have to unnecessarily load content objects to construct the `Put` operation, which holds a `Content` object.

Functionality is only implemented for the new storage model.