### PR TITLE
improve HTTP client errors

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/http/ResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/ResponseContext.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.http;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import org.projectnessie.client.http.HttpClient.Method;
 
 /** Interface for the important parts of a response. This is created after executing the request. */
 public interface ResponseContext {
@@ -43,4 +44,6 @@ public interface ResponseContext {
   String getContentType();
 
   URI getRequestedUri();
+
+  Method getRequestedMethod();
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaRequest.java
@@ -131,7 +131,7 @@ final class JavaRequest extends BaseHttpRequest {
           throw new RuntimeException(e);
         }
 
-        JavaResponseContext responseContext = new JavaResponseContext(response);
+        JavaResponseContext responseContext = new JavaResponseContext(response, method);
 
         List<BiConsumer<ResponseContext, Exception>> callbacks = context.getResponseCallbacks();
         if (callbacks != null) {

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaResponseContext.java
@@ -39,9 +39,12 @@ final class JavaResponseContext implements ResponseContext {
 
   private final HttpResponse<InputStream> response;
   private final InputStream inputStream;
+  private final org.projectnessie.client.http.HttpClient.Method method;
 
-  JavaResponseContext(HttpResponse<InputStream> response) {
+  JavaResponseContext(
+      HttpResponse<InputStream> response, org.projectnessie.client.http.HttpClient.Method method) {
     this.response = response;
+    this.method = method;
 
     try {
       this.inputStream = maybeDecompress();
@@ -73,6 +76,11 @@ final class JavaResponseContext implements ResponseContext {
   @Override
   public URI getRequestedUri() {
     return response.uri();
+  }
+
+  @Override
+  public org.projectnessie.client.http.HttpClient.Method getRequestedMethod() {
+    return method;
   }
 
   private InputStream maybeDecompress() throws IOException {

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaResponseContext.java
@@ -27,6 +27,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
+import org.projectnessie.client.http.HttpClient.Method;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.Status;
 
@@ -39,10 +40,9 @@ final class JavaResponseContext implements ResponseContext {
 
   private final HttpResponse<InputStream> response;
   private final InputStream inputStream;
-  private final org.projectnessie.client.http.HttpClient.Method method;
+  private final Method method;
 
-  JavaResponseContext(
-      HttpResponse<InputStream> response, org.projectnessie.client.http.HttpClient.Method method) {
+  JavaResponseContext(HttpResponse<InputStream> response, Method method) {
     this.response = response;
     this.method = method;
 
@@ -79,7 +79,7 @@ final class JavaResponseContext implements ResponseContext {
   }
 
   @Override
-  public org.projectnessie.client.http.HttpClient.Method getRequestedMethod() {
+  public Method getRequestedMethod() {
     return method;
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionRequest.java
@@ -55,7 +55,7 @@ final class UrlConnectionRequest extends BaseHttpRequest {
         ((HttpsURLConnection) con).setSSLSocketFactory(config.getSslContext().getSocketFactory());
       }
       RequestContext context = new RequestContextImpl(headers, uri, method, body);
-      ResponseContext responseContext = new UrlConnectionResponseContext(con, uri);
+      ResponseContext responseContext = new UrlConnectionResponseContext(con, uri, method);
       try {
 
         boolean doesOutput = prepareRequest(context);

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionResponseContext.java
@@ -26,6 +26,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
+import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.Status;
 
@@ -33,10 +34,12 @@ final class UrlConnectionResponseContext implements ResponseContext {
 
   private final HttpURLConnection connection;
   private final URI uri;
+  private final HttpClient.Method method;
 
-  UrlConnectionResponseContext(HttpURLConnection connection, URI uri) {
+  UrlConnectionResponseContext(HttpURLConnection connection, URI uri, HttpClient.Method method) {
     this.connection = connection;
     this.uri = uri;
+    this.method = method;
   }
 
   @Override
@@ -62,6 +65,11 @@ final class UrlConnectionResponseContext implements ResponseContext {
   @Override
   public URI getRequestedUri() {
     return uri;
+  }
+
+  @Override
+  public HttpClient.Method getRequestedMethod() {
+    return method;
   }
 
   private InputStream maybeDecompress(InputStream inputStream) throws IOException {

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionResponseContext.java
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
-import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.HttpClient.Method;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.Status;
 
@@ -34,9 +34,9 @@ final class UrlConnectionResponseContext implements ResponseContext {
 
   private final HttpURLConnection connection;
   private final URI uri;
-  private final HttpClient.Method method;
+  private final Method method;
 
-  UrlConnectionResponseContext(HttpURLConnection connection, URI uri, HttpClient.Method method) {
+  UrlConnectionResponseContext(HttpURLConnection connection, URI uri, Method method) {
     this.connection = connection;
     this.uri = uri;
     this.method = method;
@@ -68,7 +68,7 @@ final class UrlConnectionResponseContext implements ResponseContext {
   }
 
   @Override
-  public HttpClient.Method getRequestedMethod() {
+  public Method getRequestedMethod() {
     return method;
   }
 

--- a/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.Status;
 import org.projectnessie.error.BaseNessieClientServerException;
@@ -261,6 +262,11 @@ public class TestResponseFilter {
                       public URI getRequestedUri() {
                         return null;
                       }
+
+                      @Override
+                      public HttpClient.Method getRequestedMethod() {
+                        return null;
+                      }
                     }))
         .isInstanceOf(NessieNotAuthorizedException.class)
         .hasMessageContaining("" + Status.UNAUTHORIZED.getCode())
@@ -306,6 +312,11 @@ public class TestResponseFilter {
                       public URI getRequestedUri() {
                         return null;
                       }
+
+                      @Override
+                      public HttpClient.Method getRequestedMethod() {
+                        return null;
+                      }
                     }))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("" + Status.NOT_IMPLEMENTED.getCode())
@@ -321,7 +332,7 @@ public class TestResponseFilter {
         .isInstanceOf(NessieNotAuthorizedException.class)
         .hasMessageContaining("" + Status.UNAUTHORIZED.getCode())
         .hasMessageContaining(Status.UNAUTHORIZED.getReason())
-        .hasMessageContaining("Could not parse error object in response");
+        .hasMessageContaining("HTTP response was empty");
   }
 
   @Test
@@ -403,7 +414,7 @@ public class TestResponseFilter {
     @Override
     public InputStream getErrorStream() throws IOException {
       if (error == null) {
-        return null;
+        return new StringInputStream("");
       }
       String value = MAPPER.writeValueAsString(error);
       return new StringInputStream(value);
@@ -421,6 +432,11 @@ public class TestResponseFilter {
 
     @Override
     public URI getRequestedUri() {
+      return null;
+    }
+
+    @Override
+    public HttpClient.Method getRequestedMethod() {
       return null;
     }
   }

--- a/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
+++ b/api/client/src/test/java/org/projectnessie/client/rest/TestResponseFilter.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.HttpClient.Method;
 import org.projectnessie.client.http.ResponseContext;
 import org.projectnessie.client.http.Status;
 import org.projectnessie.error.BaseNessieClientServerException;
@@ -264,7 +264,7 @@ public class TestResponseFilter {
                       }
 
                       @Override
-                      public HttpClient.Method getRequestedMethod() {
+                      public Method getRequestedMethod() {
                         return null;
                       }
                     }))
@@ -314,13 +314,14 @@ public class TestResponseFilter {
                       }
 
                       @Override
-                      public HttpClient.Method getRequestedMethod() {
+                      public Method getRequestedMethod() {
                         return null;
                       }
                     }))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("" + Status.NOT_IMPLEMENTED.getCode())
         .hasMessageContaining(Status.NOT_IMPLEMENTED.getReason())
+        .hasMessageContaining("JSON response has unknown error format")
         .hasMessageContaining("ee7f7293-67ad-42bd-8973-179801e7120e-1")
         .hasMessageContaining("Cannot build NessieError"); // jackson parse error
   }
@@ -436,7 +437,7 @@ public class TestResponseFilter {
     }
 
     @Override
-    public HttpClient.Method getRequestedMethod() {
+    public Method getRequestedMethod() {
       return null;
     }
   }

--- a/api/client/src/test/java/org/projectnessie/client/rest/v1/TestRestV1Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/rest/v1/TestRestV1Client.java
@@ -167,6 +167,7 @@ class TestRestV1Client {
         (req, resp) -> {
           if (message == null) {
             resp.setStatus(status);
+            resp.setContentType("application/json");
           } else {
             resp.sendError(status, message);
           }
@@ -203,7 +204,7 @@ class TestRestV1Client {
           .hasMessageContaining("Not Found (HTTP/404)")
           .hasMessageContaining("/unknownPath/config")
           .hasMessageContaining(
-              "Unable to parse response body as JSON:\n<html><head><title>Error</title></head><body>the requested URL does not exist</body></html>")
+              "Response content type was not json. The response body was:\n<html><head><title>Error</title></head><body>the requested URL does not exist</body></html>")
           .hasNoSuppressedExceptions()
           .extracting("error")
           .asInstanceOf(type(NessieError.class))

--- a/api/model/src/main/java/org/projectnessie/error/NessieError.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieError.java
@@ -100,12 +100,15 @@ public interface NessieError {
   default String getFullMessage() {
     StringBuilder sb = new StringBuilder();
     sb.append(getReason()).append(" (HTTP/").append(getStatus()).append(')');
-    sb.append(": ");
+
     String serverMessage = getMessage();
     if (serverMessage == null) {
       serverMessage = "[no error message found in HTTP response]";
     }
-    sb.append(serverMessage);
+    if (!serverMessage.equals(getReason())) {
+      sb.append(": ");
+      sb.append(serverMessage);
+    }
 
     if (getServerStackTrace() != null) {
       sb.append("\n").append(getServerStackTrace());


### PR DESCRIPTION
WIP

see https://github.com/projectnessie/nessie/issues/7953

example of new error:
```
org.projectnessie.client.rest.NessieServiceException: Not Found (HTTP/404): GET http://localhost:45769/config failed
	at org.projectnessie.client.rest.ResponseCheckFilter.checkResponse(ResponseCheckFilter.java:86)
	at org.projectnessie.client.rest.NessieHttpResponseFilter.filter(NessieHttpResponseFilter.java:29)
	at org.projectnessie.client.http.impl.jdk11.JavaRequest.lambda$executeRequest$1(JavaRequest.java:143)
	at java.base/java.util.Collections$SingletonList.forEach(Collections.java:4966)
	at org.projectnessie.client.http.impl.jdk11.JavaRequest.executeRequest(JavaRequest.java:143)
	at org.projectnessie.client.http.HttpRequest.get(HttpRequest.java:106)
	at org.projectnessie.client.http.NessieApiCompatibilityFilter.check(NessieApiCompatibilityFilter.java:61)
	at org.projectnessie.client.http.TestNessieApiCompatibilityFilter.lambda$testSkipApiCompatibilityCheck$4(TestNessieApiCompatibilityFilter.java:140)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:63)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:892)
	at org.assertj.core.api.AssertionsForClassTypes.assertThatCode(AssertionsForClassTypes.java:863)
	at org.assertj.core.api.Assertions.assertThatCode(Assertions.java:1286)
	at org.projectnessie.client.http.TestNessieApiCompatibilityFilter.testSkipApiCompatibilityCheck(TestNessieApiCompatibilityFilter.java:140)
```