### PR TITLE
Add repository configuration objects

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/api/GetRepositoryConfigBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/GetRepositoryConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,13 @@
  */
 package org.projectnessie.client.api;
 
-/**
- * Interface for the Nessie V2 API implementation.
- *
- * <p>At the java client level this API uses the same builder classes and model types as API v1,
- * however the behaviour of some API methods is different.
- *
- * <p>Most changes between v1 and v2 exist at the REST level (HTTP).
- */
-public interface NessieApiV2 extends NessieApiV1 {
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.model.RepositoryConfigResponse;
 
-  GetRepositoryConfigBuilder getRepositoryConfig();
+public interface GetRepositoryConfigBuilder {
+  /** Used to add one or, by repeated invocations, more repository config types to retrieve. */
+  GetRepositoryConfigBuilder type(RepositoryConfig.Type type);
 
-  UpdateRepositoryConfigBuilder updateRepositoryConfig();
+  /** Retrieve the {@link #type(RepositoryConfig.Type) requested} repository config types. */
+  RepositoryConfigResponse get();
 }

--- a/api/client/src/main/java/org/projectnessie/client/api/UpdateRepositoryConfigBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/UpdateRepositoryConfigBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.api;
+
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.model.UpdateRepositoryConfigResponse;
+
+public interface UpdateRepositoryConfigBuilder {
+  /**
+   * Sets the repository config to create or update. Only one repository config can be created or
+   * updated.
+   */
+  UpdateRepositoryConfigBuilder repositoryConfig(RepositoryConfig update);
+
+  /**
+   * Perform the request to create or update the {@link #repositoryConfig(RepositoryConfig)
+   * repository config}.
+   */
+  UpdateRepositoryConfigResponse update() throws NessieConflictException;
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpApiV2.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpApiV2.java
@@ -32,10 +32,12 @@ import org.projectnessie.client.api.GetMultipleNamespacesBuilder;
 import org.projectnessie.client.api.GetNamespaceBuilder;
 import org.projectnessie.client.api.GetRefLogBuilder;
 import org.projectnessie.client.api.GetReferenceBuilder;
+import org.projectnessie.client.api.GetRepositoryConfigBuilder;
 import org.projectnessie.client.api.MergeReferenceBuilder;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.client.api.TransplantCommitsBuilder;
 import org.projectnessie.client.api.UpdateNamespaceBuilder;
+import org.projectnessie.client.api.UpdateRepositoryConfigBuilder;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.util.v2api.ClientSideCreateNamespace;
 import org.projectnessie.client.util.v2api.ClientSideDeleteNamespace;
@@ -175,5 +177,15 @@ public class HttpApiV2 implements NessieApiV2 {
   @Override
   public UpdateNamespaceBuilder updateProperties() {
     return new ClientSideUpdateNamespace(this);
+  }
+
+  @Override
+  public GetRepositoryConfigBuilder getRepositoryConfig() {
+    return new HttpGetRepositoryConfig(client);
+  }
+
+  @Override
+  public UpdateRepositoryConfigBuilder updateRepositoryConfig() {
+    return new HttpUpdateRepositoryConfig(client);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpGetRepositoryConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpGetRepositoryConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v2api;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.projectnessie.client.api.GetRepositoryConfigBuilder;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.HttpRequest;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.model.RepositoryConfigResponse;
+
+final class HttpGetRepositoryConfig implements GetRepositoryConfigBuilder {
+  private final HttpClient client;
+
+  private final Set<RepositoryConfig.Type> types = new HashSet<>();
+
+  HttpGetRepositoryConfig(HttpClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public GetRepositoryConfigBuilder type(RepositoryConfig.Type type) {
+    this.types.add(requireNonNull(type));
+    return this;
+  }
+
+  @Override
+  public RepositoryConfigResponse get() {
+    if (types.isEmpty()) {
+      throw new IllegalStateException("repository config types to retrieve must be set");
+    }
+
+    HttpRequest req = client.newRequest().path("config/repository");
+    types.stream().map(RepositoryConfig.Type::name).forEach(t -> req.queryParam("type", t));
+    return req.get().readEntity(RepositoryConfigResponse.class);
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpUpdateRepositoryConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpUpdateRepositoryConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v2api;
+
+import org.projectnessie.client.api.UpdateRepositoryConfigBuilder;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.model.ImmutableUpdateRepositoryConfigRequest;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.model.UpdateRepositoryConfigRequest;
+import org.projectnessie.model.UpdateRepositoryConfigResponse;
+
+final class HttpUpdateRepositoryConfig implements UpdateRepositoryConfigBuilder {
+  private final HttpClient client;
+  private RepositoryConfig update;
+
+  HttpUpdateRepositoryConfig(HttpClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public UpdateRepositoryConfigBuilder repositoryConfig(RepositoryConfig update) {
+    if (this.update != null) {
+      throw new IllegalStateException("repository config to update has already been set");
+    }
+    this.update = update;
+    return this;
+  }
+
+  @Override
+  public UpdateRepositoryConfigResponse update() throws NessieConflictException {
+    if (this.update == null) {
+      throw new IllegalStateException("repository config to update must be set");
+    }
+    UpdateRepositoryConfigRequest req =
+        ImmutableUpdateRepositoryConfigRequest.builder().config(update).build();
+    return client
+        .newRequest()
+        .path("config/repository")
+        .unwrap(NessieConflictException.class)
+        .post(req)
+        .readEntity(UpdateRepositoryConfigResponse.class);
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/api/v2/ConfigApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/ConfigApi.java
@@ -15,7 +15,12 @@
  */
 package org.projectnessie.api.v2;
 
+import java.util.List;
+import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.model.NessieConfiguration;
+import org.projectnessie.model.RepositoryConfigResponse;
+import org.projectnessie.model.UpdateRepositoryConfigRequest;
+import org.projectnessie.model.UpdateRepositoryConfigResponse;
 
 public interface ConfigApi {
 
@@ -25,4 +30,9 @@ public interface ConfigApi {
 
   /** Get the server configuration. */
   NessieConfiguration getConfig();
+
+  RepositoryConfigResponse getRepositoryConfig(List<String> repositoryConfigTypes);
+
+  UpdateRepositoryConfigResponse updateRepositoryConfig(
+      UpdateRepositoryConfigRequest repositoryConfigUpdate) throws NessieConflictException;
 }

--- a/api/model/src/main/java/org/projectnessie/api/v2/http/HttpConfigApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/http/HttpConfigApi.java
@@ -16,9 +16,12 @@
 package org.projectnessie.api.v2.http;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import java.util.List;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -28,7 +31,11 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.projectnessie.api.v2.ConfigApi;
+import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.model.NessieConfiguration;
+import org.projectnessie.model.RepositoryConfigResponse;
+import org.projectnessie.model.UpdateRepositoryConfigRequest;
+import org.projectnessie.model.UpdateRepositoryConfigResponse;
 import org.projectnessie.model.ser.Views;
 
 @Path("v2/config")
@@ -57,4 +64,63 @@ public interface HttpConfigApi extends ConfigApi {
   })
   @JsonView(Views.V2.class)
   NessieConfiguration getConfig();
+
+  @Override
+  @GET
+  @jakarta.ws.rs.GET
+  @Path("repository")
+  @jakarta.ws.rs.Path("repository")
+  @Produces(MediaType.APPLICATION_JSON)
+  @jakarta.ws.rs.Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Returns repository configurations of the requested types.",
+      operationId = "getRepositoryConfig")
+  @APIResponses({
+    @APIResponse(
+        responseCode = "200",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema =
+                    @Schema(
+                        implementation = RepositoryConfigResponse.class,
+                        title = "Repository configuration objects for the requested types.",
+                        description =
+                            "The existing configuration objects for the requested types will be returned. "
+                                + "Non-existing config objects will not be returned."))),
+    @APIResponse(responseCode = "401", description = "Invalid credentials provided")
+  })
+  @JsonView(Views.V2.class)
+  RepositoryConfigResponse getRepositoryConfig(
+      @QueryParam("type") @jakarta.ws.rs.QueryParam("type") List<String> repositoryConfigTypes);
+
+  @Override
+  @POST
+  @jakarta.ws.rs.POST
+  @Path("repository")
+  @jakarta.ws.rs.Path("repository")
+  @Produces(MediaType.APPLICATION_JSON)
+  @jakarta.ws.rs.Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Create or update a repository configuration.",
+      operationId = "getRepositoryConfig")
+  @APIResponses({
+    @APIResponse(
+        responseCode = "200",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema =
+                    @Schema(
+                        implementation = UpdateRepositoryConfigResponse.class,
+                        title = "The previous state of the repository configuration object.",
+                        description =
+                            "When a repository configuration for the same type as in the request object did not exist, "
+                                + "the response object will be null. Otherwise, if the configuration was updated, the old "
+                                + "value will be returned."))),
+    @APIResponse(responseCode = "401", description = "Invalid credentials provided")
+  })
+  @JsonView(Views.V2.class)
+  UpdateRepositoryConfigResponse updateRepositoryConfig(
+      UpdateRepositoryConfigRequest repositoryConfigUpdate) throws NessieConflictException;
 }

--- a/api/model/src/main/java/org/projectnessie/api/v2/http/HttpConfigApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/http/HttpConfigApi.java
@@ -103,7 +103,7 @@ public interface HttpConfigApi extends ConfigApi {
   @jakarta.ws.rs.Produces(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
   @Operation(
       summary = "Create or update a repository configuration.",
-      operationId = "getRepositoryConfig")
+      operationId = "updateRepositoryConfig")
   @APIResponses({
     @APIResponse(
         responseCode = "200",

--- a/api/model/src/main/java/org/projectnessie/model/GarbageCollectorConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/GarbageCollectorConfig.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.Duration;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+
+/**
+ * Configuration for Nessie Garbage Collector.
+ *
+ * <p>Some parameters for Nessie GC can and should be consistent across multiple invocations of the
+ * GC tool. Those parameters can be configured via this configuration object, persisted in Nessie,
+ * accessible via the Nessie API. Note that the Nessie GC tool shall default to the values from this
+ * configuration, but overriding these values on the command line will still be possible.
+ */
+@Schema(type = SchemaType.OBJECT, title = "Garbage collector config object")
+@Value.Immutable
+@JsonSerialize(as = ImmutableGarbageCollectorConfig.class)
+@JsonDeserialize(as = ImmutableGarbageCollectorConfig.class)
+@JsonTypeName("GARBAGE_COLLECTOR")
+public interface GarbageCollectorConfig extends RepositoryConfig {
+
+  static ImmutableGarbageCollectorConfig.Builder builder() {
+    return ImmutableGarbageCollectorConfig.builder();
+  }
+
+  @Schema(
+      description =
+          "The default cutoff policy."
+              + "\n"
+              + "Policies can be one of: "
+              + "- number of commits as an integer value "
+              + "- a duration (see java.time.Duration) "
+              + "- an ISO instant "
+              + "- 'NONE', means everything's considered as live")
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  String getDefaultCutoffPolicy();
+
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  List<ReferenceCutoffPolicy> getPerRefCutoffPolicies();
+
+  @Schema(
+      title = "Grace period for files created concurrent to GC runs.",
+      description =
+          "Files that have been created after 'gc-start-time - new-files-grace-period' are not being deleted.")
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonSerialize(using = Util.DurationSerializer.class)
+  @JsonDeserialize(using = Util.DurationDeserializer.class)
+  Duration getNewFilesGracePeriod();
+
+  @Schema(title = "The total number of expected live files for a single content.")
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  Integer getExpectedFileCountPerContent();
+
+  @Override
+  default Type getType() {
+    return Type.GARBAGE_COLLECTOR;
+  }
+
+  @Schema(
+      type = SchemaType.OBJECT,
+      title = "References cutoff policy",
+      description =
+          "Cutoff policies per reference names. Supplied as a ref-name-pattern=policy tuple. "
+              + "Reference name patterns are regular expressions.")
+  @Value.Immutable
+  @JsonSerialize(as = ImmutableReferenceCutoffPolicy.class)
+  @JsonDeserialize(as = ImmutableReferenceCutoffPolicy.class)
+  interface ReferenceCutoffPolicy {
+    static ReferenceCutoffPolicy referenceCutoffPolicy(String referenceNamePattern, String policy) {
+      return ImmutableReferenceCutoffPolicy.of(referenceNamePattern, policy);
+    }
+
+    static ImmutableReferenceCutoffPolicy.Builder builder() {
+      return ImmutableReferenceCutoffPolicy.builder();
+    }
+
+    @Schema(description = "Reference name patterns as a regular expressions.")
+    @Value.Parameter(order = 1)
+    String getReferenceNamePattern();
+
+    @Schema(
+        description =
+            "Policies can be one of: "
+                + "- number of commits as an integer value "
+                + "- a duration (see java.time.Duration) "
+                + "- an ISO instant "
+                + "- 'NONE', means everything's considered as live")
+    @Value.Parameter(order = 2)
+    String getPolicy();
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/RepositoryConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/RepositoryConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+import org.projectnessie.model.types.RepositoryConfigTypeIdResolver;
+import org.projectnessie.model.types.RepositoryConfigTypes;
+
+/** Base interface for all configurations that shall be consistent for a Nessie repository. */
+@Schema(
+    type = SchemaType.OBJECT,
+    title = "RepositoryConfig",
+    anyOf = {GarbageCollectorConfig.class},
+    discriminatorMapping = {
+      @DiscriminatorMapping(value = "GARBAGE_COLLECTOR", schema = GarbageCollectorConfig.class)
+    },
+    discriminatorProperty = "type")
+@JsonTypeIdResolver(RepositoryConfigTypeIdResolver.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type", visible = true)
+public interface RepositoryConfig {
+
+  /**
+   * Returns the {@link RepositoryConfig.Type} value for this repository config object.
+   *
+   * <p>The name of the returned value should match the JSON type name used for serializing the
+   * content object.
+   */
+  @Value.Redacted
+  @JsonIgnore
+  RepositoryConfig.Type getType();
+
+  @JsonDeserialize(using = Util.RepositoryConfigTypeDeserializer.class)
+  @JsonSerialize(using = Util.RepositoryConfigTypeSerializer.class)
+  @Schema(
+      type = SchemaType.STRING,
+      description =
+          "Declares the type of a Nessie repository config object, which is currently only "
+              + "GARBAGE_COLLECTOR, which is the discriminator mapping value of the 'RepositoryConfig' type.")
+  interface Type {
+    RepositoryConfig.Type UNKNOWN = RepositoryConfigTypes.forName("UNKNOWN");
+    RepositoryConfig.Type GARBAGE_COLLECTOR = RepositoryConfigTypes.forName("GARBAGE_COLLECTOR");
+
+    /** The name of the content-type. */
+    String name();
+
+    Class<? extends RepositoryConfig> type();
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/RepositoryConfigResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/RepositoryConfigResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+
+@Schema(type = SchemaType.OBJECT, title = "RepositoryConfigResponse")
+@Value.Immutable
+@JsonSerialize(as = ImmutableRepositoryConfigResponse.class)
+@JsonDeserialize(as = ImmutableRepositoryConfigResponse.class)
+public interface RepositoryConfigResponse {
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @Schema(
+      title = "Repository configuration objects for the requested types.",
+      description =
+          "The existing configuration objects for the requested types will be returned. "
+              + "Non-existing config objects will not be returned.")
+  List<RepositoryConfig> getConfigs();
+}

--- a/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigRequest.java
+++ b/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+
+@Schema(type = SchemaType.OBJECT, title = "UpdateRepositoryConfigRequest")
+@Value.Immutable
+@JsonSerialize(as = ImmutableUpdateRepositoryConfigRequest.class)
+@JsonDeserialize(as = ImmutableUpdateRepositoryConfigRequest.class)
+public interface UpdateRepositoryConfigRequest {
+  /**
+   * The previous value of the updated repository configuration object. This will be {@code null},
+   * if the repository configuration was created.
+   */
+  RepositoryConfig getConfig();
+}

--- a/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Nullable;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+
+@Schema(type = SchemaType.OBJECT, title = "UpdateRepositoryConfigResponse")
+@Value.Immutable
+@JsonSerialize(as = ImmutableUpdateRepositoryConfigResponse.class)
+@JsonDeserialize(as = ImmutableUpdateRepositoryConfigResponse.class)
+public interface UpdateRepositoryConfigResponse {
+  /**
+   * The previous value of the updated repository config. If no previous value for the same
+   * repository config type exists, this value will be {@code null}.
+   */
+  @Nullable
+  @jakarta.annotation.Nullable
+  @Schema(
+      implementation = RepositoryConfig.class,
+      title = "The previous state of the repository configuration object.",
+      description =
+          "When a repository configuration for the same type as in the request object did not exist, "
+              + "the response object will be null. Otherwise, if the configuration was updated, the old "
+              + "value will be returned.")
+  RepositoryConfig getPrevious();
+}

--- a/api/model/src/main/java/org/projectnessie/model/Util.java
+++ b/api/model/src/main/java/org/projectnessie/model/Util.java
@@ -21,11 +21,15 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.projectnessie.model.types.ContentTypes;
+import org.projectnessie.model.types.RepositoryConfigTypes;
 
 final class Util {
 
@@ -102,6 +106,60 @@ final class Util {
       } else {
         gen.writeString(value.name());
       }
+    }
+  }
+
+  static final class RepositoryConfigTypeDeserializer
+      extends JsonDeserializer<RepositoryConfig.Type> {
+    @Override
+    public RepositoryConfig.Type deserialize(JsonParser p, DeserializationContext ctxt)
+        throws IOException {
+      String name = p.readValueAs(String.class);
+      return name != null ? RepositoryConfigTypes.forName(name) : null;
+    }
+  }
+
+  static final class RepositoryConfigTypeSerializer extends JsonSerializer<RepositoryConfig.Type> {
+    @Override
+    public void serialize(
+        RepositoryConfig.Type value, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      if (value == null) {
+        gen.writeNull();
+      } else {
+        gen.writeString(value.name());
+      }
+    }
+  }
+
+  static class DurationSerializer extends StdSerializer<Duration> {
+    public DurationSerializer() {
+      this(Duration.class);
+    }
+
+    protected DurationSerializer(Class<Duration> t) {
+      super(t);
+    }
+
+    @Override
+    public void serialize(Duration value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException {
+      gen.writeString(value.toString());
+    }
+  }
+
+  static class DurationDeserializer extends StdDeserializer<Duration> {
+    public DurationDeserializer() {
+      this(null);
+    }
+
+    protected DurationDeserializer(Class<?> vc) {
+      super(vc);
+    }
+
+    @Override
+    public Duration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+      return Duration.parse(p.getText());
     }
   }
 }

--- a/api/model/src/main/java/org/projectnessie/model/types/GenericRepositoryConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/GenericRepositoryConfig.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.annotation.Nullable;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.immutables.value.Value;
+import org.projectnessie.model.RepositoryConfig;
+
+/**
+ * Special {@link org.projectnessie.model.RepositoryConfig} reserved for cases when the actual
+ * {@link RepositoryConfig#getType() repository config type} is not available.
+ *
+ * <p>Nessie servers cannot properly handle unknown {@link RepositoryConfig#getType() repository
+ * config types}, but with this "fallback" clients can at least deserialize the repository config
+ * object and do not fail hard / error out.
+ */
+@Value.Immutable
+@JsonSerialize(using = GenericRepositoryConfig.RepositoryConfigUnknownTypeSerializer.class)
+@JsonDeserialize(using = GenericRepositoryConfig.RepositoryConfigUnknownTypeDeserializer.class)
+public abstract class GenericRepositoryConfig implements RepositoryConfig {
+
+  @Override
+  @Value.Parameter(order = 1)
+  public abstract RepositoryConfig.Type getType();
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  @Schema(type = SchemaType.OBJECT)
+  @Value.Parameter(order = 3)
+  @JsonInclude(Include.NON_NULL)
+  @JsonUnwrapped
+  public abstract Map<String, Object> getAttributes();
+
+  static final class RepositoryConfigUnknownTypeSerializer
+      extends JsonSerializer<GenericRepositoryConfig> {
+
+    @Override
+    public void serializeWithType(
+        GenericRepositoryConfig value,
+        JsonGenerator gen,
+        SerializerProvider serializers,
+        TypeSerializer typeSer)
+        throws IOException {
+      gen.writeStartObject();
+      gen.writeStringField("type", value.getType().name());
+      for (Entry<String, Object> entry : value.getAttributes().entrySet()) {
+        gen.writeFieldName(entry.getKey());
+        gen.writeObject(entry.getValue());
+      }
+      gen.writeEndObject();
+    }
+
+    @Override
+    public void serialize(
+        GenericRepositoryConfig value, JsonGenerator gen, SerializerProvider serializers) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static final class RepositoryConfigUnknownTypeDeserializer
+      extends JsonDeserializer<GenericRepositoryConfig> {
+
+    @Override
+    public GenericRepositoryConfig deserialize(JsonParser p, DeserializationContext ctxt)
+        throws IOException {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> all = p.readValueAs(Map.class);
+      Object type = all.remove("type");
+      if (type == null) {
+        type = "UNKNOWN_CONTENT_TYPE";
+      }
+      return GenericRepositoryConfig.repositoryConfigUnknownType(type.toString(), all);
+    }
+  }
+
+  public static GenericRepositoryConfig repositoryConfigUnknownType(
+      String type, Map<String, Object> all) {
+    return ImmutableGenericRepositoryConfig.of(
+        new RepositoryConfig.Type() {
+          @Override
+          public String name() {
+            return type;
+          }
+
+          @Override
+          public Class<? extends RepositoryConfig> type() {
+            return GenericRepositoryConfig.class;
+          }
+        },
+        all);
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/types/MainRepositoryConfigTypeBundle.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/MainRepositoryConfigTypeBundle.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import org.projectnessie.model.GarbageCollectorConfig;
+
+public class MainRepositoryConfigTypeBundle implements RepositoryConfigTypeBundle {
+  @Override
+  public void register(RepositoryConfigTypeRegistry repositoryTypeRegistry) {
+    repositoryTypeRegistry.register(GarbageCollectorConfig.class);
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/types/RepositoryConfigTypeBundle.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/RepositoryConfigTypeBundle.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+/**
+ * Used to provide custom {@link org.projectnessie.model.RepositoryConfig} implementations via the
+ * Java {@link java.util.ServiceLoader service loader} mechanism.
+ */
+public interface RepositoryConfigTypeBundle {
+  void register(RepositoryConfigTypeRegistry repositoryTypeRegistry);
+}

--- a/api/model/src/main/java/org/projectnessie/model/types/RepositoryConfigTypeIdResolver.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/RepositoryConfigTypeIdResolver.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import org.projectnessie.model.RepositoryConfig;
+
+/** Dynamic {@link RepositoryConfig} object (de)serialization for <em>Jackson</em>. */
+public final class RepositoryConfigTypeIdResolver extends TypeIdResolverBase {
+
+  private JavaType baseType;
+
+  public RepositoryConfigTypeIdResolver() {}
+
+  @Override
+  public void init(JavaType bt) {
+    baseType = bt;
+  }
+
+  @Override
+  public String idFromValue(Object value) {
+    return getId(value);
+  }
+
+  @Override
+  public String idFromValueAndType(Object value, Class<?> suggestedType) {
+    return getId(value);
+  }
+
+  @Override
+  public JsonTypeInfo.Id getMechanism() {
+    return JsonTypeInfo.Id.CUSTOM;
+  }
+
+  private String getId(Object value) {
+    if (value instanceof RepositoryConfig) {
+      return ((RepositoryConfig) value).getType().name();
+    }
+
+    return null;
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) {
+    RepositoryConfig.Type subType;
+    try {
+      subType = RepositoryConfigTypes.forName(id);
+    } catch (IllegalArgumentException e) {
+      return context.constructSpecializedType(baseType, GenericRepositoryConfig.class);
+    }
+    Class<? extends RepositoryConfig> asType = subType.type();
+    if (baseType.getRawClass().isAssignableFrom(asType)) {
+      return context.constructSpecializedType(baseType, asType);
+    }
+
+    // This is rather a "test-only" code path, but it might happen in real life as well, when
+    // calling the ObjectMapper with a "too specific" type and not just RepositoryConfig.class.
+    // So we can get here for example, if the baseType (induced by the type passed to ObjectMapper),
+    // is RepositoryConfigUnknownType.class, but the type is a "well known" type like
+    // IcebergTable.class.
+    @SuppressWarnings("unchecked")
+    Class<? extends RepositoryConfig> concrete =
+        (Class<? extends RepositoryConfig>) baseType.getRawClass();
+    return context.constructSpecializedType(baseType, concrete);
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/types/RepositoryConfigTypeRegistry.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/RepositoryConfigTypeRegistry.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import org.projectnessie.model.RepositoryConfig;
+
+/** An implementation of this interface is passed to {@link RepositoryConfigTypeBundle}s. */
+public interface RepositoryConfigTypeRegistry {
+  void register(Class<? extends RepositoryConfig> type);
+}

--- a/api/model/src/main/java/org/projectnessie/model/types/RepositoryConfigTypes.java
+++ b/api/model/src/main/java/org/projectnessie/model/types/RepositoryConfigTypes.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import javax.annotation.Nonnull;
+import org.projectnessie.model.RepositoryConfig;
+
+/**
+ * Provides the registry for all {@link RepositoryConfig repository config types}.
+ *
+ * <p>Repository config types are loaded via {@link RepositoryConfigTypeBundle}s using Java's {@link
+ * ServiceLoader service loader} mechanism.
+ */
+public final class RepositoryConfigTypes {
+
+  /** Retrieve an array of all registered repository config types. */
+  public static RepositoryConfig.Type[] all() {
+    return Registry.all();
+  }
+
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public static RepositoryConfig.Type forName(String name) {
+    return Registry.forName(name);
+  }
+
+  static final class RegistryHelper implements RepositoryConfigTypeRegistry {
+
+    private final List<RepositoryConfig.Type> list = new ArrayList<>();
+    private final Map<String, RepositoryConfig.Type> names = new HashMap<>();
+
+    @Override
+    public void register(Class<? extends RepositoryConfig> type) {
+      requireNonNull(type, "Illegal repository config type registration: type must not be null");
+
+      JsonTypeName jsonTypeName = type.getAnnotation(JsonTypeName.class);
+      if (jsonTypeName == null) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Repository config type registration: %s has no @JsonTypeName annotation",
+                type.getName()));
+      }
+
+      String name = jsonTypeName.value();
+      if (name == null || name.trim().isEmpty() || !name.trim().equals(name)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Illegal repository config type registration: illegal name '%s' for %s",
+                name, type.getName()));
+      }
+      RepositoryConfig.Type repositoryConfigType = new RepositoryConfigTypeImpl(name, type);
+
+      RepositoryConfig.Type ex = names.get(name);
+      if (ex != null) {
+        throw new IllegalStateException(
+            String.format(
+                "Duplicate repository config type registration for %s/%s, existing: %s/%s",
+                name, type.getName(), ex.name(), ex.type().getName()));
+      }
+
+      add(repositoryConfigType);
+    }
+
+    void add(RepositoryConfig.Type unknownRepositoryConfigType) {
+      list.add(unknownRepositoryConfigType);
+      names.put(unknownRepositoryConfigType.name(), unknownRepositoryConfigType);
+    }
+  }
+
+  /**
+   * Internal class providing the actual registry. This is a separate class to implicitly use lazy
+   * initialization.
+   */
+  private static final class Registry {
+
+    private static final RepositoryConfig.Type[] all;
+    private static final Map<String, RepositoryConfig.Type> byName;
+
+    static {
+      RegistryHelper registryHelper = new RegistryHelper();
+
+      // Add the "DEFAULT" type.
+      RepositoryConfig.Type unknownRepositoryConfigType = new DefaultRepositoryConfigTypeImpl();
+      registryHelper.add(unknownRepositoryConfigType);
+
+      for (RepositoryConfigTypeBundle bundle :
+          ServiceLoader.load(RepositoryConfigTypeBundle.class)) {
+        bundle.register(registryHelper);
+      }
+
+      byName = Collections.unmodifiableMap(registryHelper.names);
+      all = registryHelper.list.toArray(new RepositoryConfig.Type[0]);
+    }
+
+    private static RepositoryConfig.Type[] all() {
+      return all.clone();
+    }
+
+    private static RepositoryConfig.Type forName(String name) {
+      RepositoryConfig.Type type = byName.get(name);
+      if (type == null) {
+        throw new IllegalArgumentException("No repository config type registered for name " + name);
+      }
+      return type;
+    }
+  }
+
+  /** Internally used wrapper for a {@link RepositoryConfig.Type}. */
+  private static final class RepositoryConfigTypeImpl implements RepositoryConfig.Type {
+
+    private final String name;
+
+    private final Class<? extends RepositoryConfig> type;
+
+    private RepositoryConfigTypeImpl(String name, Class<? extends RepositoryConfig> type) {
+      this.name = name;
+      this.type = type;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public Class<? extends RepositoryConfig> type() {
+      return type;
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof RepositoryConfigTypeImpl)) {
+        return false;
+      }
+      RepositoryConfigTypeImpl that = (RepositoryConfigTypeImpl) o;
+      return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return name.hashCode();
+    }
+  }
+
+  /** Internally used wrapper for the {@code UNKNOWN} repository config type. */
+  private static final class DefaultRepositoryConfigTypeImpl implements RepositoryConfig.Type {
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    @Override
+    public String toString() {
+      return name();
+    }
+
+    @Override
+    public String name() {
+      return "UNKNOWN";
+    }
+
+    @Override
+    public Class<? extends RepositoryConfig> type() {
+      throw new IllegalStateException("UNKNOWN RepositoryConfig.Type has no type");
+    }
+  }
+}

--- a/api/model/src/main/resources/META-INF/services/org.projectnessie.model.types.RepositoryConfigTypeBundle
+++ b/api/model/src/main/resources/META-INF/services/org.projectnessie.model.types.RepositoryConfigTypeBundle
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.model.types.MainRepositoryConfigTypeBundle

--- a/api/model/src/test/java/org/projectnessie/model/types/CustomTestRepositoryConfig.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/CustomTestRepositoryConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+import org.projectnessie.model.RepositoryConfig;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableCustomTestRepositoryConfig.class)
+@JsonDeserialize(as = ImmutableCustomTestRepositoryConfig.class)
+@JsonTypeName(CustomTestRepositoryConfig.TYPE)
+public abstract class CustomTestRepositoryConfig implements RepositoryConfig {
+  static final String TYPE = "TEST_CUSTOM_REPOSITORY_CONFIG_TYPE";
+
+  public abstract long getSomeLong();
+
+  public abstract String getSomeString();
+
+  @Override
+  public Type getType() {
+    return RepositoryConfigTypes.forName(TYPE);
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/CustomTestRepositoryConfigTypeBundle.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/CustomTestRepositoryConfigTypeBundle.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+public class CustomTestRepositoryConfigTypeBundle implements RepositoryConfigTypeBundle {
+
+  @Override
+  public void register(RepositoryConfigTypeRegistry repositoryConfigTypeRegistry) {
+    repositoryConfigTypeRegistry.register(CustomTestRepositoryConfig.class);
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/TestContentTypeRegistryHelper.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestContentTypeRegistryHelper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.immutables.value.Value;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.types.ContentTypes.RegistryHelper;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestContentTypeRegistryHelper {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  void badRegistrations() {
+    RegistryHelper registryHelper = new RegistryHelper();
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> registryHelper.register(Content.class))
+        .withMessage(
+            "Content-type registration: org.projectnessie.model.Content has no @JsonTypeName annotation");
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> registryHelper.register(RegistryHelperNoJsonTypeName.class))
+        .withMessage(
+            "Content-type registration: org.projectnessie.model.types.TestContentTypeRegistryHelper$RegistryHelperNoJsonTypeName has no @JsonTypeName annotation");
+
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> registryHelper.register(RegistryHelperIllegalName.class))
+        .withMessage(
+            "Illegal content-type registration: illegal name ' ILLEGAL ' for org.projectnessie.model.types.TestContentTypeRegistryHelper$RegistryHelperIllegalName");
+
+    soft.assertThatCode(() -> registryHelper.register(RegistryHelperGood.class))
+        .doesNotThrowAnyException();
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> registryHelper.register(RegistryHelperDupe.class))
+        .withMessage(
+            "Duplicate content type registration for DUPE/org.projectnessie.model.types.TestContentTypeRegistryHelper$RegistryHelperDupe, existing: DUPE/org.projectnessie.model.types.TestContentTypeRegistryHelper$RegistryHelperGood");
+  }
+
+  @Test
+  void getUnknown() {
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> ContentTypes.forName("NO_NO_NOT_THERE"))
+        .withMessage("No content type registered for name NO_NO_NOT_THERE");
+  }
+
+  @Value.Immutable
+  public abstract static class RegistryHelperNoJsonTypeName extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName("JSON_TYPE_NAME");
+    }
+  }
+
+  @Value.Immutable
+  @JsonTypeName(" ILLEGAL ")
+  public abstract static class RegistryHelperIllegalName extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName(" ILLEGAL ");
+    }
+  }
+
+  @Value.Immutable
+  @JsonTypeName("JSON_TYPE_NAME")
+  public abstract static class RegistryHelperNameMismatch extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName("JSON_TYPE_NAME");
+    }
+  }
+
+  @Value.Immutable
+  @JsonTypeName("DUPE")
+  public abstract static class RegistryHelperGood extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName("DUPE");
+    }
+  }
+
+  @Value.Immutable
+  @JsonTypeName("DUPE")
+  public abstract static class RegistryHelperDupe extends Content {
+    @Override
+    public Type getType() {
+      return ContentTypes.forName("DUPE");
+    }
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/TestCustomRepositoryConfigType.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestCustomRepositoryConfigType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.RepositoryConfig;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestCustomRepositoryConfigType {
+  static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  void directSerialization() throws Exception {
+    CustomTestRepositoryConfig testRepositoryConfig =
+        ImmutableCustomTestRepositoryConfig.builder().someLong(42L).someString("blah").build();
+
+    String json = MAPPER.writeValueAsString(testRepositoryConfig);
+
+    RepositoryConfig deserializedAsRepositoryConfig =
+        MAPPER.readValue(json, RepositoryConfig.class);
+    CustomTestRepositoryConfig deserializedAsTestRepositoryConfig =
+        MAPPER.readValue(json, CustomTestRepositoryConfig.class);
+
+    soft.assertThat(deserializedAsRepositoryConfig).isEqualTo(testRepositoryConfig);
+    soft.assertThat(deserializedAsTestRepositoryConfig).isEqualTo(testRepositoryConfig);
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/TestGenericRepositoryConfig.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestGenericRepositoryConfig.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model.types;
+
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.projectnessie.model.GarbageCollectorConfig.ReferenceCutoffPolicy.referenceCutoffPolicy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.model.GarbageCollectorConfig;
+import org.projectnessie.model.RepositoryConfig;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestGenericRepositoryConfig {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  static Stream<JsonNode> unknownRepositoryConfigType() {
+    return Stream.of(
+        new ObjectNode(JsonNodeFactory.instance)
+            .put("type", "something-unknown")
+            .put("id", "123")
+            .put("a", "b")
+            .put("c", "d"),
+        new ObjectNode(JsonNodeFactory.instance)
+            .put("type", "something-unknown")
+            .put("a", "b")
+            .set("arr", new ArrayNode(JsonNodeFactory.instance).add(42).add("foo").add(true)),
+        new ObjectNode(JsonNodeFactory.instance)
+            .put("type", "something-unknown")
+            .put("a", "b")
+            .set(
+                "c",
+                new ObjectNode(JsonNodeFactory.instance)
+                    .put("i1", "v1")
+                    .put("i2", "v2")
+                    .set("i3", new ObjectNode(JsonNodeFactory.instance).put("x1", "y1"))),
+        new ObjectNode(JsonNodeFactory.instance)
+            .put("a", "b")
+            .put("c", "d")
+            .put("type", "something-unknown"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void unknownRepositoryConfigType(JsonNode candidate) throws Exception {
+    String jsonString = MAPPER.writeValueAsString(candidate);
+    RepositoryConfig meta = MAPPER.readValue(jsonString, RepositoryConfig.class);
+
+    soft.assertThat(meta.getType().name()).isEqualTo("something-unknown");
+
+    String serialized = MAPPER.writeValueAsString(meta);
+
+    JsonNode serializedAsJsonNode = MAPPER.readValue(serialized, JsonNode.class);
+    soft.assertThat(serializedAsJsonNode).isEqualTo(candidate);
+  }
+
+  static Stream<RepositoryConfig> knownRepositoryConfigTypeAsUnknown() {
+    return Stream.of(
+        GarbageCollectorConfig.builder().build(),
+        GarbageCollectorConfig.builder()
+            .expectedFileCountPerContent(42)
+            .defaultCutoffPolicy("3")
+            .addPerRefCutoffPolicies(referenceCutoffPolicy("main", "PT30D"))
+            .build());
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void knownRepositoryConfigTypeAsUnknown(RepositoryConfig repositoryConfig) throws Exception {
+    TokenBuffer tokenBuffer = new TokenBuffer(MAPPER, false);
+    MAPPER.writeValue(tokenBuffer, repositoryConfig);
+    JsonNode jsonNode = tokenBuffer.asParser().readValueAsTree();
+
+    String jsonString = MAPPER.writeValueAsString(repositoryConfig);
+    RepositoryConfig meta = MAPPER.readValue(jsonString, RepositoryConfig.class);
+    soft.assertThat(meta).isEqualTo(repositoryConfig);
+
+    String serialized = MAPPER.writeValueAsString(meta);
+    JsonNode serializedAsJsonNode = MAPPER.readValue(serialized, JsonNode.class);
+    // Cannot "just" compare jsonNode + serializedAsJsonNode, because the integer values are added
+    // as 'int's for the one and as 'long's for the other, which makes comparing those impossible.
+    soft.assertThat(serializedAsJsonNode)
+        .asInstanceOf(type(JsonNode.class))
+        .extracting(
+            n -> n.get("type"),
+            n -> n.get("id"),
+            n -> n.get("metadataLocation"),
+            n -> n.get("sqlText"),
+            n -> n.get("dialect"))
+        .containsExactly(
+            jsonNode.get("type"),
+            jsonNode.get("id"),
+            jsonNode.get("metadataLocation"),
+            jsonNode.get("sqlText"),
+            jsonNode.get("dialect"));
+
+    RepositoryConfig deserialized = MAPPER.readValue(serialized, GenericRepositoryConfig.class);
+    soft.assertThat(deserialized)
+        .extracting(c -> c.getType().name(), c -> c.getType().type())
+        .containsExactly(repositoryConfig.getType().name(), GenericRepositoryConfig.class);
+  }
+}

--- a/api/model/src/test/java/org/projectnessie/model/types/TestRepositoryConfigTypeRegistryHelper.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestRepositoryConfigTypeRegistryHelper.java
@@ -22,11 +22,11 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.immutables.value.Value;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.projectnessie.model.Content;
-import org.projectnessie.model.types.ContentTypes.RegistryHelper;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.model.types.RepositoryConfigTypes.RegistryHelper;
 
 @ExtendWith(SoftAssertionsExtension.class)
-public class TestRegistryHelper {
+public class TestRepositoryConfigTypeRegistryHelper {
   @InjectSoftAssertions protected SoftAssertions soft;
 
   @Test
@@ -34,76 +34,76 @@ public class TestRegistryHelper {
     RegistryHelper registryHelper = new RegistryHelper();
 
     soft.assertThatIllegalArgumentException()
-        .isThrownBy(() -> registryHelper.register(Content.class))
+        .isThrownBy(() -> registryHelper.register(RepositoryConfig.class))
         .withMessage(
-            "Content-type registration: org.projectnessie.model.Content has no @JsonTypeName annotation");
+            "Repository config type registration: org.projectnessie.model.RepositoryConfig has no @JsonTypeName annotation");
 
     soft.assertThatIllegalArgumentException()
         .isThrownBy(() -> registryHelper.register(RegistryHelperNoJsonTypeName.class))
         .withMessage(
-            "Content-type registration: org.projectnessie.model.types.TestRegistryHelper$RegistryHelperNoJsonTypeName has no @JsonTypeName annotation");
+            "Repository config type registration: org.projectnessie.model.types.TestRepositoryConfigTypeRegistryHelper$RegistryHelperNoJsonTypeName has no @JsonTypeName annotation");
 
     soft.assertThatIllegalArgumentException()
         .isThrownBy(() -> registryHelper.register(RegistryHelperIllegalName.class))
         .withMessage(
-            "Illegal content-type registration: illegal name ' ILLEGAL ' for org.projectnessie.model.types.TestRegistryHelper$RegistryHelperIllegalName");
+            "Illegal repository config type registration: illegal name ' ILLEGAL ' for org.projectnessie.model.types.TestRepositoryConfigTypeRegistryHelper$RegistryHelperIllegalName");
 
     soft.assertThatCode(() -> registryHelper.register(RegistryHelperGood.class))
         .doesNotThrowAnyException();
     soft.assertThatIllegalStateException()
         .isThrownBy(() -> registryHelper.register(RegistryHelperDupe.class))
         .withMessage(
-            "Duplicate content type registration for DUPE/org.projectnessie.model.types.TestRegistryHelper$RegistryHelperDupe, existing: DUPE/org.projectnessie.model.types.TestRegistryHelper$RegistryHelperGood");
+            "Duplicate repository config type registration for DUPE/org.projectnessie.model.types.TestRepositoryConfigTypeRegistryHelper$RegistryHelperDupe, existing: DUPE/org.projectnessie.model.types.TestRepositoryConfigTypeRegistryHelper$RegistryHelperGood");
   }
 
   @Test
   void getUnknown() {
     soft.assertThatIllegalArgumentException()
-        .isThrownBy(() -> ContentTypes.forName("NO_NO_NOT_THERE"))
-        .withMessage("No content type registered for name NO_NO_NOT_THERE");
+        .isThrownBy(() -> RepositoryConfigTypes.forName("NO_NO_NOT_THERE"))
+        .withMessage("No repository config type registered for name NO_NO_NOT_THERE");
   }
 
   @Value.Immutable
-  public abstract static class RegistryHelperNoJsonTypeName extends Content {
+  public abstract static class RegistryHelperNoJsonTypeName implements RepositoryConfig {
     @Override
     public Type getType() {
-      return ContentTypes.forName("JSON_TYPE_NAME");
+      return RepositoryConfigTypes.forName("JSON_TYPE_NAME");
     }
   }
 
   @Value.Immutable
   @JsonTypeName(" ILLEGAL ")
-  public abstract static class RegistryHelperIllegalName extends Content {
+  public abstract static class RegistryHelperIllegalName implements RepositoryConfig {
     @Override
     public Type getType() {
-      return ContentTypes.forName(" ILLEGAL ");
+      return RepositoryConfigTypes.forName(" ILLEGAL ");
     }
   }
 
   @Value.Immutable
   @JsonTypeName("JSON_TYPE_NAME")
-  public abstract static class RegistryHelperNameMismatch extends Content {
+  public abstract static class RegistryHelperNameMismatch implements RepositoryConfig {
     @Override
     public Type getType() {
-      return ContentTypes.forName("JSON_TYPE_NAME");
+      return RepositoryConfigTypes.forName("JSON_TYPE_NAME");
     }
   }
 
   @Value.Immutable
   @JsonTypeName("DUPE")
-  public abstract static class RegistryHelperGood extends Content {
+  public abstract static class RegistryHelperGood implements RepositoryConfig {
     @Override
     public Type getType() {
-      return ContentTypes.forName("DUPE");
+      return RepositoryConfigTypes.forName("DUPE");
     }
   }
 
   @Value.Immutable
   @JsonTypeName("DUPE")
-  public abstract static class RegistryHelperDupe extends Content {
+  public abstract static class RegistryHelperDupe implements RepositoryConfig {
     @Override
     public Type getType() {
-      return ContentTypes.forName("DUPE");
+      return RepositoryConfigTypes.forName("DUPE");
     }
   }
 }

--- a/api/model/src/test/resources/META-INF/services/org.projectnessie.model.types.RepositoryConfigTypeBundle
+++ b/api/model/src/test/resources/META-INF/services/org.projectnessie.model.types.RepositoryConfigTypeBundle
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.model.types.CustomTestRepositoryConfigTypeBundle

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
@@ -15,8 +15,11 @@
  */
 package org.projectnessie.services.rest;
 
+import java.security.Principal;
+import java.util.function.Supplier;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ConfigApiImpl;
 import org.projectnessie.versioned.VersionStore;
@@ -26,12 +29,16 @@ import org.projectnessie.versioned.VersionStore;
 public class RestConfigService extends ConfigApiImpl {
   // Mandated by CDI 2.0
   public RestConfigService() {
-    this(null, null);
+    this(null, null, null, null);
   }
 
   @Inject
   @jakarta.inject.Inject
-  public RestConfigService(ServerConfig config, VersionStore store) {
-    super(config, store, 1);
+  public RestConfigService(
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
+    super(config, store, authorizer, principal, 1);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
@@ -16,19 +16,25 @@
 package org.projectnessie.services.rest;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import java.security.Principal;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import org.projectnessie.api.v2.http.HttpConfigApi;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.model.ImmutableRepositoryConfigResponse;
+import org.projectnessie.model.ImmutableUpdateRepositoryConfigResponse;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.model.RepositoryConfigResponse;
+import org.projectnessie.model.UpdateRepositoryConfigRequest;
+import org.projectnessie.model.UpdateRepositoryConfigResponse;
 import org.projectnessie.model.ser.Views;
 import org.projectnessie.model.types.RepositoryConfigTypes;
+import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ConfigApiImpl;
 import org.projectnessie.versioned.VersionStore;
@@ -42,13 +48,17 @@ public class RestV2ConfigResource implements HttpConfigApi {
 
   // Mandated by CDI 2.0
   public RestV2ConfigResource() {
-    this(null, null);
+    this(null, null, null, null);
   }
 
   @Inject
   @jakarta.inject.Inject
-  public RestV2ConfigResource(ServerConfig config, VersionStore store) {
-    this.config = new ConfigApiImpl(config, store, 2);
+  public RestV2ConfigResource(
+      ServerConfig config,
+      VersionStore store,
+      Authorizer authorizer,
+      Supplier<Principal> principal) {
+    this.config = new ConfigApiImpl(config, store, authorizer, principal, 2);
   }
 
   @Override
@@ -69,8 +79,10 @@ public class RestV2ConfigResource implements HttpConfigApi {
   }
 
   @Override
-  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
-      throws NessieConflictException {
-    return config.updateRepositoryConfig(repositoryConfig);
+  public UpdateRepositoryConfigResponse updateRepositoryConfig(
+      UpdateRepositoryConfigRequest repositoryConfigUpdate) throws NessieConflictException {
+    return ImmutableUpdateRepositoryConfigResponse.builder()
+        .previous(config.updateRepositoryConfig(repositoryConfigUpdate.getConfig()))
+        .build();
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
@@ -16,11 +16,19 @@
 package org.projectnessie.services.rest;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import org.projectnessie.api.v2.http.HttpConfigApi;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.model.ImmutableRepositoryConfigResponse;
 import org.projectnessie.model.NessieConfiguration;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.model.RepositoryConfigResponse;
 import org.projectnessie.model.ser.Views;
+import org.projectnessie.model.types.RepositoryConfigTypes;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ConfigApiImpl;
 import org.projectnessie.versioned.VersionStore;
@@ -47,5 +55,22 @@ public class RestV2ConfigResource implements HttpConfigApi {
   @JsonView(Views.V2.class)
   public NessieConfiguration getConfig() {
     return config.getConfig();
+  }
+
+  @Override
+  public RepositoryConfigResponse getRepositoryConfig(List<String> repositoryConfigTypes) {
+    Set<RepositoryConfig.Type> types =
+        repositoryConfigTypes.stream()
+            .map(RepositoryConfigTypes::forName)
+            .collect(Collectors.toSet());
+    return ImmutableRepositoryConfigResponse.builder()
+        .addAllConfigs(config.getRepositoryConfig(types))
+        .build();
+  }
+
+  @Override
+  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
+      throws NessieConflictException {
+    return config.updateRepositoryConfig(repositoryConfig);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/AbstractBatchAccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/AbstractBatchAccessChecker.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import org.projectnessie.model.IdentifiedContentKey;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.versioned.NamedRef;
 
 public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
@@ -124,5 +125,15 @@ public abstract class AbstractBatchAccessChecker implements BatchAccessChecker {
   @Override
   public BatchAccessChecker canViewRefLog() {
     return can(Check.canViewRefLog());
+  }
+
+  @Override
+  public BatchAccessChecker canReadRepositoryConfig(RepositoryConfig.Type repositoryConfigType) {
+    return can(Check.canReadRepositoryConfig(repositoryConfigType));
+  }
+
+  @Override
+  public BatchAccessChecker canUpdateRepositoryConfig(RepositoryConfig.Type repositoryConfigType) {
+    return can(Check.canUpdateRepositoryConfig(repositoryConfigType));
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/BatchAccessChecker.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/BatchAccessChecker.java
@@ -15,12 +15,14 @@
  */
 package org.projectnessie.services.authz;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Map;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.Detached;
 import org.projectnessie.model.IdentifiedContentKey;
 import org.projectnessie.model.Operation;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.model.Tag;
 import org.projectnessie.versioned.NamedRef;
 
@@ -66,6 +68,7 @@ public interface BatchAccessChecker {
     }
   }
 
+  @CanIgnoreReturnValue
   BatchAccessChecker can(Check check);
 
   /**
@@ -74,6 +77,7 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canViewReference(NamedRef ref);
 
   /**
@@ -81,6 +85,7 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canCreateReference(NamedRef ref);
 
   /**
@@ -91,6 +96,7 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check not granted.
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canAssignRefToHash(NamedRef ref);
 
   /**
@@ -98,6 +104,7 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canDeleteReference(NamedRef ref);
 
   /**
@@ -108,6 +115,7 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canReadEntries(NamedRef ref);
 
   /**
@@ -123,6 +131,7 @@ public interface BatchAccessChecker {
    * @param ref current reference
    * @param identifiedKey content key / ID / type to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canReadContentKey(NamedRef ref, IdentifiedContentKey identifiedKey);
 
   /**
@@ -133,6 +142,7 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canListCommitLog(NamedRef ref);
 
   /**
@@ -143,6 +153,7 @@ public interface BatchAccessChecker {
    *
    * @param ref The {@link NamedRef} to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canCommitChangeAgainstReference(NamedRef ref);
 
   /**
@@ -154,6 +165,7 @@ public interface BatchAccessChecker {
    * @param ref The {@link NamedRef} to check
    * @param identifiedKey content key / ID / type to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canReadEntityValue(NamedRef ref, IdentifiedContentKey identifiedKey);
 
   /**
@@ -166,6 +178,7 @@ public interface BatchAccessChecker {
    * @param ref The {@link NamedRef} to check
    * @param identifiedKey content key / ID / type to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canCreateEntity(NamedRef ref, IdentifiedContentKey identifiedKey);
 
   /**
@@ -178,6 +191,7 @@ public interface BatchAccessChecker {
    * @param ref The {@link NamedRef} to check
    * @param identifiedKey content key / ID / type to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canUpdateEntity(NamedRef ref, IdentifiedContentKey identifiedKey);
 
   /**
@@ -190,8 +204,16 @@ public interface BatchAccessChecker {
    * @param ref The {@link NamedRef} to check
    * @param identifiedKey content key / ID / type to check
    */
+  @CanIgnoreReturnValue
   BatchAccessChecker canDeleteEntity(NamedRef ref, IdentifiedContentKey identifiedKey);
 
   /** Checks whether the given role/principal is allowed to view the reflog entries. */
+  @CanIgnoreReturnValue
   BatchAccessChecker canViewRefLog();
+
+  @CanIgnoreReturnValue
+  BatchAccessChecker canReadRepositoryConfig(RepositoryConfig.Type repositoryConfigType);
+
+  @CanIgnoreReturnValue
+  BatchAccessChecker canUpdateRepositoryConfig(RepositoryConfig.Type repositoryConfigType);
 }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
@@ -20,6 +20,7 @@ import org.immutables.value.Value;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.versioned.NamedRef;
 
 /** Describes a check operation. */
@@ -53,12 +54,21 @@ public interface Check {
   @Value.Parameter(order = 6)
   IdentifiedContentKey identifiedKey();
 
+  @Nullable
+  @jakarta.annotation.Nullable
+  @Value.Parameter(order = 7)
+  RepositoryConfig.Type repositoryConfigType();
+
   static Check check(CheckType type) {
-    return ImmutableCheck.of(type, null, null, null, null, null);
+    return ImmutableCheck.of(type, null, null, null, null, null, null);
+  }
+
+  static Check check(CheckType type, RepositoryConfig.Type repositoryConfigType) {
+    return ImmutableCheck.of(type, null, null, null, null, null, repositoryConfigType);
   }
 
   static Check check(CheckType type, @Nullable @jakarta.annotation.Nullable NamedRef ref) {
-    return ImmutableCheck.of(type, ref, null, null, null, null);
+    return ImmutableCheck.of(type, ref, null, null, null, null, null);
   }
 
   static Check check(
@@ -73,10 +83,11 @@ public interface Check {
           identifiedKey.contentKey(),
           element.contentId(),
           identifiedKey.type(),
-          identifiedKey);
+          identifiedKey,
+          null);
     }
 
-    return ImmutableCheck.of(type, ref, null, null, null, null);
+    return ImmutableCheck.of(type, ref, null, null, null, null, null);
   }
 
   static ImmutableCheck.Builder builder(CheckType type) {
@@ -85,38 +96,44 @@ public interface Check {
 
   enum CheckType {
     /** See {@link BatchAccessChecker#canViewReference(NamedRef)}. */
-    VIEW_REFERENCE(true, false),
+    VIEW_REFERENCE(true, false, false),
     /** See {@link BatchAccessChecker#canCreateReference(NamedRef)}. */
-    CREATE_REFERENCE(true, false),
+    CREATE_REFERENCE(true, false, false),
     /** See {@link BatchAccessChecker#canAssignRefToHash(NamedRef)}. */
-    ASSIGN_REFERENCE_TO_HASH(true, false),
+    ASSIGN_REFERENCE_TO_HASH(true, false, false),
     /** See {@link BatchAccessChecker#canDeleteReference(NamedRef)}. */
-    DELETE_REFERENCE(true, false),
+    DELETE_REFERENCE(true, false, false),
     /** See {@link BatchAccessChecker#canReadEntries(NamedRef)}. */
-    READ_ENTRIES(true, false),
+    READ_ENTRIES(true, false, false),
     /** See {@link BatchAccessChecker#canReadContentKey(NamedRef, IdentifiedContentKey)}. */
-    READ_CONTENT_KEY(true, true),
+    READ_CONTENT_KEY(true, true, false),
     /** See {@link BatchAccessChecker#canListCommitLog(NamedRef)}. */
-    LIST_COMMIT_LOG(true, false),
+    LIST_COMMIT_LOG(true, false, false),
     /** See {@link BatchAccessChecker#canCommitChangeAgainstReference(NamedRef)}. */
-    COMMIT_CHANGE_AGAINST_REFERENCE(true, false),
+    COMMIT_CHANGE_AGAINST_REFERENCE(true, false, false),
     /** See {@link BatchAccessChecker#canReadEntityValue(NamedRef, IdentifiedContentKey)}. */
-    READ_ENTITY_VALUE(true, true),
+    READ_ENTITY_VALUE(true, true, false),
     /** See {@link BatchAccessChecker#canCreateEntity(NamedRef, IdentifiedContentKey)}. */
-    CREATE_ENTITY(true, true),
+    CREATE_ENTITY(true, true, false),
     /** See {@link BatchAccessChecker#canUpdateEntity(NamedRef, IdentifiedContentKey)}. */
-    UPDATE_ENTITY(true, true),
+    UPDATE_ENTITY(true, true, false),
     /** See {@link BatchAccessChecker#canDeleteEntity(NamedRef, IdentifiedContentKey)}. */
-    DELETE_ENTITY(true, true),
+    DELETE_ENTITY(true, true, false),
     /** See {@link BatchAccessChecker#canViewRefLog()}. */
-    VIEW_REFLOG(false, false);
+    VIEW_REFLOG(false, false, false),
+
+    READ_REPOSITORY_CONFIG(false, false, true),
+
+    UPDATE_REPOSITORY_CONFIG(false, false, true);
 
     private final boolean ref;
     private final boolean content;
+    private final boolean repositoryConfigType;
 
-    CheckType(boolean ref, boolean content) {
+    CheckType(boolean ref, boolean content, boolean repositoryConfigType) {
       this.ref = ref;
       this.content = content;
+      this.repositoryConfigType = repositoryConfigType;
     }
 
     public boolean isRef() {
@@ -125,6 +142,10 @@ public interface Check {
 
     public boolean isContent() {
       return content;
+    }
+
+    public boolean isRepositoryConfigType() {
+      return repositoryConfigType;
     }
   }
 
@@ -178,5 +199,13 @@ public interface Check {
 
   static Check canViewRefLog() {
     return check(CheckType.VIEW_REFLOG);
+  }
+
+  static Check canReadRepositoryConfig(RepositoryConfig.Type repositoryConfigType) {
+    return check(CheckType.READ_REPOSITORY_CONFIG, repositoryConfigType);
+  }
+
+  static Check canUpdateRepositoryConfig(RepositoryConfig.Type repositoryConfigType) {
+    return check(CheckType.UPDATE_REPOSITORY_CONFIG, repositoryConfigType);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/BaseApiImpl.java
@@ -173,7 +173,7 @@ public abstract class BaseApiImpl {
     }
   }
 
-  protected ServerConfig getConfig() {
+  protected ServerConfig getServerConfig() {
     return config;
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
@@ -15,10 +15,16 @@
  */
 package org.projectnessie.services.impl;
 
+import java.util.List;
+import java.util.Set;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieReferenceConflictException;
 import org.projectnessie.model.ImmutableNessieConfiguration;
 import org.projectnessie.model.NessieConfiguration;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.spi.ConfigService;
+import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.RepositoryInformation;
 import org.projectnessie.versioned.VersionStore;
 
@@ -50,5 +56,21 @@ public class ConfigApiImpl implements ConfigService {
         .oldestPossibleCommitTimestamp(info.getOldestPossibleCommitTimestamp())
         .additionalProperties(info.getAdditionalProperties())
         .build();
+  }
+
+  @Override
+  public List<RepositoryConfig> getRepositoryConfig(
+      Set<RepositoryConfig.Type> repositoryConfigTypes) {
+    return store.getRepositoryConfig(repositoryConfigTypes);
+  }
+
+  @Override
+  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
+      throws NessieConflictException {
+    try {
+      return store.updateRepositoryConfig(repositoryConfig);
+    } catch (ReferenceConflictException e) {
+      throw new NessieReferenceConflictException(e.getReferenceConflicts(), e.getMessage(), e);
+    }
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -110,7 +110,7 @@ public class DiffApiImpl extends BaseApiImpl implements DiffService {
 
         AuthzPaginationIterator<Diff> authz =
             new AuthzPaginationIterator<Diff>(
-                diffs, super::startAccessCheck, getConfig().accessChecksBatchSize()) {
+                diffs, super::startAccessCheck, getServerConfig().accessChecksBatchSize()) {
               @Override
               protected Set<Check> checksForEntry(Diff entry) {
                 if (entry.getFromValue().isPresent()) {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -153,7 +153,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
       AuthzPaginationIterator<ReferenceInfo<CommitMeta>> authz =
           new AuthzPaginationIterator<ReferenceInfo<CommitMeta>>(
-              references, super::startAccessCheck, getConfig().accessChecksBatchSize()) {
+              references, super::startAccessCheck, getServerConfig().accessChecksBatchSize()) {
             @Override
             protected Set<Check> checksForEntry(ReferenceInfo<CommitMeta> entry) {
               return singleton(canViewReference(entry.getNamedRef()));
@@ -175,7 +175,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
     } catch (ReferenceNotFoundException e) {
       throw new IllegalArgumentException(
           String.format(
-              "Could not find default branch '%s'.", this.getConfig().getDefaultBranch()));
+              "Could not find default branch '%s'.", this.getServerConfig().getDefaultBranch()));
     }
     return pagedResponseHandler.build();
   }
@@ -183,7 +183,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
   private GetNamedRefsParams getGetNamedRefsParams(boolean fetchMetadata) {
     return fetchMetadata
         ? GetNamedRefsParams.builder()
-            .baseReference(BranchName.of(this.getConfig().getDefaultBranch()))
+            .baseReference(BranchName.of(this.getServerConfig().getDefaultBranch()))
             .branchRetrieveOptions(RetrieveOptions.BASE_REFERENCE_RELATED_AND_COMMIT_META)
             .tagRetrieveOptions(RetrieveOptions.COMMIT_META)
             .build()
@@ -273,7 +273,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       // then do not throw a NessieNotFoundException, but re-create the default branch. In all
       // cases, re-throw the exception.
       if (!(ReferenceType.BRANCH.equals(type)
-          && refName.equals(getConfig().getDefaultBranch())
+          && refName.equals(getServerConfig().getDefaultBranch())
           && (null == targetHash || getStore().noAncestorHash().asString().equals(targetHash)))) {
         throw e;
       }
@@ -292,7 +292,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
   @Override
   public Branch getDefaultBranch() throws NessieNotFoundException {
-    Reference r = getReferenceByName(getConfig().getDefaultBranch(), FetchOption.MINIMAL);
+    Reference r = getReferenceByName(getServerConfig().getDefaultBranch(), FetchOption.MINIMAL);
     checkState(r instanceof Branch, "Default branch isn't a branch");
     return (Branch) r;
   }
@@ -343,7 +343,8 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
           referenceType,
           ref);
       checkArgument(
-          !(ref instanceof BranchName && getConfig().getDefaultBranch().equals(ref.getName())),
+          !(ref instanceof BranchName
+              && getServerConfig().getDefaultBranch().equals(ref.getName())),
           "Default branch '%s' cannot be deleted.",
           ref.getName());
 
@@ -852,7 +853,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
         AuthzPaginationIterator<KeyEntry> authz =
             new AuthzPaginationIterator<KeyEntry>(
-                entries, super::startAccessCheck, getConfig().accessChecksBatchSize()) {
+                entries, super::startAccessCheck, getServerConfig().accessChecksBatchSize()) {
               @Override
               protected Set<Check> checksForEntry(KeyEntry entry) {
                 return singleton(canReadContentKey(refWithHash.getValue(), entry.getKey()));

--- a/servers/services/src/main/java/org/projectnessie/services/spi/ConfigService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/ConfigService.java
@@ -15,7 +15,11 @@
  */
 package org.projectnessie.services.spi;
 
+import java.util.List;
+import java.util.Set;
+import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.model.NessieConfiguration;
+import org.projectnessie.model.RepositoryConfig;
 
 /**
  * Server-side interface to services providing user-visible configuration properties.
@@ -26,4 +30,9 @@ import org.projectnessie.model.NessieConfiguration;
 public interface ConfigService {
 
   NessieConfiguration getConfig();
+
+  List<RepositoryConfig> getRepositoryConfig(Set<RepositoryConfig.Type> repositoryConfigTypes);
+
+  RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
+      throws NessieConflictException;
 }

--- a/servers/services/src/test/java/org/projectnessie/services/authz/TestBatchAccessChecker.java
+++ b/servers/services/src/test/java/org/projectnessie/services/authz/TestBatchAccessChecker.java
@@ -167,6 +167,12 @@ public class TestBatchAccessChecker {
       case VIEW_REFLOG:
         checker.canViewRefLog();
         break;
+      case READ_REPOSITORY_CONFIG:
+        checker.canReadRepositoryConfig(c.repositoryConfigType());
+        break;
+      case UPDATE_REPOSITORY_CONFIG:
+        checker.canUpdateRepositoryConfig(c.repositoryConfigType());
+        break;
       default:
         throw new IllegalArgumentException("Unsupported: " + c);
     }

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestReferences.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestReferences.java
@@ -109,7 +109,9 @@ public abstract class AbstractTestReferences extends BaseTestServiceImpl {
   public void getAllReferences() {
     assertThat(allReferences())
         .anySatisfy(
-            r -> assertThat(r.getName()).isEqualTo(configApi().getConfig().getDefaultBranch()));
+            r ->
+                assertThat(r.getName())
+                    .isEqualTo(configApi().getServerConfig().getDefaultBranch()));
   }
 
   @Test
@@ -416,7 +418,7 @@ public abstract class AbstractTestReferences extends BaseTestServiceImpl {
         numCommits,
         0,
         (Branch) ref,
-        getReference(configApi().getConfig().getDefaultBranch()),
+        getReference(configApi().getServerConfig().getDefaultBranch()),
         numCommits);
 
     // fetching additional metadata for a single tag

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/BaseTestServiceImpl.java
@@ -109,7 +109,7 @@ public abstract class BaseTestServiceImpl {
   private Principal principal;
 
   protected final ConfigApiImpl configApi() {
-    return new ConfigApiImpl(config(), versionStore(), 2);
+    return new ConfigApiImpl(config(), versionStore(), authorizer(), this::principal, 2);
   }
 
   protected final TreeApiImpl treeApi() {

--- a/site/docs/develop/_config
+++ b/site/docs/develop/_config
@@ -7,3 +7,4 @@ arrange:
   - python.md
   - java.md
   - content-types.md
+  - repository-configs.md

--- a/site/docs/develop/repository-configs.md
+++ b/site/docs/develop/repository-configs.md
@@ -1,0 +1,50 @@
+# Nessie repository configurations
+
+Nessie allows to retrieve and persist configuration objects via its API. Read and/or write access to all or some
+types of repository configuration types can be restricted.
+
+The Nessie server side must know the schema of each repository configuration type via an interface that extends
+`org.projectnessie.model.RepositoryConfig` and its type must be registered. This ensures that all repository
+configuration objects comply with the implicitly defined schema.
+
+Creating and/or updating repository configurations is supposed to be a rare operation.
+
+Note: Nessie repository configurations are *not* supported with the old, legacy Nessie data model.  
+
+Nessie clients and servers need to know about the used repository config types via instances of
+`org.projectnessie.model.types.RepositoryConfigTypeBundle`. Instances of this interface are loaded via
+the standard Java services mechanism.
+
+## Known and assigned repository config  types
+
+| Repository Config Type | Model class                                      | Description                                      | Implementor    |
+|------------------------|--------------------------------------------------|--------------------------------------------------|----------------|
+| `GARBAGE_COLLECTOR`    | `org.projectnessie.model.GarbageCollectorConfig` | Configuration for Nessie GC.                     | Project Nessie |
+
+Since the ID values for repository config types must be globally unique, please register your Repository config 
+type via an [issue](https://github.com/projectnessie/nessie/issues/new/choose).
+
+In case the (Java) client reads a repository configuration object for which it does not have the corresponding
+`RepositoryConfigTypeBundle`, it will provide an instance of `GenericRepositoryConfig`, which provides a `Map`
+representing the JSON attributes (Nessie uses Jackson for JSON (de)serialization). This means, that clients are
+always able to deserialize all repository configuration types, even if the matching `RepositoryConfigTypeBundle`
+is not available to the Nessie Java client. In case you are using types of repository configs that *might* not
+be available to the Nessie Java client, for example if the Nessie classes are relocated, as in Apache Iceberg,
+be prepared to get an instance of `GenericRepositoryConfig` instead of the "right" Java type. 
+
+## Implementing your own content types
+
+TBD
+
+### Repository config type bundle
+
+`RepositoryConfigTypeBundle`s make repository config types available to Nessie clients
+and servers.
+
+Needs a resource file `META-INF/services/org.projectnessie.model.types.RepositoryConfigTypeBundle`,
+which contains the class name(s) that implement the
+`org.projectnessie.model.types.RepositoryConfigTypeBundle` interface.
+
+The `RepositoryConfigTypeBundle.register(RepositoryConfigTypeRegistry repositoryConfigTypeRegistry)`
+implementation must call the given `Registrar` with name of each repository config type and the model
+interface type that  extends `org.projectnessie.model.RepositoryConfig`.

--- a/site/docs/features/metadata_authorization.md
+++ b/site/docs/features/metadata_authorization.md
@@ -76,6 +76,10 @@ Available variables within the `<rule_expression>` are: **'op'** / **'role'** / 
 * The **'op'** variable in the `<rule_expression>` refers to the type of operation can be any of the following.
   See [BatchAccessChecker](https://github.com/projectnessie/nessie/blob/main/servers/services/src/main/java/org/projectnessie/services/authz/BatchAccessChecker.java)
   and [Check](https://github.com/projectnessie/nessie/blob/main/servers/services/src/main/java/org/projectnessie/services/authz/Check.java) types.
+  * Arguments to the CEL script for the following check-types:
+    * **'role'** refers to the user's role and can be any string.
+    * **'ref'** refers to a string representing a branch/tag name or `DETATCHED` for direct access to a commit id.
+    * **'path'** refers to the [content key](https://github.com/projectnessie/nessie/blob/main/model/src/main/java/org/projectnessie/model/ContentKey.java) for the contents of an object and can be any string
   * `VIEW_REFERENCE`
   * `CREATE_REFERENCE`
   * `DELETE_REFERENCE`
@@ -87,10 +91,12 @@ Available variables within the `<rule_expression>` are: **'op'** / **'role'** / 
   * `UPDATE_ENTITY`
   * `READ_ENTITY_VALUE`
   * `DELETE_ENTITY`
-  * `VIEW_REFLOG`.
-* The **'role'** refers to the user's role and can be any string.
-* The **'ref'** refers to a string representing a branch/tag name or `DETATCHED` for direct access to a commit id.
-* The **'path'** refers to the [content key](https://github.com/projectnessie/nessie/blob/main/model/src/main/java/org/projectnessie/model/ContentKey.java) for the contents of an object and can be any string
+  * `VIEW_REFLOG` (deprecated)
+* The following values for the **'op'**
+  * `READ_REPOSITORY_CONFIG`
+  * `UPDATE_REPOSITORY_CONFIG`
+  * Arguments to the CEL script for the repository config check-types:
+    * **'type'** argument that refers to the repository config type to be retrieved or updated.
 
 Since all available authorization rule variables are strings, the relevant CEL-specific things that are worth mentioning are shown below:
 

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -47,6 +48,7 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
 import org.projectnessie.model.ImmutableCommitMeta;
 import org.projectnessie.model.MergeKeyBehavior;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
@@ -730,5 +732,18 @@ public class PersistVersionStore implements VersionStore {
                     .operation(e.getOperation())
                     .sourceHashes(e.getSourceHashes())
                     .build());
+  }
+
+  @Override
+  public List<RepositoryConfig> getRepositoryConfig(
+      Set<RepositoryConfig.Type> repositoryConfigTypes) {
+    throw new IllegalArgumentException(
+        "Old database model does not support repository config objects");
+  }
+
+  @Override
+  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig) {
+    throw new IllegalArgumentException(
+        "Old database model does not support repository config objects");
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -26,6 +27,7 @@ import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.versioned.paging.PaginationIterator;
 
 /**
@@ -185,5 +187,17 @@ public class EventsVersionStore implements VersionStore {
   @SuppressWarnings("MustBeClosedChecker")
   public Stream<RefLogDetails> getRefLog(Hash refLogId) throws RefLogNotFoundException {
     return delegate.getRefLog(refLogId);
+  }
+
+  @Override
+  public List<RepositoryConfig> getRepositoryConfig(
+      Set<RepositoryConfig.Type> repositoryConfigTypes) {
+    return delegate.getRepositoryConfig(repositoryConfigTypes);
+  }
+
+  @Override
+  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
+      throws ReferenceConflictException {
+    return delegate.updateRepositoryConfig(repositoryConfig);
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -30,6 +31,7 @@ import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.versioned.paging.PaginationIterator;
 
 /** A {@link VersionStore} wrapper that publishes metrics via Micrometer. */
@@ -191,6 +193,20 @@ public final class MetricsVersionStore implements VersionStore {
   @Deprecated
   public Stream<RefLogDetails> getRefLog(Hash refLogId) throws RefLogNotFoundException {
     return delegateStream1Ex("getreflog", () -> delegate.getRefLog(refLogId));
+  }
+
+  @Override
+  public List<RepositoryConfig> getRepositoryConfig(
+      Set<RepositoryConfig.Type> repositoryConfigTypes) {
+    return delegate(
+        "getrepositoryconfig", () -> delegate.getRepositoryConfig(repositoryConfigTypes));
+  }
+
+  @Override
+  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
+      throws ReferenceConflictException {
+    return delegate1Ex(
+        "updaterepositoryconfig", () -> delegate.updateRepositoryConfig(repositoryConfig));
   }
 
   private void measure(String requestName, Sample sample, Exception failure) {

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -38,6 +39,7 @@ import javax.annotation.Nonnull;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.versioned.paging.PaginationIterator;
 
 /**
@@ -290,6 +292,26 @@ public class TracingVersionStore implements VersionStore {
   @Deprecated
   public Stream<RefLogDetails> getRefLog(Hash refLogId) throws RefLogNotFoundException {
     return delegate.getRefLog(refLogId);
+  }
+
+  @Override
+  public List<RepositoryConfig> getRepositoryConfig(
+      Set<RepositoryConfig.Type> repositoryConfigTypes) {
+    return callWithNoException(
+        tracer,
+        "GetRepositoryConfig",
+        b -> {},
+        () -> delegate.getRepositoryConfig(repositoryConfigTypes));
+  }
+
+  @Override
+  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
+      throws ReferenceConflictException {
+    return callWithOneException(
+        tracer,
+        "UpdateRepositoryConfig",
+        b -> {},
+        () -> delegate.updateRepositoryConfig(repositoryConfig));
   }
 
   private static SpanHolder createSpan(

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -34,6 +35,7 @@ import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
 import org.projectnessie.model.MergeBehavior;
 import org.projectnessie.model.MergeKeyBehavior;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.versioned.paging.PaginationIterator;
 
 /**
@@ -114,6 +116,11 @@ public interface VersionStore {
       throws ReferenceNotFoundException, ReferenceConflictException {
     return commit(branch, referenceHash, metadata, operations, x -> {}, (k, c) -> {});
   }
+
+  List<RepositoryConfig> getRepositoryConfig(Set<RepositoryConfig.Type> repositoryConfigTypes);
+
+  RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
+      throws ReferenceConflictException;
 
   @FunctionalInterface
   interface CommitValidator {

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractVersionStoreTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractVersionStoreTests.java
@@ -23,6 +23,8 @@ import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.testextension.NessiePersist;
 import org.projectnessie.versioned.storage.testextension.PersistExtension;
 import org.projectnessie.versioned.storage.versionstore.VersionStoreImpl;
+import org.projectnessie.versioned.tests.AbstractMergeScenarios;
+import org.projectnessie.versioned.tests.AbstractRepositoryConfig;
 import org.projectnessie.versioned.tests.AbstractVersionStoreTestBase;
 
 @ExtendWith({PersistExtension.class, SoftAssertionsExtension.class})
@@ -38,6 +40,13 @@ public class AbstractVersionStoreTests extends AbstractVersionStoreTestBase {
   @Nested
   public class MergeScenarios extends AbstractMergeScenarios {
     public MergeScenarios() {
+      super(AbstractVersionStoreTests.this.store());
+    }
+  }
+
+  @Nested
+  public class RepositoryConfig extends AbstractRepositoryConfig {
+    public RepositoryConfig() {
       super(AbstractVersionStoreTests.this.store());
     }
   }

--- a/versioned/storage/store/build.gradle.kts
+++ b/versioned/storage/store/build.gradle.kts
@@ -42,6 +42,10 @@ dependencies {
   implementation(libs.guava)
   implementation(libs.slf4j.api)
 
+  implementation(platform(libs.jackson.bom))
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+  implementation("com.fasterxml.jackson.core:jackson-databind")
+
   compileOnly(libs.immutables.builder)
   compileOnly(libs.immutables.value.annotations)
   annotationProcessor(libs.immutables.value.processor)

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RepositoryConfigBackend.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RepositoryConfigBackend.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.versionstore;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.projectnessie.nessie.relocated.protobuf.UnsafeByteOperations.unsafeWrap;
+import static org.projectnessie.versioned.storage.common.logic.CommitRetry.commitRetry;
+import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Add.commitAdd;
+import static org.projectnessie.versioned.storage.common.logic.Logics.commitLogic;
+import static org.projectnessie.versioned.storage.common.logic.Logics.indexesLogic;
+import static org.projectnessie.versioned.storage.common.logic.Logics.referenceLogic;
+import static org.projectnessie.versioned.storage.common.objtypes.CommitHeaders.EMPTY_COMMIT_HEADERS;
+import static org.projectnessie.versioned.storage.common.objtypes.StringObj.stringData;
+import static org.projectnessie.versioned.storage.common.util.Ser.SHARED_OBJECT_MAPPER;
+import static org.projectnessie.versioned.storage.versionstore.RefMapping.referenceConflictException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.ReferenceConflictException;
+import org.projectnessie.versioned.ReferenceRetryFailureException;
+import org.projectnessie.versioned.storage.common.exceptions.CommitConflictException;
+import org.projectnessie.versioned.storage.common.exceptions.CommitWrappedException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
+import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
+import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.RetryTimeoutException;
+import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
+import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
+import org.projectnessie.versioned.storage.common.indexes.StoreKey;
+import org.projectnessie.versioned.storage.common.logic.CommitLogic;
+import org.projectnessie.versioned.storage.common.logic.CommitRetry;
+import org.projectnessie.versioned.storage.common.logic.CreateCommit;
+import org.projectnessie.versioned.storage.common.logic.IndexesLogic;
+import org.projectnessie.versioned.storage.common.logic.ReferenceLogic;
+import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
+import org.projectnessie.versioned.storage.common.objtypes.CommitOp;
+import org.projectnessie.versioned.storage.common.objtypes.Compression;
+import org.projectnessie.versioned.storage.common.objtypes.StringObj;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class RepositoryConfigBackend {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryConfigBackend.class);
+
+  static final String REPO_CONFIG_REF = "nessie/configs";
+
+  RepositoryConfigBackend(Persist persist) {
+    this.persist = persist;
+  }
+
+  final Persist persist;
+
+  public List<RepositoryConfig> getConfigs(Set<RepositoryConfig.Type> repositoryConfigTypes) {
+    try {
+      Persist p = persist;
+      Reference reference = configsRef();
+      IndexesLogic indexesLogic = indexesLogic(p);
+      CommitObj head = commitLogic(p).headCommit(reference);
+      StoreIndex<CommitOp> index = indexesLogic.buildCompleteIndexOrEmpty(head);
+
+      Obj[] objs =
+          p.fetchObjs(
+              repositoryConfigTypes.stream()
+                  .map(RepositoryConfigBackend::repositoryConfigTypeToStoreKey)
+                  .map(storeKey -> valueObjIdFromIndex(index, storeKey))
+                  .toArray(ObjId[]::new));
+
+      return Arrays.stream(objs)
+          .filter(Objects::nonNull)
+          .map(StringObj.class::cast)
+          .map(RepositoryConfigBackend::deserialize)
+          .collect(Collectors.toList());
+    } catch (ObjNotFoundException | RetryTimeoutException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public RepositoryConfig updateConfig(RepositoryConfig repositoryConfig)
+      throws ReferenceConflictException {
+    RepositoryConfig.Type type = repositoryConfig.getType();
+    StoreKey storeKey = repositoryConfigTypeToStoreKey(type);
+
+    try {
+      return commitRetry(
+          persist,
+          (p, retryState) -> {
+            Reference reference;
+            try {
+              reference = configsRef();
+            } catch (RetryTimeoutException ex) {
+              throw new CommitWrappedException(new CommitRetry.RetryException(Optional.empty()));
+            }
+
+            try {
+              CommitLogic commitLogic = commitLogic(p);
+              IndexesLogic indexesLogic = indexesLogic(p);
+              CommitObj head = commitLogic.headCommit(reference);
+              StoreIndex<CommitOp> index = indexesLogic.buildCompleteIndexOrEmpty(head);
+
+              StoreIndexElement<CommitOp> existingElement = index.get(storeKey);
+              ObjId existingValueId = null;
+              UUID existingContentId = null;
+              StringObj existing = null;
+              if (existingElement != null) {
+                CommitOp op = existingElement.content();
+                if (op.action().exists()) {
+                  existingValueId = op.value();
+                  existingContentId = op.contentId();
+
+                  existing =
+                      existingValueId != null
+                          ? p.fetchTypedObj(
+                              requireNonNull(existingValueId), ObjType.STRING, StringObj.class)
+                          : null;
+                }
+              }
+              if (existingContentId == null) {
+                existingContentId = UUID.randomUUID();
+              }
+
+              StringObj newValue = serialize(repositoryConfig);
+
+              if (!requireNonNull(newValue.id()).equals(existingValueId)) {
+                CommitObj committed =
+                    commitLogic.doCommit(
+                        CreateCommit.newCommitBuilder()
+                            .message("Update config " + type.name())
+                            .parentCommitId(reference.pointer())
+                            .headers(EMPTY_COMMIT_HEADERS)
+                            .addAdds(
+                                commitAdd(
+                                    storeKey, 0, newValue.id(), existingValueId, existingContentId))
+                            .build(),
+                        singletonList(newValue));
+                p.updateReferencePointer(reference, committed.id());
+              }
+              return existing != null ? deserialize(existing) : null;
+            } catch (ObjNotFoundException | RefNotFoundException | RefConditionFailedException e) {
+              throw new CommitWrappedException(e);
+            }
+          });
+    } catch (CommitConflictException e) {
+      throw referenceConflictException(e);
+    } catch (CommitWrappedException e) {
+      Throwable c = e.getCause();
+      if (c instanceof ReferenceConflictException) {
+        throw (ReferenceConflictException) c;
+      }
+      if (c instanceof RuntimeException) {
+        throw (RuntimeException) c;
+      }
+      throw new RuntimeException(c);
+    } catch (RetryTimeoutException e) {
+      long millis = NANOSECONDS.toMillis(e.getTimeNanos());
+      String msg =
+          format(
+              "The repository config update operation could not be performed after %d retries within the configured commit timeout after %d milliseconds",
+              e.getRetry(), millis);
+      LOGGER.warn("Operation timeout: {}", msg);
+      throw new ReferenceRetryFailureException(msg, e.getRetry(), millis);
+    }
+  }
+
+  private static StringObj serialize(RepositoryConfig repositoryConfig) {
+    try {
+      ByteString text = unsafeWrap(SHARED_OBJECT_MAPPER.writeValueAsBytes(repositoryConfig));
+      return stringData("application/json", Compression.NONE, null, emptyList(), text);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static RepositoryConfig deserialize(StringObj value) {
+    try {
+      return SHARED_OBJECT_MAPPER.readValue(value.text().toByteArray(), RepositoryConfig.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Retrieves the configs-reference, creates the reference, if it does not exist. */
+  private Reference configsRef() throws RetryTimeoutException {
+    ReferenceLogic referenceLogic = referenceLogic(persist);
+    Reference reference;
+    try {
+      reference = referenceLogic.getReference(REPO_CONFIG_REF);
+    } catch (RefNotFoundException e) {
+      try {
+        reference = referenceLogic.createReference(REPO_CONFIG_REF, ObjId.EMPTY_OBJ_ID, null);
+      } catch (RefAlreadyExistsException ex) {
+        reference = ex.reference();
+        if (reference == null) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    return reference;
+  }
+
+  private static ObjId valueObjIdFromIndex(StoreIndex<CommitOp> index, StoreKey storeKey) {
+    StoreIndexElement<CommitOp> existing = index.get(storeKey);
+    if (existing == null) {
+      return null;
+    }
+    if (!existing.content().action().exists()) {
+      return null;
+    }
+    return existing.content().value();
+  }
+
+  private static StoreKey repositoryConfigTypeToStoreKey(RepositoryConfig.Type type) {
+    return StoreKey.key("configs", type.name());
+  }
+}

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -77,6 +78,7 @@ import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
+import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.Commit;
 import org.projectnessie.versioned.CommitResult;
@@ -949,5 +951,16 @@ public class VersionStoreImpl implements VersionStore {
   @Deprecated
   public Stream<RefLogDetails> getRefLog(Hash refLogId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<RepositoryConfig> getRepositoryConfig(
+      Set<RepositoryConfig.Type> repositoryConfigTypes) {
+    throw new UnsupportedOperationException("IMPLEMENT ME");
+  }
+
+  @Override
+  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig) {
+    throw new UnsupportedOperationException("IMPLEMENT ME");
   }
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -956,11 +956,12 @@ public class VersionStoreImpl implements VersionStore {
   @Override
   public List<RepositoryConfig> getRepositoryConfig(
       Set<RepositoryConfig.Type> repositoryConfigTypes) {
-    throw new UnsupportedOperationException("IMPLEMENT ME");
+    return new RepositoryConfigBackend(persist).getConfigs(repositoryConfigTypes);
   }
 
   @Override
-  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig) {
-    throw new UnsupportedOperationException("IMPLEMENT ME");
+  public RepositoryConfig updateRepositoryConfig(RepositoryConfig repositoryConfig)
+      throws ReferenceConflictException {
+    return new RepositoryConfigBackend(persist).updateConfig(repositoryConfig);
   }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMergeScenarios.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMergeScenarios.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.storage.commontests;
+package org.projectnessie.versioned.tests;
 
 import static java.util.Objects.requireNonNull;
 
@@ -46,7 +46,6 @@ import org.projectnessie.versioned.Put;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.VersionStoreException;
-import org.projectnessie.versioned.tests.AbstractNestedVersionStore;
 
 @SuppressWarnings("unused")
 @ExtendWith(SoftAssertionsExtension.class)

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractRepositoryConfig.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractRepositoryConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.tests;
+
+import static java.util.Collections.singleton;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.GarbageCollectorConfig;
+import org.projectnessie.model.ImmutableGarbageCollectorConfig;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.versioned.VersionStore;
+
+@SuppressWarnings("unused")
+@ExtendWith(SoftAssertionsExtension.class)
+public abstract class AbstractRepositoryConfig extends AbstractNestedVersionStore {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  protected AbstractRepositoryConfig(VersionStore store) {
+    super(store);
+  }
+
+  @Test
+  void createAndUpdate() throws Exception {
+    ImmutableGarbageCollectorConfig created =
+        GarbageCollectorConfig.builder()
+            .defaultCutoffPolicy("PT30D")
+            .newFilesGracePeriod(Duration.of(3, ChronoUnit.HOURS))
+            .build();
+    ImmutableGarbageCollectorConfig updated =
+        GarbageCollectorConfig.builder()
+            .defaultCutoffPolicy("PT10D")
+            .expectedFileCountPerContent(123)
+            .build();
+
+    soft.assertThat(created.getType()).isEqualTo(RepositoryConfig.Type.GARBAGE_COLLECTOR);
+    soft.assertThat(updated.getType()).isEqualTo(RepositoryConfig.Type.GARBAGE_COLLECTOR);
+
+    soft.assertThat(store.getRepositoryConfig(singleton(RepositoryConfig.Type.GARBAGE_COLLECTOR)))
+        .isEmpty();
+
+    soft.assertThat(store.updateRepositoryConfig(created)).isNull();
+
+    soft.assertThat(store.getRepositoryConfig(singleton(RepositoryConfig.Type.GARBAGE_COLLECTOR)))
+        .containsExactly(created);
+
+    soft.assertThat(store.updateRepositoryConfig(updated)).isEqualTo(created);
+
+    soft.assertThat(store.getRepositoryConfig(singleton(RepositoryConfig.Type.GARBAGE_COLLECTOR)))
+        .containsExactly(updated);
+  }
+}


### PR DESCRIPTION
Allows to retrieve and persist configuration objects via its API, via the REST v2 API using the `config/repository` endpoint. Read and/or write access to all or some types of repository configuration types can be restricted.

New storage is required for this functionality to work.

The Nessie server side must know the schema of each repository configuration type via an interface that extends `org.projectnessie.model.RepositoryConfig` and its type must be registered. This ensures that all repository configuration objects comply with the implicitly defined schema.

Creating and/or updating repository configurations is supposed to be a rare operation.

Nessie clients and servers need to know about the used repository config types via instances of `org.projectnessie.model.types.RepositoryConfigTypeBundle`. Instances of this interface are loaded via the standard Java services mechanism.
