### PR TITLE
Fix openapi self-reference and type ambiguity

### DIFF
--- a/api/model/build.gradle.kts
+++ b/api/model/build.gradle.kts
@@ -57,6 +57,10 @@ dependencies {
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)
+
+  intTestImplementation(platform(libs.testcontainers.bom))
+  intTestImplementation("org.testcontainers:testcontainers")
+  intTestImplementation(libs.awaitility)
 }
 
 extensions.configure<SmallryeOpenApiExtension> {
@@ -94,4 +98,10 @@ annotationStripper {
     annotationsToDrop("^jakarta[.].+".toRegex())
     unmodifiedClassesForJavaVersion.set(11)
   }
+}
+
+tasks.named<Test>("intTest").configure {
+  dependsOn(generateOpenApiSpec)
+  systemProperty("openapiSchemaDir", "$buildDir/generated/openapi/META-INF/openapi")
+  systemProperty("redoclyConfDir", "$projectDir/src/redocly")
 }

--- a/api/model/src/intTest/java/org/projectnessie/model/ITOpenApiValidation.java
+++ b/api/model/src/intTest/java/org/projectnessie/model/ITOpenApiValidation.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.model;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.System.getProperty;
+import static java.nio.file.Files.copy;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.exception.NotModifiedException;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.PullResponseItem;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.DockerClientFactory;
+
+public class ITOpenApiValidation {
+  @Test
+  public void validateOpenApi(@TempDir Path workDir) throws IOException, InterruptedException {
+    copy(
+        Paths.get(getProperty("openapiSchemaDir") + "/openapi.yaml"),
+        workDir.resolve("openapi.yaml"));
+
+    // The ignore-file can be re-generated using these commands:
+    //  ./gradlew :nessie-model:generateOpenApiSpec
+    //  docker run --rm \
+    //    -v $(realpath api/model/build/generated/openapi/META-INF/openapi):/spec \
+    //    docker.io/redocly/cli \
+    //    lint \
+    //    --generate-ignore-file \
+    //    openapi.yaml
+
+    copy(
+        Paths.get(getProperty("redoclyConfDir") + "/.redocly.lint-ignore.yaml"),
+        workDir.resolve(".redocly.lint-ignore.yaml"));
+
+    // Global client instance, not closable (throws an ISE)
+    @SuppressWarnings("resource")
+    DockerClient dockerClient = DockerClientFactory.instance().client();
+
+    // Intentionally a StringBuffer, because it's synchronized
+    StringBuffer buffer = new StringBuffer();
+
+    if (dockerClient
+        .listImagesCmd()
+        .withImageNameFilter("docker.io/redocly/cli:latest")
+        .exec()
+        .isEmpty()) {
+      dockerClient
+          .pullImageCmd("docker.io/redocly/cli:latest")
+          .exec(
+              new ResultCallback.Adapter<>() {
+                @Override
+                public void onNext(PullResponseItem pullResponse) {
+                  // Just print something
+                  System.out.println(pullResponse);
+                }
+              })
+          .awaitCompletion(5, MINUTES);
+    }
+
+    CreateContainerResponse exec =
+        dockerClient
+            .createContainerCmd("docker.io/redocly/cli:latest")
+            .withCmd(asList("lint", "openapi.yaml"))
+            .withHostConfig(
+                HostConfig.newHostConfig()
+                    .withBinds(Bind.parse(workDir.toAbsolutePath() + ":/spec")))
+            .exec();
+    dockerClient
+        .logContainerCmd(exec.getId())
+        .withStdOut(true)
+        .withStdErr(true)
+        .withFollowStream(true)
+        .exec(
+            new ResultCallback.Adapter<>() {
+              @Override
+              public void onNext(Frame frame) {
+                buffer.append(new String(frame.getPayload()).trim()).append('\n');
+              }
+            });
+
+    try {
+      dockerClient.startContainerCmd(exec.getId()).exec();
+
+      await()
+          .timeout(30, SECONDS)
+          .pollInterval(100, MICROSECONDS)
+          .until(
+              () -> {
+                InspectContainerResponse.ContainerState state =
+                    dockerClient.inspectContainerCmd(exec.getId()).exec().getState();
+                return FALSE.equals(state.getRunning());
+              });
+
+      InspectContainerResponse.ContainerState state =
+          dockerClient.inspectContainerCmd(exec.getId()).exec().getState();
+      assertThat(state.getExitCodeLong()).describedAs("%s", buffer).isEqualTo(0L);
+    } finally {
+      try {
+        dockerClient.stopContainerCmd(exec.getId()).exec();
+      } catch (NotModifiedException ignore) {
+        // already stopped
+      }
+      dockerClient.removeContainerCmd(exec.getId()).exec();
+    }
+  }
+}

