### PR TITLE
Fix NPE when fetching commit log with access checks enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Fixes
 
+- Fix potential NPE when fetching commit log with fetch option `ALL` and access checks enabled.
+
 ### Commits
 
 ## [0.75.0] Release (2023-12-15)

--- a/servers/quarkus-auth/src/main/java/org/projectnessie/server/authz/CelBatchAccessChecker.java
+++ b/servers/quarkus-auth/src/main/java/org/projectnessie/server/authz/CelBatchAccessChecker.java
@@ -15,19 +15,20 @@
  */
 package org.projectnessie.server.authz;
 
-import static java.util.Objects.requireNonNull;
-
 import com.google.common.collect.ImmutableMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.projectnessie.cel.tools.ScriptException;
-import org.projectnessie.model.Content;
+import org.projectnessie.model.Content.Type;
+import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.services.authz.AbstractBatchAccessChecker;
 import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.BatchAccessChecker;
 import org.projectnessie.services.authz.Check;
+import org.projectnessie.versioned.NamedRef;
 
 /**
  * A reference implementation of the {@link BatchAccessChecker} that performs access checks using
@@ -62,7 +63,10 @@ final class CelBatchAccessChecker extends AbstractBatchAccessChecker {
   }
 
   private String getRoleName() {
-    return null != context.user() ? context.user().getName() : "";
+    if (context.user() != null && context.user().getName() != null) {
+      return context.user().getName();
+    }
+    return "";
   }
 
   private void canPerformOp(Check check, Map<Check, String> failed) {
@@ -77,65 +81,48 @@ final class CelBatchAccessChecker extends AbstractBatchAccessChecker {
   }
 
   private void canPerformOpOnReference(Check check, Map<Check, String> failed) {
-    String roleName = getRoleName();
-    String refName = check.ref().getName();
-    ImmutableMap<String, Object> arguments =
-        ImmutableMap.of(
-            "ref",
-            refName,
-            "role",
-            roleName,
-            "op",
-            check.type().name(),
-            "path",
-            "",
-            "contentType",
-            "");
+    String role = getRoleName();
+    String op = check.type().name();
+    String ref = Optional.ofNullable(check.ref()).map(NamedRef::getName).orElse("");
+    Map<String, Object> arguments =
+        ImmutableMap.of("ref", ref, "role", role, "op", op, "path", "", "contentType", "");
 
     Supplier<String> errorMsgSupplier =
         () ->
             String.format(
-                "'%s' is not allowed for role '%s' on reference '%s'",
-                check.type(), roleName, refName);
+                "'%s' is not allowed for role '%s' on reference '%s'", check.type(), role, ref);
     canPerformOp(arguments, check, errorMsgSupplier, failed);
   }
 
   private void canPerformOpOnPath(Check check, Map<Check, String> failed) {
-    String roleName = getRoleName();
-    Content.Type contentType = check.contentType();
-    String contentKeyPathString = check.key().toPathString();
-    ImmutableMap<String, Object> arguments =
+    String role = getRoleName();
+    String op = check.type().name();
+    String contentType = Optional.ofNullable(check.contentType()).map(Type::name).orElse("");
+    String path = Optional.ofNullable(check.key()).map(ContentKey::toPathString).orElse("");
+    String ref = Optional.ofNullable(check.ref()).map(NamedRef::getName).orElse("");
+    Map<String, Object> arguments =
         ImmutableMap.of(
-            "ref",
-            check.ref().getName(),
-            "path",
-            contentKeyPathString,
-            "role",
-            roleName,
-            "op",
-            check.type().name(),
-            "contentType",
-            contentType != null ? contentType.name() : "");
+            "ref", ref, "path", path, "role", role, "op", op, "contentType", contentType);
 
     Supplier<String> errorMsgSupplier =
-        () ->
-            String.format(
-                "'%s' is not allowed for role '%s' on content '%s'",
-                check.type(), roleName, contentKeyPathString);
+        () -> String.format("'%s' is not allowed for role '%s' on content '%s'", op, role, path);
 
     canPerformOp(arguments, check, errorMsgSupplier, failed);
   }
 
   private void canPerformRepositoryConfig(Check check, Map<Check, String> failed) {
-    RepositoryConfig.Type repositoryConfigType = requireNonNull(check.repositoryConfigType());
+    String op = check.type().name();
+    String type =
+        Optional.ofNullable(check.repositoryConfigType())
+            .map(RepositoryConfig.Type::name)
+            .orElse("");
 
-    ImmutableMap<String, Object> arguments = ImmutableMap.of("type", repositoryConfigType.name());
+    Map<String, Object> arguments = ImmutableMap.of("type", type, "op", op);
 
     Supplier<String> errorMsgSupplier =
         () ->
             String.format(
-                "'%s' is not allowed for repository config type '%s'",
-                check.type(), repositoryConfigType.name());
+                "'%s' is not allowed for repository config type '%s'", check.type(), type);
 
     canPerformOp(arguments, check, errorMsgSupplier, failed);
   }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/Check.java
@@ -65,6 +65,10 @@ public interface Check {
     return ImmutableCheck.of(type, ref, null, null, null, null, null);
   }
 
+  static Check check(CheckType type, @Nullable NamedRef ref, @Nullable ContentKey key) {
+    return ImmutableCheck.of(type, ref, key, null, null, null, null);
+  }
+
   static Check check(
       CheckType type, @Nullable NamedRef ref, @Nullable IdentifiedContentKey identifiedKey) {
     if (identifiedKey != null) {
@@ -157,6 +161,10 @@ public interface Check {
 
   static Check canReadEntries(NamedRef ref) {
     return check(CheckType.READ_ENTRIES, ref);
+  }
+
+  static Check canReadContentKey(NamedRef ref, ContentKey key) {
+    return check(CheckType.READ_CONTENT_KEY, ref, key);
   }
 
   static Check canReadContentKey(NamedRef ref, IdentifiedContentKey identifiedKey) {

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -513,12 +513,14 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
     Set<Check> checks = newHashSetWithExpectedSize(operations.size());
     for (Operation op : operations) {
-      if (op instanceof Operation.Put) {
-        checks.add(canReadContentKey(endRef.getValue(), identifiedKeys.get(op.getKey())));
-      } else if (op instanceof Operation.Delete) {
-        checks.add(canReadContentKey(endRef.getValue(), identifiedKeys.get(op.getKey())));
-      } else {
+      if (!(op instanceof Operation.Put) && !(op instanceof Operation.Delete)) {
         throw new IllegalStateException("Unknown operation " + op);
+      }
+      IdentifiedContentKey identifiedKey = identifiedKeys.get(op.getKey());
+      if (identifiedKey != null) {
+        checks.add(canReadContentKey(endRef.getValue(), identifiedKey));
+      } else {
+        checks.add(canReadContentKey(endRef.getValue(), op.getKey()));
       }
     }
 
@@ -533,13 +535,15 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
     Map<Check, String> failures = anyCheck ? accessCheck.check() : emptyMap();
 
     for (Operation op : operations) {
-      Check check;
-      if (op instanceof Operation.Put) {
-        check = canReadContentKey(endRef.getValue(), identifiedKeys.get(op.getKey()));
-      } else if (op instanceof Operation.Delete) {
-        check = canReadContentKey(endRef.getValue(), identifiedKeys.get(op.getKey()));
-      } else {
+      if (!(op instanceof Operation.Put) && !(op instanceof Operation.Delete)) {
         throw new IllegalStateException("Unknown operation " + op);
+      }
+      IdentifiedContentKey identifiedKey = identifiedKeys.get(op.getKey());
+      Check check;
+      if (identifiedKey != null) {
+        check = canReadContentKey(endRef.getValue(), identifiedKey);
+      } else {
+        check = canReadContentKey(endRef.getValue(), op.getKey());
       }
       if (failures.containsKey(check)) {
         failedChecks.add(check);

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestAccessChecks.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestAccessChecks.java
@@ -451,4 +451,56 @@ public abstract class AbstractTestAccessChecks extends BaseTestServiceImpl {
           .hasMessageContaining(VIEW_MSG);
     }
   }
+
+  @Test
+  public void testCheckReadContentKeyOnDeletedEntity() throws Exception {
+    Branch main = createBranch("testCheckReadContentKeyOnDeletedEntity");
+
+    main =
+        commit(
+                main,
+                CommitMeta.fromMessage("commit 1"),
+                Put.of(ContentKey.of("t1"), IcebergTable.of("m1", 1, 2, 3, 4)),
+                Put.of(ContentKey.of("t2"), IcebergTable.of("m2", 1, 2, 3, 4)))
+            .getTargetBranch();
+    String parentHash = main.getHash();
+
+    main =
+        commit(main, CommitMeta.fromMessage("commit 1"), Delete.of(ContentKey.of("t2")))
+            .getTargetBranch();
+
+    Set<Check> checks = recordAccessChecks();
+    commitLog(main.getName(), ALL, null);
+
+    assertThat(checks)
+        .satisfiesOnlyOnce(
+            check -> {
+              assertThat(check.type()).isEqualTo(CheckType.READ_CONTENT_KEY);
+              assertThat(check.key()).isEqualTo(ContentKey.of("t1"));
+              assertThat(check.contentId()).isNotNull();
+            })
+        .satisfiesOnlyOnce(
+            check -> {
+              assertThat(check.type()).isEqualTo(CheckType.READ_CONTENT_KEY);
+              assertThat(check.key()).isEqualTo(ContentKey.of("t2"));
+              assertThat(check.contentId()).isNull(); // t2 doesn't exist
+            });
+
+    checks = recordAccessChecks();
+    commitLog(main.getName(), ALL, null, parentHash, null);
+
+    assertThat(checks)
+        .satisfiesOnlyOnce(
+            check -> {
+              assertThat(check.type()).isEqualTo(CheckType.READ_CONTENT_KEY);
+              assertThat(check.key()).isEqualTo(ContentKey.of("t1"));
+              assertThat(check.contentId()).isNotNull();
+            })
+        .satisfiesOnlyOnce(
+            check -> {
+              assertThat(check.type()).isEqualTo(CheckType.READ_CONTENT_KEY);
+              assertThat(check.key()).isEqualTo(ContentKey.of("t2"));
+              assertThat(check.contentId()).isNotNull(); // t2 still exists
+            });
+  }
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -682,7 +682,7 @@ public class VersionStoreImpl implements VersionStore {
             key -> {
               StoreKey storeKey = keyToStoreKey(key);
               StoreIndexElement<CommitOp> indexElement = index.get(storeKey);
-              if (indexElement == null || !indexElement.content().action().exists()) {
+              if (indexElement == null) {
                 return null;
               }
               CommitOp content = indexElement.content();

--- a/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractEntries.java
+++ b/versioned/tests/src/main/java/org/projectnessie/versioned/tests/AbstractEntries.java
@@ -250,5 +250,21 @@ public abstract class AbstractEntries extends AbstractNestedVersionStore {
                 .identifiedKey()
                 .elements()
                 .toArray(new IdentifiedContentKey.IdentifiedElement[0]));
+
+    commit = commit("Second Commit").delete(key2a).toBranch(branch);
+
+    try (PaginationIterator<KeyEntry> iter =
+        store.getKeys(commit, null, true, NO_KEY_RESTRICTIONS)) {
+      soft.assertThat(iter)
+          .toIterable()
+          .extracting(KeyEntry::getKey, KeyEntry::getContent)
+          .containsExactlyInAnyOrder(
+              tuple(content2.identifiedKey(), content2.content()),
+              tuple(content23.identifiedKey(), content23.content()),
+              tuple(content23a.identifiedKey(), content23a.content()));
+    }
+
+    soft.assertThat(store.getIdentifiedKeys(commit, newArrayList(key2a)))
+        .containsOnly(content2a.identifiedKey());
   }
 }


### PR DESCRIPTION
Fixes #7885.

This commit fixes a potential NPE when fetching commit log entries with fetch option `ALL` and access checks enabled.

The fix is twofold: first, fix `TreeApiImpl` that was incorrectly omitting content keys when creating checks for operations; when the identified key is not available; secondly, fix `CelBatchAccessChecker` that wasn't being resilient to empty script parameters.