### PR TITLE
GC Tool: ability to skip creating existing tables (IF NOT EXISTS)

### DIFF
--- a/gc/gc-repository-jdbc/src/intTest/java/org/projectnessie/gc/contents/jdbc/ITJdbcHelper.java
+++ b/gc/gc-repository-jdbc/src/intTest/java/org/projectnessie/gc/contents/jdbc/ITJdbcHelper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.projectnessie.gc.contents.jdbc.ITPostgresPersistenceSpi.dockerImage;
+
+import java.sql.Connection;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class ITJdbcHelper extends AbstractJdbcHelper {
+
+  private static PostgreSQLContainer<?> container;
+
+  @BeforeAll
+  static void createDataSource() throws Exception {
+    container = new PostgreSQLContainer<>(dockerImage("postgres"));
+    container.start();
+    initDataSource(container.getJdbcUrl());
+  }
+
+  @AfterAll
+  static void stopContainer() {
+    if (container != null) {
+      container.stop();
+    }
+  }
+
+  @Test
+  @Order(0)
+  void createTables() {
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.createTables(conn, false);
+              }
+            })
+        .doesNotThrowAnyException();
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.createTables(conn, true);
+              }
+            })
+        .as("creating tables again should not throw when ifNotExists is true")
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @Order(1)
+  void dropTables() {
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.dropTables(conn);
+              }
+            })
+        .doesNotThrowAnyException();
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.dropTables(conn);
+              }
+            })
+        .as("dropping tables again should not throw")
+        .doesNotThrowAnyException();
+  }
+}

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcHelper.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcHelper.java
@@ -45,7 +45,7 @@ public final class JdbcHelper {
 
   public static void dropTables(Connection connection) throws SQLException {
     try (Statement st = connection.createStatement()) {
-      for (String tableName : SqlDmlDdl.ALL_TABLE_NAMES) {
+      for (String tableName : SqlDmlDdl.ALL_CREATES.keySet()) {
         if (tableExists(connection, tableName)) {
           st.execute("DROP TABLE " + tableName);
         }

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcHelper.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/JdbcHelper.java
@@ -16,12 +16,15 @@
 package org.projectnessie.gc.contents.jdbc;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Spliterators.AbstractSpliterator;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -29,15 +32,40 @@ import java.util.function.Supplier;
 public final class JdbcHelper {
   private JdbcHelper() {}
 
-  public static void createTables(Connection connection) throws SQLException {
+  public static void createTables(Connection connection, boolean ifNotExists) throws SQLException {
     try (Statement st = connection.createStatement()) {
-      for (String createTable : getCreateTableStatements()) {
-        st.execute(createTable);
+      Map<String, String> createTableStatements = getCreateTableStatements();
+      for (String tableName : createTableStatements.keySet()) {
+        if (!ifNotExists || !tableExists(connection, tableName)) {
+          st.execute(createTableStatements.get(tableName));
+        }
       }
     }
   }
 
-  public static List<String> getCreateTableStatements() {
+  public static void dropTables(Connection connection) throws SQLException {
+    try (Statement st = connection.createStatement()) {
+      for (String tableName : SqlDmlDdl.ALL_TABLE_NAMES) {
+        if (tableExists(connection, tableName)) {
+          st.execute("DROP TABLE " + tableName);
+        }
+      }
+    }
+  }
+
+  private static boolean tableExists(Connection connection, String tableName) throws SQLException {
+    DatabaseMetaData meta = connection.getMetaData();
+    if (meta.storesUpperCaseIdentifiers()) {
+      tableName = tableName.toUpperCase(Locale.ROOT);
+    }
+    String catalog = connection.getCatalog();
+    String schema = connection.getSchema();
+    try (ResultSet rs = meta.getTables(catalog, schema, tableName, new String[] {"TABLE"})) {
+      return rs.next();
+    }
+  }
+
+  public static Map<String, String> getCreateTableStatements() {
     return SqlDmlDdl.ALL_CREATES;
   }
 

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/SqlDmlDdl.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/SqlDmlDdl.java
@@ -18,6 +18,7 @@ package org.projectnessie.gc.contents.jdbc;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.intellij.lang.annotations.Language;
 
 final class SqlDmlDdl {
@@ -169,13 +170,12 @@ final class SqlDmlDdl {
           + "    FROM gc_live_set_contents \n"
           + "    WHERE live_set_id = ? AND content_id = ?";
 
-  static final List<String> ALL_CREATES =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              CREATE_LIVE_SETS,
-              CREATE_LIVE_SET_CONTENTS,
-              CREATE_LIVE_SET_LOCATIONS,
-              CREATE_FILE_DELETIONS));
+  static final Map<String, String> ALL_CREATES =
+      Map.of(
+          "gc_live_sets", CREATE_LIVE_SETS,
+          "gc_live_set_contents", CREATE_LIVE_SET_CONTENTS,
+          "gc_live_set_content_locations", CREATE_LIVE_SET_LOCATIONS,
+          "gc_file_deletions", CREATE_FILE_DELETIONS);
 
   static final List<String> ALL_TABLE_NAMES =
       Collections.unmodifiableList(

--- a/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/SqlDmlDdl.java
+++ b/gc/gc-repository-jdbc/src/main/java/org/projectnessie/gc/contents/jdbc/SqlDmlDdl.java
@@ -15,9 +15,7 @@
  */
 package org.projectnessie.gc.contents.jdbc;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.intellij.lang.annotations.Language;
 
@@ -171,17 +169,9 @@ final class SqlDmlDdl {
           + "    WHERE live_set_id = ? AND content_id = ?";
 
   static final Map<String, String> ALL_CREATES =
-      Map.of(
+      ImmutableMap.of(
           "gc_live_sets", CREATE_LIVE_SETS,
           "gc_live_set_contents", CREATE_LIVE_SET_CONTENTS,
           "gc_live_set_content_locations", CREATE_LIVE_SET_LOCATIONS,
           "gc_file_deletions", CREATE_FILE_DELETIONS);
-
-  static final List<String> ALL_TABLE_NAMES =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              "gc_live_set_content_locations",
-              "gc_live_set_contents",
-              "gc_live_sets",
-              "gc_file_deletions"));
 }

--- a/gc/gc-repository-jdbc/src/test/java/org/projectnessie/gc/contents/jdbc/TestJdbcHelper.java
+++ b/gc/gc-repository-jdbc/src/test/java/org/projectnessie/gc/contents/jdbc/TestJdbcHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.sql.Connection;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+public class TestJdbcHelper extends AbstractJdbcHelper {
+
+  @BeforeAll
+  public static void createDataSource() throws Exception {
+    initDataSource("jdbc:h2:mem:nessie;MODE=PostgreSQL");
+  }
+
+  @Test
+  @Order(0)
+  void createTables() {
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.createTables(conn, false);
+              }
+            })
+        .doesNotThrowAnyException();
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.createTables(conn, true);
+              }
+            })
+        .as("creating tables again should not throw when ifNotExists is true")
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @Order(1)
+  void dropTables() {
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.dropTables(conn);
+              }
+            })
+        .doesNotThrowAnyException();
+    assertThatCode(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                JdbcHelper.dropTables(conn);
+              }
+            })
+        .as("dropping tables again should not throw")
+        .doesNotThrowAnyException();
+  }
+}

