### PR TITLE
Update Persist API to detect and handle object mismatches

### DIFF
--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.storage.cache;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
@@ -134,7 +135,7 @@ class CachingPersistImpl implements Persist {
   @Override
   public boolean storeObj(
       @jakarta.annotation.Nonnull @Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     if (persist.storeObj(obj, ignoreSoftSizeRestrictions)) {
       cache.put(obj);
       return true;
@@ -146,7 +147,7 @@ class CachingPersistImpl implements Persist {
   @Nonnull
   @jakarta.annotation.Nonnull
   public boolean[] storeObjs(@jakarta.annotation.Nonnull @Nonnull Obj[] objs)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     boolean[] stored = persist.storeObjs(objs);
     for (int i = 0; i < stored.length; i++) {
       if (stored[i]) {

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBackendRepositoryTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBackendRepositoryTests.java
@@ -33,8 +33,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
-import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
-import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
 import org.projectnessie.versioned.storage.common.logic.RepositoryLogic;
 import org.projectnessie.versioned.storage.common.objtypes.Compression;
 import org.projectnessie.versioned.storage.common.objtypes.StringObj;
@@ -117,7 +115,7 @@ public class AbstractBackendRepositoryTests {
 
   /** Check that erasing a few repos does not affect other repos. */
   @Test
-  public void createEraseSomeRepos() throws ObjTooLargeException, RefAlreadyExistsException {
+  public void createEraseSomeRepos() throws Exception {
     List<Persist> repos =
         IntStream.range(0, 10).mapToObj(x -> newRepo()).collect(Collectors.toList());
     int refs = 25;

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractIndexesLogicTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractIndexesLogicTests.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
-import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
 import org.projectnessie.versioned.storage.common.indexes.StoreKey;
@@ -378,7 +377,7 @@ public class AbstractIndexesLogicTests {
     }
   }
 
-  private ObjId fiveIncompleteCommitsWithThreeOpsEach(Persist persist) throws ObjTooLargeException {
+  private ObjId fiveIncompleteCommitsWithThreeOpsEach(Persist persist) throws Exception {
 
     String[][] keys =
         new String[][] {

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/exceptions/ObjMismatchException.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/exceptions/ObjMismatchException.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.exceptions;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.stream.Collectors.joining;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.storage.common.persist.Obj;
+
+/**
+ * Exception thrown when an object could not be stored because there is an existing version of it,
+ * and that version does not match the current object's version.
+ */
+public class ObjMismatchException extends Exception {
+
+  @Value.Immutable
+  @Value.Style(underrideToString = "asText")
+  public interface ObjMismatch {
+
+    @Value.Parameter(order = 1)
+    Obj getExistingObj();
+
+    @Value.Parameter(order = 2)
+    Obj getExpectedObj();
+
+    default String asText() {
+      return "existing: " + getExistingObj() + ", expected: " + getExpectedObj();
+    }
+
+    @Nonnull
+    @jakarta.annotation.Nonnull
+    static ObjMismatch of(
+        @Nonnull @jakarta.annotation.Nonnull Obj existingObj,
+        @Nonnull @jakarta.annotation.Nonnull Obj expectedObj) {
+      return ImmutableObjMismatch.of(existingObj, expectedObj);
+    }
+  }
+
+  public static void checkAndThrow(
+      @Nonnull @jakarta.annotation.Nonnull Obj[] existing,
+      @Nonnull @jakarta.annotation.Nonnull Obj[] expected)
+      throws ObjMismatchException {
+    checkArgument(existing.length == expected.length, "Arrays must be of same length.");
+    List<ObjMismatch> mismatches = null;
+    for (int i = 0; i < existing.length; i++) {
+      if (expected[i] != null && existing[i] != null && !expected[i].equals(existing[i])) {
+        if (mismatches == null) {
+          mismatches = new ArrayList<>();
+        }
+        mismatches.add(ObjMismatch.of(existing[i], expected[i]));
+      }
+    }
+    if (mismatches != null && !mismatches.isEmpty()) {
+      throw new ObjMismatchException(mismatches);
+    }
+  }
+
+  private final List<ObjMismatch> mismatches;
+
+  public ObjMismatchException(Obj existingObj, Obj expectedObj) {
+    this(ImmutableObjMismatch.of(existingObj, expectedObj));
+  }
+
+  public ObjMismatchException(ObjMismatch mismatch) {
+    super("Object does not match: " + mismatch);
+    this.mismatches = List.of(mismatch);
+  }
+
+  public ObjMismatchException(List<ObjMismatch> mismatches) {
+    super(
+        mismatches.size() == 1
+            ? "Object does not match: " + mismatches.get(0).asText()
+            : "Objects do not match: "
+                + mismatches.stream().map(ObjMismatch::asText).collect(joining("; ")));
+    this.mismatches = List.copyOf(mismatches);
+  }
+
+  @Nonnull
+  @jakarta.annotation.Nonnull
+  public List<ObjMismatch> getMismatches() {
+    return mismatches;
+  }
+}

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogic.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
@@ -98,17 +99,18 @@ public interface IndexesLogic {
    * @param stripedIndex the index to store
    * @return non-{@code null} ID, even if the content value already exists
    * @throws ObjTooLargeException see {@link Persist#storeObj(Obj)}
+   * @throws ObjMismatchException see {@link Persist#storeObj(Obj)}
    */
   @Nonnull
   @jakarta.annotation.Nonnull
   ObjId persistStripedIndex(@Nonnull @jakarta.annotation.Nonnull StoreIndex<CommitOp> stripedIndex)
-      throws ObjTooLargeException;
+      throws ObjTooLargeException, ObjMismatchException;
 
   @Nonnull
   @jakarta.annotation.Nonnull
   List<IndexStripe> persistIndexStripesFromIndex(
       @Nonnull @jakarta.annotation.Nonnull StoreIndex<CommitOp> stripedIndex)
-      throws ObjTooLargeException;
+      throws ObjTooLargeException, ObjMismatchException;
 
   /**
    * Updates, if necessary, all commits in the given commit and all its predecessors to contain

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/IndexesLogicImpl.java
@@ -54,6 +54,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.indexes.IndexLoader;
@@ -382,7 +383,7 @@ final class IndexesLogicImpl implements IndexesLogic {
   @Override
   public ObjId persistStripedIndex(
       @Nonnull @jakarta.annotation.Nonnull StoreIndex<CommitOp> stripedIndex)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     List<StoreIndex<CommitOp>> stripes = stripedIndex.stripes();
     if (stripes.isEmpty()) {
       return persistIndex(stripedIndex);
@@ -407,7 +408,7 @@ final class IndexesLogicImpl implements IndexesLogic {
   @Override
   public List<IndexStripe> persistIndexStripesFromIndex(
       @Nonnull @jakarta.annotation.Nonnull StoreIndex<CommitOp> stripedIndex)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     List<StoreIndex<CommitOp>> stripes = stripedIndex.stripes();
     List<Obj> toStore = new ArrayList<>();
     List<IndexStripe> indexStripes = buildIndexStripes(stripes, toStore);
@@ -440,7 +441,8 @@ final class IndexesLogicImpl implements IndexesLogic {
     return indexStripes;
   }
 
-  private ObjId persistIndex(StoreIndex<CommitOp> indexSegment) throws ObjTooLargeException {
+  private ObjId persistIndex(StoreIndex<CommitOp> indexSegment)
+      throws ObjTooLargeException, ObjMismatchException {
     if (!indexSegment.isModified()) {
       return requireNonNull(
           indexSegment.getObjId(), "Loaded index segment does not contain its ObjId");

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogicImpl.java
@@ -60,6 +60,7 @@ import javax.annotation.Nullable;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.exceptions.CommitConflictException;
 import org.projectnessie.versioned.storage.common.exceptions.CommitWrappedException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
@@ -485,7 +486,7 @@ final class ReferenceLogicImpl implements ReferenceLogic {
             RefObj ref = ref(name, pointer, refCreatedTimestamp, extendedInfoObj);
             try {
               p.storeObj(ref);
-            } catch (ObjTooLargeException e) {
+            } catch (ObjTooLargeException | ObjMismatchException e) {
               throw new RuntimeException(e);
             }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/RepositoryLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/RepositoryLogicImpl.java
@@ -40,6 +40,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.projectnessie.versioned.storage.common.exceptions.CommitConflictException;
 import org.projectnessie.versioned.storage.common.exceptions.CommitWrappedException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
@@ -185,7 +186,7 @@ final class RepositoryLogicImpl implements RepositoryLogic {
       // can safely ignore the response from storeObj() - it's fine, if the obj already exists
       persist.storeObj(string);
       b.addAdds(commitAdd(KEY_REPO_DESCRIPTION, 0, requireNonNull(string.id()), null, null));
-    } catch (ObjTooLargeException | ObjNotFoundException | IOException e) {
+    } catch (ObjTooLargeException | ObjNotFoundException | IOException | ObjMismatchException e) {
       throw new RuntimeException(e);
     }
   }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
@@ -161,7 +162,7 @@ public class ObservingPersist implements Persist {
   @Override
   @Counted(PREFIX)
   @Timed(value = PREFIX, histogram = true)
-  public boolean storeObj(@Nonnull Obj obj) throws ObjTooLargeException {
+  public boolean storeObj(@Nonnull Obj obj) throws ObjTooLargeException, ObjMismatchException {
     return delegate.storeObj(obj);
   }
 
@@ -170,7 +171,7 @@ public class ObservingPersist implements Persist {
   @Counted(PREFIX)
   @Timed(value = PREFIX, histogram = true)
   public boolean storeObj(@Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     return delegate.storeObj(obj, ignoreSoftSizeRestrictions);
   }
 
@@ -179,7 +180,8 @@ public class ObservingPersist implements Persist {
   @Counted(PREFIX)
   @Timed(value = PREFIX, histogram = true)
   @Nonnull
-  public boolean[] storeObjs(@Nonnull Obj[] objs) throws ObjTooLargeException {
+  public boolean[] storeObjs(@Nonnull Obj[] objs)
+      throws ObjTooLargeException, ObjMismatchException {
     return delegate.storeObjs(objs);
   }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
@@ -229,10 +230,12 @@ public interface Persist {
    *     with the same ID already exists.
    * @throws ObjTooLargeException thrown when a hard database row/item size limit has been hit, or a
    *     "soft" size restriction in {@link #config()}
+   * @throws ObjMismatchException thrown when an object with the same ID already exists, but the
+   *     existing object is not equal to {@code obj}.
    * @see #storeObjs(Obj[])
    */
   default boolean storeObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     return storeObj(obj, false);
   }
 
@@ -251,10 +254,12 @@ public interface Persist {
    * @throws ObjTooLargeException thrown when a hard database row/item size limit has been hit, or,
    *     if {@code ignoreSoftSizeRestrictions} is {@code false}, a "soft" size restriction in {@link
    *     #config()}
+   * @throws ObjMismatchException thrown when an object with the same ID already exists, but the
+   *     existing object is not equal to {@code obj}.
    * @see #storeObjs(Obj[])
    */
   boolean storeObj(@Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
-      throws ObjTooLargeException;
+      throws ObjTooLargeException, ObjMismatchException;
 
   /**
    * Like {@link #storeObj(Obj)}, but stores multiple objects at once.
@@ -271,11 +276,14 @@ public interface Persist {
    *     created ({@code true}) or already present ({@code false}), see {@link #storeObj(Obj)}
    * @throws ObjTooLargeException thrown when a hard database row/item size limit has been hit, or a
    *     "soft" size restriction in {@link #config()}
+   * @throws ObjMismatchException thrown when an object with the same ID already exists, but the
+   *     existing object is not equal to {@code obj}.
    * @see #storeObj(Obj)
    */
   @Nonnull
   @jakarta.annotation.Nonnull
-  boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs) throws ObjTooLargeException;
+  boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
+      throws ObjTooLargeException, ObjMismatchException;
 
   void deleteObj(@Nonnull @jakarta.annotation.Nonnull ObjId id);
 

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
@@ -226,17 +227,20 @@ class JdbcPersist extends AbstractJdbcPersist {
   @Override
   public boolean storeObj(
       @Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
-      throws ObjTooLargeException {
-    return withConnectionException(
-        false, conn -> super.storeObj(conn, obj, ignoreSoftSizeRestrictions));
+      throws ObjTooLargeException, ObjMismatchException {
+    return withConnectionExceptions(
+        (SQLRunnableExceptions<Boolean, ObjTooLargeException, ObjMismatchException>)
+            conn -> super.storeObj(conn, obj, ignoreSoftSizeRestrictions));
   }
 
   @Override
   @Nonnull
   @jakarta.annotation.Nonnull
   public boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-      throws ObjTooLargeException {
-    return withConnectionException(false, conn -> super.storeObjs(conn, objs));
+      throws ObjTooLargeException, ObjMismatchException {
+    return withConnectionExceptions(
+        (SQLRunnableExceptions<boolean[], ObjTooLargeException, ObjMismatchException>)
+            conn -> super.storeObjs(conn, objs));
   }
 
   @Override

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
@@ -77,6 +77,7 @@ import org.projectnessie.versioned.Unchanged;
 import org.projectnessie.versioned.VersionStore.CommitValidator;
 import org.projectnessie.versioned.VersionStoreException;
 import org.projectnessie.versioned.storage.common.exceptions.CommitConflictException;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
@@ -479,8 +480,11 @@ class CommitImpl extends BaseCommitHelper {
                   UUID generatedContentId;
                   while (true) {
                     generatedContentId = UUID.randomUUID();
-                    if (persist.storeObj(uniqueId("content-id", generatedContentId))) {
-                      break;
+                    try {
+                      if (persist.storeObj(uniqueId("content-id", generatedContentId))) {
+                        break;
+                      }
+                    } catch (ObjMismatchException ignored) {
                     }
                   }
                   return generatedContentId.toString();

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.storage.versionstore;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
@@ -144,14 +145,14 @@ public class PersistDelegate implements Persist {
 
   @Override
   public boolean storeObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     return delegate.storeObj(obj);
   }
 
   @Override
   public boolean storeObj(
       @Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     return delegate.storeObj(obj, ignoreSoftSizeRestrictions);
   }
 
@@ -159,7 +160,7 @@ public class PersistDelegate implements Persist {
   @Nonnull
   @jakarta.annotation.Nonnull
   public boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-      throws ObjTooLargeException {
+      throws ObjTooLargeException, ObjMismatchException {
     return delegate.storeObjs(objs);
   }
 

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/ValidatingVersionStoreImpl.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/ValidatingVersionStoreImpl.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
 import org.assertj.core.api.SoftAssertions;
 import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
 import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
@@ -117,7 +118,7 @@ public class ValidatingVersionStoreImpl extends VersionStoreImpl implements Vali
 
     @Override
     public boolean storeObj(@Nonnull @jakarta.annotation.Nonnull Obj obj)
-        throws ObjTooLargeException {
+        throws ObjTooLargeException, ObjMismatchException {
       recordWrite();
       return super.storeObj(obj);
     }
@@ -125,7 +126,7 @@ public class ValidatingVersionStoreImpl extends VersionStoreImpl implements Vali
     @Override
     public boolean storeObj(
         @Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
-        throws ObjTooLargeException {
+        throws ObjTooLargeException, ObjMismatchException {
       recordWrite();
       return super.storeObj(obj, ignoreSoftSizeRestrictions);
     }
@@ -134,7 +135,7 @@ public class ValidatingVersionStoreImpl extends VersionStoreImpl implements Vali
     @jakarta.annotation.Nonnull
     @Override
     public boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-        throws ObjTooLargeException {
+        throws ObjTooLargeException, ObjMismatchException {
       recordWrite();
       return super.storeObjs(objs);
     }

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistCommon.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistCommon.java
@@ -29,6 +29,7 @@ import org.projectnessie.model.Content;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.batching.BatchingPersist;
 import org.projectnessie.versioned.storage.batching.WriteBatching;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RetryTimeoutException;
@@ -100,7 +101,7 @@ abstract class ImportPersistCommon extends ImportCommon {
             processCommit(commit);
             commitCount++;
           }
-        } catch (ObjTooLargeException e) {
+        } catch (ObjTooLargeException | ObjMismatchException e) {
           throw new RuntimeException(e);
         }
       }
@@ -126,7 +127,8 @@ abstract class ImportPersistCommon extends ImportCommon {
     }
   }
 
-  abstract void processCommit(Commit commit) throws IOException, ObjTooLargeException;
+  abstract void processCommit(Commit commit)
+      throws IOException, ObjTooLargeException, ObjMismatchException;
 
   void processCommitOp(StoreIndex<CommitOp> index, Operation op, StoreKey storeKey) {
     byte payload = (byte) op.getPayload();
@@ -146,7 +148,7 @@ abstract class ImportPersistCommon extends ImportCommon {
           index.add(
               indexElement(
                   storeKey, commitOp(ADD, payload, value.id(), contentIdMaybe(op.getContentId()))));
-        } catch (ObjTooLargeException | IOException e) {
+        } catch (ObjTooLargeException | ObjMismatchException | IOException e) {
           throw new RuntimeException(e);
         }
         break;

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistV1.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistV1.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
 import org.projectnessie.versioned.storage.common.exceptions.RetryTimeoutException;
@@ -92,7 +93,7 @@ final class ImportPersistV1 extends ImportPersistCommon {
   }
 
   @Override
-  void processCommit(Commit commit) throws IOException, ObjTooLargeException {
+  void processCommit(Commit commit) throws IOException, ObjTooLargeException, ObjMismatchException {
     CommitMeta metadata;
     try (InputStream in = commit.getMetadata().newInput()) {
       metadata = importer.objectMapper().readValue(in, CommitMeta.class);

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistV2.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ImportPersistV2.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
 import org.projectnessie.versioned.storage.common.exceptions.RetryTimeoutException;
@@ -98,7 +99,7 @@ final class ImportPersistV2 extends ImportPersistCommon {
   }
 
   @Override
-  void processCommit(Commit commit) throws ObjTooLargeException {
+  void processCommit(Commit commit) throws ObjTooLargeException, ObjMismatchException {
     CommitHeaders.Builder headers = newCommitHeaders();
     commit
         .getHeadersList()

--- a/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
+++ b/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.exceptions.ObjMismatchException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
@@ -359,7 +360,7 @@ public abstract class AbstractExportImport {
           @Override
           public boolean storeObj(
               @Nonnull @jakarta.annotation.Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
-              throws ObjTooLargeException {
+              throws ObjTooLargeException, ObjMismatchException {
             return inmemory.storeObj(obj, ignoreSoftSizeRestrictions);
           }
 
@@ -367,7 +368,7 @@ public abstract class AbstractExportImport {
           @jakarta.annotation.Nonnull
           @Override
           public boolean[] storeObjs(@Nonnull @jakarta.annotation.Nonnull Obj[] objs)
-              throws ObjTooLargeException {
+              throws ObjTooLargeException, ObjMismatchException {
             boolean[] r = new boolean[objs.length];
             for (int i = 0; i < objs.length; i++) {
               Obj obj = objs[i];


### PR DESCRIPTION
This revision introduces exceptions for object mismatches in the `Persist.storeObj` API. These exceptions allow for better error handling when there are discrepancies between existing and expected objects. A key part of this change is the `ObjMismatchException` which provides detailed information about the mismatched objects.