### PR TITLE
Testing/object-storage-mock: support different ADLS client upload behavior

### DIFF
--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/GcsResource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/GcsResource.java
@@ -25,6 +25,7 @@ import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.projectnessie.objectstoragemock.s3.S3Constants.RANGE;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.inject.Inject;
@@ -296,7 +297,11 @@ public class GcsResource {
                 // read metadata as JSON - see
                 // https://cloud.google.com/storage/docs/json_api/v1/objects/insert
                 ObjectNode metadata = OBJECT_MAPPER.readValue(stream, ObjectNode.class);
-                String ct = metadata.get("contentType").textValue();
+                JsonNode contentTypeNode = metadata.get("contentType");
+                String ct =
+                    contentTypeNode != null
+                        ? contentTypeNode.textValue()
+                        : "application/octet-stream";
                 obj =
                     updater
                         .update(objectName, Bucket.UpdaterMode.CREATE_NEW)

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/GcsResource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/GcsResource.java
@@ -182,7 +182,6 @@ public class GcsResource {
   @GET
   @Path("/download/storage/v1/b/{bucketName:[a-z0-9.-]+}/o/{object:.+}")
   @Produces(MediaType.WILDCARD)
-  @SuppressWarnings("JavaUtilDate")
   public Response downloadObject(
       @PathParam("bucketName") String bucketName,
       @PathParam("object") String objectName,
@@ -199,7 +198,6 @@ public class GcsResource {
   @GET
   @Path("/storage/v1/b/{bucketName:[a-z0-9.-]+}/o/{object:.+}")
   @Produces(MediaType.WILDCARD)
-  @SuppressWarnings("JavaUtilDate")
   public Response getObject(
       @PathParam("bucketName") String bucketName,
       @PathParam("object") String objectName,

--- a/testing/object-storage-mock/src/test/java/org/projectnessie/objectstoragemock/TestWithGcs.java
+++ b/testing/object-storage-mock/src/test/java/org/projectnessie/objectstoragemock/TestWithGcs.java
@@ -232,6 +232,21 @@ public class TestWithGcs extends AbstractObjectStorageMockServer {
   }
 
   @Test
+  public void putObjectNoContentType() throws Exception {
+    Bucket heap = Bucket.createHeapStorageBucket();
+
+    createServer(b -> b.putBuckets(BUCKET, heap));
+
+    client.createFrom(
+        BlobInfo.newBuilder(BlobId.of(BUCKET, MY_OBJECT_KEY)).build(),
+        new ByteArrayInputStream("Hello World".getBytes(UTF_8)));
+
+    soft.assertThat(heap.object().retrieve(MY_OBJECT_KEY))
+        .extracting(MockObject::contentType, MockObject::contentLength)
+        .containsExactly("application/octet-stream", (long) "Hello World".length());
+  }
+
+  @Test
   public void heapStorage() throws Exception {
     createServer(b -> b.putBuckets(BUCKET, Bucket.createHeapStorageBucket()));
 


### PR DESCRIPTION
`DataLakeFileClient.getOutputStream(...)` uses the "old" `BlockBlob` stuff, while `DataLakeFileClient.uploadWithResponse(...)` uses the new Gen2 stuff. This change implements support for the varying behavior of the ADLS Java client.

ADLS clients can send URLs like `...myfilesystem%2fmypath` or `...myfilesystem/%2fmypath`, which lets the encoded `/` leak into the `@PathParam` - unlike GCS and S3 resources.