### PR TITLE
Include Hibernate Validator in nessie-jaxrs-testextension

### DIFF
--- a/integrations/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
+++ b/integrations/iceberg-views/src/test/java/org/apache/iceberg/nessie/BaseIcebergTest.java
@@ -56,9 +56,9 @@ import org.projectnessie.versioned.storage.testextension.PersistExtension;
 @NessieBackend(InmemoryBackendTestFactory.class)
 public class BaseIcebergTest {
 
-  @NessiePersist static Persist perssit;
+  @NessiePersist static Persist persist;
 
-  @RegisterExtension static NessieJaxRsExtension server = jaxRsExtension(() -> perssit);
+  @RegisterExtension static NessieJaxRsExtension server = jaxRsExtension(() -> persist);
 
   @TempDir public Path temp;
 
@@ -66,6 +66,7 @@ public class BaseIcebergTest {
   protected NessieApiV1 api;
   protected Configuration hadoopConfig;
   protected final String branch;
+  protected Branch reference;
   protected String uri;
 
   public BaseIcebergTest(String branch) {
@@ -87,7 +88,9 @@ public class BaseIcebergTest {
                 throw new RuntimeException(e);
               }
             });
-    api.createReference().reference(Branch.of(branch, null)).create();
+    reference =
+        (Branch)
+            api.createReference().reference(Branch.of(branch, defaultBranch.getHash())).create();
   }
 
   @BeforeEach

--- a/integrations/iceberg-views/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergViews.java
+++ b/integrations/iceberg-views/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergViews.java
@@ -83,7 +83,7 @@ public class TestNessieIcebergViews extends BaseIcebergTest {
   public void beforeEach() throws Exception {
     try {
       api.commitMultipleOperations()
-          .branchName(branch)
+          .branch(reference)
           .commitMeta(fromMessage(CREATE_REQUIRED_NAMESPACES))
           .operation(Put.of(ContentKey.of("db"), Namespace.of("db")))
           .operation(Put.of(ContentKey.of("nessie"), Namespace.of("nessie")))

--- a/servers/jax-rs-testextension/build.gradle.kts
+++ b/servers/jax-rs-testextension/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
 
   api("org.jboss.weld.se:weld-se-core")
 
+  api(libs.hibernate.validator.cdi)
+
   compileOnly(libs.microprofile.openapi)
 
   testCompileOnly(libs.microprofile.openapi)

--- a/servers/jax-rs-tests/build.gradle.kts
+++ b/servers/jax-rs-tests/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
   testImplementation(project(":nessie-versioned-storage-jdbc"))
 
   testImplementation(project(":nessie-jaxrs-testextension"))
-  testImplementation(libs.hibernate.validator.cdi)
+
   testImplementation(libs.slf4j.jcl.over.slf4j)
   testRuntimeOnly(libs.h2)
   testRuntimeOnly(libs.logback.classic)

--- a/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/cli/TestCreateMissingNamespaces.java
+++ b/tools/content-generator/src/test/java/org/projectnessie/tools/contentgenerator/cli/TestCreateMissingNamespaces.java
@@ -47,7 +47,6 @@ import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.model.Operation.Put;
-import org.projectnessie.model.Reference;
 import org.projectnessie.tools.contentgenerator.RunContentGenerator.ProcessResult;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.inmemory.InmemoryBackendTestFactory;
@@ -190,29 +189,32 @@ public class TestCreateMissingNamespaces {
 
   protected void prepareRoundtrip() throws Exception {
     Branch defaultBranch = nessieApi.getDefaultBranch();
-    Reference branch1 =
-        nessieApi
-            .createReference()
-            .sourceRefName(defaultBranch.getName())
-            .reference(Branch.of("branch1", defaultBranch.getHash()))
-            .create();
-    Reference branch2 =
-        nessieApi
-            .createReference()
-            .sourceRefName(defaultBranch.getName())
-            .reference(Branch.of("branch2", defaultBranch.getHash()))
-            .create();
-    Reference branch3 =
-        nessieApi
-            .createReference()
-            .sourceRefName(defaultBranch.getName())
-            .reference(Branch.of("branch3", defaultBranch.getHash()))
-            .create();
+    Branch branch1 =
+        (Branch)
+            nessieApi
+                .createReference()
+                .sourceRefName(defaultBranch.getName())
+                .reference(Branch.of("branch1", defaultBranch.getHash()))
+                .create();
+    Branch branch2 =
+        (Branch)
+            nessieApi
+                .createReference()
+                .sourceRefName(defaultBranch.getName())
+                .reference(Branch.of("branch2", defaultBranch.getHash()))
+                .create();
+    Branch branch3 =
+        (Branch)
+            nessieApi
+                .createReference()
+                .sourceRefName(defaultBranch.getName())
+                .reference(Branch.of("branch3", defaultBranch.getHash()))
+                .create();
 
     nessieApi
         .commitMultipleOperations()
         .commitMeta(fromMessage("foo"))
-        .branchName(branch1.getName())
+        .branch(branch1)
         .operation(Put.of(ContentKey.of("a", "b", "Table"), IcebergTable.of("meta1", 1, 2, 3, 4)))
         .operation(Put.of(ContentKey.of("a", "b", "Data"), IcebergTable.of("meta2", 1, 2, 3, 4)))
         .operation(Put.of(ContentKey.of("Data"), IcebergTable.of("meta3", 1, 2, 3, 4)))
@@ -222,14 +224,14 @@ public class TestCreateMissingNamespaces {
     nessieApi
         .commitMultipleOperations()
         .commitMeta(fromMessage("foo"))
-        .branchName(branch2.getName())
+        .branch(branch2)
         .operation(Put.of(ContentKey.of("x", "y", "Table"), IcebergTable.of("meta1", 1, 2, 3, 4)))
         .commit();
 
     nessieApi
         .commitMultipleOperations()
         .commitMeta(fromMessage("foo"))
-        .branchName(branch3.getName())
+        .branch(branch3)
         .operation(Put.of(ContentKey.of("Table"), IcebergTable.of("meta1", 1, 2, 3, 4)))
         .commit();
   }
@@ -269,17 +271,19 @@ public class TestCreateMissingNamespaces {
   @Test
   public void testCollectMissingNamespaceKeys() throws Exception {
     Branch defaultBranch = nessieApi.getDefaultBranch();
-    nessieApi
-        .createReference()
-        .sourceRefName(defaultBranch.getName())
-        .reference(Branch.of("branch", defaultBranch.getHash()))
-        .create();
+    Branch branch =
+        (Branch)
+            nessieApi
+                .createReference()
+                .sourceRefName(defaultBranch.getName())
+                .reference(Branch.of("branch", defaultBranch.getHash()))
+                .create();
 
     Branch head =
         nessieApi
             .commitMultipleOperations()
             .commitMeta(fromMessage("foo"))
-            .branchName("branch")
+            .branch(branch)
             .operation(
                 Put.of(ContentKey.of("a", "b", "Table"), IcebergTable.of("meta1", 1, 2, 3, 4)))
             .operation(


### PR DESCRIPTION
This commit adds HV as a dependency of the JAX-RS test extension, so that it is always present when running tests.

This uncovered a few places where tests were doing something wrong, but it wasn't being detected properly due to HV not being present at runtime.