### PR TITLE
Add `--author` option to `content-generator` commands

### DIFF
--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITDeleteContent.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITDeleteContent.java
@@ -78,6 +78,8 @@ class ITDeleteContent extends AbstractContentGeneratorTest {
             "delete",
             "--uri",
             NESSIE_API_URI,
+            "--author",
+            "Test Author 123 <test@example.com>",
             "--message",
             "test-message-123",
             "--branch",
@@ -92,6 +94,7 @@ class ITDeleteContent extends AbstractContentGeneratorTest {
       CommitMeta commitMeta =
           api.getCommitLog().refName(branch.getName()).get().getLogEntries().get(0).getCommitMeta();
       assertThat(commitMeta.getMessage()).contains("test-message-123");
+      assertThat(commitMeta.getAuthor()).isEqualTo("Test Author 123 <test@example.com>");
     }
   }
 }

--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITRefreshContent.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITRefreshContent.java
@@ -115,6 +115,8 @@ public class ITRefreshContent extends AbstractContentGeneratorTest {
 
     assertThat(
             runMain(
+                "--author",
+                "Test Author 123",
                 "--key",
                 key1.getElements().get(0),
                 "--key",
@@ -128,8 +130,9 @@ public class ITRefreshContent extends AbstractContentGeneratorTest {
         .first()
         .extracting(
             logEntry -> logEntry.getCommitMeta().getMessage(),
+            logEntry -> logEntry.getCommitMeta().getAuthor(),
             logEntry -> Objects.requireNonNull(logEntry.getOperations()).get(0).getKey())
-        .containsExactly("Refresh 1 key(s)", key1);
+        .containsExactly("Refresh 1 key(s)", "Test Author 123", key1);
   }
 
   @Test

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/CommittingCommand.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/CommittingCommand.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ImmutableCommitMeta;
+import picocli.CommandLine;
+
+public abstract class CommittingCommand extends AbstractCommand {
+
+  @CommandLine.Option(
+      names = {"--author"},
+      defaultValue = "${USER}",
+      description =
+          "Commit author for changes made by this command (optional, defaults to the USER env. var.)")
+  private String author;
+
+  protected CommitMeta commitMetaFromMessage(String message) {
+    ImmutableCommitMeta.Builder builder = CommitMeta.builder().message(message);
+
+    if (author != null && !author.isEmpty()) {
+      builder.author(author);
+    }
+
+    return builder.build();
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/CreateMissingNamespaces.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/CreateMissingNamespaces.java
@@ -36,7 +36,6 @@ import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.model.Operation.Put;
@@ -49,7 +48,7 @@ import picocli.CommandLine.Option;
     name = "create-missing-namespaces",
     mixinStandardHelpOptions = true,
     description = "Creates missing namespaces for content keys at branch HEADs.")
-public class CreateMissingNamespaces extends AbstractCommand {
+public class CreateMissingNamespaces extends CommittingCommand {
 
   @Option(
       names = {"-r", "--branch"},
@@ -194,8 +193,7 @@ public class CreateMissingNamespaces extends AbstractCommand {
   }
 
   @VisibleForTesting
-  static void commitCreateNamespaces(
-      NessieApiV2 api, Branch branch, List<ContentKey> missingNamespaces)
+  void commitCreateNamespaces(NessieApiV2 api, Branch branch, List<ContentKey> missingNamespaces)
       throws NessieNotFoundException, NessieConflictException {
     CommitMultipleOperationsBuilder commit = api.commitMultipleOperations().branch(branch);
     for (ContentKey nsKey : missingNamespaces) {
@@ -203,7 +201,7 @@ public class CreateMissingNamespaces extends AbstractCommand {
     }
     commit
         .commitMeta(
-            CommitMeta.fromMessage(
+            commitMetaFromMessage(
                 missingNamespaces.stream()
                     .map(ContentKey::toString)
                     .collect(Collectors.joining(", ", "Create namespaces ", ""))))

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DeleteContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DeleteContent.java
@@ -20,7 +20,6 @@ import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Operation;
 import org.projectnessie.model.Reference;
@@ -29,7 +28,7 @@ import picocli.CommandLine.Option;
 
 /** Deletes content objects. */
 @Command(name = "delete", mixinStandardHelpOptions = true, description = "Delete content objects")
-public class DeleteContent extends AbstractCommand {
+public class DeleteContent extends CommittingCommand {
 
   @Option(
       names = {"-r", "--branch"},
@@ -60,7 +59,7 @@ public class DeleteContent extends AbstractCommand {
 
       Branch head =
           api.commitMultipleOperations()
-              .commitMeta(CommitMeta.fromMessage(message))
+              .commitMeta(commitMetaFromMessage(message))
               .branch((Branch) refInfo)
               .operation(Operation.Delete.of(contentKey))
               .commit();

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
@@ -20,7 +20,6 @@ import static org.projectnessie.model.ContentKey.fromPathString;
 import static org.projectnessie.tools.contentgenerator.keygen.KeyGenerator.newKeyGenerator;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -43,7 +42,6 @@ import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.GetMultipleContentsResponse;
@@ -61,7 +59,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
 
 @Command(name = "generate", mixinStandardHelpOptions = true, description = "Generate commits")
-public class GenerateContent extends AbstractCommand {
+public class GenerateContent extends CommittingCommand {
 
   @Option(
       names = {"-b", "--num-branches"},
@@ -213,13 +211,9 @@ public class GenerateContent extends AbstractCommand {
             api.commitMultipleOperations()
                 .branch(commitToBranch)
                 .commitMeta(
-                    CommitMeta.builder()
-                        .message(
-                            String.format(
-                                "Commit #%d of %d on %s", commitNum, numCommits, branchName))
-                        .author(System.getProperty("user.name"))
-                        .authorTime(Instant.now())
-                        .build());
+                    commitMetaFromMessage(
+                        String.format(
+                            "Commit #%d of %d on %s", commitNum, numCommits, branchName)));
 
         // Collect the namespaces that we do not (yet) know whether those exist.
         Set<ContentKey> namespacesToCheck = new HashSet<>();

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/RefreshContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/RefreshContent.java
@@ -32,7 +32,6 @@ import org.projectnessie.client.api.GetContentBuilder;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Operation;
@@ -44,7 +43,7 @@ import picocli.CommandLine.Option;
     name = "content-refresh",
     mixinStandardHelpOptions = true,
     description = "Get and Put content objects without changes to refresh their storage model")
-public class RefreshContent extends AbstractCommand {
+public class RefreshContent extends CommittingCommand {
 
   @Option(
       names = {"--input"},
@@ -188,7 +187,7 @@ public class RefreshContent extends AbstractCommand {
     String msg = message == null ? ("Refresh " + contentMap.size() + " key(s)") : message;
 
     CommitMultipleOperationsBuilder request =
-        api.commitMultipleOperations().branch(branch).commitMeta(CommitMeta.fromMessage(msg));
+        api.commitMultipleOperations().branch(branch).commitMeta(commitMetaFromMessage(msg));
 
     for (Map.Entry<ContentKey, Content> entry : contentMap.entrySet()) {
       Content content = entry.getValue();


### PR DESCRIPTION
* Applies to all commands that perform commits.

* Defaults to the `USER` env. var. (which was already the case in the `generate` command).