### PR TITLE
Introduce `StringLogic` for persisted strings

### DIFF
--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBackendRepositoryTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBackendRepositoryTests.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.storage.commontests;
 
 import static org.projectnessie.versioned.storage.common.logic.Logics.repositoryLogic;
+import static org.projectnessie.versioned.storage.common.objtypes.StringObj.stringData;
 
 import java.util.Collections;
 import java.util.EnumSet;
@@ -66,7 +67,7 @@ public class AbstractBackendRepositoryTests {
                 IntStream.range(0, objs)
                     .mapToObj(
                         x ->
-                            StringObj.stringData(
+                            stringData(
                                 "content-type",
                                 Compression.NONE,
                                 "file-" + x,

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/Logics.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/Logics.java
@@ -35,4 +35,8 @@ public final class Logics {
   public static IndexesLogic indexesLogic(Persist persist) {
     return new IndexesLogicImpl(persist);
   }
+
+  public static StringLogic stringLogic(Persist persist) {
+    return new StringLogicImpl(persist);
+  }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/StringLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/StringLogic.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.logic;
+
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.objtypes.StringObj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+
+/**
+ * Provides and encapsulates all logic around string data compression and diff creation and
+ * re-assembly of diffs to complete values.
+ */
+public interface StringLogic {
+  StringValue fetchString(ObjId stringObjId) throws ObjNotFoundException;
+
+  StringValue fetchString(StringObj stringObj) throws ObjNotFoundException;
+
+  StringObj updateString(StringValue previousValue, String contentType, byte[] stringValueUtf8)
+      throws ObjNotFoundException;
+
+  StringObj updateString(StringValue previousValue, String contentType, String stringValue)
+      throws ObjNotFoundException;
+
+  /**
+   * Describes a string value and allows retrieval of complete string values. Implementations can
+   * lazily decompress data and/or re-assemble values that consist of diffs.
+   */
+  interface StringValue {
+    String contentType();
+
+    String completeValue() throws ObjNotFoundException;
+
+    ObjId objId();
+  }
+}

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/StringLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/StringLogicImpl.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.logic;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Collections.emptyList;
+import static org.projectnessie.nessie.relocated.protobuf.UnsafeByteOperations.unsafeWrap;
+import static org.projectnessie.versioned.storage.common.objtypes.StringObj.stringData;
+import static org.projectnessie.versioned.storage.common.persist.ObjType.STRING;
+
+import java.nio.charset.StandardCharsets;
+import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
+import org.projectnessie.versioned.storage.common.objtypes.Compression;
+import org.projectnessie.versioned.storage.common.objtypes.StringObj;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+
+final class StringLogicImpl implements StringLogic {
+  private final Persist persist;
+
+  StringLogicImpl(Persist persist) {
+    this.persist = persist;
+  }
+
+  @Override
+  public StringValue fetchString(ObjId stringObjId) throws ObjNotFoundException {
+    return fetchString(persist.fetchTypedObj(stringObjId, STRING, StringObj.class));
+  }
+
+  @Override
+  public StringValue fetchString(StringObj stringObj) {
+    checkState(
+        stringObj.compression() == Compression.NONE,
+        "Unsupported compression %s",
+        stringObj.compression());
+    checkState(
+        stringObj.predecessors().isEmpty(), "Predecessors in StringObj are not yet supported");
+
+    return new StringValueHolder(stringObj);
+  }
+
+  @Override
+  public StringObj updateString(
+      StringValue previousValue, String contentType, byte[] stringValueUtf8) {
+    // We currently ignore the previousValue here. It can be _later_ used to potentially store
+    // diffs.
+
+    ByteString text = unsafeWrap(stringValueUtf8);
+    return stringData("application/json", Compression.NONE, null, emptyList(), text);
+  }
+
+  @Override
+  public StringObj updateString(StringValue previousValue, String contentType, String stringValue) {
+    return updateString(previousValue, contentType, stringValue.getBytes(StandardCharsets.UTF_8));
+  }
+
+  static final class StringValueHolder implements StringValue {
+    final StringObj obj;
+
+    StringValueHolder(StringObj obj) {
+      this.obj = obj;
+    }
+
+    @Override
+    public String contentType() {
+      return obj.contentType();
+    }
+
+    @Override
+    public String completeValue() throws ObjNotFoundException {
+      return obj.text().toStringUtf8();
+    }
+
+    @Override
+    public ObjId objId() {
+      return obj.id();
+    }
+  }
+}

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -36,6 +36,7 @@ import static org.projectnessie.versioned.storage.common.objtypes.IndexObj.index
 import static org.projectnessie.versioned.storage.common.objtypes.IndexSegmentsObj.indexSegments;
 import static org.projectnessie.versioned.storage.common.objtypes.IndexStripe.indexStripe;
 import static org.projectnessie.versioned.storage.common.objtypes.RefObj.ref;
+import static org.projectnessie.versioned.storage.common.objtypes.StringObj.stringData;
 import static org.projectnessie.versioned.storage.common.objtypes.TagObj.tag;
 import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
 import static org.projectnessie.versioned.storage.mongodb.MongoDBConstants.COL_COMMIT;
@@ -957,7 +958,7 @@ public class MongoDBPersist implements Persist {
 
           @Override
           StringObj docToObj(ObjId id, Document doc) {
-            return StringObj.stringData(
+            return stringData(
                 id,
                 doc.getString(COL_STRING_CONTENT_TYPE),
                 Compression.valueOf(doc.getString(COL_STRING_COMPRESSION)),


### PR DESCRIPTION
The purpose of `StringLogic` is to (later) have a central place where (de)compression of text happens and where potentially diff-based text storage is implemented.

Callers only need to provide and consume complete strings, or maybe later input/output-streams.

This is a minor cleanup now.