### PR TITLE
Build: remove no longer needed reflection-config-plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ maven = "3.9.6"
 mavenResolver = "1.9.18"
 mockito="4.11.0"
 nessieClientVersion = "0.71.0" # Must be in sync with Nessie version in the Iceberg release.
-nessieBuildPlugins = "0.2.24"
 opentelemetry = "1.32.0"
 opentelemetryAlpha = "1.31.0-alpha"
 opentracing = "0.33.0"
@@ -181,7 +180,6 @@ annotations-stripper = { id = "org.projectnessie.annotation-stripper", version =
 errorprone = { id = "net.ltgt.errorprone", version = "3.1.0" }
 gatling = { id = "io.gatling.gradle", version = "3.9.5.6" }
 jmh = { id = "me.champeau.jmh", version = "0.7.2" }
-nessie-reflectionconfig = { id = "org.projectnessie.buildsupport.reflectionconfig", version.ref = "nessieBuildPlugins" }
 nessie-run = { id = "org.projectnessie", version = "0.30.7" }
 nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.4" }

--- a/servers/store-proto/build.gradle.kts
+++ b/servers/store-proto/build.gradle.kts
@@ -19,7 +19,6 @@ import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.ProtobufExtract
 
 plugins {
-  alias(libs.plugins.nessie.reflectionconfig)
   id("nessie-conventions-server")
   alias(libs.plugins.protobuf)
 }
@@ -47,27 +46,8 @@ tasks.named<GenerateProtoTask>("generateProto").configure {
   )
 }
 
-reflectionConfig {
-  // Consider classes that extend one of these classes...
-  classExtendsPatterns.set(
-    listOf(
-      "org.projectnessie.nessie.relocated.protobuf.GeneratedMessageV3",
-      "org.projectnessie.nessie.relocated.protobuf.GeneratedMessageV3.Builder"
-    )
-  )
-  // ... and classes the implement this interface.
-  classImplementsPatterns.set(
-    listOf("org.projectnessie.nessie.relocated.protobuf.ProtocolMessageEnum")
-  )
-  // Also include generated classes (e.g. google.protobuf.Empty) via the "runtimeClasspath",
-  // which contains the the "com.google.protobuf:protobuf-java" dependency.
-  includeConfigurations.set(listOf("runtimeClasspath"))
-}
-
 // The protobuf-plugin should ideally do this
