### PR TITLE
Update `ResponseCheckFilter` to return more human friendly error message

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
@@ -17,7 +17,6 @@ package org.projectnessie.client.rest;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -87,10 +86,6 @@ public class ResponseCheckFilter {
         exception = new NessieServiceException(error);
     }
 
-    if (error.getClientProcessingException() != null) {
-      exception.addSuppressed(error.getClientProcessingException()); // for trouble-shooting
-    }
-
     throw exception;
   }
 
@@ -104,49 +99,37 @@ public class ResponseCheckFilter {
               .status(status.getCode())
               .reason(status.getReason())
               .message("Could not parse error object in response.")
-              .clientProcessingException(
-                  new RuntimeException("Could not parse error object in response."))
+              .clientProcessingError("Could not parse error object in response.")
               .build();
     } else {
       CapturingInputStream capturing = new CapturingInputStream(inputStream);
       try {
         JsonNode errorData = reader.readTree(capturing);
-        try {
-          error = reader.treeToValue(errorData, NessieError.class);
-        } catch (JsonProcessingException e) {
-          // The error payload is valid JSON (or an empty response), but does not represent a
-          // NessieError.
-          //
-          // This can happen when the endpoint is not a Nessie REST API endpoint, but for example an
-          // OAuth2 service.
-          //
-          // Report the captured source input just in case, but do not populate
-          // `clientProcessingException`, because that would put the Jackson exception stack trace
-          // in the message of the (later) thrown exception, which is likely to be displayed to
-          // users. Humans get confused when they see stack traces, even if the reason's legit, for
-          // example an authentication failure.
-          //
-          String cap = capturing.captured().trim();
-          error =
-              ImmutableNessieError.builder()
-                  .message(
-                      cap.isEmpty()
-                          ? "got empty response body from server"
-                          : ("Could not parse error object in response beginning with: "
-                              + capturing.captured()))
-                  .status(status.getCode())
-                  .reason(status.getReason())
-                  .build();
-        }
+        error = reader.treeToValue(errorData, NessieError.class);
       } catch (IOException e) {
+        // The error payload is valid JSON (or an empty response), but does not represent a
+        // NessieError.
+        //
+        // This can happen when the endpoint is not a Nessie REST API endpoint, but for example an
+        // OAuth2 service.
+        //
+        // Report the captured source input just in case, but do not populate
+        // `clientProcessingException`, because that would put the Jackson exception stack trace
+        // in the message of the (later) thrown exception, which is likely to be displayed to
+        // users. Humans get confused when they see stack traces, even if the reason's legit, for
+        // example an authentication failure.
+        //
+        String cap = capturing.captured().trim();
         error =
             ImmutableNessieError.builder()
                 .message(
-                    "Could not parse error object in response beginning with: "
-                        + capturing.captured())
+                    cap.isEmpty()
+                        ? "got empty response body from server"
+                        : ("Could not parse error object in response beginning with: "
+                            + capturing.captured()))
                 .status(status.getCode())
                 .reason(status.getReason())
-                .clientProcessingException(e)
+                .clientProcessingError(e.toString())
                 .build();
       }
     }

