### PR TITLE
GC: Handle delete manifests and row level delete files

### DIFF
--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -71,6 +71,10 @@ dependencies {
   intTestRuntimeOnly(
     "org.apache.iceberg:iceberg-spark-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}:${libs.versions.iceberg.get()}"
   )
+  intTestRuntimeOnly(
+    "org.apache.iceberg:iceberg-spark-extensions-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}:${libs.versions.iceberg.get()}"
+  )
+
   intTestRuntimeOnly(libs.iceberg.hive.metastore)
   intTestRuntimeOnly(libs.iceberg.aws)
 

--- a/gc/gc-iceberg/src/main/java/org/apache/iceberg/ManifestReaderUtil.java
+++ b/gc/gc-iceberg/src/main/java/org/apache/iceberg/ManifestReaderUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+
+public final class ManifestReaderUtil {
+
+  private ManifestReaderUtil() {}
+
+  public static CloseableIterable<String> readPathsFromManifest(ManifestFile manifest, FileIO io) {
+    // entry.file() is package private. Hence, this Util class under iceberg package.
+    return CloseableIterable.transform(
+        ManifestFiles.open(manifest, io, null).select(ImmutableList.of("file_path")).liveEntries(),
+        entry -> entry.file().path().toString());
+  }
+}


### PR DESCRIPTION
- `ManifestFiles.readPaths` is meant only for data manifests. 
Need to use `ManifestFiles.open` (package private) which can handle both data and delete manifests.
- Add a nice testcase to gc delete files and delete manifests (this took most of the effort 😄)

Fixes https://github.com/projectnessie/nessie/issues/7477