### PR TITLE
Fix URL endpoint for injected `NessieApi` from `OldNessieServer`

### DIFF
--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
@@ -33,6 +33,9 @@ public class Version implements Comparable<Version> {
   /** See <a href="https://github.com/projectnessie/nessie/pull/6894">PR #6894</a>. */
   public static final Version MERGE_KEY_BEHAVIOR_FIX = Version.parseVersion("0.59.1");
 
+  /** see <a href="https://github.com/projectnessie/nessie/pull/7854">PR #7854</a>. */
+  public static final Version INJECTED_NESSIE_API_URL_CHANGE = Version.parseVersion("0.75.0");
+
   public static final String CURRENT_STRING = "current";
   public static final String NOT_CURRENT_STRING = "not-current";
   private final int[] tuple;

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
@@ -34,7 +34,7 @@ public class Version implements Comparable<Version> {
   public static final Version MERGE_KEY_BEHAVIOR_FIX = Version.parseVersion("0.59.1");
 
   /** See <a href="https://github.com/projectnessie/nessie/pull/7854">PR #7854</a>. */
-  public static final Version INJECTED_NESSIE_API_URL_CHANGE = Version.parseVersion("0.75.0");
+  public static final Version NESSIE_URL_API_SUFFIX = Version.parseVersion("0.75.0");
 
   public static final String CURRENT_STRING = "current";
   public static final String NOT_CURRENT_STRING = "not-current";

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/api/Version.java
@@ -33,7 +33,7 @@ public class Version implements Comparable<Version> {
   /** See <a href="https://github.com/projectnessie/nessie/pull/6894">PR #6894</a>. */
   public static final Version MERGE_KEY_BEHAVIOR_FIX = Version.parseVersion("0.59.1");
 
-  /** see <a href="https://github.com/projectnessie/nessie/pull/7854">PR #7854</a>. */
+  /** See <a href="https://github.com/projectnessie/nessie/pull/7854">PR #7854</a>. */
   public static final Version INJECTED_NESSIE_API_URL_CHANGE = Version.parseVersion("0.75.0");
 
   public static final String CURRENT_STRING = "current";

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/CurrentNessieServer.java
@@ -61,7 +61,7 @@ final class CurrentNessieServer implements NessieServer {
 
   @Override
   public URI getUri(Class<? extends NessieApi> apiType) {
-    return Util.resolveNessieUri(jersey.getUri().resolve("api/"), apiType);
+    return Util.resolveNessieUri(jersey.getUri(), serverKey.getVersion(), apiType);
   }
 
   @Override

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieServer.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/OldNessieServer.java
@@ -127,7 +127,7 @@ final class OldNessieServer implements NessieServer {
       tryStart();
     }
 
-    return Util.resolveNessieUri(uri, apiType);
+    return Util.resolveNessieUri(uri, serverKey.getVersion(), apiType);
   }
 
   private void tryStart() {

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
@@ -74,7 +74,7 @@ final class Util {
 
   static URI resolveNessieUri(URI base, Version version, Class<? extends NessieApi> apiType) {
     String suffix = NessieApiV2.class.isAssignableFrom(apiType) ? "v2" : "v1";
-    if (version.isGreaterThanOrEqual(Version.INJECTED_NESSIE_API_URL_CHANGE)) {
+    if (version.isGreaterThanOrEqual(Version.NESSIE_URL_API_SUFFIX)) {
       suffix = "api/" + suffix;
     }
     return base.resolve(suffix);

--- a/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
+++ b/compatibility/common/src/main/java/org/projectnessie/tools/compatibility/internal/Util.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.platform.engine.UniqueId;
 import org.projectnessie.client.api.NessieApi;
 import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.tools.compatibility.api.Version;
 
 final class Util {
 
@@ -71,8 +72,11 @@ final class Util {
     }
   }
 
-  static URI resolveNessieUri(URI base, Class<? extends NessieApi> apiType) {
+  static URI resolveNessieUri(URI base, Version version, Class<? extends NessieApi> apiType) {
     String suffix = NessieApiV2.class.isAssignableFrom(apiType) ? "v2" : "v1";
+    if (version.isGreaterThanOrEqual(Version.INJECTED_NESSIE_API_URL_CHANGE)) {
+      suffix = "api/" + suffix;
+    }
     return base.resolve(suffix);
   }
 }

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -156,9 +156,6 @@ class TestNessieCompatibilityExtensions {
 
   @Test
   void injectedNessieApiUrlChanged() {
-    // apiUrl 0.74.0: host:port/v2 (via OldNessieServer)
-    // apiUrl 0.75.0: host:port/v2 (via OldNessieServer) should be /api/v2 as well
-    // apiUrl current: host:port/api/v2 (via CurrentNessieServer)
     final Version versionBeforeApiUrlChange = Version.parseVersion("0.74.0");
     EngineExecutionResults result =
         EngineTestKit.engine(MultiEnvTestEngine.ENGINE_ID)

--- a/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
+++ b/compatibility/common/src/test/java/org/projectnessie/tools/compatibility/internal/TestNessieCompatibilityExtensions.java
@@ -161,16 +161,12 @@ class TestNessieCompatibilityExtensions {
         EngineTestKit.engine(MultiEnvTestEngine.ENGINE_ID)
             .configurationParameter(
                 "nessie.versions",
-                versionBeforeApiUrlChange
-                    + ","
-                    + Version.INJECTED_NESSIE_API_URL_CHANGE
-                    + ",current")
+                versionBeforeApiUrlChange + "," + Version.NESSIE_URL_API_SUFFIX + ",current")
             .selectors(selectClass(ApiEndpointServerSample.class))
             .execute();
 
     soft.assertThat(ApiEndpointServerSample.allVersions)
-        .containsExactly(
-            versionBeforeApiUrlChange, Version.INJECTED_NESSIE_API_URL_CHANGE, Version.CURRENT);
+        .containsExactly(versionBeforeApiUrlChange, Version.NESSIE_URL_API_SUFFIX, Version.CURRENT);
 
     assertNoFailedTestEvents(result);
   }


### PR DESCRIPTION
in https://github.com/projectnessie/nessie/pull/7854 `CurrentNessieServer` was adjusted to build `NessieApi` instances with an URL that includes `app/`.
However this adjustment was missing in `OldNessieServer` which caused the injected `NessieApi` instance to use a wrong endpoint and run into HTTP 404 errors since 0.75.0.