### PR TITLE
Testing: add test method timeout + more verbose reporting

### DIFF
--- a/build-logic/src/main/kotlin/nessie-testing.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-testing.gradle.kts
@@ -79,8 +79,16 @@ tasks.withType<Test>().configureEach {
   systemProperty("user.language", "en")
   systemProperty("user.country", "US")
   systemProperty("user.variant", "")
+
   jvmArgumentProviders.add(
-    CommandLineArgumentProvider { listOf("-Dtest.log.level=${testLogLevel()}") }
+    CommandLineArgumentProvider {
+      listOf(
+        "-Dtest.log.level=${testLogLevel()}",
+        "-Djunit.platform.reporting.open.xml.enabled=true",
+        "-Djunit.platform.reporting.output.dir=${reports.junitXml.outputLocation.get().asFile.absolutePath}",
+        "-Djunit.jupiter.execution.timeout.default=5m"
+      )
+    }
   )
   environment("TESTCONTAINERS_REUSE_ENABLE", "true")
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ slf4j = "1.7.36"
 undertow = "2.2.28.Final"
 
 [bundles]
-junit-testing = ["assertj-core", "mockito-core", "mockito-junit-jupiter", "junit-jupiter-api", "junit-jupiter-params"]
+junit-testing = ["assertj-core", "mockito-core", "mockito-junit-jupiter", "junit-jupiter-api", "junit-jupiter-params", "junit-platform-reporting"]
 
 [libraries]
 agroal-pool = { module = "io.agroal:agroal-pool", version = "2.3" }
@@ -93,6 +93,7 @@ jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess"
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
+junit-platform-reporting = { module = "org.junit.platform:junit-platform-reporting" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.2.13" }
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version.ref = "keycloak" }
 maven-core = { module = "org.apache.maven:maven-resolver-provider", version.ref = "maven" }


### PR DESCRIPTION
This change adds a default timeout of 5 minutes, which is quite long, but will catch hanging tests. Also adds the more verbose Open Test Reporting format to potentially investigate a hanging test using a better report format than the antique legacy XML format.

[JUnit docs for default timeouts](https://junit.org/junit5/docs/current/user-guide/#writing-tests-declarative-timeouts) 
[JUnit docs for Open Test Reporting](https://junit.org/junit5/docs/current/user-guide/#junit-platform-reporting-open-test-reporting)