### PR TITLE
Fix Quarkus warning `@Inject` on private field

### DIFF
--- a/servers/rest-common/src/main/java/org/projectnessie/services/rest/exceptions/BaseExceptionMapper.java
+++ b/servers/rest-common/src/main/java/org/projectnessie/services/rest/exceptions/BaseExceptionMapper.java
@@ -31,7 +31,7 @@ import org.projectnessie.services.rest.common.RestCommon;
 /** Code shared between concrete exception-mapper implementations. */
 public abstract class BaseExceptionMapper<T extends Throwable> implements ExceptionMapper<T> {
 
-  @Inject private ExceptionConfig config;
+  @Inject ExceptionConfig config;
 
   @Context private HttpHeaders headers;
 


### PR DESCRIPTION
Quarkus complains with a warning about the unrecommended use of `@Inject` on a `private` field, recommending package-private.