### PR TITLE
Build/nit: properly prevent missing compiler annotation warnings

### DIFF
--- a/servers/services-bench/build.gradle.kts
+++ b/servers/services-bench/build.gradle.kts
@@ -36,9 +36,13 @@ dependencies {
   implementation(project(":nessie-versioned-storage-store"))
   implementation(project(":nessie-versioned-storage-testextension"))
 
+  // 'implementation' is necessary here, becasue of the `jmhCompileGeneratedClasses` task
+  implementation(libs.microprofile.openapi)
+  implementation(platform(libs.jackson.bom))
+  implementation("com.fasterxml.jackson.core:jackson-annotations")
+
   jmhImplementation(libs.jmh.core)
   jmhAnnotationProcessor(libs.jmh.generator.annprocess)
-  jmhCompileOnly(libs.microprofile.openapi)
   jmhRuntimeOnly(project(":nessie-versioned-storage-inmemory"))
   jmhRuntimeOnly(project(":nessie-versioned-storage-cassandra"))
   jmhRuntimeOnly(project(":nessie-versioned-storage-rocksdb"))


### PR DESCRIPTION
```
warning: unknown enum constant Include.NON_EMPTY
  reason: class file for com.fasterxml.jackson.annotation.JsonInclude$Include not found
```

```
warning: unknown enum constant SchemaType.OBJECT
  reason: class file for org.eclipse.microprofile.openapi.annotations.enums.SchemaType not found
```