### PR TITLE
OAuth2 client config: "bark" with all check-errors

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -246,7 +246,7 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
         "client secret must not be empty");
     check(
         violations,
-        CONF_NESSIE_OAUTH2_ISSUER_URL + "/" + CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT,
+        CONF_NESSIE_OAUTH2_ISSUER_URL + " / " + CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT,
         getIssuerUrl().isPresent() || getTokenEndpoint().isPresent(),
         "either issuer URL or token endpoint must be set");
     if (getTokenEndpoint().isPresent()) {
@@ -303,7 +303,7 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
     if (grantType == GrantType.AUTHORIZATION_CODE) {
       check(
           violations,
-          CONF_NESSIE_OAUTH2_ISSUER_URL + "/" + CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
+          CONF_NESSIE_OAUTH2_ISSUER_URL + " / " + CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
           getIssuerUrl().isPresent() || getAuthEndpoint().isPresent(),
           "either issuer URL or authorization endpoint must be set if grant type is '%s'",
           CONF_NESSIE_OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE);
@@ -325,7 +325,7 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
     if (grantType == GrantType.DEVICE_CODE) {
       check(
           violations,
-          CONF_NESSIE_OAUTH2_ISSUER_URL + "/" + CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
+          CONF_NESSIE_OAUTH2_ISSUER_URL + " / " + CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
           getIssuerUrl().isPresent() || getDeviceAuthEndpoint().isPresent(),
           "either issuer URL or device authorization endpoint must be set if grant type is '%s'",
           CONF_NESSIE_OAUTH2_GRANT_TYPE_DEVICE_CODE);
@@ -368,8 +368,6 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
             >= 0,
         "preemptive token refresh idle timeout must be greater than or equal to %s",
         getMinPreemptiveTokenRefreshIdleTimeout());
-
-    // This check is rather useless, because the executor is created
     check(
         violations,
         CONF_NESSIE_OAUTH2_BACKGROUND_THREAD_IDLE_TIMEOUT,

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -320,7 +320,7 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
           CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_TIMEOUT,
           getAuthorizationCodeFlowTimeout().compareTo(getMinAuthorizationCodeFlowTimeout()) >= 0,
           "authorization code flow: timeout must be greater than or equal to %s",
-          Duration.ofSeconds(10));
+          getMinAuthorizationCodeFlowTimeout());
     }
     if (grantType == GrantType.DEVICE_CODE) {
       check(
@@ -334,13 +334,13 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
           CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL,
           getDeviceCodeFlowPollInterval().compareTo(getMinDeviceCodeFlowPollInterval()) >= 0,
           "device code flow: poll interval must be greater than or equal to %s",
-          Duration.ofSeconds(5));
+          getMinDeviceCodeFlowPollInterval());
       check(
           violations,
           CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_TIMEOUT,
           getDeviceCodeFlowTimeout().compareTo(getMinDeviceCodeFlowTimeout()) >= 0,
           "device code flow: timeout must be greater than or equal to %s",
-          Duration.ofSeconds(10));
+          getMinDeviceCodeFlowTimeout());
     }
     check(
         violations,

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -15,11 +15,28 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_TIMEOUT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_WEB_PORT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_AUTH_ENDPOINT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_BACKGROUND_THREAD_IDLE_TIMEOUT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_ID;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_SECRET;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_TIMEOUT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_GRANT_TYPE;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_GRANT_TYPE_DEVICE_CODE;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_GRANT_TYPE_PASSWORD;
-import static org.projectnessie.client.http.impl.HttpUtils.checkArgument;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_ISSUER_URL;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_PASSWORD;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_PREEMPTIVE_TOKEN_REFRESH_IDLE_TIMEOUT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_USERNAME;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,6 +47,8 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -200,30 +219,64 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
         "OAuth2 server replied with HTTP status code: " + status.getCode());
   }
 
+  private static void check(
+      List<String> violations, String paramKey, boolean cond, String msg, Object... args) {
+    if (!cond) {
+      if (args.length == 0) {
+        violations.add(msg + " (" + paramKey + ")");
+      } else {
+        violations.add(format(msg, args) + " (" + paramKey + ")");
+      }
+    }
+  }
+
   @Value.Check
   void check() {
-    checkArgument(
+    List<String> violations = new ArrayList<>();
+
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_CLIENT_ID,
+        !getClientId().isEmpty(),
+        "client ID must not be empty");
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_CLIENT_SECRET,
+        getClientSecret().length() > 0,
+        "client secret must not be empty");
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_ISSUER_URL + "/" + CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT,
         getIssuerUrl().isPresent() || getTokenEndpoint().isPresent(),
         "either issuer URL or token endpoint must be set");
     if (getTokenEndpoint().isPresent()) {
-      checkArgument(
-          getTokenEndpoint().get().getQuery() == null, "Token endpoint must not have a query part");
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT,
+          getTokenEndpoint().get().getQuery() == null,
+          "Token endpoint must not have a query part");
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT,
           getTokenEndpoint().get().getFragment() == null,
           "Token endpoint must not have a fragment part");
     }
     if (getAuthEndpoint().isPresent()) {
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
           getAuthEndpoint().get().getQuery() == null,
           "Authorization endpoint must not have a query part");
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
           getAuthEndpoint().get().getFragment() == null,
           "Authorization endpoint must not have a fragment part");
     }
