### PR TITLE
Use WorkerThread if parallelism is one.

### DIFF
--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/IdentifyLiveContents.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/IdentifyLiveContents.java
@@ -163,7 +163,6 @@ public abstract class IdentifyLiveContents {
       throw new IllegalStateException("identifyLiveContents() has already been called.");
     }
 
-    // If parallelism is one, use the existing thread.
     if (parallelism() == 1) {
       return this.walkAllReferences();
     }

--- a/gc/gc-base/src/main/java/org/projectnessie/gc/identify/IdentifyLiveContents.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/identify/IdentifyLiveContents.java
@@ -163,6 +163,11 @@ public abstract class IdentifyLiveContents {
       throw new IllegalStateException("identifyLiveContents() has already been called.");
     }
 
+    // If parallelism is one, use the existing thread.
+    if (parallelism() == 1) {
+      return this.walkAllReferences();
+    }
+
     ForkJoinPool forkJoinPool = new ForkJoinPool(parallelism());
     try {
       return forkJoinPool.invoke(ForkJoinTask.adapt(this::walkAllReferences));


### PR DESCRIPTION
For a single parallelism, it doesn't require spawning new threads.  