### PR TITLE
Testing: set dynamic Quarkus test-http port everywhere

### DIFF
--- a/events/quarkus/src/test/resources/application.properties
+++ b/events/quarkus/src/test/resources/application.properties
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+quarkus.http.test-port=0
+
 # Useful when debugging
 #quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
 #quarkus.vertx.max-event-loop-execute-time=PT1M

--- a/servers/quarkus-cli/src/main/resources/application.properties
+++ b/servers/quarkus-cli/src/main/resources/application.properties
@@ -98,4 +98,6 @@ quarkus.index-dependency.protobuf.artifact-id=protobuf-java
 quarkus.index-dependency.nessie-protobuf.group-id=org.projectnessie.nessie
 quarkus.index-dependency.nessie-protobuf.artifact-id=nessie-protobuf-relocated
 
+quarkus.http.test-port=0
+
 %test.quarkus.devservices.enabled=false


### PR DESCRIPTION
... to avoid port-clashes when running tests concurrently. It seems that even "just CLI" Quarkus app tests can start a http daemon, which then results in a "address already in use" test failure. This change has no negative side effects.