### PR TITLE
Mark ContentResponse.getEffectiveReference as not null

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/ContentResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/ContentResponse.java
@@ -40,10 +40,10 @@ public interface ContentResponse {
 
   /**
    * The effective reference (for example a branch or tag) including the commit ID from which the
-   * entries were fetched.
+   * entries were fetched. Never null.
    */
-  @Nullable
-  @jakarta.annotation.Nullable
+  @NotNull
+  @jakarta.validation.constraints.NotNull
   @Value.Parameter(order = 2)
   Reference getEffectiveReference();
 

--- a/api/model/src/main/java/org/projectnessie/model/DiffResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/DiffResponse.java
@@ -37,12 +37,20 @@ public interface DiffResponse extends PaginatedResponse {
 
   List<DiffEntry> getDiffs();
 
-  @Nullable
+  /**
+   * The effective "from" reference (for example a branch or tag) including the commit ID from which
+   * the diffs were fetched. Never null when using REST API v2.
+   */
+  @Nullable // Only nullable in V1
   @jakarta.annotation.Nullable
   @JsonView(Views.V2.class)
   Reference getEffectiveFromReference();
 
-  @Nullable
+  /**
+   * The effective "to" reference (for example a branch or tag) including the commit ID from which
+   * the diffs were fetched. Never null when using REST API v2.
+   */
+  @Nullable // Only nullable in V1
   @jakarta.annotation.Nullable
   @JsonView(Views.V2.class)
   Reference getEffectiveToReference();

--- a/api/model/src/main/java/org/projectnessie/model/EntriesResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/EntriesResponse.java
@@ -40,9 +40,9 @@ public interface EntriesResponse extends PaginatedResponse {
 
   /**
    * The effective reference (for example a branch or tag) including the commit ID from which the
-   * entries were fetched.
+   * entries were fetched. Never null when using REST API v2.
    */
-  @Nullable
+  @Nullable // Only nullable in V1
   @jakarta.annotation.Nullable
   @JsonView(Views.V2.class)
   Reference getEffectiveReference();

--- a/api/model/src/main/java/org/projectnessie/model/GetMultipleContentsResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/GetMultipleContentsResponse.java
@@ -42,9 +42,9 @@ public interface GetMultipleContentsResponse {
 
   /**
    * The effective reference (for example a branch or tag) including the commit ID from which the
-   * entries were fetched.
+   * contents were fetched. Never null when using REST API v2.
    */
-  @Nullable
+  @Nullable // Only nullable in V1
   @jakarta.annotation.Nullable
   @Value.Parameter(order = 2)
   @JsonView(Views.V2.class)

--- a/api/model/src/main/java/org/projectnessie/model/GetNamespacesResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/GetNamespacesResponse.java
@@ -32,8 +32,12 @@ public interface GetNamespacesResponse {
   @jakarta.validation.constraints.NotNull
   List<Namespace> getNamespaces();
 
+  /**
+   * The effective reference (for example a branch or tag) including the commit ID from which the
+   * namespaces were fetched. Cannot be null when using REST API v2.
+   */
   @JsonView(Views.V2.class)
-  @Nullable
+  @Nullable // Only nullable in V1
   @jakarta.annotation.Nullable
   Reference getEffectiveReference();
 


### PR DESCRIPTION
And also: document nullability of other similar methods.