### PR TITLE
[Nessie Catalog] Remove JUnit 4 (via Iceberg 1.4)

### DIFF
--- a/catalog/quarkus-catalog/build.gradle.kts
+++ b/catalog/quarkus-catalog/build.gradle.kts
@@ -88,7 +88,6 @@ dependencies {
 
   testFixturesApi("org.apache.iceberg:iceberg-api:$icebergVersion:tests")
   testFixturesApi("org.apache.iceberg:iceberg-core:$icebergVersion:tests")
-  testFixturesApi(libs.junit4)
 
   testFixturesApi(enforcedPlatform(libs.quarkus.bom))
   testFixturesApi("io.quarkus:quarkus-junit5")

--- a/catalog/quarkus-spark-iceberg-tests/build.gradle.kts
+++ b/catalog/quarkus-spark-iceberg-tests/build.gradle.kts
@@ -56,7 +56,6 @@ dependencies {
 
   testFixturesApi("org.apache.iceberg:iceberg-api:$versionIceberg:tests")
   testFixturesApi("org.apache.iceberg:iceberg-core:$versionIceberg:tests")
-  testFixturesImplementation(libs.junit4)
 
   testFixturesImplementation(libs.slf4j.api)
 

--- a/catalog/service/build.gradle.kts
+++ b/catalog/service/build.gradle.kts
@@ -113,7 +113,6 @@ dependencies {
 
   testFixturesApi("org.apache.iceberg:iceberg-api:$versionIceberg:tests")
   testFixturesApi("org.apache.iceberg:iceberg-core:$versionIceberg:tests")
-  testFixturesImplementation(libs.junit4)
 
   testFixturesImplementation(libs.slf4j.api)
   testFixturesRuntimeOnly(libs.logback.classic)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,7 +115,6 @@ jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess"
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
-junit4 = { module = "junit:junit", version = "4.13.2" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.2.12" }
 keycloak-admin-client-jakarta = { module = "org.keycloak:keycloak-admin-client-jakarta", version.ref = "keycloak" }
 maven-core = { module = "org.apache.maven:maven-resolver-provider", version.ref = "maven" }


### PR DESCRIPTION
Iceberg 1.4 removed JUnit 4 from the relevant test dependencies.