### PR TITLE
Add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,10 @@ out/
 build/
 !gradle-wrapper.jar
 
-# Python
+# Python & Pyenv
 venv/
 __pycache__/
+.python-version
 
 # Site
 site/site


### PR DESCRIPTION
Useful when pynessie is installed in a virtualenv with pyenv.