### PR TITLE
CI: Disable tests in Windows + macOS jobs

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -35,55 +35,55 @@ jobs:
       CI_MAC: "true"
 
     steps:
-    - name: Brew update & upgrade
-      run: |
-        echo "::group::Update Brew"
-        brew update
-        echo "::endgroup::"
-        echo "::group::Brew Upgrade"
-        brew upgrade || true
-        echo "::endgroup::"
-
-    - name: Prepare Podman
-      run: |
-        echo "::group::Install Podman"
-        brew install podman
-        echo "::endgroup::"
-
-        echo "::group::Initializing Podman"
-        podman machine init
-        echo "::endgroup::"
-
-    - name: Start Podman
-      uses: nick-fields/retry@v2
-      with:
-        max_attempts: 10
-        timeout_minutes: 5
-        retry_wait_seconds: 3
-        command: |
-          echo "::group::Starting Podman"
-          podman machine start
-          echo "::endgroup::"
-        on_retry_command: |
-          echo "::group::Stopping Podman"
-          podman machine stop
-          echo "::endgroup::"
-
-    - name: Configure Podman
-      run: |
-        echo "::group::Aliasing Podman"
-        ln -s /usr/local/bin/podman /usr/local/bin/docker
-        echo "::endgroup::"
-
-        export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/podman-machine-default/podman.sock"
-        echo "DOCKER_HOST=$DOCKER_HOST" >> ${GITHUB_ENV}
-
-        # See https://www.testcontainers.org/supported_docker_environment/
-        echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> ${GITHUB_ENV}
-
-        echo "::group::Docker info"
-        docker info
-        echo "::endgroup::"
+    #- name: Brew update & upgrade
+    #  run: |
+    #    echo "::group::Update Brew"
+    #    brew update
+    #    echo "::endgroup::"
+    #    echo "::group::Brew Upgrade"
+    #    brew upgrade || true
+    #    echo "::endgroup::"
+    #
+    #- name: Prepare Podman
+    #  run: |
+    #    echo "::group::Install Podman"
+    #    brew install podman
+    #    echo "::endgroup::"
+    #
+    #    echo "::group::Initializing Podman"
+    #    podman machine init
+    #    echo "::endgroup::"
+    #
+    #- name: Start Podman
+    #  uses: nick-fields/retry@v2
+    #  with:
+    #    max_attempts: 10
+    #    timeout_minutes: 5
+    #    retry_wait_seconds: 3
+    #    command: |
+    #      echo "::group::Starting Podman"
+    #      podman machine start
+    #      echo "::endgroup::"
+    #    on_retry_command: |
+    #      echo "::group::Stopping Podman"
+    #      podman machine stop
+    #      echo "::endgroup::"
+    #
+    #- name: Configure Podman
+    #  run: |
+    #    echo "::group::Aliasing Podman"
+    #    ln -s /usr/local/bin/podman /usr/local/bin/docker
+    #    echo "::endgroup::"
+    #
+    #    export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/podman-machine-default/podman.sock"
+    #    echo "DOCKER_HOST=$DOCKER_HOST" >> ${GITHUB_ENV}
+    #
+    #    # See https://www.testcontainers.org/supported_docker_environment/
+    #    echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> ${GITHUB_ENV}
+    #
+    #    echo "::group::Docker info"
+    #    docker info
+    #    echo "::endgroup::"
 
     - uses: actions/checkout@v3.5.3
     - name: Setup Java, Gradle
@@ -107,10 +107,10 @@ jobs:
       with:
         arguments: test --scan
 
-    - name: Gradle / integ-test
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: intTest --scan
+    #- name: Gradle / integ-test
+    #  uses: gradle/gradle-build-action@v2
+    #  with:
+    #    arguments: intTest --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -35,56 +35,6 @@ jobs:
       CI_MAC: "true"
 
     steps:
