### PR TITLE
Database adapters - back to Java 8

### DIFF
--- a/build-logic/src/main/kotlin/nessie-conventions-server8.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-server8.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
+// Java project, non-client facing, server component, Java 11
+
 plugins {
-  id("nessie-conventions-server8")
-  id("nessie-jacoco")
+  `java-library`
+  `maven-publish`
+  signing
+  id("nessie-common-base")
+  id("nessie-common-src")
+  id("nessie-java")
+  id("nessie-testing")
 }
 
-extra["maven.name"] = "Nessie - Versioned - Persist - Rocks/test-support"
-
-dependencies {
-  implementation(project(":nessie-versioned-persist-adapter"))
-  implementation(project(":nessie-versioned-persist-non-transactional"))
-  implementation(project(":nessie-versioned-persist-rocks"))
-  implementation(project(":nessie-versioned-persist-testextension"))
-  implementation(project(":nessie-versioned-persist-non-transactional-test"))
-}
+tasks.withType<JavaCompile>().configureEach { options.release.set(8) }

--- a/build-logic/src/main/kotlin/nessie-conventions-server8.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-server8.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Java project, non-client facing, server component, Java 8
+// Java project, non-client facing, server component, Java 8 (11 for tests)
 
 plugins {
   `java-library`
@@ -26,4 +26,6 @@ plugins {
   id("nessie-testing")
 }
 
-tasks.withType<JavaCompile>().configureEach { options.release.set(8) }
+tasks.withType<JavaCompile>().configureEach {
+  options.release.set(if (this.name == "compileJava") 8 else 11)
+}

--- a/build-logic/src/main/kotlin/nessie-conventions-server8.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-server8.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Java project, non-client facing, server component, Java 11
+// Java project, non-client facing, server component, Java 8
 
 plugins {
   `java-library`

--- a/servers/services/build.gradle.kts
+++ b/servers/services/build.gradle.kts
@@ -17,7 +17,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
   alias(libs.plugins.annotations.stripper)
 }

--- a/servers/store-proto/build.gradle.kts
+++ b/servers/store-proto/build.gradle.kts
@@ -20,7 +20,7 @@ import com.google.protobuf.gradle.ProtobufExtract
 
 plugins {
   alias(libs.plugins.nessie.reflectionconfig)
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   alias(libs.plugins.protobuf)
 }
 

--- a/servers/store/build.gradle.kts
+++ b/servers/store/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
   alias(libs.plugins.annotations.stripper)
 }

--- a/versioned/persist/adapter/build.gradle.kts
+++ b/versioned/persist/adapter/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/bench/build.gradle.kts
+++ b/versioned/persist/bench/build.gradle.kts
@@ -17,7 +17,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-shadow-jar")
 }
 

--- a/versioned/persist/dynamodb-test/build.gradle.kts
+++ b/versioned/persist/dynamodb-test/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/dynamodb/build.gradle.kts
+++ b/versioned/persist/dynamodb/build.gradle.kts
@@ -17,7 +17,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/inmem-test/build.gradle.kts
+++ b/versioned/persist/inmem-test/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/inmem/build.gradle.kts
+++ b/versioned/persist/inmem/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/mongodb-test/build.gradle.kts
+++ b/versioned/persist/mongodb-test/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/mongodb/build.gradle.kts
+++ b/versioned/persist/mongodb/build.gradle.kts
@@ -17,7 +17,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/nontx-test/build.gradle.kts
+++ b/versioned/persist/nontx-test/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/nontx/build.gradle.kts
+++ b/versioned/persist/nontx/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/rocks/build.gradle.kts
+++ b/versioned/persist/rocks/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/serialize-proto/build.gradle.kts
+++ b/versioned/persist/serialize-proto/build.gradle.kts
@@ -20,7 +20,7 @@ import com.google.protobuf.gradle.ProtobufExtract
 
 plugins {
   alias(libs.plugins.nessie.reflectionconfig)
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   alias(libs.plugins.protobuf)
 }
 

--- a/versioned/persist/serialize/build.gradle.kts
+++ b/versioned/persist/serialize/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/store/build.gradle.kts
+++ b/versioned/persist/store/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/testextension/build.gradle.kts
+++ b/versioned/persist/testextension/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-server") }
+plugins { id("nessie-conventions-server8") }
 
 extra["maven.name"] = "Nessie - Versioned - Persist - Testextension"
 

--- a/versioned/persist/tests/build.gradle.kts
+++ b/versioned/persist/tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-server") }
+plugins { id("nessie-conventions-server8") }
 
 extra["maven.name"] = "Nessie - Versioned - Persist - Tests"
 

--- a/versioned/persist/tx-test/build.gradle.kts
+++ b/versioned/persist/tx-test/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/persist/tx/build.gradle.kts
+++ b/versioned/persist/tx/build.gradle.kts
@@ -17,7 +17,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/spi/build.gradle.kts
+++ b/versioned/spi/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-server")
+  id("nessie-conventions-server8")
   id("nessie-jacoco")
 }
 

--- a/versioned/tests/build.gradle.kts
+++ b/versioned/tests/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("nessie-conventions-server") }
+plugins { id("nessie-conventions-server8") }
 
 extra["maven.name"] = "Nessie - Versioned Store Integration Tests"
 


### PR DESCRIPTION
SIGH, some things depend on Java 8, keeping database-adapter code compatible w/ J8.