### PR TITLE
Report a single conflict when deleting a namespace with many children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ as necessary. Empty sections will not end in the release notes.
 ### Fixes
 
 - Add namespace validation for rename operation.
+- Namespace validation now correctly reports only one conflict when deleting a namespace that has
+  children, whereas previously it reported one conflict for each child.
 
 ### Commits
 

--- a/api/model/src/main/java/org/projectnessie/error/ReferenceConflicts.java
+++ b/api/model/src/main/java/org/projectnessie/error/ReferenceConflicts.java
@@ -46,7 +46,7 @@ public interface ReferenceConflicts extends NessieErrorDetails {
     return referenceConflicts(singletonList(singleConflict));
   }
 
-  static ReferenceConflicts referenceConflicts(List<Conflict> conflicts) {
+  static ReferenceConflicts referenceConflicts(Iterable<? extends Conflict> conflicts) {
     return ImmutableReferenceConflicts.of(conflicts);
   }
 }

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1243,7 +1243,7 @@ public abstract class AbstractDatabaseAdapter<
 
     int namespacePayload = payloadForContent(Content.Type.NAMESPACE);
 
-    List<Conflict> conflicts = new ArrayList<>();
+    Set<Conflict> conflicts = new LinkedHashSet<>();
 
     for (ContentKey key : keysToCheck) {
       Byte payloadInPut = putPayloads.get(key);

--- a/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
+++ b/versioned/persist/adapter/src/main/java/org/projectnessie/versioned/persist/adapter/spi/AbstractDatabaseAdapter.java
@@ -1314,11 +1314,7 @@ public abstract class AbstractDatabaseAdapter<
         if (ckLen > nsLen && ck.startsWith(deleted)) {
           conflicts.add(
               conflict(
-                  NAMESPACE_NOT_EMPTY,
-                  deleted,
-                  format(
-                      "the namespace '%s' would be deleted, but cannot, because it has children",
-                      deleted)));
+                  NAMESPACE_NOT_EMPTY, deleted, format("namespace '%s' is not empty", deleted)));
         }
       }
     }

--- a/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceConflictException.java
+++ b/versioned/spi/src/main/java/org/projectnessie/versioned/ReferenceConflictException.java
@@ -18,7 +18,7 @@ package org.projectnessie.versioned;
 import static java.util.Collections.singletonList;
 import static org.projectnessie.error.ReferenceConflicts.referenceConflicts;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.stream.Collectors;
 import org.projectnessie.error.ReferenceConflicts;
 import org.projectnessie.model.Conflict;
@@ -40,13 +40,13 @@ public class ReferenceConflictException extends VersionStoreException {
     this(singletonList(conflict));
   }
 
-  public ReferenceConflictException(List<Conflict> conflicts) {
+  public ReferenceConflictException(Collection<Conflict> conflicts) {
     this(referenceConflicts(conflicts), buildMessage(conflicts));
   }
 
-  private static String buildMessage(List<Conflict> conflicts) {
+  private static String buildMessage(Collection<Conflict> conflicts) {
     if (conflicts.size() == 1) {
-      String msg = conflicts.get(0).message();
+      String msg = conflicts.iterator().next().message();
       return Character.toUpperCase(msg.charAt(0)) + msg.substring(1) + '.';
     }
     return "There are multiple conflicts that prevent committing the provided operations: "

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -43,10 +43,9 @@ import static org.projectnessie.versioned.storage.versionstore.TypeMapping.store
 import static org.projectnessie.versioned.store.DefaultStoreWorker.contentTypeForPayload;
 import static org.projectnessie.versioned.store.DefaultStoreWorker.payloadForContent;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -256,7 +255,7 @@ class BaseCommitHelper {
       Object2IntHashMap<ContentKey> allKeysToDelete,
       StoreIndex<CommitOp> headIndex)
       throws ReferenceConflictException {
-    List<Conflict> conflicts = new ArrayList<>();
+    Set<Conflict> conflicts = new LinkedHashSet<>();
 
     validateNamespacesExistForContentKeys(newContent, headIndex, conflicts::add);
     validateNamespacesToDeleteHaveNoChildren(allKeysToDelete, headIndex, conflicts::add);
@@ -320,7 +319,7 @@ class BaseCommitHelper {
                       Conflict.ConflictType.NAMESPACE_NOT_EMPTY,
                       namespaceKey,
                       format(
-                          "The namespace '%s' would be deleted, but cannot, because it has children.",
+                          "the namespace '%s' would be deleted, but cannot, because it has children",
                           namespaceKey)));
             }
             if (cmp > 0) {

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -318,9 +318,7 @@ class BaseCommitHelper {
                   conflict(
                       Conflict.ConflictType.NAMESPACE_NOT_EMPTY,
                       namespaceKey,
-                      format(
-                          "the namespace '%s' would be deleted, but cannot, because it has children",
-                          namespaceKey)));
+                      format("namespace '%s' is not empty", namespaceKey)));
             }
             if (cmp > 0) {
               // iterated past the namespaceKey - break

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.projectnessie.model.CommitMeta.fromMessage;
 import static org.projectnessie.model.Conflict.ConflictType.NAMESPACE_ABSENT;
+import static org.projectnessie.model.Conflict.ConflictType.NAMESPACE_NOT_EMPTY;
 import static org.projectnessie.model.Conflict.ConflictType.NOT_A_NAMESPACE;
 import static org.projectnessie.versioned.testworker.OnRefOnly.newOnRef;
 
@@ -285,7 +286,6 @@ public abstract class AbstractNamespaceValidation extends AbstractNestedVersionS
     store().create(branch, Optional.empty());
 
     Namespace ns = Namespace.of("ns");
-    ContentKey key = ContentKey.of(ns, "table");
 
     store()
         .commit(
@@ -294,7 +294,17 @@ public abstract class AbstractNamespaceValidation extends AbstractNestedVersionS
             fromMessage("initial"),
             asList(
                 Put.of(ns.toContentKey(), ns),
-                Put.of(key, childNamespace ? Namespace.of(key) : newOnRef("foo"))));
+                Put.of(ContentKey.of(ns, "table"), newOnRef("foo"))));
+
+    if (childNamespace) {
+      Namespace child = Namespace.of("ns", "child");
+      store()
+          .commit(
+              branch,
+              Optional.empty(),
+              fromMessage("child ns"),
+              singletonList(Put.of(child.toContentKey(), child)));
+    }
 
     soft.assertThatThrownBy(
             () ->
@@ -303,7 +313,16 @@ public abstract class AbstractNamespaceValidation extends AbstractNestedVersionS
                     Optional.empty(),
                     fromMessage("try delete ns"),
                     singletonList(Delete.of(ns.toContentKey()))))
