### PR TITLE
Add Apache HTTP client, choose HTTP client by name

### DIFF
--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
   compileOnly(libs.jakarta.ws.rs.api)
   compileOnly(libs.javax.ws.rs)
 
+  compileOnly(libs.httpclient5)
+
   implementation(libs.slf4j.api)
   compileOnly(libs.errorprone.annotations)
 
@@ -73,9 +75,12 @@ dependencies {
   testFixturesApi("software.amazon.awssdk:auth")
   testFixturesApi(libs.undertow.core)
   testFixturesApi(libs.undertow.servlet)
+  testFixturesApi(libs.httpclient5)
   testFixturesImplementation(libs.logback.classic)
 
   testImplementation(libs.wiremock)
+
+  testRuntimeOnly(libs.logback.classic)
 
   intTestImplementation(platform(libs.testcontainers.bom))
   intTestImplementation("org.testcontainers:testcontainers")
@@ -142,6 +147,25 @@ testing {
 
     configurations.named("testJava8Implementation") {
       extendsFrom(configurations.getByName("testImplementation"))
+    }
+
+    register("testNoApacheHttp", JvmTestSuite::class.java) {
+      useJUnitJupiter(libsRequiredVersion("junit"))
+
+      sources { java.srcDirs(sourceSets.getByName("testNoApacheHttp").java.srcDirs) }
+
+      targets {
+        all {
+          testTask.configure { useJUnitPlatform { includeTags("NoApacheHttp") } }
+
+          tasks.named("check").configure { dependsOn(testTask) }
+        }
+      }
+    }
+
+    configurations.named("testNoApacheHttpImplementation") {
+      extendsFrom(configurations.getByName("testImplementation"))
+      exclude(group = "org.apache.httpcomponents.client5")
     }
 
     jacksonTestVersions.forEach { jacksonVersion ->

--- a/api/client/src/main/java/org/projectnessie/client/NessieClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieClientBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.client;
 
+import static java.util.Collections.singleton;
 import static org.projectnessie.client.NessieConfigConstants.CONF_CONNECT_TIMEOUT;
 import static org.projectnessie.client.NessieConfigConstants.CONF_ENABLE_API_COMPATIBILITY_CHECK;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL;
@@ -39,6 +40,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -59,6 +61,11 @@ public interface NessieClientBuilder {
    * client.
    */
   String name();
+
+  /** Client names supported by this implementation. */
+  default Set<String> names() {
+    return singleton(name());
+  }
 
   /**
    * Priority ordinal used to select the most relevant {@link NessieClientBuilder} implementation.
@@ -195,9 +202,9 @@ public interface NessieClientBuilder {
    *
    * <p>Nessie clients are discovered using Java's {@link ServiceLoader service loader} mechanism.
    *
-   * <p>The selection mechanism uses the given {@link NessieClientBuilder#name() Nessie client name}
-   * or Nessie client builder implementation class name to select the client builder from the list
-   * of available implementations.
+   * <p>The selection mechanism uses the given {@link NessieClientBuilder#names() Nessie client
+   * name} or Nessie client builder implementation class name to select the client builder from the
+   * list of available implementations.
    *
    * <p>If neither a name nor an implementation class are specified, aka both parameters are {@code
    * null}, the Nessie client builder with the highest {@link NessieClientBuilder#priority()} will
@@ -207,7 +214,7 @@ public interface NessieClientBuilder {
    * discouraged.
    *
    * @param clientName the name of the Nessie client, as returned by {@link
-   *     NessieClientBuilder#name()}, or {@code null}
+   *     NessieClientBuilder#names()}, or {@code null}
    * @param clientBuilderImpl the class that implements the Nessie client builder, or {@code null}
    * @return Nessie client builder for the requested name or implementation class.
    * @throws IllegalArgumentException if no Nessie client matching the requested name and/or
@@ -222,7 +229,7 @@ public interface NessieClientBuilder {
     List<NessieClientBuilder> builders = new ArrayList<>();
     for (NessieClientBuilder clientBuilder : implementations) {
       builders.add(clientBuilder);
-      if (clientBuilder.name().equals(clientName)) {
+      if (clientBuilder.names().contains(clientName)) {
         if (clientBuilderImpl != null
             && !clientBuilderImpl.isEmpty()
             && !clientBuilder.getClass().getName().equals(clientBuilderImpl)) {

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -426,7 +426,7 @@ public final class NessieConfigConstants {
    * Optional, list of comma-separated cipher suites for SSL connections, see {@link
    * javax.net.ssl.SSLParameters#setCipherSuites(String[])}.
    *
-   * <p>This parameter only works on Java 11 and newer.
+   * <p>This parameter only works on Java 11 and newer with the Java HTTP client.
    */
   public static final String CONF_NESSIE_SSL_CIPHER_SUITES = "nessie.ssl.cipher-suites";
 
@@ -434,7 +434,7 @@ public final class NessieConfigConstants {
    * Optional, list of comma-separated protocols for SSL connections, see {@link
    * javax.net.ssl.SSLParameters#setProtocols(String[])}.
    *
-   * <p>This parameter only works on Java 11 and newer.
+   * <p>This parameter only works on Java 11 and newer with the Java HTTP client.
    */
   public static final String CONF_NESSIE_SSL_PROTOCOLS = "nessie.ssl.protocols";
 
@@ -444,7 +444,7 @@ public final class NessieConfigConstants {
    *
    * <p>Takes a comma-separated list of SNI hostnames.
    *
-   * <p>This parameter only works on Java 11 and newer.
+   * <p>This parameter only works on Java 11 and newer with the Java HTTP client.
    */
   public static final String CONF_NESSIE_SNI_HOSTS = "nessie.ssl.sni-hosts";
 
@@ -455,14 +455,14 @@ public final class NessieConfigConstants {
    * <p>Takes a single SNI hostname <em>matcher</em>, a regular expression representing the SNI
    * hostnames to match.
    *
-   * <p>This parameter only works on Java 11 and newer.
+   * <p>This parameter only works on Java 11 and newer with the Java HTTP client.
    */
   public static final String CONF_NESSIE_SNI_MATCHER = "nessie.ssl.sni-matcher";
 
   /**
    * Optional, allow HTTP/2 upgrade, if set to {@code true}.
    *
-   * <p>This parameter only works on Java 11 and newer.
+   * <p>This parameter only works on Java 11 and newer with the Java HTTP client.
    */
   public static final String CONF_NESSIE_HTTP_2 = "nessie.http2-upgrade";
 
@@ -477,7 +477,7 @@ public final class NessieConfigConstants {
    *   <li>{@code NORMAL}: Always redirect, except from HTTPS URLs to HTTP URLs.
    * </ul>
    *
-   * <p>This parameter only works on Java 11 and newer.
+   * <p>This parameter only works on Java 11 and newer with the Java HTTP client.
    */
   public static final String CONF_NESSIE_HTTP_REDIRECT = "nessie.http-redirects";
 
@@ -485,8 +485,10 @@ public final class NessieConfigConstants {
    * Optional, when running on Java 11 force the use of the old {@link java.net.URLConnection} based
    * client for HTTP, if set to {@code true}.
    *
-   * <p>This parameter only works on Java 11 and newer.
+   * @deprecated Use {@link #CONF_NESSIE_CLIENT_NAME} with the value {@code URLConnection}.
    */
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated
   public static final String CONF_FORCE_URL_CONNECTION_CLIENT =
       "nessie.force-url-connection-client";
 

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -88,7 +88,11 @@ public interface HttpClient extends AutoCloseable {
     Builder setFollowRedirects(String followRedirects);
 
     @CanIgnoreReturnValue
+    @Deprecated
     Builder setForceUrlConnectionClient(boolean forceUrlConnectionClient);
+
+    @CanIgnoreReturnValue
+    Builder setHttpClientName(String clientName);
 
     @CanIgnoreReturnValue
     Builder setReadTimeoutMillis(int readTimeoutMillis);

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -123,8 +123,15 @@ public class HttpClientBuilder extends NessieHttpClientBuilderImpl {
   }
 
   @Override
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public HttpClientBuilder withForceUrlConnectionClient(boolean forceUrlConnectionClient) {
     return (HttpClientBuilder) super.withForceUrlConnectionClient(forceUrlConnectionClient);
+  }
+
+  @Override
+  public HttpClientBuilder withClientName(String clientName) {
+    return (HttpClientBuilder) super.withClientName(clientName);
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -15,20 +15,24 @@
  */
 package org.projectnessie.client.http;
 
+import static java.util.Locale.ROOT;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.function.Function;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import org.projectnessie.client.NessieConfigConstants;
+import org.projectnessie.client.http.impl.HttpClientFactory;
 import org.projectnessie.client.http.impl.HttpRuntimeConfig;
 import org.projectnessie.client.http.impl.HttpUtils;
-import org.projectnessie.client.http.impl.jdk11.JavaHttpClient;
-import org.projectnessie.client.http.impl.jdk8.UrlConnectionClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +59,7 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
   private boolean http2Upgrade;
   private String followRedirects;
   private boolean forceUrlConnectionClient;
+  private String httpClientName;
   private int clientSpec = 2;
 
   HttpClientBuilderImpl() {}
@@ -75,6 +80,7 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
     this.http2Upgrade = other.http2Upgrade;
     this.followRedirects = other.followRedirects;
     this.forceUrlConnectionClient = other.forceUrlConnectionClient;
+    this.httpClientName = other.httpClientName;
     this.clientSpec = other.clientSpec;
   }
 
@@ -153,6 +159,12 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
   @Override
   public HttpClient.Builder setForceUrlConnectionClient(boolean forceUrlConnectionClient) {
     this.forceUrlConnectionClient = forceUrlConnectionClient;
+    return this;
+  }
+
+  @Override
+  public HttpClient.Builder setHttpClientName(String httpClientName) {
+    this.httpClientName = httpClientName;
     return this;
   }
 
@@ -240,32 +252,56 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
             .addAllResponseFilters(responseFilters)
             .isHttp11Only(!http2Upgrade)
             .followRedirects(followRedirects)
-            .forceUrlConnectionClient(forceUrlConnectionClient)
             .authentication(authentication)
             .build();
 
-    return ImplSwitch.FACTORY.apply(config);
+    String clientName = httpClientName;
+    if ("HTTP".equalsIgnoreCase(clientName)) {
+      // fall back to default
+      clientName = null;
+    }
+    if (clientName == null && forceUrlConnectionClient) {
+      // forced use of URLConnectionClient
+      clientName = "URLConnection";
+    }
+    if (clientName != null
+        && forceUrlConnectionClient
+        && !"URLConnection".equalsIgnoreCase(clientName)) {
+      throw new IllegalArgumentException(
+          "Both forceUrlConnectionClient and httpClientName are specified with incompatible values, migrate to httpClientName");
+    }
+
+    HttpClientFactory httpClientFactory =
+        clientName != null
+            ? ImplSwitch.IMPLEMENTATIONS.get(clientName.toLowerCase(ROOT))
+            : ImplSwitch.PREFERRED;
+    if (httpClientFactory == null) {
+      throw new IllegalArgumentException(
+          "No HTTP client factory for name '" + clientName + "' found");
+    }
+    return httpClientFactory.buildClient(config);
+  }
+
+  static Set<String> clientNames() {
+    return ImplSwitch.IMPLEMENTATIONS.keySet();
   }
 
   static class ImplSwitch {
-    static final Function<HttpRuntimeConfig, HttpClient> FACTORY;
+    static final Map<String, HttpClientFactory> IMPLEMENTATIONS;
+    static final HttpClientFactory PREFERRED;
 
     static {
-      Function<HttpRuntimeConfig, HttpClient> factory;
-      try {
-        Class.forName("java.net.http.HttpClient");
-        factory =
-            config ->
-                // Need the system property for tests, "normal" users can use standard
-                // configuration options.
-                Boolean.getBoolean("nessie.client.force-url-connection-client")
-                        || config.forceUrlConnectionClient()
-                    ? new UrlConnectionClient(config)
-                    : new JavaHttpClient(config);
-      } catch (ClassNotFoundException e) {
-        factory = UrlConnectionClient::new;
+      IMPLEMENTATIONS = new HashMap<>();
+      HttpClientFactory preferred = null;
+      for (HttpClientFactory s : ServiceLoader.load(HttpClientFactory.class)) {
+        if (s.available()) {
+          if (preferred == null || preferred.priority() > s.priority()) {
+            preferred = s;
+          }
+          IMPLEMENTATIONS.put(s.name().toLowerCase(ROOT), s);
+        }
       }
-      FACTORY = factory;
+      PREFERRED = preferred;
     }
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -256,6 +256,7 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
             .build();
 
     String clientName = httpClientName;
+    // "HTTP" is the name for `org.projectnessie.client.http.NessieHttpClientBuilderImpl`
     if ("HTTP".equalsIgnoreCase(clientName)) {
       // fall back to default
       clientName = null;

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -261,15 +261,14 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
       // fall back to default
       clientName = null;
     }
-    if (clientName == null && forceUrlConnectionClient) {
+
+    if (forceUrlConnectionClient) {
+      if (clientName != null && !"URLConnection".equalsIgnoreCase(clientName)) {
+        LOGGER.warn(
+            "Both forceUrlConnectionClient and httpClientName are specified with incompatible values, migrate to httpClientName");
+      }
       // forced use of URLConnectionClient
       clientName = "URLConnection";
-    }
-    if (clientName != null
-        && forceUrlConnectionClient
-        && !"URLConnection".equalsIgnoreCase(clientName)) {
-      throw new IllegalArgumentException(
-          "Both forceUrlConnectionClient and httpClientName are specified with incompatible values, migrate to httpClientName");
     }
 
     HttpClientFactory httpClientFactory =

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilder.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.http;
 
 import static org.projectnessie.client.NessieConfigConstants.CONF_FORCE_URL_CONNECTION_CLIENT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_CLIENT_NAME;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_HTTP_2;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_HTTP_REDIRECT;
 
@@ -51,11 +52,16 @@ public interface NessieHttpClientBuilder extends NessieClientBuilder {
   NessieHttpClientBuilder withFollowRedirects(String redirects);
 
   /**
-   * Whether to force using the "old" {@link java.net.URLConnection} based client when running on
-   * Java 11 and newer with Java's new HTTP client.
+   * Whether to force using the {@link java.net.URLConnection} based client.
+   *
+   * @deprecated use {@link #withClientName(String)} with the name {@code URLConnection} instead.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   NessieHttpClientBuilder withForceUrlConnectionClient(boolean forceUrlConnectionClient);
+
+  @CanIgnoreReturnValue
+  NessieHttpClientBuilder withClientName(String clientName);
 
   @CanIgnoreReturnValue
   NessieHttpClientBuilder withResponseFactory(HttpResponseFactory responseFactory);
@@ -154,6 +160,10 @@ public interface NessieHttpClientBuilder extends NessieClientBuilder {
       if (s != null) {
         withForceUrlConnectionClient(Boolean.parseBoolean(s.trim()));
       }
+      s = configuration.apply(CONF_NESSIE_CLIENT_NAME);
+      if (s != null) {
+        withClientName(s.trim());
+      }
 
       return this;
     }
@@ -169,7 +179,14 @@ public interface NessieHttpClientBuilder extends NessieClientBuilder {
     }
 
     @Override
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
     public NessieHttpClientBuilder withForceUrlConnectionClient(boolean forceUrlConnectionClient) {
+      return this;
+    }
+
+    @Override
+    public NessieHttpClientBuilder withClientName(String clientName) {
       return this;
     }
 

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
@@ -21,7 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
@@ -54,6 +56,14 @@ public class NessieHttpClientBuilderImpl
   @Override
   public String name() {
     return "HTTP";
+  }
+
+  @Override
+  public Set<String> names() {
+    Set<String> names = new HashSet<>();
+    names.add("HTTP");
+    names.addAll(HttpClientBuilderImpl.clientNames());
+    return names;
   }
 
   @Override
@@ -176,9 +186,17 @@ public class NessieHttpClientBuilderImpl
 
   @CanIgnoreReturnValue
   @Override
+  @Deprecated
   public NessieHttpClientBuilderImpl withForceUrlConnectionClient(
       boolean forceUrlConnectionClient) {
     builder.setForceUrlConnectionClient(forceUrlConnectionClient);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  @Override
+  public NessieHttpClientBuilderImpl withClientName(String clientName) {
+    builder.setHttpClientName(clientName);
     return this;
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/HttpClientFactory.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/HttpClientFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl;
+
+import org.projectnessie.client.http.HttpClient;
+
+public interface HttpClientFactory {
+
+  String name();
+
+  boolean available();
+
+  int priority();
+
+  HttpClient buildClient(HttpRuntimeConfig config);
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/HttpRuntimeConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/HttpRuntimeConfig.java
@@ -96,11 +96,6 @@ public interface HttpRuntimeConfig extends AutoCloseable {
   }
 
   @Value.Default
-  default boolean forceUrlConnectionClient() {
-    return false;
-  }
-
-  @Value.Default
   default int getClientSpec() {
     return 2;
   }

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheHttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheHttpClient.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.apache;
+
+import java.io.IOException;
+import java.net.URI;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
+import org.apache.hc.core5.pool.PoolReusePolicy;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.HttpRequest;
+import org.projectnessie.client.http.impl.HttpRuntimeConfig;
+
+final class ApacheHttpClient implements HttpClient {
+  final HttpRuntimeConfig config;
+  final CloseableHttpClient client;
+
+  ApacheHttpClient(HttpRuntimeConfig config) {
+    this.config = config;
+
+    RegistryBuilder<ConnectionSocketFactory> socketFactoryRegistryBuilder =
+        RegistryBuilder.<ConnectionSocketFactory>create()
+            .register("http", PlainConnectionSocketFactory.INSTANCE);
+
+    if (config.getSslContext() != null) {
+      SSLConnectionSocketFactory sslConnectionSocketFactory =
+          new SSLConnectionSocketFactory(config.getSslContext());
+      socketFactoryRegistryBuilder.register("https", sslConnectionSocketFactory);
+    }
+
+    PoolingHttpClientConnectionManager connManager =
+        new PoolingHttpClientConnectionManager(
+            socketFactoryRegistryBuilder.build(),
+            PoolConcurrencyPolicy.STRICT,
+            PoolReusePolicy.LIFO,
+            TimeValue.ofMinutes(5));
+
+    SocketConfig socketConfig =
+        SocketConfig.custom()
+            .setTcpNoDelay(true)
+            .setSoTimeout(Timeout.ofMilliseconds(config.getReadTimeoutMillis()))
+            .setTcpNoDelay(true)
+            .build();
+
+    connManager.setDefaultSocketConfig(socketConfig);
+    connManager.setValidateAfterInactivity(TimeValue.ofSeconds(10));
+    connManager.setMaxTotal(100);
+    connManager.setDefaultMaxPerRoute(10);
+
+    RequestConfig defaultRequestConfig =
+        RequestConfig.custom()
+            .setConnectTimeout(Timeout.ofMilliseconds(config.getConnectionTimeoutMillis()))
+            .setResponseTimeout(Timeout.ofMilliseconds(config.getReadTimeoutMillis()))
+            .setRedirectsEnabled(true)
+            .setCircularRedirectsAllowed(false)
+            .setMaxRedirects(5)
+            .setContentCompressionEnabled(!config.isDisableCompression())
+            .build();
+
+    HttpClientBuilder clientBuilder =
+        HttpClients.custom()
+            .disableDefaultUserAgent()
+            .disableAuthCaching()
+            .disableCookieManagement()
+            .setConnectionManager(connManager)
+            .setDefaultRequestConfig(defaultRequestConfig);
+    if (config.isDisableCompression()) {
+      clientBuilder.disableContentCompression();
+    }
+
+    client = clientBuilder.build();
+  }
+
+  @Override
+  public HttpRequest newRequest(URI baseUri) {
+    return new ApacheRequest(this, baseUri);
+  }
+
+  @Override
+  public URI getBaseUri() {
+    return config.getBaseUri();
+  }
+
+  @Override
+  public void close() {
+    try {
+      client.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } finally {
+      config.close();
+    }
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheHttpClientFactory.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheHttpClientFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.apache;
+
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.impl.HttpClientFactory;
+import org.projectnessie.client.http.impl.HttpRuntimeConfig;
+
+public class ApacheHttpClientFactory implements HttpClientFactory {
+  @Override
+  public HttpClient buildClient(HttpRuntimeConfig config) {
+    return new ApacheHttpClient(config);
+  }
+
+  @Override
+  public boolean available() {
+    try {
+      Class.forName("org.apache.hc.client5.http.impl.classic.CloseableHttpClient");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public int priority() {
+    return 200;
+  }
+
+  @Override
+  public String name() {
+    return "ApacheHttp";
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheRequest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.apache;
+
+import static org.projectnessie.client.http.impl.HttpUtils.HEADER_ACCEPT;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.function.BiConsumer;
+import org.apache.hc.client5.http.ConnectTimeoutException;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.HttpEntities;
+import org.projectnessie.client.http.HttpClient.Method;
+import org.projectnessie.client.http.HttpClientException;
+import org.projectnessie.client.http.HttpResponse;
+import org.projectnessie.client.http.RequestContext;
+import org.projectnessie.client.http.ResponseContext;
+import org.projectnessie.client.http.impl.BaseHttpRequest;
+import org.projectnessie.client.http.impl.HttpHeaders.HttpHeader;
+import org.projectnessie.client.http.impl.RequestContextImpl;
+
+final class ApacheRequest extends BaseHttpRequest {
+
+  private final ApacheHttpClient client;
+
+  ApacheRequest(ApacheHttpClient apacheHttpClient, URI baseUri) {
+    super(apacheHttpClient.config, baseUri);
+    this.client = apacheHttpClient;
+  }
+
+  @Override
+  public HttpResponse executeRequest(Method method, Object body) throws HttpClientException {
+
+    URI uri = uriBuilder.build();
+
+    HttpUriRequestBase request = new HttpUriRequestBase(method.name(), uri);
+
+    RequestContext context = new RequestContextImpl(headers, uri, method, body);
+
+    boolean doesOutput = prepareRequest(context);
+
+    config.getRequestFilters().forEach(a -> a.filter(context));
+
+    for (HttpHeader header : headers.allHeaders()) {
+      for (String value : header.getValues()) {
+        request.addHeader(header.getName(), value);
+      }
+    }
+
+    request.addHeader(HEADER_ACCEPT, accept);
+    if (doesOutput) {
+      HttpEntity entity =
+          HttpEntities.create(
+              os -> writeToOutputStream(context, os), ContentType.parse(contentsType));
+      request.setEntity(entity);
+    }
+
+    CloseableHttpResponse response = null;
+    try {
+      response = client.client.execute(request);
+
+      ApacheResponseContext responseContext = new ApacheResponseContext(response, uri);
+
+      List<BiConsumer<ResponseContext, Exception>> callbacks = context.getResponseCallbacks();
+      if (callbacks != null) {
+        callbacks.forEach(callback -> callback.accept(responseContext, null));
+      }
+
+      config.getResponseFilters().forEach(responseFilter -> responseFilter.filter(responseContext));
+
+      if (response.getCode() >= 400) {
+        throw new HttpClientException(
+            String.format("%s request to %s failed with HTTP/%d", method, uri, response.getCode()));
+      }
+
+      response = null;
+      return new HttpResponse(responseContext, config.getMapper());
+    } catch (ConnectTimeoutException e) {
+      throw new HttpClientException(
+          String.format(
+              "Timeout connecting to '%s' after %ds",
+              uri, config.getConnectionTimeoutMillis() / 1000),
+          e);
+    } catch (IOException e) {
+      throw new HttpClientException(e);
+    } finally {
+      if (response != null) {
+        try {
+          response.close();
+        } catch (IOException e) {
+          // ignore
+        }
+      }
+    }
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheResponseContext.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheResponseContext.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.apache;
+
+import static org.projectnessie.client.http.impl.HttpUtils.HEADER_CONTENT_TYPE;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.projectnessie.client.http.ResponseContext;
+import org.projectnessie.client.http.Status;
+
+final class ApacheResponseContext implements ResponseContext {
+
+  private final CloseableHttpResponse response;
+  private URI uri;
+
+  ApacheResponseContext(CloseableHttpResponse response, URI uri) {
+    this.response = response;
+    this.uri = uri;
+  }
+
+  @Override
+  public Status getResponseCode() {
+    return Status.fromCode(response.getCode());
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    return reader();
+  }
+
+  @Override
+  public InputStream getErrorStream() throws IOException {
+    return reader();
+  }
+
+  @Override
+  public boolean isJsonCompatibleResponse() {
+    String contentType = getContentType();
+    if (contentType == null) {
+      return false;
+    }
+    int i = contentType.indexOf(';');
+    if (i > 0) {
+      contentType = contentType.substring(0, i);
+    }
+    return contentType.endsWith("/json") || contentType.endsWith("+json");
+  }
+
+  @Override
+  public String getContentType() {
+    return headerValue(HEADER_CONTENT_TYPE);
+  }
+
+  @Override
+  public URI getRequestedUri() {
+    return uri;
+  }
+
+  private String headerValue(String name) {
+    Header header = response.getFirstHeader(name);
+    return header != null ? header.getValue() : null;
+  }
+
+  private InputStream reader() throws IOException {
+    return new RequestClosingInputStream(response);
+  }
+
+  private static final class RequestClosingInputStream extends InputStream {
+    private final InputStream in;
+    private final CloseableHttpResponse response;
+
+    RequestClosingInputStream(CloseableHttpResponse response) throws IOException {
+      this.response = response;
+      try {
+        this.in = response.getEntity().getContent();
+      } catch (IOException e) {
+        response.close();
+        throw e;
+      }
+    }
+
+    @Override
+    public int read() throws IOException {
+      return in.read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+      return in.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return in.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+      return in.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+      return in.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        in.close();
+      } finally {
+        response.close();
+      }
+    }
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClient.java
@@ -33,11 +33,11 @@ import org.projectnessie.client.http.impl.HttpRuntimeConfig;
  * implementation.
  */
 @SuppressWarnings("Since15") // IntelliJ warns about new APIs. 15 is misleading, it means 11
-public final class JavaHttpClient implements org.projectnessie.client.http.HttpClient {
+final class JavaHttpClient implements org.projectnessie.client.http.HttpClient {
   final HttpRuntimeConfig config;
   private HttpClient client;
 
-  public JavaHttpClient(HttpRuntimeConfig config) {
+  JavaHttpClient(HttpRuntimeConfig config) {
     this.config = config;
 
     HttpClient.Builder clientBuilder =

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClientFactory.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClientFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.jdk11;
+
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.impl.HttpClientFactory;
+import org.projectnessie.client.http.impl.HttpRuntimeConfig;
+
+public class JavaHttpClientFactory implements HttpClientFactory {
+  @Override
+  public HttpClient buildClient(HttpRuntimeConfig config) {
+    return new JavaHttpClient(config);
+  }
+
+  @Override
+  public boolean available() {
+    try {
+      Class.forName("java.net.http.HttpClient");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public int priority() {
+    return 80;
+  }
+
+  @Override
+  public String name() {
+    return "JavaHttp";
+  }
+}

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionClient.java
@@ -26,7 +26,7 @@ import org.projectnessie.client.http.impl.HttpRuntimeConfig;
  * <p>Assumptions: - always send/receive JSON - set headers accordingly by default - very simple
  * interactions w/ API - no cookies - no caching of connections. Could be slow
  */
-public final class UrlConnectionClient implements HttpClient {
+final class UrlConnectionClient implements HttpClient {
 
   public static final String UNSUPPORTED_CONFIG_MESSAGE =
       "Nessie's URLConnection client does not support the configuration options to specify SSL parameters. Switch to Java 11 instead.";
@@ -38,7 +38,7 @@ public final class UrlConnectionClient implements HttpClient {
    *
    * @param config http client configuration
    */
-  public UrlConnectionClient(HttpRuntimeConfig config) {
+  UrlConnectionClient(HttpRuntimeConfig config) {
     this.config = config;
     if (config.getSslParameters() != null) {
       throw new IllegalArgumentException(UNSUPPORTED_CONFIG_MESSAGE);

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionClientFactory.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk8/UrlConnectionClientFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.jdk8;
+
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.impl.HttpClientFactory;
+import org.projectnessie.client.http.impl.HttpRuntimeConfig;
+
+public class UrlConnectionClientFactory implements HttpClientFactory {
+  @Override
+  public HttpClient buildClient(HttpRuntimeConfig config) {
+    return new UrlConnectionClient(config);
+  }
+
+  @Override
+  public boolean available() {
+    return true;
+  }
+
+  @Override
+  public int priority() {
+    return 90;
+  }
+
+  @Override
+  public String name() {
+    return "URLConnection";
+  }
+}

--- a/api/client/src/main/resources/META-INF/services/org.projectnessie.client.http.impl.HttpClientFactory
+++ b/api/client/src/main/resources/META-INF/services/org.projectnessie.client.http.impl.HttpClientFactory
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2024 Dremio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.projectnessie.client.http.impl.jdk11.JavaHttpClientFactory
+org.projectnessie.client.http.impl.jdk8.UrlConnectionClientFactory
+org.projectnessie.client.http.impl.apache.ApacheHttpClientFactory

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.projectnessie.client.http.TestHttpClient;
+import org.projectnessie.client.http.BaseTestHttpClient;
 import org.projectnessie.client.http.impl.HttpUtils;
 import org.projectnessie.client.util.HttpTestServer;
 import org.projectnessie.client.util.HttpTestServer.RequestHandler;
@@ -676,7 +676,7 @@ class TestOAuth2Client {
       soft.assertThat(req.getMethod()).isEqualTo("POST");
       soft.assertThat(req.getContentType()).isEqualTo("application/x-www-form-urlencoded");
       soft.assertThat(req.getHeader("Authorization")).isEqualTo("Basic QWxpY2U6czNjcjN0");
-      Map<String, String> data = TestHttpClient.decodeFormData(req.getInputStream());
+      Map<String, String> data = BaseTestHttpClient.decodeFormData(req.getInputStream());
       if (data.containsKey("scope") && data.get("scope").equals("invalid-scope")) {
         ErrorResponse response =
             ImmutableErrorResponse.builder()
@@ -776,7 +776,7 @@ class TestOAuth2Client {
       soft.assertThat(req.getMethod()).isEqualTo("POST");
       soft.assertThat(req.getContentType()).isEqualTo("application/x-www-form-urlencoded");
       soft.assertThat(req.getHeader("Authorization")).isEqualTo("Basic QWxpY2U6czNjcjN0");
-      Map<String, String> data = TestHttpClient.decodeFormData(req.getInputStream());
+      Map<String, String> data = BaseTestHttpClient.decodeFormData(req.getInputStream());
       soft.assertThat(data).containsEntry("scope", "test");
       URI uri = URI.create(req.getRequestURL().toString());
       DeviceCodeResponse response =
@@ -797,7 +797,7 @@ class TestOAuth2Client {
       if (req.getMethod().equals("GET")) {
         writeResponseBody(resp, "<html><body>Enter device code:</body></html>");
       } else {
-        Map<String, String> data = TestHttpClient.decodeFormData(req.getInputStream());
+        Map<String, String> data = BaseTestHttpClient.decodeFormData(req.getInputStream());
         soft.assertThat(data).containsEntry("device_user_code", "CAFE-BABE");
         deviceAuthorized = true;
         writeResponseBody(resp, "{\"success\":true}");

--- a/api/client/src/test/java/org/projectnessie/client/http/impl/TestHttpClients.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/TestHttpClients.java
@@ -62,23 +62,6 @@ public class TestHttpClients {
         .hasMessage("No HTTP client factory for name 'blahblah' found");
   }
 
-  @Test
-  public void illegalCombination() {
-    assertThatThrownBy(
-            () ->
-                HttpClient.builder()
-                    .setBaseUri(URI.create("http://localhost:8080"))
-                    .setObjectMapper(new ObjectMapper())
-                    .setConnectionTimeoutMillis(15000)
-                    .setReadTimeoutMillis(15000)
-                    .setHttpClientName("apachehttp")
-                    .setForceUrlConnectionClient(true)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
-            "Both forceUrlConnectionClient and httpClientName are specified with incompatible values, migrate to httpClientName");
-  }
-
   static Stream<Arguments> clientByName() {
 
     if (JRE.currentVersion().ordinal() < JRE.JAVA_11.ordinal()) {
@@ -100,7 +83,9 @@ public class TestHttpClients {
               false),
           arguments(
               "urlconnection", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true),
-          arguments(null, "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true));
+          arguments(null, "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true),
+          arguments(
+              "apachehttp", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true));
     }
 
     return Stream.of(

--- a/api/client/src/test/java/org/projectnessie/client/http/impl/TestHttpClients.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/TestHttpClients.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.client.http.HttpClient;
+
+public class TestHttpClients {
+  @ParameterizedTest
+  @MethodSource
+  public void clientByName(
+      String clientName, String expectedClassName, boolean forceUrlConnClient) {
+    try (HttpClient client =
+        HttpClient.builder()
+            .setBaseUri(URI.create("http://localhost:8080"))
+            .setObjectMapper(new ObjectMapper())
+            .setConnectionTimeoutMillis(15000)
+            .setReadTimeoutMillis(15000)
+            .setHttpClientName(clientName)
+            .setForceUrlConnectionClient(forceUrlConnClient)
+            .build()) {
+      assertThat(client.getClass().getName()).isEqualTo(expectedClassName);
+    }
+  }
+
+  @Test
+  public void unknownClient() {
+    assertThatThrownBy(
+            () ->
+                HttpClient.builder()
+                    .setBaseUri(URI.create("http://localhost:8080"))
+                    .setObjectMapper(new ObjectMapper())
+                    .setConnectionTimeoutMillis(15000)
+                    .setReadTimeoutMillis(15000)
+                    .setHttpClientName("blahblah")
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No HTTP client factory for name 'blahblah' found");
+  }
+
+  @Test
+  public void illegalCombination() {
+    assertThatThrownBy(
+            () ->
+                HttpClient.builder()
+                    .setBaseUri(URI.create("http://localhost:8080"))
+                    .setObjectMapper(new ObjectMapper())
+                    .setConnectionTimeoutMillis(15000)
+                    .setReadTimeoutMillis(15000)
+                    .setHttpClientName("apachehttp")
+                    .setForceUrlConnectionClient(true)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Both forceUrlConnectionClient and httpClientName are specified with incompatible values, migrate to httpClientName");
+  }
+
+  static Stream<Arguments> clientByName() {
+
+    if (JRE.currentVersion().ordinal() < JRE.JAVA_11.ordinal()) {
+      return Stream.of(
+          arguments(
+              "apachehttp", "org.projectnessie.client.http.impl.apache.ApacheHttpClient", false),
+          arguments(
+              "ApacheHttp", "org.projectnessie.client.http.impl.apache.ApacheHttpClient", false),
+          arguments("http", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", false),
+          arguments("HTTP", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", false),
+          arguments(null, "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", false),
+          arguments(
+              "UrlConnection",
+              "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient",
+              false),
+          arguments(
+              "urlconnection",
+              "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient",
+              false),
+          arguments(
+              "urlconnection", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true),
+          arguments(null, "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true));
+    }
+
+    return Stream.of(
+        arguments(
+            "apachehttp", "org.projectnessie.client.http.impl.apache.ApacheHttpClient", false),
+        arguments(
+            "ApacheHttp", "org.projectnessie.client.http.impl.apache.ApacheHttpClient", false),
+        arguments(
+            "UrlConnection", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", false),
+        arguments(
+            "urlconnection", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", false),
+        arguments(
+            "urlconnection", "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true),
+        arguments(null, "org.projectnessie.client.http.impl.jdk8.UrlConnectionClient", true),
+        arguments(null, "org.projectnessie.client.http.impl.jdk11.JavaHttpClient", false),
+        arguments("http", "org.projectnessie.client.http.impl.jdk11.JavaHttpClient", false),
+        arguments("HTTP", "org.projectnessie.client.http.impl.jdk11.JavaHttpClient", false),
+        arguments("JavaHttp", "org.projectnessie.client.http.impl.jdk11.JavaHttpClient", false),
+        arguments("javahttp", "org.projectnessie.client.http.impl.jdk11.JavaHttpClient", false));
+  }
+}

--- a/api/client/src/test/java/org/projectnessie/client/http/impl/apache/TestHttpApacheClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/apache/TestHttpApacheClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.apache;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.http.BaseTestHttpClient;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.impl.HttpRuntimeConfig;
+
+public class TestHttpApacheClient extends BaseTestHttpClient {
+
+  @Override
+  protected HttpClient createClient(URI baseUri, Consumer<HttpClient.Builder> customizer) {
+    HttpClient.Builder b =
+        HttpClient.builder()
+            .setBaseUri(baseUri)
+            .setObjectMapper(MAPPER)
+            .setConnectionTimeoutMillis(15000)
+            .setReadTimeoutMillis(15000)
+            .setHttpClientName("ApacheHttp");
+    customizer.accept(b);
+    return b.build();
+  }
+
+  @Override
+  protected boolean supportsHttp2() {
+    // Note: HTTP/2 is only available with async Apache HC
+    return false;
+  }
+
+  @Test
+  void testCloseApacheClient() {
+    HttpRuntimeConfig config = mock(HttpRuntimeConfig.class);
+    when(config.getConnectionTimeoutMillis()).thenReturn(100);
+    HttpClient client = new ApacheHttpClient(config);
+    client.close();
+    verify(config).close();
+  }
+}

--- a/api/client/src/test/java/org/projectnessie/client/http/impl/jdk11/TestJavaHttpClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/jdk11/TestJavaHttpClient.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.jdk11;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.JRE;
+import org.projectnessie.client.http.BaseTestHttpClient;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.impl.HttpRuntimeConfig;
+
+public class TestJavaHttpClient extends BaseTestHttpClient {
+
+  @BeforeAll
+  public static void checkJava11() {
+    assumeThat(JRE.currentVersion()).matches(jre -> jre.ordinal() >= JRE.JAVA_11.ordinal());
+  }
+
+  @Override
+  protected HttpClient createClient(URI baseUri, Consumer<HttpClient.Builder> customizer) {
+    HttpClient.Builder b =
+        HttpClient.builder()
+            .setBaseUri(baseUri)
+            .setObjectMapper(MAPPER)
+            .setConnectionTimeoutMillis(15000)
+            .setReadTimeoutMillis(15000)
+            .setHttpClientName("JavaHttp");
+    customizer.accept(b);
+    return b.build();
+  }
+
+  @Override
+  protected boolean supportsHttp2() {
+    return true;
+  }
+
+  @Test
+  void testCloseJava11Client() {
+    HttpRuntimeConfig config = mock(HttpRuntimeConfig.class);
+    when(config.getConnectionTimeoutMillis()).thenReturn(100);
+    HttpClient client = new JavaHttpClient(config);
+    client.close();
+    verify(config).close();
+  }
+}

--- a/api/client/src/test/java/org/projectnessie/client/http/impl/jdk8/TestHttpUrlConnectionClient.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/impl/jdk8/TestHttpUrlConnectionClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.jdk8;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.http.BaseTestHttpClient;
+import org.projectnessie.client.http.HttpClient;
+import org.projectnessie.client.http.impl.HttpRuntimeConfig;
+
+public class TestHttpUrlConnectionClient extends BaseTestHttpClient {
+
+  @Override
+  protected HttpClient createClient(URI baseUri, Consumer<HttpClient.Builder> customizer) {
+    HttpClient.Builder b =
+        HttpClient.builder()
+            .setBaseUri(baseUri)
+            .setObjectMapper(MAPPER)
+            .setConnectionTimeoutMillis(15000)
+            .setReadTimeoutMillis(15000)
+            .setHttpClientName("UrlConnection");
+    customizer.accept(b);
+    return b.build();
+  }
+
+  @Override
+  protected boolean supportsHttp2() {
+    return false;
+  }
+
+  @Test
+  void testCloseJava8Client() {
+    HttpRuntimeConfig config = mock(HttpRuntimeConfig.class);
+    when(config.getConnectionTimeoutMillis()).thenReturn(100);
+    when(config.getConnectionTimeoutMillis()).thenReturn(100);
+    HttpClient client = new UrlConnectionClient(config);
+    client.close();
+    verify(config).close();
+  }
+}

--- a/api/client/src/testNoApacheHttp/java/org/projectnessie/client/http/impl/apache/TestNoApacheHttp.java
+++ b/api/client/src/testNoApacheHttp/java/org/projectnessie/client/http/impl/apache/TestNoApacheHttp.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.client.http.impl.apache;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.projectnessie.client.http.HttpClient;
+
+@Tag("NoApacheHttp")
+public class TestNoApacheHttp {
+  @Test
+  public void checkNoApacheHttpOnClasspath() {
+    assertThatThrownBy(
+            () -> Class.forName("org.apache.hc.client5.http.impl.classic.CloseableHttpClient"))
+        .isInstanceOf(ClassNotFoundException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"apachehttp", "ApacheHttp"})
+  public void apacheHttpNotAvailable(String clientName) {
+    assertThatThrownBy(
+            () ->
+                HttpClient.builder()
+                    .setBaseUri(URI.create("http://localhost:8080"))
+                    .setObjectMapper(new ObjectMapper())
+                    .setConnectionTimeoutMillis(15000)
+                    .setReadTimeoutMillis(15000)
+                    .setHttpClientName(clientName)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No HTTP client factory for name '" + clientName + "' found");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "JavaHttp", "URLConnection", "HTTP"})
+  public void defaultClientWorks(String clientName) {
+    assertThatCode(
+            () ->
+                HttpClient.builder()
+                    .setBaseUri(URI.create("http://localhost:8080"))
+                    .setObjectMapper(new ObjectMapper())
+                    .setConnectionTimeoutMillis(15000)
+                    .setReadTimeoutMillis(15000)
+                    .setHttpClientName(clientName.isEmpty() ? null : clientName)
+                    .build()
+                    .close())
+        .doesNotThrowAnyException();
+  }
+}

--- a/gc/gc-base/build.gradle.kts
+++ b/gc/gc-base/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   implementation(libs.slf4j.api)
   implementation(libs.guava)
   implementation(libs.agrona)
+  implementation(libs.httpclient5)
 
   compileOnly(libs.microprofile.openapi)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ hadoop-azure = { module = "org.apache.hadoop:hadoop-azure", version.ref = "hadoo
 hadoop-client = { module = "org.apache.hadoop:hadoop-client", version.ref = "hadoop" }
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
 hibernate-validator-cdi = { module = "org.hibernate:hibernate-validator-cdi", version = "8.0.1.Final" }
+httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version = "5.3.1" }
 iceberg-bom = { module = "org.apache.iceberg:iceberg-bom", version.ref = "iceberg" }
 immutables-builder = { module = "org.immutables:builder", version.ref = "immutables" }
 immutables-value-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }

--- a/site/docs/tools/client_config.md
+++ b/site/docs/tools/client_config.md
@@ -5,20 +5,21 @@ a way specific to the tool used.
 
 ## Common Nessie client configuration options
 
-| Configuration option               | Mandatory / default | Meaning                                                                                                                                                                   | 
-|------------------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `nessie.uri`                       | Mandatory           | Nessie REST endpoint                                                                                                                                                      |
-| `nessie.authentication.*`          | Recommended         | Authentication options, see [below](#authentication-settings)                                                                                                             |
-| `nessie.ref`                       | Mandatory           | Name of the Nessie reference, usually `main`.                                                                                                                             |
-| `nessie.ref.hash`                  | Optional            | Hash on `nessie.ref`, usually not specified.                                                                                                                              |
-| `nessie.tracing`                   | Optional            | Boolean property to optionally enable tracing.                                                                                                                            |
-| `nessie.transport.read-timeout`    | Optional            | Network level read timeout in milliseconds. When running with Java 11, this becomes a request timeout.                                                                    |
-| `nessie.transport.connect-timeout` | Optional            | Network level connect timeout in milliseconds.                                                                                                                            |
-| `nessie.http-redirects`            | Optional            | Optional, specify how redirects are handled. `NEVER`: Never redirect (default),`ALWAYS`: Always redirect, `NORMAL`: Always redirect, except from HTTPS URLs to HTTP URLs. |
-| `nessie.ssl.cipher-suites`         | Optional            | Optional, specify the set of allowed SSL cipher suites.                                                                                                                   |
-| `nessie.ssl.protocols`             | Optional            | Optional, specify the set of allowed SSL protocols.                                                                                                                       |
-| `nessie.ssl.sni-hosts`             | Optional            | Optional, specify the set of allowed SNI hosts.                                                                                                                           |
-| `nessie.ssl.sni-matcher`           | Optional            | Optional, specify a SNI matcher regular expression.                                                                                                                       |
+| Configuration option               | Mandatory / default | Meaning                                                                                                                                                                                                                                       | 
+|------------------------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `nessie.client-builder-name`       | Optional            | The HTTP client to use. Prefers the new Java HTTP client (`JavaHttp`), if running on Java 11 or newer, or the Java `URLConnection` client. The Apache HTTP client (`ApacheHttp`) can be used, if it has been made available on the classpath. |
+| `nessie.uri`                       | Mandatory           | Nessie REST endpoint                                                                                                                                                                                                                          |
+| `nessie.authentication.*`          | Recommended         | Authentication options, see [below](#authentication-settings)                                                                                                                                                                                 |
+| `nessie.ref`                       | Mandatory           | Name of the Nessie reference, usually `main`.                                                                                                                                                                                                 |
+| `nessie.ref.hash`                  | Optional            | Hash on `nessie.ref`, usually not specified.                                                                                                                                                                                                  |
+| `nessie.tracing`                   | Optional            | Boolean property to optionally enable tracing.                                                                                                                                                                                                |
+| `nessie.transport.read-timeout`    | Optional            | Network level read timeout in milliseconds. When running with Java 11, this becomes a request timeout.                                                                                                                                        |
+| `nessie.transport.connect-timeout` | Optional            | Network level connect timeout in milliseconds.                                                                                                                                                                                                |
+| `nessie.http-redirects`            | Optional            | Optional, specify how redirects are handled. `NEVER`: Never redirect (default),`ALWAYS`: Always redirect, `NORMAL`: Always redirect, except from HTTPS URLs to HTTP URLs.                                                                     |
+| `nessie.ssl.cipher-suites`         | Optional            | Optional, specify the set of allowed SSL cipher suites.                                                                                                                                                                                       |
+| `nessie.ssl.protocols`             | Optional            | Optional, specify the set of allowed SSL protocols.                                                                                                                                                                                           |
+| `nessie.ssl.sni-hosts`             | Optional            | Optional, specify the set of allowed SNI hosts.                                                                                                                                                                                               |
+| `nessie.ssl.sni-matcher`           | Optional            | Optional, specify a SNI matcher regular expression.                                                                                                                                                                                           |
 
 ### Java 11 connection pool options
 
@@ -42,8 +43,8 @@ those via its configuration mechanism.
 
 !!! note
     In case you run into issues with Nessie's new HTTP client for Java 11 and newer, you can try
-    to use the legacy `URLConnection` based HTTP client by setting the system property
-    `nessie.client.force-url-connection-client` to `true`.
+    to use the legacy `URLConnection` based HTTP client by setting the system property or configuration option
+    `nessie.client-builder-name` to `URLConnection`.
 
 ## Spark
 

--- a/tools/content-generator/build.gradle.kts
+++ b/tools/content-generator/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
 
 dependencies {
   implementation(project(":nessie-client"))
+  runtimeOnly(libs.httpclient5)
 
   implementation(libs.picocli)
   // TODO help picocli to make their annotation-processor incremental
@@ -54,6 +55,7 @@ dependencies {
   testFixturesCompileOnly(libs.picocli)
   testFixturesCompileOnly(platform(libs.jackson.bom))
   testFixturesCompileOnly("com.fasterxml.jackson.core:jackson-annotations")
+  testFixturesApi(libs.httpclient5)
 
   testImplementation(project(":nessie-jaxrs-testextension"))
 


### PR DESCRIPTION
This change adds the Apache HTTP client (synchronous, HTTP/1.1 only for now).

The Apache HTTP client is not being used by default, and only works if it is available on the classpath:

HTTP clients become somewhat pluggable with this change as well.
A specific HTTP client can be chosen via the `nessie.client-builder-name` configuration option:
* `HTTP` (default) chooses the default HTTP client
* `JavaHttp` forces the new Java HTTP client (default when running on Java 11 or newer)
* `URLConnection` forces the URLConnection based client (default when running on Java 8)
* `ApacheHttp` forces the Apache HTTP client

The configuration option `nessie.force-url-connection-client` is deprecated now, in favor of `nessie.client-builder-name=URLConnection`.
