### PR TITLE
Tag all Nessie multi-environment tests

### DIFF
--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.api.NessieApiV2;
@@ -56,6 +57,7 @@ import org.projectnessie.tools.compatibility.api.VersionCondition;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 
 @VersionCondition(maxVersion = Version.NOT_CURRENT_STRING)
+@Tag("nessie-multi-env")
 public abstract class AbstractCompatibilityTests {
 
   @NessieAPI protected NessieApiV1 api;

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/AbstractCompatibilityTests.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.assertj.core.groups.Tuple;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.api.NessieApiV2;
@@ -57,7 +56,6 @@ import org.projectnessie.tools.compatibility.api.VersionCondition;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 
 @VersionCondition(maxVersion = Version.NOT_CURRENT_STRING)
-@Tag("nessie-multi-env")
 public abstract class AbstractCompatibilityTests {
 
   @NessieAPI protected NessieApiV1 api;

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITImplicitNamespaces.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITImplicitNamespaces.java
@@ -17,6 +17,7 @@ package org.projectnessie.tools.compatibility.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.client.api.NessieApiV1;
@@ -33,6 +34,7 @@ import org.projectnessie.tools.compatibility.internal.NessieUpgradesExtension;
 
 @ExtendWith(NessieUpgradesExtension.class)
 @NessieServerProperty(name = "nessie.store.namespace-validation", value = "false")
+@Tag("nessie-multi-env")
 public class ITImplicitNamespaces {
 
   @NessieVersion Version version;

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderClients.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderClients.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.tools.compatibility.tests;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.tools.compatibility.api.Version;
 import org.projectnessie.tools.compatibility.internal.OlderNessieClientsExtension;
 
 @ExtendWith(OlderNessieClientsExtension.class)
+@Tag("nessie-multi-env")
 public class ITOlderClients extends AbstractCompatibilityTests {
   @Override
   protected Version serverVersion() {

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITOlderServers.java
@@ -17,6 +17,7 @@ package org.projectnessie.tools.compatibility.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.model.NessieConfiguration;
@@ -25,6 +26,7 @@ import org.projectnessie.tools.compatibility.api.VersionCondition;
 import org.projectnessie.tools.compatibility.internal.OlderNessieServersExtension;
 
 @ExtendWith(OlderNessieServersExtension.class)
+@Tag("nessie-multi-env")
 public class ITOlderServers extends AbstractCompatibilityTests {
 
   @Override

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgradeScenario.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgradeScenario.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +47,7 @@ import org.projectnessie.tools.compatibility.internal.RollingUpgradesExtension;
 
 @ExtendWith(RollingUpgradesExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag("nessie-multi-env")
 public class ITRollingUpgradeScenario {
   public static final String NO_ANCESTOR =
       "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d";

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgrades.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITRollingUpgrades.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,6 +50,7 @@ import org.projectnessie.tools.compatibility.internal.RollingUpgradesExtension;
 
 @ExtendWith(RollingUpgradesExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag("nessie-multi-env")
 public class ITRollingUpgrades {
 
   public static final String NO_ANCESTOR =

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITUnrelatedHistoryMerge.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITUnrelatedHistoryMerge.java
@@ -17,6 +17,7 @@ package org.projectnessie.tools.compatibility.tests;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.client.api.NessieApiV2;
@@ -35,6 +36,7 @@ import org.projectnessie.tools.compatibility.internal.OlderNessieServersExtensio
 // Common merge parent is enforced only with the new data model, hence the `PERSIST` storage kind.
 @NessieServerProperty(name = "nessie.test.storage.kind", value = "PERSIST")
 @VersionCondition(minVersion = Version.CURRENT_STRING, maxVersion = Version.CURRENT_STRING)
+@Tag("nessie-multi-env")
 public class ITUnrelatedHistoryMerge {
 
   public static final String NO_ANCESTOR =

--- a/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
+++ b/compatibility/compatibility-tests/src/intTest/java/org/projectnessie/tools/compatibility/tests/ITUpgradePath.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +62,7 @@ import org.projectnessie.versioned.storage.common.config.StoreConfig;
 
 @ExtendWith(NessieUpgradesExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Tag("nessie-multi-env")
 public class ITUpgradePath {
 
   @NessieVersion Version version;

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -125,6 +125,7 @@ import org.projectnessie.model.types.GenericRepositoryConfig;
 import org.projectnessie.model.types.ImmutableGenericRepositoryConfig;
 
 /** Nessie-API tests. */
+@org.junit.jupiter.api.Tag("nessie-multi-env")
 @NessieApiVersions // all versions
 public abstract class BaseTestNessieApi {
 


### PR DESCRIPTION
Tagging multi-env tests can be useful e.g. to include or exclude multi-env tests.

With Maven:

```xml
  <plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-surefire-plugin</artifactId>
    <configuration>
      <groups>nessie-multi-env</groups>
    </configuration>
  </plugin>
```

Or Gradle (using Groovy syntax):

```kotlin
test {
  useJUnitPlatform {
    includeTags 'nessie-multi-env'
  }
}
```  