### PR TITLE
Experimental ability to cache `Reference`s

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
@@ -20,6 +20,8 @@ import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
@@ -136,4 +138,12 @@ public interface QuarkusStoreConfig extends StoreConfig {
    */
   @WithName(CONFIG_CACHE_CAPACITY_FRACTION_ADJUST_MB)
   OptionalInt cacheCapacityFractionAdjustMB();
+
+  @WithName(CONFIG_CACHE_REFERENCE_TTL)
+  @Override
+  Optional<Duration> cacheReferenceTtl();
+
+  @WithName(CONFIG_CACHE_REFERENCE_NEGATIVE_TTL)
+  @Override
+  Optional<Duration> cacheReferenceNegativeTtl();
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusStoreConfig.java
@@ -139,11 +139,11 @@ public interface QuarkusStoreConfig extends StoreConfig {
   @WithName(CONFIG_CACHE_CAPACITY_FRACTION_ADJUST_MB)
   OptionalInt cacheCapacityFractionAdjustMB();
 
-  @WithName(CONFIG_CACHE_REFERENCE_TTL)
+  @WithName(CONFIG_REFERENCE_CACHE_TTL)
   @Override
-  Optional<Duration> cacheReferenceTtl();
+  Optional<Duration> referenceCacheTtl();
 
-  @WithName(CONFIG_CACHE_REFERENCE_NEGATIVE_TTL)
+  @WithName(CONFIG_REFERENCE_NEGATIVE_CACHE_TTL)
   @Override
-  Optional<Duration> cacheReferenceNegativeTtl();
+  Optional<Duration> referenceCacheNegativeTtl();
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/PersistProvider.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/PersistProvider.java
@@ -150,7 +150,7 @@ public class PersistProvider {
           CacheConfig.builder().capacityMb(effectiveCacheSizeMB).meterRegistry(meterRegistry);
 
       storeConfig
-          .cacheReferenceTtl()
+          .referenceCacheTtl()
           .ifPresent(
               refTtl -> {
                 LOGGER.warn(
@@ -158,7 +158,7 @@ public class PersistProvider {
                     refTtl);
                 cacheConfig.referenceTtl(refTtl);
               });
-      storeConfig.cacheReferenceNegativeTtl().ifPresent(cacheConfig::referenceNegativeTtl);
+      storeConfig.referenceCacheNegativeTtl().ifPresent(cacheConfig::referenceNegativeTtl);
 
       CacheBackend cacheBackend = PersistCaches.newBackend(cacheConfig.build());
       persist = cacheBackend.wrap(persist);

--- a/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
+++ b/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
@@ -405,10 +405,24 @@ final class BatchingPersistImpl implements BatchingPersist, ValidatingPersist {
   }
 
   @Override
+  @Nullable
+  @javax.annotation.Nullable
+  public Reference fetchReferenceForUpdate(@Nonnull @javax.annotation.Nonnull String name) {
+    return delegate().fetchReferenceForUpdate(name);
+  }
+
+  @Override
   @Nonnull
   @javax.annotation.Nonnull
   public Reference[] fetchReferences(@Nonnull @javax.annotation.Nonnull String[] names) {
     return delegate().fetchReferences(names);
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public Reference[] fetchReferencesForUpdate(@Nonnull @javax.annotation.Nonnull String[] names) {
+    return delegate().fetchReferencesForUpdate(names);
   }
 
   @Override

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -173,7 +173,7 @@ public class BigTablePersist implements Persist {
               .filter(FILTERS.family().exactMatch(FAMILY_REFS))
               .filter(FILTERS.qualifier().exactMatch(QUALIFIER_REFS));
 
-      boolean success =
+      boolean failure =
           backend
               .client()
               .checkAndMutateRow(
@@ -181,7 +181,7 @@ public class BigTablePersist implements Persist {
                       .condition(condition)
                       .otherwise(mutation));
 
-      if (success) {
+      if (failure) {
         throw new RefAlreadyExistsException(fetchReference(reference.name()));
       }
 

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheBackend.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CacheBackend.java
@@ -15,17 +15,24 @@
  */
 package org.projectnessie.versioned.storage.cache;
 
+import static org.projectnessie.versioned.storage.common.persist.ObjId.zeroLengthObjId;
+import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
+
 import jakarta.annotation.Nonnull;
 import org.projectnessie.versioned.storage.common.persist.Backend;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.Reference;
 
 /**
  * Provides the cache primitives for a caching {@link Persist} facade, suitable for multiple
  * repositories. It is adviseable to have one {@link CacheBackend} per {@link Backend}.
  */
 public interface CacheBackend {
+  Reference NON_EXISTENT_REFERENCE_SENTINEL =
+      reference("NON_EXISTENT", zeroLengthObjId(), false, -1L, null);
+
   Obj get(@Nonnull String repositoryId, @Nonnull ObjId id);
 
   void put(@Nonnull String repositoryId, @Nonnull Obj obj);
@@ -34,5 +41,13 @@ public interface CacheBackend {
 
   void clear(@Nonnull String repositoryId);
 
-  Persist wrap(@Nonnull Persist perist);
+  Persist wrap(@Nonnull Persist persist);
+
+  Reference getReference(@Nonnull String repositoryId, @Nonnull String name);
+
+  void removeReference(@Nonnull String repositoryId, @Nonnull String name);
+
+  void putReference(@Nonnull String repositoryId, @Nonnull Reference r);
+
+  void putNegative(@Nonnull String repositoryId, @Nonnull String name);
 }

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/ObjCache.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/ObjCache.java
@@ -19,6 +19,7 @@ import jakarta.annotation.Nonnull;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.Reference;
 
 /** Cache primitives for a specific repository ID, used for one {@link Persist} instance. */
 public interface ObjCache {
@@ -30,4 +31,12 @@ public interface ObjCache {
   void remove(@Nonnull ObjId id);
 
   void clear();
+
+  Reference getReference(@Nonnull String name);
+
+  void removeReference(@Nonnull String name);
+
+  void putReference(@Nonnull Reference r);
+
+  void putNegative(@Nonnull String name);
 }

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/ObjCacheImpl.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/ObjCacheImpl.java
@@ -19,6 +19,7 @@ import jakarta.annotation.Nonnull;
 import org.projectnessie.versioned.storage.common.config.StoreConfig;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
+import org.projectnessie.versioned.storage.common.persist.Reference;
 
 final class ObjCacheImpl implements ObjCache {
   private final CacheBackend backend;
@@ -47,5 +48,25 @@ final class ObjCacheImpl implements ObjCache {
   @Override
   public void clear() {
     backend.clear(repositoryId);
+  }
+
+  @Override
+  public void removeReference(@Nonnull String name) {
+    backend.removeReference(repositoryId, name);
+  }
+
+  @Override
+  public void putReference(@Nonnull Reference r) {
+    backend.putReference(repositoryId, r);
+  }
+
+  @Override
+  public Reference getReference(@Nonnull String name) {
+    return backend.getReference(repositoryId, name);
+  }
+
+  @Override
+  public void putNegative(@Nonnull String name) {
+    backend.putNegative(repositoryId, name);
   }
 }

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheConfig.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestCacheConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.cache;
+
+import static org.projectnessie.versioned.storage.cache.CacheConfig.INVALID_REFERENCE_NEGATIVE_TTL;
+import static org.projectnessie.versioned.storage.cache.CacheConfig.INVALID_REFERENCE_TTL;
+
+import java.time.Duration;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestCacheConfig {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @Test
+  public void allDefaults() {
+    soft.assertThatCode(() -> defaultBuilder().build()).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void referenceCaching() {
+    soft.assertThatCode(() -> defaultBuilder().referenceTtl(Duration.ofMinutes(1)).build())
+        .doesNotThrowAnyException();
+    soft.assertThatCode(
+            () ->
+                defaultBuilder()
+                    .referenceTtl(Duration.ofMinutes(1))
+                    .referenceNegativeTtl(Duration.ofMinutes(1))
+                    .build())
+        .doesNotThrowAnyException();
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> defaultBuilder().referenceTtl(Duration.ofMinutes(0)).build())
+        .withMessage(INVALID_REFERENCE_TTL);
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> defaultBuilder().referenceTtl(Duration.ofMinutes(-1)).build())
+        .withMessage(INVALID_REFERENCE_TTL);
+    soft.assertThatIllegalStateException()
+        .isThrownBy(() -> defaultBuilder().referenceNegativeTtl(Duration.ofMinutes(1)).build())
+        .withMessage(INVALID_REFERENCE_NEGATIVE_TTL);
+    soft.assertThatIllegalStateException()
+        .isThrownBy(
+            () ->
+                defaultBuilder()
+                    .referenceTtl(Duration.ofMinutes(1))
+                    .referenceNegativeTtl(Duration.ofMinutes(-1))
+                    .build())
+        .withMessage(INVALID_REFERENCE_NEGATIVE_TTL);
+    soft.assertThatIllegalStateException()
+        .isThrownBy(
+            () ->
+                defaultBuilder()
+                    .referenceTtl(Duration.ofMinutes(1))
+                    .referenceNegativeTtl(Duration.ofMinutes(0))
+                    .build())
+        .withMessage(INVALID_REFERENCE_NEGATIVE_TTL);
+  }
+
+  private static CacheConfig.Builder defaultBuilder() {
+    return CacheConfig.builder().capacityMb(1);
+  }
+}

--- a/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestReferenceCaching.java
+++ b/versioned/storage/cache/src/test/java/org/projectnessie/versioned/storage/cache/TestReferenceCaching.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.cache;
+
+import static org.projectnessie.versioned.storage.common.persist.ObjId.randomObjId;
+import static org.projectnessie.versioned.storage.common.persist.Reference.reference;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
+import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
+import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.common.persist.Reference;
+import org.projectnessie.versioned.storage.testextension.NessiePersist;
+import org.projectnessie.versioned.storage.testextension.PersistExtension;
+
+@ExtendWith({PersistExtension.class, SoftAssertionsExtension.class})
+public class TestReferenceCaching {
+  public static final String REF_NAME = "refs/heads/foo";
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  Persist wrapWithCache(Persist persist, LongSupplier clockNanos) {
+    return PersistCaches.newBackend(
+            CacheConfig.builder()
+                .capacityMb(32)
+                .clockNanos(clockNanos)
+                .referenceTtl(Duration.ofMinutes(1))
+                .referenceNegativeTtl(Duration.ofSeconds(1))
+                .build())
+        .wrap(persist);
+  }
+
+  // Two caching `Persist` instances, using _independent_ cache backends.
+  Persist withCache1;
+  Persist withCache2;
+
+  AtomicLong nowNanos;
+
+  @BeforeEach
+  void wrapCaches(@NessiePersist Persist persist1, @NessiePersist Persist persist2) {
+    nowNanos = new AtomicLong();
+    withCache1 = wrapWithCache(persist1, nowNanos::get);
+    withCache2 = wrapWithCache(persist2, nowNanos::get);
+  }
+
+  /** Explicit cache-expiry via {@link Persist#fetchReferenceForUpdate(String)}. */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void referenceCacheInconsistency(boolean bulk) throws Exception {
+    // Create ref via instance 1
+    Reference ref =
+        reference(REF_NAME, randomObjId(), false, withCache1.config().currentTimeMicros(), null);
+    withCache1.addReference(ref);
+
+    // Populate cache in instance 2
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isEqualTo(ref);
+
+    // Update ref via instance 1
+    Reference refUpdated = withCache1.updateReferencePointer(ref, randomObjId());
+    soft.assertThat(refUpdated).isNotEqualTo(ref);
+
+    soft.assertThat(fetchRef(withCache1, bulk, ref.name())).isEqualTo(refUpdated);
+    // Other test instance did NOT update its cache
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name()))
+        .extracting(Reference::pointer)
+        .describedAs("Previous: %s, updated: %s", ref.pointer(), refUpdated.pointer())
+        .isEqualTo(ref.pointer())
+        .isNotEqualTo(refUpdated.pointer());
+
+    //
+
+    if (bulk) {
+      soft.assertThat(withCache2.fetchReferencesForUpdate(new String[] {ref.name()}))
+          .containsExactly(refUpdated);
+    } else {
+      soft.assertThat(withCache2.fetchReferenceForUpdate(ref.name())).isEqualTo(refUpdated);
+    }
+  }
+
+  /** Reference cache TTL expiry. */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void referenceCacheExpiry(boolean bulk) throws Exception {
+    // Create ref via instance 1
+    Reference ref =
+        reference(REF_NAME, randomObjId(), false, withCache1.config().currentTimeMicros(), null);
+    withCache1.addReference(ref);
+
+    // Populate cache in instance 2
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isEqualTo(ref);
+
+    // Update ref via instance 1
+    Reference refUpdated = withCache1.updateReferencePointer(ref, randomObjId());
+    soft.assertThat(refUpdated).isNotEqualTo(ref);
+
+    soft.assertThat(fetchRef(withCache1, bulk, ref.name())).isEqualTo(refUpdated);
+    // Other test instance did NOT update its cache
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name()))
+        .extracting(Reference::pointer)
+        .describedAs("Previous: %s, updated: %s", ref.pointer(), refUpdated.pointer())
+        .isEqualTo(ref.pointer())
+        .isNotEqualTo(refUpdated.pointer());
+
+    //
+
+    nowNanos.addAndGet(Duration.ofMinutes(2).toNanos());
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isEqualTo(refUpdated);
+  }
+
+  /** Tests negative-cache behavior (non-existence of a reference). */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void referenceCacheNegativeExpiry(boolean bulk) throws Exception {
+    // Populate both caches w/ negative entries
+    soft.assertThat(fetchRef(withCache1, bulk, REF_NAME)).isNull();
+    soft.assertThat(fetchRef(withCache2, bulk, REF_NAME)).isNull();
+
+    // Create ref via instance 1
+    Reference ref =
+        reference(REF_NAME, randomObjId(), false, withCache1.config().currentTimeMicros(), null);
+    withCache1.addReference(ref);
+
+    // Cache 1 has "correct" entry
+    soft.assertThat(fetchRef(withCache1, bulk, ref.name())).isEqualTo(ref);
+    // Cache 2 has stale negative entry
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isNull();
+
+    // Expire negative cache entries
+    nowNanos.addAndGet(Duration.ofSeconds(2).toNanos());
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isEqualTo(ref);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void addReference(boolean bulk) throws Exception {
+    // Create ref via instance 1
+    Reference ref =
+        reference(REF_NAME, randomObjId(), false, withCache1.config().currentTimeMicros(), null);
+    withCache1.addReference(ref);
+
+    // Try addReference via instance 2
+    soft.assertThatThrownBy(() -> withCache2.addReference(ref))
+        .isInstanceOf(RefAlreadyExistsException.class);
+
+    // Update ref via instance 1
+    Reference refUpdated = withCache1.updateReferencePointer(ref, randomObjId());
+    soft.assertThat(refUpdated).isNotEqualTo(ref);
+
+    soft.assertThat(fetchRef(withCache1, bulk, ref.name())).isEqualTo(refUpdated);
+    // Other test instance DID populate its cache
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name()))
+        .extracting(Reference::pointer)
+        .describedAs("Previous: %s, updated: %s", ref.pointer(), refUpdated.pointer())
+        .isEqualTo(refUpdated.pointer());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void markReferenceAsDeletedAndPurge(boolean bulk) throws Exception {
+    // Create ref via instance 1
+    Reference ref =
+        reference(REF_NAME, randomObjId(), false, withCache1.config().currentTimeMicros(), null);
+    withCache1.addReference(ref);
+
+    // Try addReference via instance 2
+    soft.assertThatThrownBy(() -> withCache2.addReference(ref))
+        .isInstanceOf(RefAlreadyExistsException.class);
+
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isEqualTo(ref);
+
+    // Mark ref as deleted via instance 1
+    Reference refDeleted = withCache1.markReferenceAsDeleted(ref);
+    soft.assertThat(refDeleted).isNotEqualTo(ref);
+
+    // instance 2 still has the cached deleted instance
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isEqualTo(ref);
+
+    // Try markReferenceAsDeleted via instance 2
+    soft.assertThatThrownBy(() -> withCache2.markReferenceAsDeleted(ref))
+        .isInstanceOf(RefConditionFailedException.class);
+
+    soft.assertThat(fetchRef(withCache1, bulk, ref.name())).isEqualTo(refDeleted);
+    // Other test instance DID populate its cache
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name()))
+        .extracting(Reference::pointer)
+        .describedAs("Previous: %s, updated: %s", ref.pointer(), refDeleted.pointer())
+        .isEqualTo(refDeleted.pointer());
+
+    //
+    // purge
+    //
+
+    // Mark ref as deleted via instance 1
+    soft.assertThatCode(() -> withCache1.purgeReference(refDeleted)).doesNotThrowAnyException();
+
+    // instance 2 still has the cached deleted instance
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isEqualTo(refDeleted);
+
+    // Try markReferenceAsDeleted via instance 2
+    soft.assertThatThrownBy(() -> withCache2.purgeReference(ref))
+        .isInstanceOf(RefNotFoundException.class);
+
+    soft.assertThat(fetchRef(withCache1, bulk, ref.name())).isNull();
+    // Other test instance DID populate its cache
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void purgeVsUpdate(boolean bulk) throws Exception {
+    // Create ref via instance 1
+    Reference ref =
+        reference(REF_NAME, randomObjId(), false, withCache1.config().currentTimeMicros(), null);
+    withCache1.addReference(ref);
+
+    soft.assertThat(fetchRef(withCache2, bulk, ref.name())).isEqualTo(ref);
+
+    // Mark ref as deleted via instance 1
+    Reference refDeleted = withCache1.markReferenceAsDeleted(ref);
+    soft.assertThat(refDeleted).isNotEqualTo(ref);
+
+    // Mark ref as deleted via instance 1
+    soft.assertThatCode(() -> withCache1.purgeReference(refDeleted)).doesNotThrowAnyException();
+
+    soft.assertThat(fetchRef(withCache1, bulk, ref.name())).isNull();
+
+    soft.assertThatThrownBy(() -> withCache2.updateReferencePointer(ref, randomObjId()))
+        .isInstanceOf(RefNotFoundException.class);
+  }
+
+  static Reference fetchRef(Persist persist, boolean bulk, String refName) {
+    return bulk
+        ? persist.fetchReferences(new String[] {refName})[0]
+        : persist.fetchReference(refName);
+  }
+}

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
@@ -19,7 +19,9 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.function.Function;
 import org.immutables.value.Value;
 
@@ -66,6 +68,10 @@ public interface StoreConfig {
 
   String CONFIG_PREVIOUS_HEAD_TIME_SPAN_SECONDS = "ref-previous-head-time-span-seconds";
   long DEFAULT_PREVIOUS_HEAD_TIME_SPAN_SECONDS = 5 * 60;
+
+  String CONFIG_CACHE_REFERENCE_TTL = "cache-reference-ttl";
+
+  String CONFIG_CACHE_REFERENCE_NEGATIVE_TTL = "cache-reference-negative-ttl";
 
   /**
    * Whether namespace validation is enabled, changing this to false will break the Nessie
@@ -251,6 +257,27 @@ public interface StoreConfig {
   }
 
   /**
+   * Defines the duration how long references shall be kept in the cache. Enables reference-caching,
+   * if configured with a positive duration value, defaults to not cache references. If reference
+   * caching is enabled, it is highly recommended to also enable negative reference caching.
+   *
+   * <p><em>This is an experimental feature, currently only for single Nessie node deployments! If
+   * in doubt, leave this un-configured!</em>
+   */
+  Optional<Duration> cacheReferenceTtl();
+
+  /**
+   * Defines the duration how long sentinels for non-existing references shall be kept in the cache
+   * (negative reference caching). Enabled, if configured with a positive duration value, default is
+   * not enabled. If reference caching is enabled, it is highly recommended to also enable negative
+   * reference caching.
+   *
+   * <p><em>This is an experimental feature, currently only for single Nessie node deployments! If
+   * in doubt, leave this un-configured!</em>
+   */
+  Optional<Duration> cacheReferenceNegativeTtl();
+
+  /**
    * Retrieves the current timestamp in microseconds since epoch, using the configured {@link
    * #clock()}.
    */
@@ -334,6 +361,14 @@ public interface StoreConfig {
       if (v != null) {
         a = a.withReferencePreviousHeadTimeSpanSeconds(Long.parseLong(v.trim()));
       }
+      v = configFunction.apply(CONFIG_CACHE_REFERENCE_TTL);
+      if (v != null) {
+        a = a.withCacheReferenceTtl(Duration.parse(v.trim()));
+      }
+      v = configFunction.apply(CONFIG_CACHE_REFERENCE_NEGATIVE_TTL);
+      if (v != null) {
+        a = a.withCacheReferenceNegativeTtl(Duration.parse(v.trim()));
+      }
       return a;
     }
 
@@ -379,5 +414,11 @@ public interface StoreConfig {
     Adjustable withReferencePreviousHeadCount(int referencePreviousHeadCount);
 
     Adjustable withReferencePreviousHeadTimeSpanSeconds(long referencePreviousHeadTimeSpanSeconds);
+
+    /** See {@link StoreConfig#cacheReferenceTtl()}. */
+    Adjustable withCacheReferenceTtl(Duration cacheReferenceTtl);
+
+    /** See {@link StoreConfig#cacheReferenceNegativeTtl()}. */
+    Adjustable withCacheReferenceNegativeTtl(Duration cacheReferenceNegativeTtl);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/config/StoreConfig.java
@@ -69,9 +69,9 @@ public interface StoreConfig {
   String CONFIG_PREVIOUS_HEAD_TIME_SPAN_SECONDS = "ref-previous-head-time-span-seconds";
   long DEFAULT_PREVIOUS_HEAD_TIME_SPAN_SECONDS = 5 * 60;
 
-  String CONFIG_CACHE_REFERENCE_TTL = "cache-reference-ttl";
+  String CONFIG_REFERENCE_CACHE_TTL = "reference-cache-ttl";
 
-  String CONFIG_CACHE_REFERENCE_NEGATIVE_TTL = "cache-reference-negative-ttl";
+  String CONFIG_REFERENCE_NEGATIVE_CACHE_TTL = "reference-cache-negative-ttl";
 
   /**
    * Whether namespace validation is enabled, changing this to false will break the Nessie
@@ -264,7 +264,7 @@ public interface StoreConfig {
    * <p><em>This is an experimental feature, currently only for single Nessie node deployments! If
    * in doubt, leave this un-configured!</em>
    */
-  Optional<Duration> cacheReferenceTtl();
+  Optional<Duration> referenceCacheTtl();
 
   /**
    * Defines the duration how long sentinels for non-existing references shall be kept in the cache
@@ -275,7 +275,7 @@ public interface StoreConfig {
    * <p><em>This is an experimental feature, currently only for single Nessie node deployments! If
    * in doubt, leave this un-configured!</em>
    */
-  Optional<Duration> cacheReferenceNegativeTtl();
+  Optional<Duration> referenceCacheNegativeTtl();
 
   /**
    * Retrieves the current timestamp in microseconds since epoch, using the configured {@link
@@ -361,13 +361,13 @@ public interface StoreConfig {
       if (v != null) {
         a = a.withReferencePreviousHeadTimeSpanSeconds(Long.parseLong(v.trim()));
       }
-      v = configFunction.apply(CONFIG_CACHE_REFERENCE_TTL);
+      v = configFunction.apply(CONFIG_REFERENCE_CACHE_TTL);
       if (v != null) {
-        a = a.withCacheReferenceTtl(Duration.parse(v.trim()));
+        a = a.withReferenceCacheTtl(Duration.parse(v.trim()));
       }
-      v = configFunction.apply(CONFIG_CACHE_REFERENCE_NEGATIVE_TTL);
+      v = configFunction.apply(CONFIG_REFERENCE_NEGATIVE_CACHE_TTL);
       if (v != null) {
-        a = a.withCacheReferenceNegativeTtl(Duration.parse(v.trim()));
+        a = a.withReferenceCacheNegativeTtl(Duration.parse(v.trim()));
       }
       return a;
     }
@@ -415,10 +415,10 @@ public interface StoreConfig {
 
     Adjustable withReferencePreviousHeadTimeSpanSeconds(long referencePreviousHeadTimeSpanSeconds);
 
-    /** See {@link StoreConfig#cacheReferenceTtl()}. */
-    Adjustable withCacheReferenceTtl(Duration cacheReferenceTtl);
+    /** See {@link StoreConfig#referenceCacheTtl()}. */
+    Adjustable withReferenceCacheTtl(Duration referenceCacheTtl);
 
-    /** See {@link StoreConfig#cacheReferenceNegativeTtl()}. */
-    Adjustable withCacheReferenceNegativeTtl(Duration cacheReferenceNegativeTtl);
+    /** See {@link StoreConfig#referenceCacheNegativeTtl()}. */
+    Adjustable withReferenceCacheNegativeTtl(Duration referencecacheNegativeTtl);
   }
 }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/ReferenceLogic.java
@@ -41,8 +41,21 @@ public interface ReferenceLogic {
   List<Reference> getReferences(@Nonnull List<String> references);
 
   @Nonnull
+  List<Reference> getReferencesForUpdate(@Nonnull List<String> references);
+
+  @Nonnull
   default Reference getReference(@Nonnull String name) throws RefNotFoundException {
     List<Reference> refs = getReferences(Collections.singletonList(name));
+    Reference ref = refs.get(0);
+    if (ref == null) {
+      throw new RefNotFoundException(name);
+    }
+    return ref;
+  }
+
+  @Nonnull
+  default Reference getReferenceForUpdate(@Nonnull String name) throws RefNotFoundException {
+    List<Reference> refs = getReferencesForUpdate(Collections.singletonList(name));
     Reference ref = refs.get(0);
     if (ref == null) {
       throw new RefNotFoundException(name);

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/RepositoryLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/RepositoryLogicImpl.java
@@ -96,7 +96,7 @@ final class RepositoryLogicImpl implements RepositoryLogic {
   @Override
   public boolean repositoryExists() {
     try {
-      Reference ref = persist.fetchReference(REF_REPO.name());
+      Reference ref = persist.fetchReferenceForUpdate(REF_REPO.name());
       if (ref == null) {
         return false;
       }
@@ -207,7 +207,8 @@ final class RepositoryLogicImpl implements RepositoryLogic {
               persist,
               (p, retryState) -> {
                 try {
-                  Reference reference = requireNonNull(persist.fetchReference(REF_REPO.name()));
+                  Reference reference =
+                      requireNonNull(persist.fetchReferenceForUpdate(REF_REPO.name()));
                   return stringLogic(persist)
                       .updateStringOnRef(
                           reference,
@@ -237,7 +238,7 @@ final class RepositoryLogicImpl implements RepositoryLogic {
   @SuppressWarnings({"JavaTimeDefaultTimeZone"})
   private void initializeInternalRef(
       InternalRef internalRef, Consumer<CreateCommit.Builder> commitEnhancer) {
-    Reference reference = persist.fetchReference(internalRef.name());
+    Reference reference = persist.fetchReferenceForUpdate(internalRef.name());
 
     if (reference == null) {
       CreateCommit.Builder c =

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
@@ -124,6 +124,24 @@ public class ObservingPersist implements Persist {
   @Override
   @Counted(PREFIX)
   @Timed(value = PREFIX, histogram = true)
+  @Nullable
+  public Reference fetchReferenceForUpdate(@Nonnull String name) {
+    return delegate.fetchReferenceForUpdate(name);
+  }
+
+  @WithSpan
+  @Override
+  @Counted(PREFIX)
+  @Timed(value = PREFIX, histogram = true)
+  @Nonnull
+  public Reference[] fetchReferencesForUpdate(@Nonnull String[] names) {
+    return delegate.fetchReferencesForUpdate(names);
+  }
+
+  @WithSpan
+  @Override
+  @Counted(PREFIX)
+  @Timed(value = PREFIX, histogram = true)
   @Nonnull
   public Obj fetchObj(@Nonnull ObjId id) throws ObjNotFoundException {
     return delegate.fetchObj(id);

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/Persist.java
@@ -120,10 +120,27 @@ public interface Persist {
    * <p><em>Do not use this function from service implementations, use {@link ReferenceLogic}
    * instead!</em>
    *
+   * <p>This function leverages the references-cache, if enabled, and must only be used for read
+   * operations. Updating operations must use {@link #fetchReferenceForUpdate(String)}.
+   *
+   * <p>Database specific implementations of {@link Persist} must implement this function, without
+   * caching.
+   *
    * @return the reference or {@code null}, if it does not exist
    */
   @Nullable
   Reference fetchReference(@Nonnull String name);
+
+  /**
+   * This is similar to {@link #fetchReference(String)}, but does always fetch the reference from
+   * the backend, <em>refreshing</em> the references-cache.
+   *
+   * <p>Database specific implementations of {@link Persist} must not implement this function.
+   */
+  @Nullable
+  default Reference fetchReferenceForUpdate(@Nonnull String name) {
+    return fetchReference(name);
+  }
 
   /**
    * Like {@link #fetchReference(String)}, but finds multiple references by name at once, leveraging
@@ -131,11 +148,28 @@ public interface Persist {
    *
    * <p>Non-existing references are returned as {@code null} elements in the returned array.
    *
+   * <p>This function leverages the references-cache, if enabled, and must only be used for read
+   * operations. Updating operations must use {@link #fetchReferencesForUpdate(String[])}.
+   *
+   * <p>Database specific implementations of {@link Persist} must implement this function, without
+   * caching.
+   *
    * <p><em>Do not use this function from service implementations, use {@link ReferenceLogic}
    * instead!</em>
    */
   @Nonnull
   Reference[] fetchReferences(@Nonnull String[] names);
+
+  /**
+   * This is similar to #fetchReferences(String[]), but does always fetch the reference from the
+   * backend, <em>refreshing</em> the references-cache.
+   *
+   * <p>Database specific implementations of {@link Persist} must not implement this function.
+   */
+  @Nonnull
+  default Reference[] fetchReferencesForUpdate(@Nonnull String[] names) {
+    return fetchReferences(names);
+  }
 
   // Objects
 

--- a/versioned/storage/store/build.gradle.kts
+++ b/versioned/storage/store/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
   compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
   testImplementation(project(":nessie-server-store"))
+  testImplementation(project(":nessie-versioned-storage-cache"))
   testImplementation(project(":nessie-versioned-storage-common-tests"))
   testImplementation(project(":nessie-versioned-storage-inmemory"))
   testImplementation(project(":nessie-versioned-storage-testextension"))

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -208,7 +208,7 @@ class BaseCommitHelper {
             RefMapping refMapping = new RefMapping(p);
             Reference reference;
             try {
-              reference = refMapping.resolveNamedRef(branch);
+              reference = refMapping.resolveNamedRefForUpdate(branch);
             } catch (ReferenceNotFoundException e) {
               throw new CommitWrappedException(e);
             }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RefMapping.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/RefMapping.java
@@ -246,6 +246,10 @@ public class RefMapping {
     throw new IllegalArgumentException("Unsupported ref type, got " + ref);
   }
 
+  CommitObj resolveRefHeadForUpdate(@Nonnull NamedRef namedRef) throws ReferenceNotFoundException {
+    return resolveNamedRefHead(resolveNamedRefForUpdate(namedRef));
+  }
+
   CommitObj resolveNamedRefHead(@Nonnull NamedRef namedRef) throws ReferenceNotFoundException {
     return resolveNamedRefHead(resolveNamedRef(namedRef));
   }
@@ -264,6 +268,18 @@ public class RefMapping {
     ReferenceLogic referenceLogic = referenceLogic(persist);
     try {
       return referenceLogic.getReference(refName);
+    } catch (RefNotFoundException e) {
+      throw referenceNotFound(namedRef);
+    }
+  }
+
+  @Nonnull
+  public Reference resolveNamedRefForUpdate(@Nonnull NamedRef namedRef)
+      throws ReferenceNotFoundException {
+    String refName = namedRefToRefName(namedRef);
+    ReferenceLogic referenceLogic = referenceLogic(persist);
+    try {
+      return referenceLogic.getReferenceForUpdate(refName);
     } catch (RefNotFoundException e) {
       throw referenceNotFound(namedRef);
     }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/VersionStoreImpl.java
@@ -224,7 +224,7 @@ public class VersionStoreImpl implements VersionStore {
               ? asBranchName(namedRef.getName())
               : asTagName(namedRef.getName());
       try {
-        referenceLogic.getReference(mustNotExist);
+        referenceLogic.getReferenceForUpdate(mustNotExist);
         // A tag with the same name as the branch being created (or a branch with the same name
         // as the tag being created) already exists.
         throw referenceAlreadyExists(namedRef);
@@ -252,7 +252,7 @@ public class VersionStoreImpl implements VersionStore {
     ReferenceLogic referenceLogic = referenceLogic(persist);
     Reference expected;
     try {
-      expected = referenceLogic.getReference(refName);
+      expected = referenceLogic.getReferenceForUpdate(refName);
     } catch (RefNotFoundException e) {
       throw referenceNotFound(namedRef);
     }
@@ -323,7 +323,7 @@ public class VersionStoreImpl implements VersionStore {
       throw referenceNotFound(namedRef);
     } catch (RefConditionFailedException e) {
       RefMapping refMapping = new RefMapping(persist);
-      CommitObj headCommit = refMapping.resolveRefHead(namedRef);
+      CommitObj headCommit = refMapping.resolveRefHeadForUpdate(namedRef);
       throw referenceConflictException(
           namedRef, objIdToHash(expected), headCommit != null ? headCommit.id() : EMPTY_OBJ_ID);
     } catch (RetryTimeoutException e) {

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
@@ -97,9 +97,20 @@ public class PersistDelegate implements Persist {
   }
 
   @Override
+  public Reference fetchReferenceForUpdate(@Nonnull String name) {
+    return delegate.fetchReferenceForUpdate(name);
+  }
+
+  @Override
   @Nonnull
   public Reference[] fetchReferences(@Nonnull String[] names) {
     return delegate.fetchReferences(names);
+  }
+
+  @Override
+  @Nonnull
+  public Reference[] fetchReferencesForUpdate(@Nonnull String[] names) {
+    return delegate.fetchReferencesForUpdate(names);
   }
 
   @Override

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestRefMapping.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestRefMapping.java
@@ -398,12 +398,22 @@ public class TestRefMapping {
     soft.assertThat(refMapping.resolveNamedRef("tag")).isEqualTo(tag);
     soft.assertThat(refMapping.resolveNamedRef(BranchName.of("branch"))).isEqualTo(branch);
     soft.assertThat(refMapping.resolveNamedRef(TagName.of("tag"))).isEqualTo(tag);
+    soft.assertThat(refMapping.resolveNamedRefForUpdate(BranchName.of("branch"))).isEqualTo(branch);
+    soft.assertThat(refMapping.resolveNamedRefForUpdate(TagName.of("tag"))).isEqualTo(tag);
 
     soft.assertThat(refMapping.resolveNamedRef("empty")).isEqualTo(emptyBranch);
     soft.assertThat(refMapping.resolveNamedRef(BranchName.of("empty"))).isEqualTo(emptyBranch);
     soft.assertThat(refMapping.resolveNamedRef(TagName.of("empty"))).isEqualTo(emptyTag);
+    soft.assertThat(refMapping.resolveNamedRefForUpdate(BranchName.of("empty")))
+        .isEqualTo(emptyBranch);
+    soft.assertThat(refMapping.resolveNamedRefForUpdate(TagName.of("empty"))).isEqualTo(emptyTag);
 
     soft.assertThatThrownBy(() -> refMapping.resolveNamedRef("does-not-exist"))
+        .isInstanceOf(ReferenceNotFoundException.class);
+    soft.assertThatThrownBy(
+            () -> refMapping.resolveNamedRefForUpdate(BranchName.of("does-not-exist")))
+        .isInstanceOf(ReferenceNotFoundException.class);
+    soft.assertThatThrownBy(() -> refMapping.resolveNamedRefForUpdate(TagName.of("does-not-exist")))
         .isInstanceOf(ReferenceNotFoundException.class);
 
     soft.assertThat(refMapping.resolveNamedRefHead(branch))
@@ -421,6 +431,11 @@ public class TestRefMapping {
     soft.assertThat(refMapping.resolveRefHead(TagName.of("tag")))
         .isEqualTo(persist.fetchTypedObj(commitId, COMMIT, CommitObj.class));
     soft.assertThat(refMapping.resolveRefHead(Hash.of(commitId.toString())))
+        .isEqualTo(persist.fetchTypedObj(commitId, COMMIT, CommitObj.class));
+
+    soft.assertThat(refMapping.resolveRefHeadForUpdate(BranchName.of("branch")))
+        .isEqualTo(persist.fetchTypedObj(commitId, COMMIT, CommitObj.class));
+    soft.assertThat(refMapping.resolveRefHeadForUpdate(TagName.of("tag")))
         .isEqualTo(persist.fetchTypedObj(commitId, COMMIT, CommitObj.class));
 
     soft.assertThat(refMapping.resolveNamedRefHead(emptyBranch)).isNull();

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreReferenceCaching.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreReferenceCaching.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2022 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.versionstore;
+
+import static java.util.Collections.singletonList;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.versioned.BranchName;
+import org.projectnessie.versioned.Commit;
+import org.projectnessie.versioned.CommitResult;
+import org.projectnessie.versioned.GetNamedRefsParams;
+import org.projectnessie.versioned.Put;
+import org.projectnessie.versioned.ReferenceInfo;
+import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.storage.cache.CacheConfig;
+import org.projectnessie.versioned.storage.cache.PersistCaches;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.testextension.NessiePersist;
+import org.projectnessie.versioned.storage.testextension.PersistExtension;
+
+@ExtendWith({PersistExtension.class, SoftAssertionsExtension.class})
+public class TestVersionStoreReferenceCaching {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  Persist wrapWithCache(Persist persist, LongSupplier clockNanos) {
+    return PersistCaches.newBackend(
+            CacheConfig.builder()
+                .capacityMb(32)
+                .clockNanos(clockNanos)
+                .referenceTtl(Duration.ofMinutes(1))
+                .referenceNegativeTtl(Duration.ofSeconds(1))
+                .build())
+        .wrap(persist);
+  }
+
+  // Two caching `Persist` instances, using _independent_ cache backends.
+  Persist withCache1;
+  Persist withCache2;
+
+  AtomicLong nowNanos;
+
+  protected VersionStore store1;
+  protected VersionStore store2;
+
+  @BeforeEach
+  void wrapCaches(@NessiePersist Persist persist1, @NessiePersist Persist persist2) {
+    nowNanos = new AtomicLong();
+    withCache1 = wrapWithCache(persist1, nowNanos::get);
+    withCache2 = wrapWithCache(persist2, nowNanos::get);
+
+    store1 = ValidatingVersionStoreImpl.of(soft, withCache1);
+    store2 = ValidatingVersionStoreImpl.of(soft, withCache2);
+  }
+
+  @Test
+  public void referenceCachingConcurrentCommit() throws Exception {
+    BranchName main = BranchName.of("main");
+
+    ReferenceInfo<CommitMeta> head1 =
+        store1.getNamedRef(main.getName(), GetNamedRefsParams.DEFAULT);
+    ReferenceInfo<CommitMeta> head2 =
+        store2.getNamedRef(main.getName(), GetNamedRefsParams.DEFAULT);
+    soft.assertThat(head2).isEqualTo(head1);
+
+    CommitResult<Commit> committed1 =
+        store1.commit(
+            main,
+            Optional.of(head1.getHash()),
+            CommitMeta.fromMessage("commit via 1"),
+            singletonList(Put.of(ContentKey.of("table1"), IcebergTable.of("/foo", 1, 2, 3, 43))));
+
+    soft.assertThat(committed1.getCommit().getParentHash()).isEqualTo(head1.getHash());
+
+    ReferenceInfo<CommitMeta> head1afterCommit1 =
+        store1.getNamedRef(main.getName(), GetNamedRefsParams.DEFAULT);
+    ReferenceInfo<CommitMeta> head2afterCommit1 =
+        store2.getNamedRef(main.getName(), GetNamedRefsParams.DEFAULT);
+    soft.assertThat(head1afterCommit1.getHash())
+        .isEqualTo(committed1.getCommitHash())
+        .isNotEqualTo(head1.getHash());
+    soft.assertThat(head2afterCommit1).isEqualTo(head2);
+
+    CommitResult<Commit> committed2 =
+        store2.commit(
+            main,
+            Optional.of(head2afterCommit1.getHash()),
+            CommitMeta.fromMessage("commit via 2"),
+            singletonList(Put.of(ContentKey.of("table2"), IcebergTable.of("/foo", 1, 2, 3, 43))));
+
+    soft.assertThat(committed2.getCommit().getParentHash())
+        .isEqualTo(committed1.getCommit().getHash());
+
+    ReferenceInfo<CommitMeta> head1afterCommit2 =
+        store1.getNamedRef(main.getName(), GetNamedRefsParams.DEFAULT);
+    ReferenceInfo<CommitMeta> head2afterCommit2 =
+        store2.getNamedRef(main.getName(), GetNamedRefsParams.DEFAULT);
+    soft.assertThat(head1afterCommit2).isEqualTo(head1afterCommit1);
+    soft.assertThat(head2afterCommit2.getHash())
+        .isEqualTo(committed2.getCommitHash())
+        .isNotEqualTo(head1afterCommit2.getHash());
+
+    //
+
+    nowNanos.addAndGet(Duration.ofMinutes(5).toNanos());
+
+    ReferenceInfo<CommitMeta> head1afterExpiry =
+        store1.getNamedRef(main.getName(), GetNamedRefsParams.DEFAULT);
+    ReferenceInfo<CommitMeta> head2afterExpiry =
+        store2.getNamedRef(main.getName(), GetNamedRefsParams.DEFAULT);
+
+    soft.assertThat(head1afterExpiry).isEqualTo(head2afterExpiry).isEqualTo(head2afterCommit2);
+  }
+}

--- a/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
+++ b/versioned/storage/testextension/src/main/java/org/projectnessie/versioned/storage/testextension/ClassPersistInstances.java
@@ -19,6 +19,7 @@ import static org.projectnessie.versioned.storage.common.logic.Logics.repository
 import static org.projectnessie.versioned.storage.testextension.PersistExtension.KEY_REUSABLE_BACKEND;
 import static org.projectnessie.versioned.storage.testextension.PersistExtension.NAMESPACE;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -55,7 +56,11 @@ final class ClassPersistInstances {
     cacheBackend =
         nessiePersistCache != null && nessiePersistCache.capacityMb() >= 0
             ? PersistCaches.newBackend(
-                CacheConfig.builder().capacityMb(nessiePersistCache.capacityMb()).build())
+                CacheConfig.builder()
+                    .capacityMb(nessiePersistCache.capacityMb())
+                    .referenceTtl(Duration.ofMinutes(1))
+                    .referenceNegativeTtl(Duration.ofMinutes(1))
+                    .build())
             : null;
 
     backendTestFactory = reusableTestBackend.backendTestFactory(context);

--- a/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
+++ b/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
@@ -308,10 +308,31 @@ public abstract class AbstractExportImport {
             return inmemory.fetchReference(name);
           }
 
+          @Nullable
+          @Override
+          public Reference fetchReferenceForUpdate(@Nonnull String name) {
+            if (name.startsWith("refs/heads/branch-")) {
+              int refNum = parseInt(name.substring("refs/heads/branch-".length()));
+              return reference(
+                  name,
+                  intToObjId(refNum),
+                  false,
+                  TimeUnit.NANOSECONDS.toMicros(System.nanoTime()),
+                  null);
+            }
+            return inmemory.fetchReferenceForUpdate(name);
+          }
+
           @Nonnull
           @Override
           public Reference[] fetchReferences(@Nonnull String[] names) {
             return inmemory.fetchReferences(names);
+          }
+
+          @Nonnull
+          @Override
+          public Reference[] fetchReferencesForUpdate(@Nonnull String[] names) {
+            return fetchReferences(names);
           }
 
           @Nonnull


### PR DESCRIPTION
Adds ability to cache `Reference` objects, avoiding round-trips to the backend database, beneficial for read heavy workloads.

Reference-caching can be enabled via two new configuration options: to define the expiration time for `Reference`s (holding the current HEAD/tip) and to define the expiration time for non-existing `Reference`s.

Looking up references happens via the name of the reference, usually without the reference type (aka whether it is a branch or a tag), so Nessie has to look up both types - the given name as a branch and the given name as a tag. This is where negative-caching comes into play, because that caches the existing entry and the non-existing "other" reference type. Hence, if you enable reference-caching, it is recommended to also enable negative reference-caching.

Operations that are about to change a reference (committing and reference create/assign/delete operations), always consult the backing database, implicitly refreshing the cache.

Mutliple Nessie (against the same repository) do not communicate with each other. If for example a commit happened against one Nessie instance, the other instances may or may not return the new commit. This is why this feature is still experimental and only useful for Nessie setups with a _single_ Nessie instance. This change will be later with another change to allow distributed cache-eviction, so that other Nessie instances accessing the same repository work fine.