### PR TITLE
Fix "unlimited" behavior flexible cache

### DIFF
--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CaffeineCacheBackend.java
@@ -139,8 +139,9 @@ abstract class CaffeineCacheBackend implements CacheBackend {
 
     try {
       byte[] serialized = serializeObj(obj, Integer.MAX_VALUE, Integer.MAX_VALUE, true);
-      CacheKeyValue keyValue =
-          cacheKeyValue(repositoryId, obj.id(), MICROSECONDS.toNanos(expiresAt));
+      long expiresAtNanos =
+          expiresAt == CACHE_UNLIMITED ? CACHE_UNLIMITED : MICROSECONDS.toNanos(expiresAt);
+      CacheKeyValue keyValue = cacheKeyValue(repositoryId, obj.id(), expiresAtNanos);
       cache().put(keyValue, serialized);
     } catch (ObjTooLargeException e) {
       // this should never happen

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/CacheTestObjTypeBundle.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/CacheTestObjTypeBundle.java
@@ -28,8 +28,23 @@ public class CacheTestObjTypeBundle implements ObjTypeBundle {
 
   @Override
   public void register(Consumer<ObjType> registrar) {
+    registrar.accept(DefaultCachingObj.TYPE);
     registrar.accept(NonCachingObj.TYPE);
     registrar.accept(DynamicCachingObj.TYPE);
+  }
+
+  @Value.Immutable
+  @JsonSerialize(as = ImmutableDefaultCachingObj.class)
+  @JsonDeserialize(as = ImmutableDefaultCachingObj.class)
+  interface DefaultCachingObj extends Obj {
+    ObjType TYPE = CustomObjType.customObjType("default-caching", "cd", DefaultCachingObj.class);
+
+    @Override
+    default ObjType type() {
+      return TYPE;
+    }
+
+    String value();
   }
 
   @Value.Immutable


### PR DESCRIPTION
The current code wrongly converts the `CACHE_UNLIMITED` constant to nanosecdons, which breaks the "unlimited" case in `CaffeineCacheBackend`.