### PR TITLE
Quarkus ITs: Remove LoggerFinder error log message

### DIFF
--- a/build-logic/src/main/kotlin/nessie-testing.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-testing.gradle.kts
@@ -85,6 +85,8 @@ tasks.withType<Test>().configureEach {
   environment("TESTCONTAINERS_REUSE_ENABLE", "true")
 
   if (plugins.hasPlugin("io.quarkus")) {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+
     jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
     // Log-levels are required to be able to parse the HTTP listen URL
     jvmArgumentProviders.add(


### PR DESCRIPTION
Remove this error log message from the output when running Quarkus integration tests:
```
ERROR: The LogManager accessed before the "java.util.logging.manager" system property was set to "org.jboss.logmanager.LogManager". Results may be unexpected.
```