### PR TITLE
Renovate: only add one label

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,15 +14,15 @@
   packageRules: [
     {
       matchManagers: ["maven", "gradle", "gradle-wrapper"],
-      "labels": ["dependencies", "java"],
+      "labels": ["dependencies"],
     },
     {
       matchManagers: ["pip_requirements", "pip_setup"],
-      "labels": ["dependencies", "python"],
+      "labels": ["dependencies"],
     },
     {
       matchManagers: ["dockerfile"],
-      "labels": ["dependencies", "docker"],
+      "labels": ["dependencies"],
     },
 
     // Check for updates, merge automatically


### PR DESCRIPTION
This change is an attempt to work around the github actions issue that lets either the required checks refer to the wrong workflow run or the wrong workflow run being cancelled.