### PR TITLE
Relax CacheSizing validation rules.

### DIFF
--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheSizing.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheSizing.java
@@ -97,9 +97,6 @@ public interface CacheSizing {
 
   @Value.Check
   default void check() {
-    checkState(
-        !(fixedSizeInMB().isPresent() && fractionOfMaxHeapSize().isPresent()),
-        "Cache sizing: must not specify both fractionOfMaxHeapSize and sizeInBytes, use either.");
     if (fractionOfMaxHeapSize().isPresent()) {
       checkState(
           fractionOfMaxHeapSize().getAsDouble() > 0d && fractionOfMaxHeapSize().getAsDouble() < 1d,
@@ -109,8 +106,8 @@ public interface CacheSizing {
     if (fixedSizeInMB().isPresent()) {
       int fixed = fixedSizeInMB().getAsInt();
       checkState(
-          fixed == 0 || fixed > 64,
-          "Cache sizing: sizeInBytes must be greater than 64 MB, but is %s",
+          fixed >= 0,
+          "Cache sizing: sizeInBytes must be greater than 0, but is %s",
           fixedSizeInMB());
     }
     checkState(

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheSizing.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheSizing.java
@@ -68,7 +68,7 @@ public class TestCacheSizing {
 
   @Test
   void tinyHeapNoCache() {
-    // Assuming a 256MB max heap, requesting 70% (358MB), calc yields fractionMinSizeMb, i.e. zero
+    // Assuming a 256MB max heap, requesting 70% (179MB), calc yields fractionMinSizeMb, i.e. zero
     soft.assertThat(
             CacheSizing.builder()
                 .fractionOfMaxHeapSize(.7)

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheSizing.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheSizing.java
@@ -30,14 +30,28 @@ public class TestCacheSizing {
   @InjectSoftAssertions protected SoftAssertions soft;
 
   @Test
-  void illegalSettings() {
-    soft.assertThatIllegalStateException()
-        .isThrownBy(
-            () -> CacheSizing.builder().fixedSizeInMB(128).fractionOfMaxHeapSize(.5d).build());
+  void illegalFractionSettings() {
     soft.assertThatIllegalStateException()
         .isThrownBy(() -> CacheSizing.builder().fractionOfMaxHeapSize(-.1d).build());
     soft.assertThatIllegalStateException()
         .isThrownBy(() -> CacheSizing.builder().fractionOfMaxHeapSize(1.1d).build());
+  }
+
+  @Test
+  void illegalFixedSettings() {
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> CacheSizing.builder().fixedSizeInMB(-1).build());
+  }
+
+  @Test
+  void fixedSizeWins() {
+    soft.assertThat(
+            CacheSizing.builder()
+                .fixedSizeInMB(3)
+                .fractionOfMaxHeapSize(.5)
+                .build()
+                .calculateEffectiveSizeInMB(BYTES_512M))
+        .isEqualTo(3);
   }
 
   @Test
@@ -50,6 +64,18 @@ public class TestCacheSizing {
                 .build()
                 .calculateEffectiveSizeInMB(BYTES_256M))
         .isEqualTo(64);
+  }
+
+  @Test
+  void tinyHeapNoCache() {
+    // Assuming a 256MB max heap, requesting 70% (358MB), calc yields fractionMinSizeMb, i.e. zero
+    soft.assertThat(
+            CacheSizing.builder()
+                .fractionOfMaxHeapSize(.7)
+                .fractionMinSizeMb(0)
+                .build()
+                .calculateEffectiveSizeInMB(BYTES_256M))
+        .isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
Accept wider range of property values.

* Any non-negative value for `fixedSizeInMB` This may be useful in test / POC environments.

* `fixedSizeInMB` and `fractionOfMaxHeapSize` may be specified together (`fixedSizeInMB` wins). Allowing both values to be set can be useful in helm-based deployments that have custom Quarkus `application.properties`.

* No change to actual cache size computation logic.