### PR TITLE
Fix "older Jackson versions" tests in `:nessie-client`

### DIFF
--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -98,9 +98,13 @@ val jacksonTestVersions =
 fun JvmComponentDependencies.forJacksonVersion(jacksonVersion: String) {
   implementation(project())
 
-  implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
-  implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
-  implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+  implementation("com.fasterxml.jackson.core:jackson-core") { version { strictly(jacksonVersion) } }
+  implementation("com.fasterxml.jackson.core:jackson-annotations") {
+    version { strictly(jacksonVersion) }
+  }
+  implementation("com.fasterxml.jackson.core:jackson-databind") {
+    version { strictly(jacksonVersion) }
+  }
 }
 
 @Suppress("UnstableApiUsage")


### PR DESCRIPTION
The "older Jackson version" tests all run with the _latest_ Jackson version, because a `platform()` dependency takes precedence over "normal" version constraints, but a `version { strictly(...) }` can override a `platform()`.

This change updates the dependency decls for older Jackson versions.

Before this change:
```
$ ./gradlew :nessie-client:dependencies --configuration testJackson_2_11_4RuntimeClasspath
...
testJackson_2_11_4RuntimeClasspath - Runtime classpath of source set 'test jackson 2 11 4'.
+--- project :nessie-model
|    +--- com.fasterxml.jackson:jackson-bom:2.16.0
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.16.0 (c)
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.16.0 (c)
|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.16.0 (c)
|    +--- com.fasterxml.jackson.core:jackson-databind -> 2.16.0
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.16.0
|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.16.0 (*)
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.16.0
|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.16.0 (*)
|    |    \--- com.fasterxml.jackson:jackson-bom:2.16.0 (*)
|    \--- com.fasterxml.jackson.core:jackson-annotations -> 2.16.0 (*)
+--- com.fasterxml.jackson:jackson-bom:2.16.0 (*)
+--- com.fasterxml.jackson.core:jackson-core -> 2.16.0 (*)
+--- com.fasterxml.jackson.core:jackson-databind -> 2.16.0 (*)
+--- com.fasterxml.jackson.core:jackson-annotations -> 2.16.0 (*)
```

After this change:
```
$ ./gradlew :nessie-client:dependencies --configuration testJackson_2_11_4RuntimeClasspath
...
testJackson_2_11_4RuntimeClasspath - Runtime classpath of source set 'test jackson 2 11 4'.
+--- project :nessie-model
|    +--- com.fasterxml.jackson:jackson-bom:2.16.0
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.16.0 -> 2.11.4 (c)
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.16.0 -> 2.11.4 (c)
|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.16.0 -> 2.11.4 (c)
|    +--- com.fasterxml.jackson.core:jackson-databind -> 2.11.4
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.11.4
|    |    \--- com.fasterxml.jackson.core:jackson-core:2.11.4
|    \--- com.fasterxml.jackson.core:jackson-annotations -> 2.11.4
+--- com.fasterxml.jackson:jackson-bom:2.16.0 (*)
+--- com.fasterxml.jackson.core:jackson-core -> 2.11.4
+--- com.fasterxml.jackson.core:jackson-databind -> 2.11.4 (*)
+--- com.fasterxml.jackson.core:jackson-annotations -> 2.11.4
```