### PR TITLE
Make bulk read timeout configurable in BigTablePersist

### DIFF
--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/BigTableBackendBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/BigTableBackendBuilder.java
@@ -126,6 +126,7 @@ public class BigTableBackendBuilder implements BackendBuilder {
               .dataClient(dataClient)
               .tableAdminClient(tableAdminClient)
               .tablePrefix(bigTableConfig.tablePrefix())
+              .totalApiTimeout(bigTableConfig.totalTimeout())
               .build();
       return factory.buildBackend(c);
     } catch (Exception e) {

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackend.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackend.java
@@ -55,6 +55,7 @@ public final class BigTableBackend implements Backend {
   private static final Logger LOGGER = LoggerFactory.getLogger(BigTableBackend.class);
   static final ByteString REPO_REGEX_SUFFIX = copyFromUtf8("\\C*");
 
+  private final BigTableBackendConfig config;
   private final BigtableDataClient dataClient;
   private final BigtableTableAdminClient tableAdminClient;
   private final boolean closeClient;
@@ -63,6 +64,7 @@ public final class BigTableBackend implements Backend {
   final String tableObjs;
 
   public BigTableBackend(@Nonnull BigTableBackendConfig config, boolean closeClient) {
+    this.config = config;
     this.dataClient = config.dataClient();
     this.tableAdminClient = config.tableAdminClient();
     this.tableRefs =
@@ -70,6 +72,11 @@ public final class BigTableBackend implements Backend {
     this.tableObjs =
         config.tablePrefix().map(prefix -> prefix + '_' + TABLE_OBJS).orElse(TABLE_OBJS);
     this.closeClient = closeClient;
+  }
+
+  @Nonnull
+  public BigTableBackendConfig config() {
+    return config;
   }
 
   @Nonnull

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackendConfig.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackendConfig.java
@@ -18,6 +18,7 @@ package org.projectnessie.versioned.storage.bigtable;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import jakarta.annotation.Nullable;
+import java.time.Duration;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -29,6 +30,9 @@ public interface BigTableBackendConfig {
   BigtableTableAdminClient tableAdminClient();
 
   Optional<String> tablePrefix();
+
+  /** Total timeout (including retries) for Bigtable API calls. */
+  Optional<Duration> totalApiTimeout();
 
   static ImmutableBigTableBackendConfig.Builder builder() {
     return ImmutableBigTableBackendConfig.builder();

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableConstants.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableConstants.java
@@ -16,6 +16,7 @@
 package org.projectnessie.versioned.storage.bigtable;
 
 import com.google.protobuf.ByteString;
+import java.time.Duration;
 
 final class BigTableConstants {
 
@@ -39,7 +40,7 @@ final class BigTableConstants {
   static final int MAX_BULK_READS = 100;
   static final int MAX_BULK_MUTATIONS = 1000;
 
-  static final long READ_TIMEOUT_MILLIS = 5000L;
+  static final Duration DEFAULT_BULK_READ_TIMEOUT = Duration.ofSeconds(5);
 
   private BigTableConstants() {}
 }

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -22,6 +22,7 @@ import static com.google.protobuf.UnsafeByteOperations.unsafeWrap;
 import static java.util.Collections.singleton;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.CELL_TIMESTAMP;
+import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.DEFAULT_BULK_READ_TIMEOUT;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.FAMILY_OBJS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.FAMILY_REFS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.MAX_PARALLEL_READS;
@@ -30,7 +31,6 @@ import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUA
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUALIFIER_OBJ_TYPE;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUALIFIER_OBJ_VERS;
 import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.QUALIFIER_REFS;
-import static org.projectnessie.versioned.storage.bigtable.BigTableConstants.READ_TIMEOUT_MILLIS;
 import static org.projectnessie.versioned.storage.common.persist.ObjId.objIdFromByteBuffer;
 import static org.projectnessie.versioned.storage.serialize.ProtoSerialization.deserializeObj;
 import static org.projectnessie.versioned.storage.serialize.ProtoSerialization.deserializeReference;
@@ -689,10 +689,13 @@ public class BigTablePersist implements Persist {
       }
     }
 
+    long timeoutMillis =
+        backend.config().totalApiTimeout().orElse(DEFAULT_BULK_READ_TIMEOUT).toMillis();
+
     for (int idx = 0; idx < num; idx++) {
       ApiFuture<Row> handle = handles[idx];
       if (handle != null) {
-        Row row = handle.get(READ_TIMEOUT_MILLIS, MILLISECONDS);
+        Row row = handle.get(timeoutMillis, MILLISECONDS);
         if (row != null) {
           r[idx] = resultGen.apply(row);
         } else {


### PR DESCRIPTION
Use the same timeout as for the Bigtable Data Client in Quarkus.

Tests use the old default of 5 sec.