### PR TITLE
StoreIndexImpl: wrong estimated serialized size for empty index

### DIFF
--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/StoreIndexImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/StoreIndexImpl.java
@@ -142,7 +142,7 @@ final class StoreIndexImpl<V> implements StoreIndex<V> {
   // 'elements' j.u.ArrayList.
 
   StoreIndexImpl(ElementSerializer<V> serializer) {
-    this(new ArrayList<>(), 1, serializer, false);
+    this(new ArrayList<>(), 2, serializer, false);
   }
 
   StoreIndexImpl(


### PR DESCRIPTION
Oversight from #6976, the initial estimated serialized size should have been adopted as well. Should not be a problem in real life, because there's some headroom added for every element - and empty indexes are never persisted. But it should be correct.