### PR TITLE
Build: remove superfluous system-property hack

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -86,7 +86,7 @@ dependencies {
     api(project(":nessie-versioned-tests"))
     api(project(":nessie-versioned-transfer-proto"))
     api(project(":nessie-versioned-transfer"))
-    if (!isIntegrationsTestingEnabled()) {
+    if (!isIncludedInNesQuEIT()) {
       api(project(":iceberg-views"))
       api(project(":nessie-spark-antlr-runtime"))
       api(project(":nessie-spark-extensions-grammar"))

--- a/nessie-iceberg/gradle.properties
+++ b/nessie-iceberg/gradle.properties
@@ -22,6 +22,3 @@ org.gradle.jvmargs=\
   --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
-
-# Enable Nessie-Iceberg build, resolving Nessie artifacts differently
-systemProp.nessie.integrationsTesting.enable=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -151,9 +151,10 @@ if (gradle.parent != null && ideSyncActive) {
   }
 }
 
-// Cannot use isIntegrationsTestingEnabled() in build-logic/src/main/kotlin/Utilities.kt, because
-// settings.gradle is evaluated before build-logic.
-if (!System.getProperty("nessie.integrationsTesting.enable").toBoolean()) {
+// Cannot use isIncludedInNesQuEIT() in build-logic/src/main/kotlin/Utilities.kt, because
+// settings.gradle is evaluated before build-logic, also the the parent's rootProject is not
+// available here.
+if (gradle.parent == null) {
   loadProjects("gradle/projects.iceberg.properties", groupIdIntegrations)
 
   val sparkScala = loadProperties(file("integrations/spark-scala.properties"))


### PR DESCRIPTION
For NesQuEIT the build used the system property `systemProp.nessie.integrationsTesting.enable` to discover whether it has been included from NesQuEIT or not, which changes how some dependencies are resolved.

It is actually not necessary to use a system property, instead `Gradle.getParent().getRootProject().getName()` can be used.