### PR TITLE
GH actions - allow fork of Nessie in `projectnessie`

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -44,7 +44,7 @@ jobs:
   create-release:
     name: Bump version
     runs-on: ubuntu-22.04
-    if: github.repository_owner == 'projectnessie'
+    if: github.repository == 'projectnessie/nessie'
     env:
       BUMP_ON_BRANCH: ${{ github.event.inputs.bumpBranch }}
       BUMP_TYPE: ${{ github.event.inputs.bumpType }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -882,7 +882,7 @@ jobs:
         run: mkdocs build
         working-directory: ./site
       - name: Deploy Static Site to GitHub
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'projectnessie'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'projectnessie/nessie'
         uses: peaceiris/actions-gh-pages@v3
         with:
           external_repository: projectnessie/projectnessie.github.io

--- a/.github/workflows/container-sync.yml
+++ b/.github/workflows/container-sync.yml
@@ -13,7 +13,7 @@ jobs:
   sync:
     name: Synchronize Container Registries
     runs-on: ubuntu-22.04
-    if: github.repository_owner == 'projectnessie'
+    if: github.repository == 'projectnessie/nessie'
 
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -49,7 +49,7 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-22.04
-    if: github.repository_owner == 'projectnessie'
+    if: github.repository == 'projectnessie/nessie'
     env:
       RELEASE_FROM: ${{ github.event.inputs.releaseFromBranch }}
       BUMP_TYPE: ${{ github.event.inputs.bumpType }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -45,7 +45,7 @@ jobs:
   publish-release:
     name: Publish release
     runs-on: ubuntu-22.04
-    if: github.repository_owner == 'projectnessie'
+    if: github.repository == 'projectnessie/nessie'
     # Runs in the `release` environment, which has the necessary secrets and defines the reviewers.
     # See https://docs.github.com/en/actions/reference/environments
     environment: release

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       SPARK_LOCAL_IP: localhost
-    if: github.repository_owner == 'projectnessie'
+    if: github.repository == 'projectnessie/nessie'
 
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0


### PR DESCRIPTION
Updates a few workflows to only run in `projectnessie/nessie` but not in another Nessie repo in the `projectnessie` org.