### PR TITLE
remove unused jersey-test-framework-provider dependencies

### DIFF
--- a/compatibility/jersey/build.gradle.kts
+++ b/compatibility/jersey/build.gradle.kts
@@ -55,21 +55,6 @@ dependencies {
   implementation(
     "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2"
   )
-  implementation(
-    "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory"
-  )
-  implementation(
-    "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-external"
-  )
-  implementation(
-    "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jdk-http"
-  )
-  implementation(
-    "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-simple"
-  )
-  implementation(
-    "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jetty"
-  )
 
   implementation("org.jboss.weld.se:weld-se-core")
 }

--- a/servers/jax-rs-testextension/build.gradle.kts
+++ b/servers/jax-rs-testextension/build.gradle.kts
@@ -48,11 +48,6 @@ dependencies {
   api("org.glassfish.jersey.test-framework:jersey-test-framework-core")
   api("org.glassfish.jersey.test-framework:jersey-test-framework-util")
   api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2")
-  api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory")
-  api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-external")
-  api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jdk-http")
-  api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-simple")
-  api("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jetty")
 
   api("org.jboss.weld.se:weld-se-core")
 


### PR DESCRIPTION
one is supposed to select exactly one of the providers: https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/test-framework.html

our usage of JerseyTest uses the default (=grizzly2), so we can remove the hard dependency on the other providers.