--- a/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcHelper.java
+++ b/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.contents.jdbc;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+
+public class AbstractJdbcHelper {
+
+  protected static DataSource dataSource;
+
+  static void initDataSource(String jdbcUrl) throws Exception {
+    AgroalJdbcDataSourceProvider dsProvider =
+        AgroalJdbcDataSourceProvider.builder()
+            .jdbcUrl(jdbcUrl)
+            .usernamePasswordCredentials("test", "test")
+            .poolMinSize(1)
+            .poolMaxSize(1)
+            .poolInitialSize(1)
+            .build();
+    dataSource = dsProvider.dataSource();
+  }
+
+  @AfterAll
+  static void closeDataSource() throws Exception {
+    if (dataSource instanceof AutoCloseable) {
+      ((AutoCloseable) dataSource).close();
+    }
+  }
+}

--- a/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcPersistenceSpi.java
@@ -18,7 +18,6 @@ package org.projectnessie.gc.contents.jdbc;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.UUID;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
@@ -58,18 +57,18 @@ public abstract class AbstractJdbcPersistenceSpi extends AbstractPersistenceSpi 
   @BeforeEach
   void setup() throws Exception {
     try (Connection conn = dataSource.getConnection()) {
-      JdbcHelper.createTables(conn);
+      JdbcHelper.createTables(conn, false);
+      // Test table creation with existing tables
+      JdbcHelper.createTables(conn, true);
     }
   }
 
   @AfterEach
   void tearDown() throws Exception {
     try (Connection conn = dataSource.getConnection()) {
-      try (Statement st = conn.createStatement()) {
-        for (String tableName : SqlDmlDdl.ALL_TABLE_NAMES) {
-          st.execute(String.format("DROP TABLE %s", tableName));
-        }
-      }
+      JdbcHelper.dropTables(conn);
+      // Test table deletion with non-existing tables
+      JdbcHelper.dropTables(conn);
     }
   }
 

