### PR TITLE
Tests: Only pass the surrounding test class to `AbstractReferenceLogicTests`

### DIFF
--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractPersistTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractPersistTests.java
@@ -15,10 +15,19 @@
  */
 package org.projectnessie.versioned.storage.commontests;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInfo;
 
 /** Groups base and logic tests. */
 public abstract class AbstractPersistTests {
+  private static Class<?> surroundingTestClass;
+
+  @BeforeAll
+  static void gatherTestClass(TestInfo testInfo) {
+    surroundingTestClass = testInfo.getTestClass().orElseThrow();
+  }
+
   @Nested
   public class BaseTests extends AbstractBasePersistTests {}
 
@@ -29,7 +38,11 @@ public abstract class AbstractPersistTests {
   public class IndexesLogicTests extends AbstractIndexesLogicTests {}
 
   @Nested
-  public class ReferencesLogicTests extends AbstractReferenceLogicTests {}
+  public class ReferencesLogicTests extends AbstractReferenceLogicTests {
+    ReferencesLogicTests() {
+      super(surroundingTestClass);
+    }
+  }
 
   @Nested
   public class RepositoryLogicTests extends AbstractRepositoryLogicTests {}

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractReferenceLogicTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractReferenceLogicTests.java
@@ -71,10 +71,16 @@ import org.projectnessie.versioned.storage.testextension.PersistExtension;
 
 /** {@link ReferenceLogic} related tests to be run against every {@link Persist} implementation. */
 @ExtendWith({PersistExtension.class, SoftAssertionsExtension.class})
-public class AbstractReferenceLogicTests {
+public abstract class AbstractReferenceLogicTests {
+  private final Class<?> surroundingTestClass;
+
   @InjectSoftAssertions protected SoftAssertions soft;
 
   @NessiePersist protected Persist persist;
+
+  protected AbstractReferenceLogicTests(Class<?> surroundingTestClass) {
+    this.surroundingTestClass = surroundingTestClass;
+  }
 
   @Test
   public void internalReferencesNotVisible() {

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestReferenceLogicImpl.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestReferenceLogicImpl.java
@@ -72,6 +72,10 @@ public class TestReferenceLogicImpl extends AbstractReferenceLogicTests {
         .flatMap(f -> Arrays.stream(PostActions.values()).map(p -> arguments(f, p)));
   }
 
+  public TestReferenceLogicImpl() {
+    super(TestReferenceLogicImpl.class);
+  }
+
   @ParameterizedTest
   @MethodSource("createRecoverScenarios")
   public void createRecoverScenarios(CreateFailures createFailure, PostActions postCreateAction)


### PR DESCRIPTION
currently unused, but needed in another, bigger PR