--- a/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/ResponseCheckFilter.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -114,26 +113,29 @@ public class ResponseCheckFilter {
         JsonNode errorData = reader.readTree(capturing);
         try {
           error = reader.treeToValue(errorData, NessieError.class);
-        } catch (MismatchedInputException e) {
-          // If the error payload is valid JSON, but does not represent a NessieError, it is likely
-          // produced by Quarkus and contains the server-side logged error ID. Report the raw JSON
-          // text to the caller for trouble-shooting.
-          error =
-              ImmutableNessieError.builder()
-                  .message(capturing.captured())
-                  .status(status.getCode())
-                  .reason(status.getReason())
-                  .build();
         } catch (JsonProcessingException e) {
-          // If the error payload is valid JSON, but does not represent a NessieError, it is likely
-          // produced by Quarkus and contains the server-side logged error ID. Report the raw JSON
-          // text to the caller for trouble-shooting.
+          // The error payload is valid JSON (or an empty response), but does not represent a
+          // NessieError.
+          //
+          // This can happen when the endpoint is not a Nessie REST API endpoint, but for example an
+          // OAuth2 service.
+          //
+          // Report the captured source input just in case, but do not populate
+          // `clientProcessingException`, because that would put the Jackson exception stack trace
+          // in the message of the (later) thrown exception, which is likely to be displayed to
+          // users. Humans get confused when they see stack traces, even if the reason's legit, for
+          // example an authentication failure.
+          //
+          String cap = capturing.captured().trim();
           error =
               ImmutableNessieError.builder()
-                  .message(capturing.captured())
+                  .message(
+                      cap.isEmpty()
+                          ? "got empty response body from server"
+                          : ("Could not parse error object in response beginning with: "
+                              + capturing.captured()))
                   .status(status.getCode())
                   .reason(status.getReason())
-                  .clientProcessingException(e)
                   .build();
         }
       } catch (IOException e) {

--- a/api/model/src/main/java/org/projectnessie/error/NessieError.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieError.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
@@ -81,16 +79,16 @@ public interface NessieError {
   String getServerStackTrace();
 
   /**
-   * Client-side {@link Exception} related to the processing of the error response.
+   * Client-side error message related to the processing of the error response.
    *
-   * <p>This {@link Exception} generally represents any errors related to the decoding of the
-   * payload returned by the server to describe the error.
+   * <p>This generally represents any errors related to the decoding of the payload returned by the
+   * server to describe the error.
    */
   @JsonIgnore
   @Value.Auxiliary
   @Nullable
   @jakarta.annotation.Nullable
-  Exception getClientProcessingException();
+  String getClientProcessingError();
 
   /**
    * The full error message, including HTTP status, reason, server- and client-side exception stack
@@ -111,13 +109,10 @@ public interface NessieError {
       sb.append("\n").append(getServerStackTrace());
     }
 
-    if (getClientProcessingException() != null) {
-      StringWriter sw =
-          new StringWriter()
-              .append(
-                  "\nAdditionally, the client-side exception below was caught while decoding the HTTP response:\n");
-      getClientProcessingException().printStackTrace(new PrintWriter(sw));
-      sb.append("\n").append(sw);
+    if (getClientProcessingError() != null) {
+      sb.append(
+              "\nAdditionally, the client-side exception below was caught while decoding the HTTP response: ")
+          .append(getClientProcessingError());
     }
 
     return sb.toString();

--- a/api/model/src/main/java/org/projectnessie/error/NessieError.java
+++ b/api/model/src/main/java/org/projectnessie/error/NessieError.java
@@ -79,6 +79,22 @@ public interface NessieError {
   String getServerStackTrace();
 
   /**
+   * Client-side {@link Exception} related to the processing of the error response.
+   *
+   * <p>This {@link Exception} generally represents any errors related to the decoding of the
+   * payload returned by the server to describe the error.
+   *
+   * @deprecated Use {@link #getClientProcessingError()}
+   */
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @JsonIgnore
+  @Value.Auxiliary
+  @Nullable
+  @jakarta.annotation.Nullable
+  @Deprecated
+  Exception getClientProcessingException();
+
+  /**
    * Client-side error message related to the processing of the error response.
    *
    * <p>This generally represents any errors related to the decoding of the payload returned by the
@@ -111,8 +127,12 @@ public interface NessieError {
 
     if (getClientProcessingError() != null) {
       sb.append(
-              "\nAdditionally, the client-side exception below was caught while decoding the HTTP response: ")
+              "\nAdditionally, the client-side error below was caught while decoding the HTTP response: ")
           .append(getClientProcessingError());
+    } else if (getClientProcessingException() != null) {
+      sb.append(
+              "\nAdditionally, the client-side exception below was caught while decoding the HTTP response: ")
+          .append(getClientProcessingException());
     }
 
     return sb.toString();

--- a/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
@@ -108,7 +108,7 @@ class TestNessieError {
     e =
         ImmutableNessieError.builder()
             .from(e)
-            .clientProcessingException(new Exception("processingException"))
+            .clientProcessingError(new Exception("processingException").toString())
             .build();
     assertThat(e.getFullMessage())
         .matches(
@@ -121,10 +121,8 @@ class TestNessieError {
                     + "[)]: message\\R"
                     + "foo.bar.InternalServerError\\R"
                     + "\tat some.other.Class\\R"
-                    + "\\RAdditionally, the client-side exception below was caught while decoding the HTTP response:\\R"
-                    + "java.lang.Exception: processingException\\R"
-                    + "\tat (all//)?org.projectnessie.error.TestNessieError.fullMessage[(]TestNessieError.java:"
-                    + ".*",
+                    + "Additionally, the client-side exception below was caught while decoding the HTTP response: "
+                    + "java.lang.Exception: processingException",
                 Pattern.DOTALL));
   }
 
@@ -137,17 +135,16 @@ class TestNessieError {
             .status(HTTP_500_CODE)
             .reason(HTTP_500_MESSAGE)
             .serverStackTrace("foo.bar.InternalServerError\n" + "\tat some.other.Class")
-            .clientProcessingException(new Exception("processingException"))
+            .clientProcessingError(new Exception("processingException").toString())
             .build();
 
     String json = mapper.writeValueAsString(e0);
     NessieError e1 = mapper.readValue(json, NessieError.class);
 
-    assertThat(e1.getClientProcessingException()).isNull(); // not propagated through JSON
+    assertThat(e1.getClientProcessingError()).isNull(); // not propagated through JSON
 
     // Copy e0 without the client error
-    NessieError e2 =
-        ImmutableNessieError.builder().from(e0).clientProcessingException(null).build();
+    NessieError e2 = ImmutableNessieError.builder().from(e0).clientProcessingError(null).build();
     assertThat(e1).isEqualTo(e2);
   }
 }

--- a/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
+++ b/api/model/src/test/java/org/projectnessie/error/TestNessieError.java
@@ -121,7 +121,7 @@ class TestNessieError {
                     + "[)]: message\\R"
                     + "foo.bar.InternalServerError\\R"
                     + "\tat some.other.Class\\R"
-                    + "Additionally, the client-side exception below was caught while decoding the HTTP response: "
+                    + "Additionally, the client-side error below was caught while decoding the HTTP response: "
                     + "java.lang.Exception: processingException",
                 Pattern.DOTALL));
   }


### PR DESCRIPTION
In situations when the HTTP endpoint does not return a "proper" `NessieError`, for example HTTP/401 Unauthorized, the current implementation includes the stack trace of the JSON parsing exception in the _message_ of the exception. This is not useful and confusing. For example, a client that prints the full stack trace, would print _two_ stack traces: the "real" one and the one included in the exception message.

This change updates `ResponseCheckFilter` to _not_ include the `clientProcessingException` for a Jackson `MismatchedInputException`.

Example of a client that just prints `Exception.getMessage()`, which is not user frieldly. The information in the first line is all that people really need. It would contain the captured HTTP response, if there's any.
```
NessieNotAuthorizedException: Unauthorized (HTTP/401):

Additionally, the client-side exception below was caught while decoding the HTTP response:
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `org.projectnessie.error.ImmutableNessieError` from [Unavailable value] (token `JsonToken.NOT_AVAILABLE`)
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1767)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1541)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1488)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:224)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:187)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectReader._bind(ObjectReader.java:2099)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1249)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1267)
	at com.fasterxml.jackson.databind.ObjectReader.treeToValue(ObjectReader.java:2044)
	at org.projectnessie.client.rest.ResponseCheckFilter.decodeErrorObject(ResponseCheckFilter.java:115)
	at org.projectnessie.client.rest.ResponseCheckFilter.checkResponse(ResponseCheckFilter.java:58)
	at org.projectnessie.client.rest.NessieHttpResponseFilter.filter(NessieHttpResponseFilter.java:29)
	at org.projectnessie.client.http.impl.jdk11.JavaRequest.lambda$executeRequest$1(JavaRequest.java:143)
	at java.base/java.util.Collections$SingletonList.forEach(Collections.java:5186)
	at org.projectnessie.client.http.impl.jdk11.JavaRequest.executeRequest(JavaRequest.java:143)
	at org.projectnessie.client.http.HttpRequest.get(HttpRequest.java:106)
	at org.projectnessie.client.rest.v2.HttpApiV2.getConfig(HttpApiV2.java:66)
	at org.projectnessie.nessie.cli.commands.ConnectCommand.execute(ConnectCommand.java:52)
	at org.projectnessie.nessie.cli.commands.ConnectCommand.execute(ConnectCommand.java:33)
	at org.projectnessie.nessie.cli.cli.NessieCliImpl.executeCommand(NessieCliImpl.java:365)
	at org.projectnessie.nessie.cli.cli.NessieCliImpl.parseAndExecuteScript(NessieCliImpl.java:330)
	at org.projectnessie.nessie.cli.cli.NessieCliImpl.runRepl(NessieCliImpl.java:533)
	at org.projectnessie.nessie.cli.cli.NessieCliImpl.call(NessieCliImpl.java:219)
	at org.projectnessie.nessie.cli.cli.NessieCliImpl.call(NessieCliImpl.java:70)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at io.quarkus.picocli.runtime.PicocliRunner$EventExecutionStrategy.execute(PicocliRunner.java:26)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at io.quarkus.picocli.runtime.PicocliRunner.run(PicocliRunner.java:40)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:132)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:62)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:33)
```