### PR TITLE
BigTable: Use parallel reads for some objects to fetch

### DIFF
--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableConstants.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableConstants.java
@@ -32,6 +32,7 @@ final class BigTableConstants {
   // Tue Apr 7 08:14:21 2020 +0200
   static final long CELL_TIMESTAMP = 1586232861000L;
 
+  static final int MAX_PARALLEL_READS = 5;
   static final int MAX_BULK_READS = 100;
   static final int MAX_BULK_MUTATIONS = 1000;
 

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -26,6 +26,7 @@ import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.CEL
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.FAMILY_OBJS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.FAMILY_REFS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.MAX_BULK_READS;
+import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.MAX_PARALLEL_READS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUALIFIER_OBJS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUALIFIER_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUALIFIER_REFS;
@@ -668,6 +669,44 @@ public class BigTablePersist implements Persist {
       return;
     }
 
+    if (num <= MAX_PARALLEL_READS) {
+      bulkFetchSome(tableId, ids, r, keyGen, resultGen, notFound);
+    } else {
+      bulkFetchMany(tableId, ids, r, keyGen, resultGen, notFound);
+    }
+  }
+
+  private <ID, R> void bulkFetchSome(
+      String tableId,
+      ID[] ids,
+      R[] r,
+      Function<ID, ByteString> keyGen,
+      Function<Row, R> resultGen,
+      Consumer<ID> notFound)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    int num = ids.length;
+    @SuppressWarnings("unchecked")
+    ApiFuture<Row>[] handles = new ApiFuture[num];
+    for (int idx = 0; idx < ids.length; idx++) {
+      ID id = ids[idx];
+      if (id != null) {
+        ByteString key = keyGen.apply(id);
+        handles[idx] = backend.client().readRowAsync(tableId, key);
+      }
+    }
+
+    bulkFetchCollectResults(ids, r, resultGen, notFound, num, handles);
+  }
+
+  private <ID, R> void bulkFetchMany(
+      String tableId,
+      ID[] ids,
+      R[] r,
+      Function<ID, ByteString> keyGen,
+      Function<Row, R> resultGen,
+      Consumer<ID> notFound)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    int num = ids.length;
     @SuppressWarnings("unchecked")
     ApiFuture<Row>[] handles = new ApiFuture[num];
     int idx = 0;
@@ -684,6 +723,17 @@ public class BigTablePersist implements Persist {
       }
     }
 
+    bulkFetchCollectResults(ids, r, resultGen, notFound, num, handles);
+  }
+
+  private static <ID, R> void bulkFetchCollectResults(
+      ID[] ids,
+      R[] r,
+      Function<Row, R> resultGen,
+      Consumer<ID> notFound,
+      int num,
+      ApiFuture<Row>[] handles)
+      throws InterruptedException, ExecutionException, TimeoutException {
     for (int i = 0; i < num; i++) {
       ApiFuture<Row> handle = handles[i];
       if (handle != null) {

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -687,7 +687,7 @@ public class BigTablePersist implements Persist {
     int num = ids.length;
     @SuppressWarnings("unchecked")
     ApiFuture<Row>[] handles = new ApiFuture[num];
-    for (int idx = 0; idx < ids.length; idx++) {
+    for (int idx = 0; idx < num; idx++) {
       ID id = ids[idx];
       if (id != null) {
         ByteString key = keyGen.apply(id);


### PR DESCRIPTION
Using parallel async reads can be better than using a single bulk-fetch.

This change updates `BigTablePersis.bulkFetch` to use parallel reads when up to 5 IDs are requested.