### PR TITLE
Revert Gradle daemon heap settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.configureondemand=true
 #org.gradle.unsafe.configuration-cache-problems=warn
 # bump the Gradle daemon heap size (you can set bigger heap sizes as well)
 org.gradle.jvmargs=\
-  -Xms3g -Xmx3g -XX:MaxMetaspaceSize=768m \
+  -Xms2g -Xmx2g -XX:MaxMetaspaceSize=768m \
   -Dfile.encoding=UTF-8 \
   -Duser.language=en -Duser.country=US -Duser.variant= \
   --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION
... causes issues in IntelliJ, complaining about `-Xms3g -Xmx2g`, whereever that comes from............