### PR TITLE
Use TLS in ITOAuth2Client

### DIFF
--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -391,8 +391,7 @@ class TestOAuth2Client {
       OAuth2ClientConfig config =
           configBuilder(server, false).grantType(GrantType.AUTHORIZATION_CODE).build();
 
-      try (ResourceOwnerEmulator resourceOwner =
-              new ResourceOwnerEmulator(GrantType.AUTHORIZATION_CODE);
+      try (ResourceOwnerEmulator resourceOwner = ResourceOwnerEmulator.forAuthorizationCode();
           AuthorizationCodeFlow flow =
               new AuthorizationCodeFlow(config, resourceOwner.getConsoleOut())) {
         resourceOwner.setErrorListener(e -> flow.close());
@@ -435,7 +434,7 @@ class TestOAuth2Client {
               .deviceCodeFlowPollInterval(Duration.ofMillis(100))
               .build();
 
-      try (ResourceOwnerEmulator resourceOwner = new ResourceOwnerEmulator(GrantType.DEVICE_CODE);
+      try (ResourceOwnerEmulator resourceOwner = ResourceOwnerEmulator.forDeviceCode();
           DeviceCodeFlow flow = new DeviceCodeFlow(config, resourceOwner.getConsoleOut())) {
         resourceOwner.setErrorListener(e -> flow.close());
         Tokens tokens = flow.fetchNewTokens();

--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/ITOAuth2Authentication.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/ITOAuth2Authentication.java
@@ -64,7 +64,8 @@ public class ITOAuth2Authentication extends AbstractOAuth2Authentication {
 
   @Override
   protected ResourceOwnerEmulator newResourceOwner(GrantType grantType) throws IOException {
-    ResourceOwnerEmulator resourceOwner = new ResourceOwnerEmulator(grantType, "alice", "alice");
+    ResourceOwnerEmulator resourceOwner =
+        new ResourceOwnerEmulator(grantType, "alice", "alice", null);
     resourceOwner.replaceSystemOut();
     resourceOwner.setAuthServerBaseUri(URI.create(keycloakClient.getAuthServerUrl()));
     resourceOwner.setErrorListener(e -> api().close());


### PR DESCRIPTION
Apparently Keycloak no longer allows administration (involving OIDC) over plain HTTP.