### PR TITLE
Export: fix NPE when only the ZIP file name is supplied

### DIFF
--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ZipArchiveExporter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/files/ZipArchiveExporter.java
@@ -47,7 +47,10 @@ public abstract class ZipArchiveExporter implements ExportFileSupplier {
 
   @Value.Lazy
   ZipOutputStream zipOutput() throws IOException {
-    createDirectories(outputFile().getParent());
+    Path parent = outputFile().getParent();
+    if (parent != null) {
+      createDirectories(parent);
+    }
     return new ZipOutputStream(new BufferedOutputStream(newOutputStream(outputFile())));
   }
 


### PR DESCRIPTION
Calling the export tool with `--path=foo.zip` runs into an NPE, because the parent `Path` is not available.