-    checkArgument(!getClientId().isEmpty(), "client ID must not be empty");
-    checkArgument(getClientSecret().length() > 0, "client secret must not be empty");
     GrantType grantType = getGrantType();
-    checkArgument(
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_GRANT_TYPE,
         grantType == GrantType.CLIENT_CREDENTIALS
             || grantType == GrantType.PASSWORD
             || grantType == GrantType.AUTHORIZATION_CODE
@@ -234,61 +287,100 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
         CONF_NESSIE_OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE,
         CONF_NESSIE_OAUTH2_GRANT_TYPE_DEVICE_CODE);
     if (grantType == GrantType.PASSWORD) {
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_USERNAME,
           getUsername().isPresent() && !getUsername().get().isEmpty(),
           "username must be set if grant type is '%s'",
           CONF_NESSIE_OAUTH2_GRANT_TYPE_PASSWORD);
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_PASSWORD,
           getPassword().isPresent() && getPassword().get().length() > 0,
           "password must be set if grant type is '%s'",
           CONF_NESSIE_OAUTH2_GRANT_TYPE_PASSWORD);
     }
     if (grantType == GrantType.AUTHORIZATION_CODE) {
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_ISSUER_URL + "/" + CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
           getIssuerUrl().isPresent() || getAuthEndpoint().isPresent(),
           "either issuer URL or authorization endpoint must be set if grant type is '%s'",
           CONF_NESSIE_OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE);
       if (getAuthorizationCodeFlowWebServerPort().isPresent()) {
-        checkArgument(
+        check(
+            violations,
+            CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_WEB_PORT,
             getAuthorizationCodeFlowWebServerPort().getAsInt() >= 0
                 && getAuthorizationCodeFlowWebServerPort().getAsInt() <= 65535,
             "authorization code flow: web server port must be between 0 and 65535 (inclusive)");
       }
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_TIMEOUT,
           getAuthorizationCodeFlowTimeout().compareTo(getMinAuthorizationCodeFlowTimeout()) >= 0,
           "authorization code flow: timeout must be greater than or equal to %s",
           Duration.ofSeconds(10));
     }
     if (grantType == GrantType.DEVICE_CODE) {
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_ISSUER_URL + "/" + CONF_NESSIE_OAUTH2_AUTH_ENDPOINT,
           getIssuerUrl().isPresent() || getDeviceAuthEndpoint().isPresent(),
           "either issuer URL or device authorization endpoint must be set if grant type is '%s'",
           CONF_NESSIE_OAUTH2_GRANT_TYPE_DEVICE_CODE);
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL,
           getDeviceCodeFlowPollInterval().compareTo(getMinDeviceCodeFlowPollInterval()) >= 0,
           "device code flow: poll interval must be greater than or equal to %s",
           Duration.ofSeconds(5));
-      checkArgument(
+      check(
+          violations,
+          CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_TIMEOUT,
           getDeviceCodeFlowTimeout().compareTo(getMinDeviceCodeFlowTimeout()) >= 0,
           "device code flow: timeout must be greater than or equal to %s",
           Duration.ofSeconds(10));
     }
-    checkArgument(
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN,
         getDefaultAccessTokenLifespan().compareTo(getMinDefaultAccessTokenLifespan()) >= 0,
         "default token lifespan must be greater than or equal to %s",
         getMinDefaultAccessTokenLifespan());
-    checkArgument(
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW,
         getRefreshSafetyWindow().compareTo(getMinRefreshSafetyWindow()) >= 0,
         "refresh safety window must be greater than or equal to %s",
         getMinRefreshSafetyWindow());
-    checkArgument(
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW
+            + "/"
+            + CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN,
         getRefreshSafetyWindow().compareTo(getDefaultAccessTokenLifespan()) < 0,
         "refresh safety window must be less than the default token lifespan");
