### PR TITLE
Make `nessie.authentication.oauth2.client-secret` optional

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -137,7 +137,7 @@ public final class NessieConfigConstants {
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT token endpoint} or {@linkplain
    *       #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_ID client ID}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret}
+   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret} (if required)
    * </ul>
    *
    * <p>For the "password" grant type, the following properties must be provided:
@@ -146,7 +146,7 @@ public final class NessieConfigConstants {
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT token endpoint} or {@linkplain
    *       #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_ID client ID}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret}
+   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret} (if required)
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_USERNAME username}
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_PASSWORD password}
    * </ul>
@@ -159,7 +159,7 @@ public final class NessieConfigConstants {
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_AUTH_ENDPOINT authorization endpoint} or {@linkplain
    *       #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_ID client ID}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret}
+   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret} (if required)
    * </ul>
    *
    * <p>For the "device_code" grant type, the following properties must be provided:
@@ -170,7 +170,7 @@ public final class NessieConfigConstants {
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_DEVICE_AUTH_ENDPOINT device authorization endpoint} or
    *       {@linkplain #CONF_NESSIE_OAUTH2_ISSUER_URL issuer URL}
    *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_ID client ID}
-   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret}
+   *   <li>{@linkplain #CONF_NESSIE_OAUTH2_CLIENT_SECRET client secret} (if required)
    * </ul>
    *
    * <p>Both client and user must be properly configured with appropriate permissions in the OAuth2

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.projectnessie.client.http.HttpClientException;
+import org.projectnessie.client.http.HttpRequest;
 import org.projectnessie.client.http.HttpResponse;
 import org.projectnessie.client.http.impl.HttpUtils;
 import org.projectnessie.client.http.impl.UriBuilder;
@@ -190,12 +191,9 @@ class AuthorizationCodeFlow implements AutoCloseable {
             .clientId(config.getClientId())
             .scope(config.getScope().orElse(null))
             .build();
-    HttpResponse response =
-        config
-            .getHttpClient()
-            .newRequest(config.getResolvedTokenEndpoint())
-            .authentication(config.getBasicAuthentication())
-            .postForm(body);
+    HttpRequest request = config.getHttpClient().newRequest(config.getResolvedTokenEndpoint());
+    config.getBasicAuthentication().ifPresent(request::authentication);
+    HttpResponse response = request.postForm(body);
     Tokens tokens = response.readEntity(AuthorizationCodeTokensResponse.class);
     LOGGER.debug("Authorization Code Flow: new tokens received");
     return tokens;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticatorConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2AuthenticatorConfig.java
@@ -199,13 +199,13 @@ public interface OAuth2AuthenticatorConfig {
   String getClientId();
 
   /**
-   * The OAuth2 client secret. Must be set.
+   * The OAuth2 client secret. Must be set, if required by the IdP.
    *
    * <p>Once read by the Nessie client, the secret contents will be cleared from memory.
    *
    * @see NessieConfigConstants#CONF_NESSIE_OAUTH2_CLIENT_SECRET
    */
-  Secret getClientSecret();
+  Optional<Secret> getClientSecret();
 
   /**
    * The OAuth2 username. Only relevant for {@link GrantType#PASSWORD} grant type.

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2Client.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.HttpClientException;
+import org.projectnessie.client.http.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -296,11 +297,9 @@ class OAuth2Client implements OAuth2Authenticator, Closeable {
   }
 
   private <T> T invokeTokensEndpoint(Object request, Class<T> responseClass) {
-    return httpClient
-        .newRequest(config.getResolvedTokenEndpoint())
-        .authentication(config.getBasicAuthentication())
-        .postForm(request)
-        .readEntity(responseClass);
+    HttpRequest req = httpClient.newRequest(config.getResolvedTokenEndpoint());
+    config.getBasicAuthentication().ifPresent(req::authentication);
+    return req.postForm(request).readEntity(responseClass);
   }
 
   private boolean isAboutToExpire(Token token) {

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -22,7 +22,6 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_AUTH_ENDPOINT;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_BACKGROUND_THREAD_IDLE_TIMEOUT;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_ID;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_SECRET;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_TIMEOUT;
@@ -49,6 +48,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -169,8 +169,9 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
    * requests since it's immutable and its close method is a no-op.
    */
   @Value.Lazy
-  HttpAuthentication getBasicAuthentication() {
-    return BasicAuthenticationProvider.create(getClientId(), getClientSecret().getStringAndClear());
+  Optional<HttpAuthentication> getBasicAuthentication() {
+    return getClientSecret()
+        .map(s -> BasicAuthenticationProvider.create(getClientId(), s.getStringAndClear()));
   }
 
   /**
@@ -239,11 +240,6 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
         CONF_NESSIE_OAUTH2_CLIENT_ID,
         !getClientId().isEmpty(),
         "client ID must not be empty");
-    check(
-        violations,
-        CONF_NESSIE_OAUTH2_CLIENT_SECRET,
-        getClientSecret().length() > 0,
-        "client secret must not be empty");
     check(
         violations,
         CONF_NESSIE_OAUTH2_ISSUER_URL + " / " + CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT,

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -110,13 +110,6 @@ class TestOAuth2ClientConfig {
         Arguments.of(
             OAuth2ClientConfig.builder()
                 .clientId("Alice")
-                .clientSecret("")
-                .tokenEndpoint(URI.create("https://example.com/token")),
-            singletonList(
-                "client secret must not be empty (nessie.authentication.oauth2.client-secret)")),
-        Arguments.of(
-            OAuth2ClientConfig.builder()
-                .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))
                 .grantType(GrantType.TOKEN_EXCHANGE),
@@ -304,16 +297,6 @@ class TestOAuth2ClientConfig {
             null,
             new IllegalArgumentException(
                 "OAuth2 authentication is missing some parameters and could not be initialized: client ID must not be empty (nessie.authentication.oauth2.client-id)")),
-        Arguments.of(
-            ImmutableMap.of(
-                CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT, "https://example.com/token",
-                CONF_NESSIE_OAUTH2_CLIENT_ID, "Alice",
-                CONF_NESSIE_OAUTH2_REFRESH_SAFETY_WINDOW, "PT10S",
-                CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN, "PT30S",
-                CONF_NESSIE_OAUTH2_CLIENT_SCOPES, "test"),
-            null,
-            new IllegalArgumentException(
-                "OAuth2 authentication is missing some parameters and could not be initialized: client secret must not be empty (nessie.authentication.oauth2.client-secret)")),
         Arguments.of(
             ImmutableMap.builder()
                 .put(CONF_NESSIE_OAUTH2_ISSUER_URL, "https://example.com/")


### PR DESCRIPTION
Not all configured clients in e.g. `Keycloak` require a client secret, especially those that are "publicly" accessible. This change makes the `nessie.authentication.oauth2.client-secret` optional.
