### PR TITLE
Commit after schema creation for GC tool

### DIFF
--- a/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/commands/JdbcCreateSchema.java
+++ b/gc/gc-tool/src/main/java/org/projectnessie/gc/tool/cli/commands/JdbcCreateSchema.java
@@ -45,6 +45,8 @@ public class JdbcCreateSchema extends BaseCommand {
     }
     try (Connection conn = dataSource.getConnection()) {
       schemaCreateStrategy.apply(conn);
+      // by default autocommit is set to false, so we commit here
+      conn.commit();
     }
     commandSpec
         .commandLine()


### PR DESCRIPTION
By default the connections from the JDBC datasource do not have autocommit on, so when we create schema the results of that creation are then rolled back.  This change is intentional about committing the schema changes.