### PR TITLE
Events/Quarkus: Do not cache huge artifacts in Gradle cache

### DIFF
--- a/events/quarkus/build.gradle.kts
+++ b/events/quarkus/build.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import io.quarkus.gradle.tasks.QuarkusBuild
+
 plugins {
   alias(libs.plugins.quarkus)
   id("nessie-conventions-quarkus")
@@ -66,3 +68,10 @@ listOf("javadoc", "sourcesJar").forEach { name ->
 listOf("checkstyleTest", "compileTestJava").forEach { name ->
   tasks.named(name) { dependsOn(tasks.named("compileQuarkusTestGeneratedSourcesJava")) }
 }
+
+val quarkusBuild =
+  tasks.named<QuarkusBuild>("quarkusBuild") {
+    outputs.doNotCacheIf("Do not add huge cache artifacts to build cache") { true }
+    inputs.property("final.name", quarkus.finalName())
+    inputs.properties(quarkus.quarkusBuildProperties.get())
+  }


### PR DESCRIPTION
The cached Gradle artifacts just from the `CI intTest Quarkus` workflow step are > 600MB, because of the way the `QuarkusBuild` task works in Quarkus 2.x versions.