### PR TITLE
HttpClient: properly close resources

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -157,6 +157,7 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
             }
           }
         }
+        httpClient.close();
         if (password != null) {
           Arrays.fill(password, (byte) 0);
         }

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -242,6 +242,7 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
             .isHttp11Only(!http2Upgrade)
             .followRedirects(followRedirects)
             .forceUrlConnectionClient(forceUrlConnectionClient)
+            .authentication(authentication)
             .build();
 
     return ImplSwitch.FACTORY.apply(config);


### PR DESCRIPTION
Two resources weren't being properly closed: 

1. the `HttpAuthentication` object in `HttpRuntimeConfig`;
2. the `HttpClient` in `OAuth2Client`.