### PR TITLE
Cassandra backend: remove ALLOW FILTERING when fetching objects

### DIFF
--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraConstants.java
@@ -266,8 +266,6 @@ final class CassandraConstants {
           + COL_OBJ_ID
           + " IN ?";
 
-  static final String FIND_OBJS_TYPED = FIND_OBJS + " AND " + COL_OBJ_TYPE + "=? ALLOW FILTERING";
-
   static final String SCAN_OBJS =
       "SELECT "
           + COLS_OBJS_ALL


### PR DESCRIPTION
This commit removes the ALLOW FILTERING clause from the CQL statement executed when fetching objects with a known type.

This eliminates a Cassandra anti-pattern for these queries, which are executed very often.