### PR TITLE
Lazily deserialize `StoreIndexElement`s `content`

### DIFF
--- a/versioned/storage/common/src/jmh/java/org/projectnessie/versioned/storage/common/indexes/RealisticKeyIndexImplBench.java
+++ b/versioned/storage/common/src/jmh/java/org/projectnessie/versioned/storage/common/indexes/RealisticKeyIndexImplBench.java
@@ -23,6 +23,7 @@ import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.Actio
 import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.commitOp;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
 
+import java.util.Iterator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -35,6 +36,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 import org.projectnessie.versioned.storage.common.objtypes.CommitOp;
 import org.projectnessie.versioned.storage.common.objtypes.CommitOp.Action;
 import org.projectnessie.versioned.storage.commontests.ImmutableRealisticKeySet;
@@ -127,5 +129,14 @@ public class RealisticKeyIndexImplBench {
   public Object deserializeGetRandomKey(BenchmarkParam param) {
     StoreIndex<CommitOp> deserialized = param.keyIndexTestSet.deserialize();
     return deserialized.get(param.keyIndexTestSet.randomKey());
+  }
+
+  @Benchmark
+  public void deserializeIterate250(BenchmarkParam param, Blackhole bh) {
+    StoreIndex<CommitOp> deserialized = param.keyIndexTestSet.deserialize();
+    Iterator<StoreIndexElement<CommitOp>> iter = deserialized.iterator();
+    for (int i = 0; i < 250 && iter.hasNext(); i++) {
+      bh.consume(iter.next());
+    }
   }
 }

--- a/versioned/storage/common/src/jmh/java/org/projectnessie/versioned/storage/common/indexes/RealisticKeyIndexImplBench.java
+++ b/versioned/storage/common/src/jmh/java/org/projectnessie/versioned/storage/common/indexes/RealisticKeyIndexImplBench.java
@@ -99,6 +99,7 @@ public class RealisticKeyIndexImplBench {
   @Benchmark
   public Object serializeModifiedIndex(BenchmarkParam param) {
     StoreIndex<CommitOp> deserialized = param.keyIndexTestSet.deserialize();
+    ((StoreIndexImpl<?>) deserialized).setModified();
     return deserialized.serialize();
   }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/AbstractStoreIndexElement.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/AbstractStoreIndexElement.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.indexes;
+
+import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.Var;
+
+abstract class AbstractStoreIndexElement<V> implements StoreIndexElement<V> {
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof StoreIndexElement)) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    StoreIndexElement<?> other = (StoreIndexElement<?>) o;
+    return key().equals(other.key()) && content().equals(other.content());
+  }
+
+  @Override
+  public int hashCode() {
+    @Var int h = 5381;
+    h += (h << 5) + key().hashCode();
+    h += (h << 5) + content().hashCode();
+    return h;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper("StoreIndexElement")
+        .omitNullValues()
+        .add("key", key())
+        .add("content", content())
+        .toString();
+  }
+}

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/DirectStoreIndexElement.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/DirectStoreIndexElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,32 @@ package org.projectnessie.versioned.storage.common.indexes;
 
 import java.nio.ByteBuffer;
 