-        .isInstanceOf(ReferenceConflictException.class);
+        .hasMessage("The namespace 'ns' would be deleted, but cannot, because it has children.")
+        .asInstanceOf(type(ReferenceConflictException.class))
+        .extracting(ReferenceConflictException::getReferenceConflicts)
+        .extracting(ReferenceConflicts::conflicts, list(Conflict.class))
+        .singleElement()
+        .extracting(Conflict::conflictType, Conflict::key, Conflict::message)
+        .containsExactly(
+            NAMESPACE_NOT_EMPTY,
+            ns.toContentKey(),
+            "the namespace 'ns' would be deleted, but cannot, because it has children");
   }
 
   enum NamespaceValidationMergeTransplant {

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
@@ -314,16 +314,13 @@ public abstract class AbstractNamespaceValidation extends AbstractNestedVersionS
                     fromMessage("try delete ns"),
                     singletonList(Delete.of(ns.toContentKey()))))
         .isInstanceOf(ReferenceConflictException.class)
-        .hasMessage("The namespace 'ns' would be deleted, but cannot, because it has children.")
+        .hasMessage("Namespace 'ns' is not empty.")
         .asInstanceOf(type(ReferenceConflictException.class))
         .extracting(ReferenceConflictException::getReferenceConflicts)
         .extracting(ReferenceConflicts::conflicts, list(Conflict.class))
         .singleElement()
         .extracting(Conflict::conflictType, Conflict::key, Conflict::message)
-        .containsExactly(
-            NAMESPACE_NOT_EMPTY,
-            ns.toContentKey(),
-            "the namespace 'ns' would be deleted, but cannot, because it has children");
+        .containsExactly(NAMESPACE_NOT_EMPTY, ns.toContentKey(), "namespace 'ns' is not empty");
   }
 
   enum NamespaceValidationMergeTransplant {

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractNamespaceValidation.java
@@ -313,6 +313,7 @@ public abstract class AbstractNamespaceValidation extends AbstractNestedVersionS
                     Optional.empty(),
                     fromMessage("try delete ns"),
                     singletonList(Delete.of(ns.toContentKey()))))
+        .isInstanceOf(ReferenceConflictException.class)
         .hasMessage("The namespace 'ns' would be deleted, but cannot, because it has children.")
         .asInstanceOf(type(ReferenceConflictException.class))
         .extracting(ReferenceConflictException::getReferenceConflicts)


### PR DESCRIPTION
Previously, in this situation, the namespace validation logic would emit as many conflicts as there are children, for example if there are 2 children:

    There are multiple conflicts that prevent committing the
    provided operations: The namespace 'ns' would be deleted,
    but cannot, because it has children., The namespace 'ns'
    would be deleted, but cannot, because it has children.."

Also note that capitalization and punctuation were wrong.