### PR TITLE
Pushdown filters in TreeApiImpl.getEntries

### DIFF
--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -171,13 +171,14 @@ public final class CELUtil {
     if (model instanceof Operation) {
       return new OperationForCelImpl((Operation) model);
     }
-    if (model instanceof KeyEntry) {
-      return new KeyEntryForCelImpl((KeyEntry) model);
-    }
     if (model instanceof ContentKey) {
       return new KeyForCelImpl((ContentKey) model);
     }
     return model;
+  }
+
+  public static Object forCel(ContentKey key, Content.Type type) {
+    return new KeyEntryForCelImpl(key, type);
   }
 
   private static class KeyForCelImpl extends AbstractKeyedEntity {
@@ -198,26 +199,33 @@ public final class CELUtil {
     }
   }
 
+  /**
+   * the class does not wrap a {@link KeyEntry} because we need to be able to evaluate {@link
+   * java.util.function.BiPredicate}&lt;ContentKey, Content.Type&gt; as early as possible to avoid
+   * redundant work.
+   */
   private static class KeyEntryForCelImpl extends AbstractKeyedEntity implements KeyEntryForCel {
-    private final KeyEntry entry;
+    private final ContentKey key;
+    private final Content.Type type;
 
-    private KeyEntryForCelImpl(KeyEntry entry) {
-      this.entry = entry;
+    private KeyEntryForCelImpl(ContentKey key, Content.Type type) {
+      this.key = key;
+      this.type = type;
     }
 
     @Override
     protected ContentKey key() {
-      return entry.getKey().contentKey();
+      return key;
     }
 
     @Override
     public String getContentType() {
-      return entry.getKey().type().name();
+      return type.name();
     }
 
     @Override
     public String toString() {
-      return entry.toString();
+      return "KeyEntryForCelImpl{" + "key=" + key + ", type=" + type + "}";
     }
   }
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/VersionStore.java
@@ -24,13 +24,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
 import org.projectnessie.model.MergeBehavior;
@@ -350,7 +351,7 @@ public interface VersionStore {
     /** Filter predicate, can be {@code null}. */
     @Nullable
     @jakarta.annotation.Nullable
-    Predicate<ContentKey> contentKeyPredicate();
+    BiPredicate<ContentKey, Content.Type> contentKeyPredicate();
 
     static ImmutableKeyRestrictions.Builder builder() {
       return ImmutableKeyRestrictions.builder();

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractDiff.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractDiff.java
@@ -329,7 +329,7 @@ public abstract class AbstractDiff extends AbstractNestedVersionStore {
                 initial,
                 secondCommit,
                 KeyRestrictions.builder()
-                    .contentKeyPredicate(k -> k1.equals(k) || k3.equals(k))
+                    .contentKeyPredicate((k, t) -> k1.equals(k) || k3.equals(k))
                     .build()))
         .extracting(Diff::getFromKey, Diff::getToKey)
         .containsExactlyInAnyOrder(tuple(null, ik1), tuple(null, ik3));
@@ -338,7 +338,7 @@ public abstract class AbstractDiff extends AbstractNestedVersionStore {
             diffAsList(
                 initial,
                 secondCommit,
-                KeyRestrictions.builder().contentKeyPredicate(k -> false).build()))
+                KeyRestrictions.builder().contentKeyPredicate((k, t) -> false).build()))
         .isEmpty();
   }
 

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractEntries.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractEntries.java
@@ -151,7 +151,7 @@ public abstract class AbstractEntries extends AbstractNestedVersionStore {
             keysAsList(
                 initialCommit,
                 KeyRestrictions.builder()
-                    .contentKeyPredicate(k -> k.toPathString().startsWith(key2.toPathString()))
+                    .contentKeyPredicate((k, t) -> k.toPathString().startsWith(key2.toPathString()))
                     .build()))
         .map(e -> e.getKey().contentKey())
         .containsExactlyInAnyOrder(key2, key2a, key2b, key2c, key2d, key23, key23a, key23b);


### PR DESCRIPTION
`filterPredicate` will discard non-matching key entries in the final while loop however at that stage the entries (potentially including their content) have already been loaded and authz checks have been performed.

by applying the filters through a new `BiPredicate<ContentKey, Content.Type>` as early as possible we can avoid work that we will end up throwing away.

also fix `PersistVersionStore.getKeys` and `getDiffs` ignoring `KeyRestrictions.contentKeyPredicate`.