-public interface ElementSerializer<V> {
-  int serializedSize(V value);
+final class DirectStoreIndexElement<V> extends AbstractStoreIndexElement<V> {
+  private final StoreKey key;
+  private final V content;
 
-  /** Serialize {@code value} into {@code target}, returns {@code target}. */
-  ByteBuffer serialize(V value, ByteBuffer target);
+  DirectStoreIndexElement(StoreKey key, V content) {
+    this.key = key;
+    this.content = content;
+  }
 
-  /**
-   * Deserialize a value from {@code buffer}. Implementations must not assume that the given {@link
-   * ByteBuffer} only contains data for the value to deserialize, other data likely follows.
-   */
-  V deserialize(ByteBuffer buffer);
+  @Override
+  public StoreKey key() {
+    return key;
+  }
 
-  /**
-   * Skips an element, only updating the {@code buffer}'s {@link java.nio.ByteBuffer#position()}.
-   */
-  void skip(ByteBuffer buffer);
+  @Override
+  public V content() {
+    return content;
+  }
+
+  @Override
+  public void serializeContent(ElementSerializer<V> ser, ByteBuffer target) {
+    ser.serialize(content, target);
+  }
+
+  @Override
+  public int contentSerializedSize(ElementSerializer<V> ser) {
+    return ser.serializedSize(content);
+  }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/StoreIndexElement.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/StoreIndexElement.java
@@ -15,18 +15,19 @@
  */
 package org.projectnessie.versioned.storage.common.indexes;
 
-import org.immutables.value.Value;
+import java.nio.ByteBuffer;
 
-@Value.Immutable
 public interface StoreIndexElement<V> {
 
-  @Value.Parameter(order = 1)
   StoreKey key();
 
-  @Value.Parameter(order = 2)
   V content();
 
   static <V> StoreIndexElement<V> indexElement(StoreKey key, V content) {
-    return ImmutableStoreIndexElement.of(key, content);
+    return new DirectStoreIndexElement<>(key, content);
   }
+
+  void serializeContent(ElementSerializer<V> ser, ByteBuffer target);
+
+  int contentSerializedSize(ElementSerializer<V> ser);
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/StoreIndexImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/indexes/StoreIndexImpl.java
@@ -136,8 +136,9 @@ final class StoreIndexImpl<V> implements StoreIndex<V> {
   private final ElementSerializer<V> serializer;
 
   private final ByteBuffer serialized;
+
+  /** This buffer is used for temporary use within (de)serialization. */
   private final ByteBuffer scratchKeyBuffer = newKeyBuffer();
-  //  private final ByteBuffer preKeyBuffer = newKeyBuffer();
 
   private boolean modified;
   private ObjId objId;
@@ -461,9 +462,6 @@ final class StoreIndexImpl<V> implements StoreIndex<V> {
       }
 
       ByteBuffer previousKey = null;
-
-      // This buffer's backs the currently serialized key - use with care!
-      // Having this "singleton" instance massively reduces GC alloc/churn rate.
 
       @SuppressWarnings("UnnecessaryLocalVariable")
       ElementSerializer<V> ser = serializer;

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/ObjIdSerializer.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/ObjIdSerializer.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.storage.common.objtypes;
 
 import static org.projectnessie.versioned.storage.common.persist.ObjId.deserializeObjId;
+import static org.projectnessie.versioned.storage.common.persist.ObjId.skipObjId;
 
 import java.nio.ByteBuffer;
 import org.projectnessie.versioned.storage.common.indexes.ElementSerializer;
@@ -39,5 +40,10 @@ public final class ObjIdSerializer implements ElementSerializer<ObjId> {
   @Override
   public ObjId deserialize(ByteBuffer buffer) {
     return deserializeObjId(buffer);
+  }
+
+  @Override
+  public void skip(ByteBuffer buffer) {
+    skipObjId(buffer);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObjId.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObjId.java
@@ -161,6 +161,11 @@ public abstract class ObjId {
     return fromBytes(len, bytes);
   }
 
+  public static void skipObjId(@Nonnull @jakarta.annotation.Nonnull ByteBuffer bytes) {
+    int len = readVarInt(bytes);
+    bytes.position(bytes.position() + len);
+  }
+
   private static ObjId fromBytes(int len, ByteBuffer bytes) {
     switch (len) {
       case 0:

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/util/Ser.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/util/Ser.java
@@ -64,4 +64,13 @@ public final class Ser {
     }
     return r;
   }
+
+  public static void skipVarInt(ByteBuffer b) {
+    for (; ; ) {
+      int v = b.get() & 0xff;
+      if ((v & 0x80) == 0) {
+        break;
+      }
+    }
+  }
 }


### PR DESCRIPTION
The proposal described in #7061 _could_ bring a quite significant reduction in CPU and heap pressure, however re-serialization would add a lot more heap pressure.

This change introduces lazily deserializion of the _content_ of a `StoreIndexElement`. This already gives some nice improvement over the existing code to eagerly deserialize the _content_, because that is often not needed.

Below are the JMH results for an index with 156250 elements and a serialized size of 9228901 bytes. Heap pressure is reduced by about 25% for deserialzation (roughly 10M in this configuration).

Before this change (against the 1st commit in this PR):
```
Benchmark                                                                (deterministic)  (foldersPerLevel)  (namespaceLevels)  (tablesPerNamespace)  Mode  Cnt         Score      Error   Units
RealisticKeyIndexImplBench.deserialize                                              true                  5                  5                    50  avgt    3     14844.961 ± 2460.785   us/op
RealisticKeyIndexImplBench.deserialize:·gc.alloc.rate                               true                  5                  5                    50  avgt    3      2405.123 ±  399.027  MB/sec
RealisticKeyIndexImplBench.deserialize:·gc.alloc.rate.norm                          true                  5                  5                    50  avgt    3  37443286.030 ±    0.943    B/op
RealisticKeyIndexImplBench.deserialize:·gc.count                                    true                  5                  5                    50  avgt    3         4.000             counts
RealisticKeyIndexImplBench.deserialize:·gc.time                                     true                  5                  5                    50  avgt    3         8.000                 ms
RealisticKeyIndexImplBench.deserializeAdd                                           true                  5                  5                    50  avgt    3     11384.819 ± 5278.655   us/op
RealisticKeyIndexImplBench.deserializeAdd:·gc.alloc.rate                            true                  5                  5                    50  avgt    3      3216.608 ± 1510.121  MB/sec
RealisticKeyIndexImplBench.deserializeAdd:·gc.alloc.rate.norm                       true                  5                  5                    50  avgt    3  38388292.621 ±    2.171    B/op
RealisticKeyIndexImplBench.deserializeAdd:·gc.count                                 true                  5                  5                    50  avgt    3         5.000             counts
RealisticKeyIndexImplBench.deserializeAdd:·gc.time                                  true                  5                  5                    50  avgt    3         6.000                 ms
RealisticKeyIndexImplBench.deserializeAddSerialize                                  true                  5                  5                    50  avgt    3     23515.950 ± 9560.517   us/op
RealisticKeyIndexImplBench.deserializeAddSerialize:·gc.alloc.rate                   true                  5                  5                    50  avgt    3      1931.861 ±  774.923  MB/sec
RealisticKeyIndexImplBench.deserializeAddSerialize:·gc.alloc.rate.norm              true                  5                  5                    50  avgt    3  47627313.674 ±   12.676    B/op
RealisticKeyIndexImplBench.deserializeAddSerialize:·gc.count                        true                  5                  5                    50  avgt    3         3.000             counts
RealisticKeyIndexImplBench.deserializeAddSerialize:·gc.time                         true                  5                  5                    50  avgt    3         5.000                 ms
RealisticKeyIndexImplBench.deserializeGetRandomKey                                  true                  5                  5                    50  avgt    3     10915.480 ± 1236.127   us/op
RealisticKeyIndexImplBench.deserializeGetRandomKey:·gc.alloc.rate                   true                  5                  5                    50  avgt    3      3270.873 ±  369.704  MB/sec
RealisticKeyIndexImplBench.deserializeGetRandomKey:·gc.alloc.rate.norm              true                  5                  5                    50  avgt    3  37443308.451 ±    0.513    B/op
RealisticKeyIndexImplBench.deserializeGetRandomKey:·gc.count                        true                  5                  5                    50  avgt    3         5.000             counts
RealisticKeyIndexImplBench.deserializeGetRandomKey:·gc.time                         true                  5                  5                    50  avgt    3         9.000                 ms
RealisticKeyIndexImplBench.deserializeIterate250                                    true                  5                  5                    50  avgt    3     10857.502 ± 7434.119   us/op
RealisticKeyIndexImplBench.deserializeIterate250:·gc.alloc.rate                     true                  5                  5                    50  avgt    3      3291.342 ± 2206.207  MB/sec
RealisticKeyIndexImplBench.deserializeIterate250:·gc.alloc.rate.norm                true                  5                  5                    50  avgt    3  37443316.526 ±    6.609    B/op
RealisticKeyIndexImplBench.deserializeIterate250:·gc.count                          true                  5                  5                    50  avgt    3         5.000             counts
RealisticKeyIndexImplBench.deserializeIterate250:·gc.time                           true                  5                  5                    50  avgt    3        12.000                 ms
RealisticKeyIndexImplBench.serializeModifiedIndex                                   true                  5                  5                    50  avgt    3     23629.601 ± 1442.685   us/op
RealisticKeyIndexImplBench.serializeModifiedIndex:·gc.alloc.rate                    true                  5                  5                    50  avgt    3      1883.738 ±  113.932  MB/sec
RealisticKeyIndexImplBench.serializeModifiedIndex:·gc.alloc.rate.norm               true                  5                  5                    50  avgt    3  46680665.488 ±    0.001    B/op
RealisticKeyIndexImplBench.serializeModifiedIndex:·gc.count                         true                  5                  5                    50  avgt    3         3.000             counts
RealisticKeyIndexImplBench.serializeModifiedIndex:·gc.time                          true                  5                  5                    50  avgt    3         3.000                 ms
RealisticKeyIndexImplBench.serializeUnmodifiedIndex                                 true                  5                  5                    50  avgt    3     14755.784 ± 1599.479   us/op
RealisticKeyIndexImplBench.serializeUnmodifiedIndex:·gc.alloc.rate                  true                  5                  5                    50  avgt    3       596.915 ±   64.679  MB/sec
RealisticKeyIndexImplBench.serializeUnmodifiedIndex:·gc.alloc.rate.norm             true                  5                  5                    50  avgt    3   9237381.971 ±    0.916    B/op
RealisticKeyIndexImplBench.serializeUnmodifiedIndex:·gc.count                       true                  5                  5                    50  avgt    3         5.000             counts
RealisticKeyIndexImplBench.serializeUnmodifiedIndex:·gc.time                        true                  5                  5                    50  avgt    3         3.000                 ms
```

With this change (against the 2nd commit in this PR):
```
Benchmark                                                                (deterministic)  (foldersPerLevel)  (namespaceLevels)  (tablesPerNamespace)  Mode  Cnt         Score       Error   Units
RealisticKeyIndexImplBench.deserialize                                              true                  5                  5                    50  avgt    3      9721.956 ±   899.117   us/op
RealisticKeyIndexImplBench.deserialize:·gc.alloc.rate                               true                  5                  5                    50  avgt    3      2569.404 ±   237.707  MB/sec
RealisticKeyIndexImplBench.deserialize:·gc.alloc.rate.norm                          true                  5                  5                    50  avgt    3  26197459.948 ±     0.401    B/op
RealisticKeyIndexImplBench.deserialize:·gc.count                                    true                  5                  5                    50  avgt    3         3.000              counts
RealisticKeyIndexImplBench.deserialize:·gc.time                                     true                  5                  5                    50  avgt    3         4.000                  ms
RealisticKeyIndexImplBench.deserializeAdd                                           true                  5                  5                    50  avgt    3     10992.586 ±  5473.798   us/op
RealisticKeyIndexImplBench.deserializeAdd:·gc.alloc.rate                            true                  5                  5                    50  avgt    3      2355.529 ±  1156.122  MB/sec
RealisticKeyIndexImplBench.deserializeAdd:·gc.alloc.rate.norm                       true                  5                  5                    50  avgt    3  27142468.453 ±     2.077    B/op
RealisticKeyIndexImplBench.deserializeAdd:·gc.count                                 true                  5                  5                    50  avgt    3         4.000              counts
RealisticKeyIndexImplBench.deserializeAdd:·gc.time                                  true                  5                  5                    50  avgt    3         7.000                  ms
RealisticKeyIndexImplBench.deserializeAddSerialize                                  true                  5                  5                    50  avgt    3     23902.926 ±  7150.716   us/op
RealisticKeyIndexImplBench.deserializeAddSerialize:·gc.alloc.rate                   true                  5                  5                    50  avgt    3      1451.382 ±   435.004  MB/sec
RealisticKeyIndexImplBench.deserializeAddSerialize:·gc.alloc.rate.norm              true                  5                  5                    50  avgt    3  36377289.639 ±     2.380    B/op
RealisticKeyIndexImplBench.deserializeAddSerialize:·gc.count                        true                  5                  5                    50  avgt    3         2.000              counts
RealisticKeyIndexImplBench.deserializeAddSerialize:·gc.time                         true                  5                  5                    50  avgt    3         4.000                  ms
RealisticKeyIndexImplBench.deserializeGetRandomKey                                  true                  5                  5                    50  avgt    3     10372.860 ±  5291.237   us/op
RealisticKeyIndexImplBench.deserializeGetRandomKey:·gc.alloc.rate                   true                  5                  5                    50  avgt    3      2409.438 ±  1248.818  MB/sec
RealisticKeyIndexImplBench.deserializeGetRandomKey:·gc.alloc.rate.norm              true                  5                  5                    50  avgt    3  26197484.208 ±     2.067    B/op
RealisticKeyIndexImplBench.deserializeGetRandomKey:·gc.count                        true                  5                  5                    50  avgt    3         4.000              counts
RealisticKeyIndexImplBench.deserializeGetRandomKey:·gc.time                         true                  5                  5                    50  avgt    3         5.000                  ms
RealisticKeyIndexImplBench.deserializeIterate250                                    true                  5                  5                    50  avgt    3      9896.822 ±   362.053   us/op
RealisticKeyIndexImplBench.deserializeIterate250:·gc.alloc.rate                     true                  5                  5                    50  avgt    3      2523.990 ±    91.808  MB/sec
RealisticKeyIndexImplBench.deserializeIterate250:·gc.alloc.rate.norm                true                  5                  5                    50  avgt    3  26197492.013 ±     0.417    B/op
RealisticKeyIndexImplBench.deserializeIterate250:·gc.count                          true                  5                  5                    50  avgt    3         2.000              counts
RealisticKeyIndexImplBench.deserializeIterate250:·gc.time                           true                  5                  5                    50  avgt    3         4.000                  ms
RealisticKeyIndexImplBench.serializeModifiedIndex                                   true                  5                  5                    50  avgt    3     22920.428 ± 10699.575   us/op
RealisticKeyIndexImplBench.serializeModifiedIndex:·gc.alloc.rate                    true                  5                  5                    50  avgt    3      1474.592 ±   679.999  MB/sec
RealisticKeyIndexImplBench.serializeModifiedIndex:·gc.alloc.rate.norm               true                  5                  5                    50  avgt    3  35430641.207 ±     4.442    B/op
RealisticKeyIndexImplBench.serializeModifiedIndex:·gc.count                         true                  5                  5                    50  avgt    3         2.000              counts
RealisticKeyIndexImplBench.serializeModifiedIndex:·gc.time                          true                  5                  5                    50  avgt    3         9.000                  ms
RealisticKeyIndexImplBench.serializeUnmodifiedIndex                                 true                  5                  5                    50  avgt    3         0.007 ±     0.001   us/op
RealisticKeyIndexImplBench.serializeUnmodifiedIndex:·gc.alloc.rate                  true                  5                  5                    50  avgt    3     11286.471 ±  1088.613  MB/sec
RealisticKeyIndexImplBench.serializeUnmodifiedIndex:·gc.alloc.rate.norm             true                  5                  5                    50  avgt    3        80.000 ±     0.001    B/op
RealisticKeyIndexImplBench.serializeUnmodifiedIndex:·gc.count                       true                  5                  5                    50  avgt    3        12.000              counts
RealisticKeyIndexImplBench.serializeUnmodifiedIndex:·gc.time                        true                  5                  5                    50  avgt    3         8.000                  ms
```

The benchmark was run using Java 20.0.1, using the following command.
```bash
./gradlew :nessie-versioned-storage-common:jmhJar && java -jar versioned/storage/common/build/libs/nessie-versioned-storage-common-0.62.2-SNAPSHOT-jmh.jar \
  -p namespaceLevels=5 \
  -p foldersPerLevel=5 \
  -p tablesPerNamespace=50 \
  -p deterministic=true \
  -prof gc \
  RealisticKeyIndexImplBench
```

