### PR TITLE
Disable default OIDC tenant when authentication is disabled

### DIFF
--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -172,8 +172,8 @@ spec:
               value: {{ .Values.authentication.oidcClientId }}
             {{- end }}
             {{- else }}
-            - name: QUARKUS_LOG_CATEGORY__IO_QUARKUS_OIDC__LEVEL
-              value: "ERROR"
+            - name: QUARKUS_OIDC_TENANT_ENABLED
+              value: "false"
             {{- end }}
 
             {{- if .Values.authorization.enabled }}

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -170,8 +170,6 @@ quarkus.http.body.handle-file-uploads=false
 #quarkus.oidc.client-id=
 nessie.server.authentication.enabled=false
 nessie.server.authentication.anonymous-paths=/q/health/live,/q/health/live/,/q/health/ready,/q/health/ready/
-# to be overwritten by end user when enabling OpenID validation
-quarkus.oidc.auth-server-url=http://127.255.0.0:0/auth/realms/unset/
 quarkus.http.auth.basic=false
 # OIDC-enabled is a build-time property (cannot be overwritten at run-time), MUST be true.
 # However, we can overwrite the tenant-enabled property at run-time.

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -173,8 +173,10 @@ nessie.server.authentication.anonymous-paths=/q/health/live,/q/health/live/,/q/h
 # to be overwritten by end user when enabling OpenID validation
 quarkus.oidc.auth-server-url=http://127.255.0.0:0/auth/realms/unset/
 quarkus.http.auth.basic=false
-# OIDC-enabled is a build-time property (cannot be overwritten at run-time), MUST be true
+# OIDC-enabled is a build-time property (cannot be overwritten at run-time), MUST be true.
+# However, we can overwrite the tenant-enabled property at run-time.
 quarkus.oidc.enabled=true
+quarkus.oidc.tenant-enabled=${nessie.server.authentication.enabled}
 
 ## Quarkus swagger settings
 # fixed at buildtime

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestBasicAuthentication.java
@@ -62,6 +62,8 @@ class TestBasicAuthentication extends BaseClientAuthTest {
       return ImmutableMap.<String, String>builder()
           .putAll(super.getConfigOverrides())
           .put("quarkus.http.auth.basic", "true")
+          // Need a dummy URL to satisfy the Quarkus OIDC extension.
+          .put("quarkus.oidc.auth-server-url", "http://127.255.0.0:0/auth/realms/unset/")
           .build();
     }
   }

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestQuarkusEventsEnabledAuthEnabled.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestQuarkusEventsEnabledAuthEnabled.java
@@ -45,6 +45,8 @@ public class TestQuarkusEventsEnabledAuthEnabled extends AbstractQuarkusEvents {
           .putAll(super.getConfigOverrides())
           .put("nessie.version.store.type", IN_MEMORY.name())
           .put("quarkus.http.auth.basic", "true")
+          // Need a dummy URL to satisfy the Quarkus OIDC extension.
+          .put("quarkus.oidc.auth-server-url", "http://127.255.0.0:0/auth/realms/unset/")
           .putAll(AuthenticationEnabledProfile.AUTH_CONFIG_OVERRIDES)
           .putAll(AuthenticationEnabledProfile.SECURITY_CONFIG)
           .build();

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
@@ -78,6 +78,8 @@ public class NessieAuthorizationTestProfile extends AuthenticationEnabledProfile
         .putAll(super.getConfigOverrides())
         .putAll(AUTHZ_RULES)
         .put("nessie.server.authorization.enabled", "true")
+        // Need a dummy URL to satisfy the Quarkus OIDC extension.
+        .put("quarkus.oidc.auth-server-url", "http://127.255.0.0:0/auth/realms/unset/")
         .build();
   }
 }


### PR DESCRIPTION
See https://groups.google.com/g/quarkus-dev/c/isGqZvY829g/m/BNerQvSRAQAJ

This property is a runtime property and is likely to be more correct to set it to false, when authentication is not enabled.

Incidentally, this allows to get rid of the OIDC warning when Nessie starts.