### PR TITLE
Correct handling of reference-type query parameter

### DIFF
--- a/api/model/src/main/java/org/projectnessie/api/v2/TreeApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/TreeApi.java
@@ -91,8 +91,15 @@ public interface TreeApi {
               regexp = Validation.REF_NAME_REGEX,
               message = Validation.REF_NAME_MESSAGE)
           String name,
-      @Valid @jakarta.validation.Valid @NotNull @jakarta.validation.constraints.NotNull
-          Reference.ReferenceType type,
+      @Valid
+          @jakarta.validation.Valid
+          @NotNull
+          @jakarta.validation.constraints.NotNull
+          @Pattern(regexp = Validation.REF_TYPE_REGEX, message = Validation.REF_TYPE_MESSAGE)
+          @jakarta.validation.constraints.Pattern(
+              regexp = Validation.REF_TYPE_REGEX,
+              message = Validation.REF_TYPE_MESSAGE)
+          String type,
       @Valid @jakarta.validation.Valid @Nullable @jakarta.annotation.Nullable Reference sourceRef)
       throws NessieNotFoundException, NessieConflictException;
 
@@ -186,7 +193,13 @@ public interface TreeApi {
    * @param type Optional expected type of reference being assigned. Will be validated if present.
    */
   SingleReferenceResponse assignReference(
-      @Valid @jakarta.validation.Valid Reference.ReferenceType type,
+      @Valid
+          @jakarta.validation.Valid
+          @Pattern(regexp = Validation.REF_TYPE_REGEX, message = Validation.REF_TYPE_MESSAGE)
+          @jakarta.validation.constraints.Pattern(
+              regexp = Validation.REF_TYPE_REGEX,
+              message = Validation.REF_TYPE_MESSAGE)
+          String type,
       @Valid
           @jakarta.validation.Valid
           @NotNull
@@ -208,7 +221,13 @@ public interface TreeApi {
    * @param type Optional expected type of reference being deleted. Will be validated if present.
    */
   SingleReferenceResponse deleteReference(
-      @Valid @jakarta.validation.Valid Reference.ReferenceType type,
+      @Valid
+          @jakarta.validation.Valid
+          @Pattern(regexp = Validation.REF_TYPE_REGEX, message = Validation.REF_TYPE_MESSAGE)
+          @jakarta.validation.constraints.Pattern(
+              regexp = Validation.REF_TYPE_REGEX,
+              message = Validation.REF_TYPE_MESSAGE)
+          String type,
       @Valid
           @jakarta.validation.Valid
           @NotNull

--- a/api/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/http/HttpTreeApi.java
@@ -150,7 +150,7 @@ public interface HttpTreeApi extends TreeApi {
               examples = {@ExampleObject(ref = "referenceType")})
           @QueryParam("type")
           @jakarta.ws.rs.QueryParam("type")
-          Reference.ReferenceType type,
+          String type,
       @RequestBody(
               required = true,
               description = "Source reference data from which the new reference is to be created.",
@@ -432,7 +432,7 @@ public interface HttpTreeApi extends TreeApi {
               examples = {@ExampleObject(ref = "referenceType")})
           @QueryParam("type")
           @jakarta.ws.rs.QueryParam("type")
-          Reference.ReferenceType type,
+          String type,
       @Parameter(
               schema = @Schema(pattern = REF_NAME_PATH_ELEMENT_REGEX),
               description = CHECKED_REF_DESCRIPTION,
@@ -490,7 +490,7 @@ public interface HttpTreeApi extends TreeApi {
               examples = {@ExampleObject(ref = "referenceType")})
           @QueryParam("type")
           @jakarta.ws.rs.QueryParam("type")
-          Reference.ReferenceType type,
+          String type,
       @Parameter(
               schema = @Schema(pattern = REF_NAME_PATH_ELEMENT_REGEX),
               description = CHECKED_REF_DESCRIPTION,

--- a/api/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/api/model/src/main/java/org/projectnessie/model/Validation.java
@@ -74,7 +74,7 @@ public final class Validation {
   public static final String REF_NAME_REGEX = "^" + REF_NAME_RAW_REGEX + "$";
 
   public static final String REF_TYPE_RAW_REGEX = "BRANCH|branch|TAG|tag";
-  public static final String REF_TYPE_REGEX = "^" + REF_TYPE_RAW_REGEX + "$";
+  public static final String REF_TYPE_REGEX = "^(" + REF_TYPE_RAW_REGEX + ")$";
   public static final String REF_NAME_OR_HASH_REGEX =
       "^(?:(" + HASH_RAW_REGEX + ")|(" + REF_NAME_RAW_REGEX + "))$";
   public static final String REF_NAME_PATH_REGEX =

--- a/api/model/src/main/java/org/projectnessie/model/Validation.java
+++ b/api/model/src/main/java/org/projectnessie/model/Validation.java
@@ -72,6 +72,9 @@ public final class Validation {
   public static final String REF_NAME_RAW_REGEX =
       "(?:[A-Za-z](?:(?:(?![.][.])[A-Za-z0-9./_-])*[A-Za-z0-9_-])?)|-";
   public static final String REF_NAME_REGEX = "^" + REF_NAME_RAW_REGEX + "$";
+
+  public static final String REF_TYPE_RAW_REGEX = "BRANCH|branch|TAG|tag";
+  public static final String REF_TYPE_REGEX = "^" + REF_TYPE_RAW_REGEX + "$";
   public static final String REF_NAME_OR_HASH_REGEX =
       "^(?:(" + HASH_RAW_REGEX + ")|(" + REF_NAME_RAW_REGEX + "))$";
   public static final String REF_NAME_PATH_REGEX =
@@ -143,6 +146,10 @@ public final class Validation {
           + ", optionally followed by a "
           + RELATIVE_COMMIT_SPEC_RULE;
   public static final String REF_NAME_MESSAGE = "Reference name must " + REF_RULE;
+
+  public static final String REF_TYPE_RULE = "be either 'branch' or 'tag'";
+  public static final String REF_TYPE_MESSAGE = "Reference type name must " + REF_TYPE_RULE;
+
   public static final String REF_NAME_OR_HASH_MESSAGE =
       "Reference must be either a reference name or hash, " + REF_RULE + " or " + HASH_RULE;
   public static final String FORBIDDEN_REF_NAME_MESSAGE =


### PR DESCRIPTION
Nessie API V2 uses the Java enum `ReferenceType` directly as the type of the `type` query parameter, and not a "bare `String`". This causes some special handling: the `type` parameter _must_ be present and have a corresponding value in the `ReferenceType` enum, otherwise the HTTP response will be a HTTP/404 instead of the expected HTTP/400. The query parameter could be optional using `Optional<ReferenceType>`, but that still restricts the parameter to the enum values, returning a HTTP/404.

This change refactors the `type` parameter for create-reference, assign-reference and delete-reference to be a "bare `String`" and uses a helper function to parse the value. Parameter _value_ validation is delegated to JAX-RS using a validation regex, returning a meaningful validation message.

Fixes #7229