-    checkArgument(
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_PREEMPTIVE_TOKEN_REFRESH_IDLE_TIMEOUT,
         getPreemptiveTokenRefreshIdleTimeout().compareTo(getMinPreemptiveTokenRefreshIdleTimeout())
             >= 0,
         "preemptive token refresh idle timeout must be greater than or equal to %s",
         getMinPreemptiveTokenRefreshIdleTimeout());
+
+    // This check is rather useless, because the executor is created
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_BACKGROUND_THREAD_IDLE_TIMEOUT,
+        getBackgroundThreadIdleTimeout().compareTo(Duration.ZERO) > 0,
+        "background thread idle timeout must be greater than zero");
+
+    if (!violations.isEmpty()) {
+      throw new IllegalArgumentException(
+          "OAuth2 authentication is missing some parameters and could not be initialized: "
+              + join(", ", violations));
+    }
   }
 
   static void applyConfigOption(

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2AuthenticationProvider.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2AuthenticationProvider.java
@@ -48,8 +48,6 @@ class TestOAuth2AuthenticationProvider {
   void testNullParams() {
     assertThatThrownBy(() -> new OAuth2AuthenticationProvider().build(null))
         .isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> new OAuth2AuthenticationProvider().build(prop -> null))
-        .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> OAuth2AuthenticationProvider.create((OAuth2AuthenticatorConfig) null))
         .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> OAuth2AuthenticationProvider.create((OAuth2Authenticator) null))

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -187,7 +187,7 @@ class TestOAuth2ClientConfig {
                 .authEndpoint(URI.create("http://example.com"))
                 .authorizationCodeFlowTimeout(Duration.ofSeconds(1)),
             singletonList(
-                "authorization code flow: timeout must be greater than or equal to PT10S (nessie.authentication.oauth2.auth-code-flow.timeout)")),
+                "authorization code flow: timeout must be greater than or equal to PT30S (nessie.authentication.oauth2.auth-code-flow.timeout)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -205,7 +205,7 @@ class TestOAuth2ClientConfig {
                 .deviceAuthEndpoint(URI.create("http://example.com"))
                 .deviceCodeFlowTimeout(Duration.ofSeconds(1)),
             singletonList(
-                "device code flow: timeout must be greater than or equal to PT10S (nessie.authentication.oauth2.device-code-flow.timeout)")),
+                "device code flow: timeout must be greater than or equal to PT30S (nessie.authentication.oauth2.device-code-flow.timeout)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -70,7 +70,7 @@ class TestOAuth2ClientConfig {
         Arguments.of(
             OAuth2ClientConfig.builder().clientId("Alice").clientSecret("s3cr3t"),
             singletonList(
-                "either issuer URL or token endpoint must be set (nessie.authentication.oauth2.issuer-url/nessie.authentication.oauth2.token-endpoint)")),
+                "either issuer URL or token endpoint must be set (nessie.authentication.oauth2.issuer-url / nessie.authentication.oauth2.token-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -167,7 +167,7 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.AUTHORIZATION_CODE),
             singletonList(
-                "either issuer URL or authorization endpoint must be set if grant type is 'authorization_code' (nessie.authentication.oauth2.issuer-url/nessie.authentication.oauth2.auth-endpoint)")),
+                "either issuer URL or authorization endpoint must be set if grant type is 'authorization_code' (nessie.authentication.oauth2.issuer-url / nessie.authentication.oauth2.auth-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -195,7 +195,7 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.DEVICE_CODE),
             singletonList(
-                "either issuer URL or device authorization endpoint must be set if grant type is 'device_code' (nessie.authentication.oauth2.issuer-url/nessie.authentication.oauth2.auth-endpoint)")),
+                "either issuer URL or device authorization endpoint must be set if grant type is 'device_code' (nessie.authentication.oauth2.issuer-url / nessie.authentication.oauth2.auth-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -15,7 +15,11 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_TIMEOUT;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_AUTHORIZATION_CODE_FLOW_WEB_PORT;
@@ -41,6 +45,7 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_
 import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -52,69 +57,80 @@ class TestOAuth2ClientConfig {
 
   @ParameterizedTest
   @MethodSource
-  void testCheck(OAuth2ClientConfig.Builder config, Throwable expected) {
-    Throwable actual = catchThrowable(config::build);
-    assertThat(actual).isInstanceOf(expected.getClass()).hasMessage(expected.getMessage());
+  void testCheck(OAuth2ClientConfig.Builder config, List<String> expected) {
+    assertThatIllegalArgumentException()
+        .isThrownBy(config::build)
+        .withMessage(
+            "OAuth2 authentication is missing some parameters and could not be initialized: "
+                + join(", ", expected));
   }
 
   static Stream<Arguments> testCheck() {
     return Stream.of(
         Arguments.of(
             OAuth2ClientConfig.builder().clientId("Alice").clientSecret("s3cr3t"),
-            new IllegalArgumentException("either issuer URL or token endpoint must be set")),
+            singletonList(
+                "either issuer URL or token endpoint must be set (nessie.authentication.oauth2.issuer-url/nessie.authentication.oauth2.token-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("http://example.com?query")),
-            new IllegalArgumentException("Token endpoint must not have a query part")),
+            singletonList(
+                "Token endpoint must not have a query part (nessie.authentication.oauth2.token-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("http://example.com#fragment")),
-            new IllegalArgumentException("Token endpoint must not have a fragment part")),
+            singletonList(
+                "Token endpoint must not have a fragment part (nessie.authentication.oauth2.token-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .authEndpoint(URI.create("http://example.com?query")),
-            new IllegalArgumentException("Authorization endpoint must not have a query part")),
+            singletonList(
+                "Authorization endpoint must not have a query part (nessie.authentication.oauth2.auth-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .authEndpoint(URI.create("http://example.com#fragment")),
-            new IllegalArgumentException("Authorization endpoint must not have a fragment part")),
+            singletonList(
+                "Authorization endpoint must not have a fragment part (nessie.authentication.oauth2.auth-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token")),
-            new IllegalArgumentException("client ID must not be empty")),
+            singletonList("client ID must not be empty (nessie.authentication.oauth2.client-id)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("")
                 .tokenEndpoint(URI.create("https://example.com/token")),
-            new IllegalArgumentException("client secret must not be empty")),
+            singletonList(
+                "client secret must not be empty (nessie.authentication.oauth2.client-secret)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.TOKEN_EXCHANGE),
-            new IllegalArgumentException(
-                "grant type must be either 'client_credentials', 'password', 'authorization_code' or 'device_code'")),
+            singletonList(
+                "grant type must be either 'client_credentials', 'password', 'authorization_code' or 'device_code' (nessie.authentication.oauth2.grant-type)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.PASSWORD),
-            new IllegalArgumentException("username must be set if grant type is 'password'")),
+            asList(
+                "username must be set if grant type is 'password' (nessie.authentication.oauth2.username)",
+                "password must be set if grant type is 'password' (nessie.authentication.oauth2.password)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -122,7 +138,9 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.PASSWORD)
                 .username(""),
-            new IllegalArgumentException("username must be set if grant type is 'password'")),
+            asList(
+                "username must be set if grant type is 'password' (nessie.authentication.oauth2.username)",
+                "password must be set if grant type is 'password' (nessie.authentication.oauth2.password)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -130,7 +148,8 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.PASSWORD)
                 .username("Alice"),
-            new IllegalArgumentException("password must be set if grant type is 'password'")),
+            singletonList(
+                "password must be set if grant type is 'password' (nessie.authentication.oauth2.password)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -139,15 +158,16 @@ class TestOAuth2ClientConfig {
                 .grantType(GrantType.PASSWORD)
                 .username("Alice")
                 .password(""),
-            new IllegalArgumentException("password must be set if grant type is 'password'")),
+            singletonList(
+                "password must be set if grant type is 'password' (nessie.authentication.oauth2.password)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.AUTHORIZATION_CODE),
-            new IllegalArgumentException(
-                "either issuer URL or authorization endpoint must be set if grant type is 'authorization_code'")),
+            singletonList(
+                "either issuer URL or authorization endpoint must be set if grant type is 'authorization_code' (nessie.authentication.oauth2.issuer-url/nessie.authentication.oauth2.auth-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -156,8 +176,8 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .authEndpoint(URI.create("http://example.com"))
                 .authorizationCodeFlowWebServerPort(-1),
-            new IllegalArgumentException(
-                "authorization code flow: web server port must be between 0 and 65535 (inclusive)")),
+            singletonList(
+                "authorization code flow: web server port must be between 0 and 65535 (inclusive) (nessie.authentication.oauth2.auth-code-flow.web-port)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -166,16 +186,16 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .authEndpoint(URI.create("http://example.com"))
                 .authorizationCodeFlowTimeout(Duration.ofSeconds(1)),
-            new IllegalArgumentException(
-                "authorization code flow: timeout must be greater than or equal to PT10S")),
+            singletonList(
+                "authorization code flow: timeout must be greater than or equal to PT10S (nessie.authentication.oauth2.auth-code-flow.timeout)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.DEVICE_CODE),
-            new IllegalArgumentException(
-                "either issuer URL or device authorization endpoint must be set if grant type is 'device_code'")),
+            singletonList(
+                "either issuer URL or device authorization endpoint must be set if grant type is 'device_code' (nessie.authentication.oauth2.issuer-url/nessie.authentication.oauth2.auth-endpoint)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -184,8 +204,8 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .deviceAuthEndpoint(URI.create("http://example.com"))
                 .deviceCodeFlowTimeout(Duration.ofSeconds(1)),
-            new IllegalArgumentException(
-                "device code flow: timeout must be greater than or equal to PT10S")),
+            singletonList(
+                "device code flow: timeout must be greater than or equal to PT10S (nessie.authentication.oauth2.device-code-flow.timeout)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -194,24 +214,25 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .deviceAuthEndpoint(URI.create("http://example.com"))
                 .deviceCodeFlowPollInterval(Duration.ofSeconds(1)),
-            new IllegalArgumentException(
-                "device code flow: poll interval must be greater than or equal to PT5S")),
+            singletonList(
+                "device code flow: poll interval must be greater than or equal to PT5S (nessie.authentication.oauth2.device-code-flow.poll-interval)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .defaultAccessTokenLifespan(Duration.ofSeconds(2)),
-            new IllegalArgumentException(
-                "default token lifespan must be greater than or equal to PT10S")),
+            asList(
+                "default token lifespan must be greater than or equal to PT10S (nessie.authentication.oauth2.default-access-token-lifespan)",
+                "refresh safety window must be less than the default token lifespan (nessie.authentication.oauth2.refresh-safety-window/nessie.authentication.oauth2.default-access-token-lifespan)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .refreshSafetyWindow(Duration.ofMillis(100)),
-            new IllegalArgumentException(
-                "refresh safety window must be greater than or equal to PT1S")),
+            singletonList(
+                "refresh safety window must be greater than or equal to PT1S (nessie.authentication.oauth2.refresh-safety-window)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
@@ -219,23 +240,24 @@ class TestOAuth2ClientConfig {
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .refreshSafetyWindow(Duration.ofMinutes(10))
                 .defaultAccessTokenLifespan(Duration.ofMinutes(5)),
-            new IllegalArgumentException(
-                "refresh safety window must be less than the default token lifespan")),
+            singletonList(
+                "refresh safety window must be less than the default token lifespan (nessie.authentication.oauth2.refresh-safety-window/nessie.authentication.oauth2.default-access-token-lifespan)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .preemptiveTokenRefreshIdleTimeout(Duration.ofMillis(100)),
-            new IllegalArgumentException(
-                "preemptive token refresh idle timeout must be greater than or equal to PT1S")),
+            singletonList(
+                "preemptive token refresh idle timeout must be greater than or equal to PT1S (nessie.authentication.oauth2.preemptive-token-refresh-idle-timeout)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .backgroundThreadIdleTimeout(Duration.ZERO),
-            new IllegalArgumentException("Core threads must have nonzero keep alive times")));
+            singletonList(
+                "background thread idle timeout must be greater than zero (nessie.authentication.oauth2.background-thread-idle-timeout)")));
   }
 
   @ParameterizedTest
