### PR TITLE
Quarkus-tests: do not log OIDC connection + tracing warnings

### DIFF
--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -172,8 +172,8 @@ nessie.server.authentication.enabled=false
 nessie.server.authentication.anonymous-paths=/q/health/live,/q/health/live/,/q/health/ready,/q/health/ready/
 # to be overwritten by end user when enabling OpenID validation
 quarkus.oidc.auth-server-url=http://127.255.0.0:0/auth/realms/unset/
-# fixed at buildtime
 quarkus.http.auth.basic=false
+# OIDC-enabled is a build-time property (cannot be overwritten at run-time), MUST be true
 quarkus.oidc.enabled=true
 
 ## Quarkus swagger settings
@@ -261,3 +261,9 @@ quarkus.micrometer.binder.http-server.match-patterns=\
 # endless 'Retried waiting for GCLocker too often allocating * words' messages instead of a
 # "proper OutOfMemoryException" happen.
 %test.quarkus.micrometer.binder.jvm=false
+
+# (Most) tests do not need tracing - turn it off to have less log "spam".
+%test.quarkus.otel.traces.exporter=none
+# Turn off OIDC connection error in tests - DO NOT PUT THIS SETTING INTO YOUR PRODUCTION CODE,
+# because it would hide other OIDC issues as well!
+%test.quarkus.log.category."io.quarkus.oidc.common.runtime.OidcCommonUtils".level=OFF


### PR DESCRIPTION
The "well known OIDC connection error" that is logged at startup (during automatic OIDC endpoint discovery) cannot be disabled - also OIDC cannot be disabled at runtime (it's a build-time config setting). Can only turn off logging for the class that emits the warning - but should only be done in tests, but not in production. This change is to reduce "log spam" in tests.

Also configures trace-sampling to default to 'none' for tests. The latter removes the regularly appearing `Failed to export spans. The request could not be executed. Full error message: Connection refused: localhost/127.0.0.1:4317`