### PR TITLE
OAuth2Client: improve stack traces and reduce log frequency

### DIFF
--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
@@ -268,6 +268,7 @@ public class ITOAuth2Client {
     try (OAuth2Client client = new OAuth2Client(params)) {
       client.start();
       soft.assertThatThrownBy(client::authenticate)
+          .cause()
           .asInstanceOf(type(OAuth2Exception.class))
           .extracting(OAuth2Exception::getStatus)
           .isEqualTo(Status.UNAUTHORIZED);
@@ -281,6 +282,7 @@ public class ITOAuth2Client {
     try (OAuth2Client client = new OAuth2Client(params)) {
       client.start();
       soft.assertThatThrownBy(client::authenticate)
+          .cause()
           .asInstanceOf(type(OAuth2Exception.class))
           .extracting(OAuth2Exception::getStatus)
           .isEqualTo(Status.UNAUTHORIZED);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Authenticator.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Authenticator.java
@@ -17,12 +17,8 @@ package org.projectnessie.client.auth.oauth2;
 
 public interface OAuth2Authenticator extends AutoCloseable {
 
-  /**
-   * Attempts to authenticate the client and returns a valid {@link AccessToken}.
-   *
-   * @throws OAuth2Exception if authentication failed.
-   */
-  AccessToken authenticate() throws OAuth2Exception;
+  /** Attempts to authenticate the client and returns a valid {@link AccessToken}. */
+  AccessToken authenticate();
 
   @Override
   void close();

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -61,6 +61,7 @@ import org.slf4j.LoggerFactory;
 class OAuth2Client implements OAuth2Authenticator, Closeable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OAuth2Client.class);
+  private static final Duration MIN_WARN_INTERVAL = Duration.ofSeconds(10);
 
   private final String grantType;
   private final String username;
@@ -83,6 +84,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
   private volatile CompletionStage<Tokens> currentTokensStage;
   private volatile ScheduledFuture<?> tokenRefreshFuture;
   private volatile Instant lastAccess;
+  private volatile Instant lastWarn;
 
   OAuth2Client(OAuth2ClientParams params) {
     grantType = params.getGrantType();
@@ -126,11 +128,12 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof RuntimeException) {
+        cause.fillInStackTrace();
         throw (RuntimeException) cause;
       } else if (cause instanceof Error) {
         throw (Error) cause;
       } else {
-        throw new RuntimeException(cause);
+        throw new RuntimeException(cause.getMessage());
       }
     }
   }
@@ -222,7 +225,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
         // We raced with close(), ignore
         return;
       }
-      LOGGER.warn("Failed to schedule next token renewal, forcibly sleeping", e);
+      maybeWarn("Failed to schedule next token renewal, forcibly sleeping");
       sleeping.set(true);
     }
   }
@@ -243,9 +246,13 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
   private void log(Throwable error) {
     if (error != null) {
       boolean tokensStageCancelled = error instanceof CancellationException && closing.get();
-      if (!tokensStageCancelled) {
-        LOGGER.error("Failed to renew tokens", error);
+      if (tokensStageCancelled) {
+        return;
       }
+      if (error instanceof CompletionException) {
+        error = error.getCause();
+      }
+      maybeWarn("Failed to renew tokens: {}", error.getMessage());
     } else {
       LOGGER.debug("Successfully renewed tokens");
     }
@@ -387,6 +394,18 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
       throw e;
     } catch (Exception e) {
       throw new HttpClientException(e);
+    }
+  }
+
+  private void maybeWarn(String message, Object... args) {
+    Instant now = clock.get();
+    boolean shouldWarn =
+        lastWarn == null || Duration.between(lastWarn, now).compareTo(MIN_WARN_INTERVAL) > 0;
+    if (shouldWarn) {
+      LOGGER.warn(message, args);
+      lastWarn = now;
+    } else {
+      LOGGER.debug(message, args);
     }
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -222,7 +222,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
         // We raced with close(), ignore
         return;
       }
-      maybeWarn("Failed to schedule next token renewal, forcibly sleeping");
+      maybeWarn("Failed to schedule next token renewal, forcibly sleeping", null);
       sleeping.set(true);
     }
   }
@@ -394,15 +394,15 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
     }
   }
 
