### PR TITLE
Support assign/delete reference without type in java client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ as necessary. Empty sections will not end in the release notes.
 ### New Features
 
 ### Changes
+- Java client API to assign/delete reference operations without specifying a concrete reference type
+  (no change to REST API).
 
 ### Deprecations
 

--- a/api/client/src/main/java/org/projectnessie/client/api/AssignReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/AssignReferenceBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.api;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
+
+/**
+ * Request builder for assigning references.
+ *
+ * @since {@link NessieApiV2}
+ */
+public interface AssignReferenceBuilder extends OnReferenceBuilder<AssignReferenceBuilder> {
+  AssignReferenceBuilder assignTo(
+      @Valid @jakarta.validation.Valid @NotNull @jakarta.validation.constraints.NotNull
+          Reference assignTo);
+
+  AssignReferenceBuilder refType(Reference.ReferenceType referenceType);
+
+  @Override
+  default AssignReferenceBuilder reference(Reference reference) {
+    refType(reference.getType());
+    return OnReferenceBuilder.super.reference(reference);
+  }
+
+  void assign() throws NessieNotFoundException, NessieConflictException;
+
+  /** Assigns the reference to the specified hash and returns its updated information. */
+  Reference assignAndGet() throws NessieNotFoundException, NessieConflictException;
+}

--- a/api/client/src/main/java/org/projectnessie/client/api/AssignReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/AssignReferenceBuilder.java
@@ -19,28 +19,42 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
 
 /**
  * Request builder for assigning references.
  *
  * @since {@link NessieApiV2}
  */
