### PR TITLE
Add `--full-hashes` option to `commits` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ as necessary. Empty sections will not end in the release notes.
 ### New Features
 - Content Generator tool: added new `--hash` parameter to `commits`, `content` and `entries` 
   commands.
-- Content Generator tool: commit hashes are now printed in full when running the `commits` command.
 
 ### Changes
+- Content Generator tool: commit hashes are now printed in full when running the `commits` command.
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ as necessary. Empty sections will not end in the release notes.
 ### New Features
 - Content Generator tool: added new `--hash` parameter to `commits`, `content` and `entries` 
   commands.
+- Content Generator tool: new `--full-hashes` option to `commits` command to print full hashes
+  instead of abbreviated hashes.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ as necessary. Empty sections will not end in the release notes.
 ### New Features
 - Content Generator tool: added new `--hash` parameter to `commits`, `content` and `entries` 
   commands.
-- Content Generator tool: new `--full-hashes` option to `commits` command to print full hashes
-  instead of abbreviated hashes.
+- Content Generator tool: commit hashes are now printed in full when running the `commits` command.
 
 ### Changes
 

--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
@@ -62,16 +62,6 @@ class ITReadCommits extends AbstractContentGeneratorTest {
   }
 
   @Test
-  void readCommitsFullHashes() {
-    ProcessResult proc =
-        runGeneratorCmd(
-            "commits", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--full-hashes");
-    assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
-    List<String> output = proc.getStdOutLines();
-    assertThat(output).anySatisfy(s -> assertThat(s).matches("[0-9a-f]{32}.*" + COMMIT_MSG + ".*"));
-  }
-
-  @Test
   void readCommitsVerbose() throws Exception {
     ProcessResult proc =
         runGeneratorCmd("commits", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--verbose");

--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITReadCommits.java
@@ -62,6 +62,16 @@ class ITReadCommits extends AbstractContentGeneratorTest {
   }
 
   @Test
+  void readCommitsFullHashes() {
+    ProcessResult proc =
+        runGeneratorCmd(
+            "commits", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--full-hashes");
+    assertThat(proc).extracting(ProcessResult::getExitCode).isEqualTo(0);
+    List<String> output = proc.getStdOutLines();
+    assertThat(output).anySatisfy(s -> assertThat(s).matches("[0-9a-f]{32}.*" + COMMIT_MSG + ".*"));
+  }
+
+  @Test
   void readCommitsVerbose() throws Exception {
     ProcessResult proc =
         runGeneratorCmd("commits", "--uri", NESSIE_API_URI, "--ref", branch.getName(), "--verbose");

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
@@ -16,7 +16,6 @@
 package org.projectnessie.tools.contentgenerator.cli;
 
 import java.util.List;
-import java.util.Objects;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.CommitMeta;
@@ -53,7 +52,7 @@ public class ReadCommits extends AbstractCommand {
                     .getOut()
                     .printf(
                         "%s\t%s\t%s [%s]\n",
-                        Objects.requireNonNull(commitMeta.getHash()),
+                        commitMeta.getHash(),
                         commitMeta.getAuthorTime(),
                         commitMeta.getMessage(),
                         commitMeta.getAuthor());

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
@@ -40,11 +40,6 @@ public class ReadCommits extends AbstractCommand {
           "Hash of the commit to read content from, defaults to HEAD. Relative lookups are accepted.")
   private String hash;
 
-  @Option(
-      names = {"-f", "--full-hashes"},
-      description = "Show full hashes instead of short hashes.")
-  private boolean fullHashes = false;
-
   @Override
   public void execute() throws NessieNotFoundException {
     try (NessieApiV2 api = createNessieApiInstance()) {
@@ -58,7 +53,7 @@ public class ReadCommits extends AbstractCommand {
                     .getOut()
                     .printf(
                         "%s\t%s\t%s [%s]\n",
-                        formatHash(commitMeta),
+                        Objects.requireNonNull(commitMeta.getHash()),
                         commitMeta.getAuthorTime(),
                         commitMeta.getMessage(),
                         commitMeta.getAuthor());
@@ -78,13 +73,5 @@ public class ReadCommits extends AbstractCommand {
               });
       spec.commandLine().getOut().printf("\nDone reading commits for ref '%s'\n\n", ref);
     }
-  }
-
-  private String formatHash(CommitMeta commitMeta) {
-    String hash = Objects.requireNonNull(commitMeta.getHash());
-    if (fullHashes) {
-      return hash;
-    }
-    return hash.substring(0, 8);
   }
 }

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ReadCommits.java
@@ -40,6 +40,11 @@ public class ReadCommits extends AbstractCommand {
           "Hash of the commit to read content from, defaults to HEAD. Relative lookups are accepted.")
   private String hash;
 
+  @Option(
+      names = {"-f", "--full-hashes"},
+      description = "Show full hashes instead of short hashes.")
+  private boolean fullHashes = false;
+
   @Override
   public void execute() throws NessieNotFoundException {
     try (NessieApiV2 api = createNessieApiInstance()) {
@@ -53,7 +58,7 @@ public class ReadCommits extends AbstractCommand {
                     .getOut()
                     .printf(
                         "%s\t%s\t%s [%s]\n",
-                        Objects.requireNonNull(commitMeta.getHash()).substring(0, 8),
+                        formatHash(commitMeta),
                         commitMeta.getAuthorTime(),
                         commitMeta.getMessage(),
                         commitMeta.getAuthor());
@@ -73,5 +78,13 @@ public class ReadCommits extends AbstractCommand {
               });
       spec.commandLine().getOut().printf("\nDone reading commits for ref '%s'\n\n", ref);
     }
+  }
+
+  private String formatHash(CommitMeta commitMeta) {
+    String hash = Objects.requireNonNull(commitMeta.getHash());
+    if (fullHashes) {
+      return hash;
+    }
+    return hash.substring(0, 8);
   }
 }


### PR DESCRIPTION
...because abbreviated hashes cannot be used as valid `--hash` parameters.