### PR TITLE
Docs: Update Trino version

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Refer to [CONTRIBUTING](./CONTRIBUTING.md) for build instructions.
 
 Nessie Iceberg's integration is compatible with Iceberg as in the following table:
 
-| Nessie version | Iceberg version | Spark version                                                                                 | Hive version | Flink version          | Presto version                      |
-|----------------|-----------------|-----------------------------------------------------------------------------------------------|--------------|------------------------|-------------------------------------|
-| 0.60.1         | 1.3.0           | 3.1.x (Scala 2.12), 3.2.x (Scala 2.12+2.13), 3.3.x (Scala 2.12+2.13), 3.4.x (Scala 2.12+2.13) | n/a          | 1.15.x, 1.16.x, 1.17.x | 0.277, 0.278.x, 0.279, 0.280, 0.281 |
+| Nessie version | Iceberg version | Spark version                                                                                 | Hive version | Flink version          | Presto version                      | Trino version |
+|----------------|-----------------|-----------------------------------------------------------------------------------------------|--------------|------------------------|-------------------------------------|---------------|
+| 0.60.1         | 1.3.0           | 3.1.x (Scala 2.12), 3.2.x (Scala 2.12+2.13), 3.3.x (Scala 2.12+2.13), 3.4.x (Scala 2.12+2.13) | n/a          | 1.15.x, 1.16.x, 1.17.x | 0.277, 0.278.x, 0.279, 0.280, 0.281 | 419           |
 
 Nessie Delta Lake's integration is compatible with Delta Lake as in the following table:
 

--- a/site/docs/tools/iceberg/index.md
+++ b/site/docs/tools/iceberg/index.md
@@ -2,7 +2,7 @@
 
 Nessie works seamlessly with Iceberg in Spark3. Nessie is implemented as a custom Iceberg
 [catalog](http://iceberg.apache.org/custom-catalog/) and therefore supports all features available to any Iceberg
-client. This includes Spark structured streaming, Presto, Flink and Hive. See the [Iceberg docs](https://iceberg.apache.org)
+client. This includes Spark structured streaming, Presto, Trino, Flink and Hive. See the [Iceberg docs](https://iceberg.apache.org)
 for more info. Current Nessie Iceberg integration includes 
 the following:
 


### PR DESCRIPTION
Release notes:
https://trino.io/docs/current/release/release-419.html#iceberg-connector