### PR TITLE
S3-Mock: add local heap storage

### DIFF
--- a/testing/s3mock/src/main/java/org/projectnessie/s3mock/AwsChunkedInputStream.java
+++ b/testing/s3mock/src/main/java/org/projectnessie/s3mock/AwsChunkedInputStream.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.s3mock;
+
+import com.google.common.base.Preconditions;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+final class AwsChunkedInputStream extends InputStream {
+  private final InputStream input;
+  private AwsChunkedState state = AwsChunkedState.EXPECT_HEADER;
+  private int chunkLen;
+
+  // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html#sigv4-chunked-body-definition
+
+  // Interestingly, for a 1MB upload, the AWS sync client uses 'aws-chunked' content-encoding, but
+  // the AWS async client does not.
+
+  AwsChunkedInputStream(InputStream input) {
+    this.input = input;
+  }
+
+  enum AwsChunkedState {
+    EXPECT_HEADER,
+    DATA,
+    EXPECT_SEPARATOR,
+    EOF,
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    while (true) {
+      switch (state) {
+        case EOF:
+          return -1;
+        case EXPECT_HEADER:
+          String header = readLine();
+          if (header == null) {
+            state = AwsChunkedState.EOF;
+            break;
+          }
+          String[] parts = header.split(";");
+          chunkLen = Integer.parseInt(parts[0], 16);
+          if (chunkLen == 0) {
+            state = AwsChunkedState.EOF;
+            break;
+          }
+          // TODO verify 'chunk-signature'
+          state = AwsChunkedState.DATA;
+          break;
+        case DATA:
+          if (chunkLen == 0) {
+            state = AwsChunkedState.EXPECT_SEPARATOR;
+            break;
+          }
+          len = Math.min(chunkLen, len);
+          if (len == 0) {
+            return 0;
+          }
+          int rd = input.read(b, off, len);
+          if (rd < 0) {
+            state = AwsChunkedState.EOF;
+            return -1;
+          }
+          chunkLen -= rd;
+          return rd;
+        case EXPECT_SEPARATOR:
+          String sep = readLine();
+          if (sep == null) {
+            state = AwsChunkedState.EOF;
+            break;
+          }
+          Preconditions.checkState(
+              sep.isEmpty(), "Expecting empty separator line, but got '%s'", sep);
+          state = AwsChunkedState.EXPECT_HEADER;
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+    }
+  }
+
+  @Override
+  public int read() throws IOException {
+    byte[] buf = new byte[1];
+    int r = read(buf, 0, 1);
+    if (r < 0) {
+      return r;
+    }
+    return ((int) buf[0]) & 0xff;
+  }
+
+  private String readLine() throws IOException {
+    StringBuilder line = new StringBuilder();
+    while (true) {
+      int c = input.read();
+      if (c == -1) {
+        if (line.length() == 0) {
+          // End of stream "marker"
+          return null;
+        }
+        throw new EOFException();
+      }
+      if (c == 13) {
+        c = input.read();
+        if (c == -1) {
+          throw new EOFException();
+        }
+        if (c == 10) {
+          return line.toString();
+        } else {
+          throw new IllegalArgumentException("Illegal CR-LF sequence");
+        }
+      }
+      line.append((char) c);
+    }
+  }
+}

--- a/testing/s3mock/src/main/java/org/projectnessie/s3mock/S3Bucket.java
+++ b/testing/s3mock/src/main/java/org/projectnessie/s3mock/S3Bucket.java
@@ -51,7 +51,7 @@ public abstract class S3Bucket {
   }
 
   @Value.Default
-  public PutObject putObject() {
+  public Storer storer() {
     return (objectName, contentType, data) -> {
       throw new UnsupportedOperationException();
     };
@@ -63,8 +63,8 @@ public abstract class S3Bucket {
   }
 
   @FunctionalInterface
-  public interface PutObject {
-    void putObject(String key, String contentType, byte[] data);
+  public interface Storer {
+    void store(String key, String contentType, byte[] data);
   }
 
   @FunctionalInterface
@@ -88,7 +88,7 @@ public abstract class S3Bucket {
                 return objects.get(key);
               }
             })
-        .putObject(
+        .storer(
             (key, contentType, data) -> {
               synchronized (objects) {
                 objects.putIfAbsent(

--- a/testing/s3mock/src/main/java/org/projectnessie/s3mock/S3Bucket.java
+++ b/testing/s3mock/src/main/java/org/projectnessie/s3mock/S3Bucket.java
@@ -16,6 +16,9 @@
 package org.projectnessie.s3mock;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.TreeMap;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
 import org.projectnessie.s3mock.data.S3ObjectIdentifier;
@@ -47,9 +50,21 @@ public abstract class S3Bucket {
     return (String prefix) -> Stream.empty();
   }
 
+  @Value.Default
+  public PutObject putObject() {
+    return (objectName, contentType, data) -> {
+      throw new UnsupportedOperationException();
+    };
+  }
+
   @FunctionalInterface
   public interface Deleter {
     boolean delete(S3ObjectIdentifier objectIdentifier);
+  }
+
+  @FunctionalInterface
+  public interface PutObject {
+    void putObject(String key, String contentType, byte[] data);
   }
 
   @FunctionalInterface
@@ -61,5 +76,79 @@ public abstract class S3Bucket {
     String key();
 
     MockObject object();
+  }
+
+  public static S3Bucket createHeapStorageBucket() {
+    TreeMap<String, MockObject> objects = new TreeMap<>();
+
+    return S3Bucket.builder()
+        .object(
+            key -> {
+              synchronized (objects) {
+                return objects.get(key);
+              }
+            })
+        .putObject(
+            (key, contentType, data) -> {
+              synchronized (objects) {
+                objects.putIfAbsent(
+                    key,
+                    MockObject.builder()
+                        .contentLength(data.length)
+                        // .etag("etag")
+                        // .storageClass(StorageClass.STANDARD)
+                        .lastModified(System.currentTimeMillis())
+                        .writer(
+                            ((range, output) -> {
+                              if (range == null) {
+                                output.write(data);
+                              } else {
+                                output.write(
+                                    data, (int) range.start(), (int) (range.end() - range.start()));
+                              }
+                            }))
+                        .build());
+              }
+            })
+        .lister(
+            prefix -> {
+              Collection<String> keys;
+              synchronized (objects) {
+                keys = new ArrayList<>();
+                if (prefix != null) {
+                  for (String key : objects.tailMap(prefix, true).keySet()) {
+                    if (!key.startsWith(prefix)) {
+                      break;
+                    }
+                    keys.add(key);
+                  }
+                } else {
+                  keys.addAll(objects.keySet());
+                }
+              }
+              return keys.stream()
+                  .map(
+                      key ->
+                          new ListElement() {
+                            @Override
+                            public String key() {
+                              return key;
+                            }
+
+                            @Override
+                            public MockObject object() {
+                              synchronized (objects) {
+                                return objects.get(key);
+                              }
+                            }
+                          });
+            })
+        .deleter(
+            oid -> {
+              synchronized (objects) {
+                return objects.remove(oid.key()) != null;
+              }
+            })
+        .build();
   }
 }

--- a/testing/s3mock/src/main/java/org/projectnessie/s3mock/S3Resource.java
+++ b/testing/s3mock/src/main/java/org/projectnessie/s3mock/S3Resource.java
@@ -20,6 +20,7 @@ import static jakarta.ws.rs.core.HttpHeaders.IF_MODIFIED_SINCE;
 import static jakarta.ws.rs.core.HttpHeaders.IF_NONE_MATCH;
 import static jakarta.ws.rs.core.HttpHeaders.IF_UNMODIFIED_SINCE;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static org.projectnessie.s3mock.util.S3Constants.CONTINUATION_TOKEN;
 import static org.projectnessie.s3mock.util.S3Constants.ENCODING_TYPE;
 import static org.projectnessie.s3mock.util.S3Constants.LIST_TYPE;
@@ -31,6 +32,7 @@ import static org.projectnessie.s3mock.util.S3Constants.X_AMZ_REQUEST_ID;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.hash.Hashing;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -45,14 +47,19 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -60,6 +67,7 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.projectnessie.s3mock.S3Bucket.ListElement;
@@ -360,6 +368,66 @@ public class S3Resource {
               .lastModified(new Date(obj.lastModified()))
               .build();
         });
+  }
+
+  @PUT
+  @Path("/{bucketName:[a-z0-9.-]+}/{object:.+}")
+  @Consumes(MediaType.WILDCARD)
+  // See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+  public Response putObject(
+      @PathParam("bucketName") String bucketName,
+      @PathParam("object") String objectName,
+      @Context HttpHeaders headers,
+      InputStream stream
+      //    @HeaderParam(RANGE) Range range,
+      //    @HeaderParam(IF_MATCH) List<String> match,
+      //    @HeaderParam(IF_NONE_MATCH) List<String> noneMatch,
+      //    @HeaderParam(IF_MODIFIED_SINCE) Date modifiedSince,
+      //    @HeaderParam(IF_UNMODIFIED_SINCE) Date unmodifiedSince
+      ) {
+    return withBucket(
+        bucketName,
+        bucket -> {
+          byte[] data;
+
+          String contentEncoding = headers.getHeaderString("Content-Encoding");
+          try {
+            data = chunkedInput(contentEncoding, stream).readAllBytes();
+          } catch (Exception e) {
+            return Response.status(500, e.toString()).build();
+          }
+
+          byte[] md5 = Hashing.md5().hashBytes(data).asBytes();
+          String md5str = Base64.getEncoder().encodeToString(md5);
+          String contentMD5 = headers.getHeaderString("Content-MD5");
+          String contentType = headers.getHeaderString("Content-Type");
+          if (contentMD5 != null && !contentMD5.equals(md5str)) {
+            return Response.status(400, "Content-MD5 does not match content").build();
+          }
+          try {
+            bucket.putObject().putObject(objectName, contentType, data);
+            return Response.ok()
+                // .header("ETag", asQuotedHex(md5))
+                .header("Date", RFC_1123_DATE_TIME.format(Instant.now().atZone(ZoneId.of("UTC"))))
+                .build();
+          } catch (UnsupportedOperationException e) {
+            return Response.status(405, "PUT object not allowed").build();
+          }
+        });
+  }
+
+  private InputStream chunkedInput(String contentEncoding, InputStream input) throws IOException {
+    if (contentEncoding != null) {
+      List<String> contentEncodingList =
+          Arrays.stream(contentEncoding.split(",")).collect(Collectors.toList());
+      if (contentEncodingList.remove("identity")) {
+        // no-op
+        return input;
+      } else if (contentEncodingList.remove("aws-chunked")) {
+        return new AwsChunkedInputStream(input);
+      }
+    }
+    return input;
   }
 
   private static Response preconditionFailed() {

--- a/testing/s3mock/src/main/java/org/projectnessie/s3mock/data/S3Object.java
+++ b/testing/s3mock/src/main/java/org/projectnessie/s3mock/data/S3Object.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import jakarta.annotation.Nullable;
 import org.immutables.value.Value;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -31,17 +32,26 @@ public interface S3Object {
   String key();
 
   @JsonProperty("LastModified")
+  @Nullable
   String lastModified();
 
   @JsonProperty("ETag")
+  @Nullable
   String etag();
 
   @JsonProperty("Size")
+  @Nullable
   String size();
 
   @JsonProperty("StorageClass")
+  @Nullable
   StorageClass storageClass();
 
   @JsonProperty("Owner")
+  @Nullable
   Owner owner();
+
+  static ImmutableS3Object.Builder builder() {
+    return ImmutableS3Object.builder();
+  }
 }

--- a/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestAwsChunkedInputStream.java
+++ b/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestAwsChunkedInputStream.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.s3mock;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.google.common.base.Strings;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.utils.IoUtils;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestAwsChunkedInputStream {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @ParameterizedTest
+  @MethodSource
+  public void chunked(byte[] input, int chunkSize) throws Exception {
+    // See
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html#sigv4-chunked-body-definition
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    for (int p = 0; ; ) {
+      int remain = input.length - p;
+      int chunkLen = Math.min(remain, chunkSize);
+      if (chunkLen > 0) {
+        output.write(String.format("%x;chunk-signature=F00\r\n", chunkLen).getBytes(UTF_8));
+        output.write(input, p, chunkLen);
+        output.write("\r\n".getBytes(UTF_8));
+        p += chunkLen;
+      }
+      if (p == input.length) {
+        output.write("0;chunk-signature=BA5\r\n\r\n".getBytes(UTF_8));
+        break;
+      }
+    }
+
+    byte[] bytes = output.toByteArray();
+
+    byte[] buffered;
+    try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(bytes))) {
+      buffered = IoUtils.toByteArray(in);
+      soft.assertThat(in.read()).isEqualTo(-1);
+      soft.assertThat(in.read()).isEqualTo(-1);
+      soft.assertThat(in.read(new byte[10])).isEqualTo(-1);
+      soft.assertThat(in.read(new byte[10])).isEqualTo(-1);
+    }
+
+    byte[] single = new byte[buffered.length];
+    try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(bytes))) {
+      for (int i = 0; i < buffered.length; i++) {
+        int c = in.read();
+        if (c == -1) {
+          break;
+        }
+        single[i] = (byte) c;
+      }
+      soft.assertThat(in.read()).isEqualTo(-1);
+      soft.assertThat(in.read()).isEqualTo(-1);
+      soft.assertThat(in.read(new byte[10])).isEqualTo(-1);
+      soft.assertThat(in.read(new byte[10])).isEqualTo(-1);
+    }
+
+    soft.assertThat(single).containsExactly(input);
+    soft.assertThat(buffered).containsExactly(input);
+  }
+
+  static Stream<Arguments> chunked() {
+    return Stream.of(
+        arguments(new byte[0], 512),
+        arguments(Strings.repeat("0123456789abcdef", 2000).getBytes(UTF_8), 512),
+        arguments(Strings.repeat("0123456789abcdef", 2000).getBytes(UTF_8), 100),
+        arguments(Strings.repeat("0123456789abcdef", 2000).getBytes(UTF_8), 65536));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void malformed(byte[] input, Class<? extends Exception> expected, String message)
+      throws Exception {
+    soft.assertThatThrownBy(
+            () -> {
+              IoUtils.toByteArray(new AwsChunkedInputStream(new ByteArrayInputStream(input)));
+            })
+        .isInstanceOf(expected)
+        .hasMessageStartingWith(message);
+  }
+
+  static Stream<Arguments> malformed() {
+    return Stream.of(
+        arguments(
+            Strings.repeat("blahblah", 2000).getBytes(UTF_8),
+            IllegalArgumentException.class,
+            "metadata line too long"),
+        arguments(
+            "5;chunk-signature=F00\r".getBytes(UTF_8),
+            EOFException.class,
+            "Unexpected end of metadata line"),
+        arguments(
+            "5;chunk-signature=F00\nHello5;chunk-signature=F00\n".getBytes(UTF_8),
+            EOFException.class,
+            "Unexpected end of metadata line"),
+        arguments(
+            "5;chunk-signature=F00\r\nHello".getBytes(UTF_8),
+            EOFException.class,
+            "Expecting empty separator line, but got EOF"),
+        arguments(
+            "0;chunk-signature=F00\r\n".getBytes(UTF_8),
+            EOFException.class,
+            "Expecting empty separator line, but got EOF"),
+        arguments(
+            "5;chunk-signature=F00\r\nHell".getBytes(UTF_8),
+            EOFException.class,
+            "Unexpected end of chunk input, not enough data"),
+        arguments(
+            "5;chunk-signature=F00\r\n".getBytes(UTF_8),
+            EOFException.class,
+            "Unexpected end of chunk input, not enough data"),
+        arguments(
+            "5;chunk-signature=F00\rHello5;chunk-signature=F00\r".getBytes(UTF_8),
+            IllegalArgumentException.class,
+            "Illegal CR-LF sequence"),
+        arguments(
+            "5;chunk-signature=F00\r\nHello5;chunk-signature=F00\r\n".getBytes(UTF_8),
+            IllegalArgumentException.class,
+            "Expecting empty separator line, but got '5;chunk-signature=F00'"),
+        arguments(
+            "FOO;chunk-signature=F00\r\nHello\r\n0;chunk-signature=F00\r\n\r\n".getBytes(UTF_8),
+            NumberFormatException.class,
+            ""));
+  }
+}

--- a/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestIcebergS3MockServerS3Client.java
+++ b/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestIcebergS3MockServerS3Client.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -35,16 +37,21 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.utils.IoUtils;
 
 /**
  * Test {@link IcebergS3Mock} using {@link S3Client}. This test class is separate from {@link
@@ -317,5 +324,102 @@ public class TestIcebergS3MockServerS3Client extends AbstractIcebergS3MockServer
         // HTTP RFCs mandate that HTTP/304 must not return a message-body
         .extracting(S3Exception::statusCode)
         .isEqualTo(304);
+  }
+
+  @Test
+  public void putObject() {
+    AtomicReference<String> writtenKey = new AtomicReference<>();
+    AtomicReference<String> writtenType = new AtomicReference<>();
+    AtomicReference<byte[]> writtenData = new AtomicReference<>();
+
+    createServer(
+        b ->
+            b.putBuckets(
+                BUCKET,
+                S3Bucket.builder()
+                    .putObject(
+                        (key, contentType, data) -> {
+                          writtenKey.set(key);
+                          writtenType.set(contentType);
+                          writtenData.set(data);
+                        })
+                    .build()));
+
+    s3.putObject(
+        PutObjectRequest.builder()
+            .bucket(BUCKET)
+            .key("my-object")
+            .contentType("text/plain")
+            .build(),
+        RequestBody.fromBytes("Hello World".getBytes(StandardCharsets.UTF_8)));
+
+    soft.assertThat(writtenKey.get()).isEqualTo("my-object");
+    soft.assertThat(writtenType.get()).isEqualTo("text/plain");
+    soft.assertThat(writtenData.get()).asString().isEqualTo("Hello World");
+  }
+
+  @Test
+  public void heapStorage() throws Exception {
+    createServer(b -> b.putBuckets(BUCKET, S3Bucket.createHeapStorageBucket()));
+
+    s3.putObject(
+        PutObjectRequest.builder()
+            .bucket(BUCKET)
+            .key("my-object")
+            .contentType("text/plain")
+            .build(),
+        RequestBody.fromBytes("Hello World".getBytes(StandardCharsets.UTF_8)));
+
+    soft.assertThat(
+            IoUtils.toByteArray(
+                s3.getObject(GetObjectRequest.builder().bucket(BUCKET).key("my-object").build())))
+        .asString()
+        .isEqualTo("Hello World");
+
+    List<S3Object> contents =
+        s3.listObjects(ListObjectsRequest.builder().bucket(BUCKET).build()).contents();
+    soft.assertThat(contents).extracting(S3Object::key).containsExactly("my-object");
+
+    for (int i = 0; i < 5; i++) {
+      s3.putObject(
+          PutObjectRequest.builder()
+              .bucket(BUCKET)
+              .key("objs/o" + i)
+              .contentType("text/plain")
+              .build(),
+          RequestBody.fromBytes(("Hello World " + i).getBytes(StandardCharsets.UTF_8)));
+    }
+    for (int i = 0; i < 5; i++) {
+      s3.putObject(
+          PutObjectRequest.builder()
+              .bucket(BUCKET)
+              .key("foo/f" + i)
+              .contentType("text/plain")
+              .build(),
+          RequestBody.fromBytes(("Foo " + i).getBytes(StandardCharsets.UTF_8)));
+    }
+
+    contents = s3.listObjects(ListObjectsRequest.builder().bucket(BUCKET).build()).contents();
+    soft.assertThat(contents)
+        .extracting(S3Object::key)
+        .containsExactly(
+            "foo/f0",
+            "foo/f1",
+            "foo/f2",
+            "foo/f3",
+            "foo/f4",
+            "my-object",
+            "objs/o0",
+            "objs/o1",
+            "objs/o2",
+            "objs/o3",
+            "objs/o4");
+
+    contents =
+        s3.listObjects(ListObjectsRequest.builder().bucket(BUCKET).prefix("objs").build())
+            .contents();
+    soft.assertThat(contents)
+        .extracting(S3Object::key)
+        .containsExactly("objs/o0", "objs/o1", "objs/o2", "objs/o3", "objs/o4");
   }
 }

--- a/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestIcebergS3MockServerS3Client.java
+++ b/testing/s3mock/src/test/java/org/projectnessie/s3mock/TestIcebergS3MockServerS3Client.java
@@ -337,7 +337,7 @@ public class TestIcebergS3MockServerS3Client extends AbstractIcebergS3MockServer
             b.putBuckets(
                 BUCKET,
                 S3Bucket.builder()
-                    .putObject(
+                    .storer(
                         (key, contentType, data) -> {
                           writtenKey.set(key);
                           writtenType.set(contentType);
@@ -371,9 +371,8 @@ public class TestIcebergS3MockServerS3Client extends AbstractIcebergS3MockServer
         RequestBody.fromBytes("Hello World".getBytes(StandardCharsets.UTF_8)));
 
     soft.assertThat(
-            IoUtils.toByteArray(
+            IoUtils.toUtf8String(
                 s3.getObject(GetObjectRequest.builder().bucket(BUCKET).key("my-object").build())))
-        .asString()
         .isEqualTo("Hello World");
 
     List<S3Object> contents =


### PR DESCRIPTION
This allows us to omit starting a test container for simple S3 test cases.