### PR TITLE
Renovate: Update package pattern

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,7 +85,7 @@
     // Special versioning for Minio
     {
       matchManagers: ["dockerfile"],
-      packagePatterns: ["^minio"],
+      packagePatterns: ["^quay.io/minio/minio"],
       versioning: "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})T(?<build>\\d{2})-(?<revision>\\d{2})-\\d{2}Z",
       // see https://docs.renovatebot.com/modules/versioning/#regular-expression-versioning
       // see https://github.com/renovatebot/renovate/issues/2438


### PR DESCRIPTION
Seems that #8210 did not help much to automatically bump MinIO image versions. This change is an attempt to fix it.