### PR TITLE
Add set of roles to `AccessContext`, inject AC instead of `Principal`

### DIFF
--- a/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/PrincipalExtension.java
+++ b/compatibility/jersey/src/main/java/org/projectnessie/tools/compatibility/jersey/PrincipalExtension.java
@@ -23,7 +23,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.util.TypeLiteral;
 import java.security.Principal;
-import java.util.function.Supplier;
+import org.projectnessie.services.authz.AccessContext;
 
 /**
  * A CDI extension that always produces {@code null} {@link Principal} objects simulating execution
@@ -32,12 +32,12 @@ import java.util.function.Supplier;
 public class PrincipalExtension implements Extension {
   @SuppressWarnings("unused")
   public void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager bm) {
-    Supplier<Principal> principal = () -> null;
+    AccessContext accessContext = () -> () -> null;
 
     abd.addBean()
-        .addType(new TypeLiteral<Supplier<Principal>>() {})
+        .addType(new TypeLiteral<AccessContext>() {})
         .addQualifier(Default.Literal.INSTANCE)
         .scope(RequestScoped.class)
-        .produceWith(i -> principal);
+        .produceWith(i -> accessContext);
   }
 }

--- a/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/ContextPrincipalExtension.java
+++ b/servers/jax-rs-testextension/src/main/java/org/projectnessie/jaxrs/ext/ContextPrincipalExtension.java
@@ -23,14 +23,14 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.ws.rs.core.SecurityContext;
-import java.security.Principal;
 import java.util.function.Supplier;
+import org.projectnessie.services.authz.AccessContext;
 
 public class ContextPrincipalExtension implements Extension {
-  private final Supplier<Principal> principal;
+  private final AccessContext accessContext;
 
   public ContextPrincipalExtension(Supplier<SecurityContext> securityContext) {
-    this.principal =
+    this.accessContext =
         () -> {
           SecurityContext context = securityContext.get();
           return context == null ? null : context.getUserPrincipal();
@@ -40,9 +40,9 @@ public class ContextPrincipalExtension implements Extension {
   @SuppressWarnings("unused")
   public void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager bm) {
     abd.addBean()
-        .addType(new TypeLiteral<Supplier<Principal>>() {})
+        .addType(new TypeLiteral<AccessContext>() {})
         .addQualifier(Default.Literal.INSTANCE)
         .scope(RequestScoped.class)
-        .produceWith(i -> principal);
+        .produceWith(i -> accessContext);
   }
 }

--- a/servers/quarkus-auth/src/test/java/org/projectnessie/server/authz/TestCELAuthZ.java
+++ b/servers/quarkus-auth/src/test/java/org/projectnessie/server/authz/TestCELAuthZ.java
@@ -77,7 +77,7 @@ public class TestCELAuthZ {
     QuarkusNessieAuthorizationConfig config = buildConfig(true);
     CompiledAuthorizationRules rules = new CompiledAuthorizationRules(config);
     CelBatchAccessChecker batchAccessChecker =
-        new CelBatchAccessChecker(rules, ServerAccessContext.of("meep", () -> "some-user"));
+        new CelBatchAccessChecker(rules, ServerAccessContext.of(() -> "some-user"));
 
     soft.assertThatCode(
             () -> batchAccessChecker.canViewReference(BranchName.of("main")).checkAndThrow())
@@ -94,7 +94,7 @@ public class TestCELAuthZ {
     QuarkusNessieAuthorizationConfig config = buildConfig(true);
     CompiledAuthorizationRules rules = new CompiledAuthorizationRules(config);
     CelBatchAccessChecker batchAccessChecker =
-        new CelBatchAccessChecker(rules, ServerAccessContext.of("meep", () -> null));
+        new CelBatchAccessChecker(rules, ServerAccessContext.of(() -> null));
     Check check = Check.builder(type).build();
     if (type == CheckType.VIEW_REFERENCE) {
       soft.assertThatCode(() -> batchAccessChecker.can(check).checkAndThrow())
@@ -120,14 +120,14 @@ public class TestCELAuthZ {
     when(authorizers.select(new AuthorizerType.Literal("CEL"))).thenReturn(celAuthorizerInstance);
     soft.assertThat(
             new QuarkusAuthorizer(configEnabled, authorizers)
-                .startAccessCheck(ServerAccessContext.of("meep", () -> "some-user")))
+                .startAccessCheck(ServerAccessContext.of(() -> "some-user")))
         .isInstanceOf(CelBatchAccessChecker.class);
 
     when(celAuthorizerInstance.get()).thenReturn(celAuthorizer);
     when(authorizers.select(new AuthorizerType.Literal("CEL"))).thenReturn(celAuthorizerInstance);
     soft.assertThat(
             new QuarkusAuthorizer(configDisabled, authorizers)
-                .startAccessCheck(ServerAccessContext.of("meep", () -> "some-user")))
+                .startAccessCheck(ServerAccessContext.of(() -> "some-user")))
         .isSameAs(AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER);
   }
 

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/AccessContextProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/AccessContextProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.providers;
+
+import static java.util.Collections.emptySet;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import java.security.Principal;
+import java.util.Set;
+import org.projectnessie.services.authz.AccessContext;
+
+@RequestScoped
+public class AccessContextProvider {
+  @Inject Instance<SecurityIdentity> securityIdentity;
+
+  @Produces
+  public AccessContext produceAccessContext() {
+    return new AccessContext() {
+      @Override
+      public Principal user() {
+        return securityIdentity.isResolvable() ? securityIdentity.get().getPrincipal() : () -> null;
+      }
+
+      @Override
+      public Set<String> roleIds() {
+        return securityIdentity.isResolvable() ? securityIdentity.get().getRoles() : emptySet();
+      }
+    };
+  }
+}

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/authz/NessieAuthorizationTestProfile.java
@@ -78,6 +78,7 @@ public class NessieAuthorizationTestProfile extends AuthenticationEnabledProfile
         .putAll(super.getConfigOverrides())
         .putAll(AUTHZ_RULES)
         .put("nessie.server.authorization.enabled", "true")
+        .put("nessie.server.authorization.type", "CEL")
         // Need a dummy URL to satisfy the Quarkus OIDC extension.
         .put("quarkus.oidc.auth-server-url", "http://127.255.0.0:0/auth/realms/unset/")
         .build();

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestConfigService.java
@@ -17,8 +17,7 @@ package org.projectnessie.services.rest;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.security.Principal;
-import java.util.function.Supplier;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ConfigApiImpl;
@@ -33,10 +32,7 @@ public class RestConfigService extends ConfigApiImpl {
 
   @Inject
   public RestConfigService(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal, 1);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext, 1);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestContentService.java
@@ -19,8 +19,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.executable.ExecutableType;
 import jakarta.validation.executable.ValidateOnExecution;
-import java.security.Principal;
-import java.util.function.Supplier;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ContentApiImpl;
@@ -36,10 +35,7 @@ public class RestContentService extends ContentApiImpl {
 
   @Inject
   public RestContentService(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestDiffService.java
@@ -19,8 +19,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.executable.ExecutableType;
 import jakarta.validation.executable.ValidateOnExecution;
-import java.security.Principal;
-import java.util.function.Supplier;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.DiffApiImpl;
@@ -36,10 +35,7 @@ public class RestDiffService extends DiffApiImpl {
 
   @Inject
   public RestDiffService(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestNamespaceService.java
@@ -19,8 +19,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.executable.ExecutableType;
 import jakarta.validation.executable.ValidateOnExecution;
-import java.security.Principal;
-import java.util.function.Supplier;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.NamespaceApiImpl;
@@ -36,10 +35,7 @@ public class RestNamespaceService extends NamespaceApiImpl {
 
   @Inject
   public RestNamespaceService(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeService.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestTreeService.java
@@ -19,8 +19,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.executable.ExecutableType;
 import jakarta.validation.executable.ValidateOnExecution;
-import java.security.Principal;
-import java.util.function.Supplier;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.TreeApiImpl;
@@ -36,10 +35,7 @@ public class RestTreeService extends TreeApiImpl {
 
   @Inject
   public RestTreeService(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext);
   }
 }

--- a/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
+++ b/servers/rest-services/src/main/java/org/projectnessie/services/rest/RestV2ConfigResource.java
@@ -19,10 +19,8 @@ import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import java.security.Principal;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.projectnessie.api.v2.http.HttpConfigApi;
 import org.projectnessie.error.NessieConflictException;
@@ -35,6 +33,7 @@ import org.projectnessie.model.UpdateRepositoryConfigRequest;
 import org.projectnessie.model.UpdateRepositoryConfigResponse;
 import org.projectnessie.model.ser.Views;
 import org.projectnessie.model.types.RepositoryConfigTypes;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ConfigApiImpl;
@@ -54,11 +53,8 @@ public class RestV2ConfigResource implements HttpConfigApi {
 
   @Inject
   public RestV2ConfigResource(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    this.config = new ConfigApiImpl(config, store, authorizer, principal, 2);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    this.config = new ConfigApiImpl(config, store, authorizer, accessContext, 2);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/authz/AccessContext.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/AccessContext.java
@@ -15,13 +15,19 @@
  */
 package org.projectnessie.services.authz;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+
 import java.security.Principal;
