### PR TITLE
GC: Finally fix JDBC values specified via environment

### DIFF
--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/AgroalJdbcDataSourceProvider.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/AgroalJdbcDataSourceProvider.java
@@ -142,8 +142,7 @@ public abstract class AgroalJdbcDataSourceProvider implements JdbcDataSourceProv
           LOGGER.debug(
               "Connecting using name principal {}", ((NamePrincipal) credential).getName());
         } else if (credential instanceof SimplePassword) {
-          LOGGER.debug("Connecting using given password principal");
-          System.err.println("WORD " + ((SimplePassword) credential).getWord());
+          LOGGER.debug("Connecting using given password (not logged)");
         }
       }
 

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/AgroalJdbcDataSourceProvider.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/AgroalJdbcDataSourceProvider.java
@@ -30,9 +30,13 @@ import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Value.Immutable
 public abstract class AgroalJdbcDataSourceProvider implements JdbcDataSourceProvider {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AgroalJdbcDataSourceProvider.class);
 
   public static Builder builder() {
     return ImmutableAgroalJdbcDataSourceProvider.builder();
@@ -65,7 +69,12 @@ public abstract class AgroalJdbcDataSourceProvider implements JdbcDataSourceProv
     Builder addAllSecurityProviders(Iterable<? extends AgroalSecurityProvider> securityProviders);
 
     default Builder usernamePasswordCredentials(String jdbcUser, String jdbcPassword) {
-      addCredentials(new NamePrincipal(jdbcUser), new SimplePassword(jdbcPassword));
+      if (jdbcUser != null) {
+        addCredentials(new NamePrincipal(jdbcUser));
+      }
+      if (jdbcPassword != null) {
+        addCredentials(new SimplePassword(jdbcPassword));
+      }
       return this;
     }
 
@@ -125,6 +134,28 @@ public abstract class AgroalJdbcDataSourceProvider implements JdbcDataSourceProv
         dataSourceConfiguration.connectionPoolConfiguration();
     AgroalConnectionFactoryConfigurationSupplier connectionFactoryConfiguration =
         poolConfiguration.connectionFactoryConfiguration();
+
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Connecting to JDBC URL {}", jdbcUrl());
+      for (Object credential : credentials()) {
+        if (credential instanceof NamePrincipal) {
+          LOGGER.debug(
+              "Connecting using name principal {}", ((NamePrincipal) credential).getName());
+        } else if (credential instanceof SimplePassword) {
+          LOGGER.debug("Connecting using given password principal");
+          System.err.println("WORD " + ((SimplePassword) credential).getWord());
+        }
+      }
+
+      LOGGER.debug(
+          "JDBC pool options: initial-size={}, max-size={}, min-size={}, connection-lifetime={}, acquisition-timeout={}",
+          poolInitialSize(),
+          poolMaxSize(),
+          poolMinSize(),
+          poolConnectionLifetime(),
+          poolAcquisitionTimeout());
+      jdbcProperties().forEach((k, v) -> LOGGER.debug("Using JDBC property {}={}", k, v));
+    }
 
     poolConfiguration
         .initialSize(poolInitialSize())

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
@@ -34,9 +34,6 @@ public class JdbcOptions {
       required = true)
   String url;
 
-  @CommandLine.ArgGroup(exclusive = false)
-  JdbcUserPassword userPassword;
-
   @CommandLine.Option(
       names = "--jdbc-properties",
       description = "JDBC parameters.",
@@ -44,29 +41,23 @@ public class JdbcOptions {
       split = ",")
   Map<String, String> properties = new HashMap<>();
 
+  @CommandLine.Option(
+      names = "--jdbc-user",
+      description = "JDBC user name used to authenticate the database access.")
+  String user;
+
+  @CommandLine.Option(
+      names = "--jdbc-password",
+      description = "JDBC password used to authenticate the database access.")
+  String password;
+
   public DataSource createDataSource() throws SQLException {
     AgroalJdbcDataSourceProvider.Builder jdbcDsBuilder =
-        AgroalJdbcDataSourceProvider.builder().jdbcUrl(url);
-    if (userPassword != null) {
-      jdbcDsBuilder.usernamePasswordCredentials(userPassword.user, userPassword.password);
-    }
+        AgroalJdbcDataSourceProvider.builder()
+            .jdbcUrl(url)
+            .usernamePasswordCredentials(user, password);
     properties.forEach(jdbcDsBuilder::putJdbcProperties);
     AgroalJdbcDataSourceProvider dataSourceProvider = jdbcDsBuilder.build();
     return dataSourceProvider.dataSource();
-  }
-
-  static class JdbcUserPassword {
-
-    @CommandLine.Option(
-        names = "--jdbc-user",
-        description = "JDBC user name used to authenticate the database access.",
-        required = true)
-    String user;
-
-    @CommandLine.Option(
-        names = "--jdbc-password",
-        description = "JDBC password used to authenticate the database access.",
-        required = true)
-    String password;
   }
 }

--- a/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
+++ b/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
@@ -95,13 +95,6 @@ public class TestCLI {
         arguments(
             asList("list-deferred", "--live-set-id=00000000-0000-0000-0000-000000000000"),
             "Error: Missing required argument (specify one of these): ([--inmemory] | [[--jdbc]"),
-        // incomplete jdbc auth
-        arguments(
-            asList("mark-live", "--jdbc-url", "jdbc:foo//bar", "--jdbc-user", "user"),
-            "Error: Missing required argument(s): --jdbc-password"),
-        arguments(
-            asList("mark-live", "--jdbc-url", "jdbc:foo//bar", "--jdbc-password", "pass"),
-            "Error: Missing required argument(s): --jdbc-user="),
         // No live-set-id
         arguments(
             asList("sweep", "--jdbc-url", "jdbc:foo//bar"),


### PR DESCRIPTION
Injecting default values via the environment works fine, even the values for JDBC username and password are requested from the default-values-provider. But unfortunately picocli does _not_ inject the valid `JdbcUserPassword` `@Command.ArgGroup`.

This change pulls the user/password fields into `JdbcOptions`. However, this change updates the behavior a little bit, by not requiring username and/or password to be present, the corresponding `Principal`s will only be injected, if the values are present.

Debug logging can be used to inspect the JDBC configuration (won't log the password though), for example like this:
```
NESSIE_GC_JDBC_URL="jdbc:..." NESSIE_GC_JDBC_USER="my-username" NESSIE_GC_JDBC_PASSWORD="very-secret" \
  java \
  -Dlog.level.console=DEBUG \
  -jar nessie-gc-tool-0.68.1-SNAPSHOT.jar \
  mark --jdbc
...
2023-08-25 12:41:54,515 [main] DEBUG o.p.g.c.j.AgroalJdbcDataSourceProvider - Connecting to JDBC URL jdbc:...
2023-08-25 12:41:54,516 [main] DEBUG o.p.g.c.j.AgroalJdbcDataSourceProvider - Connecting using name principal my-username
2023-08-25 12:41:54,516 [main] DEBUG o.p.g.c.j.AgroalJdbcDataSourceProvider - Connecting using given password principal
2023-08-25 12:41:54,516 [main] DEBUG o.p.g.c.j.AgroalJdbcDataSourceProvider - JDBC pool options: initial-size=2, max-size=5, min-size=2, connection-lifetime=PT5M, acquisition-timeout=PT10S
...
```

Fixes #7405