-tasks.named<Jar>("sourcesJar").configure {
-  dependsOn(tasks.named("generateProto"), tasks.named("generateReflectionConfig"))
-}
+tasks.named<Jar>("sourcesJar").configure { dependsOn("generateProto") }
 
 tasks.withType(ProtobufExtract::class).configureEach {
   when (name) {

--- a/tools/protobuf-relocated/build.gradle.kts
+++ b/tools/protobuf-relocated/build.gradle.kts
@@ -17,7 +17,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-  alias(libs.plugins.nessie.reflectionconfig)
   id("nessie-conventions-server")
   id("nessie-shadow-jar")
 }
@@ -25,22 +24,6 @@ plugins {
 extra["maven.name"] = "Nessie - Relocated Protobuf ${libs.protobuf.java.get().version}"
 
 dependencies { compileOnly(libs.protobuf.java) }
-
-reflectionConfig {
-  // Consider classes that extend one of these classes...
-  classExtendsPatterns.set(
-    listOf(
-      "com.google.protobuf.GeneratedMessageV3",
-      "com.google.protobuf.GeneratedMessageV3.Builder"
-    )
-  )
-  // ... and classes the implement this interface.
-  classImplementsPatterns.set(listOf("com.google.protobuf.ProtocolMessageEnum"))
-  // Include the "com.google.protobuf:protobuf-java" dependency.
-  includeConfigurations.set(listOf("compileClasspath"))
-  // Relocate it to our Nessie package name.
-  relocations.put("com[.]google[.]protobuf[.]", "org.projectnessie.nessie.relocated.protobuf.$1")
-}
 
 val shadowJar = tasks.named<ShadowJar>("shadowJar")
 
@@ -58,6 +41,4 @@ tasks.named("compileJava").configure { finalizedBy(shadowJar) }
 
 tasks.named("processResources").configure { finalizedBy(shadowJar) }
 
-tasks.named("jar").configure { dependsOn("processJandexIndex", "generateReflectionConfig") }
-
-tasks.named("sourcesJar").configure { dependsOn("generateReflectionConfig") }
+tasks.named("jar").configure { dependsOn("processJandexIndex") }

--- a/versioned/storage/common-proto/build.gradle.kts
+++ b/versioned/storage/common-proto/build.gradle.kts
@@ -19,7 +19,6 @@ import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.ProtobufExtract
 
 plugins {
-  alias(libs.plugins.nessie.reflectionconfig)
   id("nessie-conventions-server")
   alias(libs.plugins.protobuf)
 }
@@ -49,27 +48,8 @@ tasks.named<GenerateProtoTask>("generateProto").configure {
   )
 }
 
-reflectionConfig {
-  // Consider classes that extend one of these classes...
-  classExtendsPatterns.set(
-    listOf(
-      "org.projectnessie.nessie.relocated.protobuf.GeneratedMessageV3",
-      "org.projectnessie.nessie.relocated.protobuf.GeneratedMessageV3.Builder"
-    )
-  )
-  // ... and classes the implement this interface.
-  classImplementsPatterns.set(
-    listOf("org.projectnessie.nessie.relocated.protobuf.ProtocolMessageEnum")
-  )
-  // Also include generated classes (e.g. google.protobuf.Empty) via the "runtimeClasspath",
-  // which contains the the "com.google.protobuf:protobuf-java" dependency.
-  includeConfigurations.set(listOf("runtimeClasspath"))
-}
-
 // The protobuf-plugin should ideally do this
-tasks.named<Jar>("sourcesJar").configure {
-  dependsOn(tasks.named("generateProto"), tasks.named("generateReflectionConfig"))
-}
+tasks.named<Jar>("sourcesJar").configure { dependsOn("generateProto") }
 
 tasks.withType(ProtobufExtract::class).configureEach {
   when (name) {

--- a/versioned/transfer-proto/build.gradle.kts
+++ b/versioned/transfer-proto/build.gradle.kts
@@ -19,7 +19,6 @@ import com.google.protobuf.gradle.ProtobufExtension
 import com.google.protobuf.gradle.ProtobufExtract
 
 plugins {
-  alias(libs.plugins.nessie.reflectionconfig)
   id("nessie-conventions-server")
   alias(libs.plugins.protobuf)
 }
@@ -45,27 +44,8 @@ tasks.named<GenerateProtoTask>("generateProto").configure {
   )
 }
 
-reflectionConfig {
-  // Consider classes that extend one of these classes...
-  classExtendsPatterns.set(
-    listOf(
-      "org.projectnessie.nessie.relocated.protobuf.GeneratedMessageV3",
-      "org.projectnessie.nessie.relocated.protobuf.GeneratedMessageV3.Builder"
-    )
-  )
-  // ... and classes the implement this interface.
-  classImplementsPatterns.set(
-    listOf("org.projectnessie.nessie.relocated.protobuf.ProtocolMessageEnum")
-  )
-  // Also include generated classes (e.g. google.protobuf.Empty) via the "runtimeClasspath",
-  // which contains the the "com.google.protobuf:protobuf-java" dependency.
-  includeConfigurations.set(listOf("runtimeClasspath"))
-}
-
 // The protobuf-plugin should ideally do this
-tasks.named<Jar>("sourcesJar").configure {
-  dependsOn(tasks.named("generateProto"), tasks.named("generateReflectionConfig"))
-}
+tasks.named<Jar>("sourcesJar").configure { dependsOn("generateProto") }
 
 tasks.withType(ProtobufExtract::class).configureEach {
   when (name) {


### PR DESCRIPTION
Was needed as long as we had a native server image.