### PR TITLE
Protect against IOBE in IndexesLogicImpl.completeIndexesInCommitChain

### DIFF
--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
@@ -485,6 +485,11 @@ final class IndexesLogicImpl implements IndexesLogic {
 
     // HEAD commit first
     List<ObjId> commitsToUpdate = findCommitsWithIncompleteIndex(commitId);
+
+    if (commitsToUpdate.isEmpty()) {
+      return;
+    }
+
     // Let the HEAD be the last element in the list, and the oldest commit being at index #0
     Collections.reverse(commitsToUpdate);
 


### PR DESCRIPTION
The observed stack trace was:

```
Caused by: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
	at java.base/java.util.Objects.checkIndex(Objects.java:372)
	at java.base/java.util.ArrayList.get(ArrayList.java:459)
	at org.projectnessie.versioned.storage.common.logic.IndexesLogicImpl.completeIndexesInCommitChain(IndexesLogicImpl.java:492)
	at org.projectnessie.versioned.storage.common.logic.IndexesLogicImpl.completeIndexesInCommitChain(IndexesLogicImpl.java:462)
	at org.projectnessie.versioned.transfer.ImportPersistCommon.lambda$importFinalize$1(ImportPersistCommon.java:82)
```

While it's hard to imagine how this can happen, it seems possible if 2 concurrent processes complete the indexes of the same commit chain in parallel.