### PR TITLE
Fix snapshot publishing

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: '0'
       - name: Setup runner
         uses: ./.github/actions/setup-runner
       - name: Setup Java, Gradle


### PR DESCRIPTION
Snapshot publishing fails since #7651 since `git describe` cannot work on the checked out repository. This PR should make it work again.