### PR TITLE
Keycloak containers: close admin clients

### DIFF
--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
@@ -112,16 +112,17 @@ public class ITOAuth2Client {
     tokenEndpoint = issuerUrl.resolve("protocol/openid-connect/token");
     authEndpoint = issuerUrl.resolve("protocol/openid-connect/auth");
     deviceAuthEndpoint = issuerUrl.resolve("protocol/openid-connect/auth/device");
-    Keycloak keycloakAdmin = KEYCLOAK.getKeycloakAdminClient();
-    master = keycloakAdmin.realms().realm("master");
-    updateMasterRealm(10, 15);
-    // Create 2 clients, one sending refresh tokens for client_credentials, the other one not
-    createClient("Client1", false);
-    createClient("Client2", true);
-    // Create a client that will act as a resource server attempting to validate access tokens
-    createClient("ResourceServer", false);
-    // Create a user that will be used to obtain access tokens via password grant
-    createUser();
+    try (Keycloak keycloakAdmin = KEYCLOAK.getKeycloakAdminClient()) {
+      master = keycloakAdmin.realms().realm("master");
+      updateMasterRealm(10, 15);
+      // Create 2 clients, one sending refresh tokens for client_credentials, the other one not
+      createClient("Client1", false);
+      createClient("Client2", true);
+      // Create a client that will act as a resource server attempting to validate access tokens
+      createClient("ResourceServer", false);
+      // Create a user that will be used to obtain access tokens via password grant
+      createUser();
+    }
   }
 
   /**

--- a/testing/keycloak-container/src/main/java/org/projectnessie/testing/keycloak/CustomKeycloakContainer.java
+++ b/testing/keycloak-container/src/main/java/org/projectnessie/testing/keycloak/CustomKeycloakContainer.java
@@ -262,9 +262,10 @@ public class CustomKeycloakContainer extends ExtendableKeycloakContainer<CustomK
     super.start();
     LOGGER.info("Keycloak started, creating realm {}...", config.realmName());
 
-    Keycloak adminClient = getKeycloakAdminClient();
     RealmRepresentation realm = createRealm();
-    adminClient.realms().create(realm);
+    try (Keycloak adminClient = getKeycloakAdminClient()) {
+      adminClient.realms().create(realm);
+    }
 
     LOGGER.info("Finished setting up Keycloak, external realm auth url: {}", getExternalRealmUri());
   }
@@ -301,8 +302,7 @@ public class CustomKeycloakContainer extends ExtendableKeycloakContainer<CustomK
   @Override
   public void stop() {
     try {
-      Keycloak adminClient = getKeycloakAdminClient();
-      if (adminClient != null) {
+      try (Keycloak adminClient = getKeycloakAdminClient()) {
         RealmResource realm = adminClient.realm(config.realmName());
         realm.remove();
       }


### PR DESCRIPTION
Prevents warning messages like below:

    RESTEASY004687: Closing a class org.jboss.resteasy.client.jaxrs.engines.ManualClosingApacheHttpClient43Engine$CleanupAction instance for you. Please close clients yourself.