### PR TITLE
Add nessie-client-testextension to nessie-bom

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   constraints {
     api(rootProject)
     api(project(":nessie-client"))
+    api(project(":nessie-client-testextension"))
     api(project(":nessie-combined-cs"))
     api(project(":nessie-compatibility-common"))
     api(project(":nessie-compatibility-tests"))


### PR DESCRIPTION
should be comparable to other testextension modules i.e. `nessie-jaxrs-testextension`