### PR TITLE
Make gc-base, gc-iceberg classes Java 8 compatible

### DIFF
--- a/build-logic/src/main/kotlin/nessie-conventions-iceberg8.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-iceberg8.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Java project using Apache Iceberg, Java 8 (11 for tests)
+
+plugins {
+  `java-library`
+  `maven-publish`
+  signing
+  id("nessie-common-base")
+  id("nessie-common-src")
+  id("nessie-java")
+  id("nessie-testing")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+  options.release.set(if (this.name == "compileJava") 8 else 11)
+}

--- a/gc/gc-base/build.gradle.kts
+++ b/gc/gc-base/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-iceberg")
+  id("nessie-conventions-iceberg8")
   id("nessie-jacoco")
 }
 

--- a/gc/gc-iceberg/build.gradle.kts
+++ b/gc/gc-iceberg/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id("nessie-conventions-iceberg")
+  id("nessie-conventions-iceberg8")
   id("nessie-jacoco")
 }
 


### PR DESCRIPTION
GC modules can be used by engines to build its own distributed GC logic. Hence, it has to be java8 compatible. 