### PR TITLE
Build: fix removal of superfluous system-property for NesQuEIT

### DIFF
--- a/build-logic/src/main/kotlin/Utilities.kt
+++ b/build-logic/src/main/kotlin/Utilities.kt
@@ -163,8 +163,7 @@ fun testLogLevel(minVerbose: String): String {
   return requested.name
 }
 
-fun isIncludedInNesQuEIT(gradle: Gradle): Boolean =
-  "tools-integration-tests" == gradle.parent?.rootProject?.name
+fun isIncludedInNesQuEIT(gradle: Gradle): Boolean = "NesQuEIT" == gradle.parent?.rootProject?.name
 
 /** Check whether the current build is run in the context of integrations-testing. */
 fun Project.isIncludedInNesQuEIT(): Boolean = isIncludedInNesQuEIT(gradle)


### PR DESCRIPTION
The previous change in #7451 assumed that the NesQuEIT project name is always `tools-integration-tests`, but that's just the directory name "on my machine(TM)".
    
Update both NesQuEIT (to set a fixed name) and Nessie build logic.