### PR TITLE
Add `NessieClientConfigSource` backed by Iceberg REST catalog properties

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -499,6 +499,8 @@ public final class NessieConfigConstants {
   public static final String CONF_ENABLE_API_COMPATIBILITY_CHECK =
       "nessie.enable-api-compatibility-check";
 
+  public static final String CONF_NESSIE_CLIENT_API_VERSION = "nessie.client-api-version";
+
   public static final int DEFAULT_READ_TIMEOUT_MILLIS = 25000;
   public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 5000;
 

--- a/api/client/src/test/java/org/projectnessie/client/config/TestNessieClientConfigSources.java
+++ b/api/client/src/test/java/org/projectnessie/client/config/TestNessieClientConfigSources.java
@@ -17,8 +17,17 @@ package org.projectnessie.client.config;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.function.Function.identity;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_AUTH_ENDPOINT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_ID;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_SCOPES;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_SECRET;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
 import static org.projectnessie.client.config.NessieClientConfigSources.dotEnvFile;
 import static org.projectnessie.client.config.NessieClientConfigSources.environmentConfigSource;
 import static org.projectnessie.client.config.NessieClientConfigSources.environmentFileConfigSource;
@@ -30,20 +39,30 @@ import static org.projectnessie.client.config.NessieClientConfigSources.systemEn
 import static org.projectnessie.client.config.NessieClientConfigSources.systemPropertiesConfigSource;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.client.config.NessieClientConfigSources.Credential;
 
 @ExtendWith(SoftAssertionsExtension.class)
 public class TestNessieClientConfigSources {
@@ -195,6 +214,164 @@ public class TestNessieClientConfigSources {
         .isEqualTo(
             Paths.get(System.getProperty("user.dir"), ".config/nessie/nessie-client.properties")
                 .toAbsolutePath());
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void fromIcebergRestCatalogProperties(
+      Map<String, String> properties, Map<String, String> expected) {
+    NessieClientConfigSource configSource =
+        NessieClientConfigSources.fromIcebergRestCatalogProperties(properties);
+    Map<String, String> produced =
+        expected.keySet().stream().collect(Collectors.toMap(identity(), configSource::getValue));
+    soft.assertThat(produced).containsExactlyInAnyOrderEntriesOf(expected);
+  }
+
+  static Stream<Arguments> fromIcebergRestCatalogProperties() {
+    return Stream.of(
+        arguments(
+            ImmutableMap.of(
+                "nessie.is-nessie-catalog", "true",
+                "nessie.core-base-uri", "http://localhost/api/",
+                "oauth2-server-uri", "http://oauth-stuff.internal/",
+                "credential", "id:secret",
+                "more", "more-value",
+                "other", "other-value"),
+            ImmutableMap.of(
+                CONF_NESSIE_URI,
+                "http://localhost/api/v2",
+                "nessie.client-api-version",
+                "2",
+                CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
+                "http://oauth-stuff.internal/",
+                CONF_NESSIE_OAUTH2_CLIENT_ID,
+                "id",
+                CONF_NESSIE_OAUTH2_CLIENT_SECRET,
+                "secret",
+                CONF_NESSIE_OAUTH2_CLIENT_SCOPES,
+                "catalog",
+                CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN,
+                "PT1H",
+                //
+                "more",
+                "more-value",
+                "nessie.other",
+                "other-value")));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void resolveTokenLifespan(Map<String, String> properties, String expected) {
+    soft.assertThat(NessieClientConfigSources.resolveTokenLifespan(properties)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> resolveTokenLifespan() {
+    return Stream.of(
+        arguments(singletonMap("token-expires-in-ms", "1234"), "PT1.234S"),
+        arguments(emptyMap(), "PT1H"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void resolveOAuthEndpoint(Map<String, String> properties, String expected) {
+    soft.assertThat(NessieClientConfigSources.resolveOAuthEndpoint(properties)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> resolveOAuthEndpoint() {
+    return Stream.of(
+        arguments(singletonMap("oauth2-server-uri", "http://foo.bar/"), "http://foo.bar/"),
+        arguments(
+            singletonMap("nessie.iceberg-base-uri", "http://foo.bar/iceberg/"),
+            "http://foo.bar/iceberg/v1/oauth/tokens"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void resolveOAuthScope(Map<String, String> properties, Set<String> expected) {
+    String resolved = NessieClientConfigSources.resolveOAuthScope(properties);
+    soft.assertThat(resolved).isNotNull();
+    List<String> list = Arrays.stream(resolved.split(" ")).collect(Collectors.toList());
+    soft.assertThat(list).containsExactlyInAnyOrderElementsOf(expected).hasSize(expected.size());
+  }
+
+  static Stream<Arguments> resolveOAuthScope() {
+    return Stream.of(
+        arguments(emptyMap(), singleton("catalog")),
+        arguments(
+            singletonMap(CONF_NESSIE_OAUTH2_CLIENT_SCOPES, "myscope"),
+            ImmutableSet.of("myscope", "catalog")),
+        arguments(ImmutableMap.of("scope", "ibscope"), ImmutableSet.of("catalog", "ibscope")),
+        arguments(
+            ImmutableMap.of(
+                CONF_NESSIE_OAUTH2_CLIENT_SCOPES,
+                " myscope   otherscope ",
+                "scope",
+                "ibscope scope2"),
+            ImmutableSet.of("myscope", "catalog", "ibscope", "otherscope", "scope2")),
+        arguments(
+            ImmutableMap.of(CONF_NESSIE_OAUTH2_CLIENT_SCOPES, "myscope ", "scope", " ibscope"),
+            ImmutableSet.of("myscope", "catalog", "ibscope")));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void resolveCredential(Map<String, String> properties, Credential expected) {
+    soft.assertThat(NessieClientConfigSources.resolveCredential(properties)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> resolveCredential() {
+    return Stream.of(
+        arguments(emptyMap(), new Credential(null, null)),
+        arguments(singletonMap("credential", "myid:secret"), new Credential("myid", "secret")),
+        arguments(
+            ImmutableMap.of(CONF_NESSIE_OAUTH2_CLIENT_ID, "nessieid", "credential", "myid:secret"),
+            new Credential("nessieid", "secret")),
+        arguments(
+            ImmutableMap.of(
+                CONF_NESSIE_OAUTH2_CLIENT_SECRET, "nessiesecret", "credential", "myid:secret"),
+            new Credential("myid", "nessiesecret")),
+        arguments(
+            ImmutableMap.of(
+                CONF_NESSIE_OAUTH2_CLIENT_ID,
+                "nessieid",
+                CONF_NESSIE_OAUTH2_CLIENT_SECRET,
+                "nessiesecret",
+                "credential",
+                "myid:secret"),
+            new Credential("nessieid", "nessiesecret")));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void resolveViaEnvironment(
+      Map<String, String> properties, String property, String defaultValue, String expected) {
+    soft.assertThat(
+            NessieClientConfigSources.resolveViaEnvironment(properties, property, defaultValue))
+        .isEqualTo(expected);
+  }
+
+  static Stream<Arguments> resolveViaEnvironment() {
+    return Stream.of(
+        arguments(emptyMap(), "something", null, null),
+        arguments(emptyMap(), "something", "fallback", "fallback"),
+        arguments(singletonMap("something", "value"), "something", null, "value"),
+        arguments(singletonMap("something", "value"), "something", "fallback", "value"),
+        arguments(singletonMap("something", "env:USER"), "something", null, System.getenv("USER")),
+        arguments(
+            singletonMap("something", "env:USER"), "something", "fallback", System.getenv("USER")));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void parseIcebergCredential(String input, Credential expected) {
+    soft.assertThat(NessieClientConfigSources.parseIcebergCredential(input)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> parseIcebergCredential() {
+    return Stream.of(
+        arguments(null, new Credential(null, null)),
+        arguments("mysecret", new Credential(null, "mysecret")),
+        arguments("myid:mysecret", new Credential("myid", "mysecret")));
   }
 
   static Map<String, String> asMap(NessieClientConfigSource configSource, String... keys) {


### PR DESCRIPTION
This allows building a Nessie client using the properties of an Iceberg REST Catalog, assuming that the REST endpoint is a Nessie Catalog.