### PR TITLE
More enhancements to docker-compose files

### DIFF
--- a/docker/authn/docker-compose.yml
+++ b/docker/authn/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   nessie:
     image: ghcr.io/projectnessie/nessie:latest
     ports:
-      - 19120:19120
+      - "19120:19120"
     depends_on:
       - keycloak
     environment:
@@ -28,11 +28,19 @@ services:
       QUARKUS_OIDC_ENABLED: true
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/realms/master
       QUARKUS_OIDC_CLIENT_ID: projectnessie
+      # QUARKUS_OIDC_TOKEN_ISSUER: any
   keycloak:
     image: quay.io/keycloak/keycloak:latest
     ports:
-      - 8080:8080
+      - "8080:8080"
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      # Required if Nessie fails to validate the issuer claim;
+      # but the admin console won't be accessible from the host system
+      # at localhost:8080 anymore; you will need to add an entry to
+      # /etc/hosts:
+      # 127.0.0.1  keycloak
+      # Another option is to set QUARKUS_OIDC_TOKEN_ISSUER above
+      KC_HOSTNAME_URL: http://keycloak:8080
     command: start-dev

--- a/docker/dynamodb/docker-compose.yml
+++ b/docker/dynamodb/docker-compose.yml
@@ -19,11 +19,11 @@ services:
   nessie:
     image: ghcr.io/projectnessie/nessie:latest
     ports:
-      - 19120:19120
+      - "19120:19120"
     depends_on:
       - dynamodb
     environment:
-      - nessie.version.store.type=DYNAMO
+      - nessie.version.store.type=DYNAMODB
       - quarkus.dynamodb.endpoint-override=http://dynamodb:8000
       - quarkus.dynamodb.aws.region=us-west-2
       - quarkus.dynamodb.aws.credentials.type=STATIC
@@ -32,4 +32,4 @@ services:
   dynamodb:
     image: amazon/dynamodb-local
     ports:
-        - 8000:8000
+        - "8000:8000"

--- a/docker/in_memory/docker-compose.yml
+++ b/docker/in_memory/docker-compose.yml
@@ -21,4 +21,4 @@ services:
     ports:
       - 19120:19120
     environment:
-      - nessie.version.store.type=INMEMORY # Ephemeral storage, data is lost during reset.
+      - nessie.version.store.type=IN_MEMORY # Ephemeral storage, data is lost during reset.

--- a/docker/mongodb/docker-compose.yml
+++ b/docker/mongodb/docker-compose.yml
@@ -19,17 +19,17 @@ services:
   nessie:
     image: ghcr.io/projectnessie/nessie:latest
     ports:
-      - 19120:19120
+      - "19120:19120"
     depends_on:
       - mongo
     environment:
-      - nessie.version.store.type=MONGO
+      - nessie.version.store.type=MONGODB
       - quarkus.mongodb.database=nessie
       - quarkus.mongodb.connection-string=mongodb://root:password@mongo:27017
   mongo:
     image: mongo
     ports:
-      - 27017:27017
+      - "27017:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: password

--- a/docker/telemetry/docker-compose.yml
+++ b/docker/telemetry/docker-compose.yml
@@ -4,11 +4,11 @@ services:
   nessie:
     image: ghcr.io/projectnessie/nessie:latest
     ports:
-      - 19120:19120
+      - "19120:19120"
     depends_on:
       - jaeger
     environment:
-      - nessie.version.store.type=INMEMORY
+      - nessie.version.store.type=IN_MEMORY
       - quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://jaeger:4317
 
   # Jaeger


### PR DESCRIPTION
This commit introduces the following enhancements:

* Introduced `KC_HOSTNAME_URL` env var in keycloak container to circumvent issuer claim validation issues;
* Switched to new storage for all examples;
* Quoted port mappings for safety.