### PR TITLE
Expose full set of Bigtable retry settings in BigTableClientsConfig

### DIFF
--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableClientsConfig.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableClientsConfig.java
@@ -15,15 +15,18 @@
  */
 package org.projectnessie.versioned.storage.bigtable;
 
+import com.google.api.gax.retrying.RetrySettings;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.OptionalInt;
 
 /**
  * Settings used to create and configure BigTable clients (data and table admin).
  *
  * @see BigTableClientsFactory
+ * @see RetrySettings
  */
 public interface BigTableClientsConfig {
 
@@ -47,15 +50,21 @@ public interface BigTableClientsConfig {
 
   Map<String, String> jwtAudienceMapping();
 
+  Optional<Duration> initialRetryDelay();
+
   Optional<Duration> maxRetryDelay();
+
+  OptionalDouble retryDelayMultiplier();
 
   OptionalInt maxAttempts();
 
   Optional<Duration> initialRpcTimeout();
 
-  Optional<Duration> totalTimeout();
+  Optional<Duration> maxRpcTimeout();
 
-  Optional<Duration> initialRetryDelay();
+  OptionalDouble rpcTimeoutMultiplier();
+
+  Optional<Duration> totalTimeout();
 
   OptionalInt minChannelCount();
 

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableClientsFactory.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableClientsFactory.java
@@ -89,8 +89,11 @@ public final class BigTableClientsFactory {
             stubSettings.readChangeStreamSettings().retrySettings())) {
       configureDuration(config.totalTimeout(), retrySettings::setTotalTimeout);
       configureDuration(config.initialRpcTimeout(), retrySettings::setInitialRpcTimeout);
+      configureDuration(config.maxRpcTimeout(), retrySettings::setMaxRpcTimeout);
+      config.rpcTimeoutMultiplier().ifPresent(retrySettings::setRpcTimeoutMultiplier);
       configureDuration(config.initialRetryDelay(), retrySettings::setInitialRetryDelay);
       configureDuration(config.maxRetryDelay(), retrySettings::setMaxRetryDelay);
+      config.retryDelayMultiplier().ifPresent(retrySettings::setRetryDelayMultiplier);
       config.maxAttempts().ifPresent(retrySettings::setMaxAttempts);
     }
 


### PR DESCRIPTION
Previously, attempting to configure `initialRpcTimeout` would lead to errors like: `IllegalStateException: max rpc timeout must not be shorter than initial timeout`