### PR TITLE
GC: Allow configuring gc-tool JDBC via env only

### DIFF
--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
@@ -23,6 +23,10 @@ import org.projectnessie.gc.contents.jdbc.AgroalJdbcDataSourceProvider;
 import picocli.CommandLine;
 
 public class JdbcOptions {
+  @CommandLine.Option(
+      names = "--jdbc",
+      description = "Flag whether to use the JDBC contents storage.")
+  boolean jdbc;
 
   @CommandLine.Option(
       names = "--jdbc-url",

--- a/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
+++ b/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
@@ -82,19 +82,19 @@ public class TestCLI {
         // missing contents-storage option
         arguments(
             singletonList("gc"),
-            "Error: Missing required argument (specify one of these): ([--inmemory] | [--jdbc-url="),
+            "Error: Missing required argument (specify one of these): ([--inmemory] | [[--jdbc]"),
         arguments(
             singletonList("mark-live"),
-            "Error: Missing required argument (specify one of these): ([--inmemory] | [--jdbc-url="),
+            "Error: Missing required argument (specify one of these): ([--inmemory] | [[--jdbc]"),
         arguments(
             asList("sweep", "--live-set-id=00000000-0000-0000-0000-000000000000"),
-            "Error: Missing required argument (specify one of these): ([--inmemory] | [--jdbc-url="),
+            "Error: Missing required argument (specify one of these): ([--inmemory] | [[--jdbc]"),
         arguments(
             asList("deferred-deletes", "--live-set-id=00000000-0000-0000-0000-000000000000"),
-            "Error: Missing required argument (specify one of these): ([--inmemory] | [--jdbc-url="),
+            "Error: Missing required argument (specify one of these): ([--inmemory] | [[--jdbc]"),
         arguments(
             asList("list-deferred", "--live-set-id=00000000-0000-0000-0000-000000000000"),
-            "Error: Missing required argument (specify one of these): ([--inmemory] | [--jdbc-url="),
+            "Error: Missing required argument (specify one of these): ([--inmemory] | [[--jdbc]"),
         // incomplete jdbc auth
         arguments(
             asList("mark-live", "--jdbc-url", "jdbc:foo//bar", "--jdbc-user", "user"),


### PR DESCRIPTION
When running the `nessie-gc` tool for example using `NESSIE_GC_JDBC_URL="jdbc:postgresql://localhost:5432/nessie_gc" NESSIE_GC_JDBC_USER=postgres NESSIE_GC_JDBC_PASSWORD=pass nessie-gc list`, it fails with `Error: Missing required argument (specify one of these): ([--inmemory] | [[--jdbc-url=<url>] [--jdbc-properties[=<String=String>[,<String=String>...]...]]... [[--jdbc-user=<user>] [--jdbc-password=<password>]]])`.

The `EnvironmentDefaultProvider` gets correctly called, but that does not seem to mark the JDBC option group in `ContentsStorageGroup` as "present". As a workaround, specify the newly introduced `--jdbc` option.

Fixes #7405