### PR TITLE
Export secondary parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ as necessary. Empty sections will not end in the release notes.
 ### Deprecations
 
 ### Fixes
+- Secondary commit parents are now properly exported and imported
 
 ### Commits
 

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
@@ -288,7 +288,7 @@ public abstract class AbstractRelativeReferences {
   void commitUnambiguous() {
     Set<ContentKey> keys =
         outer
-            .prepareCommitV2("base@" + c2 + "~1", key3, table3, 2, false)
+            .prepareCommitV2("@" + c2 + "~1", key3, table3, 2, false)
             .statusCode(200)
             .extract()
             .as(CommitResponse.class)

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
@@ -288,7 +288,7 @@ public abstract class AbstractRelativeReferences {
   void commitUnambiguous() {
     Set<ContentKey> keys =
         outer
-            .prepareCommitV2("@" + c2 + "~1", key3, table3, 2, false)
+            .prepareCommitV2("base@" + c2 + "~1", key3, table3, 2, false)
             .statusCode(200)
             .extract()
             .as(CommitResponse.class)

--- a/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImport.java
+++ b/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImport.java
@@ -462,6 +462,7 @@ public class ITExportImport {
                 })
             .build());
 
+    // Delete the temp branch so that the secondary parent won't be directly reachable anymore.
     adapter.delete(branchTemp, Optional.empty());
   }
 }

--- a/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImport.java
+++ b/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImport.java
@@ -28,7 +28,9 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -47,6 +49,8 @@ import org.projectnessie.versioned.BranchName;
 import org.projectnessie.versioned.CommitMetaSerializer;
 import org.projectnessie.versioned.CommitResult;
 import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.Hash;
+import org.projectnessie.versioned.MetadataRewriter;
 import org.projectnessie.versioned.ReferenceAlreadyExistsException;
 import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceInfo;
@@ -58,6 +62,7 @@ import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.adapter.ImmutableCommitParams;
 import org.projectnessie.versioned.persist.adapter.KeyFilterPredicate;
 import org.projectnessie.versioned.persist.adapter.KeyWithBytes;
+import org.projectnessie.versioned.persist.adapter.MergeParams;
 import org.projectnessie.versioned.store.DefaultStoreWorker;
 
 @QuarkusMainTest
@@ -289,6 +294,38 @@ public class ITExportImport {
         IcebergTable.of("meta", 42L, 43, 44, 45));
   }
 
+  @Test
+  public void testExportImportMergeCommit(
+      QuarkusMainLauncher launcher, DatabaseAdapter adapter, @TempDir Path tempDir)
+      throws Exception {
+
+    populateRepositoryWithMergeCommit(adapter);
+
+    Path zipFile = tempDir.resolve("export.zip");
+    LaunchResult result = launcher.launch("export", ExportRepository.PATH, zipFile.toString());
+    soft.assertThat(result.exitCode()).isEqualTo(0);
+    soft.assertThat(result.getOutput())
+        .contains(
+            "Exported Nessie repository, 4 commits into 1 files, 2 named references into 1 files.");
+    soft.assertThat(zipFile).isRegularFile();
+
+    result =
+        launcher.launch("import", ERASE_BEFORE_IMPORT, ImportRepository.PATH, zipFile.toString());
+    soft.assertThat(result.exitCode()).isEqualTo(0);
+    soft.assertThat(result.getOutput())
+        .contains("Export was created by Nessie version " + NessieVersion.NESSIE_VERSION + " on ")
+        .containsPattern(
+            "containing [0-9]+ named references \\(in [0-9]+ files\\) and [0-9]+ commits \\(in [0-9]+ files\\)")
+        .contains("Imported Nessie repository, 4 commits, 2 named references.")
+        .contains("Import finalization finished, total duration: ");
+
+    checkValues(
+        adapter,
+        "main",
+        ContentKey.of("namespace123", "table123"),
+        IcebergTable.of("meta3", 44, 43, 44, 45, "id123"));
+  }
+
   private void checkValues(
       DatabaseAdapter adapter, String ref, ContentKey key, IcebergTable expected)
       throws ReferenceNotFoundException {
@@ -315,6 +352,9 @@ public class ITExportImport {
             expected.getSortOrderId());
   }
 
