### PR TITLE
Apply filters early in TreeApiImpl.getEntries

### DIFF
--- a/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImport.java
+++ b/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImport.java
@@ -323,7 +323,7 @@ public class ITExportImport {
         adapter,
         "main",
         ContentKey.of("namespace123", "table123"),
-        IcebergTable.of("meta3", 44, 43, 44, 45, "id123"));
+        IcebergTable.of("meta3", 44, 43, 44, 45, tableId));
   }
 
   private void checkValues(
@@ -397,11 +397,11 @@ public class ITExportImport {
             .addPuts(
                 KeyWithBytes.of(
                     key,
-                    ContentId.of("id123"),
+                    ContentId.of(tableId),
                     (byte) payloadForContent(ICEBERG_TABLE),
                     DefaultStoreWorker.instance()
                         .toStoreOnReferenceState(
-                            IcebergTable.of("meta2", 43, 43, 44, 45, "id123"))))
+                            IcebergTable.of("meta2", 43, 43, 44, 45, tableId))))
             .build());
   }
 

--- a/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImportPersist.java
+++ b/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImportPersist.java
@@ -211,12 +211,12 @@ public class ITExportImportPersist {
         persist,
         "main",
         ContentKey.of("namespace123", "table123"),
-        IcebergTable.of("meta", 42, 43, 44, 45, "id123"));
+        IcebergTable.of("meta", 42, 43, 44, 45, contentIdStr));
     checkValues(
         persist,
         "branch-foo",
         ContentKey.of("namespace123", "table123"),
-        IcebergTable.of("meta2", 43, 43, 44, 45, "id123"));
+        IcebergTable.of("meta2", 43, 43, 44, 45, contentIdStr));
   }
 
   @Test
@@ -257,12 +257,12 @@ public class ITExportImportPersist {
         persist,
         "main",
         ContentKey.of("namespace123", "table123"),
-        IcebergTable.of("meta", 42, 43, 44, 45, "id123"));
+        IcebergTable.of("meta", 42, 43, 44, 45, contentIdStr));
     checkValues(
         persist,
         "branch-foo",
         ContentKey.of("namespace123", "table123"),
-        IcebergTable.of("meta2", 43, 43, 44, 45, "id123"));
+        IcebergTable.of("meta2", 43, 43, 44, 45, contentIdStr));
   }
 
   @Test
@@ -300,7 +300,7 @@ public class ITExportImportPersist {
         persist,
         "main",
         ContentKey.of("namespace123", "table123"),
-        IcebergTable.of("meta", 42, 43, 44, 45, "id123"));
+        IcebergTable.of("meta", 42, 43, 44, 45, contentIdStr));
   }
 
   @Test
@@ -333,7 +333,7 @@ public class ITExportImportPersist {
         persist,
         "main",
         ContentKey.of("namespace123", "table123"),
-        IcebergTable.of("meta3", 44, 43, 44, 45, "id123"));
+        IcebergTable.of("meta3", 44, 43, 44, 45, contentIdStr));
   }
 
   private void checkValues(Persist persist, String ref, ContentKey key, Content value)
@@ -347,6 +347,7 @@ public class ITExportImportPersist {
   }
 
   private final UUID contentId = UUID.randomUUID();
