### PR TITLE
Make number of access checks configurable

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusServerConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusServerConfig.java
@@ -35,4 +35,9 @@ public interface QuarkusServerConfig extends ServerConfig {
   @WithName("send-stacktrace-to-client")
   @WithDefault("false")
   boolean sendStacktraceToClient();
+
+  @Override
+  @WithName("access-checks-batch-size")
+  @WithDefault("" + ServerConfig.DEFAULT_ACCESS_CHECK_BATCH_SIZE)
+  int accessChecksBatchSize();
 }

--- a/servers/services/src/main/java/org/projectnessie/services/config/ServerConfig.java
+++ b/servers/services/src/main/java/org/projectnessie/services/config/ServerConfig.java
@@ -18,6 +18,8 @@ package org.projectnessie.services.config;
 /** Nessie server configuration to be injected into the JAX-RS application. */
 public interface ServerConfig {
 
+  int DEFAULT_ACCESS_CHECK_BATCH_SIZE = 100;
+
   /**
    * Gets the branch to use if not provided by the user.
    *
@@ -31,4 +33,8 @@ public interface ServerConfig {
    * @return {@code true} if the server should send the stack trace to the client.
    */
   boolean sendStacktraceToClient();
+
+  default int accessChecksBatchSize() {
+    return DEFAULT_ACCESS_CHECK_BATCH_SIZE;
+  }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
@@ -65,8 +65,6 @@ public abstract class BaseApiImpl {
   private final Authorizer authorizer;
   private final Supplier<Principal> principal;
 
-  protected static final int ACCESS_CHECK_BATCH_SIZE = 10;
-
   protected BaseApiImpl(
       ServerConfig config,
       VersionStore store,

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -110,7 +110,7 @@ public class DiffApiImpl extends BaseApiImpl implements DiffService {
 
         AuthzPaginationIterator<Diff> authz =
             new AuthzPaginationIterator<Diff>(
-                diffs, super::startAccessCheck, ACCESS_CHECK_BATCH_SIZE) {
+                diffs, super::startAccessCheck, getConfig().accessChecksBatchSize()) {
               @Override
               protected Set<Check> checksForEntry(Diff entry) {
                 if (entry.getFromValue().isPresent()) {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -152,7 +152,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
       AuthzPaginationIterator<ReferenceInfo<CommitMeta>> authz =
           new AuthzPaginationIterator<ReferenceInfo<CommitMeta>>(
-              references, super::startAccessCheck, ACCESS_CHECK_BATCH_SIZE) {
+              references, super::startAccessCheck, getConfig().accessChecksBatchSize()) {
             @Override
             protected Set<Check> checksForEntry(ReferenceInfo<CommitMeta> entry) {
               return singleton(canViewReference(entry.getNamedRef()));
@@ -852,7 +852,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
         AuthzPaginationIterator<KeyEntry> authz =
             new AuthzPaginationIterator<KeyEntry>(
-                entries, super::startAccessCheck, ACCESS_CHECK_BATCH_SIZE) {
+                entries, super::startAccessCheck, getConfig().accessChecksBatchSize()) {
               @Override
               protected Set<Check> checksForEntry(KeyEntry entry) {
                 return singleton(canReadContentKey(refWithHash.getValue(), entry.getKey()));

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -19,10 +19,11 @@ docker run \
 
 ### Core Settings
 
-| Property                                  | Default values | Type      | Description                                                               |
-|-------------------------------------------|----------------|-----------|---------------------------------------------------------------------------|
-| `nessie.server.default-branch`            | `main`         | `String`  | Sets the default branch to use if not provided by the user.               |
-| `nessie.server.send-stacktrace-to-client` | `false`        | `boolean` | Sets if server stack trace should be sent to the client in case of error. |
+| Property                                  | Default values | Type      | Description                                                                                                                                                                                                                                                                                                                                       |
+|-------------------------------------------|----------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `nessie.server.default-branch`            | `main`         | `String`  | Sets the default branch to use if not provided by the user.                                                                                                                                                                                                                                                                                       |
+| `nessie.server.send-stacktrace-to-client` | `false`        | `boolean` | Sets if server stack trace should be sent to the client in case of error.                                                                                                                                                                                                                                                                         |
+| `nessie.server.access-checks-batch-size`  | `100`          | `int`     | The number of entity-checks that are grouped into a call to `BatchAccessChecker`. The default value is quite conservative, it is the responsibility of the operator to adjust this value according to the capabilities of the actual authz implementation. Note that the number of checks can be exceeded depending on the context of the checks. |
 
 
 ### Version Store Settings


### PR DESCRIPTION
The hard coded default was `10`. That number is now configurable, with a new conservative default value of `100`. Operators are responsible to adjust this value to the capabilities and restrictions of the authz implementation.