--- a/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcPersistenceSpi.java
@@ -28,7 +28,7 @@ import org.projectnessie.gc.contents.tests.AbstractPersistenceSpi;
 
 public abstract class AbstractJdbcPersistenceSpi extends AbstractPersistenceSpi {
 
-  private static DataSource dataSource;
+  static DataSource dataSource;
 
   static void initDataSource(String jdbcUrl) throws Exception {
     AgroalJdbcDataSourceProvider dsProvider =
@@ -75,7 +75,7 @@ public abstract class AbstractJdbcPersistenceSpi extends AbstractPersistenceSpi 
   @Override
   protected void assertDeleted(UUID id) throws Exception {
     try (Connection conn = dataSource.getConnection()) {
-      for (String tableName : SqlDmlDdl.ALL_TABLE_NAMES) {
+      for (String tableName : SqlDmlDdl.ALL_CREATES.keySet()) {
         try (PreparedStatement st =
             conn.prepareStatement(
                 String.format("SELECT * FROM %s WHERE live_set_id = ?", tableName))) {

--- a/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/testFixtures/java/org/projectnessie/gc/contents/jdbc/AbstractJdbcPersistenceSpi.java
@@ -58,16 +58,12 @@ public abstract class AbstractJdbcPersistenceSpi extends AbstractPersistenceSpi 
   void setup() throws Exception {
     try (Connection conn = dataSource.getConnection()) {
       JdbcHelper.createTables(conn, false);
-      // Test table creation with existing tables
-      JdbcHelper.createTables(conn, true);
     }
   }
 
   @AfterEach
   void tearDown() throws Exception {
     try (Connection conn = dataSource.getConnection()) {
-      JdbcHelper.dropTables(conn);
-      // Test table deletion with non-existing tables
       JdbcHelper.dropTables(conn);
     }
   }

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/commands/JdbcCreateSchema.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/commands/JdbcCreateSchema.java
@@ -17,10 +17,10 @@ package org.projectnessie.gc.tool.cli.commands;
 
 import java.sql.Connection;
 import javax.sql.DataSource;
-import org.projectnessie.gc.contents.jdbc.JdbcHelper;
 import org.projectnessie.gc.tool.cli.Closeables;
 import org.projectnessie.gc.tool.cli.options.EnvironmentDefaultProvider;
 import org.projectnessie.gc.tool.cli.options.JdbcOptions;
+import org.projectnessie.gc.tool.cli.options.SchemaCreateStrategy;
 import picocli.CommandLine;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -39,9 +39,12 @@ public class JdbcCreateSchema extends BaseCommand {
   @Override
   protected Integer call(Closeables closeables) throws Exception {
     DataSource dataSource = closeables.maybeAdd(jdbc.createDataSource());
+    SchemaCreateStrategy schemaCreateStrategy = jdbc.getSchemaCreateStrategy();
+    if (schemaCreateStrategy == null) {
+      schemaCreateStrategy = SchemaCreateStrategy.CREATE;
+    }
     try (Connection conn = dataSource.getConnection()) {
-      JdbcHelper.createTables(conn);
-      conn.commit();
+      schemaCreateStrategy.apply(conn);
     }
     commandSpec
         .commandLine()

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/commands/JdbcDumpSchema.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/commands/JdbcDumpSchema.java
@@ -50,7 +50,7 @@ public class JdbcDumpSchema implements Callable<Integer> {
   }
 
   private void dumpStatements(Writer out) throws IOException {
-    for (String statement : JdbcHelper.getCreateTableStatements()) {
+    for (String statement : JdbcHelper.getCreateTableStatements().values()) {
       out.write(statement);
       out.write(";\n\n");
     }

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/JdbcOptions.java
@@ -51,6 +51,13 @@ public class JdbcOptions {
       description = "JDBC password used to authenticate the database access.")
   String password;
 
+  @CommandLine.Option(
+      names = "--jdbc-schema",
+      description =
+          "How to create the database schema. "
+              + "Possible values: CREATE, DROP_AND_CREATE, CREATE_IF_NOT_EXISTS.")
+  SchemaCreateStrategy schemaCreateStrategy;
+
   public DataSource createDataSource() throws SQLException {
     AgroalJdbcDataSourceProvider.Builder jdbcDsBuilder =
         AgroalJdbcDataSourceProvider.builder()
@@ -59,5 +66,9 @@ public class JdbcOptions {
     properties.forEach(jdbcDsBuilder::putJdbcProperties);
     AgroalJdbcDataSourceProvider dataSourceProvider = jdbcDsBuilder.build();
     return dataSourceProvider.dataSource();
+  }
+
+  public SchemaCreateStrategy getSchemaCreateStrategy() {
+    return schemaCreateStrategy;
   }
 }

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/LiveContentSetsStorageOptions.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/LiveContentSetsStorageOptions.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.gc.tool.cli.options;
 
+import java.sql.Connection;
 import javax.sql.DataSource;
 import org.projectnessie.gc.contents.LiveContentSetsRepository;
 import org.projectnessie.gc.contents.inmem.InMemoryPersistenceSpi;
@@ -78,6 +79,12 @@ public class LiveContentSetsStorageOptions {
   private PersistenceSpi createJdbcPersistenceSpi(Closeables closeables, JdbcOptions jdbc)
       throws Exception {
     DataSource dataSource = closeables.maybeAdd(jdbc.createDataSource());
+    SchemaCreateStrategy schemaCreateStrategy = jdbc.getSchemaCreateStrategy();
+    if (schemaCreateStrategy != null) {
+      try (Connection conn = dataSource.getConnection()) {
+        schemaCreateStrategy.apply(conn);
+      }
+    }
     return JdbcPersistenceSpi.builder().dataSource(dataSource).build();
   }
 }

--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/SchemaCreateStrategy.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/options/SchemaCreateStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.tool.cli.options;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.projectnessie.gc.contents.jdbc.JdbcHelper;
+
+public enum SchemaCreateStrategy {
+  CREATE {
+    @Override
+    public void apply(Connection conn) throws SQLException {
+      JdbcHelper.createTables(conn, false);
+    }
+  },
+  DROP_AND_CREATE {
+    @Override
+    public void apply(Connection conn) throws SQLException {
+      JdbcHelper.dropTables(conn);
+      JdbcHelper.createTables(conn, false);
+    }
+  },
+  CREATE_IF_NOT_EXISTS {
+    @Override
+    public void apply(Connection conn) throws SQLException {
+      JdbcHelper.createTables(conn, true);
+    }
+  },
+  ;
+
+  public abstract void apply(Connection conn) throws SQLException;
+}

--- a/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
+++ b/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
@@ -34,6 +34,7 @@ import javax.sql.DataSource;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -93,6 +94,13 @@ public class TestCLI {
             .poolInitialSize(1)
             .build()
             .dataSource();
+  }
+
+  @AfterAll
+  static void closeDataSource() throws Exception {
+    if (dataSource instanceof AutoCloseable) {
+      ((AutoCloseable) dataSource).close();
+    }
   }
 
   private void dropTables() throws Exception {

--- a/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
+++ b/gc/gc-tool/src/test/java/org/projectnessie/gc/tool/TestCLI.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.Connection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -43,12 +44,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.client.ext.NessieClientUri;
 import org.projectnessie.gc.contents.ContentReference;
 import org.projectnessie.gc.contents.jdbc.AgroalJdbcDataSourceProvider;
+import org.projectnessie.gc.contents.jdbc.JdbcHelper;
 import org.projectnessie.gc.contents.jdbc.JdbcPersistenceSpi;
 import org.projectnessie.gc.files.FileReference;
+import org.projectnessie.gc.tool.cli.options.SchemaCreateStrategy;
 import org.projectnessie.gc.tool.cli.util.RunCLI;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.model.ContentKey;
@@ -64,17 +68,37 @@ import org.projectnessie.versioned.storage.testextension.PersistExtension;
 public class TestCLI {
 
   public static final String JDBC_URL = "jdbc:h2:mem:nessie_gc;MODE=PostgreSQL;DB_CLOSE_DELAY=-1";
-  @NessiePersist static Persist perssit;
+  @NessiePersist static Persist persist;
 
   @InjectSoftAssertions private SoftAssertions soft;
 
-  @RegisterExtension static NessieJaxRsExtension server = jaxRsExtension(() -> perssit);
+  @RegisterExtension static NessieJaxRsExtension server = jaxRsExtension(() -> persist);
 
   private static URI nessieUri;
 
   @BeforeAll
   static void setNessieUri(@NessieClientUri URI uri) {
     nessieUri = uri;
+  }
+
+  private static DataSource dataSource;
+
+  @BeforeAll
+  static void initDataSource() throws Exception {
+    dataSource =
+        AgroalJdbcDataSourceProvider.builder()
+            .jdbcUrl(JDBC_URL)
+            .poolMinSize(1)
+            .poolMaxSize(1)
+            .poolInitialSize(1)
+            .build()
+            .dataSource();
+  }
+
+  private void dropTables() throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      JdbcHelper.dropTables(conn);
+    }
   }
 
   static Stream<Arguments> optionErrors() {
@@ -128,8 +152,19 @@ public class TestCLI {
 
   @Test
   @Order(0)
-  public void createTables() throws Exception {
+  public void createSchema() throws Exception {
+    dropTables();
     RunCLI run = RunCLI.run("create-sql-schema", "--jdbc-url", JDBC_URL);
+    soft.assertThat(run.getExitCode()).as(run::getErr).isEqualTo(0);
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaCreateStrategy.class)
+  @Order(1)
+  public void createSchemaWithStrategy(SchemaCreateStrategy strategy) throws Exception {
+    dropTables();
+    RunCLI run =
+        RunCLI.run("create-sql-schema", "--jdbc-schema", strategy.name(), "--jdbc-url", JDBC_URL);
     soft.assertThat(run.getExitCode()).as(run::getErr).isEqualTo(0);
   }
 
@@ -152,6 +187,23 @@ public class TestCLI {
   @Order(1)
   public void smokeTestJdbc() throws Exception {
     RunCLI run = RunCLI.run("gc", "--jdbc-url", JDBC_URL, "--uri", nessieUri.toString());
+    soft.assertThat(run.getExitCode()).as(run::getErr).isEqualTo(0);
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaCreateStrategy.class)
+  @Order(1)
+  public void smokeTestJdbcWithSchemaUpdate(SchemaCreateStrategy strategy) throws Exception {
+    dropTables();
+    RunCLI run =
+        RunCLI.run(
+            "gc",
+            "--jdbc-schema",
+            strategy.name(),
+            "--jdbc-url",
+            JDBC_URL,
+            "--uri",
+            nessieUri.toString());
     soft.assertThat(run.getExitCode()).as(run::getErr).isEqualTo(0);
   }
 


### PR DESCRIPTION
This commit introduces the ability to create the schema only if it does not exist. It also introduces the ability to optionally create the schema before executing the main command `gc`.

The rationale is that `gc` should typically be executed on Kubernetes as a `CronJob` but we don't want to special-case the first execution and do something different than the other executions, just because the schema doesn't exist yet.

With the new option `--jdbc-schema CREATE_IF_NOT_EXISTS`, the first job execution would find an empty schema and create the tables, while the subsequent executions would simply reuse the existing schema. Note that we don't handle schema evolution for now (could be done later).

There is also the option `--jdbc-schema DROP_AND_CREATE` if people prefer to upgrade an old schema by dropping it and recresating it afresh.

The option `--jdbc-schema` is present in all commands that embed `JdbcOptions`.