### PR TITLE
Validate default-cut-off-policy with gc config/repository APIs

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/GarbageCollectorConfig.java
+++ b/api/model/src/main/java/org/projectnessie/model/GarbageCollectorConfig.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.model;
 
+import static org.projectnessie.model.Validation.validateDefaultCutOffPolicy;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -22,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.validation.constraints.Pattern;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -57,7 +60,25 @@ public interface GarbageCollectorConfig extends RepositoryConfig {
   @Nullable
   @jakarta.annotation.Nullable
   @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Pattern(
+      regexp = Validation.DEFAULT_CUT_OFF_POLICY_REGEX,
+      message = Validation.DEFAULT_CUT_OFF_POLICY_MESSAGE)
+  @jakarta.validation.constraints.Pattern(
+      regexp = Validation.DEFAULT_CUT_OFF_POLICY_REGEX,
+      message = Validation.DEFAULT_CUT_OFF_POLICY_MESSAGE)
   String getDefaultCutoffPolicy();
+
+  /**
+   * Validation rule using {@link
+   * org.projectnessie.model.Validation#validateDefaultCutOffPolicy(String)}.
+   */
+  @Value.Check
+  default void checkDefaultPolicy() {
+    String defaultCutoffPolicy = getDefaultCutoffPolicy();
+    if (defaultCutoffPolicy != null) {
+      validateDefaultCutOffPolicy(defaultCutoffPolicy);
+    }
+  }
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   List<ReferenceCutoffPolicy> getPerRefCutoffPolicies();

--- a/api/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/api/model/src/main/java/org/projectnessie/model/Validation.java
@@ -95,6 +95,24 @@ public final class Validation {
   public static final Pattern REF_NAME_PATH_ELEMENT_PATTERN =
       Pattern.compile(REF_NAME_PATH_ELEMENT_REGEX);
 
+  /*
+   * Default Cut-Off Policy can be a number or Duration or ISO instant.
+   * Following rules are to validate the same.
+   * */
+  private static final String DURATION_REGEX =
+      "([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?";
+
+  private static final String ISO_TIME_REGEX =
+      "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?(?:Z|[+-][01]\\d:[0-5]\\d)$";
+
+  private static final String POSITIVE_INTEGER_REGEX = "^[1-9]\\d{0,10}";
+  public static final String DEFAULT_CUT_OFF_POLICY_REGEX =
+      "NONE" + "|" + POSITIVE_INTEGER_REGEX + "|" + DURATION_REGEX + "|" + ISO_TIME_REGEX;
+  public static final String DEFAULT_CUT_OFF_POLICY_MESSAGE =
+      "Default cut-off-policy must be either the number of commits, a duration (as per java.time.Duration) or an ISO instant (like 2011-12-03T10:15:30Z) ";
+  public static final Pattern DEFAULT_CUT_OFF_POLICY_PATTERN =
+      Pattern.compile(DEFAULT_CUT_OFF_POLICY_REGEX, Pattern.CASE_INSENSITIVE);
+
   public static final String HASH_RULE = "consist of the hex representation of 4-32 bytes";
   private static final String REF_RULE =
       "start with a letter, followed by letters, digits, one of the ./_- characters, "
@@ -194,6 +212,26 @@ public final class Validation {
       return referenceName;
     }
     throw new IllegalArgumentException(HASH_MESSAGE + " - but was: " + referenceName);
+  }
+
+  /** Just checks whether a string is a valid cut-off policy or not. */
+  private static boolean isValidDefaultCutoffPolicy(String policy) {
+    Objects.requireNonNull(policy, "policy must not be null");
+    Matcher matcher = DEFAULT_CUT_OFF_POLICY_PATTERN.matcher(policy);
+    return matcher.matches();
+  }
+
+  /**
+   * Validate default cutoff policy.Policies can be one of: - number of commits as an integer value,
+   * - a duration (see java.time.Duration), - an ISO instant, - 'NONE,' means everything's
+   * considered as live
+   */
+  public static void validateDefaultCutOffPolicy(String value) {
+    if (isValidDefaultCutoffPolicy(value)) {
+      return;
+    }
+    throw new IllegalArgumentException(
+        "Failed to parse default-cutoff-value '" + value + "'," + DEFAULT_CUT_OFF_POLICY_MESSAGE);
   }
 
   /**

--- a/api/model/src/test/java/org/projectnessie/model/TestValidation.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestValidation.java
@@ -289,4 +289,27 @@ class TestValidation {
       soft.assertThatCode(() -> Validation.validateNoRelativeSpec(hash)).doesNotThrowAnyException();
     }
   }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "abcDEF4242424242424242424242BEEF00DEAD42112233445566778899001122",
+        "1P12",
+        "PT10D",
+        "2011-12-03T10:15:30",
+        "2011-12-03 10:15:30"
+      })
+  void invalidDefaultCutOffPolicy(String cutOffPolicy) {
+    soft.assertThatIllegalArgumentException()
+        .isThrownBy(() -> Validation.validateDefaultCutOffPolicy(cutOffPolicy))
+        .withMessageContaining("Failed to parse default-cutoff-value");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"123", "P10D", "p20D", "p10d", "PT20.3S", "P2DT3H4M", "2011-12-03T10:15:30Z"})
+  void validateDefaultCutOffPolicy(String cutOffPolicy) {
+    soft.assertThatCode(() -> Validation.validateDefaultCutOffPolicy(cutOffPolicy))
+        .doesNotThrowAnyException();
+  }
 }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractRepositoryConfig.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractRepositoryConfig.java
@@ -42,12 +42,12 @@ public abstract class AbstractRepositoryConfig extends AbstractNestedVersionStor
   void createAndUpdate() throws Exception {
     ImmutableGarbageCollectorConfig created =
         GarbageCollectorConfig.builder()
-            .defaultCutoffPolicy("PT30D")
+            .defaultCutoffPolicy("P30D")
             .newFilesGracePeriod(Duration.of(3, ChronoUnit.HOURS))
             .build();
     ImmutableGarbageCollectorConfig updated =
         GarbageCollectorConfig.builder()
-            .defaultCutoffPolicy("PT10D")
+            .defaultCutoffPolicy("P10D")
             .expectedFileCountPerContent(123)
             .build();
 


### PR DESCRIPTION
config/repository is accepting string as defaultCutOffPolicy. which is very vague. 
Validating this using regex with Duration/ISO Instant/Positive Numeric values. 
