### PR TITLE
Remove commit-meta property containing the merge-parent commit-ID

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/CommitMeta.java
+++ b/api/model/src/main/java/org/projectnessie/model/CommitMeta.java
@@ -54,17 +54,6 @@ import org.projectnessie.model.ser.Views;
 public abstract class CommitMeta {
 
   /**
-   * Key of the {@link #getProperties() property} that indicates the merged commit ID, if the commit
-   * represents a merge commit.
-   *
-   * <p>If the commit is the result of a merge operation, the properties map <em>may</em> contain
-   * the key {@value #MERGE_PARENT_PROPERTY}, if the merge was performed with a Nessie server
-   * version, after 0.30.0, that persists the merged reference.
-   */
-  @Deprecated // for removal
-  public static final String MERGE_PARENT_PROPERTY = "_merge_parent";
-
-  /**
    * Hash of this commit.
    *
    * <p>This is not known at creation time and is only valid when reading the log.

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -699,7 +699,7 @@ public abstract class BaseTestNessieApi {
               singletonList("NessieHerself"),
               singletonList("Arctic"),
               Instant.EPOCH,
-              ImmutableMap.of("property", "value", "_merge_parent", branch.getHash()));
+              singletonMap("property", "value"));
     } else {
       api().mergeRefIntoBranch().fromRef(branch).branch(main).keepIndividualCommits(false).merge();
       main2 = api().getReference().refName(main.getName()).get();

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
@@ -22,9 +22,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
-import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
-import static org.assertj.core.data.MapEntry.entry;
 import static org.projectnessie.model.CommitMeta.fromMessage;
 import static org.projectnessie.model.FetchOption.MINIMAL;
 import static org.projectnessie.model.MergeBehavior.DROP;
@@ -258,12 +256,6 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
           .extracting(CommitMeta::getParentCommitHashes)
           .asInstanceOf(list(String.class))
           .containsExactly(baseHead.getHash(), committed2.getHash());
-      soft.assertThat(logOfMerged)
-          .first()
-          .extracting(LogEntry::getCommitMeta)
-          .extracting(CommitMeta::getProperties)
-          .asInstanceOf(map(String.class, String.class))
-          .containsExactly(entry(CommitMeta.MERGE_PARENT_PROPERTY, committed2.getHash()));
     }
   }
 


### PR DESCRIPTION
The property was deprecated for removal for a while.

Fixes #6002