### PR TITLE
Model: Make sqlText optional for IcebergView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ as necessary. Empty sections will not end in the release notes.
 - Add namespace validation for rename operation.
 - Namespace validation now correctly reports only one conflict when deleting a namespace that has
   children, whereas previously it reported one conflict for each child.
+- Make sqlText optional for IcebergView.
 
 ### Commits
 

--- a/api/model/src/main/java/org/projectnessie/model/IcebergView.java
+++ b/api/model/src/main/java/org/projectnessie/model/IcebergView.java
@@ -49,11 +49,10 @@ public abstract class IcebergView extends IcebergContent {
 
   public abstract int getSchemaId();
 
-  @NotBlank
-  @jakarta.validation.constraints.NotBlank
-  @NotNull
-  @jakarta.validation.constraints.NotNull
-  public abstract String getSqlText();
+  @Value.Default
+  public String getSqlText() {
+    return "default sql text";
+  }
 
   @Nullable
   @jakarta.annotation.Nullable // TODO this is currently undefined in Iceberg

--- a/api/model/src/main/java/org/projectnessie/model/IcebergView.java
+++ b/api/model/src/main/java/org/projectnessie/model/IcebergView.java
@@ -49,6 +49,8 @@ public abstract class IcebergView extends IcebergContent {
 
   public abstract int getSchemaId();
 
+  @NotBlank
+  @jakarta.validation.constraints.NotBlank
   @Value.Default
   public String getSqlText() {
     return "default sql text";

--- a/events/service/src/test/java/org/projectnessie/events/service/util/TestContentMapping.java
+++ b/events/service/src/test/java/org/projectnessie/events/service/util/TestContentMapping.java
@@ -118,6 +118,23 @@ class TestContentMapping {
                 .putProperty("sqlText", "sqlText")
                 .build()),
         Arguments.of(
+            org.projectnessie.model.ImmutableIcebergView.builder()
+                .id("id")
+                .metadataLocation("metadataLocation")
+                .versionId(1L)
+                .schemaId(2)
+                // no sql text
+                // no dialect
+                .build(),
+            ImmutableContent.builder()
+                .id("id")
+                .type("ICEBERG_VIEW")
+                .putProperty("metadataLocation", "metadataLocation")
+                .putProperty("versionId", 1L)
+                .putProperty("schemaId", 2)
+                .putProperty("sqlText", "default sql text")
+                .build()),
+        Arguments.of(
             org.projectnessie.model.ImmutableDeltaLakeTable.builder()
                 .id("id")
                 .addCheckpointLocationHistory("checkpoint")


### PR DESCRIPTION
Iceberg client creates a new view metadata file for every commit. Hence, Just the view metadata location is enough to be tracked from Nessie side. No need to track other fields (or make them mandatory). 

Reference: https://github.com/apache/iceberg/pull/8909#discussion_r1397190437

This PR makes `sqlText` as optional for builder.