### PR TITLE
Don't initialize the repo in V2 Import tests

### DIFF
--- a/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestExportImportV2.java
+++ b/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestExportImportV2.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.transfer;
 
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_REPOSITORY_ID;
-import static org.projectnessie.versioned.storage.common.logic.Logics.repositoryLogic;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -72,9 +71,8 @@ public class TestExportImportV2 extends BaseExportImport {
 
   @Override
   void prepareTargetRepo() {
-    // Initialize repository w/o a default branch
     persistImport.erase();
-    repositoryLogic(persistImport).initialize("main", false, b -> {});
+    // Don't initialize the repository, since the import with Persist already does that.
   }
 
   @Override

--- a/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestMigrationToPersist.java
+++ b/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestMigrationToPersist.java
@@ -76,9 +76,8 @@ public class TestMigrationToPersist extends BaseExportImport {
 
   @Override
   void prepareTargetRepo() {
-    // Initialize repository w/o a default branch
     persist.erase();
-    repositoryLogic(persist).initialize("main", false, b -> {});
+    // Don't initialize the repository, since the import with Persist already does that.
   }
 
   @Override

--- a/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestMigrationToPersist.java
+++ b/versioned/transfer/src/test/java/org/projectnessie/versioned/transfer/TestMigrationToPersist.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.versioned.transfer;
 
-import static org.projectnessie.versioned.storage.common.logic.Logics.repositoryLogic;
-
 import com.google.errorprone.annotations.MustBeClosed;
 import java.io.IOException;
 import java.util.EnumSet;


### PR DESCRIPTION
...since the import with Persist (new model) already automatically initializes the repo.