### PR TITLE
Allow Java 17 for Spark 3.3+3.4 tests

### DIFF
--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -111,7 +111,7 @@ nessieQuarkusApp {
   systemProperties.put("nessie.server.send-stacktrace-to-client", "true")
 }
 
-forceJava11ForTests()
+forceJavaVersionForTests(sparkScala.runtimeJavaVersion)
 
 tasks.withType(Test::class.java).configureEach {
   systemProperty("aws.region", "us-east-1")

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -111,4 +111,4 @@ nessieQuarkusApp {
   systemProperties.put("nessie.server.send-stacktrace-to-client", "true")
 }
 
-forceJava11ForTests()
+forceJavaVersionForTests(sparkScala.runtimeJavaVersion)

--- a/integrations/spark-extensions/build.gradle.kts
+++ b/integrations/spark-extensions/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import java.lang.IllegalArgumentException
 
 plugins {
   alias(libs.plugins.nessie.run)
@@ -68,7 +69,7 @@ nessieQuarkusApp {
   systemProperties.put("nessie.server.send-stacktrace-to-client", "true")
 }
 
-forceJava11ForTests()
+forceJavaVersionForTests(sparkScala.runtimeJavaVersion)
 
 tasks.named<ShadowJar>("shadowJar").configure {
   dependencies {


### PR DESCRIPTION
Allows running Spark tests against Java 17, if the build's running with Java 17 or newer. Otherwise use Java 11.

CI only uses Java 11, so there's no change in CI.