### PR TITLE
 Set OAuth2Client idle when Nessie client is idle

### DIFF
--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
@@ -177,13 +177,13 @@ public class ITOAuth2Client {
       // (10 secs lifespan - 5 secs safety window)
       client.start();
       assertThat(client.sleeping).isFalse();
-      Thread.sleep(5100); // will refresh tokens then enter sleep mode (idle interval 5 secs)
+      Thread.sleep(5000); // will refresh tokens then enter sleep mode (idle interval 5 secs)
       await().until(client.sleeping::get);
-      Thread.sleep(5100); // thread will exit (keep alive interval)
-      assertThat(((OAuth2TokenRefreshExecutor) client.executor).getPoolSize()).isZero();
-      Thread.sleep(5100); // access token will expire (10 secs lifespan)
+      Thread.sleep(5000); // thread will exit (keep alive interval)
+      await().until(() -> ((OAuth2TokenRefreshExecutor) client.executor).getPoolSize() == 0);
+      Thread.sleep(5000); // access token will expire (10 secs lifespan)
       // will wake up client, fetch new tokens immediately (on main thread),
-      // then schedule refresh, which will spawn a new thread
+      // then schedule refresh, which will in turn spawn a new thread
       AccessToken accessToken = client.authenticate();
       assertThat(client.sleeping).isFalse();
       assertThat(((OAuth2TokenRefreshExecutor) client.executor).getPoolSize()).isOne();

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -156,6 +156,30 @@ public final class NessieConfigConstants {
   public static final String CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW =
       "nessie.authentication.oauth2.refresh-safety-window";
 
+  public static final String DEFAULT_IDLE_INTERVAL = "PT30S";
+
+  /**
+   * Config property name ({@value #CONF_NESSIE_OAUTH2_IDLE_INTERVAL}) for the OAuth2 authentication
+   * provider. The maximum idle interval to use; if the OAuth2 provider is not used after this
+   * interval, no more token refreshes will occur, until the provider is used again. Optional,
+   * defaults to {@value #DEFAULT_IDLE_INTERVAL}. Must be a valid <a
+   * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
+   */
+  public static final String CONF_NESSIE_OAUTH2_IDLE_INTERVAL =
+      "nessie.authentication.oauth2.idle-interval";
+
+  public static final String DEFAULT_KEEP_ALIVE_INTERVAL = "PT30S";
+
+  /**
+   * Config property name ({@value #CONF_NESSIE_OAUTH2_KEEP_ALIVE_INTERVAL}) for the OAuth2
+   * authentication provider. The keep alive interval to use; if the OAuth2 provider background
+   * thread is not used after this interval, it will be stopped; a new thread will be spawned if the
+   * provider is used again. Optional, defaults to {@value #DEFAULT_KEEP_ALIVE_INTERVAL}. Must be a
+   * valid <a href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
+   */
+  public static final String CONF_NESSIE_OAUTH2_KEEP_ALIVE_INTERVAL =
+      "nessie.authentication.oauth2.keep-alive-interval";
+
   /**
    * Config property name ({@value #CONF_NESSIE_OAUTH2_CLIENT_SCOPES}) for the OAuth2 authentication
    * provider. Space-separated list of scopes to include in each request to the OAuth2 server.

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -156,34 +156,35 @@ public final class NessieConfigConstants {
   public static final String CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW =
       "nessie.authentication.oauth2.refresh-safety-window";
 
-  public static final String DEFAULT_IDLE_INTERVAL = "PT30S";
+  public static final String DEFAULT_PREEMPTIVE_TOKEN_REFRESH_IDLE_TIMEOUT = "PT30S";
 
   /**
-   * Config property name ({@value #CONF_NESSIE_OAUTH2_IDLE_INTERVAL}) for the OAuth2 authentication
-   * provider. For how long the OAuth2 provider should keep the tokens fresh, if the client is not
-   * being actively used. Setting this value too high may cause an excessive usage of network I/O
-   * and thread resources; conversely, when setting it too low, if the client is used again, the
-   * calling thread may block if the tokens are expired and need to be renewed synchronously.
-   * Optional, defaults to {@value #DEFAULT_IDLE_INTERVAL}. Must be a valid <a
+   * Config property name ({@value #CONF_NESSIE_OAUTH2_PREEMPTIVE_TOKEN_REFRESH_IDLE_TIMEOUT}) for
+   * the OAuth2 authentication provider. For how long the OAuth2 provider should keep the tokens
+   * fresh, if the client is not being actively used. Setting this value too high may cause an
+   * excessive usage of network I/O and thread resources; conversely, when setting it too low, if
+   * the client is used again, the calling thread may block if the tokens are expired and need to be
+   * renewed synchronously. Optional, defaults to {@value
+   * #DEFAULT_PREEMPTIVE_TOKEN_REFRESH_IDLE_TIMEOUT}. Must be a valid <a
    * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
-  public static final String CONF_NESSIE_OAUTH2_IDLE_INTERVAL =
-      "nessie.authentication.oauth2.idle-interval";
+  public static final String CONF_NESSIE_OAUTH2_PREEMPTIVE_TOKEN_REFRESH_IDLE_TIMEOUT =
+      "nessie.authentication.oauth2.preemptive-token-refresh-idle-timeout";
 
-  public static final String DEFAULT_KEEP_ALIVE_INTERVAL = "PT30S";
+  public static final String DEFAULT_BACKGROUND_THREAD_IDLE_TIMEOUT = "PT30S";
 
   /**
-   * Config property name ({@value #CONF_NESSIE_OAUTH2_KEEP_ALIVE_INTERVAL}) for the OAuth2
-   * authentication provider. How long the background thread should be kept running if the client is
-   * not being actively used, or no token refreshes are being executed. Optional, defaults to
-   * {@value #DEFAULT_KEEP_ALIVE_INTERVAL}. Setting this value too high will cause the background
-   * thread to keep running even if the client is not used anymore, potentially leaking thread and
-   * memory resources; conversely, setting it too low could cause the background thread to be
-   * restarted too often. Must be a valid <a
+   * Config property name ({@value #CONF_NESSIE_OAUTH2_BACKGROUND_THREAD_IDLE_TIMEOUT}) for the
+   * OAuth2 authentication provider. How long the background thread should be kept running if the
+   * client is not being actively used, or no token refreshes are being executed. Optional, defaults
+   * to {@value #DEFAULT_BACKGROUND_THREAD_IDLE_TIMEOUT}. Setting this value too high will cause the
+   * background thread to keep running even if the client is not used anymore, potentially leaking
+   * thread and memory resources; conversely, setting it too low could cause the background thread
+   * to be restarted too often. Must be a valid <a
    * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
-  public static final String CONF_NESSIE_OAUTH2_KEEP_ALIVE_INTERVAL =
-      "nessie.authentication.oauth2.keep-alive-interval";
+  public static final String CONF_NESSIE_OAUTH2_BACKGROUND_THREAD_IDLE_TIMEOUT =
+      "nessie.authentication.oauth2.background-thread-idle-timeout";
 
   /**
    * Config property name ({@value #CONF_NESSIE_OAUTH2_CLIENT_SCOPES}) for the OAuth2 authentication

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -160,9 +160,11 @@ public final class NessieConfigConstants {
 
   /**
    * Config property name ({@value #CONF_NESSIE_OAUTH2_IDLE_INTERVAL}) for the OAuth2 authentication
-   * provider. The maximum idle interval to use; if the OAuth2 provider is not used after this
-   * interval, no more token refreshes will occur, until the provider is used again. Optional,
-   * defaults to {@value #DEFAULT_IDLE_INTERVAL}. Must be a valid <a
+   * provider. For how long the OAuth2 provider should keep the tokens fresh, if the client is not
+   * being actively used. Setting this value too high may cause an excessive usage of network I/O
+   * and thread resources; conversely, when setting it too low, if the client is used again, the
+   * calling thread may block if the tokens are expired and need to be renewed synchronously.
+   * Optional, defaults to {@value #DEFAULT_IDLE_INTERVAL}. Must be a valid <a
    * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
   public static final String CONF_NESSIE_OAUTH2_IDLE_INTERVAL =
@@ -172,10 +174,13 @@ public final class NessieConfigConstants {
 
   /**
    * Config property name ({@value #CONF_NESSIE_OAUTH2_KEEP_ALIVE_INTERVAL}) for the OAuth2
-   * authentication provider. The keep alive interval to use; if the OAuth2 provider background
-   * thread is not used after this interval, it will be stopped; a new thread will be spawned if the
-   * provider is used again. Optional, defaults to {@value #DEFAULT_KEEP_ALIVE_INTERVAL}. Must be a
-   * valid <a href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
+   * authentication provider. How long the background thread should be kept running if the client is
+   * not being actively used, or no token refreshes are being executed. Optional, defaults to
+   * {@value #DEFAULT_KEEP_ALIVE_INTERVAL}. Setting this value too high will cause the background
+   * thread to keep running even if the client is not used anymore, potentially leaking thread and
+   * memory resources; conversely, setting it too low could cause the background thread to be
+   * restarted too often. Must be a valid <a
+   * href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO-8601 duration</a>.
    */
   public static final String CONF_NESSIE_OAUTH2_KEEP_ALIVE_INTERVAL =
       "nessie.authentication.oauth2.keep-alive-interval";

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -88,7 +88,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
     defaultAccessTokenLifespan = params.getDefaultAccessTokenLifespan();
     defaultRefreshTokenLifespan = params.getDefaultRefreshTokenLifespan();
     refreshSafetyWindow = params.getRefreshSafetyWindow();
-    idleInterval = params.getIdleInterval();
+    idleInterval = params.getPreemptiveTokenRefreshIdleTimeout();
     tokenExchangeEnabled = params.getTokenExchangeEnabled();
     httpClient = params.getHttpClient().addResponseFilter(this::checkErrorResponse).build();
     executor = params.getExecutor();
@@ -99,7 +99,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
     currentTokensStage =
         started
             .thenApplyAsync((v) -> fetchNewTokens(), executor)
-            .whenComplete((tokens, error) -> this.log(error));
+            .whenComplete((tokens, error) -> log(error));
     currentTokensStage.thenAccept(this::maybeScheduleTokensRenewal);
   }
 
@@ -208,7 +208,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
             .thenApply(this::refreshTokens)
             // if that fails, try fetching brand-new tokens
             .exceptionally(error -> fetchNewTokens())
-            .whenComplete((tokens, error) -> this.log(error));
+            .whenComplete((tokens, error) -> log(error));
     currentTokensStage.thenAccept(this::maybeScheduleTokensRenewal);
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -69,7 +69,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
   private final Duration idleInterval;
   private final boolean tokenExchangeEnabled;
   private final HttpClient httpClient;
-  /* Visible for testing. */ final ScheduledExecutorService executor;
+  private final ScheduledExecutorService executor;
   private final boolean shouldCloseExecutor;
   private final ObjectMapper objectMapper;
   private final CompletableFuture<Void> started = new CompletableFuture<>();

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -31,10 +31,10 @@ import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.client.http.HttpResponse;
@@ -65,6 +65,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
   private final Duration defaultAccessTokenLifespan;
   private final Duration defaultRefreshTokenLifespan;
   private final Duration refreshSafetyWindow;
+  private final Duration idleInterval;
   private final boolean tokenExchangeEnabled;
   private final HttpClient httpClient;
   private final ScheduledExecutorService executor;
@@ -72,8 +73,12 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
   private final ObjectMapper objectMapper;
   private final CompletableFuture<Void> started = new CompletableFuture<>();
 
+  /** Visible for testing. */
+  final AtomicBoolean sleeping = new AtomicBoolean();
+
   private volatile CompletionStage<Tokens> currentTokensStage;
   private volatile ScheduledFuture<?> tokenRefreshFuture;
+  private volatile Instant lastAccess;
 
   OAuth2Client(OAuth2ClientParams params) {
     grantType = params.getGrantType();
@@ -83,28 +88,26 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
     defaultAccessTokenLifespan = params.getDefaultAccessTokenLifespan();
     defaultRefreshTokenLifespan = params.getDefaultRefreshTokenLifespan();
     refreshSafetyWindow = params.getRefreshSafetyWindow();
+    idleInterval = params.getIdleInterval();
     tokenExchangeEnabled = params.getTokenExchangeEnabled();
     httpClient = params.getHttpClient().addResponseFilter(this::checkErrorResponse).build();
-    executor = params.getExecutor().orElseGet(OAuth2Client::createDefaultExecutor);
-    shouldCloseExecutor = !params.getExecutor().isPresent();
+    executor = params.getExecutor();
+    shouldCloseExecutor = executor instanceof OAuth2TokenRefreshExecutor;
     objectMapper = params.getObjectMapper();
+    lastAccess = Instant.now();
     currentTokensStage =
         started.thenApplyAsync((v) -> fetchNewTokens(), executor).whenComplete(this::log);
-    currentTokensStage.thenAccept(this::scheduleTokensRenewal);
-  }
-
-  private static ScheduledExecutorService createDefaultExecutor() {
-    return Executors.newSingleThreadScheduledExecutor(
-        runnable -> {
-          Thread thread = Executors.defaultThreadFactory().newThread(runnable);
-          thread.setDaemon(true);
-          thread.setName("oauth2-client");
-          return thread;
-        });
+    currentTokensStage.thenAccept(this::maybeScheduleTokensRenewal);
   }
 
   @Override
   public AccessToken authenticate() {
+    Instant now = Instant.now();
+    lastAccess = now;
+    if (sleeping.compareAndSet(true, false)) {
+      LOGGER.debug("Waking up...");
+      wakeUp(now);
+    }
     return getCurrentTokens().getAccessToken();
   }
 
@@ -165,35 +168,57 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
     }
   }
 
