### PR TITLE
Nit: Remove unsed Quarkus config options

### DIFF
--- a/build-logic/src/main/kotlin/nessie-jacoco.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-jacoco.gradle.kts
@@ -56,8 +56,6 @@ if (plugins.hasPlugin("io.quarkus")) {
       excludeClassLoaders =
         listOf("*QuarkusClassLoader") + (if (excluded != null) excluded else emptyList())
     }
-    systemProperty("quarkus.jacoco.report", "false")
-    systemProperty("quarkus.jacoco.reuse-data-file", "true")
   }
 }
 


### PR DESCRIPTION
... fixing following warnings when running Quarkus tests:
```
Unrecognized configuration key "*" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```