### PR TITLE
Move management endpoints to separate HTTP port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Breaking changes
 
+* The readiness, liveness, metrics and Swagger-UI endpoints starting with `/q/` have been moved from the
+  HTTP port exposing the REST endpoints to a different HTTP port (9000),
+  see [Quarkus management interface reference docs](https://quarkus.io/guides/management-interface-reference).
+  Any path starting with `/q/` can be safely removed from a possibly customized configuration
+  `nessie.server.authentication.anonymous-paths`.
+* The move of the above endpoints to the management port requires using the Nessie Helm chart for this
+  release or a newer release. Also, the Helm Chart for this release will not work with older Nessie
+  releases.
+
 ### New Features
 
 - The Nessie Helm chart now supports AWS profiles. There are now two ways to configure AWS 

--- a/api/README.md
+++ b/api/README.md
@@ -35,7 +35,7 @@ the Nessie API.
 
 The published version of the Nessie OpenAPI specification is available on [SwaggerHub](https://app.swaggerhub.com/apis/projectnessie/nessie).
 
-The current development version is available from a running Nessie server at http://localhost:19120/q/swagger-ui.
+The current development version is available from a running Nessie server at http://localhost:9000/q/swagger-ui.
 
 # Migrating from API v1 to v2
 

--- a/helm/nessie/templates/deployment.yaml
+++ b/helm/nessie/templates/deployment.yaml
@@ -228,11 +228,14 @@ spec:
             - name: nessie-server
               containerPort: 19120
               protocol: TCP
+            - name: nessie-mgmt
+              containerPort: 9000
+              protocol: TCP
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /q/health/live
-              port: 19120
+              port: 9000
               scheme: HTTP
             initialDelaySeconds: 2
             periodSeconds: 30
@@ -242,7 +245,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /q/health/ready
-              port: 19120
+              port: 9000
               scheme: HTTP
             initialDelaySeconds: 3
             periodSeconds: 45

--- a/helm/nessie/templates/management-service.yaml
+++ b/helm/nessie/templates/management-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nessie.fullname" . | printf "%s-mgmt" | quote }}
+  labels:
+    {{- include "nessie.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    {{- include "nessie.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: nessie-mgmt
+  publishNotReadyAddresses: true
+  clusterIP: None

--- a/helm/nessie/templates/servicemonitor.yaml
+++ b/helm/nessie/templates/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: nessie-server
+    - port: nessie-mgmt
       scheme: http
       {{- if .Values.serviceMonitor.interval }}
       interval: {{ .Values.serviceMonitor.interval }}

--- a/servers/quarkus-auth/src/main/java/org/projectnessie/server/authn/NessieHttpAuthenticator.java
+++ b/servers/quarkus-auth/src/main/java/org/projectnessie/server/authn/NessieHttpAuthenticator.java
@@ -104,7 +104,7 @@ public class NessieHttpAuthenticator extends HttpAuthenticator {
         QuarkusNessieAuthenticationConfig config,
         Supplier<Uni<SecurityIdentity>> anonymousSupplier) {
       this.authEnabled = config.enabled();
-      this.anonymousPaths = config.anonymousPaths();
+      this.anonymousPaths = config.anonymousPaths().orElse(Set.of());
       this.anonymousSupplier = anonymousSupplier;
     }
 

--- a/servers/quarkus-auth/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
+++ b/servers/quarkus-auth/src/main/java/org/projectnessie/server/config/QuarkusNessieAuthenticationConfig.java
@@ -19,6 +19,7 @@ import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
+import java.util.Optional;
 import java.util.Set;
 
 /** Configuration for Nessie authentication settings. */
@@ -37,5 +38,5 @@ public interface QuarkusNessieAuthenticationConfig {
    * @hidden Not present in docs on web-site.
    */
   @WithName("anonymous-paths")
-  Set<String> anonymousPaths();
+  Optional<Set<String>> anonymousPaths();
 }

--- a/servers/quarkus-auth/src/test/java/org/projectnessie/server/authn/TestNessieHttpAuthenticator.java
+++ b/servers/quarkus-auth/src/test/java/org/projectnessie/server/authn/TestNessieHttpAuthenticator.java
@@ -15,13 +15,13 @@
  */
 package org.projectnessie.server.authn;
 
-import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
+import java.util.Optional;
 import java.util.Set;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -50,8 +50,8 @@ public class TestNessieHttpAuthenticator {
               }
 
               @Override
-              public Set<String> anonymousPaths() {
-                return emptySet();
+              public Optional<Set<String>> anonymousPaths() {
+                return Optional.empty();
               }
             },
             () -> Uni.createFrom().item(ANONYMOUS_IDENTITY));
@@ -75,8 +75,8 @@ public class TestNessieHttpAuthenticator {
               }
 
               @Override
-              public Set<String> anonymousPaths() {
-                return singleton("/foo");
+              public Optional<Set<String>> anonymousPaths() {
+                return Optional.of(singleton("/foo"));
               }
             },
             () -> Uni.createFrom().item(ANONYMOUS_IDENTITY));

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -169,12 +169,15 @@ quarkus.http.body.handle-file-uploads=false
 #quarkus.oidc.credentials.secret=
 #quarkus.oidc.client-id=
 nessie.server.authentication.enabled=false
-nessie.server.authentication.anonymous-paths=/q/health/live,/q/health/live/,/q/health/ready,/q/health/ready/
 quarkus.http.auth.basic=false
 # OIDC-enabled is a build-time property (cannot be overwritten at run-time), MUST be true.
 # However, we can overwrite the tenant-enabled property at run-time.
 quarkus.oidc.enabled=true
 quarkus.oidc.tenant-enabled=${nessie.server.authentication.enabled}
+
+quarkus.management.enabled=true
+quarkus.management.port=9000
+quarkus.management.test-port=0
 
 ## Quarkus swagger settings
 # fixed at buildtime

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/TestHealthCheckNoAuthentication.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/TestHealthCheckNoAuthentication.java
@@ -29,9 +29,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @QuarkusTest
 @TestProfile(value = TestBasicAuthentication.Profile.class)
-public class TestHealthCheckAuthentication {
+public class TestHealthCheckNoAuthentication {
 
   private static RequestSpecification request() {
+    RestAssured.port = Integer.getInteger("quarkus.management.port");
     return given().when().baseUri(RestAssured.baseURI);
   }
 

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusEvents.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusEvents.java
@@ -21,6 +21,7 @@ import static org.projectnessie.quarkus.tests.profiles.BaseConfigProfile.TEST_RE
 import com.google.common.collect.ImmutableMap;
 import io.restassured.RestAssured;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collections;
 import java.util.List;
@@ -507,9 +508,17 @@ public abstract class AbstractQuarkusEvents {
   }
 
   private String getMetrics() {
+    int managementPort = Integer.getInteger("quarkus.management.port");
+    URI managementBaseUri;
+    try {
+      managementBaseUri =
+          new URI("http", null, clientUri.getHost(), managementPort, "/", null, null);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
     return RestAssured.given()
         .when()
-        .baseUri(clientUri.resolve("/").toString())
+        .baseUri(managementBaseUri.toString())
         .basePath("/q/metrics")
         .accept("*/*")
         .get()

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusRestWithMetrics.java
@@ -16,6 +16,8 @@
 package org.projectnessie.server;
 
 import io.restassured.RestAssured;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.client.ext.NessieApiVersion;
 import org.projectnessie.client.ext.NessieApiVersions;
@@ -27,9 +29,17 @@ public abstract class AbstractQuarkusRestWithMetrics extends AbstractQuarkusRest
   // this test is executed after all tests from the base class
 
   private String getMetrics() {
+    int managementPort = Integer.getInteger("quarkus.management.port");
+    URI managementBaseUri;
+    try {
+      managementBaseUri =
+          new URI("http", null, clientUri.getHost(), managementPort, "/", null, null);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
     return RestAssured.given()
         .when()
-        .baseUri(clientUri.resolve("/").toString())
+        .baseUri(managementBaseUri.toString())
         .basePath("/q/metrics")
         .accept("*/*")
         .get()

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/events/EventsEnabledProfile.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/events/EventsEnabledProfile.java
@@ -30,7 +30,6 @@ public class EventsEnabledProfile extends BaseConfigProfile {
           .put("quarkus.otel.traces.sampler", "always_on")
           .put("nessie.version.store.events.retry.initial-delay", "PT0.1S")
           .put("nessie.version.store.events.static-properties.foo", "bar")
-          .put("nessie.server.authentication.anonymous-paths", "/q/metrics")
           .build();
 
   @Override

--- a/site/docs/develop/rest.md
+++ b/site/docs/develop/rest.md
@@ -2,8 +2,8 @@
 
 Nessie's REST APIs are how all applications interact with Nessie. The APIs are specified 
 according to the openapi v3 standard and are available when running the server by going 
-to [localhost:19120/q/openapi](http://localhost:19120/q/openapi). You can also peruse the set of operations our APIs support 
+to [localhost:19120/q/openapi](http://localhost:9000/q/openapi). You can also peruse the set of operations our APIs support 
 by going to [SwaggerHub](https://app.swaggerhub.com/apis/projectnessie/nessie).
 
 If you are working in development, our Quarkus server will automatically start with 
-the swagger-ui for experimentation. You can find that at [localhost:19120/q/swagger-ui/](http://localhost:19120/q/swagger-ui/)
+the swagger-ui for experimentation. You can find that at [localhost:9000/q/swagger-ui/](http://localhost:9000/q/swagger-ui/)

--- a/site/docs/guides/ui.md
+++ b/site/docs/guides/ui.md
@@ -11,4 +11,4 @@ you can find the UI at [localhost:19120](http://localhost:19120/).
 ### Swagger UI
 
 The Swagger UI allows for testing the REST API and reading the API docs. It is available
-at  [localhost:19120/q/swagger-ui](http://localhost:19120/q/swagger-ui/).
+at  [localhost:9000/q/swagger-ui](http://localhost:9000/q/swagger-ui/).

--- a/site/in-dev/configuration.md
+++ b/site/in-dev/configuration.md
@@ -216,7 +216,7 @@ running and that the URL is correct.
 
 ### Swagger UI
 The Swagger UI allows for testing the REST API and reading the API docs. It is available 
-via [localhost:19120/q/swagger-ui](http://localhost:19120/q/swagger-ui/)
+via [localhost:9000/q/swagger-ui](http://localhost:9000/q/swagger-ui/)
 
 # Docker image options
 

--- a/site/in-dev/configuration.md
+++ b/site/in-dev/configuration.md
@@ -46,9 +46,10 @@ For more information on docker images, see [Docker image options](#docker-image-
 
 Related Quarkus settings:
 
-| Property                  | Default values | Type      | Description                           |
-|---------------------------|----------------|-----------|---------------------------------------|
-| `quarkus.http.port`       | `19120`        | `int`     | Sets the HTTP port                    |
+| Property                  | Default values | Type      | Description                                                            |
+|---------------------------|----------------|-----------|------------------------------------------------------------------------|
+| `quarkus.http.port`       | `19120`        | `int`     | Sets the HTTP port for the Nessie REST API endpoints.                  |
+| `quarkus.management.port` | `9000`         | `int`     | Sets the HTTP port for management endpoints (health, metrics, Swagger) |
 
 !!! info
     A complete set of configuration options for Quarkus can be found on [quarkus.io](https://quarkus.io/guides/all-config)


### PR DESCRIPTION
Quarkus since version 3 allows a separate HTTP endpoint for management endpoints (health, metrics, prometheus), see [Quarkus management interface docs](https://quarkus.io/guides/management-interface-reference).

This allows for example different authentication settings, but especially allows isolation of the management endpoints, to not expose those "to the public".

Fixes #7343