### PR TITLE
Add client-based test for request parameter validation

### DIFF
--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -120,6 +120,7 @@ import org.projectnessie.model.Reference.ReferenceType;
 import org.projectnessie.model.ReferencesResponse;
 import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.model.Tag;
+import org.projectnessie.model.Validation;
 import org.projectnessie.model.types.GenericRepositoryConfig;
 import org.projectnessie.model.types.ImmutableGenericRepositoryConfig;
 
@@ -1944,6 +1945,13 @@ public abstract class BaseTestNessieApi {
                     .getPrevious())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Failed to parse default-cutoff-value");
+  }
+
+  @Test
+  void invalidParameters() throws Exception {
+    assertThatThrownBy(() -> api().getEntries().refName("..invalid..").get())
+      .isInstanceOf(NessieBadRequestException.class)
+      .hasMessageContaining(Validation.REF_NAME_MESSAGE);
   }
 
   @Test

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -1950,8 +1950,8 @@ public abstract class BaseTestNessieApi {
   @Test
   void invalidParameters() throws Exception {
     assertThatThrownBy(() -> api().getEntries().refName("..invalid..").get())
-      .isInstanceOf(NessieBadRequestException.class)
-      .hasMessageContaining(Validation.REF_NAME_MESSAGE);
+        .isInstanceOf(NessieBadRequestException.class)
+        .hasMessageContaining(Validation.REF_NAME_MESSAGE);
   }
 
   @Test


### PR DESCRIPTION
Ensure validation exceptions propagate correctly though java clients.