+  private final String contentIdStr = contentId.toString();
 
   private void populateRepository(Persist persist) throws Exception {
     ReferenceLogic referenceLogic = referenceLogic(persist);
@@ -357,12 +358,12 @@ public class ITExportImportPersist {
     StoreWorker storeWorker = DefaultStoreWorker.instance();
     int payload = payloadForContent(ICEBERG_TABLE);
     ByteString contentMain =
-        storeWorker.toStoreOnReferenceState(IcebergTable.of("meta", 42, 43, 44, 45, "id123"));
+        storeWorker.toStoreOnReferenceState(IcebergTable.of("meta", 42, 43, 44, 45, contentIdStr));
     ByteString contentFoo =
-        storeWorker.toStoreOnReferenceState(IcebergTable.of("meta2", 43, 43, 44, 45, "id123"));
+        storeWorker.toStoreOnReferenceState(IcebergTable.of("meta2", 43, 43, 44, 45, contentIdStr));
 
-    ContentValueObj valueMain = contentValue(contentId.toString(), payload, contentMain);
-    ContentValueObj valueFoo = contentValue(contentId.toString(), payload, contentFoo);
+    ContentValueObj valueMain = contentValue(contentIdStr, payload, contentMain);
+    ContentValueObj valueFoo = contentValue(contentIdStr, payload, contentFoo);
 
     soft.assertThat(persist.storeObj(valueMain)).isTrue();
     StoreKey key = keyToStoreKey(ContentKey.of("namespace123", "table123"));
@@ -407,12 +408,12 @@ public class ITExportImportPersist {
     StoreWorker storeWorker = DefaultStoreWorker.instance();
     int payload = payloadForContent(ICEBERG_TABLE);
     ByteString contentTemp =
-        storeWorker.toStoreOnReferenceState(IcebergTable.of("meta3", 44, 43, 44, 45, "id123"));
+        storeWorker.toStoreOnReferenceState(IcebergTable.of("meta3", 44, 43, 44, 45, contentIdStr));
     ByteString contentMain =
-        storeWorker.toStoreOnReferenceState(IcebergTable.of("meta", 42, 43, 44, 45, "id123"));
+        storeWorker.toStoreOnReferenceState(IcebergTable.of("meta", 42, 43, 44, 45, contentIdStr));
 
-    ContentValueObj valueMain = contentValue(contentId.toString(), payload, contentMain);
-    ContentValueObj valueTemp = contentValue(contentId.toString(), payload, contentTemp);
+    ContentValueObj valueMain = contentValue(contentIdStr, payload, contentMain);
+    ContentValueObj valueTemp = contentValue(contentIdStr, payload, contentTemp);
 
     soft.assertThat(persist.storeObj(valueTemp)).isTrue();
 

--- a/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImportPersist.java
+++ b/servers/quarkus-cli/src/intTest/java/org/projectnessie/quarkus/cli/ITExportImportPersist.java
@@ -340,7 +340,7 @@ public class ITExportImportPersist {
       throws ReferenceNotFoundException {
     VersionStoreImpl store = new VersionStoreImpl(persist);
     ReferenceInfo<CommitMeta> main = store.getNamedRef(ref, GetNamedRefsParams.DEFAULT);
-    soft.assertThat(store.getKeys(main.getHash(), null, true, NO_KEY_RESTRICTIONS))
+    soft.assertThat(store.getKeys(main.getHash(), null, k -> true, NO_KEY_RESTRICTIONS))
         .toIterable()
         .extracting(e -> e.getKey().contentKey(), KeyEntry::getContent)
         .containsExactly(tuple(key, value));

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/versionstore/ObservingVersionStore.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/versionstore/ObservingVersionStore.java
@@ -27,8 +27,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
@@ -207,10 +209,10 @@ public class ObservingVersionStore implements VersionStore {
   public PaginationIterator<KeyEntry> getKeys(
       @SpanAttribute(TAG_REF) Ref ref,
       String pagingToken,
-      boolean withContent,
+      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> withContentPredicate,
       KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException {
-    return delegate.getKeys(ref, pagingToken, withContent, keyRestrictions);
+    return delegate.getKeys(ref, pagingToken, withContentPredicate, keyRestrictions);
   }
 
   @WithSpan

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/versionstore/ObservingVersionStore.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/versionstore/ObservingVersionStore.java
@@ -209,10 +209,10 @@ public class ObservingVersionStore implements VersionStore {
   public PaginationIterator<KeyEntry> getKeys(
       @SpanAttribute(TAG_REF) Ref ref,
       String pagingToken,
-      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> withContentPredicate,
+      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> loadContentPredicate,
       KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException {
-    return delegate.getKeys(ref, pagingToken, withContentPredicate, keyRestrictions);
+    return delegate.getKeys(ref, pagingToken, loadContentPredicate, keyRestrictions);
   }
 
   @WithSpan

--- a/servers/services-bench/src/jmh/java/org/projectnessie/services/ContentOpsBench.java
+++ b/servers/services-bench/src/jmh/java/org/projectnessie/services/ContentOpsBench.java
@@ -118,7 +118,7 @@ public class ContentOpsBench {
   @Benchmark
   public void getKeys(BenchmarkParam param, Blackhole bh) throws Exception {
     PaginationIterator<KeyEntry> iter =
-        param.versionStore.getKeys(param.ref.getNamedRef(), null, false, NO_KEY_RESTRICTIONS);
+        param.versionStore.getKeys(param.ref.getNamedRef(), null, null, NO_KEY_RESTRICTIONS);
     while (iter.hasNext()) {
       bh.consume(iter.next());
     }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -134,7 +134,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
       Delete delete = Delete.of(namespace.toContentKey());
 
       try (PaginationIterator<KeyEntry> keys =
-          getStore().getKeys(refWithHash.getHash(), null, false, NO_KEY_RESTRICTIONS)) {
+          getStore().getKeys(refWithHash.getHash(), null, null, NO_KEY_RESTRICTIONS)) {
         while (keys.hasNext()) {
           KeyEntry k = keys.next();
           if (Namespace.of(k.getKey().contentKey().getElements())
@@ -295,7 +295,7 @@ public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
       Hash hash,
       Predicate<KeyEntry> earlyFilterPredicate)
       throws ReferenceNotFoundException {
-    PaginationIterator<KeyEntry> iter = getStore().getKeys(hash, null, false, NO_KEY_RESTRICTIONS);
+    PaginationIterator<KeyEntry> iter = getStore().getKeys(hash, null, null, NO_KEY_RESTRICTIONS);
     return stream(spliteratorUnknownSize(iter, 0), false)
         .onClose(iter::close)
         .filter(earlyFilterPredicate)

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -582,10 +582,7 @@ public class PersistVersionStore implements VersionStore {
                       .get(entry.getKey());
               if (cs != null) {
                 ContentResult content = mapContentAndState(entry.getKey(), cs);
-                return KeyEntry.of(
-                    identifiedContentKeyFromContent(
-                        entry.getKey(), content.content(), elements -> null),
-                    content.content());
+                return KeyEntry.of(keyEntry.getKey(), content.content());
               }
             } catch (ReferenceNotFoundException e) {
               throw new IllegalStateException("Reference no longer exists", e);

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -560,8 +560,14 @@ public class PersistVersionStore implements VersionStore {
         "Key ranges not supported by the storage model in use");
     Hash hash = refToHash(ref);
 
+    Predicate<ContentKey> contentKeyPredicate = keyRestrictions.contentKeyPredicate();
+    KeyFilterPredicate keyPred =
+        contentKeyPredicate != null
+            ? (k, c, t) -> contentKeyPredicate.test(k)
+            : KeyFilterPredicate.ALLOW_ALL;
+
     @SuppressWarnings("MustBeClosedChecker")
-    Stream<KeyListEntry> source = databaseAdapter.keys(hash, KeyFilterPredicate.ALLOW_ALL);
+    Stream<KeyListEntry> source = databaseAdapter.keys(hash, keyPred);
 
     return new FilteringPaginationIterator<KeyListEntry, KeyEntry>(
         source.iterator(),

--- a/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
+++ b/versioned/persist/store/src/main/java/org/projectnessie/versioned/persist/store/PersistVersionStore.java
@@ -549,7 +549,7 @@ public class PersistVersionStore implements VersionStore {
   public PaginationIterator<KeyEntry> getKeys(
       Ref ref,
       String pagingToken,
-      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> withContentPredicate,
+      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> loadContentPredicate,
       KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException {
     checkArgument(pagingToken == null, "Paging not supported by the storage model in use");
@@ -573,7 +573,7 @@ public class PersistVersionStore implements VersionStore {
                       contentTypeForPayload(entry.getPayload()),
                       entry.getContentId().getId(),
                       elements -> null));
-          if (withContentPredicate != null && withContentPredicate.test(keyEntry)) {
+          if (loadContentPredicate != null && loadContentPredicate.test(keyEntry)) {
             try {
               ContentAndState cs =
                   databaseAdapter

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
@@ -157,10 +157,10 @@ public class EventsVersionStore implements VersionStore {
   public PaginationIterator<KeyEntry> getKeys(
       Ref ref,
       String pagingToken,
-      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> withContentPredicate,
+      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> loadContentPredicate,
       KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException {
-    return delegate.getKeys(ref, pagingToken, withContentPredicate, keyRestrictions);
+    return delegate.getKeys(ref, pagingToken, loadContentPredicate, keyRestrictions);
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/EventsVersionStore.java
@@ -22,8 +22,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
@@ -153,9 +155,12 @@ public class EventsVersionStore implements VersionStore {
 
   @Override
   public PaginationIterator<KeyEntry> getKeys(
-      Ref ref, String pagingToken, boolean withContent, KeyRestrictions keyRestrictions)
+      Ref ref,
+      String pagingToken,
+      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> withContentPredicate,
+      KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException {
-    return delegate.getKeys(ref, pagingToken, withContent, keyRestrictions);
+    return delegate.getKeys(ref, pagingToken, withContentPredicate, keyRestrictions);
   }
 
   @Override

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/KeyEntry.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/KeyEntry.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.versioned;
 
+import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
@@ -40,6 +41,8 @@ public interface KeyEntry {
 
   static KeyEntry of(
       IdentifiedContentKey key, @NotNull @jakarta.validation.constraints.NotNull Content content) {
+    Preconditions.checkArgument(key.type().equals(content.getType()));
+    Preconditions.checkArgument(key.lastElement().contentId().equals(content.getId()));
     return builder().key(key).content(content).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/KeyEntry.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/KeyEntry.java
@@ -41,8 +41,16 @@ public interface KeyEntry {
 
   static KeyEntry of(
       IdentifiedContentKey key, @NotNull @jakarta.validation.constraints.NotNull Content content) {
-    Preconditions.checkArgument(key.type().equals(content.getType()));
-    Preconditions.checkArgument(key.lastElement().contentId().equals(content.getId()));
+    Preconditions.checkArgument(
+        key.type().equals(content.getType()),
+        "Content type from key '%s' does not match actual type of content: %s",
+        key.type(),
+        content);
+    Preconditions.checkArgument(
+        key.lastElement().contentId().equals(content.getId()),
+        "Content id from key '%s' does not match actual id of content: %s",
+        key,
+        content);
     return builder().key(key).content(content).build();
   }
 }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -363,14 +363,14 @@ public interface VersionStore {
    *
    * @param ref The ref to get keys for.
    * @param pagingToken paging token to start at
-   * @param withContentPredicate whether to load and populate {@link KeyEntry#getContent()}
+   * @param loadContentPredicate whether to load and populate {@link KeyEntry#getContent()}
    * @return The stream of keys available for this ref.
    * @throws ReferenceNotFoundException if {@code ref} is not present in the store
    */
   PaginationIterator<KeyEntry> getKeys(
       Ref ref,
       String pagingToken,
-      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> withContentPredicate,
+      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> loadContentPredicate,
       KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException;
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -363,12 +363,15 @@ public interface VersionStore {
    *
    * @param ref The ref to get keys for.
    * @param pagingToken paging token to start at
-   * @param withContent whether to populate {@link KeyEntry#getContent()}
+   * @param withContentPredicate whether to load and populate {@link KeyEntry#getContent()}
    * @return The stream of keys available for this ref.
    * @throws ReferenceNotFoundException if {@code ref} is not present in the store
    */
   PaginationIterator<KeyEntry> getKeys(
-      Ref ref, String pagingToken, boolean withContent, KeyRestrictions keyRestrictions)
+      Ref ref,
+      String pagingToken,
+      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> withContentPredicate,
+      KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException;
 
   List<IdentifiedContentKey> getIdentifiedKeys(Ref ref, Collection<ContentKey> keys)

--- a/versioned/spi/src/test/java/org/projectnessie/versioned/TestEventsVersionStore.java
+++ b/versioned/spi/src/test/java/org/projectnessie/versioned/TestEventsVersionStore.java
@@ -545,11 +545,11 @@ class TestEventsVersionStore {
 
   @Test
   void testGetKeys() throws Exception {
-    when(delegate.getKeys(branch1, "token1", false, NO_KEY_RESTRICTIONS))
+    when(delegate.getKeys(branch1, "token1", null, NO_KEY_RESTRICTIONS))
         .thenReturn(iteratorKeyEntries);
     EventsVersionStore versionStore = new EventsVersionStore(delegate, sink);
     PaginationIterator<KeyEntry> result =
-        versionStore.getKeys(branch1, "token1", false, NO_KEY_RESTRICTIONS);
+        versionStore.getKeys(branch1, "token1", null, NO_KEY_RESTRICTIONS);
     assertThat(result).isSameAs(iteratorKeyEntries);
     verifyNoMoreInteractions(delegate);
     verifyNoInteractions(sink);

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -74,6 +74,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
@@ -546,7 +547,7 @@ public class VersionStoreImpl implements VersionStore {
   public PaginationIterator<KeyEntry> getKeys(
       Ref ref,
       String pagingToken,
-      Predicate<KeyEntry> loadContentPredicate,
+      @Nullable @jakarta.annotation.Nullable Predicate<KeyEntry> loadContentPredicate,
       KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException {
     KeyRanges keyRanges = keyRanges(pagingToken, keyRestrictions);

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -617,7 +617,7 @@ public class VersionStoreImpl implements VersionStore {
                     contentMapping.fetchContent(
                         requireNonNull(commitOp.value(), "Required value pointer is null"));
               }
-              return KeyEntry.of(buildIdentifiedKey(key, index, content, x -> null), content);
+              return KeyEntry.of(keyEntry.getKey(), content);
             }
             return keyEntry;
           } catch (ObjNotFoundException e) {

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -546,7 +546,7 @@ public class VersionStoreImpl implements VersionStore {
   public PaginationIterator<KeyEntry> getKeys(
       Ref ref,
       String pagingToken,
-      Predicate<KeyEntry> withContentPredicate,
+      Predicate<KeyEntry> loadContentPredicate,
       KeyRestrictions keyRestrictions)
       throws ReferenceNotFoundException {
     KeyRanges keyRanges = keyRanges(pagingToken, keyRestrictions);
@@ -611,7 +611,7 @@ public class VersionStoreImpl implements VersionStore {
                 KeyEntry.of(
                     buildIdentifiedKey(key, index, contentType, contentIdString, x -> null));
 
-            if (withContentPredicate != null && withContentPredicate.test(keyEntry)) {
+            if (loadContentPredicate != null && loadContentPredicate.test(keyEntry)) {
               if (content == null) {
                 content =
                     contentMapping.fetchContent(

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractCommits.java
@@ -200,19 +200,19 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             commit(initialCommit, "Initial Commit", base));
 
     try (PaginationIterator<KeyEntry> keys =
-        store().getKeys(branch, null, false, NO_KEY_RESTRICTIONS)) {
+        store().getKeys(branch, null, null, NO_KEY_RESTRICTIONS)) {
       soft.assertThat(stream(keys).map(e -> e.getKey().contentKey()))
           .containsExactlyInAnyOrder(keyT1, keyT2, keyT4);
     }
 
     try (PaginationIterator<KeyEntry> keys =
-        store().getKeys(secondCommit, null, false, NO_KEY_RESTRICTIONS)) {
+        store().getKeys(secondCommit, null, null, NO_KEY_RESTRICTIONS)) {
       soft.assertThat(stream(keys).map(e -> e.getKey().contentKey()))
           .containsExactlyInAnyOrder(keyT1, keyT4);
     }
 
     try (PaginationIterator<KeyEntry> keys =
-        store().getKeys(initialCommit, null, false, NO_KEY_RESTRICTIONS)) {
+        store().getKeys(initialCommit, null, null, NO_KEY_RESTRICTIONS)) {
       soft.assertThat(stream(keys).map(e -> e.getKey().contentKey()))
           .containsExactlyInAnyOrder(keyT1, keyT2, keyT3);
     }
@@ -303,7 +303,7 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
             commit(initialCommit, "Initial Commit", base));
 
     try (PaginationIterator<KeyEntry> keys =
-        store().getKeys(branch, null, false, NO_KEY_RESTRICTIONS)) {
+        store().getKeys(branch, null, null, NO_KEY_RESTRICTIONS)) {
       soft.assertThat(stream(keys).map(e -> e.getKey().contentKey()))
           .containsExactlyInAnyOrder(ContentKey.of("t1"), ContentKey.of("t2"), ContentKey.of("t3"));
     }
@@ -924,7 +924,7 @@ public abstract class AbstractCommits extends AbstractNestedVersionStore {
                       try {
                         assertThat(store().getValue(branch, key)).isNull();
                         try (PaginationIterator<KeyEntry> ignore =
-                            store().getKeys(branch, null, false, NO_KEY_RESTRICTIONS)) {}
+                            store().getKeys(branch, null, null, NO_KEY_RESTRICTIONS)) {}
                       } catch (ReferenceNotFoundException e) {
                         throw new RuntimeException(e);
                       }

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractEntries.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractEntries.java
@@ -158,7 +158,7 @@ public abstract class AbstractEntries extends AbstractNestedVersionStore {
   }
 
   List<KeyEntry> keysAsList(Ref ref, KeyRestrictions keyRestrictions) throws Exception {
-    try (PaginationIterator<KeyEntry> keys = store().getKeys(ref, null, false, keyRestrictions)) {
+    try (PaginationIterator<KeyEntry> keys = store().getKeys(ref, null, null, keyRestrictions)) {
       return newArrayList(keys);
     }
   }
@@ -185,7 +185,7 @@ public abstract class AbstractEntries extends AbstractNestedVersionStore {
     ContentResult content23a = store().getValue(commit, key23a);
 
     try (PaginationIterator<KeyEntry> iter =
-        store.getKeys(commit, null, false, NO_KEY_RESTRICTIONS)) {
+        store.getKeys(commit, null, null, NO_KEY_RESTRICTIONS)) {
       soft.assertThat(iter)
           .toIterable()
           .extracting(KeyEntry::getKey)

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractReferenceNotFound.java
@@ -133,14 +133,14 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                     s.getKeys(
                         BranchName.of("this-one-should-not-exist"),
                         null,
-                        false,
+                        null,
                         NO_KEY_RESTRICTIONS)),
         new ReferenceNotFoundFunction("getKeys/tag")
             .msg("Named reference 'this-one-should-not-exist' not found")
             .function(
                 s ->
                     s.getKeys(
-                        TagName.of("this-one-should-not-exist"), null, false, NO_KEY_RESTRICTIONS)),
+                        TagName.of("this-one-should-not-exist"), null, null, NO_KEY_RESTRICTIONS)),
         new ReferenceNotFoundFunction("getKeys/hash")
             .msg("Commit '12341234123412341234123412341234123412341234' not found")
             .function(
@@ -148,7 +148,7 @@ public abstract class AbstractReferenceNotFound extends AbstractNestedVersionSto
                     s.getKeys(
                         Hash.of("12341234123412341234123412341234123412341234"),
                         null,
-                        false,
+                        null,
                         NO_KEY_RESTRICTIONS)),
         // assign()
         new ReferenceNotFoundFunction("assign/branch/ok")

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportContents.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportContents.java
@@ -93,7 +93,7 @@ final class ExportContents extends ExportCommon {
 
     long seq = 0;
     try (PaginationIterator<KeyEntry> entries =
-        store.getKeys(ref.getNamedRef(), null, false, NO_KEY_RESTRICTIONS)) {
+        store.getKeys(ref.getNamedRef(), null, null, NO_KEY_RESTRICTIONS)) {
       while (true) {
         List<KeyEntry> batch = take(exporter.contentsBatchSize(), entries);
         if (batch.isEmpty()) {

--- a/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/BaseExportImport.java
+++ b/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/BaseExportImport.java
@@ -334,7 +334,7 @@ public abstract class BaseExportImport {
 
   List<KeyEntry> keys(VersionStore versionStore, Hash hash) {
     try (PaginationIterator<KeyEntry> keys =
-        versionStore.getKeys(hash, null, false, NO_KEY_RESTRICTIONS)) {
+        versionStore.getKeys(hash, null, null, NO_KEY_RESTRICTIONS)) {
       return newArrayList(keys);
     } catch (ReferenceNotFoundException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
`filterPredicate` will discard non-matching key entries in the final while loop however at that stage the entries (potentially including their content) have already been loaded and authz checks have been performed.

by applying the filters as early as possible we can avoid work that we will end up throwing away.

also fix a bug where `PersistVersionStore.getKeys` was ignoring `KeyRestrictions.contentKeyPredicate`.

also unify `ExportImport` tests where the payload had a different `contentId` than the key objects (and would now fail the new assertions in `KeyEntry.of`).