### PR TITLE
Custom object types: Use gz as default compression

### DIFF
--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/util/TestCompressions.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/util/TestCompressions.java
@@ -50,13 +50,13 @@ public class TestCompressions {
     AtomicReference<Compression> compression = new AtomicReference<>();
     byte[] compressed = Compressions.compressDefault(data, compression::set);
     soft.assertThat(compressed.length).isLessThan(data.length);
-    soft.assertThat(compression.get()).isSameAs(Compression.SNAPPY);
+    soft.assertThat(compression.get()).isSameAs(Compression.GZIP);
   }
 
   @ParameterizedTest
   @EnumSource(
       value = Compression.class,
-      names = {"NONE", "SNAPPY", "DEFLATE"})
+      names = {"NONE", "SNAPPY", "DEFLATE", "GZIP"})
   public void supportedCompression(Compression compression) {
     byte[] data = ("x".repeat(10)).getBytes(UTF_8);
     byte[] compressed = Compressions.compress(compression, data);
@@ -67,7 +67,8 @@ public class TestCompressions {
   @ParameterizedTest
   @EnumSource(value = Compression.class)
   public void unsupportedCompression(Compression compression) {
-    assumeThat(compression).isNotIn(Compression.NONE, Compression.SNAPPY, Compression.DEFLATE);
+    assumeThat(compression)
+        .isNotIn(Compression.NONE, Compression.SNAPPY, Compression.DEFLATE, Compression.GZIP);
     byte[] data = ("x".repeat(10)).getBytes(UTF_8);
     soft.assertThatIllegalArgumentException()
         .isThrownBy(() -> Compressions.compress(compression, data))


### PR DESCRIPTION
Custom object types currently use snappy as the default compression algorithm. The decision for Snappy was made based on some artificial test data. Now, after some more experiments, it turns out that gzip is, although a bit slower, much more space efficient than snappy, which justifies the change.

Test data was collected from a piece of data, with an uncompressed size of 12601198, gzip down to 904483, deflate down to 949417 and snappy down to 1531390. I.e. gzipped output is ~50% smaller than snappy. Since these objects are fetched from a remote database, the savings in space likely matter more than compression speed.