### PR TITLE
Adding metadataLocation in ViewVersionMetadata

### DIFF
--- a/integrations/iceberg-views/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
+++ b/integrations/iceberg-views/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
@@ -135,7 +135,8 @@ public class NessieViewOperations extends BaseMetastoreViewOperations {
               v.viewDefinition(),
               metadata.properties(),
               versions,
-              history);
+              history,
+              metadataLocation);
     }
 
     return metadata;

--- a/integrations/iceberg-views/src/main/java/org/apache/iceberg/viewdepoc/CommentUpdate.java
+++ b/integrations/iceberg-views/src/main/java/org/apache/iceberg/viewdepoc/CommentUpdate.java
@@ -93,7 +93,7 @@ public class CommentUpdate implements UpdateComment {
             viewDefinition);
     ViewVersionMetadata update =
         ViewVersionMetadata.newViewVersionMetadata(
-            version, base.location(), viewDefinition, base, base.properties());
+            version, base.location(), viewDefinition, base, base.properties(), null);
     ops.commit(base, update, new HashMap<>());
   }
 

--- a/integrations/iceberg-views/src/main/java/org/apache/iceberg/viewdepoc/ViewUtils.java
+++ b/integrations/iceberg-views/src/main/java/org/apache/iceberg/viewdepoc/ViewUtils.java
@@ -169,7 +169,7 @@ public class ViewUtils {
     if (prevViewVersionMetadata == null) {
       viewVersionMetadata =
           ViewVersionMetadata.newViewVersionMetadata(
-              version, location, definitionWithComments, viewVersionMetadataProperties);
+              version, location, definitionWithComments, viewVersionMetadataProperties, null);
     } else {
       viewVersionMetadata =
           ViewVersionMetadata.newViewVersionMetadata(
@@ -177,7 +177,8 @@ public class ViewUtils {
               location,
               definitionWithComments,
               prevViewVersionMetadata,
-              viewVersionMetadataProperties);
+              viewVersionMetadataProperties,
+              null);
     }
 
     ops.commit(prevViewVersionMetadata, viewVersionMetadata, metacatProps);


### PR DESCRIPTION
In OSS Iceberg's view, we have toJson method and fromJson method that takes metadataLocation in place, and that can be used in various places (The code snippet is from OSS Iceberg). Nessie can take advantage using this new code.