### PR TITLE
Use fluent `ObjIdHasher`

### DIFF
--- a/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
+++ b/versioned/storage/common-tests/src/main/java/org/projectnessie/versioned/storage/commontests/AbstractBasePersistTests.java
@@ -385,24 +385,22 @@ public class AbstractBasePersistTests {
 
     return Stream.of(
         // 1
-        contentValue(randomObjId(), randomContentId(), 1, fooBar),
-        contentValue(randomObjId(), randomContentId(), 127, fooBar),
-        contentValue(randomObjId(), randomContentId(), 11, fooBar),
-        contentValue(randomObjId(), randomContentId(), 33, fooBar),
+        contentValue(randomContentId(), 1, fooBar),
+        contentValue(randomContentId(), 127, fooBar),
+        contentValue(randomContentId(), 11, fooBar),
+        contentValue(randomContentId(), 33, fooBar),
         // 5
-        contentValue(randomObjId(), randomContentId(), 42, fooBar),
+        contentValue(randomContentId(), 42, fooBar),
+        indexSegments(singletonList(indexStripe(key("xyy"), key("xzz"), randomObjId()))),
         indexSegments(
-            randomObjId(), singletonList(indexStripe(key("xyy"), key("xzz"), randomObjId()))),
-        indexSegments(
-            randomObjId(),
             asList(
                 indexStripe(key(nonAscii), key(nonAscii), randomObjId()),
                 indexStripe(key("moo", "woof"), key("zoo", "woof"), randomObjId()))),
-        index(randomObjId(), emptyIndex.serialize()),
-        index(randomObjId(), index.serialize()),
+        index(emptyIndex.serialize()),
+        index(index.serialize()),
         // 10
-        tag(randomObjId(), "tag-message", newCommitHeaders().add("Foo", "Bar").build(), fooBar),
-        tag(randomObjId(), null, null, ByteString.EMPTY),
+        tag("tag-message", newCommitHeaders().add("Foo", "Bar").build(), fooBar),
+        tag(null, null, ByteString.EMPTY),
         commitBuilder()
             .id(randomObjId())
             .created(123L)
@@ -436,10 +434,9 @@ public class AbstractBasePersistTests {
             .incompleteIndex(true)
             .seq(42L)
             .build(),
-        stringData(randomObjId(), "text/plain", NONE, null, emptyList(), ByteString.EMPTY),
+        stringData("text/plain", NONE, null, emptyList(), ByteString.EMPTY),
         // 15
         stringData(
-            randomObjId(),
             "text/markdown",
             Compression.GZIP,
             "filename",
@@ -450,9 +447,9 @@ public class AbstractBasePersistTests {
                 objIdFromString("deadbeefcafebabe"),
                 objIdFromString("0000000000000000")),
             copyFromUtf8("This is not a markdown")),
-        ref(randomObjId(), "foo", randomObjId(), 123L, null),
-        ref(randomObjId(), "bar", randomObjId(), 456L, randomObjId()),
-        uniqueId(randomObjId(), "space", uuidToBytes(UUID.randomUUID())),
+        ref("foo", randomObjId(), 123L, null),
+        ref("bar", randomObjId(), 456L, randomObjId()),
+        uniqueId("space", uuidToBytes(UUID.randomUUID())),
         // custom object types
         SimpleTestObj.builder()
             .id(randomObjId())

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/CommitHeaders.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/CommitHeaders.java
@@ -19,8 +19,10 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
+import org.projectnessie.versioned.storage.common.persist.Hashable;
+import org.projectnessie.versioned.storage.common.persist.ObjIdHasher;
 
-public interface CommitHeaders {
+public interface CommitHeaders extends Hashable {
 
   CommitHeaders EMPTY_COMMIT_HEADERS = newCommitHeaders().build();
 
@@ -76,5 +78,16 @@ public interface CommitHeaders {
     }
 
     CommitHeaders build();
+  }
+
+  @Override
+  default void hash(ObjIdHasher hasher) {
+    for (String header : keySet()) {
+      hasher.hash(header);
+      List<String> values = getAll(header);
+      for (String value : values) {
+        hasher.hash(value);
+      }
+    }
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/ContentValueObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/ContentValueObj.java
@@ -16,7 +16,8 @@
 package org.projectnessie.versioned.storage.common.objtypes;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.projectnessie.versioned.storage.common.objtypes.Hashes.contentValueHash;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.VALUE;
+import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 
 import org.immutables.value.Value;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
@@ -29,7 +30,7 @@ public interface ContentValueObj extends Obj {
 
   @Override
   default ObjType type() {
-    return StandardObjType.VALUE;
+    return VALUE;
   }
 
   @Override
@@ -51,6 +52,14 @@ public interface ContentValueObj extends Obj {
   }
 
   static ContentValueObj contentValue(String contentId, int payload, ByteString data) {
-    return contentValue(contentValueHash(contentId, payload, data), contentId, payload, data);
+    return contentValue(
+        objIdHasher(VALUE)
+            .hash(contentId)
+            .hash(payload)
+            .hash(data.asReadOnlyByteBuffer())
+            .generate(),
+        contentId,
+        payload,
+        data);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexObj.java
@@ -15,7 +15,8 @@
  */
 package org.projectnessie.versioned.storage.common.objtypes;
 
-import static org.projectnessie.versioned.storage.common.objtypes.Hashes.indexHash;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.INDEX;
+import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -30,7 +31,7 @@ public interface IndexObj extends Obj {
 
   @Override
   default ObjType type() {
-    return StandardObjType.INDEX;
+    return INDEX;
   }
 
   @Override
@@ -48,6 +49,6 @@ public interface IndexObj extends Obj {
 
   @Nonnull
   static IndexObj index(@Nonnull ByteString index) {
-    return index(indexHash(index), index);
+    return index(objIdHasher(INDEX).hash(index.asReadOnlyByteBuffer()).generate(), index);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexSegmentsObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexSegmentsObj.java
@@ -15,7 +15,8 @@
  */
 package org.projectnessie.versioned.storage.common.objtypes;
 
-import static org.projectnessie.versioned.storage.common.objtypes.Hashes.indexSegmentsHash;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.INDEX_SEGMENTS;
+import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -30,7 +31,7 @@ public interface IndexSegmentsObj extends Obj {
 
   @Override
   default ObjType type() {
-    return StandardObjType.INDEX_SEGMENTS;
+    return INDEX_SEGMENTS;
   }
 
   @Override
@@ -48,6 +49,6 @@ public interface IndexSegmentsObj extends Obj {
 
   @Nonnull
   static IndexSegmentsObj indexSegments(@Nonnull List<IndexStripe> stripes) {
-    return indexSegments(indexSegmentsHash(stripes), stripes);
+    return indexSegments(objIdHasher(INDEX_SEGMENTS).hashCollection(stripes).generate(), stripes);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexStripe.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/IndexStripe.java
@@ -17,10 +17,12 @@ package org.projectnessie.versioned.storage.common.objtypes;
 
 import org.immutables.value.Value;
 import org.projectnessie.versioned.storage.common.indexes.StoreKey;
+import org.projectnessie.versioned.storage.common.persist.Hashable;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjIdHasher;
 
 @Value.Immutable
-public interface IndexStripe {
+public interface IndexStripe extends Hashable {
 
   @Value.Parameter(order = 1)
   StoreKey firstKey();
@@ -33,5 +35,13 @@ public interface IndexStripe {
 
   static IndexStripe indexStripe(StoreKey firstKey, StoreKey lastKey, ObjId segment) {
     return ImmutableIndexStripe.of(firstKey, lastKey, segment);
+  }
+
+  @Override
+  default void hash(ObjIdHasher idHasher) {
+    idHasher
+        .hash(firstKey().rawString())
+        .hash(lastKey().rawString())
+        .hash(segment().asByteBuffer());
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/RefObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/RefObj.java
@@ -15,7 +15,8 @@
  */
 package org.projectnessie.versioned.storage.common.objtypes;
 
-import static org.projectnessie.versioned.storage.common.objtypes.Hashes.refHash;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.REF;
+import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 
 import jakarta.annotation.Nullable;
 import org.immutables.value.Value;
@@ -70,7 +71,11 @@ public interface RefObj extends Obj {
   static RefObj ref(
       String name, ObjId initialPointer, long createdAtMicros, ObjId extendedInfoObj) {
     return ref(
-        refHash(name, initialPointer, createdAtMicros),
+        objIdHasher(REF)
+            .hash(name)
+            .hash(initialPointer.asByteArray())
+            .hash(createdAtMicros)
+            .generate(),
         name,
         initialPointer,
         createdAtMicros,

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/TagObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/TagObj.java
@@ -15,13 +15,15 @@
  */
 package org.projectnessie.versioned.storage.common.objtypes;
 
-import static org.projectnessie.versioned.storage.common.objtypes.Hashes.tagHash;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.TAG;
+import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 
 import jakarta.annotation.Nullable;
 import org.immutables.value.Value;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.ObjIdHasher;
 import org.projectnessie.versioned.storage.common.persist.ObjType;
 
 @Value.Immutable
@@ -56,6 +58,17 @@ public interface TagObj extends Obj {
   }
 
   static TagObj tag(String message, CommitHeaders headers, ByteString signature) {
-    return tag(tagHash(message, headers, signature), message, headers, signature);
+    ObjIdHasher hasher = objIdHasher(TAG);
+    if (message != null) {
+      hasher.hash(message);
+    }
+    if (headers != null) {
+      hasher.hash(headers);
+    }
+    if (signature != null) {
+      hasher.hash(signature.asReadOnlyByteBuffer());
+    }
+
+    return tag(hasher.generate(), message, headers, signature);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/UniqueIdObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/UniqueIdObj.java
@@ -15,7 +15,8 @@
  */
 package org.projectnessie.versioned.storage.common.objtypes;
 
-import static org.projectnessie.versioned.storage.common.objtypes.Hashes.uniqueIdHash;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.UNIQUE;
+import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 
 import jakarta.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -36,7 +37,7 @@ public interface UniqueIdObj extends Obj {
 
   @Override
   default ObjType type() {
-    return StandardObjType.UNIQUE;
+    return UNIQUE;
   }
 
   @Override
@@ -65,7 +66,10 @@ public interface UniqueIdObj extends Obj {
   }
 
   static UniqueIdObj uniqueId(String space, ByteString value) {
-    return uniqueId(uniqueIdHash(space, value), space, value);
+    return uniqueId(
+        objIdHasher(UNIQUE).hash(space).hash(value.asReadOnlyByteBuffer()).generate(),
+        space,
+        value);
   }
 
   static UniqueIdObj uniqueId(String space, UUID value) {

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Hashable.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Hashable.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.persist;
+
+public interface Hashable {
+  void hash(ObjIdHasher idHasher);
+}

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObjId.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObjId.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.storage.common.persist;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.projectnessie.nessie.relocated.protobuf.UnsafeByteOperations.unsafeWrap;
+import static org.projectnessie.versioned.storage.common.persist.ObjIdHasher.objIdHasher;
 import static org.projectnessie.versioned.storage.common.util.Hex.hexChar;
 import static org.projectnessie.versioned.storage.common.util.Hex.nibble;
 import static org.projectnessie.versioned.storage.common.util.Hex.nibbleFromLong;
@@ -27,10 +28,8 @@ import static org.projectnessie.versioned.storage.common.util.Ser.readVarInt;
 import static org.projectnessie.versioned.storage.common.util.Ser.varIntLen;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.hash.Hashing;
 import jakarta.annotation.Nonnull;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
@@ -39,10 +38,7 @@ public abstract class ObjId {
   // TODO Should this class actually be merged with the existing `Hash` class,
   //  need to move `Hash` to somewhere else though (project dependency issue ATM).
 
-  @SuppressWarnings("UnstableApiUsage")
-  public static final ObjId EMPTY_OBJ_ID =
-      ObjId.objIdFromByteArray(
-          Hashing.sha256().newHasher().putString("empty", StandardCharsets.UTF_8).hash().asBytes());
+  public static final ObjId EMPTY_OBJ_ID = objIdHasher("empty").generate();
 
   public static ObjId zeroLengthObjId() {
     return ObjIdEmpty.INSTANCE;

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObjIdHasher.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObjIdHasher.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.persist;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+public interface ObjIdHasher {
+  static ObjIdHasher objIdHasher(String typeName) {
+    return new ObjIdHasherImpl().hash(typeName);
+  }
+
+  static ObjIdHasher objIdHasher(Enum<?> enumValue) {
+    return objIdHasher(enumValue.name());
+  }
+
+  ObjIdHasher hash(boolean value);
+
+  ObjIdHasher hash(char value);
+
+  ObjIdHasher hash(int value);
+
+  ObjIdHasher hash(long value);
+
+  ObjIdHasher hash(float value);
+
+  ObjIdHasher hash(double value);
+
+  ObjIdHasher hash(Enum<?> value);
+
+  ObjIdHasher hash(Boolean value);
+
+  ObjIdHasher hash(Integer value);
+
+  ObjIdHasher hash(Long value);
+
+  ObjIdHasher hash(Float value);
+
+  ObjIdHasher hash(Double value);
+
+  ObjIdHasher hash(String value);
+
+  ObjIdHasher hash(byte[] value);
+
+  ObjIdHasher hash(ByteBuffer value);
+
+  ObjIdHasher hash(UUID value);
+
+  ObjIdHasher hash(Hashable value);
+
+  ObjIdHasher hash(ObjId value);
+
+  ObjIdHasher hashCollection(Collection<? extends Hashable> value);
+
+  ObjIdHasher hashUuidCollection(Collection<UUID> value);
+
+  ObjIdHasher hashIntCollection(Collection<Integer> value);
+
+  ObjIdHasher hashLongCollection(Collection<Long> value);
+
+  ObjIdHasher hashStringToStringMap(Map<String, String> map);
+
+  ObjId generate();
+}

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObjIdHasherImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObjIdHasherImpl.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2023 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.persist;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Map.Entry.comparingByKey;
+
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+@SuppressWarnings("UnstableApiUsage")
+final class ObjIdHasherImpl implements ObjIdHasher {
+  private final Hasher hasher;
+
+  ObjIdHasherImpl(Hasher hasher) {
+    this.hasher = hasher;
+  }
+
+  ObjIdHasherImpl() {
+    this(Hashing.sha256().newHasher());
+  }
+
+  @Override
+  public ObjIdHasher hash(boolean value) {
+    hasher.putBoolean(value);
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(char value) {
+    hasher.putChar(value);
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(int value) {
+    hasher.putInt(value);
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(long value) {
+    hasher.putLong(value);
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(float value) {
+    hasher.putFloat(value);
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(double value) {
+    hasher.putDouble(value);
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(Enum<?> value) {
+    if (value != null) {
+      hash(value.name());
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(Boolean value) {
+    if (value != null) {
+      hasher.putBoolean(value);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(Integer value) {
+    if (value != null) {
+      hasher.putInt(value);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(Long value) {
+    if (value != null) {
+      hasher.putLong(value);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(Float value) {
+    if (value != null) {
+      hasher.putFloat(value);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(Double value) {
+    if (value != null) {
+      hasher.putDouble(value);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(String value) {
+    if (value != null) {
+      hasher.putString(value, UTF_8);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(byte[] value) {
+    if (value != null) {
+      hasher.putBytes(value);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(ByteBuffer value) {
+    if (value != null) {
+      hasher.putBytes(value);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(UUID value) {
+    if (value != null) {
+      hasher.putLong(value.getMostSignificantBits());
+      hasher.putLong(value.getLeastSignificantBits());
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(ObjId value) {
+    if (value != null) {
+      hasher.putBytes(value.asByteBuffer());
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hash(Hashable value) {
+    if (value != null) {
+      value.hash(this);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hashCollection(Collection<? extends Hashable> value) {
+    if (value != null) {
+      value.forEach(this::hash);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hashUuidCollection(Collection<UUID> value) {
+    if (value != null) {
+      value.forEach(
+          uuid -> hash(uuid.getMostSignificantBits()).hash(uuid.getLeastSignificantBits()));
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hashIntCollection(Collection<Integer> value) {
+    if (value != null) {
+      value.forEach(this::hash);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hashLongCollection(Collection<Long> value) {
+    if (value != null) {
+      value.forEach(this::hash);
+    }
+    return this;
+  }
+
+  @Override
+  public ObjIdHasher hashStringToStringMap(Map<String, String> map) {
+    if (map != null) {
+      map.entrySet().stream()
+          .sorted(comparingByKey())
+          .forEach(e -> hash(e.getKey()).hash(e.getValue()));
+    }
+    return this;
+  }
+
+  @Override
+  public ObjId generate() {
+    return ObjId.objIdFromByteArray(hasher.hash().asBytes());
+  }
+}

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/persist/Hashes.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/persist/Hashes.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.versioned.storage.common.objtypes;
+package org.projectnessie.versioned.storage.common.persist;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.INDEX;
@@ -28,10 +28,17 @@ import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import java.util.List;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
-import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.objtypes.CommitHeaders;
+import org.projectnessie.versioned.storage.common.objtypes.Compression;
+import org.projectnessie.versioned.storage.common.objtypes.IndexStripe;
 
+/**
+ * Contains the code that generated {@link ObjId}s before {@link ObjIdHasher} was introduced, used
+ * to validate compatibility with the old code. This class and (parts of) the corresponding test may
+ * eventually go away.
+ */
 @SuppressWarnings("UnstableApiUsage")
-public final class Hashes {
+final class Hashes {
   private Hashes() {}
 
   public static Hasher newHasher() {

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/persist/TestObjIdHasher.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/persist/TestObjIdHasher.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.persist;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.projectnessie.versioned.storage.common.indexes.StoreIndexes.emptyImmutableIndex;
+import static org.projectnessie.versioned.storage.common.logic.Logics.commitLogic;
+import static org.projectnessie.versioned.storage.common.logic.Logics.indexesLogic;
+import static org.projectnessie.versioned.storage.common.objtypes.CommitHeaders.EMPTY_COMMIT_HEADERS;
+import static org.projectnessie.versioned.storage.common.objtypes.CommitObj.commitBuilder;
+import static org.projectnessie.versioned.storage.common.objtypes.CommitOp.COMMIT_OP_SERIALIZER;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.COMMIT;
+import static org.projectnessie.versioned.storage.common.objtypes.StandardObjType.REF;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.contentValueHash;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.hashAsObjId;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.hashCommitHeaders;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.indexHash;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.indexSegmentsHash;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.newHasher;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.refHash;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.stringDataHash;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.tagHash;
+import static org.projectnessie.versioned.storage.common.persist.Hashes.uniqueIdHash;
+import static org.projectnessie.versioned.storage.commontests.AbstractBasePersistTests.allObjectTypeSamples;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hasher;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.versioned.storage.common.config.StoreConfig;
+import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
+import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
+import org.projectnessie.versioned.storage.common.logic.ConflictHandler;
+import org.projectnessie.versioned.storage.common.logic.CreateCommit;
+import org.projectnessie.versioned.storage.common.objtypes.CommitObj;
+import org.projectnessie.versioned.storage.common.objtypes.CommitOp;
+import org.projectnessie.versioned.storage.common.objtypes.ContentValueObj;
+import org.projectnessie.versioned.storage.common.objtypes.IndexObj;
+import org.projectnessie.versioned.storage.common.objtypes.IndexSegmentsObj;
+import org.projectnessie.versioned.storage.common.objtypes.RefObj;
+import org.projectnessie.versioned.storage.common.objtypes.StandardObjType;
+import org.projectnessie.versioned.storage.common.objtypes.StringObj;
+import org.projectnessie.versioned.storage.common.objtypes.TagObj;
+import org.projectnessie.versioned.storage.common.objtypes.UniqueIdObj;
+
+@SuppressWarnings("UnstableApiUsage")
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestObjIdHasher {
+  @InjectSoftAssertions SoftAssertions soft;
+
+  @Test
+  public void nullValuesAndEmptyCollections() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher
+        .hash((Long) null)
+        .hash((Integer) null)
+        .hash((Boolean) null)
+        .hash((String) null)
+        .hash((ByteBuffer) null)
+        .hash((Hashable) null)
+        .hash((Enum<?>) null)
+        .hash((Double) null)
+        .hash((Float) null)
+        .hash((byte[]) null)
+        .hash((UUID) null)
+        .hash((ObjId) null)
+        .hashCollection(null)
+        .hashIntCollection(null)
+        .hashLongCollection(null)
+        .hashStringToStringMap(null)
+        .hashUuidCollection(null)
+        .hashCollection(emptyList())
+        .hashIntCollection(emptyList())
+        .hashLongCollection(emptyList())
+        .hashStringToStringMap(emptyMap())
+        .hashUuidCollection(emptyList());
+    verifyNoInteractions(h);
+  }
+
+  @Test
+  public void verifyPrimitive() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher.hash(true).hash(42).hash('c').hash(666L).hash(1.2d).hash(2.3f);
+    verify(h).putBoolean(true);
+    verify(h).putInt(42);
+    verify(h).putChar('c');
+    verify(h).putLong(666L);
+    verify(h).putDouble(1.2d);
+    verify(h).putFloat(2.3f);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyBoxed() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher
+        .hash(Boolean.TRUE)
+        .hash(Integer.valueOf(42))
+        .hash(Long.valueOf(666L))
+        .hash(Double.valueOf(1.2d))
+        .hash(Float.valueOf(2.3f))
+        .hash("foo")
+        .hash(new byte[] {1, 2});
+    verify(h).putBoolean(true);
+    verify(h).putInt(42);
+    verify(h).putLong(666L);
+    verify(h).putDouble(1.2d);
+    verify(h).putFloat(2.3f);
+    verify(h).putString("foo", UTF_8);
+    verify(h).putBytes(new byte[] {1, 2});
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyEnum() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher.hash(REF);
+    verify(h).putString(REF.name(), UTF_8);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyUuid() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher.hash(new UUID(123L, 456L));
+    verify(h).putLong(123L);
+    verify(h).putLong(456L);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyHashable() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher.hash(idHasher -> idHasher.hash(42L).hash(1));
+    verify(h).putLong(42L);
+    verify(h).putInt(1);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyHashableCollection() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    List<Hashable> coll =
+        asList(
+            idHasher -> idHasher.hash(1),
+            idHasher -> idHasher.hash(2),
+            idHasher -> idHasher.hash(3));
+    hasher.hashCollection(coll);
+    verify(h).putInt(1);
+    verify(h).putInt(2);
+    verify(h).putInt(3);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyUuidCollection() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher.hashUuidCollection(asList(new UUID(1L, 2L), new UUID(3L, 4L)));
+    verify(h).putLong(1L);
+    verify(h).putLong(2L);
+    verify(h).putLong(3L);
+    verify(h).putLong(4L);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyStringToStringMap() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("a", "b");
+    map.put("c", "d");
+    map.put("e", "f");
+    hasher.hashStringToStringMap(map);
+    verify(h).putString("a", UTF_8);
+    verify(h).putString("b", UTF_8);
+    verify(h).putString("c", UTF_8);
+    verify(h).putString("d", UTF_8);
+    verify(h).putString("e", UTF_8);
+    verify(h).putString("f", UTF_8);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyLongCollection() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher.hashLongCollection(asList(1L, 2L));
+    verify(h).putLong(1L);
+    verify(h).putLong(2L);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyIntCollection() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    hasher.hashIntCollection(asList(1, 2));
+    verify(h).putInt(1);
+    verify(h).putInt(2);
+    verifyNoMoreInteractions(h);
+  }
+
+  @Test
+  public void verifyGenerate() {
+    Hasher h = mock(Hasher.class);
+    ObjIdHasher hasher = new ObjIdHasherImpl(h);
+    when(h.hash()).thenReturn(HashCode.fromBytes(new byte[] {1, 2, 3, 4}));
+    ObjId id = hasher.generate();
+    verify(h).hash();
+    verifyNoMoreInteractions(h);
+    soft.assertThat(id.asByteArray()).containsExactly(1, 2, 3, 4);
+  }
+
+  /**
+   * Verify that the {@link ObjId} generation yields the same results compared to the state before
+   * the change that introduced {@link ObjIdHasher}. This test and the {@link Hashes} class may
+   * eventually go away.
+   */
+  @ParameterizedTest
+  @MethodSource("standardObjTypes")
+  public void objIdHasherProducesSameResult(Obj obj) throws Exception {
+    StandardObjType type = (StandardObjType) obj.type();
+    ObjId generatedId = obj.id();
+    ObjId previousCodeId = null;
+    switch (type) {
+      case COMMIT:
+        CommitObj commitObj = (CommitObj) obj;
+
+        CreateCommit.Builder commit =
+            CreateCommit.newCommitBuilder()
+                .parentCommitId(commitObj.directParent())
+                .message(commitObj.message())
+                .headers(commitObj.headers());
+
+        Hasher hasher =
+            newHasher()
+                .putString(COMMIT.name(), UTF_8)
+                .putBytes(commitObj.directParent().asByteBuffer())
+                .putString(commitObj.message(), UTF_8);
+        hashCommitHeaders(hasher, commitObj.headers());
+
+        StoreIndex<CommitOp> index = indexesLogic(null).incrementalIndexFromCommit(commitObj);
+        for (StoreIndexElement<CommitOp> el : index) {
+          CommitOp op = el.content();
+          if (op.action() == CommitOp.Action.REMOVE) {
+            UUID contentId = op.contentId();
+            hasher.putInt(2).putInt(op.payload()).putString(el.key().rawString(), UTF_8);
+            if (contentId != null) {
+              hasher
+                  .putLong(contentId.getMostSignificantBits())
+                  .putLong(contentId.getLeastSignificantBits());
+            }
+            commit.addRemoves(
+                CreateCommit.Remove.commitRemove(
+                    el.key(), op.payload(), ObjId.EMPTY_OBJ_ID, op.contentId()));
+          }
+        }
+        for (StoreIndexElement<CommitOp> el : index) {
+          CommitOp op = el.content();
+          if (op.action() == CommitOp.Action.ADD) {
+            UUID contentId = op.contentId();
+            hasher
+                .putInt(1)
+                .putString(el.key().rawString(), UTF_8)
+                .putInt(op.payload())
+                .putBytes(requireNonNull(op.value()).asByteBuffer());
+            if (contentId != null) {
+              hasher
+                  .putLong(contentId.getMostSignificantBits())
+                  .putLong(contentId.getLeastSignificantBits());
+            }
+            commit.addAdds(
+                CreateCommit.Add.commitAdd(
+                    el.key(), op.payload(), requireNonNull(op.value()), null, op.contentId()));
+          }
+        }
+        previousCodeId = hashAsObjId(hasher);
+
+        Persist persist = mock(Persist.class);
+        when(persist.config()).thenReturn(StoreConfig.Adjustable.empty());
+        when(persist.fetchTypedObj(commitObj.directParent(), COMMIT, CommitObj.class))
+            .thenReturn(
+                commitBuilder()
+                    .id(commitObj.directParent())
+                    .created(0L)
+                    .seq(1L)
+                    .headers(EMPTY_COMMIT_HEADERS)
+                    .message("")
+                    .incrementalIndex(emptyImmutableIndex(COMMIT_OP_SERIALIZER).serialize())
+                    .build());
+        generatedId =
+            commitLogic(persist)
+                .buildCommitObj(
+                    commit.build(),
+                    c -> ConflictHandler.ConflictResolution.CONFLICT,
+                    (k, v) -> {},
+                    (add, key, id) -> null,
+                    (add, key, id) -> null)
+                .id();
+
+        break;
+      case REF:
+        RefObj refObj = (RefObj) obj;
+        previousCodeId = refHash(refObj.name(), refObj.initialPointer(), refObj.createdAtMicros());
+        break;
+      case INDEX:
+        IndexObj indexObj = (IndexObj) obj;
+        previousCodeId = indexHash(indexObj.index());
+        break;
+      case INDEX_SEGMENTS:
+        IndexSegmentsObj indexSegmentsObj = (IndexSegmentsObj) obj;
+        previousCodeId = indexSegmentsHash(indexSegmentsObj.stripes());
+        break;
+      case TAG:
+        TagObj tagObj = (TagObj) obj;
+        previousCodeId = tagHash(tagObj.message(), tagObj.headers(), tagObj.signature());
+        break;
+      case STRING:
+        StringObj stringObj = (StringObj) obj;
+        previousCodeId =
+            stringDataHash(
+                stringObj.contentType(),
+                stringObj.compression(),
+                stringObj.filename(),
+                stringObj.predecessors(),
+                stringObj.text());
+        break;
+      case UNIQUE:
+        UniqueIdObj uniqueIdObj = (UniqueIdObj) obj;
+        previousCodeId = uniqueIdHash(uniqueIdObj.space(), uniqueIdObj.value());
+        break;
+      case VALUE:
+        ContentValueObj contentValueObj = (ContentValueObj) obj;
+        previousCodeId =
+            contentValueHash(
+                contentValueObj.contentId(), contentValueObj.payload(), contentValueObj.data());
+        break;
+      default:
+        // ignore
+        break;
+    }
+
+    soft.assertThat(generatedId).isEqualTo(previousCodeId);
+  }
+
+  static Stream<Obj> standardObjTypes() {
+    return Stream.concat(
+        allObjectTypeSamples().filter(o -> o.type() instanceof StandardObjType), moreCommitObjs());
+  }
+
+  private static Stream<Obj> moreCommitObjs() {
+    return Stream.of(
+        // CommitObj
+        );
+  }
+}

--- a/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportContents.java
+++ b/versioned/transfer/src/main/java/org/projectnessie/versioned/transfer/ExportContents.java
@@ -19,6 +19,7 @@ import static org.projectnessie.versioned.VersionStore.KeyRestrictions.NO_KEY_RE
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -37,7 +38,6 @@ import org.projectnessie.versioned.ReferenceInfo;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.VersionStore;
 import org.projectnessie.versioned.paging.PaginationIterator;
-import org.projectnessie.versioned.storage.common.objtypes.Hashes;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.store.DefaultStoreWorker;
 import org.projectnessie.versioned.transfer.files.ExportFileSupplier;
@@ -108,7 +108,7 @@ final class ExportContents extends ExportCommon {
                         ref.getNamedRef().getName(), seq + 1)));
         long micros = TimeUnit.MILLISECONDS.toMicros(currentTimestampMillis());
 
-        Hasher hasher = Hashes.newHasher();
+        Hasher hasher = Hashing.sha256().newHasher();
         hasher.putBytes(meta.asReadOnlyByteBuffer());
         hasher.putBytes(lastCommitId.asReadOnlyByteBuffer());
         hasher.putLong(seq);


### PR DESCRIPTION
The change is effectively a non-change, but introduces a simpler and fluent API to generate `ObjId`s.