### PR TITLE
Use `/` as the resteasy base path in Quarkus

### DIFF
--- a/api/client-testextension/src/main/java/org/projectnessie/client/ext/NessieApiVersion.java
+++ b/api/client-testextension/src/main/java/org/projectnessie/client/ext/NessieApiVersion.java
@@ -38,7 +38,7 @@ public enum NessieApiVersion {
   }
 
   public URI resolve(URI base) {
-    return base.resolve(getPathElement());
+    return base.resolve("api/" + getPathElement());
   }
 
   public NessieApiV1 build(NessieClientBuilder builder) {

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
@@ -61,7 +61,7 @@ final class CurrentNessieServer implements NessieServer {
 
   @Override
   public URI getUri(Class<? extends NessieApi> apiType) {
-    return Util.resolveNessieUri(jersey.getUri(), apiType);
+    return Util.resolveNessieUri(jersey.getUri().resolve("api/"), apiType);
   }
 
   @Override

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -159,7 +159,7 @@ quarkus.http.port=19120
 quarkus.http.test-port=0
 quarkus.http.access-log.enabled=true
 # fixed at buildtime
-quarkus.resteasy.path=/api
+quarkus.resteasy.path=/
 quarkus.resteasy.gzip.enabled=true
 quarkus.http.enable-compression=true
 quarkus.http.enable-decompression=true

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/error/TestNessieError.java
@@ -69,7 +69,7 @@ class TestNessieError {
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     client =
         HttpClient.builder()
-            .setBaseUri(uri.resolve("nessieErrorTest"))
+            .setBaseUri(uri.resolve("../nessieErrorTest"))
             .setObjectMapper(mapper)
             .addResponseFilter(new NessieHttpResponseFilter())
             .build();

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/QuarkusNessieClientResolver.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/QuarkusNessieClientResolver.java
@@ -30,6 +30,6 @@ public class QuarkusNessieClientResolver extends NessieClientResolver {
 
   @Override
   protected URI getBaseUri(ExtensionContext extensionContext) {
-    return URI.create(String.format("http://localhost:%d/api/v1", getQuarkusTestPort()));
+    return URI.create(String.format("http://localhost:%d/", getQuarkusTestPort()));
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigResource.java
@@ -18,6 +18,7 @@ package org.projectnessie.services.rest;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 import org.projectnessie.api.v1.http.HttpConfigApi;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.ser.Views;
@@ -25,6 +26,7 @@ import org.projectnessie.services.spi.ConfigService;
 
 /** REST endpoint to retrieve server settings. */
 @RequestScoped
+@Path("api/v1/config")
 public class RestConfigResource implements HttpConfigApi {
 
   private final ConfigService configService;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentResource.java
@@ -18,6 +18,7 @@ package org.projectnessie.services.rest;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 import org.projectnessie.api.v1.http.HttpContentApi;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Content;
@@ -29,6 +30,7 @@ import org.projectnessie.services.spi.ContentService;
 
 /** REST endpoint for the content-API. */
 @RequestScoped
+@Path("api/v1/contents")
 public class RestContentResource implements HttpContentApi {
   // Cannot extend the ContentApiImplWithAuthz class, because then CDI gets confused
   // about which interface to use - either HttpContentApi or the plain ContentApi. This can lead

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffResource.java
@@ -20,6 +20,7 @@ import static org.projectnessie.services.impl.RefUtil.toReference;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 import org.projectnessie.api.v1.http.HttpDiffApi;
 import org.projectnessie.api.v1.params.DiffParams;
 import org.projectnessie.error.NessieNotFoundException;
@@ -32,6 +33,7 @@ import org.projectnessie.services.spi.PagedResponseHandler;
 
 /** REST endpoint for the diff-API. */
 @RequestScoped
+@Path("api/v1/diffs")
 public class RestDiffResource implements HttpDiffApi {
   // Cannot extend the DiffApiImplWithAuthz class, because then CDI gets confused
   // about which interface to use - either HttpContentApi or the plain ContentApi. This can lead

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceResource.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Path;
 import org.projectnessie.api.v1.http.HttpNamespaceApi;
 import org.projectnessie.api.v1.params.MultipleNamespacesParams;
 import org.projectnessie.api.v1.params.NamespaceParams;
@@ -34,6 +35,7 @@ import org.projectnessie.services.spi.NamespaceService;
 
 /** REST endpoint for the namespace-API. */
 @RequestScoped
+@Path("api/v1/namespaces")
 public class RestNamespaceResource implements HttpNamespaceApi {
   // Cannot extend the NamespaceApiImplWithAuthz class, because then CDI gets confused
   // about which interface to use - either HttpNamespaceApi or the plain NamespaceApi. This can lead

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeResource.java
@@ -22,6 +22,7 @@ import static org.projectnessie.services.spi.TreeService.MAX_COMMIT_LOG_ENTRIES;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 import org.projectnessie.api.v1.http.HttpTreeApi;
 import org.projectnessie.api.v1.params.BaseMergeTransplant;
 import org.projectnessie.api.v1.params.CommitLogParams;
@@ -50,6 +51,7 @@ import org.projectnessie.services.spi.TreeService;
 
 /** REST endpoint for the tree-API. */
 @RequestScoped
+@Path("api/v1/trees")
 public class RestTreeResource implements HttpTreeApi {
   // Cannot extend the TreeApiImplWithAuthz class, because then CDI gets confused
   // about which interface to use - either HttpTreeApi or the plain TreeApi. This can lead

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
@@ -18,6 +18,7 @@ package org.projectnessie.services.rest;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 import java.security.Principal;
 import java.util.List;
 import java.util.Set;
@@ -41,6 +42,7 @@ import org.projectnessie.versioned.VersionStore;
 
 /** REST endpoint to retrieve server settings. */
 @RequestScoped
+@Path("api/v2/config")
 public class RestV2ConfigResource implements HttpConfigApi {
 
   private final ConfigApiImpl config;

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2TreeResource.java
@@ -23,6 +23,7 @@ import static org.projectnessie.services.spi.TreeService.MAX_COMMIT_LOG_ENTRIES;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 import java.util.List;
 import java.util.Locale;
 import org.projectnessie.api.v2.http.HttpTreeApi;
@@ -69,6 +70,7 @@ import org.projectnessie.services.spi.TreeService;
 
 /** REST endpoint for the tree-API. */
 @RequestScoped
+@Path("api/v2/trees")
 public class RestV2TreeResource implements HttpTreeApi {
 
   private final ConfigService configService;


### PR DESCRIPTION
Updates the resource implementation classes to use the `api/...` prefix, but leave the client side interfaces with `@Path` annotations without that prefix.