### PR TITLE
Enforce S3 path-style access for ObjectStorageMock

### DIFF
--- a/gc/gc-iceberg-files/src/test/java/org/projectnessie/gc/iceberg/files/TestIcebergS3Files.java
+++ b/gc/gc-iceberg-files/src/test/java/org/projectnessie/gc/iceberg/files/TestIcebergS3Files.java
@@ -18,17 +18,13 @@ package org.projectnessie.gc.iceberg.files;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.aws.HttpClientProperties;
-import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -138,7 +134,7 @@ public class TestIcebergS3Files {
 
   private IcebergFiles createIcebergFiles(MockServer server) {
     return IcebergFiles.builder()
-        .properties(icebergProperties(server))
+        .properties(server.icebergProperties())
         .hadoopConfiguration(hadoopConfiguration(server))
         .build();
   }
@@ -174,20 +170,9 @@ public class TestIcebergS3Files {
     return URI.create(String.format("s3://%s/", BUCKET)).resolve(path);
   }
 
-  protected Map<String, String> icebergProperties(MockServer server) {
-    Map<String, String> props = new HashMap<>();
-    props.put(S3FileIOProperties.ACCESS_KEY_ID, "accessKey");
-    props.put(S3FileIOProperties.SECRET_ACCESS_KEY, "secretKey");
-    props.put(S3FileIOProperties.ENDPOINT, server.getS3BaseUri().toString());
-    props.put(HttpClientProperties.CLIENT_TYPE, HttpClientProperties.CLIENT_TYPE_URLCONNECTION);
-    return props;
-  }
-
   protected Configuration hadoopConfiguration(MockServer server) {
     Configuration conf = new Configuration();
-    conf.set("fs.s3a.access.key", "accessKey");
-    conf.set("fs.s3a.secret.key", "secretKey");
-    conf.set("fs.s3a.endpoint", server.getS3BaseUri().toString());
+    server.hadoopConfiguration().forEach(conf::set);
     return conf;
   }
 }

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/Bucket.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/Bucket.java
@@ -68,6 +68,7 @@ public abstract class Bucket {
   public enum UpdaterMode {
     CREATE_NEW,
     UPDATE,
+    UPSERT,
   }
 
   public interface ObjectUpdater {

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/GcsResource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/GcsResource.java
@@ -265,7 +265,7 @@ public class GcsResource {
   @POST
   @Path("/upload/storage/v1/b/{bucketName:[a-z0-9.-]+}/o")
   @Consumes(MediaType.WILDCARD)
-  // See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+  // See https://cloud.google.com/storage/docs/uploading-objects#uploading-an-object
   public Response insertObject(
       @PathParam("bucketName") String bucketName,
       @QueryParam("name") String objectName,
@@ -284,7 +284,7 @@ public class GcsResource {
                 // Not tested
                 obj =
                     updater
-                        .update(objectName, Bucket.UpdaterMode.CREATE_NEW)
+                        .update(objectName, Bucket.UpdaterMode.UPSERT)
                         .append(0L, stream)
                         .setContentType(contentType)
                         .commit();
@@ -304,7 +304,7 @@ public class GcsResource {
                         : "application/octet-stream";
                 obj =
                     updater
-                        .update(objectName, Bucket.UpdaterMode.CREATE_NEW)
+                        .update(objectName, Bucket.UpdaterMode.UPSERT)
                         .setContentType(ct)
                         .commit();
 

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/HeapStorageBucket.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/HeapStorageBucket.java
@@ -103,6 +103,8 @@ public class HeapStorageBucket {
             throw new IllegalStateException("Object '" + key + "' does not exist");
           }
           break;
+        case UPSERT:
+          break;
         default:
           throw new IllegalArgumentException(mode.name());
       }

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/S3Resource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/S3Resource.java
@@ -87,7 +87,7 @@ import org.projectnessie.objectstoragemock.util.Holder;
 import org.projectnessie.objectstoragemock.util.PrefixSpliterator;
 import org.projectnessie.objectstoragemock.util.StartAfterSpliterator;
 
-@Path("/s3/")
+@Path("/")
 @Produces(MediaType.APPLICATION_XML)
 @Consumes(MediaType.APPLICATION_XML)
 public class S3Resource {
@@ -388,7 +388,7 @@ public class S3Resource {
 
             bucket
                 .updater()
-                .update(objectName, Bucket.UpdaterMode.CREATE_NEW)
+                .update(objectName, Bucket.UpdaterMode.UPSERT)
                 .append(0L, input)
                 .setContentType(contentType)
                 .commit();


### PR DESCRIPTION
The S3 REST endpoint of ObjectStorageMock expects the bucket as a path parameter, so virtual host style is not an option.