### PR TITLE
Add Nessie as a Source blog from Dremio website

### DIFF
--- a/site/docs/blog/index.md
+++ b/site/docs/blog/index.md
@@ -2,5 +2,6 @@
 
 Highlights
 
+* [Introducing Nessie as a Dremio Source](https://www.dremio.com/blog/introducing-nessie-as-a-dremio-source/) (June 2023)
 * [Rolling upgrade issue to 0.26.0](incident-2022-05.md) (May 2022)
 * [Namespace enforcement](namespace-enforcement.md) (May 2023)


### PR DESCRIPTION
Hi, Dremio recently added support for Nessie as a source. @snazy suggested a while ago I should open a PR to add the link to the blog to the Nessie website — this PR reflects that change. Thanks!