### PR TITLE
Remove AWS lambda mentions from README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,6 @@ Once this is done you can run your image with `docker run -p 19120:19120 quay.io
 environment variables, if any. Environment variables names must follow MicroProfile Config's [mapping
 rules](https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#environment-variables-mapping-rules).
 
-### AWS Lambda
-You can also deploy to AWS lambda function by following the steps in `servers/lambda/README.md`
-
 ## Nessie related repositories
 
 * [Nessie Demos](https://github.com/projectnessie/nessie-demos): Demos for Nessie

--- a/site/docs/features/security.md
+++ b/site/docs/features/security.md
@@ -7,7 +7,7 @@ Nessie currently supports 3 security modes:
 
 * No Security
 * Open Id Connect
-* AWS IAM Roles (limited to API calls, UI not supported)
+* AWS IAM Roles (supported only on the Nessie client side)
 
 
 ## Authorization
@@ -15,8 +15,7 @@ Nessie currently supports 3 security modes:
 Nessie authorization can only be done externally at the moment. However, because of 
 the way that the REST APIs are defined, many operations can be controlled via a layer 
 7 firewall so that users and systems can be controlled depending on what read/write 
-and types of operations should be allowed. This works especially well with Nessie run 
-as an AWS Lambda using [API gateway policies](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-iam-policy-examples.html).
+and types of operations should be allowed.
 
 ## Metadata authorization
 Nessie supports authorization on metadata. Details are described in the [Metadata Authorization](metadata_authorization.md) section.

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -8,7 +8,7 @@ template: "home.html"
 * Cross-table transactions and visibility
 * Open data lake approach, supporting Hive, Spark, Dremio, AWS Athena, etc.
 * Works with Apache Iceberg and Delta Lake tables
-* Run as a docker image, AWS Lambda or fork it on GitHub
+* Run as a docker image or fork it on GitHub
 
 Get in touch via our [Google Group](https://groups.google.com/g/projectnessie) and our
 [Zulip Chat](https://project-nessie.zulipchat.com/) and follow us on


### PR DESCRIPTION
The Nessie AWS lambda module was dropped in #6819