### PR TITLE
OAuth2 client: make cancellation of device/auth-code flows possible

### DIFF
--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
@@ -65,12 +65,16 @@ import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.client.http.HttpRequest;
 import org.projectnessie.client.http.HttpResponse;
 import org.projectnessie.client.http.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ExtendWith(SoftAssertionsExtension.class)
 public class ITOAuth2Client {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ITOAuth2Client.class);
 
   public static final String IMAGE_TAG;
 
@@ -379,6 +383,7 @@ public class ITOAuth2Client {
             .newRequest()
             .path("realms/master/protocol/openid-connect/token")
             .header("Authorization", "Bearer " + accessToken.getPayload());
+    LOGGER.debug("Trying to use token (cause of the next POST request)");
     HttpResponse response =
         request.postForm(
             ImmutableMap.of(
@@ -399,6 +404,7 @@ public class ITOAuth2Client {
   private void revokeAccessToken(HttpClient httpClient, AccessToken accessToken) {
     HttpRequest request =
         httpClient.newRequest().path("realms/master/protocol/openid-connect/revoke");
+    LOGGER.debug("Revoking token (cause of the next POST request)");
     request.postForm(ImmutableMap.of("token", accessToken.getPayload()));
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Phaser;
@@ -128,10 +129,9 @@ class AuthorizationCodeFlow implements AutoCloseable {
     try {
       return tokensFuture.get(flowTimeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
-      LOGGER.error("Timed out waiting for authorization code.");
       abort();
       throw new RuntimeException("Timed out waiting waiting for authorization code", e);
-    } catch (InterruptedException e) {
+    } catch (CancellationException | InterruptedException e) {
       abort();
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/jdk11/JavaHttpClient.java
@@ -65,6 +65,9 @@ final class JavaHttpClient implements org.projectnessie.client.http.HttpClient {
 
   @Override
   public HttpRequest newRequest(URI baseUri) {
+    if (client == null) {
+      throw new IllegalStateException("Client already closed");
+    }
     return new JavaRequest(this.config, baseUri, client::send);
   }
 
@@ -75,7 +78,10 @@ final class JavaHttpClient implements org.projectnessie.client.http.HttpClient {
 
   @Override
   public void close() {
-    client = null;
-    config.close();
+    try {
+      config.close();
+    } finally {
+      client = null;
+    }
   }
 }


### PR DESCRIPTION
Given the situation that a command line tool wants to authenticate using OAuth2 w/ a device or auth-code flow, the client waits until it gets the "authenticated" response/callback. If the user wants to cancel the authentication (think: hit ctrl-C), it's performed via a `j.l.InterruptedException`/`j.l.Thread.interrupt()`. However, interrupting the thread that performs authentication results in a bunch of exceptions being loggged uncondictionally to the console.

This change makes interrupting the authentication flow using `Thread.interrupt()` work w/o user "confusion".
