### PR TITLE
Site: some maintenance

### DIFF
--- a/site/docs/develop/spec.md
+++ b/site/docs/develop/spec.md
@@ -94,7 +94,7 @@ local cache and using `id` to look up that auxiliary data.
 ### Content Types
 
 Nessie is designed to support various table formats, and currently supports the following types.
-See also [Tables & Views](../tables).
+See also [Tables & Views](../tables/index.md).
 
 #### Iceberg Table
 

--- a/site/docs/features/intro.md
+++ b/site/docs/features/intro.md
@@ -83,7 +83,7 @@ is possible in large part due to the separation of transaction management (Nessi
 table metadata management.
 
 ## Technology 
-Nessie can be [deployed in multiple ways](../try) and is composed primarily of the Nessie service, 
+Nessie can be [deployed in multiple ways](../try/index.md) and is composed primarily of the Nessie service, 
 which exposes a set of [REST APIs](../develop/rest.md) and a simple browser UI. This service works with multiple
 libraries to expose Nessie's version control capabilities to common data management technologies.
 
@@ -102,4 +102,4 @@ Nessie was originally conceived and built by engineers at [Dremio](http://dremio
 ## Getting Started
 
 * Read more about [Nessie transactions](transactions.md)
-* Get started with the Nessie [quickstart](../try).
+* Get started with the Nessie [quickstart](../try/index.md).

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -70,8 +70,8 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.keys


### PR DESCRIPTION
Fix relative links:
```
INFO    -  Doc file 'develop/spec.md' contains an unrecognized relative link '../tables', it was left as is. Did you mean '../tables/index.md'?
INFO    -  Doc file 'features/intro.md' contains an unrecognized relative link '../try', it was left as is. Did you mean '../try/index.md'?
INFO    -  Doc file 'features/intro.md' contains an unrecognized relative link '../try', it was left as is. Did you mean '../try/index.md'?
```

Migrate to `mkdocs-material`:
```
WARNING -  Material emoji logic has been officially moved into mkdocs-material
version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
as mkdocs_material_extensions is deprecated and will no longer be
supported moving forward. This is the last release.
```

```
WARNING -  Material emoji logic has been officially moved into mkdocs-material
version 9.4. Please use Material's 'material.extensions.emoji.to_svg'
as mkdocs_material_extensions is deprecated and will no longer be
supported moving forward. This is the last release.
```