### PR TITLE
Add `detach-history` command to the ContentGenerator tool

### DIFF
--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITDetachHistory.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITDetachHistory.java
@@ -106,8 +106,8 @@ class ITDetachHistory extends AbstractContentGeneratorTest {
   @Test
   void mainBatched() throws NessieNotFoundException, NessieConflictException {
     Branch main = api.getDefaultBranch();
-    int N = 200;
-    for (int i = 1; i < N; i++) {
+    int numTables = 200;
+    for (int i = 1; i < numTables; i++) {
       main = create(api, main, table1, ContentKey.of("test-" + i));
     }
 
@@ -118,7 +118,7 @@ class ITDetachHistory extends AbstractContentGeneratorTest {
     Reference mainCompleted = api.getReference().refName(main.getName() + "-completed").get();
     assertThat(mainCompleted.getHash()).isEqualTo(main.getHash());
 
-    for (int i = 1; i < N; i++) {
+    for (int i = 1; i < numTables; i++) {
       assertThat(contentWithoutId(main.getName(), ContentKey.of("test-" + i))).isEqualTo(table1);
     }
   }

--- a/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITDetachHistory.java
+++ b/tools/content-generator/src/intTest/java/org/projectnessie/tools/contentgenerator/ITDetachHistory.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.projectnessie.tools.contentgenerator.RunContentGenerator.runGeneratorCmd;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Reference;
+
+class ITDetachHistory extends AbstractContentGeneratorTest {
+
+  private static final ContentKey key1 = ContentKey.of("test", "key1");
+  private static final ContentKey key2 = ContentKey.of("test", "key2");
+  private static final ContentKey key3 = ContentKey.of("test_key3");
+  private static final IcebergTable table1 = IcebergTable.of("meta_111", 1, 2, 3, 4);
+  private static final IcebergTable table2 = IcebergTable.of("meta_222", 1, 2, 3, 4);
+  private static final IcebergTable table3 = IcebergTable.of("meta_333", 1, 2, 3, 4);
+
+  private NessieApiV2 api;
+
+  @BeforeEach
+  void setUp() {
+    api = buildNessieApi();
+  }
+
+  private void runMain(String... args) {
+    runMain(s -> {}, args);
+  }
+
+  private void runMain(Consumer<String> stdoutWatcher, String... args) {
+    List<String> allArgs = new ArrayList<>();
+    allArgs.add("detach-history");
+    allArgs.add("--uri");
+    allArgs.add(NESSIE_API_URI);
+    allArgs.addAll(Arrays.asList(args));
+
+    RunContentGenerator.ProcessResult result =
+        runGeneratorCmd(stdoutWatcher, allArgs.toArray(new String[0]));
+    assertThat(result)
+        .describedAs(result.toString())
+        .extracting(RunContentGenerator.ProcessResult::getExitCode)
+        .isEqualTo(0);
+  }
+
+  private Content contentWithoutId(String ref, ContentKey key) throws NessieNotFoundException {
+    return get(api, ref, key).withId(null);
+  }
+
+  @Test
+  void severalBranchesAllContent() throws NessieNotFoundException, NessieConflictException {
+    Branch main = api.getDefaultBranch();
+    Branch test =
+        (Branch) api.createReference().reference(Branch.of("test1", main.getHash())).create();
+    main = create(api, main, table1, key1);
+    main = create(api, main, table2, key2);
+    test = create(api, test, table1, key1);
+    test = create(api, test, table3, key3);
+
+    runMain("--all", "--src-suffix", "-src123", "--final-suffix", "-done123");
+
+    Reference mainOrig = api.getReference().refName(main.getName() + "-src123").get();
+    assertThat(mainOrig.getHash()).isEqualTo(main.getHash());
+    Reference mainCompleted = api.getReference().refName(main.getName() + "-done123").get();
+    assertThat(mainCompleted.getHash()).isEqualTo(main.getHash());
+    Reference testOrig = api.getReference().refName(test.getName() + "-src123").get();
+    assertThat(testOrig.getHash()).isEqualTo(test.getHash());
+    Reference testCompleted = api.getReference().refName(test.getName() + "-done123").get();
+    assertThat(testCompleted.getHash()).isEqualTo(test.getHash());
+
+    assertThat(contentWithoutId(main.getName(), key1)).isEqualTo(table1);
+    assertThat(contentWithoutId(main.getName(), key2)).isEqualTo(table2);
+    assertThat(contentWithoutId(test.getName(), key1)).isEqualTo(table1);
+    assertThat(contentWithoutId(test.getName(), key3)).isEqualTo(table3);
+
+    assertThat(contentWithoutId(main.getName(), key1.getParent())).isEqualTo(key1.getNamespace());
+  }
+
+  @Test
+  void mainBatched() throws NessieNotFoundException, NessieConflictException {
+    Branch main = api.getDefaultBranch();
+    int N = 200;
+    for (int i = 1; i < N; i++) {
+      main = create(api, main, table1, ContentKey.of("test-" + i));
+    }
+
+    runMain("--all", "--batch", "7");
+
+    Reference mainOrig = api.getReference().refName(main.getName() + "-original").get();
+    assertThat(mainOrig.getHash()).isEqualTo(main.getHash());
+    Reference mainCompleted = api.getReference().refName(main.getName() + "-completed").get();
+    assertThat(mainCompleted.getHash()).isEqualTo(main.getHash());
+
+    for (int i = 1; i < N; i++) {
+      assertThat(contentWithoutId(main.getName(), ContentKey.of("test-" + i))).isEqualTo(table1);
+    }
+  }
+
+  @Test
+  void retries() throws NessieNotFoundException, NessieConflictException {
+    Branch root = api.getDefaultBranch();
+    // This branch will have concurrent changes
+    AtomicReference<Branch> main = new AtomicReference<>(root);
+    main.set(create(api, main.get(), table1, key1));
+
+    // This branch will be stable and will migrate in the first attempt
+    Branch test =
+        (Branch) api.createReference().reference(Branch.of("test1", root.getHash())).create();
+    test = create(api, test, table1, key1);
+
+    AtomicInteger count = new AtomicInteger();
+    Consumer<String> stdoutWatcher =
+        text -> {
+          if (text.contains("Reassigning references")) {
+            // Simulate some concurrent changes
+            try {
+              int c = count.getAndIncrement();
+              if (c == 0) {
+                main.set(create(api, api.getDefaultBranch(), table2, key2));
+              } else if (c == 1) {
+                main.set(create(api, api.getDefaultBranch(), table3, key3));
+              }
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          }
+        };
+    runMain(stdoutWatcher, "--all");
+
+    assertThat(count.get()).isEqualTo(3); // 2 failed attempts + 1 successful
+
+    Reference mainOrig = api.getReference().refName(main.get().getName() + "-original").get();
+    assertThat(mainOrig.getHash()).isEqualTo(main.get().getHash());
+    Reference mainCompleted = api.getReference().refName(main.get().getName() + "-completed").get();
+    assertThat(mainCompleted.getHash()).isEqualTo(main.get().getHash());
+
+    assertThat(contentWithoutId(api.getDefaultBranch().getName(), key1)).isEqualTo(table1);
+    assertThat(contentWithoutId(api.getDefaultBranch().getName(), key2)).isEqualTo(table2);
+    assertThat(contentWithoutId(api.getDefaultBranch().getName(), key3)).isEqualTo(table3);
+
+    assertThat(api.getDefaultBranch().getHash()).isNotEqualTo(main.get().getHash());
+
+    Reference testOrig = api.getReference().refName(test.getName() + "-original").get();
+    assertThat(testOrig.getHash()).isEqualTo(test.getHash());
+    Reference testCompleted = api.getReference().refName(test.getName() + "-completed").get();
+    assertThat(testCompleted.getHash()).isEqualTo(test.getHash());
+
+    assertThat(api.getReference().refName(test.getName()).get().getHash())
+        .isNotEqualTo(test.getHash());
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ContentGenerator.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/ContentGenerator.java
@@ -37,6 +37,7 @@ import picocli.CommandLine;
       ReadReferences.class,
       ReadContent.class,
       RefreshContent.class,
+      DetachHistory.class,
       DeleteContent.class,
       CreateMissingNamespaces.class,
       CommandLine.HelpCommand.class

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
@@ -158,7 +158,6 @@ public class DetachHistory extends RefreshContent {
       api.assignReference().reference(source).assignTo(target).assign();
 
       api.createReference()
-          .sourceRefName(source.getName())
           .reference(Tag.of(source.getName() + completedSuffix, source.getHash()))
           .create();
 

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
@@ -66,6 +66,12 @@ public class DetachHistory extends RefreshContent {
 
   @Override
   public void execute() throws BaseNessieClientServerException {
+    // Overview:
+    // 1) Tag old source branch HEADs (in setup()).
+    // 2) Copy the latest content to temporary branches.
+    // 3) Reassign source branches to HEADs of corresponding temporary branches.
+    // The last step may fail if there are concurrent commits to source branch, in which case
+    // the whole process is re-tried.
     try (NessieApiV2 api = createNessieApiInstance()) {
       rootHash = api.getConfig().getNoAncestorHash();
       for (int attempt = 0; attempt < maxAttempts; attempt++) {

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
@@ -93,6 +93,16 @@ public class DetachHistory extends RefreshContent {
           spec.commandLine()
               .getOut()
               .printf("Unable to complete attempt %d, retrying...%n", attempt);
+
+          // Delete any remaining temporary references
+          for (Branch target : targets.values()) {
+            try {
+              Reference tmpRef = api.getReference().refName(target.getName()).get();
+              api.deleteReference().reference(tmpRef).delete();
+            } catch (NessieNotFoundException ex) {
+              // ignore, the target reference must have been reassigned and deleted
+            }
+          }
         }
       }
     }

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.tools.contentgenerator.cli;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.error.BaseNessieClientServerException;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.error.NessieReferenceConflictException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "detach-history",
+    mixinStandardHelpOptions = true,
+    description =
+        "Get the latest contents from one or all branches, commit it directly on top of the root commit (no history), "
+            + "then reassign the original branch(es) to the new commit.")
+public class DetachHistory extends RefreshContent {
+
+  @CommandLine.Option(
+      names = {"--src-suffix"},
+      description =
+          "Name suffix for tagging the original (source) branches, defaults to '-original'.")
+  private String origSuffix = "-original";
+
+  @CommandLine.Option(
+      names = {"--final-suffix"},
+      description =
+          "Name suffix for tagging the the final stat of source branches (equivalent to the tag generated "
+              + "from the --src-suffix option). This suffix is used during retries, defaults to '-completed'.")
+  private String completedSuffix = "-completed";
+
+  @CommandLine.Option(
+      names = {"--max-attempts"},
+      description =
+          "Max attempts (in case of concurrent commits from other actors), defaults to 100.")
+  private int maxAttempts = 100;
+
+  private final Map<String, Branch> sources = new HashMap<>();
+  private final Map<String, Branch> targets = new HashMap<>();
+  private String tmpSuffix;
+  private String rootHash;
+
+  @Override
+  public void execute() throws BaseNessieClientServerException {
+    try (NessieApiV2 api = createNessieApiInstance()) {
+      rootHash = api.getConfig().getNoAncestorHash();
+      for (int attemt = 0; attemt < maxAttempts; attemt++) {
+        spec.commandLine().getOut().printf("Running attempt %d...%n", attemt);
+
+        sources.clear();
+        targets.clear();
+        tmpSuffix = "-tmp-" + UUID.randomUUID();
+
+        super.execute(); // copy content into temporary branches
+
+        try {
+          // reassign original branch names to HEADs of corresponding temporary branches
+          reassign(api);
+          break;
+        } catch (NessieReferenceConflictException e) {
+          spec.commandLine()
+              .getOut()
+              .printf("Unable to complete attempt %d, retrying...%n", attemt);
+        }
+      }
+    }
+    spec.commandLine().getOut().printf("Completed successfully%n");
+  }
+
+  @Override
+  protected void commitSameContent(
+      NessieApiV2 api, Branch source, Map<ContentKey, Content> contentMap)
+      throws BaseNessieClientServerException {
+    Branch target = setup(api, source);
+    if (target == null) {
+      return;
+    }
+
+    Map<ContentKey, Content> detachedContents = new HashMap<>();
+    contentMap.forEach((k, v) -> detachedContents.put(k, v.withId(null)));
+    super.commitSameContent(api, target, detachedContents);
+  }
+
+  private Branch setup(NessieApiV2 api, Branch source)
+      throws NessieConflictException, NessieNotFoundException {
+    Branch old = sources.putIfAbsent(source.getName(), source);
+    if (old != null && !Objects.equals(old.getHash(), source.getHash())) {
+      throw new IllegalArgumentException("Hash mismatch");
+    }
+
+    try {
+      api.getReference().refName(source.getName() + completedSuffix).get();
+      spec.commandLine().getOut().printf("Ignoring previously migrated reference '%s'%n", source);
+      return null; // already processed
+    } catch (NessieNotFoundException e) {
+      // expected
+    }
+
+    spec.commandLine().getOut().printf("Migrating '%s'%n", source);
+    String origName = source.getName() + origSuffix;
+    try {
+      Reference origRef = api.getReference().refName(origName).get();
+      api.assignReference().reference(origRef).assignTo(source).assign();
+    } catch (NessieNotFoundException e) {
+      api.createReference()
+          .sourceRefName(source.getName())
+          .reference(Tag.of(origName, source.getHash()))
+          .create();
+    }
+
+    return targets.computeIfAbsent(
+        source.getName(),
+        name -> {
+          name = name + tmpSuffix;
+          try {
+            return (Branch) api.createReference().reference(Branch.of(name, rootHash)).create();
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  private void reassign(NessieApiV2 api) throws NessieNotFoundException, NessieConflictException {
+    spec.commandLine().getOut().println("Reassigning references...");
+
+    for (Map.Entry<String, Branch> e : targets.entrySet()) {
+      String name = e.getKey();
+      Reference target = e.getValue();
+      Branch source = sources.get(name);
+
+      // get the latest hash
+      target = api.getReference().refName(target.getName()).get();
+
+      api.assignReference().reference(source).assignTo(target).assign();
+
+      api.createReference()
+          .sourceRefName(source.getName())
+          .reference(Tag.of(source.getName() + completedSuffix, source.getHash()))
+          .create();
+
+      spec.commandLine().getOut().printf("Completed migration for '%s'%n", source.getName());
+
+      api.deleteReference().reference(target).delete();
+    }
+  }
+}

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/DetachHistory.java
@@ -68,8 +68,8 @@ public class DetachHistory extends RefreshContent {
   public void execute() throws BaseNessieClientServerException {
     try (NessieApiV2 api = createNessieApiInstance()) {
       rootHash = api.getConfig().getNoAncestorHash();
-      for (int attemt = 0; attemt < maxAttempts; attemt++) {
-        spec.commandLine().getOut().printf("Running attempt %d...%n", attemt);
+      for (int attempt = 0; attempt < maxAttempts; attempt++) {
+        spec.commandLine().getOut().printf("Running attempt %d...%n", attempt);
 
         sources.clear();
         targets.clear();
@@ -80,15 +80,16 @@ public class DetachHistory extends RefreshContent {
         try {
           // reassign original branch names to HEADs of corresponding temporary branches
           reassign(api);
+
+          spec.commandLine().getOut().printf("Completed successfully%n");
           break;
         } catch (NessieReferenceConflictException e) {
           spec.commandLine()
               .getOut()
-              .printf("Unable to complete attempt %d, retrying...%n", attemt);
+              .printf("Unable to complete attempt %d, retrying...%n", attempt);
         }
       }
     }
-    spec.commandLine().getOut().printf("Completed successfully%n");
   }
 
   @Override

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/RefreshContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/RefreshContent.java
@@ -47,7 +47,7 @@ public class RefreshContent extends BulkCommittingCommand {
     }
   }
 
-  private void commitSameContent(
+  protected void commitSameContent(
       NessieApiV2 api, Branch branch, Map<ContentKey, Content> contentMap)
       throws BaseNessieClientServerException {
 


### PR DESCRIPTION
This command can be useful for repository maintenance when users do wish get rid of irrelevant commit histories while maintaining current content values.

All contents get new content IDs during this process.