### PR TITLE
Build/Gradle/Jandex/Quarkus: Attempt to fix the occasional `ConcurrentModificiationException`

### DIFF
--- a/build-logic/src/main/kotlin/nessie-common-base.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-common-base.gradle.kts
@@ -36,6 +36,7 @@ sourceSets?.withType(SourceSet::class.java)?.configureEach {
     if ("main" != sourceSet.name) {
       // No Jandex for non-main
       jandexBuildAction.set(JandexBuildAction.NONE)
+      enabled = false
     }
     if (!project.plugins.hasPlugin("io.quarkus")) {
       dependsOn(tasks.named(sourceSet.classesTaskName))


### PR DESCRIPTION
The occasional `ConcurrentModificationException`s seem to always happen with or are related to the Jandex and Quarkus plugins. This change completely disables the Jandex tasks for non-`main` source sets, hoping that this reduces the probability to hit this error. The CME happens with all Gradle versions, it just seems to happen more often with newer Gradle versions.