### PR TITLE
Disable OpenTelemetry SDK when no endpoint is defined

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/OpenTelemetryConfigSourceInterceptor.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/OpenTelemetryConfigSourceInterceptor.java
@@ -49,8 +49,9 @@ public class OpenTelemetryConfigSourceInterceptor implements ConfigSourceInterce
         configValue = configValue.withValue("true");
       } else {
         LOGGER.info(
-            "Found OpenTelemetry collector endpoint URL: {}; enabling OpenTelemetry",
-            tracesEndpoint.getValue());
+            "Found OpenTelemetry collector endpoint URL: {} (from property: {}); enabling OpenTelemetry",
+            tracesEndpoint.getValue(),
+            tracesEndpoint.getName());
       }
     }
     return configValue;

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/OpenTelemetryConfigSourceInterceptor.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/OpenTelemetryConfigSourceInterceptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.config;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpenTelemetryConfigSourceInterceptor implements ConfigSourceInterceptor {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(OpenTelemetryConfigSourceInterceptor.class);
+  private static final int APPLICATION_PROPERTIES_CLASSPATH_ORDINAL = 250;
+
+  @Override
+  public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
+    ConfigValue configValue = context.proceed(name);
+    if (configValue == null || configValue.getValue() == null) {
+      return null;
+    }
+    if (name.equals("quarkus.otel.sdk.disabled")
+        && configValue.getConfigSourceOrdinal() <= APPLICATION_PROPERTIES_CLASSPATH_ORDINAL
+        && configValue.getValue().equals("false")) {
+      // Check for a user-configured endpoint URL. If none is found, disable OpenTelemetry.
+      ConfigValue tracesEndpoint = context.proceed("quarkus.otel.exporter.otlp.traces.endpoint");
+      if (tracesEndpoint.getConfigSourceOrdinal() <= APPLICATION_PROPERTIES_CLASSPATH_ORDINAL) {
+        tracesEndpoint = context.proceed("quarkus.otel.exporter.otlp.endpoint");
+      }
+      if (tracesEndpoint.getConfigSourceOrdinal() <= APPLICATION_PROPERTIES_CLASSPATH_ORDINAL) {
+        LOGGER.info("No OpenTelemetry endpoint configured, disabling OpenTelemetry");
+        LOGGER.info(
+            "To enable OpenTelemetry, define a collector endpoint URL "
+                + "using the property: quarkus.otel.exporter.otlp.traces.endpoint");
+        configValue = configValue.withValue("true");
+      } else {
+        LOGGER.info(
+            "Found OpenTelemetry collector endpoint URL: {}; enabling OpenTelemetry",
+            tracesEndpoint.getValue());
+      }
+    }
+    return configValue;
+  }
+}

--- a/servers/quarkus-common/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/servers/quarkus-common/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2024 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.quarkus.config.OpenTelemetryConfigSourceInterceptor

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -209,11 +209,11 @@ quarkus.micrometer.binder.jvm=true
 
 # Trace collection settings
 # (see https://quarkus.io/guides/opentelemetry#quarkus-opentelemetry_quarkus.otel.logs.exporter)
+# The trace collector endpoint URL to connect to.
+# If this property is not explicitly redefined by user, OpenTelemetry SDK will be disabled when Nessie starts.
+# quarkus.otel.exporter.otlp.traces.endpoint=http://otlp-collector:4317
 quarkus.otel.traces.sampler=parentbased_always_on
 quarkus.otel.traces.sampler.arg=1.0d
-# The trace collector endpoint URL to connect to.
-# Required, except in dev mode where it is set to http://localhost:4317 automatically.
-# quarkus.otel.exporter.otlp.traces.endpoint=http://otlp-collector:4317
 
 # Version Store Events configuration
 #nessie.version.store.events.enable=true

