### PR TITLE
Move OTel wrappers to the modules defining corresponding interfaces

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -131,6 +131,7 @@ nessie-ui = { module = "org.projectnessie.nessie.ui:nessie-ui", version = "0.63.
 openapi-generator-cli = { module = "org.openapitools:openapi-generator-cli", version = "6.6.0" }
 opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry" }
 opentelemetry-bom-alpha = { module = "io.opentelemetry:opentelemetry-bom-alpha", version.ref = "opentelemetryAlpha" }
+opentelemetry-instrumentation-bom-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetryAlpha" }
 opentracing-api = { module = "io.opentracing:opentracing-api", version.ref = "opentracing" }
 opentracing-mock = { module = "io.opentracing:opentracing-mock", version.ref = "opentracing" }
 opentracing-util = { module = "io.opentracing:opentracing-util", version.ref = "opentracing" }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/QuarkusObservingPersist.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/QuarkusObservingPersist.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.providers.storage;
+
+import jakarta.inject.Singleton;
+import org.projectnessie.quarkus.providers.NotObserved;
+import org.projectnessie.versioned.storage.common.persist.ObservingPersist;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+
+/** CDI bean for {@link ObservingPersist}. */
+@Singleton
+public class QuarkusObservingPersist extends ObservingPersist {
+  public QuarkusObservingPersist(@NotObserved Persist delegate) {
+    super(delegate);
+  }
+}

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/versionstore/QuarkusObservingVersionStore.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/versionstore/QuarkusObservingVersionStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.providers.versionstore;
+
+import jakarta.inject.Singleton;
+import org.projectnessie.quarkus.providers.NotObserved;
+import org.projectnessie.versioned.ObservingVersionStore;
+import org.projectnessie.versioned.VersionStore;
+
+/** CDI bean for {@link ObservingVersionStore}. */
+@Singleton
+public class QuarkusObservingVersionStore extends ObservingVersionStore {
+  public QuarkusObservingVersionStore(@NotObserved VersionStore delegate) {
+    super(delegate);
+  }
+}

--- a/versioned/spi/build.gradle.kts
+++ b/versioned/spi/build.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
   annotationProcessor(libs.immutables.value.processor)
   compileOnly(libs.microprofile.openapi)
 
+  compileOnly(platform(libs.opentelemetry.instrumentation.bom.alpha))
+  compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations")
+  compileOnly(libs.micrometer.core)
+
   implementation(platform(libs.jackson.bom))
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/ObservingVersionStore.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/ObservingVersionStore.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.quarkus.providers.versionstore;
+package org.projectnessie.versioned;
 
 import com.google.errorprone.annotations.MustBeClosed;
 import io.micrometer.core.annotation.Counted;
 import io.micrometer.core.annotation.Timed;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
-import jakarta.inject.Singleton;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -33,34 +32,8 @@ import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IdentifiedContentKey;
 import org.projectnessie.model.RepositoryConfig;
-import org.projectnessie.quarkus.providers.NotObserved;
-import org.projectnessie.versioned.BranchName;
-import org.projectnessie.versioned.Commit;
-import org.projectnessie.versioned.CommitResult;
-import org.projectnessie.versioned.ContentResult;
-import org.projectnessie.versioned.Diff;
-import org.projectnessie.versioned.GetNamedRefsParams;
-import org.projectnessie.versioned.Hash;
-import org.projectnessie.versioned.KeyEntry;
-import org.projectnessie.versioned.MergeResult;
-import org.projectnessie.versioned.NamedRef;
-import org.projectnessie.versioned.Operation;
-import org.projectnessie.versioned.Ref;
-import org.projectnessie.versioned.RefLogDetails;
-import org.projectnessie.versioned.RefLogNotFoundException;
-import org.projectnessie.versioned.ReferenceAlreadyExistsException;
-import org.projectnessie.versioned.ReferenceAssignedResult;
-import org.projectnessie.versioned.ReferenceConflictException;
-import org.projectnessie.versioned.ReferenceCreatedResult;
-import org.projectnessie.versioned.ReferenceDeletedResult;
-import org.projectnessie.versioned.ReferenceInfo;
-import org.projectnessie.versioned.ReferenceNotFoundException;
-import org.projectnessie.versioned.RelativeCommitSpec;
-import org.projectnessie.versioned.RepositoryInformation;
-import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.paging.PaginationIterator;
 
-@Singleton
 public class ObservingVersionStore implements VersionStore {
   private final VersionStore delegate;
 
@@ -74,7 +47,7 @@ public class ObservingVersionStore implements VersionStore {
   private static final String TAG_FROM = "from";
   private static final String TAG_TO = "to";
 
-  public ObservingVersionStore(@NotObserved VersionStore delegate) {
+  public ObservingVersionStore(VersionStore delegate) {
     this.delegate = delegate;
   }
 

--- a/versioned/storage/common/build.gradle.kts
+++ b/versioned/storage/common/build.gradle.kts
@@ -31,6 +31,10 @@ dependencies {
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.findbugs.jsr305)
 
+  compileOnly(platform(libs.opentelemetry.instrumentation.bom.alpha))
+  compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations")
+  compileOnly(libs.micrometer.core)
+
   compileOnly(libs.errorprone.annotations)
   implementation(libs.agrona)
   implementation(libs.guava)

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
@@ -13,36 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.quarkus.providers.storage;
+package org.projectnessie.versioned.storage.common.persist;
 
 import io.micrometer.core.annotation.Counted;
 import io.micrometer.core.annotation.Timed;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
-import jakarta.inject.Singleton;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.projectnessie.quarkus.providers.NotObserved;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
 import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
 import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
-import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
-import org.projectnessie.versioned.storage.common.persist.Obj;
-import org.projectnessie.versioned.storage.common.persist.ObjId;
-import org.projectnessie.versioned.storage.common.persist.ObjType;
-import org.projectnessie.versioned.storage.common.persist.Persist;
-import org.projectnessie.versioned.storage.common.persist.Reference;
 
-@Singleton
 public class ObservingPersist implements Persist {
   private final Persist delegate;
 
   private static final String PREFIX = "nessie.storage.persist";
 
-  public ObservingPersist(@NotObserved Persist delegate) {
+  public ObservingPersist(Persist delegate) {
     this.delegate = delegate;
   }
 


### PR DESCRIPTION
Expose ObservingPersist and ObservingVersionStore in the modules that define their respective interfaces.

Keep Quarkus CDI beans in the quarkus-common module (extending the moved classes).