### PR TITLE
OAuth2Client: forbid recursive calls to renewTokens()

### DIFF
--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -331,7 +331,7 @@ class TestOAuth2Client {
 
   @ParameterizedTest
   @MethodSource
-  void testNextDelay(
+  void testShortestDelay(
       Instant now,
       Instant accessExp,
       Instant refreshExp,
@@ -339,11 +339,11 @@ class TestOAuth2Client {
       Duration minRefreshDelay,
       Duration expected) {
     Duration actual =
-        OAuth2Client.nextDelay(now, accessExp, refreshExp, safetyWindow, minRefreshDelay);
+        OAuth2Client.shortestDelay(now, accessExp, refreshExp, safetyWindow, minRefreshDelay);
     assertThat(actual).isEqualTo(expected);
   }
 
-  static Stream<Arguments> testNextDelay() {
+  static Stream<Arguments> testShortestDelay() {
     Instant now = Instant.now();
     Duration oneMinute = Duration.ofMinutes(1);
     Duration thirtySeconds = Duration.ofSeconds(30);


### PR DESCRIPTION
This commit is a purely technical refactoring.

It fixes a possible, although very unlikely, situation where the thread executing renewTokens could potentially re-enter that method, because the next refresh delay is too short. That would be incorrect.

This situation is only theoretical at the moment, given the current minimum delays, but making it completely impossible by design will prevent future changes from accidentally introducing a regression.