### PR TITLE
Make Conflict.conflictType non nullable

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/Conflict.java
+++ b/api/model/src/main/java/org/projectnessie/model/Conflict.java
@@ -34,8 +34,6 @@ import org.immutables.value.Value;
     ignoreUnknown = true)
 public interface Conflict {
   @Value.Parameter(order = 1)
-  @Nullable
-  @jakarta.annotation.Nullable
   @JsonDeserialize(using = ConflictType.Deserializer.class)
   ConflictType conflictType();
 
@@ -48,7 +46,7 @@ public interface Conflict {
   String message();
 
   static Conflict conflict(
-      @Nullable @jakarta.annotation.Nullable ConflictType conflictType,
+      ConflictType conflictType,
       @Nullable @jakarta.annotation.Nullable ContentKey key,
       String message) {
     return ImmutableConflict.of(conflictType, key, message);
@@ -110,7 +108,7 @@ public interface Conflict {
       public ConflictType deserialize(JsonParser p, DeserializationContext ctxt)
           throws IOException {
         String name = p.readValueAs(String.class);
-        return name != null ? ConflictType.parse(name) : null;
+        return name != null ? ConflictType.parse(name) : UNKNOWN;
       }
     }
   }

--- a/api/model/src/main/java/org/projectnessie/model/Conflict.java
+++ b/api/model/src/main/java/org/projectnessie/model/Conflict.java
@@ -35,7 +35,10 @@ import org.immutables.value.Value;
 public interface Conflict {
   @Value.Parameter(order = 1)
   @JsonDeserialize(using = ConflictType.Deserializer.class)
-  ConflictType conflictType();
+  @Value.Default
+  default ConflictType conflictType() {
+    return ConflictType.UNKNOWN;
+  }
 
   @Value.Parameter(order = 2)
   @Nullable
@@ -104,11 +107,17 @@ public interface Conflict {
     }
 
     public static final class Deserializer extends JsonDeserializer<ConflictType> {
+
+      @Override
+      public ConflictType getNullValue(DeserializationContext ctxt) {
+        return UNKNOWN;
+      }
+
       @Override
       public ConflictType deserialize(JsonParser p, DeserializationContext ctxt)
           throws IOException {
         String name = p.readValueAs(String.class);
-        return name != null ? ConflictType.parse(name) : UNKNOWN;
+        return ConflictType.parse(name);
       }
     }
   }

--- a/api/model/src/main/java/org/projectnessie/model/Conflict.java
+++ b/api/model/src/main/java/org/projectnessie/model/Conflict.java
@@ -35,10 +35,7 @@ import org.immutables.value.Value;
 public interface Conflict {
   @Value.Parameter(order = 1)
   @JsonDeserialize(using = ConflictType.Deserializer.class)
-  @Value.Default
-  default ConflictType conflictType() {
-    return ConflictType.UNKNOWN;
-  }
+  ConflictType conflictType();
 
   @Value.Parameter(order = 2)
   @Nullable

--- a/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
@@ -67,7 +67,11 @@ class TestNessieError {
                 .put("message", "msg")
                 .put("someNewField", "blah")
                 .set("key", ckJson),
-            conflict(UNKNOWN, ContentKey.of("foo"), "msg")));
+            conflict(UNKNOWN, ContentKey.of("foo"), "msg")),
+        arguments(
+            objectNode().putNull("conflictType").put("message", "msg"),
+            conflict(UNKNOWN, null, "msg")),
+        arguments(objectNode().put("message", "msg"), conflict(UNKNOWN, null, "msg")));
   }
 
   /**

--- a/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
@@ -70,8 +70,7 @@ class TestNessieError {
             conflict(UNKNOWN, ContentKey.of("foo"), "msg")),
         arguments(
             objectNode().putNull("conflictType").put("message", "msg"),
-            conflict(UNKNOWN, null, "msg")),
-        arguments(objectNode().put("message", "msg"), conflict(UNKNOWN, null, "msg")));
+            conflict(UNKNOWN, null, "msg")));
   }
 
   /**

--- a/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
@@ -67,8 +67,7 @@ class TestNessieError {
                 .put("message", "msg")
                 .put("someNewField", "blah")
                 .set("key", ckJson),
-            conflict(UNKNOWN, ContentKey.of("foo"), "msg")),
-        arguments(objectNode().put("message", "msg"), conflict(null, null, "msg")));
+            conflict(UNKNOWN, ContentKey.of("foo"), "msg")));
   }
 
   /**


### PR DESCRIPTION
`Conflict.conflictType` is marked nullable, but in practice it isn't.

The reason why it was marked nullable seems related to JSON serialization. But after checking the history of the `Conclict` type, it appears that the field `conflictType()` was present since the beginning, and always serialized. So there cannot be an older Nessie version that would serialize this type without that field. (And besides, this type is only serialized in server-to-client direction.)