### PR TITLE
Quarkus tests OOM (again)

### DIFF
--- a/events/quarkus/build.gradle.kts
+++ b/events/quarkus/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
   `java-library`
-  jacoco
   `maven-publish`
   signing
   alias(libs.plugins.quarkus)
@@ -50,7 +49,6 @@ dependencies {
   testImplementation("io.quarkus:quarkus-micrometer-registry-prometheus")
   testImplementation("io.quarkus:quarkus-junit5")
   testImplementation("io.quarkus:quarkus-junit5-mockito")
-  testImplementation("io.quarkus:quarkus-jacoco")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-trace")
 

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -104,7 +104,6 @@ dependencies {
   testFixturesApi("io.quarkus:quarkus-rest-client")
   testFixturesApi("io.quarkus:quarkus-test-security")
   testFixturesApi("io.quarkus:quarkus-test-oidc-server")
-  testFixturesApi("io.quarkus:quarkus-jacoco")
   testFixturesImplementation(libs.guava)
   testFixturesImplementation(libs.microprofile.openapi)
   testFixturesImplementation(libs.awaitility)


### PR DESCRIPTION
The `quarkus-jacoco` extension strikes again... Jacoco keeps stuff around again...

See also #6435