### PR TITLE
Move ObjIdSerializer.java to test scope

### DIFF
--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/indexes/TestStoreIndexImpl.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/indexes/TestStoreIndexImpl.java
@@ -29,7 +29,7 @@ import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.Actio
 import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.Action.NONE;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.COMMIT_OP_SERIALIZER;
 import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.commitOp;
-import static org.projectnessie.versioned.storage.common.objtypes.ObjIdSerializer.OBJ_ID_SERIALIZER;
+import static org.projectnessie.versioned.storage.common.objtypes.ObjIdElementSerializer.OBJ_ID_SERIALIZER;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.EMPTY_OBJ_ID;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.objIdFromString;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/ObjIdElementSerializer.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/ObjIdElementSerializer.java
@@ -22,10 +22,14 @@ import java.nio.ByteBuffer;
 import org.projectnessie.versioned.storage.common.indexes.ElementSerializer;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 
-public final class ObjIdSerializer implements ElementSerializer<ObjId> {
-  public static final ElementSerializer<ObjId> OBJ_ID_SERIALIZER = new ObjIdSerializer();
+/**
+ * An {@link ElementSerializer} for {@link ObjId} instances, used to facilitate testing index
+ * element serialization logic.
+ */
+public final class ObjIdElementSerializer implements ElementSerializer<ObjId> {
+  public static final ElementSerializer<ObjId> OBJ_ID_SERIALIZER = new ObjIdElementSerializer();
 
-  private ObjIdSerializer() {}
+  private ObjIdElementSerializer() {}
 
   @Override
   public int serializedSize(ObjId value) {

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/TestObjIdElementSerializer.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/objtypes/TestObjIdElementSerializer.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.versioned.storage.common.objtypes;
 
-import static org.projectnessie.versioned.storage.common.objtypes.ObjIdSerializer.OBJ_ID_SERIALIZER;
+import static org.projectnessie.versioned.storage.common.objtypes.ObjIdElementSerializer.OBJ_ID_SERIALIZER;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.deserializeObjId;
 import static org.projectnessie.versioned.storage.common.util.Ser.varIntLen;
 import static org.projectnessie.versioned.storage.common.util.Util.generateObjIdBuffer;
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 
 @ExtendWith(SoftAssertionsExtension.class)
-public class TestObjIdSerializer {
+public class TestObjIdElementSerializer {
 
   @InjectSoftAssertions SoftAssertions soft;
 


### PR DESCRIPTION
`ObjIdSerializer` seems to be a utility to help with testing index serialization logic. It can safely be moved to test scope.