### PR TITLE
Remove call to Persist.erase in ImportPersistV1.prepareRepository

### DIFF
--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistV1.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistV1.java
@@ -48,7 +48,6 @@ final class ImportPersistV1 extends ImportPersistCommon {
 
   @Override
   void prepareRepository() {
-    persist.erase();
     repositoryLogic(persist).initialize("main", false, b -> {});
   }
 


### PR DESCRIPTION
This call is redundant when using quarkus-cli that already has a "-e" switch to erase the repository. As a consequence, the repo was being deleted twice.

Since erase the repo is a slow operation that incurs in a table scan, removing this call also improves the overall import performance significantly.