### PR TITLE
fix JUnit Jupiter references

### DIFF
--- a/api/client-testextension/build.gradle.kts
+++ b/api/client-testextension/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
   id("nessie-jacoco")
 }
 
-extra["maven.name"] = "Nessie - JUnit Jupyter Test Extension for Client-Side Tests"
+extra["maven.name"] = "Nessie - JUnit Jupiter Test Extension for Client-Side Tests"
 
 dependencies {
   api(platform(libs.junit.bom))

--- a/servers/jax-rs-testextension/build.gradle.kts
+++ b/servers/jax-rs-testextension/build.gradle.kts
@@ -19,9 +19,9 @@ plugins {
   id("nessie-jacoco")
 }
 
-extra["maven.name"] = "Nessie - JUnit Jupyter Test Extension"
+extra["maven.name"] = "Nessie - JUnit Jupiter Test Extension"
 
-description = "JUnit Jupyter Extension to run tests against an \"embedded\" Nessie instance."
+description = "JUnit Jupiter Extension to run tests against an \"embedded\" Nessie instance."
 
 dependencies {
   api(project(":nessie-jaxrs"))


### PR DESCRIPTION
compare with:
https://junit.org/junit5/docs/current/user-guide

not to be confused with jupyter notebooks that we use in the nessie-demos repo