### PR TITLE
Configurable scopes in KeycloakTestResourceLifecycleManager

### DIFF
--- a/servers/quarkus-server/src/intTest/java/org/projectnessie/server/ITOAuth2Authentication.java
+++ b/servers/quarkus-server/src/intTest/java/org/projectnessie/server/ITOAuth2Authentication.java
@@ -17,6 +17,7 @@ package org.projectnessie.server;
 
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -33,7 +34,11 @@ import org.projectnessie.server.authn.AuthenticationEnabledProfile;
 @QuarkusIntegrationTest
 @QuarkusTestResource(
     restrictToAnnotatedClass = true,
-    value = KeycloakTestResourceLifecycleManager.class)
+    value = KeycloakTestResourceLifecycleManager.class,
+    initArgs =
+        @ResourceArg(
+            name = KeycloakTestResourceLifecycleManager.KEYCLOAK_CLIENT_SCOPES,
+            value = "scope1,scope2"))
 @TestProfile(ITOAuth2Authentication.Profile.class)
 public class ITOAuth2Authentication extends AbstractOAuth2Authentication {
 

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractOAuth2Authentication.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractOAuth2Authentication.java
@@ -86,6 +86,7 @@ public abstract class AbstractOAuth2Authentication extends BaseClientAuthTest {
     config.setProperty("nessie.authentication.oauth2.grant-type", "client_credentials");
     config.setProperty("nessie.authentication.oauth2.client-id", "quarkus-service-app");
     config.setProperty("nessie.authentication.oauth2.client-secret", "secret");
+    config.setProperty("nessie.authentication.oauth2.client-scopes", "scope1 scope2");
     return config;
   }
 

--- a/testing/keycloak-container/src/main/java/org/projectnessie/testing/keycloak/CustomKeycloakContainer.java
+++ b/testing/keycloak-container/src/main/java/org/projectnessie/testing/keycloak/CustomKeycloakContainer.java
@@ -66,7 +66,8 @@ public class CustomKeycloakContainer extends ExtendableKeycloakContainer<CustomK
     return ImmutableKeycloakConfig.builder();
   }
 
-  public static ClientRepresentation createServiceClient(String clientId) {
+  public static ClientRepresentation createServiceClient(
+      String clientId, List<String> clientScopes) {
     ClientRepresentation client = new ClientRepresentation();
 
     client.setClientId(clientId);
@@ -74,6 +75,7 @@ public class CustomKeycloakContainer extends ExtendableKeycloakContainer<CustomK
     client.setSecret(CLIENT_SECRET);
     client.setDirectAccessGrantsEnabled(true);
     client.setServiceAccountsEnabled(true);
+    client.setDefaultClientScopes(clientScopes);
 
     // required for authorization code grant
     client.setStandardFlowEnabled(true);


### PR DESCRIPTION
The next step will be to adapt `ITOAuthClient` to use `KeycloakTestResourceLifecycleManager`, but that's a lot more work.