-    #- name: Brew update & upgrade
-    #  run: |
-    #    echo "::group::Update Brew"
-    #    brew update
-    #    echo "::endgroup::"
-    #    echo "::group::Brew Upgrade"
-    #    brew upgrade || true
-    #    echo "::endgroup::"
-    #
-    #- name: Prepare Podman
-    #  run: |
-    #    echo "::group::Install Podman"
-    #    brew install podman
-    #    echo "::endgroup::"
-    #
-    #    echo "::group::Initializing Podman"
-    #    podman machine init
-    #    echo "::endgroup::"
-    #
-    #- name: Start Podman
-    #  uses: nick-fields/retry@v2
-    #  with:
-    #    max_attempts: 10
-    #    timeout_minutes: 5
-    #    retry_wait_seconds: 3
-    #    command: |
-    #      echo "::group::Starting Podman"
-    #      podman machine start
-    #      echo "::endgroup::"
-    #    on_retry_command: |
-    #      echo "::group::Stopping Podman"
-    #      podman machine stop
-    #      echo "::endgroup::"
-    #
-    #- name: Configure Podman
-    #  run: |
-    #    echo "::group::Aliasing Podman"
-    #    ln -s /usr/local/bin/podman /usr/local/bin/docker
-    #    echo "::endgroup::"
-    #
-    #    export DOCKER_HOST="unix:///${HOME}/.local/share/containers/podman/machine/podman-machine-default/podman.sock"
-    #    echo "DOCKER_HOST=$DOCKER_HOST" >> ${GITHUB_ENV}
-    #
-    #    # See https://www.testcontainers.org/supported_docker_environment/
-    #    echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> ${GITHUB_ENV}
-    #
-    #    echo "::group::Docker info"
-    #    docker info
-    #    echo "::endgroup::"
-
     - uses: actions/checkout@v3.5.3
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
@@ -106,11 +56,6 @@ jobs:
         SPARK_LOCAL_IP: localhost
       with:
         arguments: test --scan
-
-    #- name: Gradle / integ-test
-    #  uses: gradle/gradle-build-action@v2
-    #  with:
-    #    arguments: intTest --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -47,35 +47,6 @@ jobs:
         path: hadoop-winutils
         ref: d018bd9c919dee1448b95519351cc591a6338a00
 
-    #- name: Pull Hadoop
-    #  # A local Hadoop setup is required on Windows, very sad...
-    #  run: |
-    #    cd $HOME
-    #    Invoke-WebRequest -Uri https://dlcdn.apache.org/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz -TimeoutSec 60 -MaximumRetryCount 10 -OutFile hadoop-3.3.2.tar.gz
-    #
-    #- name: Setup Hadoop
-    #  # A local Hadoop setup is required on Windows, very sad...
-    #  run: |
-    #    echo "::group::Extract hadoop-3.3.2.tar.gz"
-    #    cd $HOME
-    #    mkdir hadoop-3.3.2
-    #    cd hadoop-3.3.2
-    #    7z e ..\hadoop-3.3.2.tar.gz
-    #    echo "::endgroup::"
-    #    echo "HADOOP_HOME=$HOME\hadoop-3.3.2" >> $env:GITHUB_ENV
-    #
-    #- name: Add Hadoop winutils
-    #  run: |
-    #    cd hadoop-winutils\hadoop-3.2.2\bin
-    #    copy *.dll $HADOOP_HOME\bin
-    #    copy *.exp $HADOOP_HOME\bin
-    #    copy *.lib $HADOOP_HOME\bin
-    #    copy *.pdb $HADOOP_HOME\bin
-    #    copy *.exe $HADOOP_HOME\bin
-    #    copy *.dll C:\windows\system32
-    #    cd ..\..\..
-    #    rm -r -fo hadoop-winutils
-
     - uses: actions/checkout@v3.5.3
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
@@ -90,25 +61,3 @@ jobs:
       with:
         cache-read-only: true
         arguments: assemble --scan
-
-    #- name: Gradle / unit test
-    #  uses: gradle/gradle-build-action@v2
-    #  env:
-    #    SPARK_LOCAL_IP: localhost
-    #  with:
-    #    arguments: test --scan
-    #
-    #- name: Gradle / integ-test
-    #  uses: gradle/gradle-build-action@v2
-    #  with:
-    #    arguments: intTest --scan
-    #
-    #- name: Capture Test Reports
-    #  uses: actions/upload-artifact@v3
-    #  if: ${{ failure() }}
-    #  with:
-    #    name: test-results
-    #    path: |
-    #      **/build/reports/*
-    #      **/build/test-results/*
-    #    retention-days: 3

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -47,34 +47,34 @@ jobs:
         path: hadoop-winutils
         ref: d018bd9c919dee1448b95519351cc591a6338a00
 
