### PR TITLE
Minor Gradle build scripts addition (noop for `main`)

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -92,6 +92,17 @@ fun Project.forceJava11ForTests() {
   }
 }
 
+fun Project.forceJava11ForTestTask(name: String) {
+  if (!JavaVersion.current().isJava11) {
+    tasks.named(name, Test::class.java).configure {
+      val javaToolchains = project.extensions.findByType(JavaToolchainService::class.java)
+      javaLauncher.set(
+        javaToolchains!!.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) }
+      )
+    }
+  }
+}
+
 fun Project.libsRequiredVersion(name: String): String {
   val libVer =
     extensions.getByType<VersionCatalogsExtension>().named("libs").findVersion(name).get()


### PR DESCRIPTION
This is a backport from the `feature/nessie-catalog-server` branch, so CI on that branch can use the saved build cache. No change for `main` (yet).