### PR TITLE
Ignore Obj.type() when using Smile serialization

### DIFF
--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Obj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Obj.java
@@ -23,5 +23,6 @@ public interface Obj {
   @JsonIgnore
   ObjId id();
 
+  @JsonIgnore
   ObjType type();
 }


### PR DESCRIPTION
Small leftover from #7771 : we don't need to serialize the object type, as this information _must_ be stored externally and provided to the deserialization logic as a separate input.