### PR TITLE
stop testing spark-extensions 3.2 on iceberg main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -747,11 +747,6 @@ jobs:
           cache-read-only: true
           arguments: :iceberg:iceberg-nessie:test --scan
 
-      - name: Nessie Spark 3.2 / 2.12 Extensions test
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest --scan
-
       - name: Nessie Spark 3.3 / 2.12 Extensions test
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
spark 3.2 support has been removed recently:
https://github.com/apache/iceberg/commit/c6bbbdbc11d42713c86dd52185f577b81d946963

see also:
https://github.com/projectnessie/query-engine-integration-tests/pull/501