### PR TITLE
BigTable: set QUALIFIER_OBJ_TYPE cell when upserting

### DIFF
--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -513,7 +513,12 @@ public class BigTablePersist implements Persist {
           .client()
           .mutateRow(
               RowMutation.create(backend.tableObjs, key)
-                  .setCell(FAMILY_OBJS, QUALIFIER_OBJS, CELL_TIMESTAMP, serialized));
+                  .setCell(FAMILY_OBJS, QUALIFIER_OBJS, CELL_TIMESTAMP, serialized)
+                  .setCell(
+                      FAMILY_OBJS,
+                      QUALIFIER_OBJ_TYPE,
+                      CELL_TIMESTAMP,
+                      OBJ_TYPE_VALUES[obj.type().ordinal()]));
     } catch (ApiException e) {
       throw apiException(e);
     }
@@ -541,7 +546,12 @@ public class BigTablePersist implements Persist {
 
         batcher.add(
             RowMutationEntry.create(key)
-                .setCell(FAMILY_OBJS, QUALIFIER_OBJS, CELL_TIMESTAMP, serialized));
+                .setCell(FAMILY_OBJS, QUALIFIER_OBJS, CELL_TIMESTAMP, serialized)
+                .setCell(
+                    FAMILY_OBJS,
+                    QUALIFIER_OBJ_TYPE,
+                    CELL_TIMESTAMP,
+                    OBJ_TYPE_VALUES[obj.type().ordinal()]));
       }
     } catch (ApiException e) {
       throw apiException(e);


### PR DESCRIPTION
Noticed when working on #7727 : `BigTablePersist` wasn't setting the `QUALIFIER_OBJ_TYPE` cell when upserting. This makes _inserted_ (not updated) objects unsearchable when searching by object type.