### PR TITLE
OAuth2Client: implement fault tolerance

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Exception.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Exception.java
@@ -23,7 +23,7 @@ public class OAuth2Exception extends HttpClientException {
   private final Status status;
   private final String errorCode;
 
-  public OAuth2Exception(Status status, ErrorResponse errorResponse) {
+  OAuth2Exception(Status status, ErrorResponse errorResponse) {
     super(createMessage(status, errorResponse));
     this.status = status;
     this.errorCode = errorResponse.getErrorCode();


### PR DESCRIPTION
See [this Zulip topic](https://project-nessie.zulipchat.com/#narrow/stream/371193-dev/topic/OAuth2.20client.20fault.20tolerance/near/398272049) for context.

Here is what I'm proposing:

1. Failures encountered when fetching tokens do not stop anymore the background refresh cycle; this allows the tokens to be eventually rotated, if the error was transient. Calls to `authenticate()` will eventually recover and succeed. If the error is permanent though (bad credentials for example), then the behavior is the same: all calls to `authenticate()` will fail.
2. Failures encountered when scheduling tasks are handled in 2 different ways:
  a. If the rejected task is the very first token fetch, then `authenticate()` will throw `RejectedExecutionException` as before;
  b. If, however, the rejected task is a background refresh task, then instead of failing, we keep the current tokens and enter sleep mode. In sleep mode, each call to `authenticate()` will, if necessary, rotate the tokens synchronously and attempt to schedule a refresh. If that schedule is rejected again and again, we stay in sleep mode forever, effectively making `authenticate()` fetch new tokens synchronously whenever they expire.