### PR TITLE
Emergency-fix of #7088

### DIFF
--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/SqlConstants.java
@@ -102,6 +102,7 @@ final class SqlConstants {
   static final String COL_REFS_DELETED = "deleted";
   static final String COL_REFS_CREATED_AT = "created_at";
   static final String COL_REFS_EXTENDED_INFO = "ext_info";
+  static final String REFS_CREATED_AT_COND = "_REFS_CREATED_AT_";
   static final String REFS_EXTENDED_INFO_COND = "_REFS_EXTENDED_INFO_";
   static final String UPDATE_REFERENCE_POINTER =
       "UPDATE "
@@ -118,7 +119,8 @@ final class SqlConstants {
           + COL_REFS_DELETED
           + "=? AND "
           + COL_REFS_CREATED_AT
-          + "=? AND "
+          + REFS_CREATED_AT_COND
+          + " AND "
           + COL_REFS_EXTENDED_INFO
           + REFS_EXTENDED_INFO_COND;
   static final String PURGE_REFERENCE =
@@ -134,7 +136,8 @@ final class SqlConstants {
           + COL_REFS_DELETED
           + "=? AND "
           + COL_REFS_CREATED_AT
-          + "=? AND "
+          + REFS_CREATED_AT_COND
+          + " AND "
           + COL_REFS_EXTENDED_INFO
           + REFS_EXTENDED_INFO_COND;
   static final String MARK_REFERENCE_AS_DELETED =
@@ -152,7 +155,8 @@ final class SqlConstants {
           + COL_REFS_DELETED
           + "=? AND "
           + COL_REFS_CREATED_AT
-          + "=? AND "
+          + REFS_CREATED_AT_COND
+          + " AND "
           + COL_REFS_EXTENDED_INFO
           + REFS_EXTENDED_INFO_COND;
   static final String ADD_REFERENCE =

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -356,8 +356,12 @@ public class MongoDBPersist implements Persist {
         name,
         binaryToObjId(doc.get(COL_REFERENCES_POINTER, Binary.class)),
         doc.getBoolean(COL_REFERENCES_DELETED),
-        doc.getLong(COL_REFERENCES_CREATED_AT),
+        refCreatedAt(doc),
         binaryToObjId(doc.get(COL_REFERENCES_EXTENDED_INFO, Binary.class)));
+  }
+
+  private static Long refCreatedAt(Document doc) {
+    return doc.containsKey(COL_REFERENCES_CREATED_AT) ? doc.getLong(COL_REFERENCES_CREATED_AT) : 0L;
   }
 
   @Nonnull
@@ -376,7 +380,7 @@ public class MongoDBPersist implements Persist {
               name,
               binaryToObjId(doc.get(COL_REFERENCES_POINTER, Binary.class)),
               doc.getBoolean(COL_REFERENCES_DELETED),
-              doc.getLong(COL_REFERENCES_CREATED_AT),
+              refCreatedAt(doc),
               binaryToObjId(doc.get(COL_REFERENCES_EXTENDED_INFO, Binary.class)));
       for (int i = 0; i < names.length; i++) {
         if (name.equals(names[i])) {


### PR DESCRIPTION
In #7088 the newly added attribute for the reference created-at-timestamp causes issues with MongoDB + JDBC.

This PR fixes those issues.