### PR TITLE
Make AbstractTestRestApiPersist extend BaseTestNessieRest

### DIFF
--- a/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestRestApiPersist.java
+++ b/servers/jax-rs-tests/src/test/java/org/projectnessie/jaxrs/tests/AbstractTestRestApiPersist.java
@@ -25,7 +25,7 @@ import org.projectnessie.versioned.storage.testextension.NessiePersist;
 import org.projectnessie.versioned.storage.testextension.PersistExtension;
 
 @ExtendWith(PersistExtension.class)
-abstract class AbstractTestRestApiPersist extends BaseTestNessieApi {
+abstract class AbstractTestRestApiPersist extends BaseTestNessieRest {
 
   @NessiePersist protected static Persist persist;
 


### PR DESCRIPTION
BaseTestNessieRest is a subtype of BaseTestNessieApi. There is no reason to prevent AbstractTestRestApiPersist from running the extra, REST-specific tests declared there.

Note that the old-model equivalent of
AbstractTestRestApiPersist is AbstractTestRestApi, which already extends BaseTestNessieRest.