-  private void maybeWarn(String message, Object... args) {
+  private void maybeWarn(String message, Throwable error) {
     Instant now = clock.get();
     boolean shouldWarn =
         lastWarn == null || Duration.between(lastWarn, now).compareTo(MIN_WARN_INTERVAL) > 0;
     if (shouldWarn) {
-      LOGGER.warn(message, args);
+      LOGGER.warn(message, error);
       lastWarn = now;
     } else {
-      LOGGER.debug(message, args);
+      LOGGER.debug(message, error);
     }
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -127,13 +127,10 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
       throw new RuntimeException(e);
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
-      if (cause instanceof RuntimeException) {
-        cause.fillInStackTrace();
-        throw (RuntimeException) cause;
-      } else if (cause instanceof Error) {
+      if (cause instanceof Error) {
         throw (Error) cause;
       } else {
-        throw new RuntimeException(cause.getMessage());
+        throw new RuntimeException(cause);
       }
     }
   }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -249,7 +249,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
       if (error instanceof CompletionException) {
         error = error.getCause();
       }
-      maybeWarn("Failed to renew tokens: {}", error.getMessage());
+      maybeWarn("Failed to renew tokens", error);
     } else {
       LOGGER.debug("Successfully renewed tokens");
     }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -130,7 +130,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
       if (cause instanceof Error) {
         throw (Error) cause;
       } else {
-        throw new RuntimeException(cause);
+        throw new RuntimeException("Cannot acquire a valid OAuth2 access token", cause);
       }
     }
   }

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -157,7 +157,7 @@ class TestOAuth2Client {
 
         client.start();
         soft.assertThatThrownBy(client::authenticate)
-            .isInstanceOf(RejectedExecutionException.class);
+            .hasCauseInstanceOf(RejectedExecutionException.class);
 
         // should have scheduled a refresh, when that refresh is executed successfully,
         // client should recover
@@ -253,7 +253,7 @@ class TestOAuth2Client {
         client.start();
         Runnable renewalTask = currentRenewalTask.get();
         soft.assertThat(renewalTask).isNotNull();
-        soft.assertThatThrownBy(client::authenticate).isInstanceOf(OAuth2Exception.class);
+        soft.assertThatThrownBy(client::authenticate).hasCauseInstanceOf(OAuth2Exception.class);
 
         // Emulate executor running the scheduled refresh task, then throwing an exception
         // => propagate the error but schedule another refresh
@@ -261,7 +261,7 @@ class TestOAuth2Client {
         renewalTask.run();
         soft.assertThat(currentRenewalTask.get()).isNotNull().isNotSameAs(renewalTask);
         renewalTask = currentRenewalTask.get();
-        soft.assertThatThrownBy(client::authenticate).isInstanceOf(OAuth2Exception.class);
+        soft.assertThatThrownBy(client::authenticate).hasCauseInstanceOf(OAuth2Exception.class);
 
         // Emulate executor running the scheduled refresh task again, then finally getting tokens
         // => should recover and return initial tokens + schedule next refresh
@@ -289,7 +289,7 @@ class TestOAuth2Client {
         // => should propagate the error but schedule another refresh
         handlerRef.set(failureHandler);
         now = now.plus(Duration.ofHours(3));
-        soft.assertThatThrownBy(client::authenticate).isInstanceOf(OAuth2Exception.class);
+        soft.assertThatThrownBy(client::authenticate).hasCauseInstanceOf(OAuth2Exception.class);
         soft.assertThat(client.sleeping).isFalse();
         soft.assertThat(currentRenewalTask.get()).isNotNull().isNotSameAs(renewalTask);
         renewalTask = currentRenewalTask.get();
@@ -300,7 +300,7 @@ class TestOAuth2Client {
         renewalTask.run();
         soft.assertThat(currentRenewalTask.get()).isSameAs(renewalTask);
         soft.assertThat(client.sleeping).isTrue();
-        soft.assertThatThrownBy(client::getCurrentTokens).isInstanceOf(OAuth2Exception.class);
+        soft.assertThatThrownBy(client::getCurrentTokens).hasCauseInstanceOf(OAuth2Exception.class);
 
         // Emulate waking up, then fetching tokens immediately because no tokens are available,
         // then scheduling next refresh

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractOAuth2Authentication.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractOAuth2Authentication.java
@@ -17,6 +17,7 @@ package org.projectnessie.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
@@ -52,8 +53,10 @@ public abstract class AbstractOAuth2Authentication extends BaseClientAuthTest {
     NessieAuthentication authentication = oauth2Authentication(wrongPasswordConfig());
     withClientCustomizer(b -> b.withAuthentication(authentication));
     assertThatThrownBy(() -> api().getAllReferences().stream())
-        .isInstanceOfSatisfying(
-            OAuth2Exception.class, e -> assertThat(e.getStatus()).isEqualTo(Status.UNAUTHORIZED));
+        .cause()
+        .asInstanceOf(type(OAuth2Exception.class))
+        .extracting(OAuth2Exception::getStatus)
+        .isEqualTo(Status.UNAUTHORIZED);
   }
 
   protected Properties clientCredentialsConfig() {


### PR DESCRIPTION
One more PR inspired by my musings with `OAuthClient` in a Spark session:

1. When `authenticate()` throws, the thrown error now has a more meaningful stack trace.
2. When attempting to recover from a failure, failed attempts would all be logged, one per second (the minimum
refresh interval), until success or sleep mode is reached. From now on, only one failed attempt is logged every 10 seconds, and at WARN level instead of ERROR.