### PR TITLE
Ref-indexes: supply `int/refs` HEAD commit ID to check in reference-r…

### DIFF
--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractIndexesLogicTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractIndexesLogicTests.java
@@ -52,6 +52,7 @@ import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
 import org.projectnessie.versioned.storage.common.indexes.StoreKey;
 import org.projectnessie.versioned.storage.common.logic.CommitLogic;
 import org.projectnessie.versioned.storage.common.logic.IndexesLogic;
+import org.projectnessie.versioned.storage.common.logic.SuppliedCommitIndex;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.objtypes.CommitOp;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
@@ -75,6 +76,7 @@ public class AbstractIndexesLogicTests {
         .doesNotThrowAnyException();
     soft.assertThat(indexesLogic.createIndexSupplier(() -> EMPTY_OBJ_ID))
         .extracting(Supplier::get)
+        .extracting(SuppliedCommitIndex::index)
         .extracting(StoreIndex::elementCount)
         .isEqualTo(0);
   }
@@ -177,8 +179,8 @@ public class AbstractIndexesLogicTests {
     soft.assertThat(persist.fetchObj(commit.id())).isEqualTo(commit);
 
     soft.assertThat(indexesLogic.createIndexSupplier(commit::id).get())
-        .isEqualTo(index)
-        .containsExactly(remove, incrementalAdd, add, incrementalRemove);
+        .extracting(SuppliedCommitIndex::index)
+        .isEqualTo(index);
   }
 
   @Test

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogic.java
@@ -38,7 +38,7 @@ public interface IndexesLogic {
 
   @Nonnull
   @jakarta.annotation.Nonnull
-  Supplier<StoreIndex<CommitOp>> createIndexSupplier(
+  Supplier<SuppliedCommitIndex> createIndexSupplier(
       @Nonnull @jakarta.annotation.Nonnull Supplier<ObjId> commitIdSupplier);
 
   @Nonnull

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
@@ -26,6 +26,7 @@ import static org.projectnessie.versioned.storage.common.indexes.StoreIndexes.la
 import static org.projectnessie.versioned.storage.common.indexes.StoreIndexes.newStoreIndex;
 import static org.projectnessie.versioned.storage.common.logic.CommitLogQuery.commitLogQuery;
 import static org.projectnessie.versioned.storage.common.logic.Logics.commitLogic;
+import static org.projectnessie.versioned.storage.common.logic.SuppliedCommitIndex.suppliedCommitIndex;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitObj.commitBuilder;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.Action.INCREMENTAL_ADD;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.Action.INCREMENTAL_REMOVE;
@@ -82,7 +83,7 @@ final class IndexesLogicImpl implements IndexesLogic {
   @Override
   @Nonnull
   @jakarta.annotation.Nonnull
-  public Supplier<StoreIndex<CommitOp>> createIndexSupplier(
+  public Supplier<SuppliedCommitIndex> createIndexSupplier(
       @Nonnull @jakarta.annotation.Nonnull Supplier<ObjId> commitIdSupplier) {
     return memoize(
         () -> {
@@ -92,7 +93,7 @@ final class IndexesLogicImpl implements IndexesLogic {
                 EMPTY_OBJ_ID.equals(commitId)
                     ? null
                     : persist.fetchTypedObj(commitId, COMMIT, CommitObj.class);
-            return buildCompleteIndexOrEmpty(c);
+            return suppliedCommitIndex(commitId, buildCompleteIndexOrEmpty(c));
           } catch (ObjNotFoundException e) {
             throw new RuntimeException(e);
           }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogicImpl.java
@@ -170,6 +170,8 @@ import org.projectnessie.versioned.storage.common.persist.Reference;
  */
 final class ReferenceLogicImpl implements ReferenceLogic {
 
+  private static final String REF_REFS_ADVANCED = "ref-refs advanced";
+
   private final Persist persist;
 
   ReferenceLogicImpl(Persist persist) {
@@ -193,7 +195,7 @@ final class ReferenceLogicImpl implements ReferenceLogic {
     }
     Reference[] refs = persist.fetchReferences(refsArray);
 
-    Supplier<StoreIndex<CommitOp>> refsIndexSupplier = createRefsIndexSupplier(refs[refRefsIndex]);
+    Supplier<SuppliedCommitIndex> refsIndexSupplier = createRefsIndexSupplier(refs[refRefsIndex]);
 
     List<Reference> r = new ArrayList<>(refCount);
     for (int i = 0; i < refCount; i++) {
@@ -226,14 +228,14 @@ final class ReferenceLogicImpl implements ReferenceLogic {
             .map(StoreKey::key)
             .orElse(prefix);
 
-    StoreIndex<CommitOp> index = createRefsIndexSupplier().get();
+    SuppliedCommitIndex index = createRefsIndexSupplier().get();
 
     return new QueryIter(index, prefix, begin, referencesQuery.prefetch());
   }
 
   private final class QueryIter extends AbstractIterator<Reference>
       implements PagedResult<Reference, String> {
-    private final StoreIndex<CommitOp> index;
+    private final SuppliedCommitIndex index;
     private final Iterator<StoreIndexElement<CommitOp>> base;
     private final StoreKey prefix;
 
@@ -242,10 +244,10 @@ final class ReferenceLogicImpl implements ReferenceLogic {
     private Iterator<Reference> referenceIterator = emptyIterator();
 
     private QueryIter(
-        StoreIndex<CommitOp> index, StoreKey prefix, StoreKey begin, boolean prefetch) {
+        SuppliedCommitIndex index, StoreKey prefix, StoreKey begin, boolean prefetch) {
       this.index = index;
       this.prefix = prefix;
-      this.base = index.iterator(begin, null, prefetch);
+      this.base = index.index().iterator(begin, null, prefetch);
       this.referencesBatch = new ArrayList<>(REFERENCES_BATCH_SIZE);
     }
 
@@ -356,11 +358,11 @@ final class ReferenceLogicImpl implements ReferenceLogic {
     checkArgument(!isInternalReferenceName(name));
 
     Reference reference = persist.fetchReference(name);
-    Supplier<StoreIndex<CommitOp>> indexSupplier = null;
+    Supplier<SuppliedCommitIndex> indexSupplier = null;
     if (reference == null) {
       StoreKey nameKey = key(name);
       indexSupplier = createRefsIndexSupplier();
-      StoreIndexElement<CommitOp> index = indexSupplier.get().get(nameKey);
+      StoreIndexElement<CommitOp> index = indexSupplier.get().index().get(nameKey);
       if (index == null) {
         // not there --> okay
         throw new RefNotFoundException(reference(name, expectedPointer, false));
@@ -391,7 +393,7 @@ final class ReferenceLogicImpl implements ReferenceLogic {
       persist.markReferenceAsDeleted(reference);
     }
 
-    commitDeleteReference(reference);
+    commitDeleteReference(reference, null);
 
     persist.purgeReference(reference);
 
@@ -464,8 +466,8 @@ final class ReferenceLogicImpl implements ReferenceLogic {
       CommitConflict conflict = e.conflicts().get(0);
       checkState(conflict.conflictType() == KEY_EXISTS, "Unexpected conflict type %s", conflict);
 
-      Supplier<StoreIndex<CommitOp>> indexSupplier = createRefsIndexSupplier();
-      StoreIndexElement<CommitOp> el = indexSupplier.get().get(key(name));
+      Supplier<SuppliedCommitIndex> indexSupplier = createRefsIndexSupplier();
+      StoreIndexElement<CommitOp> el = indexSupplier.get().index().get(key(name));
       checkNotNull(el, "Key %s missing in index", name);
 
       Reference existing = persist.fetchReference(name);
@@ -497,12 +499,17 @@ final class ReferenceLogicImpl implements ReferenceLogic {
 
   @VisibleForTesting // needed to simulate recovery scenarios
   // Note: commitForReference is for testing, to test race conditions
-  void commitDeleteReference(Reference reference) throws RetryTimeoutException {
+  void commitDeleteReference(Reference reference, ObjId expectedRefRefsHead)
+      throws RetryTimeoutException {
     try {
       commitRetry(
           persist,
           (p, retryState) -> {
             Reference refRefs = requireNonNull(p.fetchReference(REF_REFS.name()));
+            if (expectedRefRefsHead != null && !refRefs.pointer().equals(expectedRefRefsHead)) {
+              throw new RuntimeException(REF_REFS_ADVANCED);
+            }
+
             CommitObj commit;
             try {
               commit = p.fetchTypedObj(refRefs.pointer(), COMMIT, CommitObj.class);
@@ -601,9 +608,11 @@ final class ReferenceLogicImpl implements ReferenceLogic {
   private Reference maybeRecover(
       @Nonnull @jakarta.annotation.Nonnull String name,
       Reference ref,
-      @Nonnull @jakarta.annotation.Nonnull Supplier<StoreIndex<CommitOp>> refsIndexSupplier) {
+      @Nonnull @jakarta.annotation.Nonnull Supplier<SuppliedCommitIndex> refsIndexSupplier) {
     if (ref == null) {
-      StoreIndexElement<CommitOp> commitOp = refsIndexSupplier.get().get(key(name));
+      SuppliedCommitIndex suppliedIndex = refsIndexSupplier.get();
+
+      StoreIndexElement<CommitOp> commitOp = suppliedIndex.index().get(key(name));
 
       if (commitOp == null) {
         // Reference not in index - nothing to do.
@@ -627,6 +636,10 @@ final class ReferenceLogicImpl implements ReferenceLogic {
         }
         ref = reference(name, initialRef.initialPointer(), false);
         try {
+          if (refRefsOutOfDate(suppliedIndex)) {
+            return null;
+          }
+
           ref = persist.addReference(ref);
         } catch (RefAlreadyExistsException e) {
           ref = e.reference();
@@ -638,7 +651,9 @@ final class ReferenceLogicImpl implements ReferenceLogic {
       }
 
     } else if (ref.deleted()) {
-      StoreIndexElement<CommitOp> commitOp = refsIndexSupplier.get().get(key(name));
+      SuppliedCommitIndex suppliedIndex = refsIndexSupplier.get();
+
+      StoreIndexElement<CommitOp> commitOp = suppliedIndex.index().get(key(name));
 
       if (commitOp == null) {
         throw new RuntimeException("Loaded Reference is marked as deleted, but not found in index");
@@ -647,7 +662,11 @@ final class ReferenceLogicImpl implements ReferenceLogic {
       CommitOp commitOpContent = commitOp.content();
       if (commitOpContent.action().exists()) {
         try {
-          commitDeleteReference(ref);
+          if (refRefsOutOfDate(suppliedIndex)) {
+            return ref;
+          }
+
+          commitDeleteReference(ref, suppliedIndex.pointer());
           persist.purgeReference(ref);
         } catch (RefNotFoundException e) {
           // ignore
@@ -670,8 +689,13 @@ final class ReferenceLogicImpl implements ReferenceLogic {
     return ref;
   }
 
+  private boolean refRefsOutOfDate(SuppliedCommitIndex index) {
+    Reference refRefs = persist.fetchReference(REF_REFS.name());
+    return !index.pointer().equals(requireNonNull(refRefs).pointer());
+  }
+
   @VisibleForTesting
-  Supplier<StoreIndex<CommitOp>> createRefsIndexSupplier() {
+  Supplier<SuppliedCommitIndex> createRefsIndexSupplier() {
     return indexesLogic(persist)
         .createIndexSupplier(
             () -> {
@@ -681,7 +705,7 @@ final class ReferenceLogicImpl implements ReferenceLogic {
   }
 
   @VisibleForTesting
-  Supplier<StoreIndex<CommitOp>> createRefsIndexSupplier(Reference refRefs) {
+  Supplier<SuppliedCommitIndex> createRefsIndexSupplier(Reference refRefs) {
     return indexesLogic(persist)
         .createIndexSupplier(() -> refRefs != null ? refRefs.pointer() : EMPTY_OBJ_ID);
   }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/SuppliedCommitIndex.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/SuppliedCommitIndex.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.logic;
+
+import org.immutables.value.Value;
+import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
+import org.projectnessie.versioned.storage.common.objtypes.CommitOp;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+
+@Value.Immutable
+public interface SuppliedCommitIndex {
+  @Value.Parameter(order = 1)
+  ObjId pointer();
+
+  @Value.Parameter(order = 2)
+  StoreIndex<CommitOp> index();
+
+  static SuppliedCommitIndex suppliedCommitIndex(ObjId pointer, StoreIndex<CommitOp> index) {
+    return ImmutableSuppliedCommitIndex.of(pointer, index);
+  }
+}

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestReferenceLogicImpl.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestReferenceLogicImpl.java
@@ -172,7 +172,7 @@ public class TestReferenceLogicImpl extends AbstractReferenceLogicTests {
       case AFTER_MARK_DELETE:
         break;
       case AFTER_COMMIT_DELETED:
-        refLogic.commitDeleteReference(deleted);
+        refLogic.commitDeleteReference(deleted, null);
         break;
       default:
         throw new IllegalArgumentException();
@@ -234,7 +234,7 @@ public class TestReferenceLogicImpl extends AbstractReferenceLogicTests {
 
   private static boolean indexActionExists(ReferenceLogicImpl refLogic, String name) {
     StoreKey key = key(name);
-    StoreIndexElement<CommitOp> el = refLogic.createRefsIndexSupplier().get().get(key);
+    StoreIndexElement<CommitOp> el = refLogic.createRefsIndexSupplier().get().index().get(key);
     return el != null && el.content().action().exists();
   }
 


### PR DESCRIPTION
…ecovery

Allows reference-recovery to "stop early", if the references were modified since the load of the references-index and when recovery actually kicks in. This is mostly relevant when querying references though.