### PR TITLE
CI/Testing: Let Renovate manage Docker image references

### DIFF
--- a/api/client/src/intTest/resources/org/projectnessie/client/auth/oauth2/Dockerfile-keycloak-version
+++ b/api/client/src/intTest/resources/org/projectnessie/client/auth/oauth2/Dockerfile-keycloak-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM quay.io/keycloak/keycloak:23.0.6

--- a/api/model/src/intTest/resources/org/projectnessie/model/Dockerfile-redocly-version
+++ b/api/model/src/intTest/resources/org/projectnessie/model/Dockerfile-redocly-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM docker.io/redocly/cli:1.8.2

--- a/gc/gc-repository-jdbc/src/intTest/java/org/projectnessie/gc/contents/jdbc/ITPostgresPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/intTest/java/org/projectnessie/gc/contents/jdbc/ITPostgresPersistenceSpi.java
@@ -15,6 +15,11 @@
  */
 package org.projectnessie.gc.contents.jdbc;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -26,8 +31,7 @@ public class ITPostgresPersistenceSpi extends AbstractJdbcPersistenceSpi {
   @BeforeAll
   static void createDataSource() throws Exception {
 
-    String version = System.getProperty("it.nessie.container.postgres.tag", "latest");
-    container = new PostgreSQLContainer<>("postgres:" + version);
+    container = new PostgreSQLContainer<>(dockerImage("postgres"));
     container.start();
 
     initDataSource(container.getJdbcUrl());
@@ -37,6 +41,24 @@ public class ITPostgresPersistenceSpi extends AbstractJdbcPersistenceSpi {
   static void stopContainer() {
     if (container != null) {
       container.stop();
+    }
+  }
+
+  protected static String dockerImage(String dbName) {
+    URL resource = ITPostgresPersistenceSpi.class.getResource("Dockerfile-" + dbName + "-version");
+    try (InputStream in = resource.openConnection().getInputStream()) {
+      String[] imageTag =
+          Arrays.stream(new String(in.readAllBytes(), UTF_8).split("\n"))
+              .map(String::trim)
+              .filter(l -> l.startsWith("FROM "))
+              .map(l -> l.substring(5).trim().split(":"))
+              .findFirst()
+              .orElseThrow();
+      String image = imageTag[0];
+      String version = System.getProperty("it.nessie.container." + dbName + ".tag", imageTag[1]);
+      return image + ':' + version;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to extract tag from " + resource, e);
     }
   }
 }

--- a/gc/gc-repository-jdbc/src/intTest/resources/org/projectnessie/gc/contents/jdbc/Dockerfile-postgres-version
+++ b/gc/gc-repository-jdbc/src/intTest/resources/org/projectnessie/gc/contents/jdbc/Dockerfile-postgres-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM postgres:16.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,9 +29,6 @@ quarkus = "3.6.7"
 slf4j = "1.7.36"
 undertow = "2.2.28.Final"
 
-# Docker image tags
-postgresContainerTag = "14"
-
 [bundles]
 junit-testing = ["assertj-core", "mockito-core", "mockito-junit-jupiter", "junit-jupiter-api", "junit-jupiter-params"]
 

--- a/servers/quarkus-server/build.gradle.kts
+++ b/servers/quarkus-server/build.gradle.kts
@@ -157,14 +157,6 @@ quarkusAppPartsBuild.configure {
   inputs.files(openapiSource)
 }
 
-tasks.withType<Test>().configureEach {
-  systemProperty(
-    "it.nessie.container.postgres.tag",
-    System.getProperty("it.nessie.container.postgres.tag", libs.versions.postgresContainerTag.get())
-  )
-  systemProperty("keycloak.docker.tag", libs.versions.keycloak.get())
-}
-
 val quarkusBuild = tasks.named<QuarkusBuild>("quarkusBuild")
 
 // Expose runnable jar via quarkusRunner configuration for integration-tests that require the

--- a/servers/quarkus-tests/src/main/resources/org/projectnessie/quarkus/tests/profiles/Dockerfile-postgres-version
+++ b/servers/quarkus-tests/src/main/resources/org/projectnessie/quarkus/tests/profiles/Dockerfile-postgres-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM postgres:16.1

--- a/testing/keycloak-container/src/main/resources/org/projectnessie/testing/keycloak/Dockerfile-keycloak-version
+++ b/testing/keycloak-container/src/main/resources/org/projectnessie/testing/keycloak/Dockerfile-keycloak-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM quay.io/keycloak/keycloak:23.0.6

--- a/testing/nessie-container/src/main/java/org/projectnessie/testing/nessie/NessieContainer.java
+++ b/testing/nessie-container/src/main/java/org/projectnessie/testing/nessie/NessieContainer.java
@@ -15,9 +15,14 @@
  */
 package org.projectnessie.testing.nessie;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.io.InputStream;
 import java.net.URI;
+import java.net.URL;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -46,14 +51,35 @@ public class NessieContainer extends GenericContainer<NessieContainer> {
 
   @Value.Immutable
   public abstract static class NessieConfig {
+
+    public static final String DEFAULT_IMAGE;
+    public static final String DEFAULT_TAG;
+
+    static {
+      URL resource = NessieConfig.class.getResource("Dockerfile-nessie-version");
+      try (InputStream in = resource.openConnection().getInputStream()) {
+        String[] imageTag =
+            Arrays.stream(new String(in.readAllBytes(), UTF_8).split("\n"))
+                .map(String::trim)
+                .filter(l -> l.startsWith("FROM "))
+                .map(l -> l.substring(5).trim().split(":"))
+                .findFirst()
+                .orElseThrow();
+        DEFAULT_IMAGE = imageTag[0];
+        DEFAULT_TAG = imageTag[1];
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to extract tag from " + resource, e);
+      }
+    }
+
     @Value.Default
     public String dockerImage() {
-      return "ghcr.io/projectnessie/nessie";
+      return DEFAULT_IMAGE;
     }
 
     @Value.Default
     public String dockerTag() {
-      return "latest";
+      return DEFAULT_TAG;
     }
 
     @Nullable

--- a/testing/nessie-container/src/main/resources/org/projectnessie/testing/nessie/Dockerfile-nessie-version
+++ b/testing/nessie-container/src/main/resources/org/projectnessie/testing/nessie/Dockerfile-nessie-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM ghcr.io/projectnessie/nessie:0.76.6

--- a/testing/s3minio/src/main/resources/org/projectnessie/minio/Dockerfile-minio-version
+++ b/testing/s3minio/src/main/resources/org/projectnessie/minio/Dockerfile-minio-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM quay.io/minio/minio:RELEASE.2024-01-31T20-20-33Z

--- a/versioned/storage/bigtable/src/main/resources/org/projectnessie/versioned/storage/bigtable/Dockerfile-google-cloud-sdk-version
+++ b/versioned/storage/bigtable/src/main/resources/org/projectnessie/versioned/storage/bigtable/Dockerfile-google-cloud-sdk-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM docker.io/google/cloud-sdk:462.0.1

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraBackendTestFactory.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraBackendTestFactory.java
@@ -27,7 +27,7 @@ public class CassandraBackendTestFactory extends AbstractCassandraBackendTestFac
           + "-Dcassandra.initial_token=0";
 
   public CassandraBackendTestFactory() {
-    super("cassandra", "cassandra", emptyList());
+    super("cassandra", emptyList());
   }
 
   @Override

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/ScyllaDBBackendTestFactory.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/ScyllaDBBackendTestFactory.java
@@ -27,7 +27,6 @@ public class ScyllaDBBackendTestFactory extends AbstractCassandraBackendTestFact
 
   public ScyllaDBBackendTestFactory() {
     super(
-        "scylladb/scylla",
         "scylladb",
         asList(
             "--smp",

--- a/versioned/storage/cassandra/src/main/resources/org/projectnessie/versioned/storage/cassandra/Dockerfile-cassandra-version
+++ b/versioned/storage/cassandra/src/main/resources/org/projectnessie/versioned/storage/cassandra/Dockerfile-cassandra-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM docker.io/cassandra:5.0

--- a/versioned/storage/cassandra/src/main/resources/org/projectnessie/versioned/storage/cassandra/Dockerfile-scylladb-version
+++ b/versioned/storage/cassandra/src/main/resources/org/projectnessie/versioned/storage/cassandra/Dockerfile-scylladb-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM docker.io/scylladb/scylla:5.4.1

--- a/versioned/storage/dynamodb/src/main/resources/org/projectnessie/versioned/storage/dynamodb/Dockerfile-dynamodb-local-version
+++ b/versioned/storage/dynamodb/src/main/resources/org/projectnessie/versioned/storage/dynamodb/Dockerfile-dynamodb-local-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM docker.io/amazon/dynamodb-local:2.2.1

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/CockroachBackendTestFactory.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/CockroachBackendTestFactory.java
@@ -19,7 +19,7 @@ import jakarta.annotation.Nonnull;
 import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
-public class CockroachBackendTestFactory extends PostgreSQLBackendTestFactory {
+public class CockroachBackendTestFactory extends ContainerBackendTestFactory {
 
   @Override
   public String getName() {
@@ -29,7 +29,6 @@ public class CockroachBackendTestFactory extends PostgreSQLBackendTestFactory {
   @Nonnull
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {
-    String version = System.getProperty("it.nessie.container.cockroach.tag", "latest");
-    return new CockroachContainer("cockroachdb/cockroach:" + version);
+    return new CockroachContainer(dockerImage("cockroach"));
   }
 }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/PostgreSQLBackendTestFactory.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/PostgreSQLBackendTestFactory.java
@@ -29,7 +29,7 @@ public class PostgreSQLBackendTestFactory extends ContainerBackendTestFactory {
   @Nonnull
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {
-    String version = System.getProperty("it.nessie.container.postgres.tag", "latest");
-    return new PostgreSQLContainer<>("postgres:" + version);
+    String dockerImage = dockerImage("postgres");
+    return new PostgreSQLContainer<>(dockerImage);
   }
 }

--- a/versioned/storage/jdbc/src/main/resources/org/projectnessie/versioned/storage/jdbc/Dockerfile-cockroach-version
+++ b/versioned/storage/jdbc/src/main/resources/org/projectnessie/versioned/storage/jdbc/Dockerfile-cockroach-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM cockroachdb/cockroach:v23.1.14

--- a/versioned/storage/jdbc/src/main/resources/org/projectnessie/versioned/storage/jdbc/Dockerfile-postgres-version
+++ b/versioned/storage/jdbc/src/main/resources/org/projectnessie/versioned/storage/jdbc/Dockerfile-postgres-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM postgres:16.1

--- a/versioned/storage/mongodb/src/main/resources/org/projectnessie/versioned/storage/mongodb/Dockerfile-mongodb-version
+++ b/versioned/storage/mongodb/src/main/resources/org/projectnessie/versioned/storage/mongodb/Dockerfile-mongodb-version
@@ -1,0 +1,3 @@
+# Dockerfile to provide the image name and tag to a test.
+# Version is managed by Renovate - do not edit.
+FROM mongo:5.0.24


### PR DESCRIPTION
Use specific versions for Docker images instead of `latest`, versions to be managed by Renovate.

Adds a "dummy" `Dockerfile` for each referenced image, which can be managed by Renovate. The code that uses the Docker image extracts the image name and tag from that `Dockerfile`.

The code to extract the image name and tag is duplicated in a couple of places, but introducing a separate project just for this functionality feels overkill. It is rather unlikely that the image/tag parsing code will change. Also some "dummy" `Dockerfile`s are duplicated.

Fixes #8014