### PR TITLE
Fix Quarkus Swagger UI

### DIFF
--- a/api/model/src/main/resources/META-INF/openapi.yaml
+++ b/api/model/src/main/resources/META-INF/openapi.yaml
@@ -42,39 +42,24 @@ servers:
   #     repositoryId:
   #       description: The repository ID (mandatory) of your Arctic catalog. See "Catalog Endpoint" in "General Information"/"Catalog Settings" on the Dremio Cloud Arctic Catalogs page
   #       default: ""
-  - url: "http://{host}:19120/api"
-    description: Nessie Quarkus server running, usually locally, used for development purposes
-    variables:
-      host:
-        description: The host address for the specified server
-        default: localhost
-  - url: "{scheme}://{host}/{basePath}"
-    description: Generic server URL, port inferred from the scheme
-    variables:
-      scheme:
-        description: Either http or https.
-        default: https
-      host:
-        description: The server's host name
-        default: localhost
-      basePath:
-        description: Nessie Core API base path.
-        default: "/api/"
   - url: "{scheme}://{host}:{port}/{basePath}"
-    description: Generic base server URL, with all parts configurable
+    description: Nessie REST API endpoint.
     variables:
       scheme:
         description: The scheme of the URI, either http or https.
-        default: https
+        default: http
       host:
         description: The host address for the specified server
         default: localhost
       port:
         description: The port used when addressing the host
-        default: "443"
+        default: "19120"
       basePath:
-        description: Nessie Core API base path.
-        default: "/api/"
+        description: |
+          Nessie Core API base path.
+          When using the Swagger UI from Quarkus from the `/q/swagger-ui` URL, leave the `basePath` value empty.
+          Otherwise use `/api/` for `basePath`.
+        default: ""
 
 paths: {} # inferred from java annotations
 


### PR DESCRIPTION
PR #7266 broke the Swagger UI in Nessie-Quarkus. The Swagger UI in Quarkus is a bit special, and the OpenAPI spec is heavily adopted by Quarkus itself - it especially rewrites the endpoint paths. For example `/v2/config` becomes `/api/v2/config` in Quarkus' generated OpenAPI spec. The server settings in Quarkus' Swagger UI is "a bit opinionated", because it doesn't really allow to change the "base path" - and because the "base path" of the first server in the openapi.yaml file has `/api/` as the "base path", the Quarkus Swagger UI wants to invoke the endpoints at for example `/api/api/v2/config`, which doesn't work. This change fixes this.

Sadly, the Swagger UI doesn't show long descriptions for server entries - the description is appended to the single-line select-box. And descriptions for the individual URL variables are not shown at all.

Beside the above changes, this change also:
* Fixes the `from` in the `pullOpenApiSpec` task definition, so Gradle picks up changes to the source file correctly.
* Updates the build script to reference the `quarkusAppPartsBuild` task instead of `quarkusBuild` (change in the Quarkus 3 Gradle plugin).
* Fix the version number shown in Quarkus Swagger UI
* Remove the security section from Quarkus' generated openapi spec (it's wrong, points to 172.255.0.0).