### PR TITLE
Separate Keycloak and Nessie test containers

### DIFF
--- a/rest-catalog/quarkus-spark-iceberg-tests/build.gradle.kts
+++ b/rest-catalog/quarkus-spark-iceberg-tests/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
   intTestImplementation(libs.slf4j.log4j.over.slf4j)
 
   intTestImplementation(nessieProject("nessie-client"))
+  intTestImplementation(nessieProject("nessie-keycloak-testcontainer"))
   intTestImplementation(nessieProject("nessie-nessie-testcontainer"))
 
   intTestImplementation(

--- a/rest-catalog/quarkus-spark-iceberg-tests/src/intTest/java/org/projectnessie/restcatalog/intttests/ITNessieCatalogServerSparkSQL.java
+++ b/rest-catalog/quarkus-spark-iceberg-tests/src/intTest/java/org/projectnessie/restcatalog/intttests/ITNessieCatalogServerSparkSQL.java
@@ -82,7 +82,9 @@ public class ITNessieCatalogServerSparkSQL extends AbstractNessieSparkSqlExtensi
             .dockerNetworkId(networkId)
             .fromProperties(emptyMap())
             .authEnabled(true)
-            .oidcFromCustomKeycloakContainer(keycloakContainer)
+            .oidcHostIp(keycloakContainer.getExternalIp())
+            .oidcInternalRealmUri(keycloakContainer.getInternalRealmUri().toString())
+            .oidcTokenIssuerUri(keycloakContainer.getTokenIssuerUri().toString())
             .build();
     nessieCoreContainer = nessieConfig.createContainer();
     nessieCoreContainer.start();

--- a/rest-catalog/quarkus-spark-iceberg-tests/src/intTest/java/org/projectnessie/restcatalog/intttests/ITNessieCatalogServerSparkSQL.java
+++ b/rest-catalog/quarkus-spark-iceberg-tests/src/intTest/java/org/projectnessie/restcatalog/intttests/ITNessieCatalogServerSparkSQL.java
@@ -82,7 +82,7 @@ public class ITNessieCatalogServerSparkSQL extends AbstractNessieSparkSqlExtensi
             .dockerNetworkId(networkId)
             .fromProperties(emptyMap())
             .authEnabled(true)
-            .keycloakContainerSupplier(() -> keycloakContainer)
+            .oidcFromCustomKeycloakContainer(keycloakContainer)
             .build();
     nessieCoreContainer = nessieConfig.createContainer();
     nessieCoreContainer.start();

--- a/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/NessieDockerTestResourceLifecycleManager.java
+++ b/servers/quarkus-tests/src/main/java/org/projectnessie/quarkus/tests/profiles/NessieDockerTestResourceLifecycleManager.java
@@ -74,7 +74,13 @@ public class NessieDockerTestResourceLifecycleManager
   @Override
   public Map<String, String> start() {
     CustomKeycloakContainer keycloak = KeycloakTestResourceLifecycleManager.getKeycloak();
-    nessie = containerConfig.oidcFromCustomKeycloakContainer(keycloak).build().createContainer();
+    nessie =
+        containerConfig
+            .oidcHostIp(keycloak.getExternalIp())
+            .oidcInternalRealmUri(keycloak.getInternalRealmUri().toString())
+            .oidcTokenIssuerUri(keycloak.getTokenIssuerUri().toString())
+            .build()
+            .createContainer();
 
     LOGGER.info("Starting Nessie container...");
     nessie.start();

--- a/testing/keycloak-container/src/main/java/org/projectnessie/testing/keycloak/CustomKeycloakContainer.java
+++ b/testing/keycloak-container/src/main/java/org/projectnessie/testing/keycloak/CustomKeycloakContainer.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.testing.keycloak;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import dasniko.testcontainers.keycloak.ExtendableKeycloakContainer;
 import java.net.URI;
@@ -332,6 +334,18 @@ public class CustomKeycloakContainer extends ExtendableKeycloakContainer<CustomK
         String.format(
             "%s%srealms/%s",
             getInternalRootUri(), ensureSlashes(getContextPath()), config.realmName()));
+  }
+
+  public String getExternalIp() {
+    return requireNonNull(
+            getContainerInfo(),
+            "Keycloak container object available, but container info is null. Is the Keycloak container started?")
+        .getNetworkSettings()
+        .getNetworks()
+        .values()
+        .iterator()
+        .next()
+        .getIpAddress();
   }
 
   /**

--- a/testing/nessie-container/build.gradle.kts
+++ b/testing/nessie-container/build.gradle.kts
@@ -21,8 +21,6 @@ extra["maven.name"] = "Nessie - Nessie testcontainer"
 dependencies {
   implementation(libs.slf4j.api)
   implementation(libs.testcontainers.testcontainers)
-  // compileOnly, for non-custom-keycloak use cases
-  compileOnly(project(":nessie-keycloak-testcontainer"))
 
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.findbugs.jsr305)

--- a/testing/nessie-container/build.gradle.kts
+++ b/testing/nessie-container/build.gradle.kts
@@ -20,7 +20,9 @@ extra["maven.name"] = "Nessie - Nessie testcontainer"
 
 dependencies {
   implementation(libs.slf4j.api)
-  api(project(":nessie-keycloak-testcontainer"))
+  implementation(libs.testcontainers.testcontainers)
+  // compileOnly, for non-custom-keycloak use cases
+  compileOnly(project(":nessie-keycloak-testcontainer"))
 
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.findbugs.jsr305)

--- a/testing/nessie-container/src/main/java/org/projectnessie/testing/nessie/NessieContainer.java
+++ b/testing/nessie-container/src/main/java/org/projectnessie/testing/nessie/NessieContainer.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import org.immutables.value.Value;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.projectnessie.testing.keycloak.CustomKeycloakContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -101,13 +100,6 @@ public class NessieContainer extends GenericContainer<NessieContainer> {
 
       @CanIgnoreReturnValue
       Builder authEnabled(boolean authEnabled);
-
-      default Builder oidcFromCustomKeycloakContainer(
-          CustomKeycloakContainer customKeycloakContainer) {
-        return oidcHostIp(customKeycloakContainer.getExternalIp())
-            .oidcInternalRealmUri(customKeycloakContainer.getInternalRealmUri().toString())
-            .oidcTokenIssuerUri(customKeycloakContainer.getTokenIssuerUri().toString());
-      }
 
       @CanIgnoreReturnValue
       Builder oidcInternalRealmUri(String oidcInternalRealmUri);


### PR DESCRIPTION
The Nessie testcontainer does not necessarily need the Keycloak container, but has a "hard" compile+runtime dependency to it. This change removes the implicit runtime dependency and also allows using a different Keycloak container, if needed.