### PR TITLE
GC: Bump spark version for integration tests

### DIFF
--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 extra["maven.name"] = "Nessie - GC - Integration tests"
 
-val sparkScala = useSparkScalaVersionsForProject("3.3", "2.12")
+val sparkScala = useSparkScalaVersionsForProject("3.4", "2.12")
 
 dependencies {
   implementation(libs.hadoop.client)

--- a/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieS3.java
+++ b/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieS3.java
@@ -91,6 +91,16 @@ public class ITSparkIcebergNessieS3 extends SparkSqlTestBase {
   }
 
   @Override
+  protected Map<String, String> sparkHadoop() {
+    Map<String, String> r = new HashMap<>();
+    r.put("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+    r.put("fs.s3a.access.key", minio.accessKey());
+    r.put("fs.s3a.secret.key", minio.secretKey());
+    r.put("fs.s3a.endpoint", minio.s3endpoint());
+    return r;
+  }
+
+  @Override
   protected Map<String, String> nessieParams() {
     Map<String, String> r = new HashMap<>(super.nessieParams());
     r.put(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.aws.s3.S3FileIO");

--- a/gc/gc-tool-inttest/build.gradle.kts
+++ b/gc/gc-tool-inttest/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 extra["maven.name"] = "Nessie - GC - CLI integration test"
 
-val sparkScala = useSparkScalaVersionsForProject("3.3", "2.12")
+val sparkScala = useSparkScalaVersionsForProject("3.4", "2.12")
 
 dependencies {
   implementation(nessieProject("nessie-gc-tool", "shadow"))


### PR DESCRIPTION
I am trying to add row level delete test case for integration test. But it couldn't seem to work with existing spark-3.3 dependency. Hence, bumping to spark-3.4 (where it seems to work)