### PR TITLE
Add a generic resolveHash method to VersionStore

### DIFF
--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -140,6 +140,13 @@ public class PersistVersionStore implements VersionStore {
     return databaseAdapter.hashOnReference(namedReference, hashOnReference);
   }
 
+  @Override
+  public Hash resolveHash(Hash hash, List<RelativeCommitSpec> relativeLookups) {
+    checkArgument(
+        relativeLookups.isEmpty(), "Relative lookups not supported for old database model");
+    return hash;
+  }
+
   @Nonnull
   @jakarta.annotation.Nonnull
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
@@ -126,6 +126,12 @@ public class EventsVersionStore implements VersionStore {
     return delegate.hashOnReference(namedReference, hashOnReference, relativeLookups);
   }
 
+  @Override
+  public Hash resolveHash(Hash hash, List<RelativeCommitSpec> relativeLookups)
+      throws ReferenceNotFoundException {
+    return delegate.resolveHash(hash, relativeLookups);
+  }
+
   @Nonnull
   @jakarta.annotation.Nonnull
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/MetricsVersionStore.java
@@ -72,6 +72,12 @@ public final class MetricsVersionStore implements VersionStore {
         () -> delegate.hashOnReference(namedReference, hashOnReference, relativeLookups));
   }
 
+  @Override
+  public Hash resolveHash(Hash hash, List<RelativeCommitSpec> relativeLookups)
+      throws ReferenceNotFoundException {
+    return delegate1Ex("resolvehash", () -> delegate.resolveHash(hash, relativeLookups));
+  }
+
   @Nonnull
   @jakarta.annotation.Nonnull
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/TracingVersionStore.java
@@ -105,6 +105,16 @@ public class TracingVersionStore implements VersionStore {
         () -> delegate.hashOnReference(namedReference, hashOnReference, relativeLookups));
   }
 
+  @Override
+  public Hash resolveHash(Hash hash, List<RelativeCommitSpec> relativeLookups)
+      throws ReferenceNotFoundException {
+    return callWithOneException(
+        tracer,
+        "ResolveHash",
+        b -> b.setAttribute(TAG_HASH, safeToString(hash)),
+        () -> delegate.resolveHash(hash, relativeLookups));
+  }
+
   @Nonnull
   @jakarta.annotation.Nonnull
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -64,6 +64,22 @@ public interface VersionStore {
       throws ReferenceNotFoundException;
 
   /**
+   * Resolves the given hash by applying the relative lookup specs and returns the resolved hash.
+   *
+   * <p>If {@code relativeLookups} is empty, {@code hash} will be returned.
+   *
+   * <p>Contrary to {@link #hashOnReference(NamedRef, Optional, List)}, this method does not
+   * validate that the hash is reachable from any reference.
+   *
+   * @param hash The starting hash
+   * @param relativeLookups The relative lookup specs to apply
+   * @return The resolved hash
+   * @throws ReferenceNotFoundException if the hash does not exist
+   */
+  Hash resolveHash(Hash hash, List<RelativeCommitSpec> relativeLookups)
+      throws ReferenceNotFoundException;
+
+  /**
    * Retrieve the hash for "no ancestor" (or "beginning of time"), which is a hash for which no
    * commit exists. "no ancestor" or "beginning of time" are the initial hash of the default branch
    * and branches that are created via {@link #create(NamedRef, Optional)} without specifying the

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestEventsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestEventsVersionStore.java
@@ -497,6 +497,17 @@ class TestEventsVersionStore {
   }
 
   @Test
+  void testResolveHash() throws ReferenceNotFoundException {
+    when(delegate.resolveHash(hash1, emptyList())).thenReturn(hash1);
+    EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);
+    Hash actualHash = versionStore.resolveHash(hash1, emptyList());
+    assertThat(actualHash).isEqualTo(hash1);
+    verify(delegate).resolveHash(eq(hash1), eq(emptyList()));
+    verifyNoMoreInteractions(delegate);
+    verifyNoInteractions(sink);
+  }
+
+  @Test
   void testNoAncestor() throws ReferenceNotFoundException {
     when(delegate.noAncestorHash()).thenReturn(hash1);
     EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RefMapping.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RefMapping.java
@@ -323,8 +323,7 @@ public class RefMapping {
     return startCommit;
   }
 
-  @VisibleForTesting
-  CommitObj relativeSpec(CommitObj startCommit, List<RelativeCommitSpec> relativespecs)
+  public CommitObj relativeSpec(CommitObj startCommit, List<RelativeCommitSpec> relativespecs)
       throws ReferenceNotFoundException {
     CommitLogic commitLogic = commitLogic(persist);
     for (RelativeCommitSpec spec : relativespecs) {

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -195,6 +195,21 @@ public class VersionStoreImpl implements VersionStore {
   }
 
   @Override
+  public Hash resolveHash(Hash hash, List<RelativeCommitSpec> relativeLookups)
+      throws ReferenceNotFoundException {
+    if (relativeLookups.isEmpty()) {
+      return hash;
+    }
+    try {
+      CommitObj commit = commitLogic(persist).fetchCommit(hashToObjId(hash));
+      commit = new RefMapping(persist).relativeSpec(commit, relativeLookups);
+      return commit != null ? objIdToHash(commit.id()) : NO_ANCESTOR;
+    } catch (ObjNotFoundException e) {
+      throw referenceNotFound(e);
+    }
+  }
+
+  @Override
   public ReferenceCreatedResult create(NamedRef namedRef, Optional<Hash> targetHash)
       throws ReferenceNotFoundException, ReferenceAlreadyExistsException {
     ReferenceLogic referenceLogic = referenceLogic(persist);


### PR DESCRIPTION
Required for #7268.

For context: the existing `hashOnReference` method has the down side of throwing `ReferenceNotFound` if the hash is not reachable from the given `NamedRef` – even if the hash exists. This makes supporting relative hashes across the board harder to implement and could introduce unwanted behavioral changes in existing endpoints.