### PR TITLE
GC: Fix log level property interpolation and default to INFO

### DIFF
--- a/gc/gc-tool/src/main/resources/logback.xml
+++ b/gc/gc-tool/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
     </encoder>
   </appender>
   <root>
-    <level value="\${log.level.console:-INFO}"/>
+    <level value="${log.level.console:-INFO}"/>
     <appender-ref ref="console"/>
   </root>
 </configuration>


### PR DESCRIPTION
As per the official [Logback documentation](https://logback.qos.ch/manual/configuration.html#variableSubstitution) in order for a variable/system property to be substituted in the config file, it is sufficient to provide it as `$VARIABLE`, there is no need for any escape. In fact, escaping with a backslash causes logback to switch over to DEBUG level logging.

Fixes #7406