### PR TITLE
Expose object cache metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ as necessary. Empty sections will not end in the release notes.
 
 ### New Features
 
+- Exposes object cache metrics, meters use the tags `application="Nessie",cache="nessie-objects"`
+
 ### Changes
 
 ### Deprecations
 
 ### Fixes
+
+- Fix incorrectly calculated object cache maximum weight.
 
 ### Commits
 

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/PersistProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/PersistProvider.java
@@ -17,6 +17,7 @@ package org.projectnessie.quarkus.providers.storage;
 
 import static org.projectnessie.versioned.storage.common.logic.Logics.repositoryLogic;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.runtime.Startup;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -115,7 +116,7 @@ public class PersistProvider {
   @Singleton
   @Startup
   @NotObserved
-  public Persist producePersist() {
+  public Persist producePersist(MeterRegistry meterRegistry) {
     VersionStoreType versionStoreType = versionStoreConfig.getVersionStoreType();
     if (!versionStoreType.isNewStorage()) {
       return null;
@@ -149,7 +150,7 @@ public class PersistProvider {
 
     String cacheInfo;
     if (effectiveCacheSizeMB > 0) {
-      CacheBackend cacheBackend = PersistCaches.newBackend(effectiveCacheSizeMB);
+      CacheBackend cacheBackend = PersistCaches.newBackend(effectiveCacheSizeMB, meterRegistry);
       persist = cacheBackend.wrap(persist);
       cacheInfo = "with " + effectiveCacheSizeMB + " MB objects cache";
     } else {

--- a/versioned/storage/cache/build.gradle.kts
+++ b/versioned/storage/cache/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
   implementation(libs.guava)
   implementation(libs.caffeine)
+  implementation(libs.micrometer.core)
 
   compileOnly(libs.immutables.builder)
   compileOnly(libs.immutables.value.annotations)

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -15,11 +15,16 @@
  */
 package org.projectnessie.versioned.storage.cache;
 
+import static java.util.Collections.singletonList;
 import static org.projectnessie.versioned.storage.serialize.ProtoSerialization.serializeObj;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.cache.CaffeineStatsCounter;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.persist.Obj;
@@ -31,6 +36,7 @@ import org.projectnessie.versioned.storage.serialize.ProtoSerialization;
 abstract class CaffeineCacheBackend implements CacheBackend {
 
   public static final int JAVA_OBJ_HEADER = 32;
+  public static final String CACHE_NAME = "nessie-objects";
 
   static ImmutableCaffeineCacheBackend.Builder builder() {
     return ImmutableCaffeineCacheBackend.builder();
@@ -38,17 +44,22 @@ abstract class CaffeineCacheBackend implements CacheBackend {
 
   abstract long capacity();
 
+  @Nullable
+  @jakarta.annotation.Nullable
+  abstract MeterRegistry meterRegistry();
+
   @Value.Derived
   Cache<CacheKey, byte[]> cache() {
-    // IMPORTANT!
-    // When changing the configuration of the Caffeine cache, make sure to run the
-    // _native_ Quarkus tests and adopt the `@ReflectionConfig` in
-    // org.projectnessie.quarkus.providers.PersistProvider.
-    return Caffeine.newBuilder()
-        .maximumWeight(capacity())
-        .recordStats()
-        .weigher(this::weigher)
-        .build();
+    Caffeine<CacheKey, byte[]> cacheBuilder =
+        Caffeine.newBuilder().maximumWeight(capacity() * 1024L * 1024L).weigher(this::weigher);
+    MeterRegistry meterRegistry = meterRegistry();
+    if (meterRegistry != null) {
+      cacheBuilder.recordStats(() -> new CaffeineStatsCounter(meterRegistry, CACHE_NAME));
+      meterRegistry
+          .counter("cache_capacity_mb", singletonList(Tag.of("cache", CACHE_NAME)))
+          .increment(capacity());
+    }
+    return cacheBuilder.build();
   }
 
   @Override

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -56,9 +56,8 @@ abstract class CaffeineCacheBackend implements CacheBackend {
     MeterRegistry meterRegistry = meterRegistry();
     if (meterRegistry != null) {
       cacheBuilder.recordStats(() -> new CaffeineStatsCounter(meterRegistry, CACHE_NAME));
-      meterRegistry
-          .counter("cache_capacity_mb", singletonList(Tag.of("cache", CACHE_NAME)))
-          .increment(capacity());
+      meterRegistry.gauge(
+          "cache_capacity_mb", singletonList(Tag.of("cache", CACHE_NAME)), "", x -> capacity());
     }
     return cacheBuilder.build();
   }

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -42,6 +42,7 @@ abstract class CaffeineCacheBackend implements CacheBackend {
     return ImmutableCaffeineCacheBackend.builder();
   }
 
+  /** Cache capacity in MB. */
   abstract long capacity();
 
   @Nullable

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/PersistCaches.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/PersistCaches.java
@@ -15,11 +15,13 @@
  */
 package org.projectnessie.versioned.storage.cache;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 public final class PersistCaches {
   private PersistCaches() {}
 
   /** Produces a {@link CacheBackend} with the given maximum capacity. */
-  public static CacheBackend newBackend(long capacity) {
-    return CaffeineCacheBackend.builder().capacity(capacity).build();
+  public static CacheBackend newBackend(long capacity, MeterRegistry meterRegistry) {
+    return CaffeineCacheBackend.builder().capacity(capacity).meterRegistry(meterRegistry).build();
   }
 }

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/PersistCaches.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/PersistCaches.java
@@ -21,7 +21,7 @@ public final class PersistCaches {
   private PersistCaches() {}
 
   /** Produces a {@link CacheBackend} with the given maximum capacity. */
-  public static CacheBackend newBackend(long capacity, MeterRegistry meterRegistry) {
-    return CaffeineCacheBackend.builder().capacity(capacity).meterRegistry(meterRegistry).build();
+  public static CacheBackend newBackend(long capacityMb, MeterRegistry meterRegistry) {
+    return CaffeineCacheBackend.builder().capacity(capacityMb).meterRegistry(meterRegistry).build();
   }
 }

--- a/versioned/storage/testextension/build.gradle.kts
+++ b/versioned/storage/testextension/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.findbugs.jsr305)
 
+  implementation(libs.micrometer.core)
+
   compileOnly(libs.errorprone.annotations)
   implementation(libs.guava)
 

--- a/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
+++ b/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
@@ -52,7 +52,9 @@ final class ClassPersistInstances {
     NessiePersistCache nessiePersistCache =
         PersistExtension.annotationInstance(context, NessiePersistCache.class);
     cacheBackend =
-        nessiePersistCache != null ? PersistCaches.newBackend(nessiePersistCache.capacity()) : null;
+        nessiePersistCache != null
+            ? PersistCaches.newBackend(nessiePersistCache.capacity(), null)
+            : null;
 
     backendTestFactory = reusableTestBackend.backendTestFactory(context);
   }


### PR DESCRIPTION
Currently there's no way to inspect the runtime behavior of Nessie's object cache, nor a way to inspect its configuration.

This change exposes the runtime metrics and the cache's configuration.

Example output from Quarkus' metrics endpoint:
```
cache_gets_total{application="Nessie",cache="nessie-objects",result="hit"} 1006.0 # {span_id="237f43a65f9b9b55",trace_id="2d010ee3253ad98c2075ed4dbf72d6e5"} 1.0 1697710156.971
cache_gets_total{application="Nessie",cache="nessie-objects",result="miss"} 0.0
cache_loads_seconds_max{application="Nessie",cache="nessie-objects",result="success"} 0.0
cache_loads_seconds_max{application="Nessie",cache="nessie-objects",result="failure"} 0.0
cache_loads_seconds_count{application="Nessie",cache="nessie-objects",result="success"} 0.0
cache_loads_seconds_sum{application="Nessie",cache="nessie-objects",result="success"} 0.0
cache_loads_seconds_count{application="Nessie",cache="nessie-objects",result="failure"} 0.0
cache_loads_seconds_sum{application="Nessie",cache="nessie-objects",result="failure"} 0.0
cache_evictions_count{application="Nessie",cache="nessie-objects",cause="REPLACED"} 0.0
cache_evictions_sum{application="Nessie",cache="nessie-objects",cause="REPLACED"} 0.0
cache_evictions_count{application="Nessie",cache="nessie-objects",cause="COLLECTED"} 0.0
cache_evictions_sum{application="Nessie",cache="nessie-objects",cause="COLLECTED"} 0.0
cache_evictions_count{application="Nessie",cache="nessie-objects",cause="EXPIRED"} 0.0
cache_evictions_sum{application="Nessie",cache="nessie-objects",cause="EXPIRED"} 0.0
cache_evictions_count{application="Nessie",cache="nessie-objects",cause="SIZE"} 0.0
cache_evictions_sum{application="Nessie",cache="nessie-objects",cause="SIZE"} 0.0
cache_evictions_count{application="Nessie",cache="nessie-objects",cause="EXPLICIT"} 0.0
cache_evictions_sum{application="Nessie",cache="nessie-objects",cause="EXPLICIT"} 0.0
cache_evictions_max{application="Nessie",cache="nessie-objects",cause="REPLACED"} 0.0
cache_evictions_max{application="Nessie",cache="nessie-objects",cause="COLLECTED"} 0.0
cache_evictions_max{application="Nessie",cache="nessie-objects",cause="EXPIRED"} 0.0
cache_evictions_max{application="Nessie",cache="nessie-objects",cause="SIZE"} 0.0
cache_evictions_max{application="Nessie",cache="nessie-objects",cause="EXPLICIT"} 0.0
cache_capacity_mb_total{application="Nessie",cache="nessie-objects"} 21145.0
```
All but the `cache_capacity_mb_total` are generated by the `CaffeineStatsCounter` included in Micrometer. `cache_capacity_mb_total` represents the configured cache capacity in MB.

This change also fixes a bug in the Cache weigher - the configured maximum weight was incorrect.