### PR TITLE
Add --hash parameter to content-generator commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ as necessary. Empty sections will not end in the release notes.
 ### Breaking changes
 
 ### New Features
+- Content Generator tool: added new `--hash` parameter to `commits`, `content` and `entries` 
+  commands.
 
 ### Changes
 

--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadContent.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadContent.java
@@ -21,10 +21,14 @@ import static org.projectnessie.tools.contentgenerator.RunContentGenerator.runGe
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.Operation;
 import org.projectnessie.tools.contentgenerator.RunContentGenerator.ProcessResult;
 
 class ITReadContent extends AbstractContentGeneratorTest {
@@ -80,5 +84,49 @@ class ITReadContent extends AbstractContentGeneratorTest {
         .anySatisfy(s -> assertThat(s).contains("key[0]: " + CONTENT_KEY.getElements().get(0)));
     assertThat(output)
         .anySatisfy(s -> assertThat(s).contains("key[1]: " + CONTENT_KEY.getElements().get(1)));
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"%1$s|true", "%2$s|false", "%2$s~1|true"},
+      delimiter = '|')
+  void readContentsWithHash(String hash, boolean expectContent) throws Exception {
+
+    String c1 = branch.getHash();
+    try (NessieApiV2 api = buildNessieApi()) {
+      branch =
+          api.commitMultipleOperations()
+              .branchName(branch.getName())
+              .hash(c1)
+              .commitMeta(CommitMeta.fromMessage("Second commit"))
+              .operation(Operation.Delete.of(CONTENT_KEY))
+              .commit();
+    }
+    String c2 = branch.getHash();
+
+    ProcessResult proc =
+        runGeneratorCmd(
+            "content",
+            "--uri",
+            NESSIE_API_URI,
+            "--ref",
+            branch.getName(),
+            "--hash",
+            String.format(hash, c1, c2),
+            "--key",
+            CONTENT_KEY.getElements().get(0),
+            "--key",
+            CONTENT_KEY.getElements().get(1));
+    assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
+    List<String> output = proc.getStdOutLines();
+    if (expectContent) {
+      assertThat(output)
+          .contains("Key: " + CONTENT_KEY)
+          .anySatisfy(s -> assertThat(s).contains("Value: IcebergTable"));
+    } else {
+      assertThat(output)
+          .doesNotContain("Key: " + CONTENT_KEY)
+          .noneSatisfy(s -> assertThat(s).contains("Value: IcebergTable"));
+    }
   }
 }

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
@@ -34,12 +34,18 @@ public class ReadCommits extends AbstractCommand {
       description = "Name of the branch/tag to read the commit log from, defaults to 'main'")
   private String ref = "main";
 
+  @Option(
+      names = {"-H", "--hash"},
+      description =
+          "Hash of the commit to read content from, defaults to HEAD. Relative lookups are accepted.")
+  private String hash;
+
   @Override
   public void execute() throws NessieNotFoundException {
     try (NessieApiV2 api = createNessieApiInstance()) {
       spec.commandLine().getOut().printf("Reading commits for ref '%s'\n\n", ref);
       FetchOption fetchOption = isVerbose() ? FetchOption.ALL : FetchOption.MINIMAL;
-      api.getCommitLog().refName(ref).fetch(fetchOption).stream()
+      api.getCommitLog().refName(ref).hashOnRef(hash).fetch(fetchOption).stream()
           .forEach(
               logEntry -> {
                 CommitMeta commitMeta = logEntry.getCommitMeta();

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadContent.java
@@ -35,6 +35,12 @@ public class ReadContent extends AbstractCommand {
   private String ref = "main";
 
   @Option(
+      names = {"-H", "--hash"},
+      description =
+          "Hash of the commit to read content from, defaults to HEAD. Relative lookups are accepted.")
+  private String hash;
+
+  @Option(
       names = {"-k", "--key"},
       description = "Content key to use",
       required = true)
@@ -46,7 +52,7 @@ public class ReadContent extends AbstractCommand {
       ContentKey contentKey = ContentKey.of(key);
       spec.commandLine().getOut().printf("Reading content for key '%s'\n\n", contentKey);
       GetMultipleContentsResponse contents =
-          api.getContent().refName(ref).key(contentKey).getWithResponse();
+          api.getContent().refName(ref).hashOnRef(hash).key(contentKey).getWithResponse();
       Map<ContentKey, Content> contentMap = contents.toContentsMap();
       spec.commandLine().getOut().printf("Content at '%s'\n", contents.getEffectiveReference());
       for (Map.Entry<ContentKey, Content> entry : contentMap.entrySet()) {

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadEntries.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadEntries.java
@@ -35,6 +35,12 @@ public class ReadEntries extends AbstractCommand {
   private String ref = "main";
 
   @Option(
+      names = {"-H", "--hash"},
+      description =
+          "Hash of the commit to read content from, defaults to HEAD. Relative lookups are accepted.")
+  private String hash;
+
+  @Option(
       names = {"-C", "--with-content"},
       description = "Include content for each entry.")
   private boolean withContent;
@@ -45,7 +51,7 @@ public class ReadEntries extends AbstractCommand {
 
     try (NessieApiV2 api = createNessieApiInstance()) {
       out.printf("Listing entries for reference '%s'.%n%n", ref);
-      api.getEntries().refName(ref).withContent(withContent).stream()
+      api.getEntries().refName(ref).hashOnRef(hash).withContent(withContent).stream()
           .forEach(
               entry -> {
                 out.printf("Key: %s%n", entry.getName());


### PR DESCRIPTION
This commit adds a `--hash` parameter to the following commands:

* ReadCommits
* ReadContent
* ReadEntries