-public interface AssignReferenceBuilder extends OnReferenceBuilder<AssignReferenceBuilder> {
-  AssignReferenceBuilder assignTo(
+public interface AssignReferenceBuilder<T extends Reference>
+    extends ChangeReferenceBuilder<AssignReferenceBuilder<Reference>> {
+
+  @SuppressWarnings("unchecked")
+  default AssignReferenceBuilder<Branch> asBranch() {
+    refType(Reference.ReferenceType.BRANCH);
+    return (AssignReferenceBuilder<Branch>) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  default AssignReferenceBuilder<Tag> asTag() {
+    refType(Reference.ReferenceType.TAG);
+    return (AssignReferenceBuilder<Tag>) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  default <R extends Reference> AssignReferenceBuilder<R> reference(R reference) {
+    return (AssignReferenceBuilder<R>) ChangeReferenceBuilder.super.reference(reference);
+  }
+
+  AssignReferenceBuilder<T> assignTo(
       @Valid @jakarta.validation.Valid @NotNull @jakarta.validation.constraints.NotNull
           Reference assignTo);
-
-  AssignReferenceBuilder refType(Reference.ReferenceType referenceType);
-
-  @Override
-  default AssignReferenceBuilder reference(Reference reference) {
-    refType(reference.getType());
-    return OnReferenceBuilder.super.reference(reference);
-  }
 
   void assign() throws NessieNotFoundException, NessieConflictException;
 
   /** Assigns the reference to the specified hash and returns its updated information. */
-  Reference assignAndGet() throws NessieNotFoundException, NessieConflictException;
+  T assignAndGet() throws NessieNotFoundException, NessieConflictException;
 }

--- a/api/client/src/main/java/org/projectnessie/client/api/ChangeReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/ChangeReferenceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2020 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.http.v2api;
+package org.projectnessie.client.api;
 
-import org.projectnessie.client.api.AssignReferenceBuilder;
-import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.model.Reference;
 
-final class HttpAssignReference
-    extends BaseHttpAssignReference<Reference, AssignReferenceBuilder<Reference>>
-    implements AssignReferenceBuilder<Reference> {
+public interface ChangeReferenceBuilder<B> {
 
-  HttpAssignReference(HttpClient client) {
-    super(client);
+  B refType(Reference.ReferenceType referenceType);
+
+  B refName(String name);
+
+  B hash(String hash);
+
+  @SuppressWarnings("unchecked")
+  default <R extends Reference> ChangeReferenceBuilder<?> reference(R reference) {
+    refName(reference.getName());
+    hash(reference.getHash());
+    refType(reference.getType());
+    return this;
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/api/DeleteReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/DeleteReferenceBuilder.java
@@ -17,25 +17,38 @@ package org.projectnessie.client.api;
 
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
 
 /**
  * Request builder for deleting references.
  *
  * @since {@link NessieApiV2}
  */
-public interface DeleteReferenceBuilder extends OnReferenceBuilder<DeleteReferenceBuilder> {
+public interface DeleteReferenceBuilder<T>
+    extends ChangeReferenceBuilder<DeleteReferenceBuilder<Reference>> {
 
-  DeleteReferenceBuilder refType(Reference.ReferenceType referenceType);
+  @SuppressWarnings("unchecked")
+  default DeleteReferenceBuilder<Branch> asBranch() {
+    refType(Reference.ReferenceType.BRANCH);
+    return (DeleteReferenceBuilder<Branch>) this;
+  }
 
+  @SuppressWarnings("unchecked")
+  default DeleteReferenceBuilder<Tag> asTag() {
+    refType(Reference.ReferenceType.TAG);
+    return (DeleteReferenceBuilder<Tag>) this;
+  }
+
+  @SuppressWarnings("unchecked")
   @Override
-  default DeleteReferenceBuilder reference(Reference reference) {
-    refType(reference.getType());
-    return OnReferenceBuilder.super.reference(reference);
+  default <R extends Reference> DeleteReferenceBuilder<R> reference(R reference) {
+    return (DeleteReferenceBuilder<R>) ChangeReferenceBuilder.super.reference(reference);
   }
 
   void delete() throws NessieConflictException, NessieNotFoundException;
 
   /** Deletes the reference and returns its information as it was just before deletion. */
-  Reference getAndDelete() throws NessieNotFoundException, NessieConflictException;
+  T getAndDelete() throws NessieNotFoundException, NessieConflictException;
 }

--- a/api/client/src/main/java/org/projectnessie/client/api/DeleteReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/DeleteReferenceBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.api;
+
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
+
+/**
+ * Request builder for deleting references.
+ *
+ * @since {@link NessieApiV2}
+ */
+public interface DeleteReferenceBuilder extends OnReferenceBuilder<DeleteReferenceBuilder> {
+
+  DeleteReferenceBuilder refType(Reference.ReferenceType referenceType);
+
+  @Override
+  default DeleteReferenceBuilder reference(Reference reference) {
+    refType(reference.getType());
+    return OnReferenceBuilder.super.reference(reference);
+  }
+
+  void delete() throws NessieConflictException, NessieNotFoundException;
+
+  /** Deletes the reference and returns its information as it was just before deletion. */
+  Reference getAndDelete() throws NessieNotFoundException, NessieConflictException;
+}

--- a/api/client/src/main/java/org/projectnessie/client/api/NessieApiV2.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/NessieApiV2.java
@@ -28,4 +28,10 @@ public interface NessieApiV2 extends NessieApiV1 {
   GetRepositoryConfigBuilder getRepositoryConfig();
 
   UpdateRepositoryConfigBuilder updateRepositoryConfig();
+
+  /** Delete a branch or a tag. */
+  DeleteReferenceBuilder deleteReference();
+
+  /** Update a branch or a tag (make it point to an arbitrary commit). */
+  AssignReferenceBuilder assignReference();
 }

--- a/api/client/src/main/java/org/projectnessie/client/api/NessieApiV2.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/NessieApiV2.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.client.api;
 
+import org.projectnessie.model.Reference;
+
 /**
  * Interface for the Nessie V2 API implementation.
  *
@@ -30,8 +32,36 @@ public interface NessieApiV2 extends NessieApiV1 {
   UpdateRepositoryConfigBuilder updateRepositoryConfig();
 
   /** Delete a branch or a tag. */
-  DeleteReferenceBuilder deleteReference();
+  DeleteReferenceBuilder<Reference> deleteReference();
 
   /** Update a branch or a tag (make it point to an arbitrary commit). */
-  AssignReferenceBuilder assignReference();
+  AssignReferenceBuilder<Reference> assignReference();
+
+  /**
+   * @deprecated Use {@code assignReference().asTag()} instead.
+   */
+  @Override
+  @Deprecated
+  AssignTagBuilder assignTag();
+
+  /**
+   * @deprecated Use {@code assignReference().asBranch()} instead.
+   */
+  @Override
+  @Deprecated
+  AssignBranchBuilder assignBranch();
+
+  /**
+   * @deprecated Use {@code deleteReference().asTag()} instead.
+   */
+  @Override
+  @Deprecated
+  DeleteTagBuilder deleteTag();
+
+  /**
+   * @deprecated Use {@code deleteReference().asBranch()} instead.
+   */
+  @Override
+  @Deprecated
+  DeleteBranchBuilder deleteBranch();
 }

--- a/api/client/src/main/java/org/projectnessie/client/api/NessieApiV2.java
+++ b/api/client/src/main/java/org/projectnessie/client/api/NessieApiV2.java
@@ -38,6 +38,8 @@ public interface NessieApiV2 extends NessieApiV1 {
   AssignReferenceBuilder<Reference> assignReference();
 
   /**
+   * {@inheritDoc}
+   *
    * @deprecated Use {@code assignReference().asTag()} instead.
    */
   @Override
@@ -45,6 +47,8 @@ public interface NessieApiV2 extends NessieApiV1 {
   AssignTagBuilder assignTag();
 
   /**
+   * {@inheritDoc}
+   *
    * @deprecated Use {@code assignReference().asBranch()} instead.
    */
   @Override
@@ -52,6 +56,8 @@ public interface NessieApiV2 extends NessieApiV1 {
   AssignBranchBuilder assignBranch();
 
   /**
+   * {@inheritDoc}
+   *
    * @deprecated Use {@code deleteReference().asTag()} instead.
    */
   @Override
@@ -59,6 +65,8 @@ public interface NessieApiV2 extends NessieApiV1 {
   DeleteTagBuilder deleteTag();
 
   /**
+   * {@inheritDoc}
+   *
    * @deprecated Use {@code deleteReference().asBranch()} instead.
    */
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseAssignReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseAssignReferenceBuilder.java
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.http.v2api;
+package org.projectnessie.client.builder;
 
-import org.projectnessie.client.api.AssignBranchBuilder;
-import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 
-final class HttpAssignBranch extends BaseHttpAssignReference<AssignBranchBuilder, Branch>
-    implements AssignBranchBuilder {
+public abstract class BaseAssignReferenceBuilder<R> extends BaseOnReferenceBuilder<R> {
 
-  HttpAssignBranch(HttpClient client) {
-    super(client, Reference.ReferenceType.BRANCH);
+  protected Reference assignTo;
+
+  protected BaseAssignReferenceBuilder(Reference.ReferenceType assumedType) {
+    super(assumedType);
+  }
+
+  @SuppressWarnings("unchecked")
+  public R assignTo(Reference assignTo) {
+    this.assignTo = assignTo;
+    return (R) this;
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseAssignReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseAssignReferenceBuilder.java
@@ -17,13 +17,9 @@ package org.projectnessie.client.builder;
 
 import org.projectnessie.model.Reference;
 
-public abstract class BaseAssignReferenceBuilder<R> extends BaseOnReferenceBuilder<R> {
+public abstract class BaseAssignReferenceBuilder<R> extends BaseChangeReferenceBuilder<R> {
 
   protected Reference assignTo;
-
-  protected BaseAssignReferenceBuilder(Reference.ReferenceType assumedType) {
-    super(assumedType);
-  }
 
   @SuppressWarnings("unchecked")
   public R assignTo(Reference assignTo) {

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseChangeReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseChangeReferenceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,32 @@
  */
 package org.projectnessie.client.builder;
 
-import org.projectnessie.client.api.OnReferenceBuilder;
+import org.projectnessie.client.api.ChangeReferenceBuilder;
+import org.projectnessie.model.Reference.ReferenceType;
 
-abstract class BaseOnReferenceBuilder<R extends OnReferenceBuilder<R>>
-    implements OnReferenceBuilder<R> {
+public abstract class BaseChangeReferenceBuilder<B> implements ChangeReferenceBuilder<B> {
   protected String refName;
-  protected String hashOnRef;
+  protected String expectedHash;
+  protected ReferenceType type;
 
   @SuppressWarnings("unchecked")
   @Override
-  public R refName(String refName) {
-    this.refName = refName;
-    return (R) this;
+  public B refName(String name) {
+    this.refName = name;
+    return (B) this;
   }
 
   @SuppressWarnings("unchecked")
   @Override
-  public R hashOnRef(String hashOnRef) {
-    this.hashOnRef = hashOnRef;
-    return (R) this;
+  public B refType(ReferenceType referenceType) {
+    this.type = referenceType;
+    return (B) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public B hash(String hash) {
+    this.expectedHash = hash;
+    return (B) this;
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/builder/BaseOnReferenceBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/builder/BaseOnReferenceBuilder.java
@@ -15,24 +15,54 @@
  */
 package org.projectnessie.client.builder;
 
-import org.projectnessie.client.api.OnReferenceBuilder;
+import org.projectnessie.model.Reference;
 
-abstract class BaseOnReferenceBuilder<R extends OnReferenceBuilder<R>>
-    implements OnReferenceBuilder<R> {
+public abstract class BaseOnReferenceBuilder<R> {
   protected String refName;
   protected String hashOnRef;
+  protected Reference.ReferenceType type;
+
+  public BaseOnReferenceBuilder() {
+    this(null);
+  }
+
+  public BaseOnReferenceBuilder(Reference.ReferenceType assumedType) {
+    this.type = assumedType;
+  }
 
   @SuppressWarnings("unchecked")
-  @Override
+  public R branchName(String branchName) {
+    this.refName = branchName;
+    this.type = Reference.ReferenceType.BRANCH;
+    return (R) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public R tagName(String tagName) {
+    this.refName = tagName;
+    this.type = Reference.ReferenceType.TAG;
+    return (R) this;
+  }
+
+  @SuppressWarnings("unchecked")
   public R refName(String refName) {
     this.refName = refName;
     return (R) this;
   }
 
   @SuppressWarnings("unchecked")
-  @Override
   public R hashOnRef(String hashOnRef) {
     this.hashOnRef = hashOnRef;
+    return (R) this;
+  }
+
+  public R hash(String hashOnRef) {
+    return hashOnRef(hashOnRef);
+  }
+
+  @SuppressWarnings("unchecked")
+  public R refType(Reference.ReferenceType referenceType) {
+    this.type = referenceType;
     return (R) this;
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
@@ -15,24 +15,29 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import org.projectnessie.client.builder.BaseAssignBranchBuilder;
+import org.projectnessie.client.api.AssignBranchBuilder;
+import org.projectnessie.client.builder.BaseAssignReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 
-final class HttpAssignBranch extends BaseAssignBranchBuilder {
+final class HttpAssignBranch extends BaseAssignReferenceBuilder<AssignBranchBuilder>
+    implements AssignBranchBuilder {
 
   private final NessieApiClient client;
 
   HttpAssignBranch(NessieApiClient client) {
+    super(Reference.ReferenceType.BRANCH);
     this.client = client;
   }
 
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
-    client.getTreeApi().assignReference(Reference.ReferenceType.BRANCH, branchName, hash, assignTo);
+    client
+        .getTreeApi()
+        .assignReference(Reference.ReferenceType.BRANCH, refName, hashOnRef, assignTo);
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignBranch.java
@@ -29,15 +29,20 @@ final class HttpAssignBranch extends BaseAssignReferenceBuilder<AssignBranchBuil
   private final NessieApiClient client;
 
   HttpAssignBranch(NessieApiClient client) {
-    super(Reference.ReferenceType.BRANCH);
     this.client = client;
+    refType(Reference.ReferenceType.BRANCH);
+  }
+
+  @Override
+  public AssignBranchBuilder branchName(String branchName) {
+    return refName(branchName);
   }
 
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
     client
         .getTreeApi()
-        .assignReference(Reference.ReferenceType.BRANCH, refName, hashOnRef, assignTo);
+        .assignReference(Reference.ReferenceType.BRANCH, refName, expectedHash, assignTo);
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
@@ -15,24 +15,27 @@
  */
 package org.projectnessie.client.http.v1api;
 
-import org.projectnessie.client.builder.BaseAssignTagBuilder;
+import org.projectnessie.client.api.AssignTagBuilder;
+import org.projectnessie.client.builder.BaseAssignReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
 
-final class HttpAssignTag extends BaseAssignTagBuilder {
+final class HttpAssignTag extends BaseAssignReferenceBuilder<AssignTagBuilder>
+    implements AssignTagBuilder {
 
   private final NessieApiClient client;
 
   HttpAssignTag(NessieApiClient client) {
+    super(Reference.ReferenceType.TAG);
     this.client = client;
   }
 
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
-    client.getTreeApi().assignReference(Reference.ReferenceType.TAG, tagName, hash, assignTo);
+    client.getTreeApi().assignReference(Reference.ReferenceType.TAG, refName, hashOnRef, assignTo);
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v1api/HttpAssignTag.java
@@ -20,7 +20,7 @@ import org.projectnessie.client.builder.BaseAssignReferenceBuilder;
 import org.projectnessie.client.http.NessieApiClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.model.Reference;
+import org.projectnessie.model.Reference.ReferenceType;
 import org.projectnessie.model.Tag;
 
 final class HttpAssignTag extends BaseAssignReferenceBuilder<AssignTagBuilder>
@@ -29,13 +29,18 @@ final class HttpAssignTag extends BaseAssignReferenceBuilder<AssignTagBuilder>
   private final NessieApiClient client;
 
   HttpAssignTag(NessieApiClient client) {
-    super(Reference.ReferenceType.TAG);
     this.client = client;
+    refType(ReferenceType.TAG);
+  }
+
+  @Override
+  public AssignTagBuilder tagName(String tagName) {
+    return refName(tagName);
   }
 
   @Override
   public void assign() throws NessieNotFoundException, NessieConflictException {
-    client.getTreeApi().assignReference(Reference.ReferenceType.TAG, refName, hashOnRef, assignTo);
+    client.getTreeApi().assignReference(ReferenceType.TAG, refName, expectedHash, assignTo);
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpAssignReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpAssignReference.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v2api;
+
+import org.projectnessie.client.builder.BaseAssignReferenceBuilder;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.SingleReferenceResponse;
+
+abstract class BaseHttpAssignReference<R, T extends Reference>
+    extends BaseAssignReferenceBuilder<R> {
+  private final HttpClient client;
+
+  BaseHttpAssignReference(HttpClient client, Reference.ReferenceType assumedType) {
+    super(assumedType);
+    this.client = client;
+  }
+
+  public void assign() throws NessieNotFoundException, NessieConflictException {
+    assignAndGet();
+  }
+
+  @SuppressWarnings("unchecked")
+  public T assignAndGet() throws NessieNotFoundException, NessieConflictException {
+    return (T)
+        client
+            .newRequest()
+            .path("trees/{ref}")
+            .resolveTemplate("ref", Reference.toPathString(refName, hashOnRef))
+            .queryParam("type", type != null ? type.name() : null)
+            .unwrap(NessieNotFoundException.class, NessieConflictException.class)
+            .put(assignTo)
+            .readEntity(SingleReferenceResponse.class)
+            .getReference();
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpAssignReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpAssignReference.java
@@ -22,12 +22,12 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.SingleReferenceResponse;
 
-abstract class BaseHttpAssignReference<R, T extends Reference>
-    extends BaseAssignReferenceBuilder<R> {
+abstract class BaseHttpAssignReference<T extends Reference, B>
+    extends BaseAssignReferenceBuilder<B> {
+
   private final HttpClient client;
 
-  BaseHttpAssignReference(HttpClient client, Reference.ReferenceType assumedType) {
-    super(assumedType);
+  BaseHttpAssignReference(HttpClient client) {
     this.client = client;
   }
 
@@ -41,7 +41,7 @@ abstract class BaseHttpAssignReference<R, T extends Reference>
         client
             .newRequest()
             .path("trees/{ref}")
-            .resolveTemplate("ref", Reference.toPathString(refName, hashOnRef))
+            .resolveTemplate("ref", Reference.toPathString(refName, expectedHash))
             .queryParam("type", type != null ? type.name() : null)
             .unwrap(NessieNotFoundException.class, NessieConflictException.class)
             .put(assignTo)

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpDeleteReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpDeleteReference.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.v2api;
+
+import org.projectnessie.client.builder.BaseOnReferenceBuilder;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.SingleReferenceResponse;
+
+abstract class BaseHttpDeleteReference<R, T extends Reference> extends BaseOnReferenceBuilder<R> {
+  private final HttpClient client;
+
+  BaseHttpDeleteReference(HttpClient client, Reference.ReferenceType assumedType) {
+    super(assumedType);
+    this.client = client;
+  }
+
+  public void delete() throws NessieConflictException, NessieNotFoundException {
+    getAndDelete();
+  }
+
+  @SuppressWarnings("unchecked")
+  public T getAndDelete() throws NessieNotFoundException, NessieConflictException {
+    return (T)
+        client
+            .newRequest()
+            .path("trees/{ref}")
+            .resolveTemplate("ref", Reference.toPathString(refName, hashOnRef))
+            .queryParam("type", type != null ? type.name() : null)
+            .unwrap(NessieConflictException.class, NessieNotFoundException.class)
+            .delete()
+            .readEntity(SingleReferenceResponse.class)
+            .getReference();
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpDeleteReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/BaseHttpDeleteReference.java
@@ -15,18 +15,19 @@
  */
 package org.projectnessie.client.http.v2api;
 
-import org.projectnessie.client.builder.BaseOnReferenceBuilder;
+import org.projectnessie.client.builder.BaseChangeReferenceBuilder;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.SingleReferenceResponse;
 
-abstract class BaseHttpDeleteReference<R, T extends Reference> extends BaseOnReferenceBuilder<R> {
+abstract class BaseHttpDeleteReference<T extends Reference, B>
+    extends BaseChangeReferenceBuilder<B> {
+
   private final HttpClient client;
 
-  BaseHttpDeleteReference(HttpClient client, Reference.ReferenceType assumedType) {
-    super(assumedType);
+  BaseHttpDeleteReference(HttpClient client) {
     this.client = client;
   }
 
@@ -40,7 +41,7 @@ abstract class BaseHttpDeleteReference<R, T extends Reference> extends BaseOnRef
         client
             .newRequest()
             .path("trees/{ref}")
-            .resolveTemplate("ref", Reference.toPathString(refName, hashOnRef))
+            .resolveTemplate("ref", Reference.toPathString(refName, expectedHash))
             .queryParam("type", type != null ? type.name() : null)
             .unwrap(NessieConflictException.class, NessieNotFoundException.class)
             .delete()

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpApiV2.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpApiV2.java
@@ -16,12 +16,14 @@
 package org.projectnessie.client.http.v2api;
 
 import org.projectnessie.client.api.AssignBranchBuilder;
+import org.projectnessie.client.api.AssignReferenceBuilder;
 import org.projectnessie.client.api.AssignTagBuilder;
 import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
 import org.projectnessie.client.api.CreateNamespaceBuilder;
 import org.projectnessie.client.api.CreateReferenceBuilder;
 import org.projectnessie.client.api.DeleteBranchBuilder;
 import org.projectnessie.client.api.DeleteNamespaceBuilder;
+import org.projectnessie.client.api.DeleteReferenceBuilder;
 import org.projectnessie.client.api.DeleteTagBuilder;
 import org.projectnessie.client.api.GetAllReferencesBuilder;
 import org.projectnessie.client.api.GetCommitLogBuilder;
@@ -126,6 +128,16 @@ public class HttpApiV2 implements NessieApiV2 {
   @Override
   public DeleteBranchBuilder deleteBranch() {
     return new HttpDeleteBranch(client);
+  }
+
+  @Override
+  public AssignReferenceBuilder assignReference() {
+    return new HttpAssignReference(client);
+  }
+
+  @Override
+  public DeleteReferenceBuilder deleteReference() {
+    return new HttpDeleteReference(client);
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignBranch.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignBranch.java
@@ -18,12 +18,18 @@ package org.projectnessie.client.http.v2api;
 import org.projectnessie.client.api.AssignBranchBuilder;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.Reference;
+import org.projectnessie.model.Reference.ReferenceType;
 
-final class HttpAssignBranch extends BaseHttpAssignReference<AssignBranchBuilder, Branch>
+final class HttpAssignBranch extends BaseHttpAssignReference<Branch, AssignBranchBuilder>
     implements AssignBranchBuilder {
 
   HttpAssignBranch(HttpClient client) {
-    super(client, Reference.ReferenceType.BRANCH);
+    super(client);
+    refType(ReferenceType.BRANCH);
+  }
+
+  @Override
+  public AssignBranchBuilder branchName(String branchName) {
+    return refName(branchName);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignReference.java
@@ -13,19 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.builder;
+package org.projectnessie.client.http.v2api;
 
-import org.projectnessie.client.api.AssignTagBuilder;
+import org.projectnessie.client.api.AssignReferenceBuilder;
+import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.model.Reference;
 
-public abstract class BaseAssignTagBuilder extends BaseOnTagBuilder<AssignTagBuilder>
-    implements AssignTagBuilder {
+final class HttpAssignReference extends BaseHttpAssignReference<AssignReferenceBuilder, Reference>
+    implements AssignReferenceBuilder {
 
-  protected Reference assignTo;
-
-  @Override
-  public AssignTagBuilder assignTo(Reference assignTo) {
-    this.assignTo = assignTo;
-    return this;
+  HttpAssignReference(HttpClient client) {
+    super(client, null);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignTag.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignTag.java
@@ -15,37 +15,15 @@
  */
 package org.projectnessie.client.http.v2api;
 
-import org.projectnessie.client.builder.BaseAssignTagBuilder;
+import org.projectnessie.client.api.AssignTagBuilder;
 import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.error.NessieConflictException;
-import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Reference;
-import org.projectnessie.model.SingleReferenceResponse;
 import org.projectnessie.model.Tag;
 
-final class HttpAssignTag extends BaseAssignTagBuilder {
-  private final HttpClient client;
+final class HttpAssignTag extends BaseHttpAssignReference<AssignTagBuilder, Tag>
+    implements AssignTagBuilder {
 
   HttpAssignTag(HttpClient client) {
-    this.client = client;
-  }
-
-  @Override
-  public void assign() throws NessieNotFoundException, NessieConflictException {
-    assignAndGet();
-  }
-
-  @Override
-  public Tag assignAndGet() throws NessieNotFoundException, NessieConflictException {
-    return (Tag)
-        client
-            .newRequest()
-            .path("trees/{ref}")
-            .resolveTemplate("ref", Reference.toPathString(tagName, hash))
-            .queryParam("type", Reference.ReferenceType.TAG.name())
-            .unwrap(NessieNotFoundException.class, NessieConflictException.class)
-            .put(assignTo)
-            .readEntity(SingleReferenceResponse.class)
-            .getReference();
+    super(client, Reference.ReferenceType.TAG);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignTag.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpAssignTag.java
@@ -17,13 +17,19 @@ package org.projectnessie.client.http.v2api;
 
 import org.projectnessie.client.api.AssignTagBuilder;
 import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.model.Reference;
+import org.projectnessie.model.Reference.ReferenceType;
 import org.projectnessie.model.Tag;
 
-final class HttpAssignTag extends BaseHttpAssignReference<AssignTagBuilder, Tag>
+final class HttpAssignTag extends BaseHttpAssignReference<Tag, AssignTagBuilder>
     implements AssignTagBuilder {
 
   HttpAssignTag(HttpClient client) {
-    super(client, Reference.ReferenceType.TAG);
+    super(client);
+    refType(ReferenceType.TAG);
+  }
+
+  @Override
+  public AssignTagBuilder tagName(String tagName) {
+    return refName(tagName);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteBranch.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteBranch.java
@@ -18,11 +18,18 @@ package org.projectnessie.client.http.v2api;
 import org.projectnessie.client.api.DeleteBranchBuilder;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.model.Branch;
-import org.projectnessie.model.Reference;
+import org.projectnessie.model.Reference.ReferenceType;
 
-final class HttpDeleteBranch extends BaseHttpDeleteReference<DeleteBranchBuilder, Branch>
+final class HttpDeleteBranch extends BaseHttpDeleteReference<Branch, DeleteBranchBuilder>
     implements DeleteBranchBuilder {
+
   HttpDeleteBranch(HttpClient client) {
-    super(client, Reference.ReferenceType.BRANCH);
+    super(client);
+    refType(ReferenceType.BRANCH);
+  }
+
+  @Override
+  public DeleteBranchBuilder branchName(String branchName) {
+    return refName(branchName);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteBranch.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteBranch.java
@@ -16,38 +16,13 @@
 package org.projectnessie.client.http.v2api;
 
 import org.projectnessie.client.api.DeleteBranchBuilder;
-import org.projectnessie.client.builder.BaseOnBranchBuilder;
 import org.projectnessie.client.http.HttpClient;
-import org.projectnessie.error.NessieConflictException;
-import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
-import org.projectnessie.model.SingleReferenceResponse;
 
-final class HttpDeleteBranch extends BaseOnBranchBuilder<DeleteBranchBuilder>
+final class HttpDeleteBranch extends BaseHttpDeleteReference<DeleteBranchBuilder, Branch>
     implements DeleteBranchBuilder {
-  private final HttpClient client;
-
   HttpDeleteBranch(HttpClient client) {
-    this.client = client;
-  }
-
-  @Override
-  public void delete() throws NessieConflictException, NessieNotFoundException {
-    getAndDelete();
-  }
-
-  @Override
-  public Branch getAndDelete() throws NessieNotFoundException, NessieConflictException {
-    return (Branch)
-        client
-            .newRequest()
-            .path("trees/{ref}")
-            .resolveTemplate("ref", Reference.toPathString(branchName, hash))
-            .queryParam("type", Reference.ReferenceType.BRANCH.name())
-            .unwrap(NessieConflictException.class, NessieNotFoundException.class)
-            .delete()
-            .readEntity(SingleReferenceResponse.class)
-            .getReference();
+    super(client, Reference.ReferenceType.BRANCH);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteReference.java
@@ -13,19 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.client.builder;
+package org.projectnessie.client.http.v2api;
 
-import org.projectnessie.client.api.AssignBranchBuilder;
+import org.projectnessie.client.api.DeleteReferenceBuilder;
+import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.model.Reference;
 
-public abstract class BaseAssignBranchBuilder extends BaseOnBranchBuilder<AssignBranchBuilder>
-    implements AssignBranchBuilder {
+final class HttpDeleteReference extends BaseHttpDeleteReference<DeleteReferenceBuilder, Reference>
+    implements DeleteReferenceBuilder {
 
-  protected Reference assignTo;
-
-  @Override
-  public AssignBranchBuilder assignTo(Reference assignTo) {
-    this.assignTo = assignTo;
-    return this;
+  HttpDeleteReference(HttpClient client) {
+    super(client, null);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/v2api/HttpDeleteReference.java
@@ -19,10 +19,11 @@ import org.projectnessie.client.api.DeleteReferenceBuilder;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.model.Reference;
 
-final class HttpDeleteReference extends BaseHttpDeleteReference<DeleteReferenceBuilder, Reference>
-    implements DeleteReferenceBuilder {
+final class HttpDeleteReference
+    extends BaseHttpDeleteReference<Reference, DeleteReferenceBuilder<Reference>>
+    implements DeleteReferenceBuilder<Reference> {
 
   HttpDeleteReference(HttpClient client) {
-    super(client, null);
+    super(client);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/hash/HashValidator.java
+++ b/servers/services/src/main/java/org/projectnessie/services/hash/HashValidator.java
@@ -17,7 +17,6 @@ package org.projectnessie.services.hash;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 @FunctionalInterface
@@ -28,7 +27,7 @@ public interface HashValidator {
 
   /** Validates that a hash has been provided (absolute or relative). */
   HashValidator REQUIRED_HASH =
-      (name, parsed) -> Objects.requireNonNull(parsed, String.format("%s must be provided.", name));
+      (name, parsed) -> checkArgument(parsed != null, String.format("%s must be provided.", name));
 
   /**
    * Validates that, if a hash was provided, it is unambiguous. A hash is unambiguous if it starts

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -308,6 +308,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       ReferenceType referenceType, String referenceName, String expectedHash, Reference assignTo)
       throws NessieNotFoundException, NessieConflictException {
     try {
+      checkArgument(expectedHash != null, "Expected hash must be provided");
 
       ResolvedHash oldRef =
           getHashResolver()


### PR DESCRIPTION
#7282 allowed skipping type parameters in REST API requests to 
delete / assign references (tags or branches). However, the java 
client API still required the user to know the exact reference 
type and use type-specific API methods for those operations.

This change introduces generic assign / delete reference operations
to the java client to keep it functionally aligned to the REST API.

* Add new `AssignReferenceBuilder` and `DeleteReferenceBuilder`
  interfaces with corresponding methods in `NessieApiV2`.

* Introduce common base classes to share builder code across API
  methods. Refactor old requests builders to use the shared base
  classes.

* Fix validation exception in HashValidator.REQUIRED_HASH to make
  it produce "bad request" (400) errors at the API level as opposed
  to "internal server error" (500).