@@ -280,7 +302,8 @@ class TestOAuth2ClientConfig {
                 CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN, "PT30S",
                 CONF_NESSIE_OAUTH2_CLIENT_SCOPES, "test"),
             null,
-            new NullPointerException("client ID must not be null")),
+            new IllegalArgumentException(
+                "OAuth2 authentication is missing some parameters and could not be initialized: client ID must not be empty (nessie.authentication.oauth2.client-id)")),
         Arguments.of(
             ImmutableMap.of(
                 CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT, "https://example.com/token",
@@ -289,7 +312,8 @@ class TestOAuth2ClientConfig {
                 CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN, "PT30S",
                 CONF_NESSIE_OAUTH2_CLIENT_SCOPES, "test"),
             null,
-            new NullPointerException("client secret must not be null")),
+            new IllegalArgumentException(
+                "OAuth2 authentication is missing some parameters and could not be initialized: client secret must not be empty (nessie.authentication.oauth2.client-secret)")),
         Arguments.of(
             ImmutableMap.builder()
                 .put(CONF_NESSIE_OAUTH2_ISSUER_URL, "https://example.com/")


### PR DESCRIPTION
The current validation of oauth2 options fails immediately for the first validation error. This can be more user friendly by throwing one exception with all violations, which is what this change does. It also replaces the "NPE-validation" for client-ID+secret from `OAuth2AuthenticatorConfig` to "IAE-validation" in `OAuth2ClientConfig`.

The change results in better validation error messages, which also include the config parameter key.