### PR TITLE
Improve error message when JDBC/C* columns are missing

### DIFF
--- a/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/AbstractTestCassandraBackendFactory.java
+++ b/versioned/storage/cassandra/src/intTest/java/org/projectnessie/versioned/storage/cassandra/AbstractTestCassandraBackendFactory.java
@@ -191,13 +191,13 @@ public abstract class AbstractTestCassandraBackendFactory {
         soft.assertThat(backend).isNotNull().isInstanceOf(CassandraBackend.class);
         soft.assertThatIllegalStateException()
             .isThrownBy(backend::setupSchema)
-            .withMessageStartingWith("Expected columns [")
-            .withMessageContaining("] do not contain all columns [")
-            .withMessageContaining(
-                "] for table '"
+            .withMessageStartingWith(
+                "The database table "
                     + TABLE_REFS
-                    + "'. DDL template:\nCREATE TABLE nessie."
-                    + TABLE_REFS);
+                    + " is missing mandatory columns created_at,deleted,ext_info,pointer,prev_ptr.\n"
+                    + "Found columns : boo,meep,ref_name,repo\n"
+                    + "Expected columns : ")
+            .withMessageContaining("DDL template:\nCREATE TABLE nessie." + TABLE_REFS);
       }
 
       executeDDL(client, "DROP TABLE IF EXISTS nessie." + TABLE_REFS);

--- a/versioned/storage/jdbc/src/testFixtures/java/org/projectnessie/versioned/storage/jdbc/AbstractTestJdbcBackendFactory.java
+++ b/versioned/storage/jdbc/src/testFixtures/java/org/projectnessie/versioned/storage/jdbc/AbstractTestJdbcBackendFactory.java
@@ -225,10 +225,13 @@ public abstract class AbstractTestJdbcBackendFactory {
           soft.assertThat(backend).isNotNull().isInstanceOf(JdbcBackend.class);
           soft.assertThatIllegalStateException()
               .isThrownBy(backend::setupSchema)
-              .withMessageStartingWith("Expected columns [")
-              .withMessageContaining("] do not match the existing columns [")
-              .withMessageContaining(
-                  "] for table '" + TABLE_REFS + "'. DDL template:\nCREATE TABLE " + TABLE_REFS);
+              .withMessageStartingWith(
+                  "The database table "
+                      + TABLE_REFS
+                      + " is missing mandatory columns created_at,deleted,ext_info,pointer,prev_ptr.\n"
+                      + "Found columns : boo,meep,ref_name,repo\n"
+                      + "Expected columns : ")
+              .withMessageContaining("DDL template:\nCREATE TABLE " + TABLE_REFS);
         }
       } finally {
         ((AutoCloseable) dataSource).close();


### PR DESCRIPTION
The new error message is
```
The database table <table-name> is missing mandatory columns a,b,c.
Found columns : <existing sorted columns>
Expected columns : <expected sorted columns>
DDL template:
CREATE TABLE ...
```
and was
```
Expected columns <unsorted column names> do not match the existing columns <unsorted column names> for table '<table>'. DDL template:
CREATE TABLE ..."
```