### PR TITLE
Faster export w/ new data model

### DIFF
--- a/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/ExportRepository.java
+++ b/servers/quarkus-cli/src/main/java/org/projectnessie/quarkus/cli/ExportRepository.java
@@ -47,6 +47,7 @@ public class ExportRepository extends BaseCommand {
   static final String OUTPUT_BUFFER_SIZE = "--output-buffer-size";
   static final String SINGLE_BRANCH = "--single-branch-current-content";
   static final String CONTENT_BATCH_SIZE = "--content-batch-size";
+  static final String COMMIT_BATCH_SIZE = "--commit-batch-size";
 
   enum Format {
     ZIP,
@@ -116,6 +117,14 @@ public class ExportRepository extends BaseCommand {
       })
   private Integer contentsBatchSize;
 
+  @CommandLine.Option(
+      names = COMMIT_BATCH_SIZE,
+      description =
+          "Batch size when reading commits and their associated contents, defaults to "
+              + ExportImportConstants.DEFAULT_COMMIT_BATCH_SIZE
+              + ".")
+  private Integer commitBatchSize;
+
   @Override
   protected Integer callWithDatabaseAdapter() throws Exception {
     return export(
@@ -159,6 +168,9 @@ public class ExportRepository extends BaseCommand {
       }
       if (contentsBatchSize != null) {
         builder.contentsBatchSize(contentsBatchSize);
+      }
+      if (commitBatchSize != null) {
+        builder.commitBatchSize(commitBatchSize);
       }
 
       PrintWriter out = spec.commandLine().getOut();

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/Batcher.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/Batcher.java
@@ -27,14 +27,13 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
  * Buffers a configurable amount of objects and passes those as batches to a consumer, should be
  * used in a <em>try-with-resource</em>.
  */
-final class BatchWriter<T> implements AutoCloseable {
+final class Batcher<T> implements AutoCloseable {
   private final Set<T> buffer;
   private final int capacity;
   private final Consumer<List<T>> flush;
 
-  static BatchWriter<CommitLogEntry> commitBatchWriter(
-      int batchSize, DatabaseAdapter databaseAdapter) {
-    return new BatchWriter<>(
+  static Batcher<CommitLogEntry> commitBatchWriter(int batchSize, DatabaseAdapter databaseAdapter) {
+    return new Batcher<>(
         batchSize,
         entries -> {
           try {
@@ -47,7 +46,7 @@ final class BatchWriter<T> implements AutoCloseable {
         });
   }
 
-  BatchWriter(int capacity, Consumer<List<T>> flush) {
+  Batcher(int capacity, Consumer<List<T>> flush) {
     this.capacity = capacity;
     this.flush = flush;
     this.buffer = Sets.newLinkedHashSetWithExpectedSize(capacity);

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportDatabaseAdapter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportDatabaseAdapter.java
@@ -112,8 +112,8 @@ final class ImportDatabaseAdapter extends ImportCommon {
     int keyListDistance =
         requireNonNull(importer.databaseAdapter()).getConfig().getKeyListDistance();
 
-    try (BatchWriter<CommitLogEntry> commitBatchWriter =
-        BatchWriter.commitBatchWriter(importer.commitBatchSize(), importer.databaseAdapter())) {
+    try (Batcher<CommitLogEntry> commitBatcher =
+        Batcher.commitBatchWriter(importer.commitBatchSize(), importer.databaseAdapter())) {
 
       for (String fileName : exportMeta.getCommitsFilesList()) {
         try (InputStream input = importFiles.newFileInput(fileName)) {
@@ -173,7 +173,7 @@ final class ImportDatabaseAdapter extends ImportCommon {
                       }
                     });
 
-            commitBatchWriter.add(logEntry.build());
+            commitBatcher.add(logEntry.build());
             commitCount++;
 
             importer.progressListener().progress(ProgressEvent.COMMIT_WRITTEN);

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/NessieExporter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/NessieExporter.java
@@ -85,6 +85,12 @@ public abstract class NessieExporter {
 
     Builder contentsBatchSize(int batchSize);
 
+    /**
+     * Optional, specify the number of commit log entries to be written at once, defaults to {@value
+     * ExportImportConstants#DEFAULT_COMMIT_BATCH_SIZE}.
+     */
+    Builder commitBatchSize(int commitBatchSize);
+
     NessieExporter build();
   }
 
@@ -165,6 +171,11 @@ public abstract class NessieExporter {
   @Value.Default
   int expectedCommitCount() {
     return ExportImportConstants.DEFAULT_EXPECTED_COMMIT_COUNT;
+  }
+
+  @Value.Default
+  int commitBatchSize() {
+    return ExportImportConstants.DEFAULT_COMMIT_BATCH_SIZE;
   }
 
   abstract ExportFileSupplier exportFileSupplier();


### PR DESCRIPTION
As described in #6961, exports from the new Nessie data model suffer
from single point queries for each exported commit to retrieve the
operations' contents.

This change leverages the existing `BatchWriter` (renamed to `Batcher`)
to buffer a configurable amount of commits and then fetch the associated
`Obj`s using bulk loads.

Fixes #6961
