### PR TITLE
GC: Fix duplicate-key error w/ PostgreSQL

### DIFF
--- a/gc/gc-base-tests/src/main/java/org/projectnessie/gc/contents/tests/AbstractPersistenceSpi.java
+++ b/gc/gc-base-tests/src/main/java/org/projectnessie/gc/contents/tests/AbstractPersistenceSpi.java
@@ -391,6 +391,20 @@ public abstract class AbstractPersistenceSpi {
   }
 
   @Test
+  void identifyDuplicateContentReferences() throws Exception {
+    LiveSetVals vals1 = new LiveSetVals();
+    vals1.startIdentify();
+    soft.assertThat(persistenceSpi.addIdentifiedLiveContent(vals1.id, vals1.refs.stream()))
+        .isEqualTo(vals1.refs.size());
+    for (ContentReference ref : vals1.refs) {
+      soft.assertThat(persistenceSpi.addIdentifiedLiveContent(vals1.id, Stream.of(ref)))
+          .isEqualTo(0L);
+    }
+    soft.assertThat(persistenceSpi.addIdentifiedLiveContent(vals1.id, vals1.refs.stream()))
+        .isEqualTo(0L);
+  }
+
+  @Test
   void identifiedContents() throws Exception {
     LiveSetVals vals1 = new LiveSetVals();
     vals1.startIdentify();

--- a/gc/gc-repository-jdbc/build.gradle.kts
+++ b/gc/gc-repository-jdbc/build.gradle.kts
@@ -49,17 +49,23 @@ dependencies {
   compileOnly(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
-  testImplementation(project(":nessie-gc-base-tests"))
+  testFixturesApi(project(":nessie-gc-base"))
+  testFixturesApi(project(":nessie-gc-base-tests"))
 
-  testRuntimeOnly(libs.logback.classic)
+  testFixturesRuntimeOnly(libs.logback.classic)
 
-  testImplementation(libs.guava)
+  testFixturesApi(libs.guava)
 
-  testImplementation(platform(libs.jackson.bom))
-  testCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
+  testFixturesApi(platform(libs.jackson.bom))
+  testFixturesCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
-  testCompileOnly(libs.microprofile.openapi)
+  testFixturesCompileOnly(libs.microprofile.openapi)
 
-  testImplementation(platform(libs.junit.bom))
-  testImplementation(libs.bundles.junit.testing)
+  testFixturesApi(platform(libs.junit.bom))
+  testFixturesApi(libs.bundles.junit.testing)
+
+  intTestImplementation(libs.postgresql)
+  intTestImplementation(platform(libs.testcontainers.bom))
+  intTestImplementation("org.testcontainers:postgresql")
+  intTestRuntimeOnly(libs.docker.java.api)
 }

--- a/gc/gc-repository-jdbc/src/intTest/java/org/projectnessie/gc/contents/jdbc/ITJdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/intTest/java/org/projectnessie/gc/contents/jdbc/ITJdbcPersistenceSpi.java
@@ -15,12 +15,28 @@
  */
 package org.projectnessie.gc.contents.jdbc;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.PostgreSQLContainer;
 
-public class TestJdbcPersistenceSpi extends AbstractJdbcPersistenceSpi {
+public class ITJdbcPersistenceSpi extends AbstractJdbcPersistenceSpi {
+
+  private static PostgreSQLContainer<?> container;
 
   @BeforeAll
   static void createDataSource() throws Exception {
-    initDataSource("jdbc:h2:mem:nessie;MODE=PostgreSQL");
+
+    String version = System.getProperty("it.nessie.container.postgres.tag", "latest");
+    container = new PostgreSQLContainer<>("postgres:" + version);
+    container.start();
+
+    initDataSource(container.getJdbcUrl());
+  }
+
+  @AfterAll
+  static void stopContainer() {
+    if (container != null) {
+      container.stop();
+    }
   }
 }

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcPersistenceSpi.java
@@ -234,14 +234,9 @@ public abstract class JdbcPersistenceSpi implements PersistenceSpi {
               throw new UnsupportedOperationException(
                   "Unsupported content type " + ref.contentType());
             }
-            try {
-              // TODO add batch updates
-              stmt.executeUpdate();
+            // TODO add batch updates
+            if (stmt.executeUpdate() != 0) {
               count++;
-            } catch (SQLException e) {
-              if (!isIntegrityConstraintViolation(e)) {
-                throw e;
-              }
             }
           }
           return count;
@@ -271,13 +266,7 @@ public abstract class JdbcPersistenceSpi implements PersistenceSpi {
           stmt.setString(2, contentId);
           for (URI baseLocation : baseLocations) {
             stmt.setString(3, baseLocation.toString());
-            try {
-              stmt.executeUpdate();
-            } catch (SQLException e) {
-              if (!isIntegrityConstraintViolation(e)) {
-                throw e;
-              }
-            }
+            stmt.executeUpdate();
           }
           return null;
         },
@@ -378,13 +367,8 @@ public abstract class JdbcPersistenceSpi implements PersistenceSpi {
             stmt.setString(2, f.base().toString());
             stmt.setString(3, f.path().toString());
             stmt.setLong(4, f.modificationTimeMillisEpoch());
-            try {
-              stmt.executeUpdate();
+            if (stmt.executeUpdate() != 0) {
               count++;
-            } catch (SQLException e) {
-              if (!isIntegrityConstraintViolation(e)) {
-                throw e;
-              }
             }
           }
           return count;

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/SqlDmlDdl.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/SqlDmlDdl.java
@@ -72,7 +72,8 @@ final class SqlDmlDdl {
   @Language("SQL")
   static final String INSERT_FILE_DELETIONS =
       "INSERT INTO gc_file_deletions \n"
-          + "    (live_set_id, base_uri, path_uri, modification_timestamp) VALUES (?, ?, ?, ?)";
+          + "    (live_set_id, base_uri, path_uri, modification_timestamp) VALUES (?, ?, ?, ?) \n"
+          + "    ON CONFLICT DO NOTHING";
 
   @Language("SQL")
   static final String SELECT_FILE_DELETIONS =
@@ -109,7 +110,8 @@ final class SqlDmlDdl {
   @Language("SQL")
   static final String INSERT_CONTENT_LOCATION =
       "INSERT INTO gc_live_set_content_locations \n"
-          + "    (live_set_id, content_id, base_location) VALUES (?, ?, ?)";
+          + "    (live_set_id, content_id, base_location) VALUES (?, ?, ?) \n"
+          + "    ON CONFLICT DO NOTHING";
 
   @Language("SQL")
   static final String SELECT_CONTENT_LOCATION =
@@ -158,7 +160,8 @@ final class SqlDmlDdl {
   static final String ADD_CONTENT =
       "INSERT INTO gc_live_set_contents \n"
           + "    (live_set_id, content_id, commit_id, content_key, content_type, metadata_location, snapshot_id) \n"
-          + "    VALUES (?, ?, ?, ?, ?, ?, ?)";
+          + "    VALUES (?, ?, ?, ?, ?, ?, ?) \n"
+          + "    ON CONFLICT DO NOTHING";
 
   @Language("SQL")
   static final String SELECT_CONTENT_REFERENCES =

--- a/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcPersistenceSpi.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.projectnessie.gc.contents.spi.PersistenceSpi;
+import org.projectnessie.gc.contents.tests.AbstractPersistenceSpi;
+
+public abstract class AbstractJdbcPersistenceSpi extends AbstractPersistenceSpi {
+
+  private static DataSource dataSource;
+
+  static void initDataSource(String jdbcUrl) throws Exception {
+    AgroalJdbcDataSourceProvider dsProvider =
+        AgroalJdbcDataSourceProvider.builder()
+            .jdbcUrl(jdbcUrl)
+            .usernamePasswordCredentials("test", "test")
+            .poolMinSize(1)
+            .poolMaxSize(1)
+            .poolInitialSize(1)
+            .build();
+    dataSource = dsProvider.dataSource();
+  }
+
+  @AfterAll
+  static void closeDataSource() throws Exception {
+    if (dataSource instanceof AutoCloseable) {
+      ((AutoCloseable) dataSource).close();
+    }
+  }
+
+  @Override
+  protected PersistenceSpi createPersistenceSpi() {
+    return JdbcPersistenceSpi.builder().dataSource(dataSource).build();
+  }
+
+  @BeforeEach
+  void setup() throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      JdbcHelper.createTables(conn);
+    }
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      try (Statement st = conn.createStatement()) {
+        for (String tableName : SqlDmlDdl.ALL_TABLE_NAMES) {
+          st.execute(String.format("DROP TABLE %s", tableName));
+        }
+      }
+    }
+  }
+
+  @Override
+  protected void assertDeleted(UUID id) throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      for (String tableName : SqlDmlDdl.ALL_TABLE_NAMES) {
+        try (PreparedStatement st =
+            conn.prepareStatement(
+                String.format("SELECT * FROM %s WHERE live_set_id = ?", tableName))) {
+          st.setString(1, id.toString());
+          try (ResultSet rs = st.executeQuery()) {
+            soft.assertThat(rs.next()).as(tableName).isFalse();
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
As reported in #7408, Nessie GC does not work correctly against PostgreSQL.

Although there is at least one test case that exercises the relevant code paths with the "failing" data scenarios, the tests did not fail due to a (now) obvious difference between H2 (used in the tests) and PostgreSQL. This change keeps the H2 in-memory tests and introduces ITs for PostgreSQL. The "difference" was actually H2 _not_ operating in PostgreSQL-mode.

`JdbcPersisxtenceSpi` did check for duplicate keys and should have ignored those via the `isIntegrityConstraintViolation(SQLException)` check, but that approach was wrong, because a failure marks the database transaction as "aborted", so having an `ON CONFLICT DO NOTHING` is the right approach. That change simplifies the code a little.

Fixes #7408