### PR TITLE
Do not add Jandex index to shadow-jars

### DIFF
--- a/build-logic/src/main/kotlin/nessie-shadow-jar.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-shadow-jar.gradle.kts
@@ -29,3 +29,5 @@ tasks.named<Jar>("jar") {
   dependsOn(shadowJar)
   archiveClassifier.set("raw")
 }
+
+tasks.withType<ShadowJar>().configureEach { exclude("META-INF/jandex.idx") }

--- a/servers/quarkus-cli/src/main/resources/application.properties
+++ b/servers/quarkus-cli/src/main/resources/application.properties
@@ -88,5 +88,7 @@ quarkus.index-dependency.guava.group-id=com.google.guava
 quarkus.index-dependency.guava.artifact-id=guava
 quarkus.index-dependency.protobuf.group-id=com.google.protobuf
 quarkus.index-dependency.protobuf.artifact-id=protobuf-java
+quarkus.index-dependency.nessie-protobuf.group-id=org.projectnessie.nessie
+quarkus.index-dependency.nessie-protobuf.artifact-id=nessie-protobuf-relocated
 
 %test.quarkus.devservices.enabled=false

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -187,6 +187,8 @@ quarkus.index-dependency.guava.group-id=com.google.guava
 quarkus.index-dependency.guava.artifact-id=guava
 quarkus.index-dependency.protobuf.group-id=com.google.protobuf
 quarkus.index-dependency.protobuf.artifact-id=protobuf-java
+quarkus.index-dependency.nessie-protobuf.group-id=org.projectnessie.nessie
+quarkus.index-dependency.nessie-protobuf.artifact-id=nessie-protobuf-relocated
 
 # Metrics collection settings
 quarkus.micrometer.enabled=true


### PR DESCRIPTION
The shadow plugin currently takes (one) `META-INF/jandex.idx` file and adds it to the generated jar. That index however does not correspond to the actual contents of the (shadow) jar.

For Quarkus, adds appropriate configuration to have the missing index generated by the Quarkus build.