### PR TITLE
Nessie-Java-API: Add builder methods for extended merge behaviors

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/api/MergeTransplantBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/MergeTransplantBuilder.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.api;
 import javax.validation.constraints.Pattern;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.MergeBehavior;
+import org.projectnessie.model.MergeKeyBehavior;
 import org.projectnessie.model.Validation;
 
 public interface MergeTransplantBuilder<R extends MergeTransplantBuilder<R>>
@@ -44,4 +45,6 @@ public interface MergeTransplantBuilder<R extends MergeTransplantBuilder<R>>
   R defaultMergeMode(MergeBehavior mergeBehavior);
 
   R mergeMode(ContentKey key, MergeBehavior mergeBehavior);
+
+  R mergeKeyBehavior(MergeKeyBehavior mergeKeyBehavior);
 }

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseMergeTransplantBuilder.java
@@ -86,11 +86,16 @@ public abstract class BaseMergeTransplantBuilder<B extends OnBranchBuilder<B>>
 
   @SuppressWarnings("unchecked")
   public B mergeMode(ContentKey key, MergeBehavior mergeBehavior) {
+    return mergeKeyBehavior(MergeKeyBehavior.of(key, mergeBehavior));
+  }
+
+  @SuppressWarnings("unchecked")
+  public B mergeKeyBehavior(MergeKeyBehavior mergeKeyBehavior) {
     if (mergeModes == null) {
       mergeModes = new HashMap<>();
     }
 
-    mergeModes.put(key, MergeKeyBehavior.of(key, mergeBehavior));
+    mergeModes.put(mergeKeyBehavior.getKey(), mergeKeyBehavior);
     return (B) this;
   }
 }


### PR DESCRIPTION
The Nessie Java-API is missing builder methods to handle external conflict resolution. This change just adds the missing functions.