--- a/api/model/src/main/java/org/projectnessie/model/EntriesResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/EntriesResponse.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 import org.projectnessie.model.ser.Views;
 
@@ -58,6 +59,7 @@ public interface EntriesResponse extends PaginatedResponse {
     @NotNull
     @jakarta.validation.constraints.NotNull
     @Value.Parameter(order = 2)
+    @Schema(ref = "#/components/schemas/Type") // workaround self-referencing 'ref'
     Content.Type getType();
 
     @NotNull

--- a/api/model/src/main/java/org/projectnessie/model/GarbageCollectorConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/GarbageCollectorConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.immutables.value.Value;
 
 /**
@@ -35,6 +36,7 @@ import org.immutables.value.Value;
  * configuration, but overriding these values on the command line will still be possible.
  */
 @Schema(type = SchemaType.OBJECT, title = "Garbage collector config object")
+@Tag(name = "v2")
 @Value.Immutable
 @JsonSerialize(as = ImmutableGarbageCollectorConfig.class)
 @JsonDeserialize(as = ImmutableGarbageCollectorConfig.class)

--- a/api/model/src/main/java/org/projectnessie/model/RepositoryConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/RepositoryConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.immutables.value.Value;
 import org.projectnessie.model.types.RepositoryConfigTypeIdResolver;
 import org.projectnessie.model.types.RepositoryConfigTypes;
@@ -36,32 +37,35 @@ import org.projectnessie.model.types.RepositoryConfigTypes;
       @DiscriminatorMapping(value = "GARBAGE_COLLECTOR", schema = GarbageCollectorConfig.class)
     },
     discriminatorProperty = "type")
