### PR TITLE
Add new `entries` command to `content-generator`

### DIFF
--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadEntries.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadEntries.java
@@ -41,7 +41,7 @@ class ITReadEntries extends AbstractContentGeneratorTest {
   @Test
   void listEntries() {
     ProcessResult proc =
-        runGeneratorCmd("list-entries", "--uri", NESSIE_API_URI, "--ref", branch.getName());
+        runGeneratorCmd("entries", "--uri", NESSIE_API_URI, "--ref", branch.getName());
 
     assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
     List<String> output = proc.getStdOutLines();
@@ -52,8 +52,7 @@ class ITReadEntries extends AbstractContentGeneratorTest {
   @Test
   void listEntriesVerbose() {
     ProcessResult proc =
-        runGeneratorCmd(
-            "list-entries", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--verbose");
+        runGeneratorCmd("entries", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--verbose");
     assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
     List<String> output = proc.getStdOutLines();
 
@@ -68,7 +67,7 @@ class ITReadEntries extends AbstractContentGeneratorTest {
   void listEntriesWithContent() {
     ProcessResult proc =
         runGeneratorCmd(
-            "list-entries", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--with-content");
+            "entries", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--with-content");
     assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
     List<String> output = proc.getStdOutLines();
 

--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadEntries.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadEntries.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.tools.contentgenerator.RunContentGenerator.runGeneratorCmd;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.tools.contentgenerator.RunContentGenerator.ProcessResult;
+
+class ITReadEntries extends AbstractContentGeneratorTest {
+
+  private Branch branch;
+
+  @BeforeEach
+  void setup() throws NessieConflictException, NessieNotFoundException {
+    try (NessieApiV2 api = buildNessieApi()) {
+      branch = makeCommit(api);
+    }
+  }
+
+  @Test
+  void listEntries() {
+    ProcessResult proc =
+        runGeneratorCmd("list-entries", "--uri", NESSIE_API_URI, "--ref", branch.getName());
+
+    assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
+    List<String> output = proc.getStdOutLines();
+
+    assertThat(output).anySatisfy(s -> assertThat(s).contains(CONTENT_KEY.toString()));
+  }
+
+  @Test
+  void listEntriesVerbose() {
+    ProcessResult proc =
+        runGeneratorCmd(
+            "list-entries", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--verbose");
+    assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
+    List<String> output = proc.getStdOutLines();
+
+    assertThat(output).anySatisfy(s -> assertThat(s).contains(CONTENT_KEY.toString()));
+    assertThat(output)
+        .anySatisfy(s -> assertThat(s).contains("key[0]: " + CONTENT_KEY.getElements().get(0)));
+    assertThat(output)
+        .anySatisfy(s -> assertThat(s).contains("key[1]: " + CONTENT_KEY.getElements().get(1)));
+  }
+
+  @Test
+  void listEntriesWithContent() {
+    ProcessResult proc =
+        runGeneratorCmd(
+            "list-entries", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--with-content");
+    assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
+    List<String> output = proc.getStdOutLines();
+
+    assertThat(output).anySatisfy(s -> assertThat(s).contains(CONTENT_KEY.toString()));
+    assertThat(output).anySatisfy(s -> assertThat(s).contains("testMeta"));
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ContentGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ContentGenerator.java
@@ -24,6 +24,7 @@ import picocli.CommandLine;
     versionProvider = NessieVersionProvider.class,
     subcommands = {
       GenerateContent.class,
+      ReadEntries.class,
       ReadCommits.class,
       ReadReferences.class,
       ReadContent.class,

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadEntries.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadEntries.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.tools.contentgenerator.cli;
 
+import java.io.PrintWriter;
 import java.util.List;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.NessieNotFoundException;
@@ -40,29 +41,31 @@ public class ReadEntries extends AbstractCommand {
 
   @Override
   public void execute() throws NessieNotFoundException {
+    PrintWriter out = spec.commandLine().getOut();
+
     try (NessieApiV2 api = createNessieApiInstance()) {
-      spec.commandLine().getOut().printf("Listing entries for reference '%s'.%n%n", ref);
+      out.printf("Listing entries for reference '%s'.%n%n", ref);
       api.getEntries().refName(ref).withContent(withContent).stream()
           .forEach(
               entry -> {
-                spec.commandLine().getOut().printf("Key: %s%n", entry.getName());
+                out.printf("Key: %s%n", entry.getName());
                 if (isVerbose()) {
                   List<String> key = entry.getName().getElements();
                   for (int i = 0; i < key.size(); i++) {
-                    spec.commandLine().getOut().printf("  key[%d]: %s%n", i, key.get(i));
+                    out.printf("  key[%d]: %s%n", i, key.get(i));
                   }
                 }
 
-                spec.commandLine().getOut().printf("Type: %s%n", entry.getType());
-                spec.commandLine().getOut().printf("Content ID: %s%n", entry.getContentId());
+                out.printf("Type: %s%n", entry.getType());
+                out.printf("Content ID: %s%n", entry.getContentId());
 
                 if (entry.getContent() != null) {
-                  spec.commandLine().getOut().printf("Value: %s%n", entry.getContent());
+                  out.printf("Value: %s%n", entry.getContent());
                 }
 
-                spec.commandLine().getOut().println();
+                out.println();
               });
-      spec.commandLine().getOut().printf("Done listing entries.%n");
+      out.printf("Done listing entries.%n");
     }
   }
 }

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadEntries.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadEntries.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import java.util.List;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.error.NessieNotFoundException;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(
+    name = "list-entries",
+    mixinStandardHelpOptions = true,
+    description = "List entries (keys) with the associated object type and ID.")
+public class ReadEntries extends AbstractCommand {
+
+  @Option(
+      names = {"-r", "--ref"},
+      description = "Name of the branch/tag to read content from, defaults to 'main'")
+  private String ref = "main";
+
+  @Option(
+      names = {"-C", "--with-content"},
+      description = "Include content for each entry.")
+  private boolean withContent;
+
+  @Override
+  public void execute() throws NessieNotFoundException {
+    try (NessieApiV2 api = createNessieApiInstance()) {
+      spec.commandLine().getOut().printf("Listing entries for reference '%s'.%n%n", ref);
+      api.getEntries().refName(ref).withContent(withContent).stream()
+          .forEach(
+              entry -> {
+                spec.commandLine().getOut().printf("Key: %s%n", entry.getName());
+                if (isVerbose()) {
+                  List<String> key = entry.getName().getElements();
+                  for (int i = 0; i < key.size(); i++) {
+                    spec.commandLine().getOut().printf("  key[%d]: %s%n", i, key.get(i));
+                  }
+                }
+
+                spec.commandLine().getOut().printf("Type: %s%n", entry.getType());
+                spec.commandLine().getOut().printf("Content ID: %s%n", entry.getContentId());
+
+                if (entry.getContent() != null) {
+                  spec.commandLine().getOut().printf("Value: %s%n", entry.getContent());
+                }
+
+                spec.commandLine().getOut().println();
+              });
+      spec.commandLine().getOut().printf("Done listing entries.%n");
+    }
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadEntries.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadEntries.java
@@ -22,9 +22,10 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 @Command(
-    name = "list-entries",
+    name = "entries",
     mixinStandardHelpOptions = true,
-    description = "List entries (keys) with the associated object type and ID.")
+    description =
+        "List entries (keys) with the associated object type, ID and (optionally) content.")
 public class ReadEntries extends AbstractCommand {
 
   @Option(


### PR DESCRIPTION
Useful tool for exploring repositories when java runtime is available, but not python.