### PR TITLE
Let OAuth2 errors not lot stack traces

### DIFF
--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
@@ -268,7 +268,6 @@ public class ITOAuth2Client {
     try (OAuth2Client client = new OAuth2Client(params)) {
       client.start();
       soft.assertThatThrownBy(client::authenticate)
-          .cause()
           .asInstanceOf(type(OAuth2Exception.class))
           .extracting(OAuth2Exception::getStatus)
           .isEqualTo(Status.UNAUTHORIZED);
@@ -282,7 +281,6 @@ public class ITOAuth2Client {
     try (OAuth2Client client = new OAuth2Client(params)) {
       client.start();
       soft.assertThatThrownBy(client::authenticate)
-          .cause()
           .asInstanceOf(type(OAuth2Exception.class))
           .extracting(OAuth2Exception::getStatus)
           .isEqualTo(Status.UNAUTHORIZED);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -129,6 +129,8 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
       Throwable cause = e.getCause();
       if (cause instanceof Error) {
         throw (Error) cause;
+      } else if (cause instanceof HttpClientException) {
+        throw (HttpClientException) cause;
       } else {
         throw new RuntimeException("Cannot acquire a valid OAuth2 access token", cause);
       }
@@ -399,7 +401,11 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
     boolean shouldWarn =
         lastWarn == null || Duration.between(lastWarn, now).compareTo(MIN_WARN_INTERVAL) > 0;
     if (shouldWarn) {
-      LOGGER.warn(message, error);
+      if (error instanceof HttpClientException) {
+        LOGGER.warn("{}: {}", message, error.toString());
+      } else {
+        LOGGER.warn(message, error);
+      }
       lastWarn = now;
     } else {
       LOGGER.debug(message, error);

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieApiCompatibilityFilter.java
@@ -59,6 +59,11 @@ public class NessieApiCompatibilityFilter implements RequestFilter {
     JsonNode config;
     try {
       config = httpClient.newRequest().path("config").get().readEntity(JsonNode.class);
+    } catch (HttpClientException e) {
+      LOGGER.warn(
+          "API compatibility check: failed to contact config endpoint, proceeding without check: {}",
+          e.toString());
+      return;
     } catch (Exception e) {
       LOGGER.warn(
           "API compatibility check: failed to contact config endpoint, proceeding without check",

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -253,7 +253,7 @@ class TestOAuth2Client {
         client.start();
         Runnable renewalTask = currentRenewalTask.get();
         soft.assertThat(renewalTask).isNotNull();
-        soft.assertThatThrownBy(client::authenticate).hasCauseInstanceOf(OAuth2Exception.class);
+        soft.assertThatThrownBy(client::authenticate).isInstanceOf(OAuth2Exception.class);
 
         // Emulate executor running the scheduled refresh task, then throwing an exception
         // => propagate the error but schedule another refresh
@@ -261,7 +261,7 @@ class TestOAuth2Client {
         renewalTask.run();
         soft.assertThat(currentRenewalTask.get()).isNotNull().isNotSameAs(renewalTask);
         renewalTask = currentRenewalTask.get();
-        soft.assertThatThrownBy(client::authenticate).hasCauseInstanceOf(OAuth2Exception.class);
+        soft.assertThatThrownBy(client::authenticate).isInstanceOf(OAuth2Exception.class);
 
         // Emulate executor running the scheduled refresh task again, then finally getting tokens
         // => should recover and return initial tokens + schedule next refresh
@@ -289,7 +289,7 @@ class TestOAuth2Client {
         // => should propagate the error but schedule another refresh
         handlerRef.set(failureHandler);
         now = now.plus(Duration.ofHours(3));
-        soft.assertThatThrownBy(client::authenticate).hasCauseInstanceOf(OAuth2Exception.class);
+        soft.assertThatThrownBy(client::authenticate).isInstanceOf(OAuth2Exception.class);
         soft.assertThat(client.sleeping).isFalse();
         soft.assertThat(currentRenewalTask.get()).isNotNull().isNotSameAs(renewalTask);
         renewalTask = currentRenewalTask.get();
@@ -300,7 +300,7 @@ class TestOAuth2Client {
         renewalTask.run();
         soft.assertThat(currentRenewalTask.get()).isSameAs(renewalTask);
         soft.assertThat(client.sleeping).isTrue();
-        soft.assertThatThrownBy(client::getCurrentTokens).hasCauseInstanceOf(OAuth2Exception.class);
+        soft.assertThatThrownBy(client::getCurrentTokens).isInstanceOf(OAuth2Exception.class);
 
         // Emulate waking up, then fetching tokens immediately because no tokens are available,
         // then scheduling next refresh

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractOAuth2Authentication.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractOAuth2Authentication.java
@@ -53,7 +53,6 @@ public abstract class AbstractOAuth2Authentication extends BaseClientAuthTest {
     NessieAuthentication authentication = oauth2Authentication(wrongPasswordConfig());
     withClientCustomizer(b -> b.withAuthentication(authentication));
     assertThatThrownBy(() -> api().getAllReferences().stream())
-        .cause()
         .asInstanceOf(type(OAuth2Exception.class))
         .extracting(OAuth2Exception::getStatus)
         .isEqualTo(Status.UNAUTHORIZED);


### PR DESCRIPTION
Currently all `OAuth2Exception`s are logged with their full stack trace although those have a good explanation. Those are not "errors" in the sense of a code issue or bug but issues to be resolved by users.