### PR TITLE
Fix compilation warning

### DIFF
--- a/versioned/persist/tx/build.gradle.kts
+++ b/versioned/persist/tx/build.gradle.kts
@@ -41,6 +41,9 @@ dependencies {
   compileOnly(libs.h2)
   compileOnly(libs.postgresql)
 
+  compileOnly(platform(libs.jackson.bom))
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+
   testFixturesApi(project(":nessie-versioned-persist-adapter"))
   testFixturesApi(project(":nessie-versioned-persist-serialize"))
   testFixturesApi(project(":nessie-versioned-spi"))


### PR DESCRIPTION
Without this fix, the build complains about:

```
warning: unknown enum constant Include.NON_EMPTY
  reason: class file for com.fasterxml.jackson.annotation.JsonInclude$Include not found
1 warning
```