### PR TITLE
Fix inability to delete some references

### DIFF
--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogicImpl.java
@@ -570,8 +570,7 @@ final class ReferenceLogicImpl implements ReferenceLogic {
             } catch (ObjNotFoundException e) {
               throw new RuntimeException("Internal error getting reference creation log commit", e);
             }
-            StoreIndex<CommitOp> index =
-                indexesLogic(persist).incrementalIndexForUpdate(commit, Optional.empty());
+            StoreIndex<CommitOp> index = indexesLogic(persist).buildCompleteIndexOrEmpty(commit);
 
             StoreKey key = key(reference.name());
 

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestReferenceLogicImpl.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestReferenceLogicImpl.java
@@ -87,7 +87,7 @@ public class TestReferenceLogicImpl extends AbstractReferenceLogicTests {
   }
 
   @Test
-  public void manyBranches(
+  public void referencesInStripedIndex(
       @NessiePersist @NessieStoreConfig(name = CONFIG_MAX_INCREMENTAL_INDEX_SIZE, value = "2048")
           Persist persist)
       throws Exception {

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestReferenceLogicImpl.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestReferenceLogicImpl.java
@@ -107,7 +107,7 @@ public class TestReferenceLogicImpl extends AbstractReferenceLogicTests {
     CommitObj refRefsCommit = requireNonNull(commitLogic(persist).fetchCommit(refRefs.pointer()));
     soft.assertThat(refRefsCommit.referenceIndexStripes())
         .describedAs(
-            "This test requires must exercise against a striped reference-index, adjust the 'num' parameter.")
+            "This test must be exercised against a striped reference-index, adjust the 'num' parameter.")
         .isNotEmpty();
 
     ArrayList<Reference> created = newArrayList(refLogic.queryReferences(referencesQuery()));
@@ -116,8 +116,6 @@ public class TestReferenceLogicImpl extends AbstractReferenceLogicTests {
         .map(Reference::name)
         .containsAll(IntStream.range(0, num).mapToObj(refName).collect(Collectors.toList()))
         .hasSize(num + 1);
-
-    refLogic.queryReferences(referencesQuery()).forEachRemaining(ref -> {});
 
     for (int i = 0; i < num; i++) {
       String name = refName.apply(i);


### PR DESCRIPTION
The new storage model's commit logic, which provides support for name indexes, is also used to provide the index of references. When a reference is about to be deleted, the logic checks whether the reference to be deleted is in that index. Unfortunately, `ReferenceLogicImpl.commitDeleteReference()` only considered the _incremental_ index and not the "spilled out" reference stripes, so that a reference that is not in the incremental index cannot be deleted. The fix is a simple one-line change to load the whole index and not just the incremental one.