+@Tag(name = "v2")
 @JsonTypeIdResolver(RepositoryConfigTypeIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type", visible = true)
 public interface RepositoryConfig {
 
   /**
-   * Returns the {@link RepositoryConfig.Type} value for this repository config object.
+   * Returns the {@link Type} value for this repository config object.
    *
    * <p>The name of the returned value should match the JSON type name used for serializing the
-   * content object.
+   * repository config object.
    */
   @Value.Redacted
   @JsonIgnore
-  RepositoryConfig.Type getType();
+  Type getType();
 
   @JsonDeserialize(using = Util.RepositoryConfigTypeDeserializer.class)
   @JsonSerialize(using = Util.RepositoryConfigTypeSerializer.class)
   @Schema(
       type = SchemaType.STRING,
+      name = "RepositoryConfigType",
       description =
           "Declares the type of a Nessie repository config object, which is currently only "
               + "GARBAGE_COLLECTOR, which is the discriminator mapping value of the 'RepositoryConfig' type.")
+  @Tag(name = "v2")
   interface Type {
-    RepositoryConfig.Type UNKNOWN = RepositoryConfigTypes.forName("UNKNOWN");
-    RepositoryConfig.Type GARBAGE_COLLECTOR = RepositoryConfigTypes.forName("GARBAGE_COLLECTOR");
+    Type UNKNOWN = RepositoryConfigTypes.forName("UNKNOWN");
+    Type GARBAGE_COLLECTOR = RepositoryConfigTypes.forName("GARBAGE_COLLECTOR");
 
-    /** The name of the content-type. */
+    /** The name of the repository config type. */
     String name();
 
     Class<? extends RepositoryConfig> type();

--- a/api/model/src/main/java/org/projectnessie/model/RepositoryConfigResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/RepositoryConfigResponse.java
@@ -21,9 +21,11 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.immutables.value.Value;
 
 @Schema(type = SchemaType.OBJECT, title = "RepositoryConfigResponse")
+@Tag(name = "v2")
 @Value.Immutable
 @JsonSerialize(as = ImmutableRepositoryConfigResponse.class)
 @JsonDeserialize(as = ImmutableRepositoryConfigResponse.class)

--- a/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigRequest.java
+++ b/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigRequest.java
@@ -19,9 +19,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.immutables.value.Value;
 
 @Schema(type = SchemaType.OBJECT, title = "UpdateRepositoryConfigRequest")
+@Tag(name = "v2")
 @Value.Immutable
 @JsonSerialize(as = ImmutableUpdateRepositoryConfigRequest.class)
 @JsonDeserialize(as = ImmutableUpdateRepositoryConfigRequest.class)

--- a/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/UpdateRepositoryConfigResponse.java
@@ -20,9 +20,11 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Nullable;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.immutables.value.Value;
 
 @Schema(type = SchemaType.OBJECT, title = "UpdateRepositoryConfigResponse")
+@Tag(name = "v2")
 @Value.Immutable
 @JsonSerialize(as = ImmutableUpdateRepositoryConfigResponse.class)
 @JsonDeserialize(as = ImmutableUpdateRepositoryConfigResponse.class)

--- a/api/model/src/redocly/.redocly.lint-ignore.yaml
+++ b/api/model/src/redocly/.redocly.lint-ignore.yaml
@@ -1,0 +1,158 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redoc.ly/docs/cli/ for more information.
+openapi.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-invalid-media-type-examples:
+    - '#/paths/~1v1~1contents/post/responses/200/content/application~1json/schema'
+    - >-
+      #/paths/~1v1~1contents~1{key}/get/responses/200/content/application~1json/schema
+    - >-
+      #/paths/~1v1~1diffs~1{fromRefWithHash}...{toRefWithHash}/get/responses/200/content/application~1json/schema
+    - '#/components/examples/namespace/value'
+    - '#/components/examples/namespacesResponse/value/namespaces/0'
+    - '#/components/examples/namespacesResponse/value/namespaces/0/type'
+    - '#/components/examples/namespacesResponse/value/namespaces/1'
+    - '#/components/examples/namespacesResponse/value/namespaces/1/type'
+    - '#/components/examples/referencesResponse/value/references/0/type'
+    - '#/components/examples/referencesResponse/value/references/1/type'
+    - '#/components/examples/referencesResponse/value/references/2/type'
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/0/type
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/1/type
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/2/type
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/3/type
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/4/type
+    - >-
+      #/paths/~1v1~1trees~1branch~1{branchName}~1commit/post/requestBody/content/application~1json/schema
+    - '#/components/examples/refObj/value/type'
+    - >-
+      #/paths/~1v1~1trees~1branch~1{branchName}~1merge/post/requestBody/content/application~1json/schema
+    - '#/components/examples/mergeResponseSuccess/value/details/0/conflictType'
+    - '#/components/examples/mergeResponseSuccess/value/wasApplied'
+    - '#/components/examples/mergeResponseSuccess/value/wasSuccessful'
+    - '#/components/examples/mergeResponseFail/value/details/0/conflictType'
+    - '#/components/examples/mergeResponseFail/value/wasApplied'
+    - '#/components/examples/mergeResponseFail/value/wasSuccessful'
+    - >-
+      #/paths/~1v1~1trees~1branch~1{branchName}~1transplant/post/requestBody/content/application~1json/schema
+    - '#/components/examples/refObjNew/value/type'
+    - >-
+      #/paths/~1v1~1trees~1tree~1{ref}~1log/get/responses/200/content/application~1json/schema
+    - '#/components/examples/tagObj/value/type'
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/0/metadata/commitMetaOfHEAD
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/0/metadata/commitMetaOfHEAD/author
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/0/metadata/commitMetaOfHEAD/properties
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/1/metadata/commitMetaOfHEAD
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/1/metadata/commitMetaOfHEAD/author
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/1/metadata/commitMetaOfHEAD/properties
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/3/metadata/commitMetaOfHEAD
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/3/metadata/commitMetaOfHEAD/author
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/3/metadata/commitMetaOfHEAD/properties
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/4/metadata/commitMetaOfHEAD
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/4/metadata/commitMetaOfHEAD/author
+    - >-
+      #/components/examples/referencesResponseWithMetadata/value/references/4/metadata/commitMetaOfHEAD/properties
+    - '#/components/examples/singleReferenceResponse/value/reference/type'
+    - >-
+      #/paths/~1v2~1trees~1{branch}~1history~1commit/post/requestBody/content/application~1json/schema
+    - '#/components/examples/commitResponse/value/targetBranch/type'
+    - '#/components/examples/commitResponse/value/addedContents/0/contentId'
+    - >-
+      #/paths/~1v2~1trees~1{branch}~1history~1merge/post/requestBody/content/application~1json/schema
+    - >-
+      #/paths/~1v2~1trees~1{branch}~1history~1transplant/post/requestBody/content/application~1json/schema
+    - >-
+      #/paths/~1v2~1trees~1{from-ref}~1diff~1{to-ref}/get/responses/200/content/application~1json/schema
+    - >-
+      #/components/examples/singleReferenceResponseWithMetadata/value/reference/metadata/commitMetaOfHEAD
+    - >-
+      #/components/examples/singleReferenceResponseWithMetadata/value/reference/metadata/commitMetaOfHEAD/author
+    - >-
+      #/components/examples/singleReferenceResponseWithMetadata/value/reference/metadata/commitMetaOfHEAD/properties
+    - >-
+      #/components/examples/singleReferenceResponseWithMetadata/value/reference/type
+    - >-
+      #/paths/~1v2~1trees~1{ref}~1contents/get/responses/200/content/application~1json/schema
+    - >-
+      #/paths/~1v2~1trees~1{ref}~1contents/post/responses/200/content/application~1json/schema
+    - >-
+      #/paths/~1v2~1trees~1{ref}~1contents~1{key}/get/responses/200/content/application~1json/schema
+    - >-
+      #/paths/~1v2~1trees~1{ref}~1entries/get/responses/default/content/application~1json/schema
+    - >-
+      #/paths/~1v2~1trees~1{ref}~1history/get/responses/200/content/application~1json/schema
+  operation-summary:
+    - '#/paths/~1v1~1namespaces~1namespace~1{ref}~1{name}/post/summary'
+    - '#/paths/~1v1~1namespaces~1{ref}/get/summary'
+  no-unused-components:
+    - '#/components/schemas/CommitResponse'
+    - '#/components/schemas/DiffResponse'
+    - '#/components/schemas/GetMultipleContentsResponse'
+    - '#/components/schemas/LogResponse'
+    - '#/components/schemas/MergeResponse'
+    - '#/components/schemas/NessieConfiguration'
+    - '#/components/schemas/RepositoryConfigResponse'
+    - '#/components/schemas/RepositoryConfigResponse_V2'
+    - '#/components/schemas/RepositoryConfigType'
+    - '#/components/schemas/SingleReferenceResponse'
+    - '#/components/schemas/UpdateRepositoryConfigRequest'
+    - '#/components/schemas/UpdateRepositoryConfigResponse'
+    - '#/components/schemas/UpdateRepositoryConfigResponse_V2'
+    - '#/components/examples/ContentKey'
+    - '#/components/examples/expr_by_commit_operations_in_namespace'
+    - '#/components/examples/types'
+  security-defined:
+    - '#/paths/~1v1~1config/get'
+    - '#/paths/~1v1~1contents/post'
+    - '#/paths/~1v1~1contents~1{key}/get'
+    - '#/paths/~1v1~1diffs~1{fromRefWithHash}...{toRefWithHash}/get'
+    - '#/paths/~1v1~1namespaces~1namespace~1{ref}~1{name}/get'
+    - '#/paths/~1v1~1namespaces~1namespace~1{ref}~1{name}/put'
+    - '#/paths/~1v1~1namespaces~1namespace~1{ref}~1{name}/post'
+    - '#/paths/~1v1~1namespaces~1namespace~1{ref}~1{name}/delete'
+    - '#/paths/~1v1~1namespaces~1{ref}/get'
+    - '#/paths/~1v1~1reflogs/get'
+    - '#/paths/~1v1~1trees/get'
+    - '#/paths/~1v1~1trees~1branch~1{branchName}~1commit/post'
+    - '#/paths/~1v1~1trees~1branch~1{branchName}~1merge/post'
+    - '#/paths/~1v1~1trees~1branch~1{branchName}~1transplant/post'
+    - '#/paths/~1v1~1trees~1tree/get'
+    - '#/paths/~1v1~1trees~1tree/post'
+    - '#/paths/~1v1~1trees~1tree~1{ref}/get'
+    - '#/paths/~1v1~1trees~1tree~1{ref}~1entries/get'
+    - '#/paths/~1v1~1trees~1tree~1{ref}~1log/get'
+    - '#/paths/~1v1~1trees~1{referenceType}~1{referenceName}/put'
+    - '#/paths/~1v1~1trees~1{referenceType}~1{referenceName}/delete'
+    - '#/paths/~1v2~1config/get'
+    - '#/paths/~1v2~1config~1repository/get'
+    - '#/paths/~1v2~1config~1repository/post'
+    - '#/paths/~1v2~1trees/get'
+    - '#/paths/~1v2~1trees/post'
+    - '#/paths/~1v2~1trees~1{branch}~1history~1commit/post'
+    - '#/paths/~1v2~1trees~1{branch}~1history~1merge/post'
+    - '#/paths/~1v2~1trees~1{branch}~1history~1transplant/post'
+    - '#/paths/~1v2~1trees~1{from-ref}~1diff~1{to-ref}/get'
+    - '#/paths/~1v2~1trees~1{ref}/get'
+    - '#/paths/~1v2~1trees~1{ref}/put'
+    - '#/paths/~1v2~1trees~1{ref}/delete'
+    - '#/paths/~1v2~1trees~1{ref}~1contents/get'
+    - '#/paths/~1v2~1trees~1{ref}~1contents/post'
+    - '#/paths/~1v2~1trees~1{ref}~1contents~1{key}/get'
+    - '#/paths/~1v2~1trees~1{ref}~1entries/get'
+    - '#/paths/~1v2~1trees~1{ref}~1history/get'


### PR DESCRIPTION
The generated openapi-yaml has an error, because the `Type_V1` and `Type_v2` schemas have a "self-reference". This change fixes this by adding an explicit `ref` to `EntriesResponse.Entry.getType()`.

Also updates the repository-configs with the "v2" tag.

Also (re)names the type schema for `RepositoryConfig.Type` to `RepositoryConfigType`, which was ambiguous with `Content.Type`, as both resolved to the same OpenAPI schema `Type`.

Also adds an integration test to lint/validate the generated `openapi.yaml` file.

Self-referencing schemas:
```yaml
components:
  schemas:
    ...
    Type:
      description: "Declares the type of a Nessie content object, which is currently\
        \ one of ICEBERG_TABLE, DELTA_LAKE_TABLE, ICEBERG_VIEW, NAMESPACE or UDF,\
        \ which are the discriminator mapping values of the 'Content' type."
      type: string
    Type_V1:
      $ref: '#/components/schemas/Type_V1'
    Type_V2:
      $ref: '#/components/schemas/Type_V2'
```