### PR TITLE
Fetch names references: replace `fetchReference`-per-ref w/ bulk-fetch

### DIFF
--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogicImpl.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
+import static java.util.Collections.emptyIterator;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static org.projectnessie.nessie.relocated.protobuf.ByteString.copyFromUtf8;
@@ -226,31 +227,62 @@ final class ReferenceLogicImpl implements ReferenceLogic {
     private final Iterator<StoreIndexElement<CommitOp>> base;
     private final StoreKey prefix;
 
+    private static final int REFERENCES_BATCH_SIZE = 50;
+    private final List<String> referencesBatch;
+    private Iterator<Reference> referenceIterator = emptyIterator();
+
     private QueryIter(
         StoreIndex<CommitOp> index, StoreKey prefix, StoreKey begin, boolean prefetch) {
       this.index = index;
       this.prefix = prefix;
       this.base = index.iterator(begin, null, prefetch);
+      this.referencesBatch = new ArrayList<>(REFERENCES_BATCH_SIZE);
     }
 
     @Override
     protected Reference computeNext() {
       while (true) {
+        if (referenceIterator.hasNext()) {
+          return referenceIterator.next();
+        }
+
         if (!base.hasNext()) {
+          if (fetchReferencesBatch()) {
+            continue;
+          }
           return endOfData();
         }
 
         StoreIndexElement<CommitOp> el = base.next();
         StoreKey k = el.key();
-        if (prefix != null && !k.startsWith(prefix)) {
-          return endOfData();
-        }
-        String name = k.rawString();
-        Reference r = maybeRecover(name, persist.fetchReference(el.key().rawString()), () -> index);
-        if (r != null) {
-          return r;
+        if (prefix == null || k.startsWith(prefix)) {
+          String name = k.rawString();
+          referencesBatch.add(name);
+          if (referencesBatch.size() == REFERENCES_BATCH_SIZE) {
+            fetchReferencesBatch();
+          }
         }
       }
+    }
+
+    private boolean fetchReferencesBatch() {
+      if (referencesBatch.isEmpty()) {
+        return false;
+      }
+      Reference[] refs = persist.fetchReferences(referencesBatch.toArray(new String[0]));
+      List<Reference> refsList = new ArrayList<>(refs.length);
+      for (int i = 0; i < refs.length; i++) {
+        Reference ref = refs[i];
+        ref = maybeRecover(referencesBatch.get(i), ref, () -> index);
+        if (ref != null) {
+          refsList.add(ref);
+        }
+      }
+
+      referencesBatch.clear();
+      referenceIterator = refsList.iterator();
+
+      return true;
     }
 
     @Nonnull


### PR DESCRIPTION
When listing named references, each `Reference` was fetched with one `Persist.fetchReference()` per reference. This change replaces this with a bulk-fetch of up to 50 references using `Persist.fetchReferences`.