### PR TITLE
Add runtime dependency to AWS STS in the GC tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ as necessary. Empty sections will not end in the release notes.
 - Secondary commit parents are now properly exported and imported
 - Fix volume declarations for RocksDB in Helm
 - Remove unnecessary repository-deletion when importing a legacy Nessie repo
+- GC Tool uber-jar now includes AWS STS classes
 
 ### Commits
 

--- a/gc/gc-tool/build.gradle.kts
+++ b/gc/gc-tool/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
   implementation(platform(libs.awssdk.bom))
   runtimeOnly("software.amazon.awssdk:s3")
   runtimeOnly("software.amazon.awssdk:url-connection-client")
+  runtimeOnly("software.amazon.awssdk:sts")
 
   implementation(libs.picocli)
   annotationProcessor(libs.picocli.codegen)


### PR DESCRIPTION
This commit adds a runtime dependency to software.amazon.awssdk:sts in gc-tool.

This dependency may be required when instantiating S3FileIO objects. The stack trace is:

    Caused by: java.lang.NoClassDefFoundError: software/amazon/awssdk/services/sts/model/Tag
      at org.apache.iceberg.aws.AwsProperties.toStsTags(AwsProperties.java:1771)
      at org.apache.iceberg.aws.AwsProperties.<init>(AwsProperties.java:1061)
      at org.apache.iceberg.aws.AwsClientFactories$DefaultAwsClientFactory.initialize(AwsClientFactories.java:141)
      at org.apache.iceberg.aws.AwsClientFactories.loadClientFactory(AwsClientFactories.java:87)
      at org.apache.iceberg.aws.AwsClientFactories.from(AwsClientFactories.java:60)
      at org.apache.iceberg.aws.S3FileIOAwsClientFactories.initialize(S3FileIOAwsClientFactories.java:45)
      at org.apache.iceberg.aws.s3.S3FileIO.initialize(S3FileIO.java:367)

This dependency is already present in gc-iceberg-files:

    testFixturesRuntimeOnly("software.amazon.awssdk:sts")

 Not having it in gc-tool seems like an oversight.