-    - name: Pull Hadoop
-      # A local Hadoop setup is required on Windows, very sad...
-      run: |
-        cd $HOME
-        Invoke-WebRequest -Uri https://dlcdn.apache.org/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz -TimeoutSec 60 -MaximumRetryCount 10 -OutFile hadoop-3.3.2.tar.gz
-
-    - name: Setup Hadoop
-      # A local Hadoop setup is required on Windows, very sad...
-      run: |
-        echo "::group::Extract hadoop-3.3.2.tar.gz"
-        cd $HOME
-        mkdir hadoop-3.3.2
-        cd hadoop-3.3.2
-        7z e ..\hadoop-3.3.2.tar.gz
-        echo "::endgroup::"
-        echo "HADOOP_HOME=$HOME\hadoop-3.3.2" >> $env:GITHUB_ENV
-
-    - name: Add Hadoop winutils
-      run: |
-        cd hadoop-winutils\hadoop-3.2.2\bin
-        copy *.dll $HADOOP_HOME\bin
-        copy *.exp $HADOOP_HOME\bin
-        copy *.lib $HADOOP_HOME\bin
-        copy *.pdb $HADOOP_HOME\bin
-        copy *.exe $HADOOP_HOME\bin
-        copy *.dll C:\windows\system32
-        cd ..\..\..
-        rm -r -fo hadoop-winutils
+    #- name: Pull Hadoop
+    #  # A local Hadoop setup is required on Windows, very sad...
+    #  run: |
+    #    cd $HOME
+    #    Invoke-WebRequest -Uri https://dlcdn.apache.org/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz -TimeoutSec 60 -MaximumRetryCount 10 -OutFile hadoop-3.3.2.tar.gz
+    #
+    #- name: Setup Hadoop
+    #  # A local Hadoop setup is required on Windows, very sad...
+    #  run: |
+    #    echo "::group::Extract hadoop-3.3.2.tar.gz"
+    #    cd $HOME
+    #    mkdir hadoop-3.3.2
+    #    cd hadoop-3.3.2
+    #    7z e ..\hadoop-3.3.2.tar.gz
+    #    echo "::endgroup::"
+    #    echo "HADOOP_HOME=$HOME\hadoop-3.3.2" >> $env:GITHUB_ENV
+    #
+    #- name: Add Hadoop winutils
+    #  run: |
+    #    cd hadoop-winutils\hadoop-3.2.2\bin
+    #    copy *.dll $HADOOP_HOME\bin
+    #    copy *.exp $HADOOP_HOME\bin
+    #    copy *.lib $HADOOP_HOME\bin
+    #    copy *.pdb $HADOOP_HOME\bin
+    #    copy *.exe $HADOOP_HOME\bin
+    #    copy *.dll C:\windows\system32
+    #    cd ..\..\..
+    #    rm -r -fo hadoop-winutils
 
     - uses: actions/checkout@v3.5.3
     - name: Setup Java, Gradle
@@ -91,24 +91,24 @@ jobs:
         cache-read-only: true
         arguments: assemble --scan
 
-    - name: Gradle / unit test
-      uses: gradle/gradle-build-action@v2
-      env:
-        SPARK_LOCAL_IP: localhost
-      with:
-        arguments: test --scan
-
+    #- name: Gradle / unit test
+    #  uses: gradle/gradle-build-action@v2
+    #  env:
+    #    SPARK_LOCAL_IP: localhost
+    #  with:
+    #    arguments: test --scan
+    #
     #- name: Gradle / integ-test
     #  uses: gradle/gradle-build-action@v2
     #  with:
     #    arguments: intTest --scan
-
-    - name: Capture Test Reports
-      uses: actions/upload-artifact@v3
-      if: ${{ failure() }}
-      with:
-        name: test-results
-        path: |
-          **/build/reports/*
-          **/build/test-results/*
-        retention-days: 3
+    #
+    #- name: Capture Test Reports
+    #  uses: actions/upload-artifact@v3
+    #  if: ${{ failure() }}
+    #  with:
+    #    name: test-results
+    #    path: |
+    #      **/build/reports/*
+    #      **/build/test-results/*
+    #    retention-days: 3

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -98,10 +98,10 @@ jobs:
       with:
         arguments: test --scan
 
-    - name: Gradle / integ-test
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: intTest --scan
+    #- name: Gradle / integ-test
+    #  uses: gradle/gradle-build-action@v2
+    #  with:
+    #    arguments: intTest --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Running tests on GH Windows+Mac runners was always brittle and recently never succeeded. The value of these tests is quite low, so CI for these environments is now limited to building Nessie and running only unit but no integration tests on macOS and no tests on Windows GH runners.