### PR TITLE
Introduce `CHANGELOG.md`, include in release information

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -129,6 +129,12 @@ jobs:
         bump-helm-version: 'true'
         bump-site-version: 'true'
 
+    - name: Patch changelog
+      uses: gradle/gradle-build-action@v2
+      with:
+        cache-disabled: true
+        arguments: :patchChangelog
+
     # Updates the site/docs/try/releases.md file, takes the first four lines (the big heading),
     # adds a heading with the version and a note referencing the release notes on GitHub,
     # followed by the Git change log, finalized with the remainder of the
@@ -142,6 +148,10 @@ jobs:
         See [Release information on GitHub](https://github.com/projectnessie/nessie/releases/tag/nessie-${RELEASE_VERSION}).
         
         !
+
+        # Add section from CHANGELOG.md for the version to release
+        ./gradlew --quiet --console=plain getChangelog --no-header --no-links >> /tmp/releases.md
+        echo "### Commits" >> /tmp/releases.md
         
         git log --perl-regexp --author '^(?!.*renovate|.*nessie-release-workflow).*$'\
           --format='format:* %s' ${LAST_TAG}..HEAD . |\

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -213,6 +213,10 @@ jobs:
         The attached [\`nessie-helm-${RELEASE_VERSION}.tgz\`](${Q_HELM_CHART_URL}) is a packaged Helm chart, which can be downloaded and installed via Helm.
         There is also the [Nessie Helm chart repo](https://charts.projectnessie.org/), which can be added and used to install the Nessie Helm chart.
 
+        ## Changelog
+        
+        $(./gradlew --quiet --console=plain getChangelog --no-header --no-links)
+
         ## Full Changelog (minus renovate commits):
 
         $(cat ${DIR}/release-log)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Nessie Changelog
+The Nessie changelog is used to give users and contributors more information than just the list of commits.
+Entries are grouped in sections like _Highlights_ or _Upgrade notes_, the provided sections can be adjusted
+as necessary. Empty sections will not end in the release notes.
+
+## [Unreleased]
+
+### Highlights
+
+### Upgrade notes
+
+### New Features
+
+### Changes
+
+### Deprecations
+
+### Fixes
+
+### Commits
+
+## [0.65.0] Release (2023-06-14)
+- Revert Gradle 8.2.1 (#7239)
+- Add Nessie as a Source announcement blog from Dremio website (#7236)
+- Add `--author` option to `content-generator` commands (#7232)
+- Add repository configuration objects (#7233)
+- Fix retrieval of default branch (#7227)
+- Allow re-adds in same commit (#7225)
+- Allow snapshot versions in dependencies (#7224)
+- IDE: Cleanup Idea excludes (#7223)
+- Spark-tests: disable UI (#7222)
+- Compatibility tests: move to new storage model (#6910)
+- Use testcontainers-bom (#7216)
+- Reference keycloak-admin-client-jakarta (#7215)
+- Post Quarkus 3: Remove no longer needed dependency exclusion (#7214)
+- Bump to Quarkus 3.2.0.Final (#6146)
+- CI: Add some missing `--scan` Gradle flags (#7210)
+- Update main README after UI sources moved (#7207)
+- Forbid relative hashes in commits, merges and transplants (#7193)
+- Remove misplaced license header (#7203)
+- More diff-tests (#7192)
+- removed extra tab (#7189)
+- Tests: Make `ITCassandraBackendFactory` less flaky (#7186)
+- IntelliJ: Exclude some more directories from indexing (#7181)
+
+[Unreleased]: https://github.com/projectnessie/nessie/commits
+[0.65.0]: https://github.com/projectnessie/nessie/compare/nessie-0.64.0...nessie-0.65.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+import org.jetbrains.changelog.date
+
 plugins {
   eclipse
   id("nessie-conventions-root")
   alias(libs.plugins.nexus.publish.plugin)
+  alias(libs.plugins.jetbrains.changelog)
 }
 
 apply<ReleaseSupportPlugin>()
@@ -108,4 +111,24 @@ spotless {
     // Must be repeated :( - there's no "addTarget" or so
     target("nessie-iceberg/*.gradle.kts", "*.gradle.kts", "build-logic/*.gradle.kts")
   }
+}
+
+changelog {
+  repositoryUrl.set("https://github.com/projectnessie/nessie")
+  title.set("Nessie Changelog")
+  versionPrefix.set("nessie-")
+  header.set(provider { "${version.get()} Release (${date()})" })
+  groups.set(
+    listOf(
+      "Highlights",
+      "Upgrade notes",
+      "Breaking changes",
+      "New Features",
+      "Changes",
+      "Deprecations",
+      "Fixes",
+      "Commits"
+    )
+  )
+  version.set(provider { project.version.toString() })
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -178,3 +178,4 @@ nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version =
 protobuf = { id = "com.google.protobuf", version = "0.9.4" }
 quarkus = { id = "io.quarkus", version.ref = "quarkus" }
 smallrye-openapi = { id = "io.smallrye.openapi", version = "3.4.0" }
+jetbrains-changelog = { id = "org.jetbrains.changelog",  version = "2.1.2"}


### PR DESCRIPTION
The information about a specific Nessie release is pretty rudimentary, consists only of a list of commits. Interesting, important and relevant information, for example about upgrade notes, release highlights, potentially breaking changes, is missing in the release notes.

This change introduces the `CHANGELOG.md` file. Relevant information is to be added to an appropriate section for `Unreleased`. The list of sections is not fixed and can be changed and extended, depending on the impact of an individual change/PR.

The Nessie release workflows leverage Jetbrains' [_Gradle Changelog Plugin_](https://github.com/JetBrains/gradle-changelog-plugin) to promote `Unreleased` to a release in `CHANGELOG.md` and to extract the changelog for the current release, which is then added to `site/docs/try/releases.md` and the Github release notes. The changelog-plugin is "clever enough" to purge empty sections for a release.

This is the command to extract information about the latest release
```bash
./gradlew --quiet --console=plain getChangelog --no-header --no-links
```

Using `./gradlew getChangelog --unreleased` shows information about the not-yet-released code.