-  private void scheduleTokensRenewal(Tokens currentTokens) {
+  private void maybeScheduleTokensRenewal(Tokens currentTokens) {
     Instant now = Instant.now();
+    if (idle(now)) {
+      sleeping.set(true);
+      LOGGER.debug("Sleeping...");
+    } else {
+      scheduleOrExecuteTokensRenewal(currentTokens, now, MIN_REFRESH_DELAY);
+    }
+  }
+
+  private void scheduleOrExecuteTokensRenewal(
+      Tokens currentTokens, Instant now, Duration minRefreshDelay) {
     Instant accessExpirationTime =
         tokenExpirationTime(now, currentTokens.getAccessToken(), defaultAccessTokenLifespan);
     Instant refreshExpirationTime =
         tokenExpirationTime(now, currentTokens.getRefreshToken(), defaultRefreshTokenLifespan);
     Duration delay =
-        nextDelay(now, accessExpirationTime, refreshExpirationTime, refreshSafetyWindow);
-    LOGGER.debug("Scheduling token refresh in {}", delay);
-    tokenRefreshFuture =
-        executor.schedule(
-            () -> {
-              currentTokensStage = renewTokens();
-              currentTokensStage.thenAccept(this::scheduleTokensRenewal);
-            },
-            delay.toMillis(),
-            TimeUnit.MILLISECONDS);
+        nextDelay(
+            now, accessExpirationTime, refreshExpirationTime, refreshSafetyWindow, minRefreshDelay);
+    if (delay.isZero()) {
+      LOGGER.debug("Refreshing expired tokens immediately");
+      renewTokens();
+    } else {
+      LOGGER.debug("Scheduling token refresh in {}", delay);
+      tokenRefreshFuture =
+          executor.schedule(this::renewTokens, delay.toMillis(), TimeUnit.MILLISECONDS);
+    }
   }
 
-  private CompletionStage<Tokens> renewTokens() {
-    return currentTokensStage
-        // try refreshing the current tokens
-        .thenApply(this::refreshTokens)
-        // if that fails, try fetching brand-new tokens
-        .exceptionally(error -> fetchNewTokens())
-        .whenComplete(this::log);
+  private void renewTokens() {
+    CompletionStage<Tokens> oldTokensStage = currentTokensStage;
+    currentTokensStage =
+        oldTokensStage
+            // try refreshing the current tokens
+            .thenApply(this::refreshTokens)
+            // if that fails, try fetching brand-new tokens
+            .exceptionally(error -> fetchNewTokens())
+            .whenComplete(this::log);
+    currentTokensStage.thenAccept(this::maybeScheduleTokensRenewal);
   }
 
-  private void log(Tokens tokens, Throwable error) {
+  /** Visible for testing. */
+  boolean idle(Instant now) {
+    return Duration.between(lastAccess, now).compareTo(idleInterval) > 0;
+  }
+
+  private void wakeUp(Instant now) {
+    scheduleOrExecuteTokensRenewal(getCurrentTokens(), now, Duration.ZERO);
+  }
+
+  private void log(Tokens redacted, Throwable error) {
     if (error != null) {
       LOGGER.error("Failed to renew tokens", error);
     } else {
@@ -268,14 +293,15 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
       Instant now,
       Instant accessExpirationTime,
       Instant refreshExpirationTime,
-      Duration refreshSafetyWindow) {
+      Duration refreshSafetyWindow,
+      Duration minRefreshDelay) {
     Instant expirationTime =
         accessExpirationTime.isBefore(refreshExpirationTime)
             ? accessExpirationTime
             : refreshExpirationTime;
     Duration delay = Duration.between(now, expirationTime).minus(refreshSafetyWindow);
-    if (delay.compareTo(MIN_REFRESH_DELAY) < 0) {
-      delay = MIN_REFRESH_DELAY;
+    if (delay.compareTo(minRefreshDelay) < 0) {
+      delay = minRefreshDelay;
     }
     return delay;
   }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
@@ -46,7 +46,7 @@ final class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
   private static final class TokenRefreshThread extends Thread {
 
     TokenRefreshThread(Runnable r) {
-      super(r, "oauth2-token-refresh");
+      super(r, "nessie-client-oauth2-token-refresh");
     }
 
     @Override

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
@@ -23,7 +23,7 @@ import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
+final class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OAuth2TokenRefreshExecutor.class);
 
@@ -33,7 +33,7 @@ class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
     allowCoreThreadTimeOut(true);
   }
 
-  private static class OAuth2TokenRefreshThreadFactory implements ThreadFactory {
+  private static final class OAuth2TokenRefreshThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(@Nonnull Runnable r) {
@@ -43,7 +43,7 @@ class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
     }
   }
 
-  private static class TokenRefreshThread extends Thread {
+  private static final class TokenRefreshThread extends Thread {
 
     TokenRefreshThread(Runnable r) {
       super(r, "oauth2-token-refresh");

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
@@ -33,7 +33,7 @@ class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
     allowCoreThreadTimeOut(true);
   }
 
-  static class OAuth2TokenRefreshThreadFactory implements ThreadFactory {
+  private static class OAuth2TokenRefreshThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(@Nonnull Runnable r) {
@@ -50,7 +50,7 @@ class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
 
       @Override
       public synchronized void start() {
-        LOGGER.debug("Starting new thread for OAuth2 token refresh");
+        LOGGER.debug("Starting new OAuth2 token refresh thread");
         super.start();
       }
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.auth.oauth2;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+
+class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
+
+  OAuth2TokenRefreshExecutor(Duration keepAlive) {
+    super(1, new OAuth2TokenRefreshThreadFactory());
+    setKeepAliveTime(keepAlive.toNanos(), TimeUnit.NANOSECONDS);
+    allowCoreThreadTimeOut(true);
+  }
+
+  static class OAuth2TokenRefreshThreadFactory implements ThreadFactory {
+
+    @Override
+    public Thread newThread(@Nonnull Runnable r) {
+      Thread thread = new Thread(r, "oauth2-token-refresh");
+      thread.setDaemon(true);
+      return thread;
+    }
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
@@ -41,26 +41,26 @@ class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
       thread.setDaemon(true);
       return thread;
     }
+  }
 
-    private static class TokenRefreshThread extends Thread {
+  private static class TokenRefreshThread extends Thread {
 
-      public TokenRefreshThread(Runnable r) {
-        super(r, "oauth2-token-refresh");
-      }
+    TokenRefreshThread(Runnable r) {
+      super(r, "oauth2-token-refresh");
+    }
 
-      @Override
-      public synchronized void start() {
-        LOGGER.debug("Starting new OAuth2 token refresh thread");
-        super.start();
-      }
+    @Override
+    public synchronized void start() {
+      LOGGER.debug("Starting new OAuth2 token refresh thread");
+      super.start();
+    }
 
-      @Override
-      public void run() {
-        try {
-          super.run();
-        } finally {
-          LOGGER.debug("OAuth2 token refresh thread exiting");
-        }
+    @Override
+    public void run() {
+      try {
+        super.run();
+      } finally {
+        LOGGER.debug("OAuth2 token refresh thread exiting");
       }
     }
   }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2TokenRefreshExecutor.java
@@ -50,13 +50,8 @@ class OAuth2TokenRefreshExecutor extends ScheduledThreadPoolExecutor {
     }
 
     @Override
-    public synchronized void start() {
-      LOGGER.debug("Starting new OAuth2 token refresh thread");
-      super.start();
-    }
-
-    @Override
     public void run() {
+      LOGGER.debug("Starting new OAuth2 token refresh thread");
       try {
         super.run();
       } finally {

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -361,7 +361,7 @@ class TestOAuth2Client {
             oneMinute,
             MIN_REFRESH_DELAY,
             MIN_REFRESH_DELAY),
-        // expirationTime - no safety window <= ZERO (immediate refresh use case)
+        // expirationTime - safety window <= ZERO (immediate refresh use case)
         Arguments.of(now, now.plus(oneMinute), now.plus(oneMinute), oneMinute, ZERO, ZERO));
   }
 

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -85,12 +85,12 @@ class TestOAuth2Client {
       ImmutableOAuth2ClientParams params = paramsBuilder(server).executor(executor).build();
       params.getHttpClient().setSslContext(server.getSslContext());
 
-      AtomicBoolean overrideIdle = new AtomicBoolean();
+      AtomicBoolean forceIdle = new AtomicBoolean();
       try (OAuth2Client client =
           new OAuth2Client(params) {
             @Override
             boolean idle(Instant now) {
-              if (overrideIdle.get()) {
+              if (forceIdle.get()) {
                 return true;
               }
               return super.idle(now);
@@ -129,7 +129,7 @@ class TestOAuth2Client {
         assertThat(client.getCurrentTokens()).isInstanceOf(RefreshTokensResponse.class);
 
         // emulate executor running the scheduled renewal task and detecting that the client is idle
-        overrideIdle.set(true);
+        forceIdle.set(true);
         currentRenewalTask.get().run();
         assertThat(client.sleeping).isTrue();
 

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientParams.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientParams.java
@@ -87,11 +87,12 @@ class TestOAuth2ClientParams {
             new IllegalArgumentException(
                 "refresh safety window must be less than the default token lifespan")),
         Arguments.of(
-            newBuilder().idleInterval(MIN_IDLE_INTERVAL.minusSeconds(1)),
+            newBuilder().preemptiveTokenRefreshIdleTimeout(MIN_IDLE_INTERVAL.minusSeconds(1)),
             new IllegalArgumentException(
-                "idle interval must be greater than or equal to " + MIN_IDLE_INTERVAL)),
+                "preemptive token refresh idle timeout must be greater than or equal to "
+                    + MIN_IDLE_INTERVAL)),
         Arguments.of(
-            newBuilder().keepAliveInterval(Duration.ZERO),
+            newBuilder().backgroundThreadIdleTimeout(Duration.ZERO),
             new IllegalArgumentException("Core threads must have nonzero keep alive times")));
   }
 

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientParams.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientParams.java
@@ -23,6 +23,8 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT;
+import static org.projectnessie.client.auth.oauth2.OAuth2ClientParams.MIN_IDLE_INTERVAL;
+import static org.projectnessie.client.auth.oauth2.OAuth2ClientParams.MIN_REFRESH_DELAY;
 
 import java.net.URI;
 import java.time.Duration;
@@ -71,14 +73,13 @@ class TestOAuth2ClientParams {
             newBuilder().grantType("password").username("Alice").password(""),
             new IllegalArgumentException("password must be set if grant type is 'password'")),
         Arguments.of(
-            newBuilder()
-                .defaultAccessTokenLifespan(OAuth2ClientParams.MIN_REFRESH_DELAY.minusSeconds(1)),
+            newBuilder().defaultAccessTokenLifespan(MIN_REFRESH_DELAY.minusSeconds(1)),
             new IllegalArgumentException(
-                "default token lifespan must be greater than or equal to PT1S")),
+                "default token lifespan must be greater than or equal to " + MIN_REFRESH_DELAY)),
         Arguments.of(
-            newBuilder().refreshSafetyWindow(OAuth2ClientParams.MIN_REFRESH_DELAY.minusSeconds(1)),
+            newBuilder().refreshSafetyWindow(MIN_REFRESH_DELAY.minusSeconds(1)),
             new IllegalArgumentException(
-                "refresh safety window must be greater than or equal to PT1S")),
+                "refresh safety window must be greater than or equal to " + MIN_REFRESH_DELAY)),
         Arguments.of(
             newBuilder()
                 .refreshSafetyWindow(Duration.ofMinutes(10))
@@ -86,13 +87,12 @@ class TestOAuth2ClientParams {
             new IllegalArgumentException(
                 "refresh safety window must be less than the default token lifespan")),
         Arguments.of(
-            newBuilder().idleInterval(OAuth2ClientParams.MIN_IDLE_INTERVAL.minusSeconds(1)),
-            new IllegalArgumentException("idle interval must be greater than or equal to PT5S")),
-        Arguments.of(
-            newBuilder()
-                .keepAliveInterval(OAuth2ClientParams.MIN_KEEP_ALIVE_INTERVAL.minusSeconds(1)),
+            newBuilder().idleInterval(MIN_IDLE_INTERVAL.minusSeconds(1)),
             new IllegalArgumentException(
-                "keep alive interval must be greater than or equal to PT5S")));
+                "idle interval must be greater than or equal to " + MIN_IDLE_INTERVAL)),
+        Arguments.of(
+            newBuilder().keepAliveInterval(Duration.ZERO),
+            new IllegalArgumentException("Core threads must have nonzero keep alive times")));
   }
 
   @ParameterizedTest

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientParams.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientParams.java
@@ -84,7 +84,15 @@ class TestOAuth2ClientParams {
                 .refreshSafetyWindow(Duration.ofMinutes(10))
                 .defaultAccessTokenLifespan(Duration.ofMinutes(5)),
             new IllegalArgumentException(
-                "refresh safety window must be less than the default token lifespan")));
+                "refresh safety window must be less than the default token lifespan")),
+        Arguments.of(
+            newBuilder().idleInterval(OAuth2ClientParams.MIN_IDLE_INTERVAL.minusSeconds(1)),
+            new IllegalArgumentException("idle interval must be greater than or equal to PT5S")),
+        Arguments.of(
+            newBuilder()
+                .keepAliveInterval(OAuth2ClientParams.MIN_KEEP_ALIVE_INTERVAL.minusSeconds(1)),
+            new IllegalArgumentException(
+                "keep alive interval must be greater than or equal to PT5S")));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
This PR introduces 2 mechanisms to mitigate the situation where the Nessie client is idle but the OAuth2 client keeps consuming resources:

1. An idle interval after which the tokens are not refreshed anymore. When the token is needed again, if it's expired, it will be renewed from step 1.
2. A keep alive interval after which the background thread is stopped. If a refresh is needed again, a new thread will be spawned.

It was hard to create tests for these new features. I will see if I can improve that more.