### PR TITLE
Enforce expected hash presence when creating and assigning references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,7 @@ jobs:
       ICEBERG_DIR: included-builds/iceberg
       ICEBERG_MAIN_REPOSITORY: apache/iceberg
       ICEBERG_MAIN_BRANCH: master
-      ICEBERG_PATCH_REPOSITORY: snazy/iceberg
+      ICEBERG_PATCH_REPOSITORY: adutra/iceberg
       ICEBERG_PATCH_BRANCH: iceberg-nesqueit
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,7 @@ jobs:
       ICEBERG_DIR: included-builds/iceberg
       ICEBERG_MAIN_REPOSITORY: apache/iceberg
       ICEBERG_MAIN_BRANCH: master
-      ICEBERG_PATCH_REPOSITORY: adutra/iceberg
+      ICEBERG_PATCH_REPOSITORY: snazy/iceberg
       ICEBERG_PATCH_BRANCH: iceberg-nesqueit
       SPARK_LOCAL_IP: localhost
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ as necessary. Empty sections will not end in the release notes.
 ### Changes
 - Java client API to assign/delete reference operations without specifying a concrete reference type
   (no change to REST API).
+- Creating and assigning references now requires a target hash to be specified.
 
 ### Deprecations
 

--- a/api/NESSIE-SPEC-2-0.md
+++ b/api/NESSIE-SPEC-2-0.md
@@ -22,6 +22,13 @@ well-specified behaviours.
 
 Refer to the [Nessie API documentation](./README.md) for the meaning of Nessie-specific terms.
 
+# 2.1.2
+
+* Released with Nessie version 0.68.0.
+* The `createReference` and `assignReference` endpoints now return a `BAD_REQUEST` error if the target reference
+  does not specify any hash. Previously, the server would silently resolve a missing hash to the HEAD of the target
+  reference.
+
 # 2.1.1
 
 * Released with Nessie version 0.67.0.

