### PR TITLE
Propagate index stripes from parent to child commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ as necessary. Empty sections will not end in the release notes.
 ### Deprecations
 
 ### Fixes
-- Fixed potential index corruption when importing repositories using the new storage model that 
+- Fixed potential index corruption when importing repositories into the new storage model that 
   could cause some contents to become inaccessible.
 
 ### Commits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ as necessary. Empty sections will not end in the release notes.
 ### Deprecations
 
 ### Fixes
+- Fixed potential index corruption when importing repositories using the new storage model that 
+  could cause some contents to become inaccessible.
 
 ### Commits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ as necessary. Empty sections will not end in the release notes.
 ### Deprecations
 
 ### Fixes
-- Fixed potential index corruption when importing repositories into the new storage model that 
-  could cause some contents to become inaccessible.
+- Fixed potential index corruption when importing repositories with many keys into the new storage 
+  model that could cause some contents to become inaccessible.
 
 ### Commits
 

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractIndexesLogicTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractIndexesLogicTests.java
@@ -409,6 +409,7 @@ public class AbstractIndexesLogicTests {
         index.add(indexElement(k, commitOp(ADD, 42, v, cid)));
       }
 
+      // incremental index has size 175, max configured is 200
       c.incrementalIndex(index.serialize());
       CommitObj commit = c.build();
       persist.storeObj(commit);

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractIndexesLogicTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractIndexesLogicTests.java
@@ -18,7 +18,6 @@ package org.projectnessie.versioned.storage.commontests;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.projectnessie.versioned.storage.common.indexes.StoreIndexElement.indexElement;
@@ -44,13 +43,12 @@ import static org.projectnessie.versioned.storage.commontests.KeyIndexTestSet.ba
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
-import java.util.stream.IntStream;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.projectnessie.versioned.storage.common.config.StoreConfig.Adjustable;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
@@ -345,18 +343,14 @@ public class AbstractIndexesLogicTests {
     soft.assertThat(indexesLogic.commitOperations(commit)).containsExactly(add1, add2, remove1);
   }
 
-  private static final String LARGE_STRING =
-      IntStream.range(0, 100).mapToObj(i -> "x").collect(joining());
-
   @SuppressWarnings("unused")
-  static Adjustable persistWithSmallIndexSizeWithStripes(Adjustable config) {
+  static StoreConfig.Adjustable persistWithSmallIndexSize(StoreConfig.Adjustable config) {
     return config.withMaxIncrementalIndexSize(200);
   }
 
   @Test
   void completeIndexesInCommitChainWithStripes(
-      @NessiePersist(configMethod = "persistWithSmallIndexSizeWithStripes") Persist persist)
-      throws Exception {
+      @NessiePersist(configMethod = "persistWithSmallIndexSize") Persist persist) throws Exception {
 
     ObjId currentId = fiveIncompleteCommitsWithThreeOpsEach(persist);
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
@@ -564,9 +564,7 @@ final class IndexesLogicImpl implements IndexesLogic {
         int parents = Math.min(parentsPerCommit - 1, parent.tail().size());
         List<ObjId> tail = new ArrayList<>(parents + 1);
         tail.add(parent.id());
-        for (int j = 0; j < parents; j++) {
-          tail.add(parent.tail().get(j));
-        }
+        tail.addAll(parent.tail().subList(0, parents));
         c.tail(tail);
       }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
@@ -537,12 +537,15 @@ final class IndexesLogicImpl implements IndexesLogic {
 
       StoreIndex<CommitOp> newIndex;
       ObjId referenceIndex;
+      List<IndexStripe> indexStripes;
       if (parent != null) {
         newIndex = incrementalIndexForUpdate(parent, Optional.empty());
         referenceIndex = parent.referenceIndex();
+        indexStripes = parent.referenceIndexStripes();
       } else {
         newIndex = newStoreIndex(COMMIT_OP_SERIALIZER);
         referenceIndex = null;
+        indexStripes = Collections.emptyList();
       }
 
       commitOperations(current).forEach(newIndex::add);
@@ -552,6 +555,7 @@ final class IndexesLogicImpl implements IndexesLogic {
               .from(current)
               .incompleteIndex(false)
               .referenceIndex(referenceIndex)
+              .referenceIndexStripes(indexStripes)
               .incrementalIndex(newIndex.serialize())
               .build();
       newCommit = commitLogic.updateCommit(newCommit);

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/CommitObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/CommitObj.java
@@ -101,6 +101,9 @@ public interface CommitObj extends Obj {
     Builder addTail(ObjId element);
 
     @CanIgnoreReturnValue
+    Builder tail(Iterable<? extends ObjId> elements);
+
+    @CanIgnoreReturnValue
     Builder addSecondaryParents(ObjId element);
 
     @CanIgnoreReturnValue

--- a/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/NessiePersist.java
+++ b/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/NessiePersist.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.persist.Persist;
 
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
@@ -27,18 +29,16 @@ import java.lang.annotation.Target;
 public @interface NessiePersist {
 
   /**
-   * Optional: name of method to update the {@link
-   * org.projectnessie.versioned.storage.common.config.StoreConfig configuration} for the {@link
-   * org.projectnessie.versioned.storage.common.persist.Persist}.
+   * Optional: name of method to update the {@linkplain StoreConfig.Adjustable configuration} for
+   * the {@link Persist}.
    *
    * <p>The method must be
    *
    * <ul>
    *   <li>static
    *   <li>not private
-   *   <li>have a single parameter {@code
-   *       org.projectnessie.versioned.storage.common.config.StoreConfig}
-   *   <li>return {@code org.projectnessie.versioned.storage.common.config.StoreConfig}
+   *   <li>have a single parameter {@link StoreConfig.Adjustable}
+   *   <li>return {@link StoreConfig.Adjustable}
    * </ul>
    *
    * <p>Example:
@@ -47,7 +47,7 @@ public @interface NessiePersist {
    *   &#64;NessiePersist(configMethod = "applyTestClock")
    *   protected static Persist persist;
    *
-   *   static StoreConfig applyTestClock(StoreConfig config) {
+   *   static StoreConfig.Adjustable applyTestClock(StoreConfig.Adjustable config) {
    *     return ...
    *   }
    * </code></pre>

--- a/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/PersistExtension.java
+++ b/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/PersistExtension.java
@@ -245,7 +245,7 @@ public class PersistExtension implements BeforeAllCallback, BeforeEachCallback, 
           findMethod(
                   context.getRequiredTestClass(),
                   persistAnnotation.configMethod(),
-                  StoreConfig.class)
+                  StoreConfig.Adjustable.class)
               .orElseThrow(
                   () ->
                       new IllegalArgumentException(


### PR DESCRIPTION
Not propagating index stripes in the commit chain can potentially make some entries unreachable.

I don't have a proper unit test yet, will try to add one soonish, but I manually verified that this PR fixes some broken imports containing a huge number of entries per commit.