### PR TITLE
Custom obj types should not persist class name

### DIFF
--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
@@ -273,7 +273,7 @@ public class CassandraPersist implements Persist {
         row -> {
           ObjType objType = ObjTypes.forName(requireNonNull(row.getString(COL_OBJ_TYPE.name())));
           ObjId id = deserializeObjId(row.getString(COL_OBJ_ID.name()));
-          return ObjSerializers.forType(objType).deserialize(row, id);
+          return ObjSerializers.forType(objType).deserialize(row, objType, id);
         };
 
     Obj[] r;
@@ -464,7 +464,7 @@ public class CassandraPersist implements Persist {
         }
 
         ObjId id = deserializeObjId(row.getString(COL_OBJ_ID.name()));
-        return ObjSerializers.forType(type).deserialize(row, id);
+        return ObjSerializers.forType(type).deserialize(row, type, id);
       }
     }
   }

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/CommitObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/CommitObjSerializer.java
@@ -38,6 +38,7 @@ import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.objtypes.CommitType;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.HeaderEntry;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Headers;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Stripe;
@@ -155,7 +156,7 @@ public class CommitObjSerializer implements ObjSerializer<CommitObj> {
   }
 
   @Override
-  public CommitObj deserialize(Row row, ObjId id) {
+  public CommitObj deserialize(Row row, ObjType type, ObjId id) {
     CommitObj.Builder b =
         CommitObj.commitBuilder()
             .id(id)

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/ContentValueObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/ContentValueObjSerializer.java
@@ -32,6 +32,7 @@ import org.projectnessie.versioned.storage.cassandra.CqlColumnType;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.objtypes.ContentValueObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj> {
 
@@ -80,7 +81,7 @@ public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj>
   }
 
   @Override
-  public ContentValueObj deserialize(Row row, ObjId id) {
+  public ContentValueObj deserialize(Row row, ObjType type, ObjId id) {
     ByteString value = CassandraSerde.deserializeBytes(row, COL_VALUE_DATA.name());
     if (value != null) {
       return contentValue(

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/IndexObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/IndexObjSerializer.java
@@ -32,6 +32,7 @@ import org.projectnessie.versioned.storage.cassandra.CqlColumnType;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.objtypes.IndexObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class IndexObjSerializer implements ObjSerializer<IndexObj> {
 
@@ -78,7 +79,7 @@ public class IndexObjSerializer implements ObjSerializer<IndexObj> {
   }
 
   @Override
-  public IndexObj deserialize(Row row, ObjId id) {
+  public IndexObj deserialize(Row row, ObjType type, ObjId id) {
     ByteString indexValue = CassandraSerde.deserializeBytes(row, COL_INDEX_INDEX.name());
     if (indexValue != null) {
       return index(id, indexValue);

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/IndexSegmentsObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/IndexSegmentsObjSerializer.java
@@ -36,6 +36,7 @@ import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeExceptio
 import org.projectnessie.versioned.storage.common.objtypes.IndexSegmentsObj;
 import org.projectnessie.versioned.storage.common.objtypes.IndexStripe;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Stripe;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Stripes;
 
@@ -91,7 +92,7 @@ public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsOb
   }
 
   @Override
-  public IndexSegmentsObj deserialize(Row row, ObjId id) {
+  public IndexSegmentsObj deserialize(Row row, ObjType type, ObjId id) {
     try {
       Stripes stripes = Stripes.parseFrom(row.getByteBuffer(COL_SEGMENTS_STRIPES.name()));
       List<IndexStripe> stripeList =

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/ObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/ObjSerializer.java
@@ -22,6 +22,7 @@ import org.projectnessie.versioned.storage.cassandra.CqlColumn;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public interface ObjSerializer<O extends Obj> {
 
@@ -33,5 +34,5 @@ public interface ObjSerializer<O extends Obj> {
       O obj, BoundStatementBuilder stmt, int incrementalIndexLimit, int maxSerializedIndexSize)
       throws ObjTooLargeException;
 
-  O deserialize(Row row, ObjId id);
+  O deserialize(Row row, ObjType type, ObjId id);
 }

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/RefObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/RefObjSerializer.java
@@ -31,6 +31,7 @@ import org.projectnessie.versioned.storage.cassandra.CqlColumnType;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.objtypes.RefObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class RefObjSerializer implements ObjSerializer<RefObj> {
 
@@ -83,7 +84,7 @@ public class RefObjSerializer implements ObjSerializer<RefObj> {
   }
 
   @Override
-  public RefObj deserialize(Row row, ObjId id) {
+  public RefObj deserialize(Row row, ObjType type, ObjId id) {
     return ref(
         id,
         row.getString(COL_REF_NAME.name()),

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/StringObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/StringObjSerializer.java
@@ -32,6 +32,7 @@ import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeExceptio
 import org.projectnessie.versioned.storage.common.objtypes.Compression;
 import org.projectnessie.versioned.storage.common.objtypes.StringObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class StringObjSerializer implements ObjSerializer<StringObj> {
 
@@ -95,7 +96,7 @@ public class StringObjSerializer implements ObjSerializer<StringObj> {
   }
 
   @Override
-  public StringObj deserialize(Row row, ObjId id) {
+  public StringObj deserialize(Row row, ObjType type, ObjId id) {
     return stringData(
         id,
         row.getString(COL_STRING_CONTENT_TYPE.name()),

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/TagObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/TagObjSerializer.java
@@ -35,6 +35,7 @@ import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeExceptio
 import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
 import org.projectnessie.versioned.storage.common.objtypes.TagObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.HeaderEntry;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Headers;
 
@@ -93,7 +94,7 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
   }
 
   @Override
-  public TagObj deserialize(Row row, ObjId id) {
+  public TagObj deserialize(Row row, ObjType type, ObjId id) {
     CommitHeaders tagHeaders = null;
     try {
       Headers headers = Headers.parseFrom(row.getByteBuffer(COL_TAG_HEADERS.name()));

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/UniqueIdObjSerializer.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/serializers/UniqueIdObjSerializer.java
@@ -31,6 +31,7 @@ import org.projectnessie.versioned.storage.cassandra.CqlColumnType;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
 
@@ -76,7 +77,7 @@ public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
   }
 
   @Override
-  public UniqueIdObj deserialize(Row row, ObjId id) {
+  public UniqueIdObj deserialize(Row row, ObjType type, ObjId id) {
     return uniqueId(
         id,
         row.getString(COL_UNIQUE_SPACE.name()),

--- a/versioned/storage/common-proto/src/main/proto/org/projectnessie/versioned/storage/common/proto/storage.proto
+++ b/versioned/storage/common-proto/src/main/proto/org/projectnessie/versioned/storage/common/proto/storage.proto
@@ -141,7 +141,7 @@ message ReferencePreviousProto {
 }
 
 message CustomProto {
-  string target_class = 1;
+  string obj_type = 1;
   bytes data = 2;
   CompressionProto compression = 3;
 }

--- a/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/ProtoSerialization.java
+++ b/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/ProtoSerialization.java
@@ -54,6 +54,8 @@ import org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj;
 import org.projectnessie.versioned.storage.common.persist.ImmutableReference;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
+import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.persist.Reference;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.CommitProto;
@@ -510,16 +512,13 @@ public final class ProtoSerialization {
   }
 
   private static Obj deserializeCustom(ObjId id, CustomProto custom) {
+    ObjType type = ObjTypes.forShortName(custom.getObjType());
     return SmileSerialization.deserializeObj(
-        id,
-        custom.getData().toByteArray(),
-        custom.getTargetClass(),
-        custom.getCompression().name());
+        id, custom.getData().toByteArray(), type.targetClass(), custom.getCompression().name());
   }
 
   private static CustomProto.Builder serializeCustom(Obj obj) {
-    CustomProto.Builder builder =
-        CustomProto.newBuilder().setTargetClass(obj.type().targetClass().getName());
+    CustomProto.Builder builder = CustomProto.newBuilder().setObjType(obj.type().shortName());
     byte[] bytes =
         SmileSerialization.serializeObj(
             obj,

--- a/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/SmileSerialization.java
+++ b/versioned/storage/common-serialize/src/main/java/org/projectnessie/versioned/storage/serialize/SmileSerialization.java
@@ -27,6 +27,8 @@ import org.projectnessie.versioned.storage.common.json.ObjIdHelper;
 import org.projectnessie.versioned.storage.common.objtypes.Compression;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
+import org.projectnessie.versioned.storage.common.persist.ObjTypes;
 import org.projectnessie.versioned.storage.common.util.Compressions;
 
 public final class SmileSerialization {
@@ -35,26 +37,14 @@ public final class SmileSerialization {
 
   private SmileSerialization() {}
 
-  public static Obj deserializeObj(
-      ObjId id, byte[] data, String targetClassFqdn, String compression) {
-    try {
-      @SuppressWarnings("unchecked")
-      Class<? extends Obj> targetClass = (Class<? extends Obj>) Class.forName(targetClassFqdn);
-      return deserializeObj(id, data, targetClass, compression);
-    } catch (ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+  public static Obj deserializeObj(ObjId id, byte[] data, String typeName, String compression) {
+    ObjType type = ObjTypes.forName(typeName);
+    return deserializeObj(id, data, type.targetClass(), compression);
   }
 
-  public static Obj deserializeObj(
-      ObjId id, ByteBuffer data, String targetClassFqdn, String compression) {
-    try {
-      @SuppressWarnings("unchecked")
-      Class<? extends Obj> targetClass = (Class<? extends Obj>) Class.forName(targetClassFqdn);
-      return deserializeObj(id, data, targetClass, compression);
-    } catch (ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+  public static Obj deserializeObj(ObjId id, ByteBuffer data, String typeName, String compression) {
+    ObjType type = ObjTypes.forName(typeName);
+    return deserializeObj(id, data, type.targetClass(), compression);
   }
 
   public static Obj deserializeObj(

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/objtypes/AnotherTestBean.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/objtypes/AnotherTestBean.java
@@ -15,15 +15,32 @@
  */
 package org.projectnessie.versioned.storage.commontests.objtypes;
 
-import java.util.function.Consumer;
-import org.projectnessie.versioned.storage.common.persist.ObjType;
-import org.projectnessie.versioned.storage.common.persist.ObjTypeBundle;
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.projectnessie.versioned.storage.common.persist.ObjId;
 
-public class CustomObjTypeBundle implements ObjTypeBundle {
+public interface AnotherTestBean {
 
-  @Override
-  public void register(Consumer<ObjType> registrar) {
-    registrar.accept(SimpleTestObj.TYPE);
-    registrar.accept(AnotherTestObj.TYPE);
-  }
+  @Nullable
+  ObjId parent();
+
+  @Nullable
+  String text();
+
+  @Nullable
+  Number number();
+
+  @Nullable
+  Map<String, String> map();
+
+  @Nullable
+  List<String> list();
+
+  @Nullable
+  Instant instant();
+
+  Optional<String> optional();
 }

--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/objtypes/AnotherTestObj.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/objtypes/AnotherTestObj.java
@@ -15,15 +15,26 @@
  */
 package org.projectnessie.versioned.storage.commontests.objtypes;
 
-import java.util.function.Consumer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+import org.projectnessie.versioned.storage.common.objtypes.SimpleObjType;
+import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjType;
-import org.projectnessie.versioned.storage.common.persist.ObjTypeBundle;
 
-public class CustomObjTypeBundle implements ObjTypeBundle {
+@Value.Immutable
+@JsonSerialize(as = ImmutableAnotherTestObj.class)
+@JsonDeserialize(as = ImmutableAnotherTestObj.class)
+public interface AnotherTestObj extends Obj, AnotherTestBean {
+
+  ObjType TYPE = new SimpleObjType<>("another", "oth", AnotherTestObj.class);
 
   @Override
-  public void register(Consumer<ObjType> registrar) {
-    registrar.accept(SimpleTestObj.TYPE);
-    registrar.accept(AnotherTestObj.TYPE);
+  default ObjType type() {
+    return TYPE;
+  }
+
+  static ImmutableAnotherTestObj.Builder builder() {
+    return ImmutableAnotherTestObj.builder();
   }
 }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
@@ -514,7 +514,7 @@ public class DynamoDBPersist implements Persist {
     ObjType type = ObjTypes.forShortName(attributeValue.s());
     ObjSerializer<?> serializer = ObjSerializers.forType(type);
     Map<String, AttributeValue> inner = item.get(serializer.attributeName()).m();
-    return serializer.fromMap(id, inner);
+    return serializer.fromMap(id, type, inner);
   }
 
   @Nonnull

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/CommitObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/CommitObjSerializer.java
@@ -42,6 +42,7 @@ import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.objtypes.CommitType;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class CommitObjSerializer implements ObjSerializer<CommitObj> {
@@ -112,7 +113,7 @@ public class CommitObjSerializer implements ObjSerializer<CommitObj> {
   }
 
   @Override
-  public CommitObj fromMap(ObjId id, Map<String, AttributeValue> i) {
+  public CommitObj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i) {
     CommitObj.Builder b =
         commitBuilder()
             .id(id)

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ContentValueObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ContentValueObjSerializer.java
@@ -25,6 +25,7 @@ import static software.amazon.awssdk.services.dynamodb.model.AttributeValue.from
 import java.util.Map;
 import org.projectnessie.versioned.storage.common.objtypes.ContentValueObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj> {
@@ -56,7 +57,7 @@ public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj>
   }
 
   @Override
-  public ContentValueObj fromMap(ObjId id, Map<String, AttributeValue> i) {
+  public ContentValueObj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i) {
     return contentValue(
         id,
         attributeToString(i, COL_VALUE_CONTENT_ID),

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/IndexObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/IndexObjSerializer.java
@@ -25,6 +25,7 @@ import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.objtypes.IndexObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class IndexObjSerializer implements ObjSerializer<IndexObj> {
@@ -56,7 +57,7 @@ public class IndexObjSerializer implements ObjSerializer<IndexObj> {
   }
 
   @Override
-  public IndexObj fromMap(ObjId id, Map<String, AttributeValue> i) {
+  public IndexObj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i) {
     return index(id, requireNonNull(attributeToBytes(i, COL_INDEX_INDEX)));
   }
 }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/IndexSegmentsObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/IndexSegmentsObjSerializer.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.projectnessie.versioned.storage.common.objtypes.IndexSegmentsObj;
 import org.projectnessie.versioned.storage.common.objtypes.IndexStripe;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsObj> {
@@ -51,7 +52,7 @@ public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsOb
   }
 
   @Override
-  public IndexSegmentsObj fromMap(ObjId id, Map<String, AttributeValue> i) {
+  public IndexSegmentsObj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i) {
     List<IndexStripe> stripes = new ArrayList<>();
     fromStripesAttrList(i.get(COL_SEGMENTS_STRIPES), stripes::add);
     return indexSegments(id, stripes);

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ObjSerializer.java
@@ -35,5 +35,5 @@ public interface ObjSerializer<O extends Obj> {
       O obj, Map<String, AttributeValue> i, int incrementalIndexSize, int maxSerializedIndexSize)
       throws ObjTooLargeException;
 
-  O fromMap(ObjId id, Map<String, AttributeValue> i);
+  O fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i);
 }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ObjSerializers.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/ObjSerializers.java
@@ -51,7 +51,7 @@ public final class ObjSerializers {
 
   @Nonnull
   public static ObjSerializer<Obj> forType(@Nonnull ObjType type) {
-    ObjSerializer<?> serializer = CustomObjSerializer.INSTANCE;
+    ObjSerializer<?> serializer;
     if (type instanceof StandardObjType) {
       switch ((StandardObjType) type) {
         case COMMIT:
@@ -81,6 +81,8 @@ public final class ObjSerializers {
         default:
           throw new IllegalArgumentException("Unknown standard object type: " + type);
       }
+    } else {
+      serializer = CustomObjSerializer.INSTANCE;
     }
     @SuppressWarnings("unchecked")
     ObjSerializer<Obj> cast = (ObjSerializer<Obj>) serializer;

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/RefObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/RefObjSerializer.java
@@ -24,6 +24,7 @@ import static software.amazon.awssdk.services.dynamodb.model.AttributeValue.from
 import java.util.Map;
 import org.projectnessie.versioned.storage.common.objtypes.RefObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class RefObjSerializer implements ObjSerializer<RefObj> {
@@ -60,7 +61,7 @@ public class RefObjSerializer implements ObjSerializer<RefObj> {
   }
 
   @Override
-  public RefObj fromMap(ObjId id, Map<String, AttributeValue> i) {
+  public RefObj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i) {
     String createdAtStr = attributeToString(i, COL_REF_CREATED_AT);
     long createdAt = createdAtStr != null ? Long.parseLong(createdAtStr) : 0L;
     return ref(

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/StringObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/StringObjSerializer.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.projectnessie.versioned.storage.common.objtypes.Compression;
 import org.projectnessie.versioned.storage.common.objtypes.StringObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class StringObjSerializer implements ObjSerializer<StringObj> {
@@ -70,7 +71,7 @@ public class StringObjSerializer implements ObjSerializer<StringObj> {
   }
 
   @Override
-  public StringObj fromMap(ObjId id, Map<String, AttributeValue> i) {
+  public StringObj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i) {
     List<ObjId> predecessors = new ArrayList<>();
     attributeToObjIds(i, COL_STRING_PREDECESSORS, predecessors::add);
     return stringData(

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/TagObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/TagObjSerializer.java
@@ -31,6 +31,7 @@ import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
 import org.projectnessie.versioned.storage.common.objtypes.TagObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class TagObjSerializer implements ObjSerializer<TagObj> {
@@ -84,7 +85,7 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
   }
 
   @Override
-  public TagObj fromMap(ObjId id, Map<String, AttributeValue> i) {
+  public TagObj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i) {
     CommitHeaders tagHeaders = null;
     AttributeValue headerMap = i.get(COL_TAG_HEADERS);
     if (headerMap != null) {

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/UniqueIdObjSerializer.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/serializers/UniqueIdObjSerializer.java
@@ -24,6 +24,7 @@ import static software.amazon.awssdk.services.dynamodb.model.AttributeValue.from
 import java.util.Map;
 import org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
@@ -53,7 +54,7 @@ public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
   }
 
   @Override
-  public UniqueIdObj fromMap(ObjId id, Map<String, AttributeValue> i) {
+  public UniqueIdObj fromMap(ObjId id, ObjType type, Map<String, AttributeValue> i) {
     return uniqueId(
         id, attributeToString(i, COL_UNIQUE_SPACE), attributeToBytes(i, COL_UNIQUE_VALUE));
   }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -425,7 +425,7 @@ abstract class AbstractJdbcPersist implements Persist {
     String objType = rs.getString(COL_OBJ_TYPE);
     ObjType type = ObjTypes.forName(objType);
     ObjSerializer<Obj> serializer = ObjSerializers.forType(type);
-    return serializer.deserialize(rs, id);
+    return serializer.deserialize(rs, type, id);
   }
 
   protected final boolean storeObj(

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/CommitObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/CommitObjSerializer.java
@@ -38,6 +38,7 @@ import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
 import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.objtypes.CommitType;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.HeaderEntry;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Headers;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Stripe;
@@ -139,7 +140,7 @@ public class CommitObjSerializer implements ObjSerializer<CommitObj> {
   }
 
   @Override
-  public CommitObj deserialize(ResultSet rs, ObjId id) throws SQLException {
+  public CommitObj deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException {
     CommitObj.Builder b =
         CommitObj.commitBuilder()
             .id(id)

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/ContentValueObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/ContentValueObjSerializer.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.projectnessie.versioned.storage.common.objtypes.ContentValueObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.jdbc.DatabaseSpecific;
 import org.projectnessie.versioned.storage.jdbc.JdbcColumnType;
 
@@ -67,7 +68,7 @@ public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj>
   }
 
   @Override
-  public ContentValueObj deserialize(ResultSet rs, ObjId id) throws SQLException {
+  public ContentValueObj deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException {
     return contentValue(
         id,
         rs.getString(COL_VALUE_CONTENT_ID),

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/IndexObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/IndexObjSerializer.java
@@ -29,6 +29,7 @@ import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.objtypes.IndexObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.jdbc.DatabaseSpecific;
 import org.projectnessie.versioned.storage.jdbc.JdbcColumnType;
 
@@ -65,7 +66,7 @@ public class IndexObjSerializer implements ObjSerializer<IndexObj> {
   }
 
   @Override
-  public IndexObj deserialize(ResultSet rs, ObjId id) throws SQLException {
+  public IndexObj deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException {
     ByteString index = deserializeBytes(rs, COL_INDEX_INDEX);
     if (index != null) {
       return index(id, index);

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/IndexSegmentsObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/IndexSegmentsObjSerializer.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.projectnessie.versioned.storage.common.objtypes.IndexSegmentsObj;
 import org.projectnessie.versioned.storage.common.objtypes.IndexStripe;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Stripe;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Stripes;
 import org.projectnessie.versioned.storage.jdbc.DatabaseSpecific;
@@ -77,7 +78,7 @@ public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsOb
   }
 
   @Override
-  public IndexSegmentsObj deserialize(ResultSet rs, ObjId id) throws SQLException {
+  public IndexSegmentsObj deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException {
     try {
       Stripes stripes = Stripes.parseFrom(rs.getBytes(COL_SEGMENTS_STRIPES));
       List<IndexStripe> stripeList =

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/ObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/ObjSerializer.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.jdbc.DatabaseSpecific;
 import org.projectnessie.versioned.storage.jdbc.JdbcColumnType;
 
@@ -40,7 +41,7 @@ public interface ObjSerializer<O extends Obj> {
       DatabaseSpecific databaseSpecific)
       throws SQLException, ObjTooLargeException;
 
-  O deserialize(ResultSet rs, ObjId id) throws SQLException;
+  O deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException;
 
   default void setNull(
       PreparedStatement ps, Function<String, Integer> nameToIdx, DatabaseSpecific databaseSpecific)

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/RefObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/RefObjSerializer.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.projectnessie.versioned.storage.common.objtypes.RefObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.jdbc.DatabaseSpecific;
 import org.projectnessie.versioned.storage.jdbc.JdbcColumnType;
 
@@ -71,7 +72,7 @@ public class RefObjSerializer implements ObjSerializer<RefObj> {
   }
 
   @Override
-  public RefObj deserialize(ResultSet rs, ObjId id) throws SQLException {
+  public RefObj deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException {
     return ref(
         id,
         rs.getString(COL_REF_NAME),

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/StringObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/StringObjSerializer.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import org.projectnessie.versioned.storage.common.objtypes.Compression;
 import org.projectnessie.versioned.storage.common.objtypes.StringObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.jdbc.DatabaseSpecific;
 import org.projectnessie.versioned.storage.jdbc.JdbcColumnType;
 
@@ -76,7 +77,7 @@ public class StringObjSerializer implements ObjSerializer<StringObj> {
   }
 
   @Override
-  public StringObj deserialize(ResultSet rs, ObjId id) throws SQLException {
+  public StringObj deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException {
     return stringData(
         id,
         rs.getString(COL_STRING_CONTENT_TYPE),

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/TagObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/TagObjSerializer.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
 import org.projectnessie.versioned.storage.common.objtypes.TagObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.HeaderEntry;
 import org.projectnessie.versioned.storage.common.proto.StorageTypes.Headers;
 import org.projectnessie.versioned.storage.jdbc.DatabaseSpecific;
@@ -77,7 +78,7 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
   }
 
   @Override
-  public TagObj deserialize(ResultSet rs, ObjId id) throws SQLException {
+  public TagObj deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException {
     CommitHeaders tagHeaders = null;
     try {
       Headers headers = Headers.parseFrom(deserializeBytes(rs, COL_TAG_HEADERS));

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/UniqueIdObjSerializer.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/serializers/UniqueIdObjSerializer.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.jdbc.DatabaseSpecific;
 import org.projectnessie.versioned.storage.jdbc.JdbcColumnType;
 
@@ -63,7 +64,7 @@ public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
   }
 
   @Override
-  public UniqueIdObj deserialize(ResultSet rs, ObjId id) throws SQLException {
+  public UniqueIdObj deserialize(ResultSet rs, ObjType type, ObjId id) throws SQLException {
     return uniqueId(id, rs.getString(COL_UNIQUE_SPACE), deserializeBytes(rs, COL_UNIQUE_VALUE));
   }
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -549,7 +549,7 @@ public class MongoDBPersist implements Persist {
     ObjType type = ObjTypes.forShortName(doc.getString(COL_OBJ_TYPE));
     ObjSerializer<?> serializer = ObjSerializers.forType(type);
     Document inner = doc.get(serializer.fieldName(), Document.class);
-    return serializer.docToObj(id, inner);
+    return serializer.docToObj(id, type, inner);
   }
 
   private Document objToDoc(@Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/CommitObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/CommitObjSerializer.java
@@ -36,6 +36,7 @@ import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
 import org.projectnessie.versioned.storage.common.objtypes.CommitType;
 import org.projectnessie.versioned.storage.common.objtypes.IndexStripe;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class CommitObjSerializer implements ObjSerializer<CommitObj> {
 
@@ -101,7 +102,7 @@ public class CommitObjSerializer implements ObjSerializer<CommitObj> {
   }
 
   @Override
-  public CommitObj docToObj(ObjId id, Document doc) {
+  public CommitObj docToObj(ObjId id, ObjType type, Document doc) {
     CommitObj.Builder b =
         commitBuilder()
             .id(id)

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/ContentValueObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/ContentValueObjSerializer.java
@@ -23,6 +23,7 @@ import org.bson.Document;
 import org.bson.types.Binary;
 import org.projectnessie.versioned.storage.common.objtypes.ContentValueObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj> {
 
@@ -50,7 +51,7 @@ public class ContentValueObjSerializer implements ObjSerializer<ContentValueObj>
   }
 
   @Override
-  public ContentValueObj docToObj(ObjId id, Document doc) {
+  public ContentValueObj docToObj(ObjId id, ObjType type, Document doc) {
     return contentValue(
         id,
         doc.getString(COL_VALUE_CONTENT_ID),

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/CustomObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/CustomObjSerializer.java
@@ -20,6 +20,7 @@ import org.bson.types.Binary;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 import org.projectnessie.versioned.storage.serialize.SmileSerialization;
 
 public class CustomObjSerializer implements ObjSerializer<Obj> {
@@ -28,7 +29,6 @@ public class CustomObjSerializer implements ObjSerializer<Obj> {
 
   private static final String COL_CUSTOM = "x";
 
-  private static final String COL_CUSTOM_CLASS = "xc";
   private static final String COL_CUSTOM_DATA = "xd";
   private static final String COL_CUSTOM_COMPRESSION = "xC";
 
@@ -42,7 +42,6 @@ public class CustomObjSerializer implements ObjSerializer<Obj> {
   @Override
   public void objToDoc(Obj obj, Document doc, int incrementalIndexLimit, int maxSerializedIndexSize)
       throws ObjTooLargeException {
-    doc.put(COL_CUSTOM_CLASS, obj.type().targetClass().getName());
     doc.put(
         COL_CUSTOM_DATA,
         new Binary(
@@ -51,9 +50,9 @@ public class CustomObjSerializer implements ObjSerializer<Obj> {
   }
 
   @Override
-  public Obj docToObj(ObjId id, Document doc) {
+  public Obj docToObj(ObjId id, ObjType type, Document doc) {
     byte[] data = doc.get(COL_CUSTOM_DATA, Binary.class).getData();
     return SmileSerialization.deserializeObj(
-        id, data, doc.getString(COL_CUSTOM_CLASS), doc.getString(COL_CUSTOM_COMPRESSION));
+        id, data, type.targetClass(), doc.getString(COL_CUSTOM_COMPRESSION));
   }
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/IndexObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/IndexObjSerializer.java
@@ -25,6 +25,7 @@ import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.objtypes.IndexObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class IndexObjSerializer implements ObjSerializer<IndexObj> {
 
@@ -52,7 +53,7 @@ public class IndexObjSerializer implements ObjSerializer<IndexObj> {
   }
 
   @Override
-  public IndexObj docToObj(ObjId id, Document doc) {
+  public IndexObj docToObj(ObjId id, ObjType type, Document doc) {
     return index(id, binaryToBytes(doc.get(COL_INDEX_INDEX, Binary.class)));
   }
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/IndexSegmentsObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/IndexSegmentsObjSerializer.java
@@ -25,6 +25,7 @@ import org.bson.Document;
 import org.projectnessie.versioned.storage.common.objtypes.IndexSegmentsObj;
 import org.projectnessie.versioned.storage.common.objtypes.IndexStripe;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsObj> {
 
@@ -47,7 +48,7 @@ public class IndexSegmentsObjSerializer implements ObjSerializer<IndexSegmentsOb
   }
 
   @Override
-  public IndexSegmentsObj docToObj(ObjId id, Document doc) {
+  public IndexSegmentsObj docToObj(ObjId id, ObjType type, Document doc) {
     List<IndexStripe> stripes = new ArrayList<>();
     fromStripesDocList(doc, COL_SEGMENTS_STRIPES, stripes::add);
     return indexSegments(id, stripes);

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/ObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/ObjSerializer.java
@@ -32,5 +32,5 @@ public interface ObjSerializer<O extends Obj> {
   void objToDoc(O obj, Document doc, int incrementalIndexLimit, int maxSerializedIndexSize)
       throws ObjTooLargeException;
 
-  O docToObj(ObjId id, Document doc);
+  O docToObj(ObjId id, ObjType type, Document doc);
 }

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/RefObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/RefObjSerializer.java
@@ -23,6 +23,7 @@ import org.bson.Document;
 import org.bson.types.Binary;
 import org.projectnessie.versioned.storage.common.objtypes.RefObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class RefObjSerializer implements ObjSerializer<RefObj> {
 
@@ -55,7 +56,7 @@ public class RefObjSerializer implements ObjSerializer<RefObj> {
   }
 
   @Override
-  public RefObj docToObj(ObjId id, Document doc) {
+  public RefObj docToObj(ObjId id, ObjType type, Document doc) {
     return ref(
         id,
         doc.getString(COL_REF_NAME),

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/StringObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/StringObjSerializer.java
@@ -26,6 +26,7 @@ import org.bson.types.Binary;
 import org.projectnessie.versioned.storage.common.objtypes.Compression;
 import org.projectnessie.versioned.storage.common.objtypes.StringObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class StringObjSerializer implements ObjSerializer<StringObj> {
 
@@ -63,7 +64,7 @@ public class StringObjSerializer implements ObjSerializer<StringObj> {
   }
 
   @Override
-  public StringObj docToObj(ObjId id, Document doc) {
+  public StringObj docToObj(ObjId id, ObjType type, Document doc) {
     return stringData(
         id,
         doc.getString(COL_STRING_CONTENT_TYPE),

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/TagObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/TagObjSerializer.java
@@ -27,6 +27,7 @@ import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
 import org.projectnessie.versioned.storage.common.objtypes.TagObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class TagObjSerializer implements ObjSerializer<TagObj> {
 
@@ -71,7 +72,7 @@ public class TagObjSerializer implements ObjSerializer<TagObj> {
   }
 
   @Override
-  public TagObj docToObj(ObjId id, Document doc) {
+  public TagObj docToObj(ObjId id, ObjType type, Document doc) {
     CommitHeaders tagHeaders = null;
     Document headerDoc = doc.get(COL_TAG_HEADERS, Document.class);
     if (headerDoc != null) {

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/UniqueIdObjSerializer.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/serializers/UniqueIdObjSerializer.java
@@ -23,6 +23,7 @@ import org.bson.Document;
 import org.bson.types.Binary;
 import org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
 
@@ -48,7 +49,7 @@ public class UniqueIdObjSerializer implements ObjSerializer<UniqueIdObj> {
   }
 
   @Override
-  public UniqueIdObj docToObj(ObjId id, Document doc) {
+  public UniqueIdObj docToObj(ObjId id, ObjType type, Document doc) {
     return uniqueId(
         id,
         doc.getString(COL_UNIQUE_SPACE),


### PR DESCRIPTION
Custom object types do not need to and should not persist the fully qualified _implementation_ class for the custom object type, because it can be inferred from the type. This saves a bunch of storage but more importantly allows later refactorings of custom obj types. Since custom object types are not used yet, this change is safe. Not changing the column names for CQL + SQL in case users have already migrated their tables.