--- a/site/docs/try/configuration.md
+++ b/site/docs/try/configuration.md
@@ -55,9 +55,6 @@ For more information on docker images, see [Docker image options](#docker-image-
 
 [migrate]: ../tools/migration.md
 
-!!! info
-    Starting with Nessie 0.66.0, tracing and metrics are always used, if OpenTelemetry is enabled via the Quarkus configuration.
-
 ### Support for the database specific implementations
 
 | Database         | Status                                           | Configuration value for `nessie.version.store.type`     | Notes                                                                                                                                                                                                                           |
@@ -234,13 +231,13 @@ Metrics are published using prometheus and can be collected via standard methods
 Since Nessie 0.46.0, traces are published using OpenTelemetry. See [Using
 OpenTelemetry](https://quarkus.io/guides/opentelemetry) in the Quarkus documentation.
 
-In order for the server to publish its traces, the
-`quarkus.otel.exporter.otlp.endpoint` property _must_ be set. Its value must be a
+In order for the server to enable OpenTelemetry and publish its traces, the
+`quarkus.otel.exporter.otlp.traces.endpoint` property _must_ be defined. Its value must be a
 valid collector endpoint URL, with either `http://` or `https://` scheme. The collector must talk
 the OpenTelemetry protocol (OTLP) and the port must be its gRPC port (by default 4317), e.g.
-"http://otlp-collector:4317".
+"http://otlp-collector:4317". _If this property is not set, the server will not publish traces._
 
-Alternatively, it's possible to disable opentelemetry completely at runtime by setting the following 
+Alternatively, it's possible to forcibly disable OpenTelemetry at runtime by setting the following 
 property: `quarkus.otel.sdk.disabled=true`.
 
 #### Troubleshooting traces
@@ -248,16 +245,8 @@ property: `quarkus.otel.sdk.disabled=true`.
 If the server is unable to publish traces, check first for a log warning message like the following:
 
 ```
-WARN  [io.qua.ope.run.exp.otl.LateBoundBatchSpanProcessor] (vert.x-eventloop-thread-5) No BatchSpanProcessor delegate specified, no action taken.
-```
-
-This means that the `quarkus.otel.exporter.otlp.endpoint` property is not set. Set
-it to a valid OTLP connector URL and try again.
-
-If you see a log error message like the following:
-
-```
-SEVERE [io.ope.exp.int.grp.OkHttpGrpcExporter] (OkHttp http://localhost:4317/...) Failed to export spans. The request could not be executed. Full error message: Failed to connect to localhost/0:0:0:0:0:0:0:1:4317
+SEVERE [io.ope.exp.int.grp.OkHttpGrpcExporter] (OkHttp http://localhost:4317/...) Failed to export spans. 
+The request could not be executed. Full error message: Failed to connect to localhost/0:0:0:0:0:0:0:1:4317
 ```
 
 This means that the server is unable to connect to the collector. Check that the collector is


### PR DESCRIPTION
This change introduces a conditional enablement of OpenTelemetry SDK, depending on whether a collector endpoint has been explicitly provided by the user or not.

This is inspired by #8000, but it's trickier to solve for one main reason: the 3 runtime properties `quarkus.otel.sdk.disabled`, `quarkus.otel.exporter.otlp.endpoint` and `quarkus.otel.exporter.otlp.traces.endpoint` have default values set by `DefaultValuesConfigSource`.

So the best we can do is: detect whether those properties have been overwritten or not. If they were, then leave OpenTelemetry enabled; if not, disable OpenTelemetry.

This could have one minor impact: users willing to use OpenTelemetry, but relying on the default value of `quarkus.otel.exporter.otlp.traces.endpoint` (which is `http://localhost:4317`) now would need to re-define it for OpenTelemetry to stay enabled. I am not sure there are any users in this situation though, since the docs already ask users to define this property explicitly.

Helm chart users are not affected, since the chart already redefines the endpoint property.

Incidentally, this allows to get rid of the SEVERE warning messages when the user doesn't want OpenTelemetry enabled.