--- a/api/model/src/main/java/org/projectnessie/api/v2/params/Merge.java
+++ b/api/model/src/main/java/org/projectnessie/api/v2/params/Merge.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -93,14 +92,14 @@ public interface Merge extends BaseMergeTransplant {
    *
    * <p>Since Nessie spec 2.1.1, the hash can be absolute or relative.
    */
-  @NotBlank
-  @jakarta.validation.constraints.NotBlank
   @Pattern(
       regexp = Validation.HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
       message = Validation.HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
   @jakarta.validation.constraints.Pattern(
       regexp = Validation.HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
       message = Validation.HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
+  @Nullable
+  @jakarta.annotation.Nullable
   String getFromHash();
 
   /**

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
@@ -394,7 +394,7 @@ public abstract class AbstractRelativeReferences {
   @NessieApiVersions(versions = NessieApiVersion.V2)
   public void assignReferenceFromDetachedUnambiguous() {
     NessieError error = expectError(rest().body(etl1).put("trees/@{hash}", c2 + "~1"), 400);
-    checkError(error, BAD_REQUEST, "Reference to assign from must be a branch or a tag.");
+    checkError(error, BAD_REQUEST, "Assignment target must be a branch or a tag.");
   }
 
   /**
@@ -405,7 +405,7 @@ public abstract class AbstractRelativeReferences {
   @NessieApiVersions(versions = NessieApiVersion.V2)
   public void assignReferenceFromDetachedAmbiguous() {
     NessieError error = expectError(rest().body(etl1).put("trees/@{hash}", "~1"), 400);
-    checkError(error, BAD_REQUEST, "Reference to assign from must be a branch or a tag.");
+    checkError(error, BAD_REQUEST, "Assignment target must be a branch or a tag.");
   }
 
   /**

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
@@ -1501,7 +1501,7 @@ public abstract class AbstractRelativeReferences {
   @NessieApiVersions(versions = NessieApiVersion.V2)
   void getDiffFromRefAmbiguousDetached() {
     NessieError error = expectError(rest().get("trees/@{from}/diff/base@{to}", "~1", "~2"), 400);
-    checkError(error, BAD_REQUEST, "From hash must contain a starting commit ID.");
+    checkError(error, BAD_REQUEST, "\"From\" hash must contain a starting commit ID.");
   }
 
   /**
@@ -1512,7 +1512,7 @@ public abstract class AbstractRelativeReferences {
   @NessieApiVersions(versions = NessieApiVersion.V2)
   void getDiffToRefAmbiguousDetached() {
     NessieError error = expectError(rest().get("trees/base@{from}/diff/@{to}", "~1", "~2"), 400);
-    checkError(error, BAD_REQUEST, "To hash must contain a starting commit ID.");
+    checkError(error, BAD_REQUEST, "\"To\" hash must contain a starting commit ID.");
   }
 
   private static Branch expectBranch(Response base) {

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/AbstractRelativeReferences.java
@@ -24,6 +24,7 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -48,6 +49,7 @@ import org.projectnessie.model.LogResponse;
 import org.projectnessie.model.MergeResponse;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.SingleReferenceResponse;
+import org.projectnessie.model.Tag;
 
 /** A set of tests specifically aimed at testing relative references in API v2. */
 public abstract class AbstractRelativeReferences {
@@ -87,6 +89,8 @@ public abstract class AbstractRelativeReferences {
          etl1          c3
                          \
          etl2             c4 -- c5
+                           |
+                          tag1
     */
     assumeTrue(outer.isNewModel());
     Branch base = outer.createBranchV2("base");
@@ -100,19 +104,20 @@ public abstract class AbstractRelativeReferences {
     Branch etl2 = outer.createBranchV2("etl2", etl1);
     etl2 = outer.commitV2(etl2, key4, table4);
     c4 = etl2.getHash();
+    outer.createTagV2("tag1", etl2);
     etl2 = outer.commitV2(etl2, key5, table5);
     c5 = etl2.getHash();
   }
 
   /**
-   * Can create a reference from a hash that is unambiguous. Expect a 200 response with the created
-   * reference.
+   * Can create a reference from a branch + unambiguous target hash. Expect a 200 response with the
+   * created reference.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void createReferenceUnambiguous() {
+  public void createReferenceFromBranchUnambiguous() {
     Reference reference =
-        expectReference(
+        expectBranch(
             rest()
                 .queryParam("name", "branch1")
                 .queryParam("type", "branch")
@@ -123,30 +128,12 @@ public abstract class AbstractRelativeReferences {
   }
 
   /**
-   * Can create a reference from a hash that is unambiguous and DETACHED. Expect a 200 response with
-   * the created reference.
+   * Cannot create a reference from a branch + ambiguous target hash (writing operation). The hash
+   * must contain a starting commit ID. Expect a BAD_REQUEST error.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void createReferenceUnambiguousDetached() {
-    Reference reference =
-        expectReference(
-            rest()
-                .queryParam("name", "branch1")
-                .queryParam("type", "branch")
-                .body(Detached.of(c2 + "~1"))
-                .post("trees"));
-    assertThat(reference.getName()).isEqualTo("branch1");
-    assertThat(reference.getHash()).isEqualTo(c1);
-  }
-
-  /**
-   * Cannot create a reference from a hash that is ambiguous (writing operation). The hash must
-   * contain a starting commit ID. Expect a BAD_REQUEST error.
-   */
-  @Test
-  @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void createReferenceAmbiguous() {
+  public void createReferenceFromBranchAmbiguous() {
     NessieError error =
         expectError(
             rest()
@@ -158,137 +145,437 @@ public abstract class AbstractRelativeReferences {
     checkError(error, BAD_REQUEST, "Target hash must contain a starting commit ID.");
   }
 
-  /**
-   * Can assign a reference from a hash that is unambiguous, but the hash is not the current hash of
-   * the reference. Expect a REFERENCE_CONFLICT error.
-   */
+  /** Cannot create a reference from a branch + missing target hash. Expect a BAD_REQUEST error. */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void assignReferenceFromUnambiguousConflict() {
-    NessieError error = expectError(rest().body(etl1).put("trees/base@{hash}", c2 + "~1"), 409);
-    checkError(
-        error, ErrorCode.REFERENCE_CONFLICT, "Named-reference 'base' is not at expected hash");
-  }
-
-  /**
-   * Can assign a reference from a hash that is unambiguous, and the hash is the current HEAD of the
-   * reference. Expect a 200 response.
-   *
-   * <p>This is a convoluted case as the only way to use a relative reference that resolves to the
-   * HEAD of a branch is to use a timestamp in the future that resolves to the HEAD itself.
-   */
-  @Test
-  @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void assignReferenceFromUnambiguousSuccess() {
-    Reference base =
-        expectReference(
-            rest().body(etl1).put("trees/base@{hash}", c2 + "*" + Instant.now().plusSeconds(60)));
-    outer.soft.assertThat(base.getHash()).isEqualTo(c3);
-  }
-
-  /**
-   * Cannot assign a reference from a hash that is ambiguous (writing operation). The hash must
-   * contain a starting commit ID. Expect a BAD_REQUEST error.
-   */
-  @Test
-  @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void assignReferenceFromAmbiguous() {
-    NessieError error = expectError(rest().body(etl1).put("trees/base@{hash}", "^1"), 400);
-    checkError(error, BAD_REQUEST, "Expected hash must contain a starting commit ID.");
-  }
-
-  /**
-   * Cannot assign a reference from a DETACHED hash that is ambiguous (DETACHED requires
-   * unambiguous). The hash must contain a starting commit ID. Expect a BAD_REQUEST error.
-   */
-  @Test
-  @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void assignReferenceFromAmbiguousDetached() {
-    NessieError error = expectError(rest().body(etl1).put("trees/@~1"), 400);
-    checkError(error, BAD_REQUEST, "Expected hash must contain a starting commit ID.");
-  }
-
-  /**
-   * Can assign a reference to a hash that is unambiguous. Expect a 200 response with the updated
-   * reference.
-   */
-  @Test
-  @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void assignReferenceToUnambiguous() {
-    etl1 =
-        expectReference(
-            rest().body(Branch.of("base", c2 + "~1")).put("trees/etl1@{hash}", etl1.getHash()));
-    outer.soft.assertThat(etl1.getHash()).isEqualTo(c1);
-  }
-
-  /**
-   * Can assign a reference to a hash that is unambiguous adn DETACHED. Expect a 200 response with
-   * the updated reference.
-   */
-  @Test
-  @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void assignReferenceToUnambiguousDetached() {
-    etl1 =
-        expectReference(
-            rest().body(Detached.of(c2 + "~1")).put("trees/etl1@{hash}", etl1.getHash()));
-    outer.soft.assertThat(etl1.getHash()).isEqualTo(c1);
-  }
-
-  /**
-   * Cannot assign a reference to a hash that is ambiguous (writing operation). The hash must
-   * contain a starting commit ID. Expect a BAD_REQUEST error.
-   */
-  @Test
-  @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void assignReferenceToAmbiguous() {
+  public void createReferenceFromBranchHead() {
     NessieError error =
         expectError(
             rest()
-                .body(Branch.of("base", "*2023-01-01T00:00:00.000Z"))
-                .put("trees/etl1@{hash}", etl1.getHash()),
+                .queryParam("name", "branch1")
+                .queryParam("type", "branch")
+                .body(Branch.of("etl2", null))
+                .post("trees"),
+            400);
+    checkError(error, BAD_REQUEST, "Target hash must be provided.");
+  }
+
+  /**
+   * Can create a reference from a tag + unambiguous target hash. Expect a 200 response with the
+   * created reference.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void createReferenceFromTagUnambiguous() {
+    Reference reference =
+        expectBranch(
+            rest()
+                .queryParam("name", "branch1")
+                .queryParam("type", "branch")
+                .body(Tag.of("tag1", c4 + "~1"))
+                .post("trees"));
+    assertThat(reference.getName()).isEqualTo("branch1");
+    assertThat(reference.getHash()).isEqualTo(c3);
+  }
+
+  /**
+   * Cannot create a reference from a tag + ambiguous target hash (writing operation). The hash must
+   * contain a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void createReferenceFromTagAmbiguous() {
+    NessieError error =
+        expectError(
+            rest()
+                .queryParam("name", "branch1")
+                .queryParam("type", "branch")
+                .body(Tag.of("tag1", "~1"))
+                .post("trees"),
+            400);
+    checkError(error, BAD_REQUEST, "Target hash must contain a starting commit ID.");
+  }
+
+  /** Cannot create a reference from a tag + missing target hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void createReferenceFromTagHead() {
+    NessieError error =
+        expectError(
+            rest()
+                .queryParam("name", "branch1")
+                .queryParam("type", "branch")
+                .body(Tag.of("tag1", null))
+                .post("trees"),
+            400);
+    checkError(error, BAD_REQUEST, "Target hash must be provided.");
+  }
+
+  /**
+   * Can create a reference from a DETACHED + unambiguous target hash. Expect a 200 response with
+   * the created reference.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void createReferenceFromDetachedUnambiguous() {
+    Reference reference =
+        expectBranch(
+            rest()
+                .queryParam("name", "branch1")
+                .queryParam("type", "branch")
+                .body(Detached.of(c2 + "~1"))
+                .post("trees"));
+    assertThat(reference.getName()).isEqualTo("branch1");
+    assertThat(reference.getHash()).isEqualTo(c1);
+  }
+
+  /**
+   * Cannot create a reference from a DETACHED + ambiguous target hash (writing operation). The hash
+   * must contain a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void createReferenceFromDetachedAmbiguous() {
+    NessieError error =
+        expectError(
+            rest()
+                .queryParam("name", "branch1")
+                .queryParam("type", "branch")
+                .body(Detached.of("~1"))
+                .post("trees"),
             400);
     checkError(error, BAD_REQUEST, "Target hash must contain a starting commit ID.");
   }
 
   /**
-   * Can delete a reference that is unambiguous, but the hash is not the current HEAD of the
-   * reference. Expect a REFERENCE_CONFLICT error.
+   * Can assign a reference from a branch + unambiguous expected hash, and the hash is the current
+   * HEAD of the reference. Expect a 200 response.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void deleteReferenceUnambiguousConflict() {
-    NessieError error = expectError(rest().delete("trees/base@{hash}", c2 + "~1"), 409);
+  public void assignReferenceFromBranchUnambiguous() {
+    Reference base = expectBranch(rest().body(etl1).put("trees/base@{hash}", c3 + "~1"));
+    outer.soft.assertThat(base.getHash()).isEqualTo(c3);
+  }
+
+  /**
+   * Cannot assign a reference from a branch + unambiguous expected hash, when the hash is not the
+   * current head of the reference. Expect a REFERENCE_CONFLICT error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromBranchUnambiguousNotAtExpectedHash() {
+    NessieError error = expectError(rest().body(etl1).put("trees/base@{hash}", c3 + "~2"), 409);
     checkError(
         error, ErrorCode.REFERENCE_CONFLICT, "Named-reference 'base' is not at expected hash");
   }
 
   /**
-   * Can delete a reference that is unambiguous, and the hash is the current HEAD of the reference.
-   * Expect a 200 response with the deleted reference.
-   *
-   * <p>This is a convoluted case as the only way to use a relative reference that resolves to the
-   * HEAD of a branch is to use a timestamp in the future that resolves to the HEAD itself.
+   * Cannot assign a reference from a branch + unambiguous expected hash, when the hash is not
+   * reachable from the current head of the reference. Expect a REFERENCE_CONFLICT error.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  public void deleteReferenceUnambiguousSuccess() {
-    Reference base =
-        expectReference(
-            rest().delete("trees/base@{hash}", c2 + "*" + Instant.now().plusSeconds(60)));
+  public void assignReferenceFromBranchUnambiguousExpectedHashUnreachable() {
+    NessieError error = expectError(rest().body(etl1).put("trees/base@{hash}", c5 + "~1"), 409);
+    checkError(
+        error, ErrorCode.REFERENCE_CONFLICT, "Named-reference 'base' is not at expected hash");
+  }
+
+  /**
+   * Cannot assign a reference from a branch + unambiguous expected hash, when the hash does not
+   * exist. Expect a REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromBranchUnambiguousExpectedHashNonExistent() {
+    NessieError error = expectError(rest().body(etl1).put("trees/base@cafebabe~1"), 404);
+    checkError(error, ErrorCode.REFERENCE_NOT_FOUND, "Commit 'cafebabe' not found");
+  }
+
+  /**
+   * Cannot assign a reference from a branch + ambiguous expected hash (writing operation). The hash
+   * must contain a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromBranchAmbiguous() {
+    NessieError error = expectError(rest().body(etl1).put("trees/base@{hash}", "^1"), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must contain a starting commit ID.");
+  }
+
+  /**
+   * Cannot assign a reference from a branch + missing expected hash. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromBranchHead() {
+    NessieError error = expectError(rest().body(etl1).put("trees/base"), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must be provided.");
+  }
+
+  /**
+   * Can assign a reference from a tag + unambiguous expected hash, and the hash is the current HEAD
+   * of the reference. Expect a 200 response.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromTagUnambiguous() {
+    Reference base = expectTag(rest().body(etl1).put("trees/tag1@{hash}", c5 + "~1"));
+    outer.soft.assertThat(base.getHash()).isEqualTo(c3);
+  }
+
+  /**
+   * Cannot assign a reference from a tag + unambiguous expected hash, when the hash is not the
+   * current head of the reference. Expect a REFERENCE_CONFLICT error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromTagUnambiguousNotAtExpectedHash() {
+    NessieError error = expectError(rest().body(etl1).put("trees/tag1@{hash}", c5 + "~2"), 409);
+    checkError(
+        error, ErrorCode.REFERENCE_CONFLICT, "Named-reference 'tag1' is not at expected hash");
+  }
+
+  /**
+   * Cannot assign a reference from a tag + unambiguous expected hash, when the hash is not
+   * reachable from the current head of the reference. Expect a REFERENCE_CONFLICT error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromTagUnambiguousExpectedHashUnreachable() {
+    NessieError error =
+        expectError(
+            rest()
+                .body(etl1)
+                .put(
+                    "trees/tag1@{hash}",
+                    c5 + "*" + Instant.now().plusSeconds(60) /* resolves to c5 itself */),
+            409);
+    checkError(
+        error, ErrorCode.REFERENCE_CONFLICT, "Named-reference 'tag1' is not at expected hash");
+  }
+
+  /**
+   * Cannot assign a reference from a tag + unambiguous expected hash, when the hash does not exist.
+   * Expect a REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromTagUnambiguousExpectedHashNonExistent() {
+    NessieError error = expectError(rest().body(etl1).put("trees/tag1@cafebabe~1"), 404);
+    checkError(error, ErrorCode.REFERENCE_NOT_FOUND, "Commit 'cafebabe' not found");
+  }
+
+  /**
+   * Cannot assign a reference from a tag + ambiguous expected hash (writing operation). The hash
+   * must contain a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromTagAmbiguous() {
+    NessieError error = expectError(rest().body(etl1).put("trees/tag1@{hash}", "~1"), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must contain a starting commit ID.");
+  }
+
+  /** Cannot assign a reference from a tag + missing expected hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromTagHead() {
+    NessieError error = expectError(rest().body(etl1).put("trees/tag1"), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must be provided.");
+  }
+
+  /**
+   * Cannot assign a reference from a DETACHED ref (assign-from ref must be a branch or a tag).
+   * Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromDetachedUnambiguous() {
+    NessieError error = expectError(rest().body(etl1).put("trees/@{hash}", c2 + "~1"), 400);
+    checkError(error, BAD_REQUEST, "Reference to assign from must be a branch or a tag.");
+  }
+
+  /**
+   * Cannot assign a reference from a DETACHED ref (assign-from ref must be a branch or a tag).
+   * Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceFromDetachedAmbiguous() {
+    NessieError error = expectError(rest().body(etl1).put("trees/@{hash}", "~1"), 400);
+    checkError(error, BAD_REQUEST, "Reference to assign from must be a branch or a tag.");
+  }
+
+  /**
+   * Can assign a reference to a branch + unambiguous target hash. Expect a 200 response with the
+   * updated reference.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceToBranchUnambiguous() {
+    etl1 =
+        expectBranch(
+            rest().body(Branch.of("base", c2 + "~1")).put("trees/etl1@{hash}", etl1.getHash()));
+    outer.soft.assertThat(etl1.getHash()).isEqualTo(c1);
+  }
+
+  /** Cannot assign a reference to a branch + ambiguous target hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceToBranchAmbiguous() {
+    NessieError error =
+        expectError(
+            rest().body(Branch.of("etl2", "~1")).put("trees/etl1@{hash}", etl1.getHash()), 400);
+    checkError(error, BAD_REQUEST, "Target hash must contain a starting commit ID.");
+  }
+
+  /** Cannot assign a reference to a branch + missing target hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceToBranchHead() {
+    NessieError error =
+        expectError(
+            rest().body(Branch.of("base", null)).put("trees/etl1@{hash}", etl1.getHash()), 400);
+    checkError(error, BAD_REQUEST, "Target hash must be provided.");
+  }
+
+  /**
+   * Can assign a reference to a tag + unambiguous target hash. Expect a 200 response with the
+   * updated reference.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceToTagUnambiguous() {
+    etl1 =
+        expectBranch(
+            rest().body(Tag.of("tag1", c4 + "~1")).put("trees/etl1@{hash}", etl1.getHash()));
+    outer.soft.assertThat(etl1.getHash()).isEqualTo(c3);
+  }
+
+  /**
+   * Cannot assign a reference to a tag + ambiguous target hash (writing operation). Expect a
+   * BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceToTagAmbiguous() {
+    NessieError error =
+        expectError(
+            rest().body(Tag.of("tag1", "~1")).put("trees/etl1@{hash}", etl1.getHash()), 400);
+    checkError(error, BAD_REQUEST, "Target hash must contain a starting commit ID.");
+  }
+
+  /** Cannot assign a reference to a tag + missing target hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceToTagHead() {
+    NessieError error =
+        expectError(
+            rest().body(Tag.of("tag1", null)).put("trees/etl1@{hash}", etl1.getHash()), 400);
+    checkError(error, BAD_REQUEST, "Target hash must be provided.");
+  }
+
+  /**
+   * Can assign a reference to a DETACHED + unambiguous target hash. Expect a 200 response with the
+   * updated reference.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceToDetachedUnambiguous() {
+    etl1 =
+        expectBranch(rest().body(Detached.of(c2 + "~1")).put("trees/etl1@{hash}", etl1.getHash()));
+    outer.soft.assertThat(etl1.getHash()).isEqualTo(c1);
+  }
+
+  /**
+   * Cannot assign a reference to a DETACHED + ambiguous target hash (writing operation). The hash
+   * must contain a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void assignReferenceToDetachedAmbiguous() {
+    NessieError error =
+        expectError(rest().body(Detached.of("~1")).put("trees/etl1@{hash}", etl1.getHash()), 400);
+    checkError(error, BAD_REQUEST, "Target hash must contain a starting commit ID.");
+  }
+
+  /**
+   * Can delete a reference at an unambiguous expected hash, and the hash is the current HEAD of the
+   * reference. Expect a 200 response with the deleted reference.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void deleteReferenceUnambiguous() {
+    Reference base = expectBranch(rest().delete("trees/base@{hash}", c3 + "~1"));
     outer.soft.assertThat(base.getHash()).isEqualTo(c2);
   }
 
   /**
-   * Can commit to a reference that is unambiguous, even if the hash is not the current HEAD of the
-   * reference, since there are no conflicts between the expected hash and HEAD. Expect a 200
-   * response with the add contents.
+   * Cannot delete a reference at an unambiguous expected hash, when the hash is not the current
+   * HEAD of the reference. Expect a REFERENCE_CONFLICT error.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void commitUnambiguous() {
+  public void deleteReferenceUnambiguousNotAtExpectedHash() {
+    NessieError error = expectError(rest().delete("trees/base@{hash}", c3 + "~2"), 409);
+    checkError(
+        error, ErrorCode.REFERENCE_CONFLICT, "Named-reference 'base' is not at expected hash");
+  }
+
+  /**
+   * Cannot delete a reference at an unambiguous expected hash, when the hash is not reachable from
+   * the current HEAD of the reference. Expect a REFERENCE_CONFLICT error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void deleteReferenceUnambiguousExpectedHashUnreachable() {
+    NessieError error = expectError(rest().delete("trees/base@{hash}", c5 + "~1"), 409);
+    checkError(
+        error, ErrorCode.REFERENCE_CONFLICT, "Named-reference 'base' is not at expected hash");
+  }
+
+  /**
+   * Cannot delete a reference at an unambiguous expected hash, when the hash does not exist. Expect
+   * a REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void deleteReferenceUnambiguousExpectedHashNonExistent() {
+    NessieError error = expectError(rest().delete("trees/base@{hash}", "cafebabe~1"), 404);
+    checkError(error, ErrorCode.REFERENCE_NOT_FOUND, "Commit 'cafebabe' not found");
+  }
+
+  /**
+   * Cannot delete a reference at an ambiguous expected hash (writing operation). The hash must
+   * contain a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void deleteReferenceAmbiguous() {
+    NessieError error = expectError(rest().delete("trees/base@{hash}", "^1"), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must contain a starting commit ID.");
+  }
+
+  /** Cannot delete a reference without expected hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void deleteReferenceHead() {
+    NessieError error = expectError(rest().delete("trees/base"), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must be provided.");
+  }
+
+  /**
+   * Can commit to a branch + unambiguous expected hash, and the hash is the current HEAD of the
+   * reference. Expect a 200 response with the add contents.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void commitToBranchUnambiguous() {
     Set<ContentKey> keys =
         outer
-            .prepareCommitV2("base@" + c2 + "~1", key3, table3, 2, false)
+            .prepareCommitV2("base@" + c3 + "~1", key3, table3, 2, false)
             .statusCode(200)
             .extract()
             .as(CommitResponse.class)
@@ -298,55 +585,256 @@ public abstract class AbstractRelativeReferences {
   }
 
   /**
-   * Cannot commit to a reference that is ambiguous (writing operation). The hash must contain a
-   * starting commit ID. Expect a BAD_REQUEST error.
+   * Can commit to a branch + unambiguous expected hash, even if the hash is not the current HEAD of
+   * the reference, since there are no conflicts between the expected hash and HEAD. Expect a 200
+   * response with the add contents.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void commitAmbiguous() {
+  void commitToBranchUnambiguousNotAtExpectedHash() {
+    Set<ContentKey> keys =
+        outer
+            .prepareCommitV2("base@" + c3 + "~2", key3, table3, 2, false)
+            .statusCode(200)
+            .extract()
+            .as(CommitResponse.class)
+            .toAddedContentsMap()
+            .keySet();
+    assertThat(keys).containsOnly(key3);
+  }
+
+  /**
+   * Cannot commit to a branch + unambiguous expected hash, when the hash is not reachable from the
+   * current HEAD of the reference. Expect a REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void commitToBranchUnambiguousUnreachable() {
+    NessieError error =
+        expectError(outer.prepareCommitV2("base@" + c5 + "~1", key3, table3, 2, false), 404);
+    checkError(
+        error,
+        ErrorCode.REFERENCE_NOT_FOUND,
+        "Could not find commit '" + c4 + "' in reference 'base'");
+  }
+
+  /**
+   * Cannot commit to a branch + unambiguous expected hash, when the hash does not exist. Expect a
+   * REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void commitToBranchUnambiguousNonExistent() {
+    NessieError error =
+        expectError(outer.prepareCommitV2("base@cafebabe~1", key3, table3, 2, false), 404);
+    checkError(error, ErrorCode.REFERENCE_NOT_FOUND, "Commit 'cafebabe' not found");
+  }
+
+  /**
+   * Cannot commit to a branch + ambiguous expected hash (writing operation). The hash must contain
+   * a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void commitToBranchAmbiguous() {
     NessieError error =
         expectError(
             outer.prepareCommitV2("base*2023-01-01T00:00:00.000Z", key3, table3, 2, false), 400);
     checkError(error, BAD_REQUEST, "Expected hash must contain a starting commit ID.");
   }
 
+  /** Cannot commit to a branch without expected hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void commitToBranchHead() {
+    NessieError error = expectError(outer.prepareCommitV2("base", key3, table3, 2, false), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must be provided.");
+  }
+
   /**
-   * Can merge from a reference that is unambiguous. Expect a 200 response with the merge result.
+   * Cannot commit to a tag + unambiguous expected hash (target reference must be a branch), even if
+   * the hash is unambiguous.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void mergeFromUnambiguous() {
+  public void commitToTagUnambiguous() {
+    NessieError error =
+        expectError(outer.prepareCommitV2("tag1@" + c4 + "~1", key3, table3, 2, false), 400);
+    checkError(error, BAD_REQUEST, "Reference to commit into must be a branch.");
+  }
+
+  /** Cannot commit to a tag + ambiguous expected hash (target reference must be a branch). */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void commitToTagAmbiguous() {
+    NessieError error = expectError(outer.prepareCommitV2("tag1@~1", key3, table3, 2, false), 400);
+    checkError(error, BAD_REQUEST, "Reference to commit into must be a branch.");
+  }
+
+  /** Cannot commit to a tag without expected hash (target reference must be a branch). */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void commitToTagHead() {
+    NessieError error = expectError(outer.prepareCommitV2("tag1", key3, table3, 2, false), 400);
+    checkError(error, BAD_REQUEST, "Reference to commit into must be a branch.");
+  }
+
+  /**
+   * Cannot commit to a DETACHED ref (target reference must be a branch). Expect a BAD_REQUEST
+   * error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void commitToDetachedUnambiguous() {
+    NessieError error =
+        expectError(outer.prepareCommitV2("@" + c5 + "~1", key3, table3, 2, false), 400);
+    checkError(error, BAD_REQUEST, "Reference to commit into must be a branch.");
+  }
+
+  /**
+   * Cannot commit to a DETACHED ref (target reference must be a branch). Expect a BAD_REQUEST
+   * error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void commitToDetachedAmbiguous() {
+    NessieError error = expectError(outer.prepareCommitV2("@~1", key3, table3, 2, false), 400);
+    checkError(error, BAD_REQUEST, "Reference to commit into must be a branch.");
+  }
+
+  /**
+   * Can merge from a branch + unambiguous source hash. Expect a 200 response with the merge result.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void mergeFromBranchUnambiguous() {
     MergeResponse response = expectMerge(outer.prepareMergeV2("base@" + c2, "etl2", c5 + "~2", 2));
     checkMerge(response, c2, c2);
   }
 
   /**
-   * Cannot merge from a reference that is ambiguous (writing operation). The hash must contain a
-   * starting commit ID. Expect a BAD_REQUEST error.
+   * Cannot merge from a reference + ambiguous source hash (writing operation). The hash must
+   * contain a starting commit ID. Expect a BAD_REQUEST error.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void mergeFromAmbiguous() {
+  void mergeFromBranchAmbiguous() {
     NessieError error =
         expectError(
             outer.prepareMergeV2("base@" + c2, "etl1", "*2023-01-01T00:00:00.000Z", 2), 400);
     checkError(error, BAD_REQUEST, "Source hash must contain a starting commit ID.");
   }
 
+  /** Cannot merge from a reference without source hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeFromBranchHead() {
+    NessieError error = expectError(outer.prepareMergeV2("base@" + c2, "etl1", null, 2), 400);
+    checkError(error, BAD_REQUEST, "Source hash must be provided.");
+  }
+
   /**
-   * Can merge to a reference that is unambiguous, even if the hash is not the current HEAD of the
-   * reference, since for merges and transplants, the expected hash is purely informational. Expect
-   * a 200 response with the merge result.
+   * Can merge from a tag + unambiguous source hash. Expect a 200 response with the merge result.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void mergeToUnambiguous() {
-    MergeResponse response = expectMerge(outer.prepareMergeV2("base@" + c2 + "~1", "etl1", c3, 2));
+  public void mergeFromTagUnambiguous() {
+    MergeResponse response = expectMerge(outer.prepareMergeV2("base@" + c2, "tag1", c5 + "~1", 2));
     checkMerge(response, c2, c2);
   }
 
   /**
-   * Cannot merge to a reference that is ambiguous (writing operation). The hash must contain a
+   * Cannot merge from a tag + ambiguous source hash (writing operation). The hash must contain a
+   * starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeFromTagAmbiguous() {
+    NessieError error = expectError(outer.prepareMergeV2("base@" + c2, "tag1", "~2", 2), 400);
+    checkError(error, BAD_REQUEST, "Source hash must contain a starting commit ID.");
+  }
+
+  /** Cannot merge from a tag without source hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeFromTagHead() {
+    NessieError error = expectError(outer.prepareMergeV2("base@" + c2, "tag1", null, 2), 400);
+    checkError(error, BAD_REQUEST, "Source hash must be provided.");
+  }
+
+  /**
+   * Can merge from a DETACHED ref + unambiguous source hash. Expect a 200 response with the merge
+   * result.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeFromDetachedUnambiguous() {
+    MergeResponse response =
+        expectMerge(outer.prepareMergeV2("base@" + c2, "DETACHED", c5 + "~2", 2));
+    checkMerge(response, c2, c2);
+  }
+
+  /**
+   * Cannot merge from a DETACHED ref + ambiguous source hash (writing operation). The hash must
+   * contain a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeFromDetachedAmbiguous() {
+    NessieError error = expectError(outer.prepareMergeV2("base@" + c2, "DETACHED", "~2", 2), 400);
+    checkError(error, BAD_REQUEST, "Source hash must contain a starting commit ID.");
+  }
+
+  /**
+   * Can merge to a branch + unambiguous expected hash, and the hash is the current HEAD of the
+   * reference. Expect a 200 response with the merge result.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void mergeToBranchUnambiguous() {
+    MergeResponse response = expectMerge(outer.prepareMergeV2("base@" + c3 + "~1", "etl1", c3, 2));
+    checkMerge(response, c2, c2);
+  }
+
+  /**
+   * Can merge to a branch + unambiguous expected hash, even if the hash is not the current HEAD of
+   * the reference, since for merges and transplants, the expected hash is purely informational.
+   * Expect a 200 response with the merge result.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void mergeToBranchUnambiguousNotAtExpectedHash() {
+    MergeResponse response = expectMerge(outer.prepareMergeV2("base@" + c3 + "~2", "etl1", c3, 2));
+    checkMerge(response, c2, c2);
+  }
+
+  /**
+   * Cannot merge to a branch + unambiguous expected hash, when the hash is not reachable from the
+   * current HEAD of the reference. Expect a REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void mergeToBranchUnambiguousExpectedHashUnreachable() {
+    NessieError error = expectError(outer.prepareMergeV2("base@" + c5 + "~1", "etl1", c3, 2), 404);
+    checkError(
+        error,
+        ErrorCode.REFERENCE_NOT_FOUND,
+        "Could not find commit '" + c4 + "' in reference 'base'");
+  }
+
+  /**
+   * Cannot merge to a branch + unambiguous expected hash, when the hash does not exist. Expect a
+   * REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void mergeToBranchUnambiguousExpectedHashNonExistent() {
+    NessieError error = expectError(outer.prepareMergeV2("base@cafebabe~1", "etl1", c3, 2), 404);
+    checkError(error, ErrorCode.REFERENCE_NOT_FOUND, "Commit 'cafebabe' not found");
+  }
+
+  /**
+   * Cannot merge to a branch + ambiguous expected hash (writing operation). The hash must contain a
    * starting commit ID. Expect a BAD_REQUEST error.
    *
    * <p>Note: since for merges and transplants, the expected hash is purely informational, ambiguous
@@ -354,19 +842,79 @@ public abstract class AbstractRelativeReferences {
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void mergeToAmbiguous() {
+  void mergeToBranchAmbiguous() {
     NessieError error =
         expectError(outer.prepareMergeV2("base@*2023-01-01T00:00:00.000Z", "etl1", c3, 2), 400);
     checkError(error, BAD_REQUEST, "Expected hash must contain a starting commit ID.");
   }
 
+  /** Cannot merge to a branch without expected hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeToBranchHead() {
+    NessieError error = expectError(outer.prepareMergeV2("base", "etl1", c3, 2), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must be provided.");
+  }
+
   /**
-   * Can transplant from a reference that is unambiguous. Expect a 200 response with the transplant
-   * result.
+   * Cannot merge to a tag (target reference must be a branch), even with unambiguous expected hash.
+   * Expect a BAD_REQUEST error.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void transplantFromUnambiguous() {
+  public void mergeToTagUnambiguous() {
+    NessieError error = expectError(outer.prepareMergeV2("tag1@" + c4 + "~1", "etl1", c3, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to merge into must be a branch.");
+  }
+
+  /** Cannot merge to a tag (target reference must be a branch). Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeToTagAmbiguous() {
+    NessieError error = expectError(outer.prepareMergeV2("tag1@~1", "etl1", c3, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to merge into must be a branch.");
+  }
+
+  /**
+   * Cannot merge to a tag without expected hash (target reference must be a branch). Expect a
+   * BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeToTagHead() {
+    NessieError error = expectError(outer.prepareMergeV2("tag1", "etl1", c3, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to merge into must be a branch.");
+  }
+
+  /**
+   * Cannot merge to a DETACHED ref (target reference must be a branch), even with unambiguous
+   * expected hash. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeToDetachedUnambiguous() {
+    NessieError error = expectError(outer.prepareMergeV2("@" + c5 + "~1", "etl1", c3, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to merge into must be a branch.");
+  }
+
+  /**
+   * Cannot merge to a DETACHED ref (target reference must be a branch). Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void mergeToDetachedAmbiguous() {
+    NessieError error =
+        expectError(outer.prepareMergeV2("@*2023-01-01T00:00:00.000Z", "etl1", c3, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to merge into must be a branch.");
+  }
+
+  /**
+   * Can transplant from a reference + unambiguous source hashes. Expect a 200 response with the
+   * transplant result.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void transplantFromBranchUnambiguous() {
     List<String> hashes =
         Arrays.asList(
             c5 + "~1", // c4
@@ -377,12 +925,12 @@ public abstract class AbstractRelativeReferences {
   }
 
   /**
-   * Cannot transplant from a reference that is ambiguous (writing operation). The hash must contain
-   * a starting commit ID. Expect a BAD_REQUEST error.
+   * Cannot transplant from a reference + ambiguous source hashes (writing operation). The hash must
+   * contain a starting commit ID. Expect a BAD_REQUEST error.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void transplantFromAmbiguous() {
+  void transplantFromBranchAmbiguous() {
     List<String> hashes = Arrays.asList(c5, "~1");
     NessieError error =
         expectError(outer.prepareTransplantV2("base@" + c2, "etl2", hashes, 2), 400);
@@ -393,34 +941,201 @@ public abstract class AbstractRelativeReferences {
   }
 
   /**
-   * Can transplant to a reference that is unambiguous, even if the hash is not the current HEAD of
-   * the reference, since for merges and transplants, the expected hash is purely informational.
-   * Expect a 200 response with the transplant result.
+   * Can transplant from a tag + unambiguous source hash. Expect a 200 response with the transplant
+   * result.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void transplantToUnambiguous() {
-    List<String> hashes = Arrays.asList(c3, c4, c5);
+  public void transplantFromTagUnambiguous() {
+    List<String> hashes = Collections.singletonList(c4 + "~1");
     MergeResponse response =
-        expectMerge(outer.prepareTransplantV2("base@" + c2 + "~1", "etl2", hashes, 2));
+        expectMerge(outer.prepareTransplantV2("base@" + c2, "tag1", hashes, 2));
     outer.soft.assertThat(response.getEffectiveTargetHash()).isEqualTo(c2);
   }
 
   /**
-   * Cannot transplant to a reference that is ambiguous (writing operation). The hash must contain a
-   * starting commit ID. Expect a BAD_REQUEST error.
+   * Cannot transplant from a tag + ambiguous source hash (writing operation). The hash must contain
+   * a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantFromTagAmbiguous() {
+    List<String> hashes = Collections.singletonList("~1");
+    NessieError error =
+        expectError(outer.prepareTransplantV2("base@" + c2, "tag1", hashes, 2), 400);
+    outer
+        .soft
+        .assertThat(error.getMessage())
+        .contains("Hash to transplant must contain a starting commit ID.");
+  }
+
+  /**
+   * Can transplant from a DETACHED ref + unambiguous source hash. Expect a 200 response with the
+   * transplant result.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantFromDetachedUnambiguous() {
+    List<String> hashes = Collections.singletonList(c5 + "~1");
+    MergeResponse response =
+        expectMerge(outer.prepareTransplantV2("base@" + c2, "DETACHED", hashes, 2));
+    outer.soft.assertThat(response.getEffectiveTargetHash()).isEqualTo(c2);
+  }
+
+  /**
+   * Cannot transplant from a DETACHED ref + ambiguous source hash (writing operation). The hash
+   * must contain a starting commit ID. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantFromDetachedAmbiguous() {
+    List<String> hashes = Collections.singletonList("~1");
+    NessieError error =
+        expectError(outer.prepareTransplantV2("base@" + c2, "DETACHED", hashes, 2), 400);
+    outer
+        .soft
+        .assertThat(error.getMessage())
+        .contains("Hash to transplant must contain a starting commit ID.");
+  }
+
+  /**
+   * Can transplant to a branch + unambiguous expected hash, and the hash is the current HEAD of the
+   * reference. Expect a 200 response with the transplant result.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void transplantToBranchUnambiguous() {
+    List<String> hashes = Arrays.asList(c3, c4, c5);
+    MergeResponse response =
+        expectMerge(outer.prepareTransplantV2("base@" + c3 + "~1", "etl2", hashes, 2));
+    outer.soft.assertThat(response.getEffectiveTargetHash()).isEqualTo(c2);
+  }
+
+  /**
+   * Can transplant to a branch + unambiguous expected hash, even if the hash is not the current
+   * HEAD of the reference, since for merges and transplants, the expected hash is purely
+   * informational. Expect a 200 response with the transplant result.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void transplantToBranchUnambiguousNotAtExpectedHash() {
+    List<String> hashes = Arrays.asList(c3, c4, c5);
+    MergeResponse response =
+        expectMerge(outer.prepareTransplantV2("base@" + c3 + "~2", "etl2", hashes, 2));
+    outer.soft.assertThat(response.getEffectiveTargetHash()).isEqualTo(c2);
+  }
+
+  /**
+   * Cannot transplant to a branch + unambiguous expected hash, when the hash is not reachable from
+   * the current HEAD of the reference. Expect a REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void transplantToBranchUnambiguousExpectedHashUnreachable() {
+    List<String> hashes = Arrays.asList(c3, c4, c5);
+    NessieError error =
+        expectError(outer.prepareTransplantV2("base@" + c5 + "~1", "etl2", hashes, 2), 404);
+    checkError(
+        error,
+        ErrorCode.REFERENCE_NOT_FOUND,
+        "Could not find commit '" + c4 + "' in reference 'base'");
+  }
+
+  /**
+   * Cannot transplant to a branch + unambiguous expected hash, when the hash does not exist. Expect
+   * a REFERENCE_NOT_FOUND error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  void transplantToBranchUnambiguousExpectedHashNonExistent() {
+    List<String> hashes = Arrays.asList(c3, c4, c5);
+    NessieError error =
+        expectError(outer.prepareTransplantV2("base@cafebabe~1", "etl2", hashes, 2), 404);
+    checkError(error, ErrorCode.REFERENCE_NOT_FOUND, "Commit 'cafebabe' not found");
+  }
+
+  /**
+   * Cannot transplant to a branch + ambiguous expected hash (writing operation). The hash must
+   * contain a starting commit ID. Expect a BAD_REQUEST error.
    *
    * <p>Note: since for merges and transplants, the expected hash is purely informational, ambiguous
    * hashes could in theory be allowed, but this would be confusing to users.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
-  void transplantToAmbiguous() {
+  void transplantToBranchAmbiguous() {
     List<String> hashes = Arrays.asList(c5, c4);
     NessieError error =
         expectError(
             outer.prepareTransplantV2("base@*2023-01-01T00:00:00.000Z", "etl2", hashes, 2), 400);
     checkError(error, BAD_REQUEST, "Expected hash must contain a starting commit ID.");
+  }
+
+  /** Cannot transplant to a branch without expected hash. Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantToBranchHead() {
+    List<String> hashes = Arrays.asList(c5, c4);
+    NessieError error = expectError(outer.prepareTransplantV2("base", "etl2", hashes, 2), 400);
+    checkError(error, BAD_REQUEST, "Expected hash must be provided.");
+  }
+
+  /**
+   * Cannot transplant to a tag (target reference must be a branch), even with unambiguous expected
+   * hash. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantToTagUnambiguous() {
+    List<String> hashes = Arrays.asList(c3, c4, c5);
+    NessieError error =
+        expectError(outer.prepareTransplantV2("tag1@" + c4 + "~1", "etl2", hashes, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to transplant into must be a branch.");
+  }
+
+  /** Cannot transplant to a tag (target reference must be a branch). Expect a BAD_REQUEST error. */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantToTagAmbiguous() {
+    List<String> hashes = Arrays.asList(c5, c4);
+    NessieError error = expectError(outer.prepareTransplantV2("tag1@~1", "etl2", hashes, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to transplant into must be a branch.");
+  }
+
+  /** Cannot transplant to a tag without expected hash (target reference must be a branch). */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantToTagHead() {
+    List<String> hashes = Arrays.asList(c5, c4);
+    NessieError error = expectError(outer.prepareTransplantV2("tag1", "etl2", hashes, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to transplant into must be a branch.");
+  }
+
+  /**
+   * Cannot transplant to a DETACHED ref (target reference must be a branch), even with unambiguous
+   * expected hash. Expect a BAD_REQUEST error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantToDetachedUnambiguous() {
+    List<String> hashes = Arrays.asList(c3, c4, c5);
+    NessieError error =
+        expectError(outer.prepareTransplantV2("@" + c5 + "~1", "etl2", hashes, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to transplant into must be a branch.");
+  }
+
+  /**
+   * Cannot transplant to a DETACHED ref (target reference must be a branch). Expect a BAD_REQUEST
+   * error.
+   */
+  @Test
+  @NessieApiVersions(versions = NessieApiVersion.V2)
+  public void transplantToDetachedAmbiguous() {
+    List<String> hashes = Arrays.asList(c5, c4);
+    NessieError error =
+        expectError(
+            outer.prepareTransplantV2("@*2023-01-01T00:00:00.000Z", "etl2", hashes, 2), 400);
+    checkError(error, BAD_REQUEST, "Reference to transplant into must be a branch.");
   }
 
   /**
@@ -696,10 +1411,7 @@ public abstract class AbstractRelativeReferences {
     checkError(error, BAD_REQUEST, "Youngest hash must contain a starting commit ID.");
   }
 
-  /**
-   * Can get the commit log with an oldest hash that is unambiguous. Expect a 200 response with the
-   * log.
-   */
+  /** Can get the commit log with an oldest unambiguous hash. Expect a 200 response with the log. */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
   void getCommitLogOldestHashUnambiguous() {
@@ -709,8 +1421,8 @@ public abstract class AbstractRelativeReferences {
   }
 
   /**
-   * Can get the commit log with an oldest hash that is unambiguous on a DETACHED ref. Expect a 200
-   * response with the log.
+   * Can get the commit log with an oldest unambiguous hash on a DETACHED ref. Expect a 200 response
+   * with the log.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
@@ -722,8 +1434,8 @@ public abstract class AbstractRelativeReferences {
   }
 
   /**
-   * Can get the commit log with an oldest hash that is ambiguous (reading operation). Expect a 200
-   * response with the log.
+   * Can get the commit log with an oldest ambiguous hash (reading operation). Expect a 200 response
+   * with the log.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
@@ -734,8 +1446,8 @@ public abstract class AbstractRelativeReferences {
   }
 
   /**
-   * Cannot get the commit log with an oldest hash that is ambiguous on a DETACHED ref (DETACHED
-   * requires unambiguous). Expect a BAD_REQUEST error.
+   * Cannot get the commit log with an oldest ambiguous hash on a DETACHED ref (DETACHED requires
+   * unambiguous). Expect a BAD_REQUEST error.
    */
   @Test
   @NessieApiVersions(versions = NessieApiVersion.V2)
@@ -803,8 +1515,13 @@ public abstract class AbstractRelativeReferences {
     checkError(error, BAD_REQUEST, "To hash must contain a starting commit ID.");
   }
 
-  private static Branch expectReference(Response base) {
+  private static Branch expectBranch(Response base) {
     return (Branch)
+        base.then().statusCode(200).extract().as(SingleReferenceResponse.class).getReference();
+  }
+
+  private static Tag expectTag(Response base) {
+    return (Tag)
         base.then().statusCode(200).extract().as(SingleReferenceResponse.class).getReference();
   }
 

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -406,8 +406,8 @@ public abstract class BaseTestNessieApi {
     soft.assertThatThrownBy(() -> createReference(Tag.of("tag2", null), main.getName()))
         .isInstanceOf(NessieBadRequestException.class);
 
-    Reference branch2 = createReference(Branch.of("branch2", null), main.getName());
-    soft.assertThat(branch2).isEqualTo(Branch.of("branch2", EMPTY));
+    soft.assertThatThrownBy(() -> createReference(Branch.of("branch2", null), main.getName()))
+        .isInstanceOf(NessieBadRequestException.class);
 
     // not exist
 
@@ -589,7 +589,10 @@ public abstract class BaseTestNessieApi {
   public void referencesWithLimitInFirstPage() throws Exception {
     assumeFalse(pagingSupported(api().getAllReferences()));
     // Verify that result limiting produces expected errors when paging is not supported
-    api().createReference().reference(Branch.of("branch", null)).create();
+    api()
+        .createReference()
+        .reference(Branch.of("branch", api().getDefaultBranch().getHash()))
+        .create();
     assertThatThrownBy(() -> api().getAllReferences().maxRecords(1).get())
         .isInstanceOf(NessieBadRequestException.class)
         .hasMessageContaining("Paging not supported");

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/versionstore/ObservingVersionStore.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/versionstore/ObservingVersionStore.java
@@ -144,7 +144,7 @@ public class ObservingVersionStore implements VersionStore {
   @Timed(value = PREFIX, histogram = true)
   public ReferenceAssignedResult assign(
       @SpanAttribute(TAG_REF) NamedRef ref,
-      @SpanAttribute(TAG_EXPECTED_HASH) Optional<Hash> expectedHash,
+      @SpanAttribute(TAG_EXPECTED_HASH) Hash expectedHash,
       @SpanAttribute(TAG_TARGET_HASH) Hash targetHash)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return delegate.assign(ref, expectedHash, targetHash);
@@ -166,7 +166,7 @@ public class ObservingVersionStore implements VersionStore {
   @Counted(PREFIX)
   @Timed(value = PREFIX, histogram = true)
   public ReferenceDeletedResult delete(
-      @SpanAttribute(TAG_REF) NamedRef ref, @SpanAttribute(TAG_HASH) Optional<Hash> hash)
+      @SpanAttribute(TAG_REF) NamedRef ref, @SpanAttribute(TAG_HASH) Hash hash)
       throws ReferenceNotFoundException, ReferenceConflictException {
     return delegate.delete(ref, hash);
   }

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractTestBasicOperations.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractTestBasicOperations.java
@@ -56,7 +56,10 @@ abstract class AbstractTestBasicOperations {
 
   void getCatalog(String branch) throws BaseNessieClientServerException {
     if (branch != null) {
-      api.createReference().reference(Branch.of(branch, null)).sourceRefName("main").create();
+      api.createReference()
+          .reference(Branch.of(branch, api.getDefaultBranch().getHash()))
+          .sourceRefName("main")
+          .create();
     }
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/hash/HashResolver.java
+++ b/servers/services/src/main/java/org/projectnessie/services/hash/HashResolver.java
@@ -117,7 +117,7 @@ public final class HashResolver {
       ResolvedHash head,
       @Nullable @jakarta.annotation.Nullable String hashOnRef,
       HashValidator validator)
-      throws ReferenceNotFoundException {
+      throws NessieReferenceNotFoundException {
     return resolveHashOnRef(head.getNamedRef(), head.getHead().orElse(null), hashOnRef, validator);
   }
 
@@ -135,7 +135,7 @@ public final class HashResolver {
       @Nullable @jakarta.annotation.Nullable Hash currentHead,
       @Nullable @jakarta.annotation.Nullable String hashOnRef,
       HashValidator validator)
-      throws ReferenceNotFoundException {
+      throws NessieReferenceNotFoundException {
     checkState(currentHead != null || hashOnRef != null);
     Optional<ParsedHash> parsed = ParsedHash.parse(hashOnRef, store.noAncestorHash());
     if (ref == DetachedRef.INSTANCE) {
@@ -150,7 +150,12 @@ public final class HashResolver {
       // Resolve the hash against DETACHED because we are only interested in
       // resolving the hash, not checking if it is on the branch. This will
       // be done later on.
-      resolved = store.hashOnReference(DetachedRef.INSTANCE, Optional.of(resolved), relativeParts);
+      try {
+        resolved =
+            store.hashOnReference(DetachedRef.INSTANCE, Optional.of(resolved), relativeParts);
+      } catch (ReferenceNotFoundException e) {
+        throw new NessieReferenceNotFoundException(e.getMessage(), e);
+      }
     }
     return ResolvedHash.of(ref, Optional.ofNullable(currentHead), resolved);
   }

--- a/servers/services/src/main/java/org/projectnessie/services/hash/HashResolver.java
+++ b/servers/services/src/main/java/org/projectnessie/services/hash/HashResolver.java
@@ -17,8 +17,6 @@ package org.projectnessie.services.hash;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static org.projectnessie.services.hash.HashValidator.ANY_HASH;
-import static org.projectnessie.services.hash.HashValidator.REQUIRED_UNAMBIGUOUS_HASH;
 
 import java.util.Collections;
 import java.util.List;
@@ -57,12 +55,12 @@ public final class HashResolver {
     checkArgument(
         namedRef == null || !namedRef.equals(DetachedRef.REF_NAME),
         "Cannot resolve DETACHED to HEAD");
-    return resolveHashOnRef(namedRef, null, "", ANY_HASH);
+    return resolveHashOnRef(namedRef, null);
   }
 
   /**
    * Resolves the given {@code namedRef} to {@code hashOnRef} if present, otherwise to its current
-   * HEAD, if available.
+   * HEAD, if available. Uses the {@link HashValidator#DEFAULT} instance.
    *
    * <p>Throws if the reference does not exist, the hash is invalid, or is not present on the
    * reference.
@@ -70,16 +68,21 @@ public final class HashResolver {
    * <p>If {@code namedRef} is {@link DetachedRef}, then a non-null {@code hashOnRef} is required.
    *
    * <p>If {@code namedRef} is null, the default branch will be used.
-   *
-   * <p>The parameter {@code name} is used for error messages.
-   *
-   * <p>A hash validator must be provided to perform extra validations on the parsed hashed. If no
-   * extra validation is required, {@link HashValidator#ANY_HASH} can be used.
+   */
+  public ResolvedHash resolveHashOnRef(
+      @Nullable @jakarta.annotation.Nullable String namedRef,
+      @Nullable @jakarta.annotation.Nullable String hashOnRef)
+      throws NessieReferenceNotFoundException {
+    return resolveHashOnRef(namedRef, hashOnRef, HashValidator.DEFAULT);
+  }
+
+  /**
+   * Same as {@link #resolveHashOnRef(String, String)} but allows to pass a custom {@link
+   * HashValidator}.
    */
   public ResolvedHash resolveHashOnRef(
       @Nullable @jakarta.annotation.Nullable String namedRef,
       @Nullable @jakarta.annotation.Nullable String hashOnRef,
-      String name,
       HashValidator validator)
       throws NessieReferenceNotFoundException {
     if (null == namedRef) {
@@ -94,12 +97,8 @@ public final class HashResolver {
         ReferenceInfo<CommitMeta> refInfo = store.getNamedRef(namedRef, GetNamedRefsParams.DEFAULT);
         ref = refInfo.getNamedRef();
         currentHead = refInfo.getHash();
-        // Shortcut: use HEAD, if hashOnRef is null or empty
-        if (hashOnRef == null || hashOnRef.isEmpty()) {
-          return ResolvedHash.of(ref, Optional.empty(), Optional.of(currentHead));
-        }
       }
-      return resolveHashOnRef(ref, currentHead, hashOnRef, name, validator);
+      return resolveHashOnRef(ref, currentHead, hashOnRef, validator);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
     }
@@ -112,16 +111,14 @@ public final class HashResolver {
    * <p>This is useful to compute more hashes against a first resolved hash, e.g. when
    * transplanting.
    *
-   * <p>See {@link #resolveHashOnRef(String, String, String, HashValidator)} for important caveats.
+   * <p>See {@link #resolveHashOnRef(String, String)} for important caveats.
    */
   public ResolvedHash resolveHashOnRef(
       ResolvedHash head,
       @Nullable @jakarta.annotation.Nullable String hashOnRef,
-      String name,
       HashValidator validator)
       throws ReferenceNotFoundException {
-    return resolveHashOnRef(
-        head.getNamedRef(), head.getHead().orElse(null), hashOnRef, name, validator);
+    return resolveHashOnRef(head.getNamedRef(), head.getHead().orElse(null), hashOnRef, validator);
   }
 
   /**
@@ -131,33 +128,30 @@ public final class HashResolver {
    * <p>Either {@code currentHead} or {@code hashOnRef} must be non-null. It's the caller's
    * responsibility to validate that any user-provided input meets this requirement.
    *
-   * <p>See {@link #resolveHashOnRef(String, String, String, HashValidator)} for important caveats.
+   * <p>See {@link #resolveHashOnRef(String, String)} for important caveats.
    */
   public ResolvedHash resolveHashOnRef(
       NamedRef ref,
       @Nullable @jakarta.annotation.Nullable Hash currentHead,
       @Nullable @jakarta.annotation.Nullable String hashOnRef,
-      String name,
       HashValidator validator)
       throws ReferenceNotFoundException {
     checkState(currentHead != null || hashOnRef != null);
     Optional<ParsedHash> parsed = ParsedHash.parse(hashOnRef, store.noAncestorHash());
     if (ref == DetachedRef.INSTANCE) {
-      validator = validator.and(REQUIRED_UNAMBIGUOUS_HASH);
+      validator.hashMustBePresent().hashMustNotBeAmbiguous();
     }
-    validator.validate(name, parsed.orElse(null));
-    Hash startOrHead = parsed.flatMap(ParsedHash::getAbsolutePart).orElse(currentHead);
-    checkState(startOrHead != null);
+    validator.validate(ref, parsed.orElse(null));
+    Hash resolved = parsed.flatMap(ParsedHash::getAbsolutePart).orElse(currentHead);
+    checkState(resolved != null);
     List<RelativeCommitSpec> relativeParts =
         parsed.map(ParsedHash::getRelativeParts).orElse(Collections.emptyList());
-    Optional<Hash> resolved = Optional.of(startOrHead);
     if (!relativeParts.isEmpty()) {
       // Resolve the hash against DETACHED because we are only interested in
       // resolving the hash, not checking if it is on the branch. This will
       // be done later on.
-      resolved =
-          Optional.ofNullable(store.hashOnReference(DetachedRef.INSTANCE, resolved, relativeParts));
+      resolved = store.hashOnReference(DetachedRef.INSTANCE, Optional.of(resolved), relativeParts);
     }
-    return ResolvedHash.of(ref, resolved, Optional.ofNullable(currentHead));
+    return ResolvedHash.of(ref, Optional.ofNullable(currentHead), resolved);
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/hash/HashResolver.java
+++ b/servers/services/src/main/java/org/projectnessie/services/hash/HashResolver.java
@@ -133,9 +133,6 @@ public final class HashResolver {
       throws ReferenceNotFoundException {
     checkState(currentHead != null || hashOnRef != null);
     Optional<ParsedHash> parsed = ParsedHash.parse(hashOnRef, store.noAncestorHash());
-    if (ref == DetachedRef.INSTANCE) {
-      validator.hashMustBePresent().hashMustNotBeAmbiguous();
-    }
     validator.validate(ref, parsed.orElse(null));
     Hash resolved = parsed.flatMap(ParsedHash::getAbsolutePart).orElse(currentHead);
     checkState(resolved != null);

--- a/servers/services/src/main/java/org/projectnessie/services/hash/HashValidator.java
+++ b/servers/services/src/main/java/org/projectnessie/services/hash/HashValidator.java
@@ -17,50 +17,122 @@ package org.projectnessie.services.hash;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import javax.annotation.Nullable;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.NamedRef;
+import org.projectnessie.versioned.TagName;
 
-@FunctionalInterface
-public interface HashValidator {
+public final class HashValidator {
 
-  /** No-op, for any parseable hash. */
-  HashValidator ANY_HASH = (name, parsed) -> {};
+  public static final HashValidator DEFAULT = new HashValidator();
+
+  private final String refName;
+  private final String hashName;
+
+  private HashValidation validation = (namedRef, parsed) -> {};
+
+  public HashValidator() {
+    this("Hash");
+  }
+
+  public HashValidator(String hashName) {
+    this("Reference", hashName);
+  }
+
+  public HashValidator(String refName, String hashName) {
+    this.refName = refName;
+    this.hashName = hashName;
+  }
+
+  /**
+   * Validates the provided ref and hash.
+   *
+   * @param namedRef the namedRef, required.
+   * @param parsed the parsed hash, or {@code null} if no hash was provided.
+   */
+  public void validate(
+      NamedRef namedRef, @Nullable @jakarta.annotation.Nullable ParsedHash parsed) {
+    validation.validate(namedRef, parsed);
+  }
+
+  /** Validates that a named ref is a branch. */
+  @CanIgnoreReturnValue
+  public HashValidator refMustBeBranch() {
+    validation = validation.and(HashValidation.refMustBeBranch(refName));
+    return this;
+  }
+
+  /** Validates that a named ref is a branch or a tag. */
+  @CanIgnoreReturnValue
+  public HashValidator refMustBeBranchOrTag() {
+    validation = validation.and(HashValidation.refMustBeBranchOrTag(refName));
+    return this;
+  }
 
   /** Validates that a hash has been provided (absolute or relative). */
-  HashValidator REQUIRED_HASH =
-      (name, parsed) -> checkArgument(parsed != null, String.format("%s must be provided.", name));
+  @CanIgnoreReturnValue
+  public HashValidator hashMustBePresent() {
+    validation = validation.and(HashValidation.hashMustBePresent(hashName));
+    return this;
+  }
 
   /**
    * Validates that, if a hash was provided, it is unambiguous. A hash is unambiguous if it starts
    * with an absolute part, because it will always resolve to the same hash, even if it also has
    * relative parts.
    */
-  HashValidator UNAMBIGUOUS_HASH =
-      (name, parsed) ->
+  @CanIgnoreReturnValue
+  public HashValidator hashMustNotBeAmbiguous() {
+    validation = validation.and(HashValidation.hashMustNotBeAmbiguous(hashName));
+    return this;
+  }
+
+  @FunctionalInterface
+  private interface HashValidation {
+
+    static HashValidation refMustBeBranch(String refName) {
+      return (namedRef, parsed) ->
+          checkArgument(namedRef instanceof BranchName, "%s must be a branch.", refName);
+    }
+
+    static HashValidation refMustBeBranchOrTag(String refName) {
+      return (namedRef, parsed) ->
+          checkArgument(
+              namedRef instanceof BranchName || namedRef instanceof TagName,
+              "%s must be a branch or a tag.",
+              refName);
+    }
+
+    static HashValidation hashMustBePresent(String hashName) {
+      return (namedRef, parsed) -> checkArgument(parsed != null, "%s must be provided.", hashName);
+    }
+
+    static HashValidation hashMustNotBeAmbiguous(String hashName) {
+      return (namedRef, parsed) ->
           checkArgument(
               parsed == null || parsed.getAbsolutePart().isPresent(),
-              String.format("%s must contain a starting commit ID.", name));
+              "%s must contain a starting commit ID.",
+              hashName);
+    }
 
-  /**
-   * Validates that a hash has been provided, and that it is unambiguous (that is, it starts with an
-   * absolute part).
-   */
-  HashValidator REQUIRED_UNAMBIGUOUS_HASH = REQUIRED_HASH.and(UNAMBIGUOUS_HASH);
+    /**
+     * Validates the provided ref and hash.
+     *
+     * @param namedRef the namedRef, required.
+     * @param parsed the parsed hash, or {@code null} if no hash was provided
+     */
+    void validate(NamedRef namedRef, @Nullable @jakarta.annotation.Nullable ParsedHash parsed);
 
-  /**
-   * Validates the provided hash.
-   *
-   * @param name the name of the hash parameter, for error messages
-   * @param parsed the parsed hash, or {@code null} if no hash was provided
-   */
-  void validate(String name, @Nullable @jakarta.annotation.Nullable ParsedHash parsed);
-
-  /**
-   * Returns a new {@link HashValidator} that validates against both {@code this} and {@code other}.
-   */
-  default HashValidator and(HashValidator other) {
-    return (name, parsed) -> {
-      validate(name, parsed);
-      other.validate(name, parsed);
-    };
+    /**
+     * Returns a new {@link HashValidator} that validates against both {@code this} and {@code
+     * other}.
+     */
+    default HashValidation and(HashValidation other) {
+      return (namedRef, parsed) -> {
+        validate(namedRef, parsed);
+        other.validate(namedRef, parsed);
+      };
+    }
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/hash/HashValidator.java
+++ b/servers/services/src/main/java/org/projectnessie/services/hash/HashValidator.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import javax.annotation.Nullable;
 import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.DetachedRef;
 import org.projectnessie.versioned.NamedRef;
 import org.projectnessie.versioned.TagName;
 
@@ -32,8 +33,7 @@ public final class HashValidator {
 
   private boolean refMustBeBranch;
   private boolean refMustBeBranchOrTag;
-  private boolean hashMustBePresent;
-  private boolean hashMustNotBeAmbiguous;
+  private boolean hashMustBeUnambiguous;
 
   public HashValidator() {
     this("Hash");
@@ -65,12 +65,10 @@ public final class HashValidator {
           "%s must be a branch or a tag.",
           refDescription);
     }
-    if (hashMustBePresent) {
+    if (hashMustBeUnambiguous || namedRef == DetachedRef.INSTANCE) {
       checkArgument(parsed != null, "%s must be provided.", hashDescription);
-    }
-    if (hashMustNotBeAmbiguous) {
       checkArgument(
-          parsed == null || parsed.getAbsolutePart().isPresent(),
+          parsed.getAbsolutePart().isPresent(),
           "%s must contain a starting commit ID.",
           hashDescription);
     }
@@ -90,21 +88,14 @@ public final class HashValidator {
     return this;
   }
 
-  /** Validates that a hash has been provided (absolute or relative). */
-  @CanIgnoreReturnValue
-  public HashValidator hashMustBePresent() {
-    hashMustBePresent = true;
-    return this;
-  }
-
   /**
-   * Validates that, if a hash was provided, it is unambiguous. A hash is unambiguous if it starts
-   * with an absolute part, because it will always resolve to the same hash, even if it also has
-   * relative parts.
+   * Validates that a hash is unambiguous. A hash is unambiguous if it is present and starts with an
+   * absolute part, because it will always resolve to the same hash, even if it also has relative
+   * parts.
    */
   @CanIgnoreReturnValue
-  public HashValidator hashMustNotBeAmbiguous() {
-    hashMustNotBeAmbiguous = true;
+  public HashValidator hashMustBeUnambiguous() {
+    hashMustBeUnambiguous = true;
     return this;
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/hash/ResolvedHash.java
+++ b/servers/services/src/main/java/org/projectnessie/services/hash/ResolvedHash.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.services.hash;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.util.Optional;
 import org.immutables.value.Value;
 import org.projectnessie.versioned.DetachedRef;
@@ -37,28 +35,12 @@ public interface ResolvedHash extends WithHash<NamedRef> {
   NamedRef getNamedRef();
 
   /**
-   * The user-provided hash. Only present if a hash was actually provided and successfully parsed;
-   * will be empty if the hash was implicitly resolved to the ref's HEAD.
-   *
-   * <p>If this is empty, then {@link #getHead()} is guaranteed to be non-empty.
-   *
-   * <p>If the provided hash had relative specs, this hash will be the result of resolving those
-   * specs against its absolute part, or the ref's HEAD if it doesn't have an absolute part.
-   */
-  Optional<Hash> getProvidedHash();
-
-  /**
    * The ref's HEAD, if available. Will always be empty for {@link DetachedRef}. Exposed mostly to
    * avoid re-fetching the HEAD many times.
-   *
-   * <p>If this is empty, then {@link #getProvidedHash()} is guaranteed to be non-empty.
    */
   Optional<Hash> getHead();
 
-  /**
-   * The effective resolved hash, never {@code null}. Will either be {@link #getProvidedHash()} if
-   * present, or {@link #getHead()} otherwise.
-   */
+  /** The effective resolved hash, never {@code null}. */
   @Override
   Hash getHash();
 
@@ -68,16 +50,7 @@ public interface ResolvedHash extends WithHash<NamedRef> {
     return getNamedRef();
   }
 
-  static ResolvedHash of(NamedRef ref, Optional<Hash> providedHash, Optional<Hash> head) {
-    checkState(
-        providedHash.isPresent() || head.isPresent(),
-        "Either providedHash or head must be present");
-    Hash effective = providedHash.orElseGet(head::get);
-    return ImmutableResolvedHash.builder()
-        .namedRef(ref)
-        .providedHash(providedHash)
-        .head(head)
-        .hash(effective)
-        .build();
+  static ResolvedHash of(NamedRef ref, Optional<Hash> head, Hash resolved) {
+    return ImmutableResolvedHash.builder().namedRef(ref).head(head).hash(resolved).build();
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.services.impl;
 
-import static org.projectnessie.services.hash.HashValidator.ANY_HASH;
-
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +34,7 @@ import org.projectnessie.model.Tag;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.BatchAccessChecker;
 import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.services.hash.HashValidator;
 import org.projectnessie.services.hash.ResolvedHash;
 import org.projectnessie.services.spi.ContentService;
 import org.projectnessie.versioned.BranchName;
@@ -62,7 +61,7 @@ public class ContentApiImpl extends BaseApiImpl implements ContentService {
       ContentKey key, String namedRef, String hashOnRef, boolean withDocumentation)
       throws NessieNotFoundException {
     ResolvedHash ref =
-        getHashResolver().resolveHashOnRef(namedRef, hashOnRef, "Expected hash", ANY_HASH);
+        getHashResolver().resolveHashOnRef(namedRef, hashOnRef, new HashValidator("Expected hash"));
     try {
       ContentResult obj = getStore().getValue(ref.getHash(), key);
       BatchAccessChecker accessCheck = startAccessCheck();
@@ -83,7 +82,8 @@ public class ContentApiImpl extends BaseApiImpl implements ContentService {
       throws NessieNotFoundException {
     try {
       ResolvedHash ref =
-          getHashResolver().resolveHashOnRef(namedRef, hashOnRef, "Expected hash", ANY_HASH);
+          getHashResolver()
+              .resolveHashOnRef(namedRef, hashOnRef, new HashValidator("Expected hash"));
 
       BatchAccessChecker check = startAccessCheck().canViewReference(ref.getValue());
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
@@ -60,9 +60,10 @@ public class ContentApiImpl extends BaseApiImpl implements ContentService {
   public ContentResponse getContent(
       ContentKey key, String namedRef, String hashOnRef, boolean withDocumentation)
       throws NessieNotFoundException {
-    ResolvedHash ref =
-        getHashResolver().resolveHashOnRef(namedRef, hashOnRef, new HashValidator("Expected hash"));
     try {
+      ResolvedHash ref =
+          getHashResolver()
+              .resolveHashOnRef(namedRef, hashOnRef, new HashValidator("Expected hash"));
       ContentResult obj = getStore().getValue(ref.getHash(), key);
       BatchAccessChecker accessCheck = startAccessCheck();
       if (obj != null) {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -75,18 +75,22 @@ public class DiffApiImpl extends BaseApiImpl implements DiffService {
       List<ContentKey> requestedKeys,
       String filter)
       throws NessieNotFoundException {
-    ResolvedHash from =
-        getHashResolver().resolveHashOnRef(fromRef, fromHash, new HashValidator("From hash"));
-    ResolvedHash to =
-        getHashResolver().resolveHashOnRef(toRef, toHash, new HashValidator("To hash"));
-    NamedRef fromNamedRef = from.getNamedRef();
-    NamedRef toNamedRef = to.getNamedRef();
-    fromReference.accept(from);
-    toReference.accept(to);
-
-    startAccessCheck().canViewReference(fromNamedRef).canViewReference(toNamedRef).checkAndThrow();
 
     try {
+      ResolvedHash from =
+          getHashResolver().resolveHashOnRef(fromRef, fromHash, new HashValidator("From hash"));
+      ResolvedHash to =
+          getHashResolver().resolveHashOnRef(toRef, toHash, new HashValidator("To hash"));
+      NamedRef fromNamedRef = from.getNamedRef();
+      NamedRef toNamedRef = to.getNamedRef();
+      fromReference.accept(from);
+      toReference.accept(to);
+
+      startAccessCheck()
+          .canViewReference(fromNamedRef)
+          .canViewReference(toNamedRef)
+          .checkAndThrow();
+
       Predicate<ContentKey> contentKeyPredicate = null;
       if (requestedKeys != null && !requestedKeys.isEmpty()) {
         contentKeyPredicate = new HashSet<>(requestedKeys)::contains;

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -78,9 +78,9 @@ public class DiffApiImpl extends BaseApiImpl implements DiffService {
 
     try {
       ResolvedHash from =
-          getHashResolver().resolveHashOnRef(fromRef, fromHash, new HashValidator("From hash"));
+          getHashResolver().resolveHashOnRef(fromRef, fromHash, new HashValidator("\"From\" hash"));
       ResolvedHash to =
-          getHashResolver().resolveHashOnRef(toRef, toHash, new HashValidator("To hash"));
+          getHashResolver().resolveHashOnRef(toRef, toHash, new HashValidator("\"To\" hash"));
       NamedRef fromNamedRef = from.getNamedRef();
       NamedRef toNamedRef = to.getNamedRef();
       fromReference.accept(from);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -18,7 +18,6 @@ package org.projectnessie.services.impl;
 import static java.util.Collections.singleton;
 import static org.projectnessie.services.authz.Check.canReadContentKey;
 import static org.projectnessie.services.authz.Check.canViewReference;
-import static org.projectnessie.services.hash.HashValidator.ANY_HASH;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -38,6 +37,7 @@ import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.AuthzPaginationIterator;
 import org.projectnessie.services.authz.Check;
 import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.services.hash.HashValidator;
 import org.projectnessie.services.hash.ResolvedHash;
 import org.projectnessie.services.spi.DiffService;
 import org.projectnessie.services.spi.PagedResponseHandler;
@@ -76,8 +76,9 @@ public class DiffApiImpl extends BaseApiImpl implements DiffService {
       String filter)
       throws NessieNotFoundException {
     ResolvedHash from =
-        getHashResolver().resolveHashOnRef(fromRef, fromHash, "From hash", ANY_HASH);
-    ResolvedHash to = getHashResolver().resolveHashOnRef(toRef, toHash, "To hash", ANY_HASH);
+        getHashResolver().resolveHashOnRef(fromRef, fromHash, new HashValidator("From hash"));
+    ResolvedHash to =
+        getHashResolver().resolveHashOnRef(toRef, toHash, new HashValidator("To hash"));
     NamedRef fromNamedRef = from.getNamedRef();
     NamedRef toNamedRef = to.getNamedRef();
     fromReference.accept(from);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -19,7 +19,6 @@ import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
 import static org.projectnessie.error.ContentKeyErrorDetails.contentKeyErrorDetails;
 import static org.projectnessie.model.Validation.validateHash;
-import static org.projectnessie.services.hash.HashValidator.ANY_HASH;
 import static org.projectnessie.services.impl.RefUtil.toReference;
 import static org.projectnessie.versioned.VersionStore.KeyRestrictions.NO_KEY_RESTRICTIONS;
 
@@ -163,8 +162,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
       if (hashOnRef != null) {
         validateHash(hashOnRef);
       }
-      ResolvedHash resolved =
-          getHashResolver().resolveHashOnRef(refName, hashOnRef, "Hash", ANY_HASH);
+      ResolvedHash resolved = getHashResolver().resolveHashOnRef(refName, hashOnRef);
       return getNamespace(namespace, resolved.getHash());
     } catch (ReferenceNotFoundException e) {
       throw refNotFoundException(e);
@@ -203,8 +201,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
     if (hashOnRef != null) {
       validateHash(hashOnRef);
     }
-    ResolvedHash refWithHash =
-        getHashResolver().resolveHashOnRef(refName, hashOnRef, "Hash", ANY_HASH);
+    ResolvedHash refWithHash = getHashResolver().resolveHashOnRef(refName, hashOnRef);
     try {
       // Note: `Namespace` objects are supposed to get more attributes (e.g. a properties map)
       // which will make it impossible to use the `Namespace` object itself as an identifier to

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -81,8 +81,8 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
       throws NessieReferenceNotFoundException {
     Preconditions.checkArgument(!namespace.isEmpty(), "Namespace name must not be empty");
 
-    ResolvedHash refWithHash = getHashResolver().resolveToHead(refName);
     try {
+      ResolvedHash refWithHash = getHashResolver().resolveToHead(refName);
 
       try {
         Optional<Content> explicitlyCreatedNamespace =
@@ -127,8 +127,8 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
   @Override
   public void deleteNamespace(String refName, Namespace namespaceToDelete)
       throws NessieReferenceNotFoundException, NessieNamespaceNotFoundException {
-    ResolvedHash refWithHash = getHashResolver().resolveToHead(refName);
     try {
+      ResolvedHash refWithHash = getHashResolver().resolveToHead(refName);
       Namespace namespace = getNamespace(namespaceToDelete, refWithHash.getHash());
       Delete delete = Delete.of(namespace.toContentKey());
 
@@ -201,8 +201,8 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
     if (hashOnRef != null) {
       validateHash(hashOnRef);
     }
-    ResolvedHash refWithHash = getHashResolver().resolveHashOnRef(refName, hashOnRef);
     try {
+      ResolvedHash refWithHash = getHashResolver().resolveHashOnRef(refName, hashOnRef);
       // Note: `Namespace` objects are supposed to get more attributes (e.g. a properties map)
       // which will make it impossible to use the `Namespace` object itself as an identifier to
       // subtract the set of explicitly created namespaces from the set of implicitly created ones.

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -332,7 +332,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
           .canAssignRefToHash(oldRef.getNamedRef())
           .checkAndThrow();
 
-      getStore().assign(oldRef.getNamedRef(), Optional.of(oldRef.getHash()), newRef.getHash());
+      getStore().assign(oldRef.getNamedRef(), oldRef.getHash(), newRef.getHash());
       return RefUtil.toReference(oldRef.getNamedRef(), newRef.getHash());
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);
@@ -371,7 +371,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
                   expectedHash,
                   new HashValidator("Expected hash").hashMustBeUnambiguous());
 
-      Hash deletedAthash = getStore().delete(ref, Optional.of(refToDelete.getHash())).getHash();
+      Hash deletedAthash = getStore().delete(ref, refToDelete.getHash()).getHash();
       return RefUtil.toReference(ref, deletedAthash);
     } catch (ReferenceNotFoundException e) {
       throw new NessieReferenceNotFoundException(e.getMessage(), e);

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -311,7 +311,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
               .resolveHashOnRef(
                   referenceName,
                   expectedHash,
-                  new HashValidator("Reference to assign from", "Expected hash")
+                  new HashValidator("Assignment target", "Expected hash")
                       .refMustBeBranchOrTag()
                       .hashMustBePresent()
                       .hashMustNotBeAmbiguous());

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -267,7 +267,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
               .resolveHashOnRef(
                   sourceRefName,
                   targetHash,
-                  new HashValidator("Target hash").hashMustBePresent().hashMustNotBeAmbiguous());
+                  new HashValidator("Target hash").hashMustBeUnambiguous());
       check.canViewReference(targetRef.getNamedRef());
       targetHashObj = Optional.of(targetRef.getHash());
     } catch (ReferenceNotFoundException e) {
@@ -313,14 +313,13 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
                   expectedHash,
                   new HashValidator("Assignment target", "Expected hash")
                       .refMustBeBranchOrTag()
-                      .hashMustBePresent()
-                      .hashMustNotBeAmbiguous());
+                      .hashMustBeUnambiguous());
       ResolvedHash newRef =
           getHashResolver()
               .resolveHashOnRef(
                   assignTo.getName(),
                   assignTo.getHash(),
-                  new HashValidator("Target hash").hashMustBePresent().hashMustNotBeAmbiguous());
+                  new HashValidator("Target hash").hashMustBeUnambiguous());
 
       checkArgument(
           referenceType == null || referenceType == RefUtil.referenceType(oldRef.getNamedRef()),
@@ -370,7 +369,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
                   resolved.getNamedRef(),
                   resolved.getHash(),
                   expectedHash,
-                  new HashValidator("Expected hash").hashMustBePresent().hashMustNotBeAmbiguous());
+                  new HashValidator("Expected hash").hashMustBeUnambiguous());
 
       Hash deletedAthash = getStore().delete(ref, Optional.of(refToDelete.getHash())).getHash();
       return RefUtil.toReference(ref, deletedAthash);
@@ -622,9 +621,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
               .resolveHashOnRef(
                   fromRefName,
                   lastHash,
-                  new HashValidator("Hash to transplant")
-                      .hashMustBePresent()
-                      .hashMustNotBeAmbiguous());
+                  new HashValidator("Hash to transplant").hashMustBeUnambiguous());
 
       ResolvedHash toRef =
           getHashResolver()
@@ -633,8 +630,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
                   expectedHash,
                   new HashValidator("Reference to transplant into", "Expected hash")
                       .refMustBeBranch()
-                      .hashMustBePresent()
-                      .hashMustNotBeAmbiguous());
+                      .hashMustBeUnambiguous());
 
       startAccessCheck()
           .canViewReference(fromRef.getNamedRef())
@@ -646,11 +642,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
         transplants.add(
             getHashResolver()
                 .resolveHashOnRef(
-                    fromRef,
-                    hash,
-                    new HashValidator("Hash to transplant")
-                        .hashMustBePresent()
-                        .hashMustNotBeAmbiguous())
+                    fromRef, hash, new HashValidator("Hash to transplant").hashMustBeUnambiguous())
                 .getHash());
       }
 
@@ -719,9 +711,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
       ResolvedHash fromRef =
           getHashResolver()
               .resolveHashOnRef(
-                  fromRefName,
-                  fromHash,
-                  new HashValidator("Source hash").hashMustBePresent().hashMustNotBeAmbiguous());
+                  fromRefName, fromHash, new HashValidator("Source hash").hashMustBeUnambiguous());
       ResolvedHash toRef =
           getHashResolver()
               .resolveHashOnRef(
@@ -729,8 +719,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
                   expectedHash,
                   new HashValidator("Reference to merge into", "Expected hash")
                       .refMustBeBranch()
-                      .hashMustBePresent()
-                      .hashMustNotBeAmbiguous());
+                      .hashMustBeUnambiguous());
 
       checkArgument(toRef.getNamedRef() instanceof BranchName, "Can only merge into branches.");
 
@@ -1058,8 +1047,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
                   expectedHash,
                   new HashValidator("Reference to commit into", "Expected hash")
                       .refMustBeBranch()
-                      .hashMustBePresent()
-                      .hashMustNotBeAmbiguous());
+                      .hashMustBeUnambiguous());
 
       Hash newHash =
           getStore()

--- a/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
+++ b/servers/services/src/main/java/org/projectnessie/services/spi/TreeService.java
@@ -198,8 +198,6 @@ public interface TreeService {
           String branchName,
       @Valid
           @jakarta.validation.Valid
-          @NotNull
-          @jakarta.validation.constraints.NotNull
           @Pattern(
               regexp = HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
               message = HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
@@ -247,8 +245,6 @@ public interface TreeService {
           String branchName,
       @Valid
           @jakarta.validation.Valid
-          @NotNull
-          @jakarta.validation.constraints.NotNull
           @Pattern(
               regexp = HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
               message = HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
@@ -267,8 +263,6 @@ public interface TreeService {
           String fromRefName,
       @Valid
           @jakarta.validation.Valid
-          @NotBlank
-          @jakarta.validation.constraints.NotBlank
           @Pattern(
               regexp = HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
               message = HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)
@@ -329,8 +323,6 @@ public interface TreeService {
           String branch,
       @Valid
           @jakarta.validation.Valid
-          @NotNull
-          @jakarta.validation.constraints.NotNull
           @Pattern(
               regexp = HASH_OR_RELATIVE_COMMIT_SPEC_REGEX,
               message = HASH_OR_RELATIVE_COMMIT_SPEC_MESSAGE)

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestAssign.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestAssign.java
@@ -44,9 +44,18 @@ public abstract class AbstractTestAssign extends BaseTestServiceImpl {
     String testTag = "testTag";
     Reference testTagRef = createTag(testTag, main);
     soft.assertThat(testTagRef.getHash()).isNotNull();
-    treeApi().assignReference(TAG, testTag, testTagRef.getHash(), refMode.transform(main));
-    testTagRef = getReference(testTag);
-    soft.assertThat(testTagRef.getHash()).isEqualTo(main.getHash());
+    Reference transformed = refMode.transform(main);
+    String expectedHash = testTagRef.getHash();
+    if (refMode == ReferenceMode.NAME_ONLY) {
+      soft.assertThatThrownBy(
+              () -> treeApi().assignReference(TAG, testTag, expectedHash, transformed))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Target hash must be provided");
+    } else {
+      treeApi().assignReference(TAG, testTag, expectedHash, transformed);
+      testTagRef = getReference(testTag);
+      soft.assertThat(testTagRef.getHash()).isEqualTo(main.getHash());
+    }
   }
 
   @ParameterizedTest
@@ -62,15 +71,23 @@ public abstract class AbstractTestAssign extends BaseTestServiceImpl {
     soft.assertThat(branch.getHash()).isNotEqualTo(main.getHash());
 
     // Assign the test branch to main
-    Branch assignedBranch =
-        (Branch)
-            treeApi()
-                .assignReference(
-                    BRANCH, branch.getName(), branch.getHash(), refMode.transform(main));
-    soft.assertThat(assignedBranch.getHash()).isEqualTo(main.getHash());
+    Reference transformed = refMode.transform(main);
+    if (refMode == ReferenceMode.NAME_ONLY) {
+      soft.assertThatThrownBy(
+              () ->
+                  treeApi()
+                      .assignReference(BRANCH, branch.getName(), branch.getHash(), transformed))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Target hash must be provided");
+    } else {
+      Branch assignedBranch =
+          (Branch)
+              treeApi().assignReference(BRANCH, branch.getName(), branch.getHash(), transformed);
+      soft.assertThat(assignedBranch.getHash()).isEqualTo(main.getHash());
 
-    Reference currentBranch = getReference(branch.getName());
-    soft.assertThat(assignedBranch).isEqualTo(currentBranch);
+      Reference currentBranch = getReference(branch.getName());
+      soft.assertThat(assignedBranch).isEqualTo(currentBranch);
+    }
   }
 
   @ParameterizedTest
@@ -86,11 +103,19 @@ public abstract class AbstractTestAssign extends BaseTestServiceImpl {
     soft.assertThat(tag.getHash()).isNotEqualTo(main.getHash());
 
     // Assign the test tag to main
-    Tag assignedTag =
-        (Tag) treeApi().assignReference(TAG, tag.getName(), tag.getHash(), refMode.transform(main));
-    soft.assertThat(assignedTag.getHash()).isEqualTo(main.getHash());
+    Reference transformed = refMode.transform(main);
+    if (refMode == ReferenceMode.NAME_ONLY) {
+      soft.assertThatThrownBy(
+              () -> treeApi().assignReference(TAG, tag.getName(), tag.getHash(), transformed))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Target hash must be provided");
+    } else {
+      Tag assignedTag =
+          (Tag) treeApi().assignReference(TAG, tag.getName(), tag.getHash(), transformed);
+      soft.assertThat(assignedTag.getHash()).isEqualTo(main.getHash());
 
-    Reference currentTag = getReference(tag.getName());
-    soft.assertThat(assignedTag).isEqualTo(currentTag);
+      Reference currentTag = getReference(tag.getName());
+      soft.assertThat(assignedTag).isEqualTo(currentTag);
+    }
   }
 }

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestReferences.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestReferences.java
@@ -172,18 +172,20 @@ public abstract class AbstractTestReferences extends BaseTestServiceImpl {
     // Tag without sourceRefName & null hash
     soft.assertThatThrownBy(() -> treeApi().createReference(tagName1, TAG, null, null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Tag-creation requires a target named-reference and hash.");
+        .hasMessageContaining("Target hash must be provided.");
     // Tag without hash
     soft.assertThatThrownBy(() -> treeApi().createReference(tagName1, TAG, null, main.getName()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Tag-creation requires a target named-reference and hash.");
+        .hasMessageContaining("Target hash must be provided.");
     // legit Tag with name + hash
     Tag refTag1 = createTag(tagName2, main);
     soft.assertThat(refTag1).isEqualTo(Tag.of(tagName2, main.getHash()));
 
     // Branch without hash
-    Reference refBranch1 = treeApi().createReference(branchName1, BRANCH, null, main.getName());
-    soft.assertThat(refBranch1).isEqualTo(Branch.of(branchName1, main.getHash()));
+    soft.assertThatThrownBy(
+            () -> treeApi().createReference(branchName1, BRANCH, null, main.getName()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Target hash must be provided");
     // Branch with name + hash
     Reference refBranch2 =
         treeApi().createReference(branchName2, BRANCH, main.getHash(), main.getName());

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -383,9 +383,9 @@ public class PersistVersionStore implements VersionStore {
   }
 
   @Override
-  public ReferenceAssignedResult assign(NamedRef ref, Optional<Hash> expectedHash, Hash targetHash)
+  public ReferenceAssignedResult assign(NamedRef ref, Hash expectedHash, Hash targetHash)
       throws ReferenceNotFoundException, ReferenceConflictException {
-    return databaseAdapter.assign(ref, expectedHash, targetHash);
+    return databaseAdapter.assign(ref, Optional.of(expectedHash), targetHash);
   }
 
   @Override
@@ -395,9 +395,9 @@ public class PersistVersionStore implements VersionStore {
   }
 
   @Override
-  public ReferenceDeletedResult delete(NamedRef ref, Optional<Hash> hash)
+  public ReferenceDeletedResult delete(NamedRef ref, Hash hash)
       throws ReferenceNotFoundException, ReferenceConflictException {
-    return databaseAdapter.delete(ref, hash);
+    return databaseAdapter.delete(ref, Optional.of(hash));
   }
 
   @Nonnull

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
@@ -86,7 +86,7 @@ public class EventsVersionStore implements VersionStore {
   }
 
   @Override
-  public ReferenceAssignedResult assign(NamedRef ref, Optional<Hash> expectedHash, Hash targetHash)
+  public ReferenceAssignedResult assign(NamedRef ref, Hash expectedHash, Hash targetHash)
       throws ReferenceNotFoundException, ReferenceConflictException {
     ReferenceAssignedResult result = delegate.assign(ref, expectedHash, targetHash);
     resultSink.accept(result);
@@ -103,7 +103,7 @@ public class EventsVersionStore implements VersionStore {
   }
 
   @Override
-  public ReferenceDeletedResult delete(NamedRef ref, Optional<Hash> hash)
+  public ReferenceDeletedResult delete(NamedRef ref, Hash hash)
       throws ReferenceNotFoundException, ReferenceConflictException {
     ReferenceDeletedResult result = delegate.delete(ref, hash);
     resultSink.accept(result);

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -244,8 +244,7 @@ public interface VersionStore {
    * not match.
    *
    * @param ref The named ref to be assigned
-   * @param expectedHash The current head of the NamedRef to validate before updating. If not
-   *     present, force assignment.
+   * @param expectedHash The current head of the NamedRef to validate before updating (required).
    * @param targetHash The hash that this ref should refer to.
    * @return A {@link ReferenceAssignedResult} containing the previous and current head of the
    *     reference
@@ -254,7 +253,7 @@ public interface VersionStore {
    * @throws ReferenceConflictException if {@code expectedHash} is not empty and its value doesn't
    *     match the stored hash for {@code ref}
    */
-  ReferenceAssignedResult assign(NamedRef ref, Optional<Hash> expectedHash, Hash targetHash)
+  ReferenceAssignedResult assign(NamedRef ref, Hash expectedHash, Hash targetHash)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**
@@ -278,14 +277,14 @@ public interface VersionStore {
    * <p>Throws exception if the optional hash does not match the provided ref.
    *
    * @param ref The NamedRef to be deleted.
-   * @param hash An optional hash. If provided, this operation will only succeed if the branch is
-   *     pointing at the provided
+   * @param hash The expected hash (required). The operation will only succeed if the branch is
+   *     pointing at the provided hash.
    * @return A {@link ReferenceDeletedResult} containing the head of the deleted reference
    * @throws ReferenceNotFoundException if {@code ref} is not present in the store
    * @throws ReferenceConflictException if {@code hash} doesn't match the stored hash for {@code
    *     ref}
    */
-  ReferenceDeletedResult delete(NamedRef ref, Optional<Hash> hash)
+  ReferenceDeletedResult delete(NamedRef ref, Hash hash)
       throws ReferenceNotFoundException, ReferenceConflictException;
 
   /**

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestEventsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestEventsVersionStore.java
@@ -407,11 +407,11 @@ class TestEventsVersionStore {
             .previousHash(hash1)
             .currentHash(hash2)
             .build();
-    when(delegate.assign(branch1, Optional.of(hash1), hash2)).thenReturn(expectedResult);
+    when(delegate.assign(branch1, hash1, hash2)).thenReturn(expectedResult);
     EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);
-    ReferenceAssignedResult actualResult = versionStore.assign(branch1, Optional.of(hash1), hash2);
+    ReferenceAssignedResult actualResult = versionStore.assign(branch1, hash1, hash2);
     assertThat(actualResult).isEqualTo(expectedResult);
-    verify(delegate).assign(branch1, Optional.of(hash1), hash2);
+    verify(delegate).assign(branch1, hash1, hash2);
     verify(sink).accept(expectedResult);
     verifyNoMoreInteractions(delegate, sink);
   }
@@ -419,15 +419,14 @@ class TestEventsVersionStore {
   @ParameterizedTest
   @ValueSource(classes = {ReferenceNotFoundException.class, ReferenceConflictException.class})
   void testAssignFailure(Class<? extends VersionStoreException> e) throws Exception {
-    when(delegate.assign(branch1, Optional.of(hash1), hash2))
+    when(delegate.assign(branch1, hash1, hash2))
         .thenAnswer(
             invocation -> {
               throw e.getConstructor(String.class).newInstance("irrelevant");
             });
     EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);
-    assertThatThrownBy(() -> versionStore.assign(branch1, Optional.of(hash1), hash2))
-        .isInstanceOf(e);
-    verify(delegate).assign(branch1, Optional.of(hash1), hash2);
+    assertThatThrownBy(() -> versionStore.assign(branch1, hash1, hash2)).isInstanceOf(e);
+    verify(delegate).assign(branch1, hash1, hash2);
     verifyNoMoreInteractions(delegate, sink);
   }
 
@@ -462,11 +461,11 @@ class TestEventsVersionStore {
   void testDeleteSuccess() throws Exception {
     ReferenceDeletedResult expectedResult =
         ImmutableReferenceDeletedResult.builder().namedRef(branch1).hash(hash2).build();
-    when(delegate.delete(branch1, Optional.of(hash1))).thenReturn(expectedResult);
+    when(delegate.delete(branch1, hash1)).thenReturn(expectedResult);
     EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);
-    ReferenceDeletedResult actualResult = versionStore.delete(branch1, Optional.of(hash1));
+    ReferenceDeletedResult actualResult = versionStore.delete(branch1, hash1);
     assertThat(actualResult).isEqualTo(expectedResult);
-    verify(delegate).delete(branch1, Optional.of(hash1));
+    verify(delegate).delete(branch1, hash1);
     verify(sink).accept(expectedResult);
     verifyNoMoreInteractions(delegate, sink);
   }
@@ -474,14 +473,14 @@ class TestEventsVersionStore {
   @ParameterizedTest
   @ValueSource(classes = {ReferenceNotFoundException.class, ReferenceConflictException.class})
   void testDeleteFailure(Class<? extends VersionStoreException> e) throws Exception {
-    when(delegate.delete(branch1, Optional.of(hash1)))
+    when(delegate.delete(branch1, hash1))
         .thenAnswer(
             invocation -> {
               throw e.getConstructor(String.class).newInstance("irrelevant");
             });
     EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);
-    assertThatThrownBy(() -> versionStore.delete(branch1, Optional.of(hash1))).isInstanceOf(e);
-    verify(delegate).delete(branch1, Optional.of(hash1));
+    assertThatThrownBy(() -> versionStore.delete(branch1, hash1)).isInstanceOf(e);
+    verify(delegate).delete(branch1, hash1);
     verifyNoMoreInteractions(delegate, sink);
   }
 

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RefMapping.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RefMapping.java
@@ -184,11 +184,10 @@ public class RefMapping {
   }
 
   public static void verifyExpectedHash(
-      Hash referenceCurrentHead, NamedRef reference, Optional<Hash> expectedHead)
+      Hash referenceCurrentHead, NamedRef reference, Hash expectedHead)
       throws ReferenceConflictException {
-    if (expectedHead.isPresent() && !referenceCurrentHead.equals(expectedHead.get())) {
-      throw referenceConflictException(
-          reference, expectedHead.get(), hashToObjId(referenceCurrentHead));
+    if (!referenceCurrentHead.equals(expectedHead)) {
+      throw referenceConflictException(reference, expectedHead, hashToObjId(referenceCurrentHead));
     }
   }
 

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestRefMapping.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestRefMapping.java
@@ -315,17 +315,12 @@ public class TestRefMapping {
     soft.assertThatCode(
             () ->
                 RefMapping.verifyExpectedHash(
-                    Hash.of("1234"), BranchName.of("foo-branch"), Optional.of(Hash.of("1234"))))
-        .doesNotThrowAnyException();
-    soft.assertThatCode(
-            () ->
-                RefMapping.verifyExpectedHash(
-                    Hash.of("1234"), BranchName.of("foo-branch"), Optional.empty()))
+                    Hash.of("1234"), BranchName.of("foo-branch"), Hash.of("1234")))
         .doesNotThrowAnyException();
     soft.assertThatThrownBy(
             () ->
                 RefMapping.verifyExpectedHash(
-                    Hash.of("1234"), BranchName.of("foo-branch"), Optional.of(Hash.of("5678"))))
+                    Hash.of("1234"), BranchName.of("foo-branch"), Hash.of("5678")))
         .isInstanceOf(ReferenceConflictException.class)
         .hasMessage("Named-reference 'foo-branch' is not at expected hash '5678', but at '1234'.");
   }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractAssign.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractAssign.java
@@ -61,33 +61,27 @@ public abstract class AbstractAssign extends AbstractNestedVersionStore {
 
     final Hash anotherCommit = commit("Another commit").toBranch(branch);
     ReferenceAssignedResult referenceAssignedResult =
-        store().assign(TagName.of("tag2"), Optional.of(commit), anotherCommit);
+        store().assign(TagName.of("tag2"), commit, anotherCommit);
     soft.assertThat(referenceAssignedResult.getPreviousHash()).isEqualTo(commit);
     soft.assertThat(referenceAssignedResult.getCurrentHash()).isEqualTo(anotherCommit);
     soft.assertThat(referenceAssignedResult.getNamedRef()).isEqualTo(TagName.of("tag2"));
 
-    referenceAssignedResult = store().assign(TagName.of("tag3"), Optional.empty(), anotherCommit);
+    referenceAssignedResult = store().assign(TagName.of("tag3"), commit, anotherCommit);
     soft.assertThat(referenceAssignedResult.getPreviousHash()).isEqualTo(commit);
     soft.assertThat(referenceAssignedResult.getCurrentHash()).isEqualTo(anotherCommit);
     soft.assertThat(referenceAssignedResult.getNamedRef()).isEqualTo(TagName.of("tag3"));
 
-    soft.assertThatThrownBy(
-            () -> store().assign(BranchName.of("baz"), Optional.empty(), anotherCommit))
+    soft.assertThatThrownBy(() -> store().assign(BranchName.of("baz"), commit, anotherCommit))
         .isInstanceOf(ReferenceNotFoundException.class);
-    soft.assertThatThrownBy(
-            () -> store().assign(TagName.of("unknowon-tag"), Optional.empty(), anotherCommit))
+    soft.assertThatThrownBy(() -> store().assign(TagName.of("unknowon-tag"), commit, anotherCommit))
         .isInstanceOf(ReferenceNotFoundException.class);
 
-    soft.assertThatThrownBy(
-            () -> store().assign(TagName.of("tag1"), Optional.of(initialHash), commit))
+    soft.assertThatThrownBy(() -> store().assign(TagName.of("tag1"), initialHash, commit))
+        .isInstanceOf(ReferenceConflictException.class);
+    soft.assertThatThrownBy(() -> store().assign(TagName.of("tag1"), initialHash, anotherCommit))
         .isInstanceOf(ReferenceConflictException.class);
     soft.assertThatThrownBy(
-            () -> store().assign(TagName.of("tag1"), Optional.of(initialHash), anotherCommit))
-        .isInstanceOf(ReferenceConflictException.class);
-    soft.assertThatThrownBy(
-            () ->
-                store()
-                    .assign(TagName.of("tag1"), Optional.of(commit), Hash.of("1234567890abcdef")))
+            () -> store().assign(TagName.of("tag1"), commit, Hash.of("1234567890abcdef")))
         .isInstanceOf(ReferenceNotFoundException.class);
 
     soft.assertThat(commitsList(branch, false))
@@ -127,7 +121,7 @@ public abstract class AbstractAssign extends AbstractNestedVersionStore {
     BranchName testBranch = BranchName.of("testBranch");
     Hash testBranchHash = store.create(testBranch, Optional.empty()).getHash();
     ReferenceAssignedResult referenceAssignedResult =
-        store.assign(testBranch, Optional.of(testBranchHash), main.getHash());
+        store.assign(testBranch, testBranchHash, main.getHash());
     soft.assertThat(referenceAssignedResult.getPreviousHash()).isEqualTo(main.getHash());
     soft.assertThat(referenceAssignedResult.getCurrentHash()).isEqualTo(testBranchHash);
     soft.assertThat(referenceAssignedResult.getNamedRef()).isEqualTo(testBranch);
@@ -137,7 +131,7 @@ public abstract class AbstractAssign extends AbstractNestedVersionStore {
 
     TagName testTag = TagName.of("testTag");
     Hash testTagHash = store.create(testTag, Optional.empty()).getHash();
-    referenceAssignedResult = store.assign(testTag, Optional.of(testTagHash), main.getHash());
+    referenceAssignedResult = store.assign(testTag, testTagHash, main.getHash());
     soft.assertThat(referenceAssignedResult.getPreviousHash()).isEqualTo(main.getHash());
     soft.assertThat(referenceAssignedResult.getCurrentHash()).isEqualTo(testTagHash);
     soft.assertThat(referenceAssignedResult.getNamedRef()).isEqualTo(testTag);

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
@@ -141,17 +141,17 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
     soft.assertThat(commitsList(commitHash, false))
         .contains(commit(commitHash, "Some commit", initialHash));
 
-    soft.assertThatThrownBy(() -> store().delete(branch, Optional.of(initialHash)))
+    soft.assertThatThrownBy(() -> store().delete(branch, initialHash))
         .isInstanceOf(ReferenceConflictException.class);
 
-    store().delete(branch, Optional.of(anotherCommitHash));
+    store().delete(branch, anotherCommitHash);
     soft.assertThatThrownBy(() -> store().hashOnReference(branch, Optional.empty(), emptyList()))
         .isInstanceOf(ReferenceNotFoundException.class);
     try (PaginationIterator<ReferenceInfo<CommitMeta>> str =
         store().getNamedRefs(GetNamedRefsParams.DEFAULT, null)) {
       soft.assertThat(stream(str).filter(this::filterMainBranch)).isEmpty();
     }
-    soft.assertThatThrownBy(() -> store().delete(branch, Optional.of(commitHash)))
+    soft.assertThatThrownBy(() -> store().delete(branch, commitHash))
         .isInstanceOf(ReferenceNotFoundException.class);
   }
 

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -1190,7 +1190,7 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                 .fromRef(source)
                 .fromHash(sourceHead)
                 .toBranch(target)
-                .expectedHash(Optional.ofNullable(targetHead))
+                .expectedHash(Optional.of(targetHead))
                 .putMergeKeyBehaviors(key1, MergeKeyBehavior.of(key1, MergeBehavior.DROP))
                 .putMergeKeyBehaviors(key2, MergeKeyBehavior.of(key2, MergeBehavior.DROP))
                 .dryRun(dryRun)

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractMerge.java
@@ -1190,7 +1190,7 @@ public abstract class AbstractMerge extends AbstractNestedVersionStore {
                 .fromRef(source)
                 .fromHash(sourceHead)
                 .toBranch(target)
-                .expectedHash(Optional.of(targetHead))
+                .expectedHash(Optional.ofNullable(targetHead))
                 .putMergeKeyBehaviors(key1, MergeKeyBehavior.of(key1, MergeBehavior.DROP))
                 .putMergeKeyBehaviors(key2, MergeKeyBehavior.of(key2, MergeBehavior.DROP))
                 .dryRun(dryRun)

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
@@ -157,7 +157,7 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                 s ->
                     s.assign(
                         BranchName.of("this-one-should-not-exist"),
-                        Optional.empty(),
+                        s.noAncestorHash(),
                         s.noAncestorHash())),
         new ReferenceNotFoundFunction("assign/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
@@ -165,15 +165,17 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                 s ->
                     s.assign(
                         BranchName.of("main"),
-                        Optional.empty(),
+                        s.noAncestorHash(),
                         Hash.of("12341234123412341234123412341234123412341234"))),
         // delete()
         new ReferenceNotFoundFunction("delete/branch")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.delete(BranchName.of("this-one-should-not-exist"), Optional.empty())),
+            .function(
+                s -> s.delete(BranchName.of("this-one-should-not-exist"), s.noAncestorHash())),
         new ReferenceNotFoundFunction("delete/tag")
             .msg("Named reference 'this-one-should-not-exist' not found")
-            .function(s -> s.delete(BranchName.of("this-one-should-not-exist"), Optional.empty())),
+            .function(
+                s -> s.delete(BranchName.of("this-one-should-not-exist"), s.noAncestorHash())),
         // create()
         new ReferenceNotFoundFunction("create/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferences.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferences.java
@@ -107,7 +107,7 @@ public abstract class AbstractReferences extends AbstractNestedVersionStore {
     soft.assertThatThrownBy(() -> store().create(branch, Optional.of(hash)))
         .isInstanceOf(ReferenceAlreadyExistsException.class);
 
-    ReferenceDeletedResult referenceDeletedResult = store().delete(branch, Optional.of(hash));
+    ReferenceDeletedResult referenceDeletedResult = store().delete(branch, hash);
     soft.assertThat(referenceDeletedResult.getHash()).isEqualTo(hash);
     soft.assertThat(referenceDeletedResult.getNamedRef()).isEqualTo(branch);
 
@@ -117,7 +117,7 @@ public abstract class AbstractReferences extends AbstractNestedVersionStore {
         store().getNamedRefs(GetNamedRefsParams.DEFAULT, null)) {
       soft.assertThat(stream(str).filter(this::filterMainBranch)).hasSize(2); // bar + baz
     }
-    soft.assertThatThrownBy(() -> store().delete(branch, Optional.of(hash)))
+    soft.assertThatThrownBy(() -> store().delete(branch, hash))
         .isInstanceOf(ReferenceNotFoundException.class);
   }
 
@@ -176,7 +176,7 @@ public abstract class AbstractReferences extends AbstractNestedVersionStore {
     soft.assertThat(commitsList(anotherTag, false)).hasSize(1);
     soft.assertThat(commitsList(commitHash, false)).hasSize(1); // empty commit should not be listed
 
-    ReferenceDeletedResult referenceDeletedResult = store().delete(tag, Optional.of(initialHash));
+    ReferenceDeletedResult referenceDeletedResult = store().delete(tag, initialHash);
     soft.assertThat(referenceDeletedResult.getHash()).isEqualTo(initialHash);
     soft.assertThat(referenceDeletedResult.getNamedRef()).isEqualTo(tag);
 
@@ -186,7 +186,7 @@ public abstract class AbstractReferences extends AbstractNestedVersionStore {
         store().getNamedRefs(GetNamedRefsParams.DEFAULT, null)) {
       soft.assertThat(stream(str).filter(this::filterMainBranch)).hasSize(2); // foo + another-tag
     }
-    soft.assertThatThrownBy(() -> store().delete(tag, Optional.of(initialHash)))
+    soft.assertThatThrownBy(() -> store().delete(tag, initialHash))
         .isInstanceOf(ReferenceNotFoundException.class);
   }
 

--- a/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/BaseExportImport.java
+++ b/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/BaseExportImport.java
@@ -139,8 +139,8 @@ public abstract class BaseExportImport {
                   Hash b = vs.create(branch, Optional.of(vs.noAncestorHash())).getHash();
                   b = commit10(vs, 0, branch, b);
 
-                  vs.delete(BranchName.of("a"), Optional.of(a));
-                  vs.delete(BranchName.of("b"), Optional.of(b));
+                  vs.delete(BranchName.of("a"), a);
+                  vs.delete(BranchName.of("b"), b);
 
                   headsAndForks.addHeads(a.asBytes());
                   deleted.accept(a.asBytes());


### PR DESCRIPTION
This commit also refactors the HashValidator and HashResolver APIs
to achieve better error messages.

This commit also enhances the set of tests in `AbstractRelativeReferences` and adds:

* Tests for references without hashes (resolving to HEAD when allowed)
* Tests for all kinds of references (branches, tags and detached)
* Tests for expected hashes in various situations: 
  * Resolving to HEAD
  * Resolving to an ancestor of HEAD
  * Resolving to an unreachable commit from HEAD
  * Non-existent hash

Some validation constraints in `TreeService` and `Merge` related to hashes were
lifted, in order to let HashValidator validate them and produce
standardized error messages.