### PR TITLE
Cleanup: explicitly annotate `ignoreUnknown` for types that allow this

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
@@ -15,9 +15,6 @@
  */
 package org.projectnessie.client.rest;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_INVALID_SUBTYPE;
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,18 +27,11 @@ import org.projectnessie.client.http.Status;
 import org.projectnessie.error.ErrorCode;
 import org.projectnessie.error.ImmutableNessieError;
 import org.projectnessie.error.NessieError;
-import org.projectnessie.error.NessieErrorDetails;
 import org.projectnessie.error.NessieUnavailableException;
 
 public class ResponseCheckFilter {
 
-  /**
-   * Object mapper that ignores unknown properties and unknown subtypes, so it is able to process
-   * instances of {@link NessieError} and especially {@link NessieErrorDetails} with added/unknown
-   * properties or unknown subtypes of the latter.
-   */
-  private static final ObjectMapper MAPPER =
-      new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES).disable(FAIL_ON_INVALID_SUBTYPE);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * check that response had a valid return code. Throw exception if not.

--- a/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -15,8 +15,6 @@
  */
 package org.projectnessie.client.rest;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_INVALID_SUBTYPE;
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -70,8 +68,7 @@ import software.amazon.awssdk.utils.StringInputStream;
 @ExtendWith(SoftAssertionsExtension.class)
 public class TestResponseFilter {
 
-  private static final ObjectMapper MAPPER =
-      new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES).disable(FAIL_ON_INVALID_SUBTYPE);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @InjectSoftAssertions protected SoftAssertions soft;
 

--- a/api/model/src/main/java/org/projectnessie/error/NessieError.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieError.java
@@ -16,6 +16,7 @@
 package org.projectnessie.error;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,6 +37,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableNessieError.class)
 @JsonDeserialize(as = ImmutableNessieError.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface NessieError {
 
   /** HTTP status code of this error. */

--- a/api/model/src/main/java/org/projectnessie/error/NessieErrorDetails.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieErrorDetails.java
@@ -16,6 +16,7 @@
 package org.projectnessie.error;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -36,6 +37,7 @@ import org.immutables.value.Value;
     discriminatorProperty = "type")
 @JsonTypeIdResolver(NessieErrorDetailsTypeIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type", visible = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface NessieErrorDetails {
   @Value.Redacted
   @JsonIgnore

--- a/api/model/src/main/java/org/projectnessie/model/Conflict.java
+++ b/api/model/src/main/java/org/projectnessie/model/Conflict.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -28,6 +29,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableConflict.class)
 @JsonDeserialize(as = ImmutableConflict.class)
+@JsonIgnoreProperties(
+    // need to ignore unknown properties as this type can be used in `ReferenceConflicts`
+    ignoreUnknown = true)
 public interface Conflict {
   @Value.Parameter(order = 1)
   @Nullable

--- a/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
@@ -15,7 +15,6 @@
  */
 package org.projectnessie.error;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.projectnessie.model.Conflict.ConflictType.UNEXPECTED_HASH;
@@ -81,8 +80,7 @@ class TestNessieError {
   @ParameterizedTest
   @MethodSource("conflictDeserialization")
   void conflictDeserialization(JsonNode input, Conflict expected) throws Exception {
-    Conflict parsedConflict =
-        new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES).treeToValue(input, Conflict.class);
+    Conflict parsedConflict = new ObjectMapper().treeToValue(input, Conflict.class);
     Assertions.assertThat(parsedConflict).isEqualTo(expected);
   }
 


### PR DESCRIPTION
Replaces the custom `ObjectMapper` configuration with settings on the affected types, which seems cleaner and allows using "standard" `ObjectMapper`s.