### PR TITLE
Helm chart: disable OIDC warnings when authentication is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ as necessary. Empty sections will not end in the release notes.
 - Content Generator tool: tool now prints the total number of elements returned when running the 
   `commits`, `references` and `entries` commands.
 - Helm charts: OpenTelemetry SDK is now completely disabled when tracing is disabled.
+- Helm charts: when auth is disabled, Quarkus OIDC doesn't print warnings anymore during startup.
 
 ### Deprecations
 

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -171,6 +171,9 @@ spec:
             - name: QUARKUS_OIDC_CLIENT_ID
               value: {{ .Values.authentication.oidcClientId }}
             {{- end }}
+            {{- else }}
+            - name: QUARKUS_LOG_CATEGORY__IO_QUARKUS_OIDC__LEVEL
+              value: "ERROR"
             {{- end }}
 
             {{- if .Values.authorization.enabled }}


### PR DESCRIPTION
Inspired by #7459. This PR suppresses these annoying warnings when auth is disabled:

```text
2023-08-31 18:50:35,832 WARN  [io.qua.oid.com.run.OidcCommonUtils] (vert.x-eventloop-thread-1) OIDC Server is not available:: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:58166
Caused by: java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.Net.pollConnect(Native Method)
	at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:672)
	at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:946)
	at io.netty.channel.socket.nio.NioSocketChannel.doFinishConnect(NioSocketChannel.java:337)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:334)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:776)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)

2023-08-31 18:50:35,834 WARN  [io.qua.oid.run.OidcRecorder] (vert.x-eventloop-thread-1) OIDC server is not available at the 'http://localhost:58166/auth/realms/master' URL. Please make sure it is correct. Note it has to end with a realm value if you work with Keycloak, for example: 'https://localhost:8180/auth/realms/quarkus'
2023-08-31 18:50:35,834 WARN  [io.qua.oid.run.OidcRecorder] (vert.x-eventloop-thread-1) Tenant 'Default': 'OIDC Server is not available'. OIDC server is not available yet, an attempt to connect will be made duiring the first request. Access to resources protected by this tenant may fail if OIDC server will not become available
```

There is no way to actually disable the OIDC extension since it's a build-time property. But we can at least make the logs less verbose :-)