### PR TITLE
[Docs]: Fix iceberg-links on docs with latest url

### DIFF
--- a/site/docs/develop/index.md
+++ b/site/docs/develop/index.md
@@ -15,7 +15,7 @@ creators.
 The Iceberg format relies on a set of metadata files stored with (or near) the actual
 data tables. This allows Iceberg to fulfill the same role as the Hive Metastore for transactions without the need for
 expensive metadata scans or centralized planning (see [Iceberg
-performance](https://iceberg.apache.org/performance/)). This includes
+performance](https://iceberg.apache.org/docs/latest/performance/)). This includes
 things such as partitioning (including hidden partitions), schema migrations, appends and deletes.  It does however
 require a pointer to the active metadata set to function. This pointer allows the Iceberg client to acquire and read the
 current schema, files and partitions in the dataset. Iceberg currently relies on the Hive metastore or hdfs to perform

--- a/site/docs/tools/iceberg/flink.md
+++ b/site/docs/tools/iceberg/flink.md
@@ -3,7 +3,7 @@
 !!! note    
     Detailed steps on how to set up Pyspark + Iceberg + Flink + Nessie with Python is available on [Binder](https://mybinder.org/v2/gh/projectnessie/nessie-demos/main?filepath=notebooks/nessie-iceberg-flink-demo-nba.ipynb)
 
-In order to use Flink with Python API, you will need to make sure `pyflink` have access to all Hadoop JARs as mentioned in these [docs](https://iceberg.apache.org/flink/#preparation-when-using-flinks-python-api). After that, you will need to make sure `iceberg-flink-runtime` is added to Flink. This can be done by adding the iceberg JAR to `pyflink` via `env.add_jar`, e.g: `env.add_jars("file://path/to/jar/iceberg-flink-runtime-{{ versions.iceberg }}.jar")`. This can be shown below:
+In order to use Flink with Python API, you will need to make sure `pyflink` have access to all Hadoop JARs as mentioned in these [docs](https://iceberg.apache.org/docs/latest/flink/#flinks-python-api). After that, you will need to make sure `iceberg-flink-runtime` is added to Flink. This can be done by adding the iceberg JAR to `pyflink` via `env.add_jar`, e.g: `env.add_jars("file://path/to/jar/iceberg-flink-runtime-{{ versions.iceberg }}.jar")`. This can be shown below:
 
 ```python
 import os
@@ -35,7 +35,7 @@ table_env.execute_sql(
 
 With the above statement, we have created a Nessie catalog (via Iceberg) that Flink will use to manage the tables.
 
-For more general information about Flink and Iceberg, refer to [Iceberg and Flink documentation](https://iceberg.apache.org/flink/).
+For more general information about Flink and Iceberg, refer to [Iceberg and Flink documentation](https://iceberg.apache.org/docs/latest/flink/).
 
 
 ## Configuration 
@@ -95,4 +95,4 @@ SELECT * FROM `<catalog_name>`.`<database_name>`.`<table_name>@<branch>#<hash>`;
 
 ## Other DDL statements
 
-To read and write into tables that are managed by Iceberg and Nessie, typical Flink SQL queries can be used. Refer to this documentation [here](https://iceberg.apache.org/flink/#ddl-commands) for more information.
+To read and write into tables that are managed by Iceberg and Nessie, typical Flink SQL queries can be used. Refer to this documentation [here](https://iceberg.apache.org/docs/latest/flink-ddl/) for more information.

--- a/site/docs/tools/iceberg/hive.md
+++ b/site/docs/tools/iceberg/hive.md
@@ -5,11 +5,11 @@
 
 To access Hive via Iceberg, you will need to make sure `iceberg-hive-runtime` is added to Hive. This can be done either by adding the JAR file to `auxlib` folder in Hive home directory, by adding the JAR file to `hive-site.xml` file or via Hive shell, e.g: `add jar /path/to/iceberg-hive-runtime.jar;`. Nessie's Iceberg module is already included with `iceberg-hive-runtime` JAR distribution.
 
-For more general information about Hive and Iceberg, refer to [Iceberg and Hive documentation](https://iceberg.apache.org/hive/).
+For more general information about Hive and Iceberg, refer to [Iceberg and Hive documentation](https://iceberg.apache.org/docs/latest/hive/).
 
 ## Configuration 
 
-To configure a Nessie Catalog in Hive, first it needs to be [registered in Hive](https://iceberg.apache.org/hive/#custom-iceberg-catalogs), this can be done by configuring the following properties in Hive (Replace `<catalog_name>` with the name of your catalog):
+To configure a Nessie Catalog in Hive, first it needs to be [registered in Hive](https://iceberg.apache.org/docs/latest/hive/#custom-iceberg-catalogs), this can be done by configuring the following properties in Hive (Replace `<catalog_name>` with the name of your catalog):
 
 ```
 SET iceberg.catalog.<catalog_name>.catalog-impl=org.apache.iceberg.nessie.NessieCatalog
@@ -61,7 +61,7 @@ Whereby the above properties are explained as below:
 
 ## Writing and reading tables
 
-To read and write into tables that are managed by Iceberg and Nessie, typical Hive SQL queries can be used. Refer to this documentation [here](https://iceberg.apache.org/hive/#querying-with-sql) for more information.
+To read and write into tables that are managed by Iceberg and Nessie, typical Hive SQL queries can be used. Refer to this documentation [here](https://iceberg.apache.org/docs/latest/hive/#dml-commands) for more information.
 
 **Note**: Hive doesn't support the notation of `<table>@<branch>`, therefore everytime you want to execute against a specific branch, you will need to set this property to point to the working branch, e.g: `SET iceberg.catalog.<catalog_name>.ref=main`. E.g:
 ```

--- a/site/docs/tools/iceberg/index.md
+++ b/site/docs/tools/iceberg/index.md
@@ -1,8 +1,8 @@
 # Overview
 
 Nessie works seamlessly with Iceberg in Spark3. Nessie is implemented as a custom Iceberg
-[catalog](http://iceberg.apache.org/custom-catalog/) and therefore supports all features available to any Iceberg
-client. This includes Spark structured streaming, Presto, Trino, Flink and Hive. See the [Iceberg docs](https://iceberg.apache.org)
+[catalog](https://iceberg.apache.org/docs/latest/custom-catalog/) and therefore supports all features available to any Iceberg
+client. This includes Spark structured streaming, Presto, Trino, Flink and Hive. See the [Iceberg docs](https://iceberg.apache.org/docs/latest/)
 for more info. Current Nessie Iceberg integration includes 
 the following:
 

--- a/site/docs/tools/iceberg/spark.md
+++ b/site/docs/tools/iceberg/spark.md
@@ -55,7 +55,7 @@ In pyspark, usage would look like...
     The config parameter `spark.jars` only takes a list of jar files and does not resolve
     transitive dependencies.
 
-The docs for the [Java API](https://iceberg.apache.org/java-api-quickstart) in Iceberg explain how to use a `Catalog`.
+The docs for the [Java API](https://iceberg.apache.org/docs/latest/java-api-quickstart/) in Iceberg explain how to use a `Catalog`.
 The only change is that a Nessie catalog should be instantiated
 
 === "Java"
@@ -232,7 +232,7 @@ iceberg metadata is finally written to disk and a commit takes place on Nessie.
 Now that we have created an Iceberg table in nessie we can write to it. The iceberg `DataSourceV2` allows for either
 `overwrite` or `append` mode in a standard `spark.write`.
 
-Spark support is constantly evolving. See the [iceberg](https://iceberg.apache.org/spark-writes/) docs for an up-to-date support table.
+Spark support is constantly evolving. See the [iceberg](https://iceberg.apache.org/docs/latest/spark-writes/) docs for an up-to-date support table.
 
 ### Spark3
 
@@ -266,7 +266,7 @@ Spark3 table creation/insertion is as follows:
     INSERT INTO nessie.testing.city VALUES (1, 'a', 1, 'comment')
     ```
 
-The full list of operations can be found [here](https://iceberg.apache.org/spark-writes/). Everything that Iceberg
+The full list of operations can be found [here](https://iceberg.apache.org/docs/latest/spark-writes/). Everything that Iceberg
 supports the Nessie Iceberg Catalog also supports.
 
 ## Reading


### PR DESCRIPTION
Few of the URLs have been outdated. I updated with the corresponding URLs from Iceberg home page. 