### PR TITLE
Combined Nessie server+client for testing

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   constraints {
     api(rootProject)
     api(project(":nessie-client"))
+    api(project(":nessie-combined-cs"))
     api(project(":nessie-compatibility-common"))
     api(project(":nessie-compatibility-tests"))
     api(project(":nessie-compatibility-jersey"))

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -1,6 +1,7 @@
 nessie-bom=bom
 nessie-client=api/client
 nessie-client-testextension=api/client-testextension
+nessie-combined-cs=testing/combined-cs
 nessie-compatibility-common=compatibility/common
 nessie-compatibility-tests=compatibility/compatibility-tests
 nessie-compatibility-jersey=compatibility/jersey

--- a/testing/combined-cs/README.md
+++ b/testing/combined-cs/README.md
@@ -1,0 +1,10 @@
+# Nessie Client directly accessing a Nessie backend
+
+... without REST or any other intermediate protocol.
+
+**NOT FOR PRODUCTION USE**
+
+* No access checks
+* (possibly) not fully tested and (possibly) does not provide the same behavior
+* Meant for testing use cases that do not want to or cannot use (another) Jersey/Weld instance
+* (Currently?) only implemented for (and useful with?) an in-memory backend

--- a/testing/combined-cs/build.gradle.kts
+++ b/testing/combined-cs/build.gradle.kts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id("nessie-conventions-server")
+  id("nessie-jacoco")
+}
+
+extra["maven.name"] = "Nessie - Combined Client and Server"
+
+dependencies {
+  api(project(":nessie-client"))
+  api(project(":nessie-model"))
+  implementation(project(":nessie-rest-services"))
+  implementation(project(":nessie-services"))
+  implementation(project(":nessie-server-store"))
+  implementation(project(":nessie-versioned-spi"))
+  implementation(project(":nessie-versioned-persist-store"))
+  implementation(project(":nessie-versioned-storage-common"))
+  implementation(project(":nessie-versioned-storage-inmemory"))
+  implementation(project(":nessie-versioned-storage-store"))
+  implementation(libs.slf4j.api)
+
+  // javax/jakarta
+  compileOnly(libs.jakarta.ws.rs.api)
+  compileOnly(libs.javax.ws.rs21)
+  compileOnly(libs.jakarta.enterprise.cdi.api)
+  compileOnly(libs.javax.enterprise.cdi.api)
+  compileOnly(libs.jakarta.annotation.api)
+  compileOnly(libs.findbugs.jsr305)
+  compileOnly(libs.jakarta.validation.api)
+  compileOnly(libs.javax.validation.api)
+
+  compileOnly(libs.microprofile.openapi)
+
+  compileOnly(libs.hibernate.validator.cdi)
+
+  implementation(platform(libs.jackson.bom))
+  implementation("com.fasterxml.jackson.core:jackson-databind")
+  compileOnly("com.fasterxml.jackson.core:jackson-annotations")
+
+  compileOnly(libs.bundles.junit.testing)
+  compileOnly(project(":nessie-client-testextension"))
+  compileOnly("org.junit.jupiter:junit-jupiter-engine")
+
+  testImplementation(project(":nessie-jaxrs-tests"))
+
+  testRuntimeOnly(libs.h2)
+  testRuntimeOnly(libs.logback.classic)
+
+  // javax/jakarta
+  testCompileOnly(libs.jakarta.annotation.api)
+  testCompileOnly(libs.findbugs.jsr305)
+
+  testCompileOnly(libs.microprofile.openapi)
+
+  testImplementation(libs.bundles.junit.testing)
+  testImplementation(project(":nessie-client-testextension"))
+  testCompileOnly("org.junit.jupiter:junit-jupiter-engine")
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/BaseCombinedAssignReference.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/BaseCombinedAssignReference.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.builder.BaseAssignReferenceBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
+
+abstract class BaseCombinedAssignReference<T extends Reference, B>
+    extends BaseAssignReferenceBuilder<B> {
+
+  private final TreeApi treeApi;
+
+  BaseCombinedAssignReference(TreeApi treeApi) {
+    this.treeApi = treeApi;
+  }
+
+  public void assign() throws NessieNotFoundException, NessieConflictException {
+    assignAndGet();
+  }
+
+  @SuppressWarnings("unchecked")
+  public T assignAndGet() throws NessieNotFoundException, NessieConflictException {
+    try {
+      String type = super.type != null ? super.type.name() : null;
+      return (T)
+          treeApi
+              .assignReference(type, Reference.toPathString(refName, expectedHash), assignTo)
+              .getReference();
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/BaseCombinedDeleteReference.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/BaseCombinedDeleteReference.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.builder.BaseChangeReferenceBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
+
+abstract class BaseCombinedDeleteReference<T extends Reference, B>
+    extends BaseChangeReferenceBuilder<B> {
+
+  private final TreeApi treeApi;
+
+  BaseCombinedDeleteReference(TreeApi treeApi) {
+    this.treeApi = treeApi;
+  }
+
+  public void delete() throws NessieConflictException, NessieNotFoundException {
+    getAndDelete();
+  }
+
+  @SuppressWarnings("unchecked")
+  public T getAndDelete() throws NessieNotFoundException, NessieConflictException {
+    String type = super.type != null ? super.type.name() : null;
+    try {
+      return (T)
+          treeApi
+              .deleteReference(type, Reference.toPathString(refName, expectedHash))
+              .getReference();
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedAssignBranch.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedAssignBranch.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.api.AssignBranchBuilder;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Reference.ReferenceType;
+
+final class CombinedAssignBranch extends BaseCombinedAssignReference<Branch, AssignBranchBuilder>
+    implements AssignBranchBuilder {
+
+  CombinedAssignBranch(TreeApi treeApi) {
+    super(treeApi);
+    refType(ReferenceType.BRANCH);
+  }
+
+  @Override
+  public AssignBranchBuilder branchName(String branchName) {
+    return refName(branchName);
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedAssignReference.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedAssignReference.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.api.AssignReferenceBuilder;
+import org.projectnessie.model.Reference;
+
+final class CombinedAssignReference
+    extends BaseCombinedAssignReference<Reference, AssignReferenceBuilder<Reference>>
+    implements AssignReferenceBuilder<Reference> {
+
+  CombinedAssignReference(TreeApi treeApi) {
+    super(treeApi);
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedAssignTag.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedAssignTag.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.api.AssignTagBuilder;
+import org.projectnessie.model.Reference.ReferenceType;
+import org.projectnessie.model.Tag;
+
+final class CombinedAssignTag extends BaseCombinedAssignReference<Tag, AssignTagBuilder>
+    implements AssignTagBuilder {
+
+  CombinedAssignTag(TreeApi treeApi) {
+    super(treeApi);
+    refType(ReferenceType.TAG);
+  }
+
+  @Override
+  public AssignTagBuilder tagName(String tagName) {
+    return refName(tagName);
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientBuilder.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import java.security.Principal;
+import java.util.function.Supplier;
+import org.projectnessie.client.NessieClientBuilder;
+import org.projectnessie.client.api.NessieApi;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.services.authz.AbstractBatchAccessChecker;
+import org.projectnessie.services.authz.Authorizer;
+import org.projectnessie.services.config.ServerConfig;
+import org.projectnessie.services.impl.ConfigApiImpl;
+import org.projectnessie.services.impl.ContentApiImpl;
+import org.projectnessie.services.impl.DiffApiImpl;
+import org.projectnessie.services.impl.TreeApiImpl;
+import org.projectnessie.services.rest.RestV2ConfigResource;
+import org.projectnessie.services.rest.RestV2TreeResource;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.versionstore.VersionStoreImpl;
+
+/**
+ * Builder for a {@link NessieApiV2} client that directly accesses the {@linkplain
+ * #withPersist(Persist) provided <code>Persist</code>} instance.
+ */
+public class CombinedClientBuilder extends NessieClientBuilder.AbstractNessieClientBuilder {
+  private Persist persist;
+
+  public CombinedClientBuilder() {}
+
+  @Override
+  public String name() {
+    return "Combined";
+  }
+
+  @Override
+  public int priority() {
+    return 50;
+  }
+
+  public NessieClientBuilder withPersist(Persist persist) {
+    this.persist = persist;
+    return this;
+  }
+
+  @Override
+  public <API extends NessieApi> API build(Class<API> apiContract) {
+    ServerConfig serverConfig =
+        new ServerConfig() {
+          @Override
+          public String getDefaultBranch() {
+            return "main";
+          }
+
+          @Override
+          public boolean sendStacktraceToClient() {
+            return true;
+          }
+        };
+
+    VersionStore versionStore = new VersionStoreImpl(persist);
+    Authorizer authorizer = c -> AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER;
+    Supplier<Principal> principalSupplier = () -> null;
+
+    ConfigApiImpl configService =
+        new ConfigApiImpl(serverConfig, versionStore, authorizer, principalSupplier, 2);
+    TreeApiImpl treeService =
+        new TreeApiImpl(serverConfig, versionStore, authorizer, principalSupplier);
+    ContentApiImpl contentService =
+        new ContentApiImpl(serverConfig, versionStore, authorizer, principalSupplier);
+    DiffApiImpl diffService =
+        new DiffApiImpl(serverConfig, versionStore, authorizer, principalSupplier);
+
+    RestV2ConfigResource configResource =
+        new RestV2ConfigResource(serverConfig, versionStore, authorizer, principalSupplier);
+    RestV2TreeResource treeResource =
+        new RestV2TreeResource(configService, treeService, contentService, diffService);
+
+    // Optimistic cast...
+    @SuppressWarnings("unchecked")
+    API r = (API) new CombinedClientImpl(configResource, treeResource);
+    return r;
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientImpl.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientImpl.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.ConfigApi;
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.api.v2.params.GetReferenceParams;
+import org.projectnessie.client.api.AssignBranchBuilder;
+import org.projectnessie.client.api.AssignReferenceBuilder;
+import org.projectnessie.client.api.AssignTagBuilder;
+import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
+import org.projectnessie.client.api.CreateReferenceBuilder;
+import org.projectnessie.client.api.DeleteBranchBuilder;
+import org.projectnessie.client.api.DeleteReferenceBuilder;
+import org.projectnessie.client.api.DeleteTagBuilder;
+import org.projectnessie.client.api.GetAllReferencesBuilder;
+import org.projectnessie.client.api.GetCommitLogBuilder;
+import org.projectnessie.client.api.GetContentBuilder;
+import org.projectnessie.client.api.GetDiffBuilder;
+import org.projectnessie.client.api.GetEntriesBuilder;
+import org.projectnessie.client.api.GetReferenceBuilder;
+import org.projectnessie.client.api.GetRepositoryConfigBuilder;
+import org.projectnessie.client.api.MergeReferenceBuilder;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.client.api.TransplantCommitsBuilder;
+import org.projectnessie.client.api.UpdateRepositoryConfigBuilder;
+import org.projectnessie.error.ErrorCode;
+import org.projectnessie.error.ImmutableNessieError;
+import org.projectnessie.error.NessieBadRequestException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.NessieConfiguration;
+import org.projectnessie.model.Reference;
+
+final class CombinedClientImpl implements NessieApiV2 {
+
+  private final ConfigApi configApi;
+  private final TreeApi treeApi;
+
+  CombinedClientImpl(ConfigApi configApi, TreeApi treeApi) {
+    this.configApi = configApi;
+    this.treeApi = treeApi;
+  }
+
+  static RuntimeException maybeWrapException(RuntimeException e) {
+    if (e instanceof IllegalArgumentException) {
+      NessieBadRequestException ex =
+          new NessieBadRequestException(
+              ImmutableNessieError.builder()
+                  .errorCode(ErrorCode.BAD_REQUEST)
+                  .message(e.getMessage())
+                  .status(400)
+                  .reason("Bad request")
+                  .build());
+      ex.initCause(e);
+      return ex;
+    }
+    return e;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public NessieConfiguration getConfig() {
+    return configApi.getConfig();
+  }
+
+  @Override
+  public Branch getDefaultBranch() throws NessieNotFoundException {
+    return (Branch)
+        treeApi.getReferenceByName(GetReferenceParams.builder().ref("-").build()).getReference();
+  }
+
+  @Override
+  public GetContentBuilder getContent() {
+    return new CombinedGetContent(treeApi);
+  }
+
+  @Override
+  public GetAllReferencesBuilder getAllReferences() {
+    return new CombinedGetAllReferences(treeApi);
+  }
+
+  @Override
+  public CreateReferenceBuilder createReference() {
+    return new CombinedCreateReference(treeApi);
+  }
+
+  @Override
+  public GetReferenceBuilder getReference() {
+    return new CombinedGetReference(treeApi);
+  }
+
+  @Override
+  public GetEntriesBuilder getEntries() {
+    return new CombinedGetEntries(treeApi);
+  }
+
+  @Override
+  public GetCommitLogBuilder getCommitLog() {
+    return new CombinedGetCommitLog(treeApi);
+  }
+
+  @Override
+  public TransplantCommitsBuilder transplantCommitsIntoBranch() {
+    return new CombinedTransplantCommits(treeApi);
+  }
+
+  @Override
+  public MergeReferenceBuilder mergeRefIntoBranch() {
+    return new CombinedMergeReference(treeApi);
+  }
+
+  @Override
+  public CommitMultipleOperationsBuilder commitMultipleOperations() {
+    return new CombinedCommitMultipleOperations(treeApi);
+  }
+
+  @Override
+  public GetDiffBuilder getDiff() {
+    return new CombinedGetDiff(treeApi);
+  }
+
+  @Override
+  public GetRepositoryConfigBuilder getRepositoryConfig() {
+    return new CombinedGetRepositoryConfig(configApi);
+  }
+
+  @Override
+  public UpdateRepositoryConfigBuilder updateRepositoryConfig() {
+    return new CombinedUpdateRepositoryConfig(configApi);
+  }
+
+  @Override
+  public DeleteReferenceBuilder<Reference> deleteReference() {
+    return new CombinedDeleteReference(treeApi);
+  }
+
+  @Override
+  public AssignReferenceBuilder<Reference> assignReference() {
+    return new CombinedAssignReference(treeApi);
+  }
+
+  @Override
+  public AssignTagBuilder assignTag() {
+    return new CombinedAssignTag(treeApi);
+  }
+
+  @Override
+  public AssignBranchBuilder assignBranch() {
+    return new CombinedAssignBranch(treeApi);
+  }
+
+  @Override
+  public DeleteTagBuilder deleteTag() {
+    return new CombinedDeleteTag(treeApi);
+  }
+
+  @Override
+  public DeleteBranchBuilder deleteBranch() {
+    return new CombinedDeleteBranch(treeApi);
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedCommitMultipleOperations.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedCommitMultipleOperations.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.builder.BaseCommitMultipleOperationsBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitResponse;
+import org.projectnessie.model.Reference;
+
+final class CombinedCommitMultipleOperations extends BaseCommitMultipleOperationsBuilder {
+  private final TreeApi treeApi;
+
+  CombinedCommitMultipleOperations(TreeApi treeApi) {
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  public Branch commit() throws NessieNotFoundException, NessieConflictException {
+    return commitWithResponse().getTargetBranch();
+  }
+
+  @Override
+  public CommitResponse commitWithResponse()
+      throws NessieNotFoundException, NessieConflictException {
+    try {
+      return treeApi.commitMultipleOperations(
+          Reference.toPathString(branchName, hash), operations.build());
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedCreateReference.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedCreateReference.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.builder.BaseCreateReferenceBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Detached;
+import org.projectnessie.model.Reference;
+
+public class CombinedCreateReference extends BaseCreateReferenceBuilder {
+
+  private final TreeApi treeApi;
+
+  protected CombinedCreateReference(TreeApi treeApi) {
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  public Reference create() throws NessieNotFoundException, NessieConflictException {
+    Reference source;
+    if (sourceRefName == null) {
+      if (reference.getHash() == null) {
+        source = null;
+      } else {
+        source = Detached.of(reference.getHash());
+      }
+    } else {
+      source = Branch.of(sourceRefName, reference.getHash());
+    }
+
+    try {
+      return treeApi
+          .createReference(reference.getName(), reference.getType().name(), source)
+          .getReference();
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedDeleteBranch.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedDeleteBranch.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.api.DeleteBranchBuilder;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Reference.ReferenceType;
+
+final class CombinedDeleteBranch extends BaseCombinedDeleteReference<Branch, DeleteBranchBuilder>
+    implements DeleteBranchBuilder {
+
+  CombinedDeleteBranch(TreeApi treeApi) {
+    super(treeApi);
+    refType(ReferenceType.BRANCH);
+  }
+
+  @Override
+  public DeleteBranchBuilder branchName(String branchName) {
+    return refName(branchName);
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedDeleteReference.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedDeleteReference.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.api.DeleteReferenceBuilder;
+import org.projectnessie.model.Reference;
+
+final class CombinedDeleteReference
+    extends BaseCombinedDeleteReference<Reference, DeleteReferenceBuilder<Reference>>
+    implements DeleteReferenceBuilder<Reference> {
+
+  CombinedDeleteReference(TreeApi treeApi) {
+    super(treeApi);
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedDeleteTag.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedDeleteTag.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.api.DeleteTagBuilder;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
+
+final class CombinedDeleteTag extends BaseCombinedDeleteReference<Tag, DeleteTagBuilder>
+    implements DeleteTagBuilder {
+
+  CombinedDeleteTag(TreeApi treeApi) {
+    super(treeApi);
+    refType(Reference.ReferenceType.TAG);
+  }
+
+  @Override
+  public DeleteTagBuilder tagName(String tagName) {
+    return refName(tagName);
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetAllReferences.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetAllReferences.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.api.v2.params.ReferencesParams;
+import org.projectnessie.client.builder.BaseGetAllReferencesBuilder;
+import org.projectnessie.model.ReferencesResponse;
+
+final class CombinedGetAllReferences extends BaseGetAllReferencesBuilder<ReferencesParams> {
+
+  private final TreeApi treeApi;
+
+  CombinedGetAllReferences(TreeApi treeApi) {
+    super(ReferencesParams::forNextPage);
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  protected ReferencesParams params() {
+    return ReferencesParams.builder()
+        .fetchOption(fetchOption)
+        .filter(filter)
+        .maxRecords(maxRecords)
+        .build();
+  }
+
+  @Override
+  protected ReferencesResponse get(ReferencesParams p) {
+    try {
+      return treeApi.getAllReferences(p);
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetCommitLog.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetCommitLog.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.api.v2.params.CommitLogParams;
+import org.projectnessie.client.builder.BaseGetCommitLogBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.Reference;
+
+final class CombinedGetCommitLog extends BaseGetCommitLogBuilder<CommitLogParams> {
+
+  private final TreeApi treeApi;
+
+  CombinedGetCommitLog(TreeApi treeApi) {
+    super(CommitLogParams::forNextPage);
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  protected CommitLogParams params() {
+    return CommitLogParams.builder()
+        .fetchOption(fetchOption)
+        .startHash(untilHash)
+        .maxRecords(maxRecords)
+        .filter(filter)
+        .build();
+  }
+
+  @Override
+  protected LogResponse get(CommitLogParams p) throws NessieNotFoundException {
+    try {
+      return treeApi.getCommitLog(Reference.toPathString(refName, hashOnRef), p);
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetContent.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetContent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import java.util.Map;
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.client.builder.BaseGetContentBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.ContentResponse;
+import org.projectnessie.model.GetMultipleContentsResponse;
+import org.projectnessie.model.Reference;
+
+final class CombinedGetContent extends BaseGetContentBuilder {
+  private final TreeApi treeApi;
+
+  CombinedGetContent(TreeApi treeApi) {
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  public Map<ContentKey, Content> get() throws NessieNotFoundException {
+    return getWithResponse().toContentsMap();
+  }
+
+  @Override
+  public ContentResponse getSingle(ContentKey key) throws NessieNotFoundException {
+    if (!request.build().getRequestedKeys().isEmpty()) {
+      throw new IllegalStateException(
+          "Must not use getSingle() with key() or keys(), pass the single key to getSingle()");
+    }
+    try {
+      String ref = Reference.toPathString(refName, hashOnRef);
+      if (ref.isEmpty()) {
+        ref = "-";
+      }
+      return treeApi.getContent(key, ref, false);
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+
+  @Override
+  public GetMultipleContentsResponse getWithResponse() throws NessieNotFoundException {
+    try {
+      String ref = Reference.toPathString(refName, hashOnRef);
+      if (ref.isEmpty()) {
+        // This is rather a hack to make
+        // org.projectnessie.jaxrs.tests.BaseTestNessieApi.contentsOnDefaultBranch[V1]
+        // pass.
+        ref = "-";
+      }
+      return treeApi.getMultipleContents(ref, request.build(), false);
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetDiff.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetDiff.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.api.v2.params.DiffParams;
+import org.projectnessie.client.builder.BaseGetDiffBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.DiffResponse;
+import org.projectnessie.model.Reference;
+
+final class CombinedGetDiff extends BaseGetDiffBuilder<DiffParams> {
+  private final TreeApi treeApi;
+
+  CombinedGetDiff(TreeApi treeApi) {
+    super(DiffParams::forNextPage);
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  protected DiffParams params() {
+    return DiffParams.builder()
+        .fromRef(Reference.toPathString(fromRefName, fromHashOnRef))
+        .toRef(Reference.toPathString(toRefName, toHashOnRef))
+        .maxRecords(maxRecords)
+        .minKey(minKey)
+        .maxKey(maxKey)
+        .prefixKey(prefixKey)
+        .filter(filter)
+        .requestedKeys(keys)
+        .build();
+  }
+
+  @Override
+  public DiffResponse get(DiffParams params) throws NessieNotFoundException {
+    try {
+      return treeApi.getDiff(params);
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetEntries.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetEntries.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.api.v2.params.EntriesParams;
+import org.projectnessie.client.builder.BaseGetEntriesBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.EntriesResponse;
+import org.projectnessie.model.Reference;
+
+final class CombinedGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
+
+  private final TreeApi treeApi;
+
+  CombinedGetEntries(TreeApi treeApi) {
+    super(EntriesParams::forNextPage);
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  protected EntriesParams params() {
+    return EntriesParams.builder() // TODO: namespace, derive prefix
+        .filter(filter)
+        .minKey(minKey)
+        .maxKey(maxKey)
+        .prefixKey(prefixKey)
+        .requestedKeys(keys)
+        .maxRecords(maxRecords)
+        .withContent(withContent)
+        .build();
+  }
+
+  @Override
+  protected EntriesResponse get(EntriesParams p) throws NessieNotFoundException {
+    try {
+      return treeApi.getEntries(Reference.toPathString(refName, hashOnRef), p);
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetReference.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetReference.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.api.v2.params.GetReferenceParams;
+import org.projectnessie.client.builder.BaseGetReferenceBuilder;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Reference;
+
+final class CombinedGetReference extends BaseGetReferenceBuilder {
+
+  private final TreeApi treeApi;
+
+  CombinedGetReference(TreeApi treeApi) {
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  public Reference get() throws NessieNotFoundException {
+    try {
+      return treeApi
+          .getReferenceByName(
+              GetReferenceParams.builder().ref(refName).fetchOption(fetchOption).build())
+          .getReference();
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetRepositoryConfig.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetRepositoryConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.projectnessie.api.v2.ConfigApi;
+import org.projectnessie.client.api.GetRepositoryConfigBuilder;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.model.RepositoryConfigResponse;
+
+final class CombinedGetRepositoryConfig implements GetRepositoryConfigBuilder {
+  private final ConfigApi configApi;
+
+  private final Set<RepositoryConfig.Type> types = new HashSet<>();
+
+  CombinedGetRepositoryConfig(ConfigApi configApi) {
+    this.configApi = configApi;
+  }
+
+  @Override
+  public GetRepositoryConfigBuilder type(RepositoryConfig.Type type) {
+    this.types.add(requireNonNull(type));
+    return this;
+  }
+
+  @Override
+  public RepositoryConfigResponse get() {
+    if (types.isEmpty()) {
+      throw new IllegalStateException("repository config types to retrieve must be set");
+    }
+
+    try {
+      return configApi.getRepositoryConfig(
+          types.stream().map(RepositoryConfig.Type::name).collect(Collectors.toList()));
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedMergeReference.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedMergeReference.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.api.v2.params.ImmutableMerge;
+import org.projectnessie.client.api.MergeReferenceBuilder;
+import org.projectnessie.client.builder.BaseMergeReferenceBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.MergeResponse;
+import org.projectnessie.model.Reference;
+
+final class CombinedMergeReference extends BaseMergeReferenceBuilder {
+  private final TreeApi treeApi;
+
+  public CombinedMergeReference(TreeApi treeApi) {
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  public MergeReferenceBuilder keepIndividualCommits(boolean keepIndividualCommits) {
+    if (keepIndividualCommits) {
+      throw new IllegalArgumentException("Commits are always squashed during merge operations.");
+    }
+    return this;
+  }
+
+  @Override
+  public MergeResponse merge() throws NessieNotFoundException, NessieConflictException {
+    ImmutableMerge.Builder merge =
+        ImmutableMerge.builder()
+            .fromHash(fromHash)
+            .fromRefName(fromRefName)
+            .message(message)
+            .commitMeta(commitMeta)
+            .isDryRun(dryRun)
+            .isFetchAdditionalInfo(fetchAdditionalInfo)
+            .isReturnConflictAsResult(returnConflictAsResult);
+
+    if (defaultMergeMode != null) {
+      merge.defaultKeyMergeMode(defaultMergeMode);
+    }
+
+    if (mergeModes != null) {
+      merge.keyMergeModes(mergeModes.values());
+    }
+
+    try {
+      return treeApi.mergeRefIntoBranch(Reference.toPathString(branchName, hash), merge.build());
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedNessieClientFactory.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedNessieClientFactory.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import static org.projectnessie.client.NessieClientBuilder.createClientBuilder;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.engine.UniqueId;
+import org.projectnessie.client.NessieClientBuilder;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.ext.NessieClientCustomizer;
+import org.projectnessie.client.ext.NessieClientFactory;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.logic.Logics;
+import org.projectnessie.versioned.storage.common.persist.Backend;
+import org.projectnessie.versioned.storage.common.persist.BackendFactory;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.PersistFactory;
+import org.projectnessie.versioned.storage.inmemory.InmemoryBackendConfig;
+import org.projectnessie.versioned.storage.inmemory.InmemoryBackendFactory;
+
+/**
+ * JUnit-extension providing a {@link org.projectnessie.client.api.NessieApiV2} instance that
+ * directly accesses an in-memory {@link Persist} instance.
+ */
+public class CombinedNessieClientFactory
+    implements Extension, ParameterResolver, BeforeEachCallback {
+  private static final ExtensionContext.Namespace NAMESPACE =
+      ExtensionContext.Namespace.create(CombinedNessieClientFactory.class);
+
+  public static final String API_VERSION_SEGMENT_TYPE = "nessie-api";
+  private static final NessieApiVersion DEFAULT_API_VERSION = NessieApiVersion.V2;
+
+  private boolean isNessieClient(ParameterContext parameterContext) {
+    return parameterContext.getParameter().getType().isAssignableFrom(NessieClientFactory.class);
+  }
+
+  @Override
+  public boolean supportsParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return isNessieClient(parameterContext);
+  }
+
+  @Override
+  public Object resolveParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    if (isNessieClient(parameterContext)) {
+      return clientFactoryForContext(extensionContext);
+    }
+
+    throw new IllegalStateException("Unsupported parameter: " + parameterContext);
+  }
+
+  private NessieClientFactory clientFactoryForContext(ExtensionContext extensionContext) {
+    NessieApiVersion apiVersion = apiVersion(extensionContext);
+    List<NessieClientCustomizer> customizers =
+        extensionContext
+            .getTestInstances()
+            .map(
+                i ->
+                    i.getAllInstances().stream()
+                        .filter(ti -> ti instanceof NessieClientCustomizer)
+                        .map(ti -> (NessieClientCustomizer) ti)
+                        .collect(Collectors.toList()))
+            .orElse(Collections.emptyList());
+
+    Persist persist = persist(extensionContext);
+
+    if (!customizers.isEmpty()) {
+      NessieClientCustomizer testCustomizer =
+          (builder, version) -> {
+            for (NessieClientCustomizer customizer : customizers) {
+              builder = customizer.configure(builder, version);
+            }
+            return builder;
+          };
+
+      return new ClientFactory(apiVersion, persist) {
+        @Override // Note: this object is not serializable
+        @Nonnull
+        @jakarta.annotation.Nonnull
+        public NessieApiV1 make(NessieClientCustomizer customizer) {
+          return super.make(
+              (builder, version) ->
+                  customizer.configure(testCustomizer.configure(builder, version), version));
+        }
+      };
+    }
+
+    // We use a serializable impl. here as a workaround for @QuarkusTest instances, whose parameters
+    // are deep-cloned by the Quarkus test extension.
+    return new ClientFactory(apiVersion, persist);
+  }
+
+  private Persist persist(ExtensionContext extensionContext) {
+    return extensionContext
+        .getStore(NAMESPACE)
+        .getOrComputeIfAbsent(
+            "persistSupplier",
+            x -> {
+              PersistFactory persistFactory = backend(extensionContext).createFactory();
+              return persistFactory.newPersist(StoreConfig.Adjustable.empty());
+            },
+            Persist.class);
+  }
+
+  private Backend backend(ExtensionContext extensionContext) {
+    return extensionContext
+        .getStore(NAMESPACE)
+        .getOrComputeIfAbsent(
+            "backendSupplier",
+            x -> {
+              BackendFactory<InmemoryBackendConfig> backendFactory = new InmemoryBackendFactory();
+              return backendFactory.buildBackend(backendFactory.newConfigInstance());
+            },
+            Backend.class);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext extensionContext) {
+    Logics.repositoryLogic(persist(extensionContext)).initialize("main");
+  }
+
+  static NessieApiVersion apiVersion(ExtensionContext context) {
+    return UniqueId.parse(context.getUniqueId()).getSegments().stream()
+        .filter(s -> API_VERSION_SEGMENT_TYPE.equals(s.getType()))
+        .map(UniqueId.Segment::getValue)
+        .findFirst()
+        .map(NessieApiVersion::valueOf)
+        .orElse(DEFAULT_API_VERSION);
+  }
+
+  private static class ClientFactory implements NessieClientFactory, Serializable {
+    private final NessieApiVersion apiVersion;
+    private final Persist persist;
+
+    private ClientFactory(NessieApiVersion apiVersion, Persist persist) {
+      this.apiVersion = apiVersion;
+      this.persist = persist;
+    }
+
+    @Override
+    public NessieApiVersion apiVersion() {
+      return apiVersion;
+    }
+
+    @Override
+    @Nonnull
+    @jakarta.annotation.Nonnull
+    public NessieApiV1 make(NessieClientCustomizer customizer) {
+      NessieClientBuilder clientBuilder =
+          createClientBuilder("Combined", null)
+              .asInstanceOf(CombinedClientBuilder.class)
+              .withPersist(persist);
+
+      NessieClientBuilder builder = customizer.configure(clientBuilder, apiVersion);
+      return apiVersion.build(builder);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedTransplantCommits.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedTransplantCommits.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.TreeApi;
+import org.projectnessie.api.v2.params.ImmutableTransplant;
+import org.projectnessie.client.api.TransplantCommitsBuilder;
+import org.projectnessie.client.builder.BaseTransplantCommitsBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.MergeResponse;
+import org.projectnessie.model.Reference;
+
+final class CombinedTransplantCommits extends BaseTransplantCommitsBuilder {
+  private final TreeApi treeApi;
+
+  public CombinedTransplantCommits(TreeApi treeApi) {
+    this.treeApi = treeApi;
+  }
+
+  @Override
+  public TransplantCommitsBuilder keepIndividualCommits(boolean keepIndividualCommits) {
+    if (!keepIndividualCommits) {
+      throw new IllegalArgumentException(
+          "Individual commits are always kept during transplant operations.");
+    }
+    return this;
+  }
+
+  @Override
+  public MergeResponse transplant() throws NessieNotFoundException, NessieConflictException {
+    ImmutableTransplant.Builder transplant =
+        ImmutableTransplant.builder()
+            .message(message)
+            .fromRefName(fromRefName)
+            .hashesToTransplant(hashesToTransplant)
+            .isDryRun(dryRun)
+            .isReturnConflictAsResult(returnConflictAsResult)
+            .isFetchAdditionalInfo(fetchAdditionalInfo);
+
+    if (defaultMergeMode != null) {
+      transplant.defaultKeyMergeMode(defaultMergeMode);
+    }
+
+    if (mergeModes != null) {
+      transplant.keyMergeModes(mergeModes.values());
+    }
+
+    try {
+      return treeApi.transplantCommitsIntoBranch(
+          Reference.toPathString(branchName, hash), transplant.build());
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedUpdateRepositoryConfig.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedUpdateRepositoryConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.projectnessie.api.v2.ConfigApi;
+import org.projectnessie.client.api.UpdateRepositoryConfigBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.model.ImmutableUpdateRepositoryConfigRequest;
+import org.projectnessie.model.RepositoryConfig;
+import org.projectnessie.model.UpdateRepositoryConfigRequest;
+import org.projectnessie.model.UpdateRepositoryConfigResponse;
+
+final class CombinedUpdateRepositoryConfig implements UpdateRepositoryConfigBuilder {
+  private final ConfigApi configApi;
+  private RepositoryConfig update;
+
+  CombinedUpdateRepositoryConfig(ConfigApi configApi) {
+    this.configApi = configApi;
+  }
+
+  @Override
+  public UpdateRepositoryConfigBuilder repositoryConfig(RepositoryConfig update) {
+    if (this.update != null) {
+      throw new IllegalStateException("repository config to update has already been set");
+    }
+    this.update = update;
+    return this;
+  }
+
+  @Override
+  public UpdateRepositoryConfigResponse update() throws NessieConflictException {
+    if (this.update == null) {
+      throw new IllegalStateException("repository config to update must be set");
+    }
+    UpdateRepositoryConfigRequest req =
+        ImmutableUpdateRepositoryConfigRequest.builder().config(update).build();
+    try {
+      return configApi.updateRepositoryConfig(req);
+    } catch (RuntimeException e) {
+      throw CombinedClientImpl.maybeWrapException(e);
+    }
+  }
+}

--- a/testing/combined-cs/src/main/resources/META-INF/services/org.projectnessie.client.NessieClientBuilder
+++ b/testing/combined-cs/src/main/resources/META-INF/services/org.projectnessie.client.NessieClientBuilder
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2023 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.projectnessie.nessie.combined.CombinedClientBuilder

--- a/testing/combined-cs/src/test/java/org/projectnessie/nessie/combined/TestNessieApiCombined.java
+++ b/testing/combined-cs/src/test/java/org/projectnessie/nessie/combined/TestNessieApiCombined.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.combined;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.jaxrs.tests.BaseTestNessieApi;
+
+@ExtendWith(CombinedNessieClientFactory.class)
+public class TestNessieApiCombined extends BaseTestNessieApi {
+  @Override
+  protected boolean fullPagingSupport() {
+    return true;
+  }
+}


### PR DESCRIPTION
Introduce a new `:nessie-combined-cs` module (under `testing/`) providing a Nessie-API (v2) client that directly calls the service implementations, using the v2 REST endpoint implementations. This eliminates the need for a Jersey/Weld based Nessie endpoint for testing purposes. The implementation in this PR (currently) provides only a new-storage model in-memory backend.