### PR TITLE
BigTable: use Batcher consistently for bulk mutations

### DIFF
--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackend.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackend.java
@@ -203,7 +203,6 @@ final class BigTableBackend implements Backend {
       for (Row row : rows) {
         batcher.add(RowMutationEntry.create(row.getKey()).deleteRow());
       }
-      batcher.sendOutstanding();
     } catch (ApiException e) {
       throw apiException(e);
     } catch (InterruptedException e) {

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackend.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackend.java
@@ -196,7 +196,7 @@ final class BigTableBackend implements Backend {
 
     Query query =
         Query.create(tableId)
-            .filter(FILTERS.chain().filter(FILTERS.value().strip()).filter(repoFilter(prefixes)));
+            .filter(FILTERS.chain().filter(repoFilter(prefixes)).filter(FILTERS.value().strip()));
 
     try (Batcher<RowMutationEntry, Void> batcher = dataClient.newBulkMutationBatcher(tableId)) {
       ServerStream<Row> rows = dataClient.readRows(query);

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackendFactory.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackendFactory.java
@@ -65,6 +65,13 @@ public class BigTableBackendFactory implements BackendFactory<BigTableBackendCon
       retrySettings.setMaxRetryDelay(maxRetryDelay);
     }
 
+    stubSettings
+        .bulkMutateRowsSettings()
+        .setBatchingSettings(
+            stubSettings.bulkMutateRowsSettings().getBatchingSettings().toBuilder()
+                .setElementCountThreshold((long) BigTableConstants.MAX_BULK_MUTATIONS)
+                .build());
+
     // Enable tracing & metrics
     BigtableDataSettings.enableOpenCensusStats();
     BigtableDataSettings.enableGfeOpenCensusStats();

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -489,7 +489,6 @@ public class BigTablePersist implements Persist {
         ByteString key = dbKey(id);
         batcher.add(RowMutationEntry.create(key).deleteRow());
       }
-      batcher.sendOutstanding();
     } catch (ApiException e) {
       throw apiException(e);
     } catch (InterruptedException e) {
@@ -545,7 +544,6 @@ public class BigTablePersist implements Persist {
             RowMutationEntry.create(key)
                 .setCell(FAMILY_OBJS, QUALIFIER_OBJS, CELL_TIMESTAMP, serialized));
       }
-      batcher.sendOutstanding();
     } catch (ApiException e) {
       throw apiException(e);
     } catch (InterruptedException e) {
@@ -683,7 +681,6 @@ public class BigTablePersist implements Persist {
           }
           idx++;
         }
-        batcher.sendOutstanding();
       }
     }
 

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -25,7 +25,6 @@ import static org.projectnessie.versioned.storage.bigtable.BigTableBackend.REPO_
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.CELL_TIMESTAMP;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.FAMILY_OBJS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.FAMILY_REFS;
-import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.MAX_BULK_MUTATIONS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.MAX_BULK_READS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUALIFIER_OBJS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUALIFIER_OBJ_TYPE;
@@ -40,7 +39,6 @@ import static org.projectnessie.versioned.storage.serialize.ProtoSerialization.s
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.batching.Batcher;
 import com.google.api.gax.rpc.ApiException;
-import com.google.cloud.bigtable.data.v2.models.BulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
@@ -49,6 +47,7 @@ import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.common.collect.AbstractIterator;
 import com.google.protobuf.ByteString;
 import java.nio.ByteBuffer;
@@ -475,17 +474,21 @@ public class BigTablePersist implements Persist {
 
   @Override
   public void deleteObjs(@Nonnull @jakarta.annotation.Nonnull ObjId[] ids) {
-    BulkMutation bulk = BulkMutation.create(backend.tableObjs);
-    for (ObjId id : ids) {
-      ByteString key = dbKey(id);
-      bulk.add(key, Mutation.create().deleteRow());
-      if (bulk.getEntryCount() == MAX_BULK_MUTATIONS) {
-        backend.client().bulkMutateRows(bulk);
-        bulk = BulkMutation.create(backend.tableObjs);
-      }
+    if (ids.length == 0) {
+      return;
     }
-    if (bulk.getEntryCount() > 0) {
-      backend.client().bulkMutateRows(bulk);
+    try (Batcher<RowMutationEntry, Void> batcher =
+        backend.client().newBulkMutationBatcher(backend.tableObjs)) {
+      for (ObjId id : ids) {
+        ByteString key = dbKey(id);
+        batcher.add(RowMutationEntry.create(key).deleteRow());
+      }
+      batcher.sendOutstanding();
+    } catch (ApiException e) {
+      throw apiException(e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
     }
   }
 
@@ -519,26 +522,29 @@ public class BigTablePersist implements Persist {
       return;
     }
 
-    BulkMutation bulkMutation = BulkMutation.create(backend.tableObjs);
-    for (Obj obj : objs) {
-      ObjId id = obj.id();
-      checkArgument(id != null, "Obj to store must have a non-null ID");
+    try (Batcher<RowMutationEntry, Void> batcher =
+        backend.client().newBulkMutationBatcher(backend.tableObjs)) {
+      for (Obj obj : objs) {
+        ObjId id = obj.id();
+        checkArgument(id != null, "Obj to store must have a non-null ID");
 
-      ByteString key = dbKey(id);
+        ByteString key = dbKey(id);
 
-      ByteString serialized =
-          unsafeWrap(
-              serializeObj(
-                  obj, effectiveIncrementalIndexSizeLimit(), effectiveIndexSegmentSizeLimit()));
+        ByteString serialized =
+            unsafeWrap(
+                serializeObj(
+                    obj, effectiveIncrementalIndexSizeLimit(), effectiveIndexSegmentSizeLimit()));
 
-      bulkMutation.add(
-          key, Mutation.create().setCell(FAMILY_OBJS, QUALIFIER_OBJS, CELL_TIMESTAMP, serialized));
-    }
-
-    try {
-      backend.client().bulkMutateRows(bulkMutation);
+        batcher.add(
+            RowMutationEntry.create(key)
+                .setCell(FAMILY_OBJS, QUALIFIER_OBJS, CELL_TIMESTAMP, serialized));
+      }
+      batcher.sendOutstanding();
     } catch (ApiException e) {
       throw apiException(e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
     }
   }
 

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -138,10 +138,13 @@ public class BigTablePersist implements Persist {
       bulkFetch(
           backend.tableRefs, names, r, this::dbKey, BigTablePersist::referenceFromRow, name -> {});
       return r;
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+    } catch (ExecutionException | TimeoutException e) {
       throw new RuntimeException(e);
     } catch (ApiException e) {
       throw apiException(e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
     }
   }
 
@@ -357,10 +360,13 @@ public class BigTablePersist implements Persist {
       }
 
       return r;
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+    } catch (ExecutionException | TimeoutException e) {
       throw new RuntimeException(e);
     } catch (ApiException e) {
       throw apiException(e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
Switching to `Batcher` for bulk mutations has shown significant performance improvements in `eraseRepositoriesTable` method.

This method has also been given 2 other minor improvements:

1. Use a "value strip" filter to remove all cells from returned rows (as we don't need them);
2. Avoid creating an interleave filter if only one repository prefix is being erased.