+import java.util.Set;
 
 /** Provides some context about a role/principal that accesses Nessie resources. */
 public interface AccessContext {
-  /** Provide a unique id for the operation being validated (for correlation purposes). */
-  String operationId();
-
   /** Provide the user identity. */
   Principal user();
+
+  default Set<String> roleIds() {
+    String name = user().getName();
+    return name.isEmpty() ? emptySet() : singleton(name);
+  }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/authz/ServerAccessContext.java
+++ b/servers/services/src/main/java/org/projectnessie/services/authz/ServerAccessContext.java
@@ -23,13 +23,11 @@ import org.immutables.value.Value;
 public abstract class ServerAccessContext implements AccessContext {
 
   @Override
-  public abstract String operationId();
-
-  @Override
+  @Value.Parameter(order = 1)
   @Nullable
   public abstract Principal user();
 
-  public static ServerAccessContext of(String operationId, Principal principal) {
-    return ImmutableServerAccessContext.builder().operationId(operationId).user(principal).build();
+  public static ServerAccessContext of(Principal principal) {
+    return ImmutableServerAccessContext.builder().user(principal).build();
   }
 }

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ConfigApiImpl.java
@@ -17,16 +17,15 @@ package org.projectnessie.services.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.security.Principal;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieReferenceConflictException;
 import org.projectnessie.model.ImmutableNessieConfiguration;
 import org.projectnessie.model.NessieConfiguration;
 import org.projectnessie.model.RepositoryConfig;
 import org.projectnessie.model.types.GenericRepositoryConfig;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.BatchAccessChecker;
 import org.projectnessie.services.config.ServerConfig;
@@ -43,9 +42,9 @@ public class ConfigApiImpl extends BaseApiImpl implements ConfigService {
       ServerConfig config,
       VersionStore store,
       Authorizer authorizer,
-      Supplier<Principal> principal,
+      AccessContext accessContext,
       int actualApiVersion) {
-    super(config, store, authorizer, principal);
+    super(config, store, authorizer, accessContext);
     this.actualApiVersion = actualApiVersion;
   }
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/ContentApiImpl.java
@@ -15,10 +15,8 @@
  */
 package org.projectnessie.services.impl;
 
-import java.security.Principal;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.projectnessie.error.NessieContentNotFoundException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -31,6 +29,7 @@ import org.projectnessie.model.GetMultipleContentsResponse;
 import org.projectnessie.model.GetMultipleContentsResponse.ContentWithKey;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.BatchAccessChecker;
 import org.projectnessie.services.config.ServerConfig;
@@ -49,11 +48,8 @@ import org.projectnessie.versioned.WithHash;
 public class ContentApiImpl extends BaseApiImpl implements ContentService {
 
   public ContentApiImpl(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/DiffApiImpl.java
@@ -21,7 +21,6 @@ import static org.projectnessie.services.authz.Check.canViewReference;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import java.security.Principal;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -29,12 +28,12 @@ import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.DiffResponse.DiffEntry;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.AuthzPaginationIterator;
 import org.projectnessie.services.authz.Check;
@@ -54,11 +53,8 @@ import org.projectnessie.versioned.paging.PaginationIterator;
 public class DiffApiImpl extends BaseApiImpl implements DiffService {
 
   public DiffApiImpl(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/NamespaceApiImpl.java
@@ -25,7 +25,6 @@ import static org.projectnessie.versioned.VersionStore.KeyRestrictions.NO_KEY_RE
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.MustBeClosed;
 import jakarta.annotation.Nullable;
-import java.security.Principal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,7 +33,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.projectnessie.api.v1.NamespaceApi;
 import org.projectnessie.api.v1.params.NamespaceParams;
@@ -51,6 +49,7 @@ import org.projectnessie.model.ImmutableNamespace;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.model.Operation.Delete;
 import org.projectnessie.model.Operation.Put;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.BatchAccessChecker;
 import org.projectnessie.services.config.ServerConfig;
@@ -69,11 +68,8 @@ import org.projectnessie.versioned.paging.PaginationIterator;
 public class NamespaceApiImpl extends BaseApiImpl implements NamespaceService {
 
   public NamespaceApiImpl(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext);
   }
 
   @Override

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -46,7 +46,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import jakarta.annotation.Nullable;
-import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -62,7 +61,6 @@ import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.projectnessie.cel.tools.Script;
 import org.projectnessie.cel.tools.ScriptException;
@@ -99,6 +97,7 @@ import org.projectnessie.model.ReferenceHistoryState;
 import org.projectnessie.model.ReferenceMetadata;
 import org.projectnessie.model.Tag;
 import org.projectnessie.model.Validation;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.authz.AuthzPaginationIterator;
 import org.projectnessie.services.authz.BatchAccessChecker;
@@ -138,11 +137,8 @@ import org.projectnessie.versioned.paging.PaginationIterator;
 public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
   public TreeApiImpl(
-      ServerConfig config,
-      VersionStore store,
-      Authorizer authorizer,
-      Supplier<Principal> principal) {
-    super(config, store, authorizer, principal);
+      ServerConfig config, VersionStore store, Authorizer authorizer, AccessContext accessContext) {
+    super(config, store, authorizer, accessContext);
   }
 
   @Override

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientBuilder.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientBuilder.java
@@ -16,11 +16,11 @@
 package org.projectnessie.nessie.combined;
 
 import java.security.Principal;
-import java.util.function.Supplier;
 import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.api.NessieApi;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.services.authz.AbstractBatchAccessChecker;
+import org.projectnessie.services.authz.AccessContext;
 import org.projectnessie.services.authz.Authorizer;
 import org.projectnessie.services.config.ServerConfig;
 import org.projectnessie.services.impl.ConfigApiImpl;
@@ -74,19 +74,26 @@ public class CombinedClientBuilder extends NessieClientBuilder.AbstractNessieCli
 
     VersionStore versionStore = new VersionStoreImpl(persist);
     Authorizer authorizer = c -> AbstractBatchAccessChecker.NOOP_ACCESS_CHECKER;
-    Supplier<Principal> principalSupplier = () -> null;
+
+    AccessContext accessContext =
+        new AccessContext() {
+          @Override
+          public Principal user() {
+            return null;
+          }
+        };
 
     ConfigApiImpl configService =
-        new ConfigApiImpl(serverConfig, versionStore, authorizer, principalSupplier, 2);
+        new ConfigApiImpl(serverConfig, versionStore, authorizer, accessContext, 2);
     TreeApiImpl treeService =
-        new TreeApiImpl(serverConfig, versionStore, authorizer, principalSupplier);
+        new TreeApiImpl(serverConfig, versionStore, authorizer, accessContext);
     ContentApiImpl contentService =
-        new ContentApiImpl(serverConfig, versionStore, authorizer, principalSupplier);
+        new ContentApiImpl(serverConfig, versionStore, authorizer, accessContext);
     DiffApiImpl diffService =
-        new DiffApiImpl(serverConfig, versionStore, authorizer, principalSupplier);
+        new DiffApiImpl(serverConfig, versionStore, authorizer, accessContext);
 
     RestV2ConfigResource configResource =
-        new RestV2ConfigResource(serverConfig, versionStore, authorizer, principalSupplier);
+        new RestV2ConfigResource(serverConfig, versionStore, authorizer, accessContext);
     RestV2TreeResource treeResource =
         new RestV2TreeResource(configService, treeService, contentService, diffService);
 


### PR DESCRIPTION
This change resolves the "chicken and egg" problem of the Quarkus-only `SecurityIdentity` which provides the `Principal` and set of roles plus other attributes. Services receive the `AccessContext` instead of just the `Principal`, which then allows evaluating roles in AuthZ.
