### PR TITLE
Helm chart: disable OpenTelemetry SDK when tracing is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ as necessary. Empty sections will not end in the release notes.
   commands.
 - Content Generator tool: tool now prints the total number of elements returned when running the 
   `commits`, `references` and `entries` commands.
+- Helm charts: OpenTelemetry SDK is now completely disabled when tracing is disabled.
 
 ### Deprecations
 

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -205,6 +205,9 @@ spec:
               value: {{ .Values.tracing.sample | quote }}
             {{- end }}
             {{- end }}
+            {{- else }}
+            - name: QUARKUS_OTEL_SDK_DISABLED
+              value: "true"
             {{- end }}
 
             {{ list .Values.advancedConfig "" | include "nessie.propsToEnvVars" | nindent 12 }}


### PR DESCRIPTION
Fixes #7458 