### PR TITLE
CI/Publish: Mitigate Gradle's annoying CME bug and GH's HTTP/502

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -112,9 +112,19 @@ jobs:
       run: |
         rm -rf "${ARTIFACTS}"
         mkdir -p "${ARTIFACTS}"
-        
+
+        echo "::group::Gradle build"
+        # 2 Retries - due to Gradle's old and unfixed CME bug
+        ./gradlew compileAll jar testClasses || \
+          ./gradlew compileAll jar testClasses || \
+          ./gradlew compileAll jar testClasses 
+        echo "::endgroup::"
+
         echo "::group::Publish to Sonatype"
-        ./gradlew --no-watch-fs --no-daemon publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar
+        # 2 Retries - to mitigate "HTTP/502 Bad Gateway" issues
+        ./gradlew publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar || \
+          ./gradlew publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar || \
+          ./gradlew publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar
         mv servers/quarkus-server/build/nessie-quarkus-${RELEASE_VERSION}-runner.jar "${ARTIFACTS}"
         mv servers/quarkus-cli/build/nessie-quarkus-cli-${RELEASE_VERSION}-runner.jar "${ARTIFACTS}"
         echo "::endgroup::"

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -25,19 +25,28 @@ jobs:
       - name: Setup Java, Gradle
         uses: ./.github/actions/dev-tool-java
 
+      - name: Gradle / setup
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-disabled: true
+          arguments: projects
+
       - name: Gradle / publish snapshot
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_ACCESS_ID }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          cache-disabled: true
-          arguments: |
-            --no-watch-fs --no-daemon 
-            publishToSonatype closeAndReleaseSonatypeStagingRepository
-            -Prelease -Puber-jar
+        run: |
+          # 2 Retries - due to Gradle's old and unfixed CME bug
+          ./gradlew compileAll jar testClasses || \
+            ./gradlew compileAll jar testClasses || \
+            ./gradlew compileAll jar testClasses 
+
+          # 2 Retries - to mitigate "HTTP/502 Bad Gateway" issues
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar || \
+            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar || \
+            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar
 
       - name: Docker images publishing
         env:


### PR DESCRIPTION
Various [snapshot-publish workflow runs](https://github.com/projectnessie/nessie/actions/workflows/snapshot-publish.yml) failed because of the still unfixed [Gradle CME bug](https://github.com/gradle/gradle/issues/25751) and transient network issues (HTTP/502 Bad Gateway).

This change updates the release + snapshot publish workflow by adding 2 retries and separating build from publication.