### PR TITLE
Build/nit: missing annotation dependency

### DIFF
--- a/versioned/transfer/build.gradle.kts
+++ b/versioned/transfer/build.gradle.kts
@@ -83,6 +83,8 @@ dependencies {
 
   intTestRuntimeOnly(libs.h2)
 
+  testCompileOnly(libs.microprofile.openapi)
+
   // javax/jakarta
   testFixturesImplementation(libs.jakarta.annotation.api)
 


### PR DESCRIPTION
Fixes
```
warning: unknown enum constant SchemaType.OBJECT
  reason: class file for org.eclipse.microprofile.openapi.annotations.enums.SchemaType not found
```