+  static String namespaceId = UUID.randomUUID().toString();
+  static String tableId = UUID.randomUUID().toString();
+
   private static void populateRepository(DatabaseAdapter adapter)
       throws ReferenceConflictException,
           ReferenceNotFoundException,
@@ -325,8 +365,6 @@ public class ITExportImport {
     ByteString commitMeta =
         CommitMetaSerializer.METADATA_SERIALIZER.toBytes(CommitMeta.fromMessage("hello"));
     ContentKey key = ContentKey.of("namespace123", "table123");
-    String namespaceId = UUID.randomUUID().toString();
-    String tableId = UUID.randomUUID().toString();
     CommitResult<CommitLogEntry> main =
         adapter.commit(
             ImmutableCommitParams.builder()
@@ -365,5 +403,65 @@ public class ITExportImport {
                         .toStoreOnReferenceState(
                             IcebergTable.of("meta2", 43, 43, 44, 45, "id123"))))
             .build());
+  }
+
+  private void populateRepositoryWithMergeCommit(DatabaseAdapter adapter) throws Exception {
+    populateRepository(adapter);
+
+    BranchName branchMain = BranchName.of("main");
+    BranchName branchTemp = BranchName.of("temp");
+
+    Hash mainHead = adapter.namedRef("main", GetNamedRefsParams.DEFAULT).getHash();
+    adapter.create(branchTemp, mainHead);
+
+    ContentKey key = ContentKey.of("namespace123", "table123");
+    CommitResult<CommitLogEntry> temp =
+        adapter.commit(
+            ImmutableCommitParams.builder()
+                .toBranch(branchTemp)
+                .commitMetaSerialized(
+                    CommitMetaSerializer.METADATA_SERIALIZER.toBytes(
+                        CommitMeta.fromMessage("hello from temp")))
+                .addPuts(
+                    KeyWithBytes.of(
+                        key.getParent(),
+                        ContentId.of(namespaceId),
+                        (byte) payloadForContent(NAMESPACE),
+                        DefaultStoreWorker.instance()
+                            .toStoreOnReferenceState(
+                                Namespace.builder()
+                                    .id(namespaceId)
+                                    .addElements("namespace123")
+                                    .build())),
+                    KeyWithBytes.of(
+                        key,
+                        ContentId.of(tableId),
+                        (byte) payloadForContent(ICEBERG_TABLE),
+                        DefaultStoreWorker.instance()
+                            .toStoreOnReferenceState(
+                                IcebergTable.of("meta3", 44, 43, 44, 45, tableId))))
+                .build());
+
+    adapter.merge(
+        MergeParams.builder()
+            .mergeFromHash(temp.getCommitHash())
+            .fromRef(branchTemp)
+            .toBranch(branchMain)
+            .keepIndividualCommits(false)
+            .updateCommitMetadata(
+                new MetadataRewriter<>() {
+                  @Override
+                  public ByteString rewriteSingle(ByteString metadata) {
+                    return ByteString.copyFromUtf8(metadata.toStringUtf8() + " merged");
+                  }
+
+                  @Override
+                  public ByteString squash(List<ByteString> metadata, int numCommits) {
+                    return rewriteSingle(metadata.get(0));
+                  }
+                })
+            .build());
+
+    adapter.delete(branchTemp, Optional.empty());
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencesUtil.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/ReferencesUtil.java
@@ -89,6 +89,11 @@ public final class ReferencesUtil {
       return handleCommit(entry.getHash(), entry.getParents().get(0));
     }
 
+    public boolean isCommitNew(Hash commitId) {
+      int cv = commits.getValue(commitId);
+      return (cv & MASK_COMMIT_SEEN) == 0;
+    }
+
     public boolean handleCommit(Hash commitId, Hash parent) {
 
       int cv = commits.getValue(commitId);

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
@@ -1126,6 +1126,7 @@ final class CommitLogicImpl implements CommitLogic {
 
         if (identify.handleCommit(commit)) {
           commitHandler.accept(commit);
+          // no need to bother with secondary parents, we are scanning everything anyway
         }
       }
     }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IdentifyHeadsAndForkPoints.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IdentifyHeadsAndForkPoints.java
@@ -54,6 +54,11 @@ public class IdentifyHeadsAndForkPoints {
     return handleCommit(entry.id(), entry.directParent());
   }
 
+  public boolean isCommitNew(ObjId commitId) {
+    int cv = commits.getValue(commitId);
+    return (cv & MASK_COMMIT_SEEN) == 0;
+  }
+
   public boolean handleCommit(ObjId commitId, ObjId parent) {
 
     int cv = commits.getValue(commitId);

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportDatabaseAdapter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportDatabaseAdapter.java
@@ -103,7 +103,7 @@ final class ExportDatabaseAdapter extends ExportCommon {
                 Deque<Hash> commitsToProcess = new ArrayDeque<>();
                 commitsToProcess.push(head);
                 while (!commitsToProcess.isEmpty()) {
-                  Hash hash = commitsToProcess.pop();
+                  Hash hash = commitsToProcess.pollFirst();
                   if (identify.isCommitNew(hash)) {
                     try (Stream<CommitLogEntry> commits = databaseAdapter.commitLog(hash)) {
                       for (Iterator<CommitLogEntry> commitIter = commits.iterator();
@@ -115,7 +115,7 @@ final class ExportDatabaseAdapter extends ExportCommon {
                         commitHandler.accept(commit);
                         for (Hash parent : commit.getAdditionalParents()) {
                           if (identify.isCommitNew(parent)) {
-                            commitsToProcess.push(parent);
+                            commitsToProcess.offerLast(parent);
                           }
                         }
                       }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportDatabaseAdapter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportDatabaseAdapter.java
@@ -97,9 +97,8 @@ final class ExportDatabaseAdapter extends ExportCommon {
           .map(ReferenceInfo::getHash)
           .forEach(
               head -> {
-                try {
-                  scanCommitLogChain(
-                      databaseAdapter.commitLog(head), identify, commitHandler, databaseAdapter);
+                try (Stream<CommitLogEntry> commits = databaseAdapter.commitLog(head)) {
+                  scanCommitLogChain(commits, identify, commitHandler, databaseAdapter);
                 } catch (ReferenceNotFoundException e) {
                   throw new RuntimeException(e);
                 }
@@ -122,9 +121,8 @@ final class ExportDatabaseAdapter extends ExportCommon {
           if (identify.handleCommit(commit)) {
             commitHandler.accept(commit);
             for (Hash hash : commit.getAdditionalParents()) {
-              try {
-                scanCommitLogChain(
-                    databaseAdapter.commitLog(hash), identify, commitHandler, databaseAdapter);
+              try (Stream<CommitLogEntry> secondaryLineage = databaseAdapter.commitLog(hash)) {
+                scanCommitLogChain(secondaryLineage, identify, commitHandler, databaseAdapter);
               } catch (ReferenceNotFoundException e) {
                 throw new RuntimeException(e);
               }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportDatabaseAdapter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportDatabaseAdapter.java
@@ -103,7 +103,7 @@ final class ExportDatabaseAdapter extends ExportCommon {
                 Deque<Hash> commitsToProcess = new ArrayDeque<>();
                 commitsToProcess.offerFirst(head);
                 while (!commitsToProcess.isEmpty()) {
-                  Hash hash = commitsToProcess.pollFirst();
+                  Hash hash = commitsToProcess.removeFirst();
                   if (identify.isCommitNew(hash)) {
                     try (Stream<CommitLogEntry> commits = databaseAdapter.commitLog(hash)) {
                       for (Iterator<CommitLogEntry> commitIter = commits.iterator();
@@ -115,7 +115,7 @@ final class ExportDatabaseAdapter extends ExportCommon {
                         commitHandler.accept(commit);
                         for (Hash parent : commit.getAdditionalParents()) {
                           if (identify.isCommitNew(parent)) {
-                            commitsToProcess.offerLast(parent);
+                            commitsToProcess.addLast(parent);
                           }
                         }
                       }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportDatabaseAdapter.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportDatabaseAdapter.java
@@ -101,7 +101,7 @@ final class ExportDatabaseAdapter extends ExportCommon {
           .forEach(
               head -> {
                 Deque<Hash> commitsToProcess = new ArrayDeque<>();
-                commitsToProcess.push(head);
+                commitsToProcess.offerFirst(head);
                 while (!commitsToProcess.isEmpty()) {
                   Hash hash = commitsToProcess.pollFirst();
                   if (identify.isCommitNew(hash)) {

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
@@ -109,7 +109,7 @@ final class ExportPersist extends ExportCommon {
         .forEachRemaining(
             ref -> {
               Deque<ObjId> commitsToProcess = new ArrayDeque<>();
-              commitsToProcess.push(ref.pointer());
+              commitsToProcess.offerFirst(ref.pointer());
               while (!commitsToProcess.isEmpty()) {
                 ObjId id = commitsToProcess.pollFirst();
                 if (identify.isCommitNew(id)) {

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
@@ -115,11 +115,12 @@ final class ExportPersist extends ExportCommon {
                 Iterator<CommitObj> commitIter = commitLogic.commitLog(commitLogQuery(id));
                 while (commitIter.hasNext()) {
                   CommitObj commit = commitIter.next();
-                  if (identify.handleCommit(commit)) {
-                    commitHandler.accept(commit);
-                    for (ObjId objId : commit.secondaryParents()) {
-                      commitsToProcess.push(objId);
-                    }
+                  if (!identify.handleCommit(commit)) {
+                    break;
+                  }
+                  commitHandler.accept(commit);
+                  for (ObjId objId : commit.secondaryParents()) {
+                    commitsToProcess.push(objId);
                   }
                 }
               }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
@@ -111,7 +111,7 @@ final class ExportPersist extends ExportCommon {
               Deque<ObjId> commitsToProcess = new ArrayDeque<>();
               commitsToProcess.offerFirst(ref.pointer());
               while (!commitsToProcess.isEmpty()) {
-                ObjId id = commitsToProcess.pollFirst();
+                ObjId id = commitsToProcess.removeFirst();
                 if (identify.isCommitNew(id)) {
                   Iterator<CommitObj> commitIter = commitLogic.commitLog(commitLogQuery(id));
                   while (commitIter.hasNext()) {
@@ -122,7 +122,7 @@ final class ExportPersist extends ExportCommon {
                     commitHandler.accept(commit);
                     for (ObjId parentId : commit.secondaryParents()) {
                       if (identify.isCommitNew(parentId)) {
-                        commitsToProcess.offerLast(parentId);
+                        commitsToProcess.addLast(parentId);
                       }
                     }
                   }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
@@ -112,15 +112,19 @@ final class ExportPersist extends ExportCommon {
               commitsToProcess.push(ref.pointer());
               while (!commitsToProcess.isEmpty()) {
                 ObjId id = commitsToProcess.pop();
-                Iterator<CommitObj> commitIter = commitLogic.commitLog(commitLogQuery(id));
-                while (commitIter.hasNext()) {
-                  CommitObj commit = commitIter.next();
-                  if (!identify.handleCommit(commit)) {
-                    break;
-                  }
-                  commitHandler.accept(commit);
-                  for (ObjId objId : commit.secondaryParents()) {
-                    commitsToProcess.push(objId);
+                if (identify.isCommitNew(id)) {
+                  Iterator<CommitObj> commitIter = commitLogic.commitLog(commitLogQuery(id));
+                  while (commitIter.hasNext()) {
+                    CommitObj commit = commitIter.next();
+                    if (!identify.handleCommit(commit)) {
+                      break;
+                    }
+                    commitHandler.accept(commit);
+                    for (ObjId parentId : commit.secondaryParents()) {
+                      if (identify.isCommitNew(parentId)) {
+                        commitsToProcess.push(parentId);
+                      }
+                    }
                   }
                 }
               }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportPersist.java
@@ -111,7 +111,7 @@ final class ExportPersist extends ExportCommon {
               Deque<ObjId> commitsToProcess = new ArrayDeque<>();
               commitsToProcess.push(ref.pointer());
               while (!commitsToProcess.isEmpty()) {
-                ObjId id = commitsToProcess.pop();
+                ObjId id = commitsToProcess.pollFirst();
                 if (identify.isCommitNew(id)) {
                   Iterator<CommitObj> commitIter = commitLogic.commitLog(commitLogQuery(id));
                   while (commitIter.hasNext()) {
@@ -122,7 +122,7 @@ final class ExportPersist extends ExportCommon {
                     commitHandler.accept(commit);
                     for (ObjId parentId : commit.secondaryParents()) {
                       if (identify.isCommitNew(parentId)) {
-                        commitsToProcess.push(parentId);
+                        commitsToProcess.offerLast(parentId);
                       }
                     }
                   }


### PR DESCRIPTION
This commit fixes an issue when a secondary parent is not exported, because it is not reachable through any live reference.

In such cases, an `ObjNotFoundException` was being thrown on import.