### PR TITLE
Site: exlude old releases from search index, fix released-version title and page-dir

### DIFF
--- a/site/in-dev/index-release.md
+++ b/site/in-dev/index-release.md
@@ -1,3 +1,7 @@
+---
+title: "Nessie ::NESSIE_VERSION::"
+---
+
 # Nessie ::NESSIE_VERSION::
 
 GitHub [release page](https://github.com/projectnessie/nessie/releases/tag/nessie-::NESSIE_VERSION::) for ::NESSIE_VERSION::.

--- a/site/in-dev/index.md
+++ b/site/in-dev/index.md
@@ -1,3 +1,7 @@
+---
+title: "Nessie (UNRELEASED)"
+---
+
 # Nessie (UNRELEASED)
 
 **DISCLAIMER** You are viewing the docs for the **next** Nessie version.


### PR DESCRIPTION
The site search index currently returns results for _all_ Nessie versions, but should better only return results for the latest released version.
