### PR TITLE
Add NessieUnavailableException (HTTP 503)

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
@@ -31,6 +31,7 @@ import org.projectnessie.error.ErrorCode;
 import org.projectnessie.error.ImmutableNessieError;
 import org.projectnessie.error.NessieError;
 import org.projectnessie.error.NessieErrorDetails;
+import org.projectnessie.error.NessieUnavailableException;
 
 public class ResponseCheckFilter {
 
@@ -77,6 +78,9 @@ public class ResponseCheckFilter {
     switch (status) {
       case INTERNAL_SERVER_ERROR:
         exception = new NessieInternalServerException(error);
+        break;
+      case SERVICE_UNAVAILABLE:
+        exception = new NessieUnavailableException(error);
         break;
       case UNAUTHORIZED:
         // Note: UNAUTHORIZED at this point cannot be a Nessie-controlled error.

--- a/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -59,6 +59,7 @@ import org.projectnessie.error.NessieError;
 import org.projectnessie.error.NessieForbiddenException;
 import org.projectnessie.error.NessieReferenceConflictException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
+import org.projectnessie.error.NessieUnavailableException;
 import org.projectnessie.error.NessieUnsupportedMediaTypeException;
 import org.projectnessie.error.ReferenceConflicts;
 import org.projectnessie.model.Conflict;
@@ -338,6 +339,11 @@ public class TestResponseFilter {
         arguments(Status.UNAUTHORIZED, ErrorCode.UNKNOWN, NessieNotAuthorizedException.class),
         arguments(Status.FORBIDDEN, ErrorCode.FORBIDDEN, NessieForbiddenException.class),
         arguments(Status.FORBIDDEN, ErrorCode.UNKNOWN, NessieServiceException.class),
+        arguments(Status.SERVICE_UNAVAILABLE, ErrorCode.UNKNOWN, NessieUnavailableException.class),
+        arguments(
+            Status.SERVICE_UNAVAILABLE,
+            ErrorCode.SERVICE_UNAVAILABLE,
+            NessieUnavailableException.class),
         arguments(Status.TOO_MANY_REQUESTS, ErrorCode.UNKNOWN, NessieServiceException.class),
         arguments(
             Status.TOO_MANY_REQUESTS,

--- a/api/model/src/main/java/org/projectnessie/error/ErrorCode.java
+++ b/api/model/src/main/java/org/projectnessie/error/ErrorCode.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
  */
 public enum ErrorCode {
   UNKNOWN(500, null),
+  SERVICE_UNAVAILABLE(503, NessieUnavailableException::new),
   REFERENCE_NOT_FOUND(404, NessieReferenceNotFoundException::new),
   REFERENCE_ALREADY_EXISTS(409, NessieReferenceAlreadyExistsException::new),
   CONTENT_NOT_FOUND(404, NessieContentNotFoundException::new),

--- a/api/model/src/main/java/org/projectnessie/error/NessieUnavailableException.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieUnavailableException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.error;
+
+/**
+ * Represents failures related to Nessie being temporarily unavailable. These errors can be retried
+ * with a back-off.
+ */
+public class NessieUnavailableException extends NessieRuntimeException {
+  public NessieUnavailableException(NessieError error) {
+    super(error);
+  }
+}


### PR DESCRIPTION
Introduce a dedicated java client exception type for HTTP 503 (SERVICE_UNAVAILABLE) REST API responses.