### PR TITLE
OAuth2Client: fully support public clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ as necessary. Empty sections will not end in the release notes.
 
 ### Highlights
 
+- The Nessie client now supports public clients when using OAuth 2 authentication. Public clients 
+  are clients that do not have a client secret; they are compatible with the `password`, 
+  `authorization_code`, and `device_code` grant types. See the
+  [Nessie documentation](https://projectnessie.org/tools/client_config/#authentication-settings) 
+  for details.
+
 ### Upgrade notes
 
 ### Breaking changes

--- a/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
+++ b/api/client/src/intTest/java/org/projectnessie/client/auth/oauth2/ITOAuth2Client.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -76,7 +77,7 @@ public class ITOAuth2Client {
 
   static {
     URL resource = ITOAuth2Client.class.getResource("Dockerfile-keycloak-version");
-    try (InputStream in = resource.openConnection().getInputStream()) {
+    try (InputStream in = Objects.requireNonNull(resource).openConnection().getInputStream()) {
       String[] imageTag =
           IOUtils.readLines(in, UTF_8).stream()
               .map(String::trim)
@@ -116,11 +117,14 @@ public class ITOAuth2Client {
     try (Keycloak keycloakAdmin = KEYCLOAK.getKeycloakAdminClient()) {
       master = keycloakAdmin.realms().realm("master");
       updateMasterRealm(10, 15);
-      // Create 2 clients, one sending refresh tokens for client_credentials, the other one not
-      createClient("Client1", false);
-      createClient("Client2", true);
+      // Create 2 clients, one sending refresh tokens, the other one not
+      createClient("Private1", true, false);
+      createClient("Private2", true, true);
+      // Public clients, no client secret
+      createClient("Public1", false, false);
+      createClient("Public2", false, true);
       // Create a client that will act as a resource server attempting to validate access tokens
-      createClient("ResourceServer", false);
+      createClient("ResourceServer", true, false);
       // Create a user that will be used to obtain access tokens via password grant
       createUser();
     }
@@ -146,17 +150,17 @@ public class ITOAuth2Client {
    */
   @Test
   void testOAuth2ClientWithBackgroundRefresh() throws Exception {
-    OAuth2ClientConfig config1 = clientConfig("Client1", false).build();
-    OAuth2ClientConfig config2 = clientConfig("Client2", false).grantType(PASSWORD).build();
+    OAuth2ClientConfig config1 = clientConfig("Private1", true, false).build();
+    OAuth2ClientConfig config2 = clientConfig("Private2", true, false).grantType(PASSWORD).build();
     OAuth2ClientConfig config3 =
-        clientConfig("Client2", false).grantType(AUTHORIZATION_CODE).build();
+        clientConfig("Public1", false, false).grantType(AUTHORIZATION_CODE).build();
     ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     try (OAuth2Client client1 = new OAuth2Client(config1);
         OAuth2Client client2 = new OAuth2Client(config2);
         OAuth2Client client3 = new OAuth2Client(config3);
         ResourceOwnerEmulator resourceOwner =
             new ResourceOwnerEmulator(AUTHORIZATION_CODE, "Alice", "s3cr3t");
-        HttpClient validatingClient = validatingHttpClient("Client1").build()) {
+        HttpClient validatingClient = validatingHttpClient("Private1").build()) {
       resourceOwner.replaceSystemOut();
       resourceOwner.setAuthServerBaseUri(URI.create(KEYCLOAK.getAuthServerUrl()));
       resourceOwner.setErrorListener(e -> executor.shutdownNow());
@@ -168,6 +172,7 @@ public class ITOAuth2Client {
               () -> {
                 tryUseAccessToken(validatingClient, client1.getCurrentTokens().getAccessToken());
                 tryUseAccessToken(validatingClient, client2.getCurrentTokens().getAccessToken());
+                tryUseAccessToken(validatingClient, client3.getCurrentTokens().getAccessToken());
               },
               0,
               1,
@@ -187,7 +192,7 @@ public class ITOAuth2Client {
   /**
    * Dummy sentence to make Checkstyle happy.
    *
-   * <p>This test exercises the OAuth2 client with the following steps:
+   * <p>This test exercises the OAuth2 client with the following setup:
    *
    * <ul>
    *   <li>endpoint discovery on;
@@ -201,12 +206,13 @@ public class ITOAuth2Client {
   @EnumSource(
       value = GrantType.class,
       names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void testOAuth2ClientInitialRefreshToken(GrantType initialGrantType) throws Exception {
-    OAuth2ClientConfig config = clientConfig("Client2", true).grantType(initialGrantType).build();
+  void testOAuth2RefreshTokenOn(GrantType initialGrantType) throws Exception {
+    OAuth2ClientConfig config =
+        clientConfig("Private2", true, true).grantType(initialGrantType).build();
     try (OAuth2Client client = new OAuth2Client(config);
         AutoCloseable ignored = newTestSetup(initialGrantType, client);
-        HttpClient validatingClient = validatingHttpClient("Client2").build()) {
-      // first request: client credentials grant
+        HttpClient validatingClient = validatingHttpClient("Private2").build()) {
+      // first request: initial grant
       Tokens firstTokens = client.fetchNewTokens();
       soft.assertThat(firstTokens).isInstanceOf(expectedResponseClass(initialGrantType));
       soft.assertThat(firstTokens.getRefreshToken()).isNotNull();
@@ -216,84 +222,170 @@ public class ITOAuth2Client {
       soft.assertThat(refreshedTokens).isInstanceOf(RefreshTokensResponse.class);
       soft.assertThat(refreshedTokens.getRefreshToken()).isNotNull();
       tryUseAccessToken(validatingClient, refreshedTokens.getAccessToken());
-      compareTokens(firstTokens, refreshedTokens, "Client2");
+      compareTokens(firstTokens, refreshedTokens, "Private2");
     }
   }
 
   /**
    * Dummy sentence to make Checkstyle happy.
    *
-   * <p>This test exercises the OAuth2 client with the following steps:
+   * <p>This test exercises the OAuth2 client with the following setup:
    *
    * <ul>
-   *   <li>client_credentials grant type for obtaining the access token;
+   *   <li>client_credentials, password, authorization_code or device_code grant type for obtaining
+   *       the access token;
    *   <li>no refresh token sent on the initial response;
-   *   <li>token exchange for obtaining the refresh token;
-   *   <li>refresh_token grant type for refreshing the access token.
+   *   <li>token exchange for obtaining the refresh token.
    * </ul>
    */
-  @Test
-  void testOAuth2ClientTokenExchange() {
-    OAuth2ClientConfig config = clientConfig("Client1", false).build();
+  @ParameterizedTest
+  @EnumSource(
+      value = GrantType.class,
+      names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
+  void testOAuth2RefreshTokenOff(GrantType initialGrantType) throws Exception {
+    OAuth2ClientConfig config =
+        clientConfig("Private1", true, false).grantType(initialGrantType).build();
     try (OAuth2Client client = new OAuth2Client(config);
-        HttpClient validatingClient = validatingHttpClient("Client1").build()) {
-      // first request: client credentials grant
+        AutoCloseable ignored = newTestSetup(initialGrantType, client);
+        HttpClient validatingClient = validatingHttpClient("Private1").build()) {
+      // first request: initial grant
       Tokens firstTokens = client.fetchNewTokens();
-      soft.assertThat(firstTokens).isInstanceOf(ClientCredentialsTokensResponse.class);
+      soft.assertThat(firstTokens).isInstanceOf(expectedResponseClass(initialGrantType));
       soft.assertThat(firstTokens.getRefreshToken()).isNull();
       tryUseAccessToken(validatingClient, firstTokens.getAccessToken());
       // second request: token exchange since no refresh token was sent
       Tokens exchangedTokens = client.refreshTokens(firstTokens);
       soft.assertThat(exchangedTokens).isInstanceOf(TokensExchangeResponse.class);
-      soft.assertThat(exchangedTokens.getRefreshToken()).isNotNull();
+      soft.assertThat(exchangedTokens.getRefreshToken()).isNull();
       tryUseAccessToken(validatingClient, exchangedTokens.getAccessToken());
-      compareTokens(firstTokens, exchangedTokens, "Client1");
-      // third request: refresh token grant
-      Tokens refreshedTokens = client.refreshTokens(exchangedTokens);
-      soft.assertThat(refreshedTokens).isInstanceOf(RefreshTokensResponse.class);
-      soft.assertThat(refreshedTokens.getRefreshToken()).isNotNull();
-      tryUseAccessToken(validatingClient, refreshedTokens.getAccessToken());
-      compareTokens(exchangedTokens, refreshedTokens, "Client1");
+      compareTokens(firstTokens, exchangedTokens, "Private1");
     }
   }
 
   /**
    * Dummy sentence to make Checkstyle happy.
    *
-   * <p>This test exercises the OAuth2 client with the following steps:
+   * <p>This test exercises the OAuth2 client with the following setup:
    *
    * <ul>
-   *   <li>client_credentials grant type for obtaining the access token;
+   *   <li>client_credentials, password, authorization_code or device_code grant type for obtaining
+   *       the access token;
    *   <li>no refresh token sent on the initial response;
    *   <li>no token exchange for obtaining the refresh token;
    *   <li>another client credentials grant for refreshing the access token.
    * </ul>
    */
-  @Test
-  void testOAuth2ClientNoRefreshToken() {
-    OAuth2ClientConfig config = clientConfig("Client1", false).tokenExchangeEnabled(false).build();
+  @ParameterizedTest
+  @EnumSource(
+      value = GrantType.class,
+      names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
+  void testOAuth2ClientRefreshTokenOffTokenExchangeDisabled(GrantType initialGrantType)
+      throws Exception {
+    OAuth2ClientConfig config =
+        clientConfig("Private1", true, false)
+            .grantType(initialGrantType)
+            .tokenExchangeEnabled(false)
+            .build();
     try (OAuth2Client client = new OAuth2Client(config);
-        HttpClient validatingClient = validatingHttpClient("Client1").build()) {
+        AutoCloseable ignored = newTestSetup(initialGrantType, client);
+        HttpClient validatingClient = validatingHttpClient("Private1").build()) {
       // first request: client credentials grant
       Tokens firstTokens = client.fetchNewTokens();
-      soft.assertThat(firstTokens).isInstanceOf(ClientCredentialsTokensResponse.class);
       soft.assertThat(firstTokens.getRefreshToken()).isNull();
+      soft.assertThat(firstTokens).isInstanceOf(expectedResponseClass(initialGrantType));
       tryUseAccessToken(validatingClient, firstTokens.getAccessToken());
       // second request: another client credentials grant since no refresh token was sent
       // and token exchange is disabled – cannot call refreshTokens() tokens here
       soft.assertThatThrownBy(() -> client.refreshTokens(firstTokens))
           .isInstanceOf(MustFetchNewTokensException.class);
       Tokens nextTokens = client.fetchNewTokens();
-      soft.assertThat(nextTokens).isInstanceOf(ClientCredentialsTokensResponse.class);
       soft.assertThat(nextTokens.getRefreshToken()).isNull();
+      soft.assertThat(nextTokens).isInstanceOf(expectedResponseClass(initialGrantType));
       tryUseAccessToken(validatingClient, nextTokens.getAccessToken());
-      compareTokens(firstTokens, nextTokens, "Client1");
+      compareTokens(firstTokens, nextTokens, "Private1");
+    }
+  }
+
+  /**
+   * Dummy sentence to make Checkstyle happy.
+   *
+   * <p>This test exercises the OAuth2 client with the following setup:
+   *
+   * <ul>
+   *   <li>endpoint discovery on;
+   *   <li>public client (no client secret);
+   *   <li>password, authorization_code or device_code grant type for obtaining the initial access
+   *       token;
+   *   <li>refresh token sent on the initial response;
+   *   <li>refresh_token grant type for refreshing the access token.
+   * </ul>
+   */
+  @ParameterizedTest
+  @EnumSource(
+      value = GrantType.class,
+      names = {"PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
+  void testOAuth2ClientPublicRefreshTokenOn(GrantType initialGrantType) throws Exception {
+    OAuth2ClientConfig config =
+        clientConfig("Public2", false, true).grantType(initialGrantType).build();
+    try (OAuth2Client client = new OAuth2Client(config);
+        AutoCloseable ignored = newTestSetup(initialGrantType, client);
+        HttpClient validatingClient = validatingHttpClient("Private2").build()) {
+      // first request: initial grant
+      Tokens firstTokens = client.fetchNewTokens();
+      soft.assertThat(firstTokens).isInstanceOf(expectedResponseClass(initialGrantType));
+      soft.assertThat(firstTokens.getRefreshToken()).isNotNull();
+      tryUseAccessToken(validatingClient, firstTokens.getAccessToken());
+      // second request: refresh token grant
+      Tokens refreshedTokens = client.refreshTokens(firstTokens);
+      soft.assertThat(refreshedTokens).isInstanceOf(RefreshTokensResponse.class);
+      soft.assertThat(refreshedTokens.getRefreshToken()).isNotNull();
+      tryUseAccessToken(validatingClient, refreshedTokens.getAccessToken());
+      compareTokens(firstTokens, refreshedTokens, "Public2");
+    }
+  }
+
+  /**
+   * Dummy sentence to make Checkstyle happy.
+   *
+   * <p>This test exercises the OAuth2 client with the following setup:
+   *
+   * <ul>
+   *   <li>endpoint discovery on;
+   *   <li>public client (no client secret);
+   *   <li>password, authorization_code or device_code grant type for obtaining the initial access
+   *       token;
+   *   <li>no refresh token sent on the initial response;
+   *   <li>token exchange for obtaining the refresh token.
+   * </ul>
+   */
+  @ParameterizedTest
+  @EnumSource(
+      value = GrantType.class,
+      names = {"PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
+  void testOAuth2ClientPublicRefreshTokenOff(GrantType initialGrantType) throws Exception {
+    OAuth2ClientConfig config =
+        clientConfig("Public1", false, true).grantType(initialGrantType).build();
+    try (OAuth2Client client = new OAuth2Client(config);
+        AutoCloseable ignored = newTestSetup(initialGrantType, client);
+        HttpClient validatingClient = validatingHttpClient("Private2").build()) {
+      // first request: initial grant
+      Tokens firstTokens = client.fetchNewTokens();
+      soft.assertThat(firstTokens).isInstanceOf(expectedResponseClass(initialGrantType));
+      soft.assertThat(firstTokens.getRefreshToken()).isNull();
+      tryUseAccessToken(validatingClient, firstTokens.getAccessToken());
+      // second request: token exchange since no refresh token was sent
+      Tokens exchangedTokens = client.refreshTokens(firstTokens);
+      soft.assertThat(exchangedTokens).isInstanceOf(TokensExchangeResponse.class);
+      soft.assertThat(exchangedTokens.getRefreshToken()).isNull();
+      tryUseAccessToken(validatingClient, exchangedTokens.getAccessToken());
+      compareTokens(firstTokens, exchangedTokens, "Public1");
     }
   }
 
   @Test
   void testOAuth2ClientUnauthorizedBadClientSecret() {
-    OAuth2ClientConfig config = clientConfig("Client1", false).clientSecret("BAD SECRET").build();
+    OAuth2ClientConfig config =
+        clientConfig("Private1", true, false).clientSecret("BAD SECRET").build();
     try (OAuth2Client client = new OAuth2Client(config)) {
       client.start();
       soft.assertThatThrownBy(client::authenticate)
@@ -306,7 +398,7 @@ public class ITOAuth2Client {
   @Test
   void testOAuth2ClientUnauthorizedBadPassword() {
     OAuth2ClientConfig config =
-        clientConfig("Client2", false).grantType(PASSWORD).password("BAD PASSWORD").build();
+        clientConfig("Private2", true, false).grantType(PASSWORD).password("BAD PASSWORD").build();
     try (OAuth2Client client = new OAuth2Client(config)) {
       client.start();
       soft.assertThatThrownBy(client::authenticate)
@@ -319,7 +411,7 @@ public class ITOAuth2Client {
   @Test
   void testOAuth2ClientUnauthorizedBadAuthorizationCode() throws Exception {
     OAuth2ClientConfig config =
-        clientConfig("Client2", false).grantType(AUTHORIZATION_CODE).build();
+        clientConfig("Private2", true, false).grantType(AUTHORIZATION_CODE).build();
     try (OAuth2Client client = new OAuth2Client(config);
         ResourceOwnerEmulator resourceOwner =
             new ResourceOwnerEmulator(AUTHORIZATION_CODE, "Alice", "s3cr3t")) {
@@ -337,7 +429,8 @@ public class ITOAuth2Client {
 
   @Test
   void testOAuth2ClientDeviceCodeAccessDenied() throws Exception {
-    OAuth2ClientConfig config = clientConfig("Client2", false).grantType(DEVICE_CODE).build();
+    OAuth2ClientConfig config =
+        clientConfig("Private2", true, false).grantType(DEVICE_CODE).build();
     try (OAuth2Client client = new OAuth2Client(config);
         ResourceOwnerEmulator resourceOwner =
             new ResourceOwnerEmulator(DEVICE_CODE, "Alice", "s3cr3t")) {
@@ -356,9 +449,9 @@ public class ITOAuth2Client {
 
   @Test
   void testOAuth2ClientExpiredToken() {
-    OAuth2ClientConfig config = clientConfig("Client1", false).build();
+    OAuth2ClientConfig config = clientConfig("Private1", true, false).build();
     try (OAuth2Client client = new OAuth2Client(config);
-        HttpClient validatingClient = validatingHttpClient("Client1").build()) {
+        HttpClient validatingClient = validatingHttpClient("Private1").build()) {
       Tokens tokens = client.fetchNewTokens();
       // Emulate a token expiration; we don't want to wait 10 seconds just for the token to really
       // expire.
@@ -412,11 +505,11 @@ public class ITOAuth2Client {
         .isEqualTo(clientId);
   }
 
-  private static OAuth2ClientConfig.Builder clientConfig(String clientId, boolean discovery) {
+  private static OAuth2ClientConfig.Builder clientConfig(
+      String clientId, boolean confidential, boolean discovery) {
     OAuth2ClientConfig.Builder builder =
         OAuth2ClientConfig.builder()
             .clientId(clientId)
-            .clientSecret("s3cr3t")
             .username("Alice")
             .password("s3cr3t")
             // Otherwise Keycloak complains about missing scope, but still issues tokens
@@ -428,6 +521,9 @@ public class ITOAuth2Client {
             .ignoreDeviceCodeFlowServerPollInterval(true)
             .minDeviceCodeFlowPollInterval(Duration.ofSeconds(1))
             .deviceCodeFlowPollInterval(Duration.ofSeconds(1));
+    if (confidential) {
+      builder.clientSecret("s3cr3t");
+    }
     if (discovery) {
       builder.issuerUrl(issuerUrl);
     } else {
@@ -454,26 +550,32 @@ public class ITOAuth2Client {
   }
 
   @SuppressWarnings("resource")
-  private static void createClient(String id, boolean sendRefreshTokenOnClientCredentialsRequest) {
+  private static void createClient(String id, boolean confidential, boolean useRefreshTokens) {
     ClientRepresentation client = new ClientRepresentation();
     client.setId(id); // internal ID
     client.setClientId(id); // client ID is what applications need to use to authenticate
-    client.setSecret("s3cr3t");
-    client.setServiceAccountsEnabled(true); // required for client credentials grant
+    client.setPublicClient(!confidential);
+    if (confidential) {
+      client.setSecret("s3cr3t");
+    }
+    client.setServiceAccountsEnabled(confidential); // required for client credentials grant
     client.setDirectAccessGrantsEnabled(true); // required for password grant
     client.setStandardFlowEnabled(true); // required for authorization code grant
     client.setRedirectUris(ImmutableList.of("http://localhost:*"));
-    client.setAuthorizationServicesEnabled(true); // required to request UMA tokens
-    client.setPublicClient(false);
+    client.setAuthorizationServicesEnabled(confidential); // required to request UMA tokens
     client.setAttributes(
         ImmutableMap.of(
+            "use.refresh.tokens",
+            String.valueOf(useRefreshTokens),
             "client_credentials.use_refresh_token",
-            String.valueOf(sendRefreshTokenOnClientCredentialsRequest),
+            String.valueOf(useRefreshTokens),
             "oauth2.device.authorization.grant.enabled",
             "true"));
-    ResourceServerRepresentation settings = new ResourceServerRepresentation();
-    settings.setPolicyEnforcementMode(PolicyEnforcementMode.DISABLED);
-    client.setAuthorizationSettings(settings);
+    if (confidential) {
+      ResourceServerRepresentation settings = new ResourceServerRepresentation();
+      settings.setPolicyEnforcementMode(PolicyEnforcementMode.DISABLED);
+      client.setAuthorizationSettings(settings);
+    }
     Response response = master.clients().create(client);
     assertThat(response.getStatus()).isEqualTo(201);
   }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AbstractFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AbstractFlow.java
@@ -39,7 +39,7 @@ abstract class AbstractFlow implements Flow {
 
   DeviceCodeResponse invokeDeviceAuthEndpoint() {
     DeviceCodeRequest.Builder request =
-        ImmutableDeviceCodeRequest.builder().scope(config.getScope().orElse(null));
+        DeviceCodeRequest.builder().scope(config.getScope().orElse(null));
     if (!config.getClientSecret().isPresent()) {
       request.clientId(config.getClientId());
     }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AbstractFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AbstractFlow.java
@@ -19,6 +19,30 @@ import java.net.URI;
 import org.projectnessie.client.http.HttpRequest;
 import org.projectnessie.client.http.HttpResponse;
 
+/**
+ * Infrastructure shared by all flows.
+ *
+ * <p>The general behavior adopted by the OAuth2 client wrt to client authentication is as follows:
+ *
+ * <p>For confidential clients:
+ *
+ * <ol>
+ *   <li>Authenticate the client with a Basic authentication header (while it is also possible to
+ *       authenticate using {@code client_id} + {@code client_secret} in the request body, the OAuth
+ *       2.0 spec considers this method less secure, so we don't use it);
+ *   <li>Do NOT include {@code client_id} nor {@code client_secret} in the request body, since the
+ *       spec also forbids more than one authentication method in each request.
+ * </ol>
+ *
+ * <p>For public clients:
+ *
+ * <ol>
+ *   <li>Do not include any Basic authentication header (since there is no client secret);
+ *   <li>But do include {@code client_id} in the request body, in order to identify the client
+ *       (according to the spec, including {@code client_id} is mandatory for public clients using
+ *       the Authorization Code Grant, and optional for other grants – but we always include it).
+ * </ol>
+ */
 abstract class AbstractFlow implements Flow {
 
   final OAuth2ClientConfig config;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
@@ -119,6 +119,7 @@ class AuthorizationCodeFlow extends AbstractFlow {
         new UriBuilder(authEndpoint.resolve("/"))
             .path(authEndpoint.getPath())
             .queryParam("response_type", "code")
+            // client ID is required in all cases here
             .queryParam("client_id", config.getClientId())
             .queryParam("scope", config.getScope().orElse(null))
             .queryParam("redirect_uri", redirectUri)
@@ -224,13 +225,8 @@ class AuthorizationCodeFlow extends AbstractFlow {
 
   private Tokens fetchNewTokens(String code) {
     LOGGER.debug("Authorization Code Flow: fetching new tokens");
-    AuthorizationCodeTokensRequest request =
-        ImmutableAuthorizationCodeTokensRequest.builder()
-            .code(code)
-            .redirectUri(redirectUri)
-            .clientId(config.getClientId())
-            .scope(config.getScope().orElse(null))
-            .build();
+    AuthorizationCodeTokensRequest.Builder request =
+        ImmutableAuthorizationCodeTokensRequest.builder().code(code).redirectUri(redirectUri);
     Tokens tokens = invokeTokenEndpoint(request, AuthorizationCodeTokensResponse.class);
     LOGGER.debug("Authorization Code Flow: new tokens received");
     return tokens;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
@@ -119,7 +119,6 @@ class AuthorizationCodeFlow extends AbstractFlow {
         new UriBuilder(authEndpoint.resolve("/"))
             .path(authEndpoint.getPath())
             .queryParam("response_type", "code")
-            // client ID is required in all cases here
             .queryParam("client_id", config.getClientId())
             .queryParam("scope", config.getScope().orElse(null))
             .queryParam("redirect_uri", redirectUri)

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeFlow.java
@@ -226,7 +226,7 @@ class AuthorizationCodeFlow extends AbstractFlow {
   private Tokens fetchNewTokens(String code) {
     LOGGER.debug("Authorization Code Flow: fetching new tokens");
     AuthorizationCodeTokensRequest.Builder request =
-        ImmutableAuthorizationCodeTokensRequest.builder().code(code).redirectUri(redirectUri);
+        AuthorizationCodeTokensRequest.builder().code(code).redirectUri(redirectUri);
     Tokens tokens = invokeTokenEndpoint(request, AuthorizationCodeTokensResponse.class);
     LOGGER.debug("Authorization Code Flow: new tokens received");
     return tokens;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeTokensRequest.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -40,11 +41,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableAuthorizationCodeTokensRequest.class)
 @JsonDeserialize(as = ImmutableAuthorizationCodeTokensRequest.class)
+@JsonTypeName(GrantType.Constants.AUTHORIZATION_CODE)
 interface AuthorizationCodeTokensRequest extends PublicTokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "authorization_code". */
   @Value.Derived
-  @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
     return GrantType.AUTHORIZATION_CODE;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeTokensRequest.java
@@ -42,7 +42,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableAuthorizationCodeTokensRequest.class)
 @JsonDeserialize(as = ImmutableAuthorizationCodeTokensRequest.class)
 @JsonTypeName(GrantType.Constants.AUTHORIZATION_CODE)
-interface AuthorizationCodeTokensRequest extends PublicTokensRequestBase {
+interface AuthorizationCodeTokensRequest extends TokensRequestBase, PublicClientRequest {
 
   /** REQUIRED. Value MUST be set to "authorization_code". */
   @Value.Derived
@@ -63,7 +63,9 @@ interface AuthorizationCodeTokensRequest extends PublicTokensRequestBase {
     return ImmutableAuthorizationCodeTokensRequest.builder();
   }
 
-  interface Builder extends PublicTokensRequestBase.Builder<AuthorizationCodeTokensRequest> {
+  interface Builder
+      extends TokensRequestBase.Builder<AuthorizationCodeTokensRequest>,
+          PublicClientRequest.Builder<AuthorizationCodeTokensRequest> {
     @CanIgnoreReturnValue
     Builder code(String code);
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeTokensRequest.java
@@ -39,10 +39,10 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableAuthorizationCodeTokensRequest.class)
 @JsonDeserialize(as = ImmutableAuthorizationCodeTokensRequest.class)
-interface AuthorizationCodeTokensRequest extends TokensRequestBase {
+interface AuthorizationCodeTokensRequest extends PublicTokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "authorization_code". */
-  @Value.Default
+  @Value.Derived
   @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
@@ -57,7 +57,9 @@ interface AuthorizationCodeTokensRequest extends TokensRequestBase {
   @JsonProperty("redirect_uri")
   String getRedirectUri();
 
-  /** REQUIRED. The client ID. */
-  @JsonProperty("client_id")
-  String getClientId();
+  interface Builder extends PublicTokensRequestBase.Builder<AuthorizationCodeTokensRequest> {
+    Builder code(String code);
+
+    Builder redirectUri(String redirectUri);
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeTokensRequest.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.auth.oauth2;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.immutables.value.Value;
 
 /**
@@ -57,9 +58,15 @@ interface AuthorizationCodeTokensRequest extends PublicTokensRequestBase {
   @JsonProperty("redirect_uri")
   String getRedirectUri();
 
+  static Builder builder() {
+    return ImmutableAuthorizationCodeTokensRequest.builder();
+  }
+
   interface Builder extends PublicTokensRequestBase.Builder<AuthorizationCodeTokensRequest> {
+    @CanIgnoreReturnValue
     Builder code(String code);
 
+    @CanIgnoreReturnValue
     Builder redirectUri(String redirectUri);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsFlow.java
@@ -30,10 +30,8 @@ class ClientCredentialsFlow extends AbstractFlow {
 
   @Override
   public Tokens fetchNewTokens(@Nullable Tokens ignored) {
-    ClientCredentialsTokensRequest request =
-        ImmutableClientCredentialsTokensRequest.builder()
-            .scope(config.getScope().orElse(null))
-            .build();
+    ClientCredentialsTokensRequest.Builder request =
+        ImmutableClientCredentialsTokensRequest.builder();
     return invokeTokenEndpoint(request, ClientCredentialsTokensResponse.class);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsFlow.java
@@ -30,8 +30,7 @@ class ClientCredentialsFlow extends AbstractFlow {
 
   @Override
   public Tokens fetchNewTokens(@Nullable Tokens ignored) {
-    ClientCredentialsTokensRequest.Builder request =
-        ImmutableClientCredentialsTokensRequest.builder();
+    ClientCredentialsTokensRequest.Builder request = ClientCredentialsTokensRequest.builder();
     return invokeTokenEndpoint(request, ClientCredentialsTokensResponse.class);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsTokensRequest.java
@@ -15,7 +15,7 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
@@ -38,11 +38,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableClientCredentialsTokensRequest.class)
 @JsonDeserialize(as = ImmutableClientCredentialsTokensRequest.class)
+@JsonTypeName(GrantType.Constants.CLIENT_CREDENTIALS)
 interface ClientCredentialsTokensRequest extends TokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "client_credentials". */
   @Value.Derived
-  @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
     return GrantType.CLIENT_CREDENTIALS;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsTokensRequest.java
@@ -41,10 +41,12 @@ import org.immutables.value.Value;
 interface ClientCredentialsTokensRequest extends TokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "client_credentials". */
-  @Value.Default
+  @Value.Derived
   @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
     return GrantType.CLIENT_CREDENTIALS;
   }
+
+  interface Builder extends TokensRequestBase.Builder<ClientCredentialsTokensRequest> {}
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/ClientCredentialsTokensRequest.java
@@ -48,5 +48,9 @@ interface ClientCredentialsTokensRequest extends TokensRequestBase {
     return GrantType.CLIENT_CREDENTIALS;
   }
 
+  static Builder builder() {
+    return ImmutableClientCredentialsTokensRequest.builder();
+  }
+
   interface Builder extends TokensRequestBase.Builder<ClientCredentialsTokensRequest> {}
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeFlow.java
@@ -96,7 +96,7 @@ class DeviceCodeFlow extends AbstractFlow {
 
   @Override
   public Tokens fetchNewTokens(@Nullable Tokens currentTokens) {
-    DeviceCodeResponse response = requestDeviceCode();
+    DeviceCodeResponse response = invokeDeviceAuthEndpoint();
     checkPollInterval(response.getInterval());
     console.println();
     console.println(MSG_PREFIX + "======= Nessie authentication required =======");
@@ -129,10 +129,6 @@ class DeviceCodeFlow extends AbstractFlow {
     }
   }
 
-  private DeviceCodeResponse requestDeviceCode() {
-    return invokeDeviceAuthEndpoint();
-  }
-
   private void checkPollInterval(Duration serverPollInterval) {
     if (!config.ignoreDeviceCodeFlowServerPollInterval()
         && serverPollInterval != null
@@ -161,7 +157,7 @@ class DeviceCodeFlow extends AbstractFlow {
     try {
       LOGGER.debug("Device Code Flow: polling for new tokens");
       DeviceCodeTokensRequest.Builder request =
-          ImmutableDeviceCodeTokensRequest.builder().deviceCode(deviceCode);
+          DeviceCodeTokensRequest.builder().deviceCode(deviceCode);
       Tokens tokens = invokeTokenEndpoint(request, DeviceCodeTokensResponse.class);
       LOGGER.debug("Device Code Flow: new tokens received");
       tokensFuture.complete(tokens);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeFlow.java
@@ -130,12 +130,7 @@ class DeviceCodeFlow extends AbstractFlow {
   }
 
   private DeviceCodeResponse requestDeviceCode() {
-    DeviceCodeRequest body =
-        ImmutableDeviceCodeRequest.builder()
-            // don't include client id, it's in the basic auth header
-            .scope(config.getScope().orElse(null))
-            .build();
-    return invokeEndpoint(config.getResolvedDeviceAuthEndpoint(), body, DeviceCodeResponse.class);
+    return invokeDeviceAuthEndpoint();
   }
 
   private void checkPollInterval(Duration serverPollInterval) {
@@ -165,12 +160,8 @@ class DeviceCodeFlow extends AbstractFlow {
   private void pollForNewTokens(String deviceCode) {
     try {
       LOGGER.debug("Device Code Flow: polling for new tokens");
-      DeviceCodeTokensRequest request =
-          ImmutableDeviceCodeTokensRequest.builder()
-              .deviceCode(deviceCode)
-              .scope(config.getScope().orElse(null))
-              // don't include client id, it's in the basic auth header
-              .build();
+      DeviceCodeTokensRequest.Builder request =
+          ImmutableDeviceCodeTokensRequest.builder().deviceCode(deviceCode);
       Tokens tokens = invokeTokenEndpoint(request, DeviceCodeTokensResponse.class);
       LOGGER.debug("Device Code Flow: new tokens received");
       tokensFuture.complete(tokens);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeRequest.java
@@ -29,15 +29,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableDeviceCodeRequest.class)
 @JsonDeserialize(as = ImmutableDeviceCodeRequest.class)
-interface DeviceCodeRequest {
-
-  /**
-   * The client identifier as described in Section 2.2 of [RFC6749]. REQUIRED if the client is not
-   * authenticating with the authorization server as described in Section 3.2.1. of [RFC6749].
-   */
-  @Nullable
-  @JsonProperty("client_id")
-  String getClientId();
+interface DeviceCodeRequest extends PublicClientRequest {
 
   @Nullable
   @JsonProperty("scope")
@@ -47,10 +39,7 @@ interface DeviceCodeRequest {
     return ImmutableDeviceCodeRequest.builder();
   }
 
-  interface Builder {
-    @CanIgnoreReturnValue
-    Builder clientId(String clientId);
-
+  interface Builder extends PublicClientRequest.Builder<DeviceCodeRequest> {
     @CanIgnoreReturnValue
     Builder scope(String scope);
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeRequest.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.auth.oauth2;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
@@ -42,11 +43,18 @@ interface DeviceCodeRequest {
   @JsonProperty("scope")
   String getScope();
 
+  static Builder builder() {
+    return ImmutableDeviceCodeRequest.builder();
+  }
+
   interface Builder {
+    @CanIgnoreReturnValue
     Builder clientId(String clientId);
 
+    @CanIgnoreReturnValue
     Builder scope(String scope);
 
+    @SuppressWarnings("ClassEscapesDefinedScope")
     DeviceCodeRequest build();
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeRequest.java
@@ -41,4 +41,12 @@ interface DeviceCodeRequest {
   @Nullable
   @JsonProperty("scope")
   String getScope();
+
+  interface Builder {
+    Builder clientId(String clientId);
+
+    Builder scope(String scope);
+
+    DeviceCodeRequest build();
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeTokensRequest.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.auth.oauth2;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.immutables.value.Value;
 
 /**
@@ -56,7 +57,12 @@ interface DeviceCodeTokensRequest extends PublicTokensRequestBase {
   @JsonProperty("device_code")
   String getDeviceCode();
 
+  static Builder builder() {
+    return ImmutableDeviceCodeTokensRequest.builder();
+  }
+
   interface Builder extends PublicTokensRequestBase.Builder<DeviceCodeTokensRequest> {
+    @CanIgnoreReturnValue
     Builder deviceCode(String deviceCode);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeTokensRequest.java
@@ -42,7 +42,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableDeviceCodeTokensRequest.class)
 @JsonDeserialize(as = ImmutableDeviceCodeTokensRequest.class)
 @JsonTypeName(GrantType.Constants.DEVICE_CODE)
-interface DeviceCodeTokensRequest extends PublicTokensRequestBase {
+interface DeviceCodeTokensRequest extends TokensRequestBase, PublicClientRequest {
 
   /** REQUIRED. Value MUST be set to "urn:ietf:params:oauth:grant-type:device_code" */
   @Value.Derived
@@ -62,7 +62,10 @@ interface DeviceCodeTokensRequest extends PublicTokensRequestBase {
     return ImmutableDeviceCodeTokensRequest.builder();
   }
 
-  interface Builder extends PublicTokensRequestBase.Builder<DeviceCodeTokensRequest> {
+  interface Builder
+      extends TokensRequestBase.Builder<DeviceCodeTokensRequest>,
+          PublicClientRequest.Builder<DeviceCodeTokensRequest> {
+
     @CanIgnoreReturnValue
     Builder deviceCode(String deviceCode);
   }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeTokensRequest.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -40,11 +41,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableDeviceCodeTokensRequest.class)
 @JsonDeserialize(as = ImmutableDeviceCodeTokensRequest.class)
+@JsonTypeName(GrantType.Constants.DEVICE_CODE)
 interface DeviceCodeTokensRequest extends PublicTokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "urn:ietf:params:oauth:grant-type:device_code" */
   @Value.Derived
-  @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
     return GrantType.DEVICE_CODE;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/DeviceCodeTokensRequest.java
@@ -18,7 +18,6 @@ package org.projectnessie.client.auth.oauth2;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /**
@@ -40,10 +39,10 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableDeviceCodeTokensRequest.class)
 @JsonDeserialize(as = ImmutableDeviceCodeTokensRequest.class)
-interface DeviceCodeTokensRequest extends TokensRequestBase {
+interface DeviceCodeTokensRequest extends PublicTokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "urn:ietf:params:oauth:grant-type:device_code" */
-  @Value.Default
+  @Value.Derived
   @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
@@ -57,11 +56,7 @@ interface DeviceCodeTokensRequest extends TokensRequestBase {
   @JsonProperty("device_code")
   String getDeviceCode();
 
-  /**
-   * The client identifier as described in Section 2.2 of [RFC6749]. REQUIRED if the client is not
-   * authenticating with the authorization server as described in Section 3.2.1. of [RFC6749].
-   */
-  @JsonProperty("client_id")
-  @Nullable
-  String getClientId();
+  interface Builder extends PublicTokensRequestBase.Builder<DeviceCodeTokensRequest> {
+    Builder deviceCode(String deviceCode);
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/GrantType.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/GrantType.java
@@ -31,7 +31,7 @@ public enum GrantType {
   PASSWORD("password") {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
-      return new ResourceOwnerPasswordFlow(config);
+      return new PasswordFlow(config);
     }
   },
   AUTHORIZATION_CODE("authorization_code") {

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/GrantType.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/GrantType.java
@@ -22,25 +22,25 @@ public enum GrantType {
 
   // initial grant types
 
-  CLIENT_CREDENTIALS("client_credentials") {
+  CLIENT_CREDENTIALS(Constants.CLIENT_CREDENTIALS) {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
       return new ClientCredentialsFlow(config);
     }
   },
-  PASSWORD("password") {
+  PASSWORD(Constants.PASSWORD) {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
       return new PasswordFlow(config);
     }
   },
-  AUTHORIZATION_CODE("authorization_code") {
+  AUTHORIZATION_CODE(Constants.AUTHORIZATION_CODE) {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
       return new AuthorizationCodeFlow(config);
     }
   },
-  DEVICE_CODE("urn:ietf:params:oauth:grant-type:device_code") {
+  DEVICE_CODE(Constants.DEVICE_CODE) {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
       return new DeviceCodeFlow(config);
@@ -49,13 +49,13 @@ public enum GrantType {
 
   // grant types for refreshing tokens (cannot be used for initial token acquisition)
 
-  REFRESH_TOKEN("refresh_token") {
+  REFRESH_TOKEN(Constants.REFRESH_TOKEN) {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
       return new RefreshTokensFlow(config);
     }
   },
-  TOKEN_EXCHANGE("urn:ietf:params:oauth:grant-type:token-exchange") {
+  TOKEN_EXCHANGE(Constants.TOKEN_EXCHANGE) {
     @Override
     Flow newFlow(OAuth2ClientConfig config) {
       return new TokenExchangeFlow(config);
@@ -88,5 +88,15 @@ public enum GrantType {
 
   public boolean requiresUserInteraction() {
     return this == AUTHORIZATION_CODE || this == DEVICE_CODE;
+  }
+
+  public static class Constants {
+
+    public static final String CLIENT_CREDENTIALS = "client_credentials";
+    public static final String PASSWORD = "password";
+    public static final String AUTHORIZATION_CODE = "authorization_code";
+    public static final String DEVICE_CODE = "urn:ietf:params:oauth:grant-type:device_code";
+    public static final String REFRESH_TOKEN = "refresh_token";
+    public static final String TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -22,6 +22,7 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_AUTH_ENDPOINT;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_BACKGROUND_THREAD_IDLE_TIMEOUT;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_ID;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_CLIENT_SECRET;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEFAULT_ACCESS_TOKEN_LIFESPAN;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_POLL_INTERVAL;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_OAUTH2_DEVICE_CODE_FLOW_TIMEOUT;
@@ -240,6 +241,12 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
         CONF_NESSIE_OAUTH2_CLIENT_ID,
         !getClientId().isEmpty(),
         "client ID must not be empty");
+    check(
+        violations,
+        CONF_NESSIE_OAUTH2_GRANT_TYPE + " / " + CONF_NESSIE_OAUTH2_CLIENT_SECRET,
+        getClientSecret().isPresent() || getGrantType() != GrantType.CLIENT_CREDENTIALS,
+        "client secret must not be empty when grant type is '%s'",
+        CONF_NESSIE_OAUTH2_GRANT_TYPE_CLIENT_CREDENTIALS);
     check(
         violations,
         CONF_NESSIE_OAUTH2_ISSUER_URL + " / " + CONF_NESSIE_OAUTH2_TOKEN_ENDPOINT,

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/OAuth2ClientConfig.java
@@ -117,6 +117,11 @@ abstract class OAuth2ClientConfig implements OAuth2AuthenticatorConfig {
     return Clock.systemUTC()::instant;
   }
 
+  @Value.Derived
+  boolean isPublicClient() {
+    return !getClientSecret().isPresent();
+  }
+
   @Value.Lazy
   JsonNode getOpenIdProviderMetadata() {
     URI issuerUrl = getIssuerUrl().orElseThrow(IllegalStateException::new);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordFlow.java
@@ -22,9 +22,9 @@ import javax.annotation.Nullable;
  * href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.3">Resource Owner Password
  * Credentials Grant</a> flow.
  */
-class ResourceOwnerPasswordFlow extends AbstractFlow {
+class PasswordFlow extends AbstractFlow {
 
-  ResourceOwnerPasswordFlow(OAuth2ClientConfig config) {
+  PasswordFlow(OAuth2ClientConfig config) {
     super(config);
   }
 
@@ -37,12 +37,8 @@ class ResourceOwnerPasswordFlow extends AbstractFlow {
             .getPassword()
             .map(Secret::getString)
             .orElseThrow(() -> new IllegalStateException("Password is required"));
-    PasswordTokensRequest request =
-        ImmutablePasswordTokensRequest.builder()
-            .username(username)
-            .password(password)
-            .scope(config.getScope().orElse(null))
-            .build();
+    PasswordTokensRequest.Builder request =
+        ImmutablePasswordTokensRequest.builder().username(username).password(password);
     return invokeTokenEndpoint(request, PasswordTokensResponse.class);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordFlow.java
@@ -38,7 +38,7 @@ class PasswordFlow extends AbstractFlow {
             .map(Secret::getString)
             .orElseThrow(() -> new IllegalStateException("Password is required"));
     PasswordTokensRequest.Builder request =
-        ImmutablePasswordTokensRequest.builder().username(username).password(password);
+        PasswordTokensRequest.builder().username(username).password(password);
     return invokeTokenEndpoint(request, PasswordTokensResponse.class);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordTokensRequest.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -39,11 +40,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutablePasswordTokensRequest.class)
 @JsonDeserialize(as = ImmutablePasswordTokensRequest.class)
+@JsonTypeName(GrantType.Constants.PASSWORD)
 interface PasswordTokensRequest extends PublicTokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "password". */
   @Value.Derived
-  @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
     return GrantType.PASSWORD;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordTokensRequest.java
@@ -41,7 +41,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutablePasswordTokensRequest.class)
 @JsonDeserialize(as = ImmutablePasswordTokensRequest.class)
 @JsonTypeName(GrantType.Constants.PASSWORD)
-interface PasswordTokensRequest extends PublicTokensRequestBase {
+interface PasswordTokensRequest extends TokensRequestBase, PublicClientRequest {
 
   /** REQUIRED. Value MUST be set to "password". */
   @Value.Derived
@@ -62,7 +62,9 @@ interface PasswordTokensRequest extends PublicTokensRequestBase {
     return ImmutablePasswordTokensRequest.builder();
   }
 
-  interface Builder extends PublicTokensRequestBase.Builder<PasswordTokensRequest> {
+  interface Builder
+      extends TokensRequestBase.Builder<PasswordTokensRequest>,
+          PublicClientRequest.Builder<PasswordTokensRequest> {
     @CanIgnoreReturnValue
     Builder username(String username);
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordTokensRequest.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.auth.oauth2;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.immutables.value.Value;
 
 /**
@@ -56,9 +57,15 @@ interface PasswordTokensRequest extends PublicTokensRequestBase {
   @JsonProperty("password")
   String getPassword();
 
+  static Builder builder() {
+    return ImmutablePasswordTokensRequest.builder();
+  }
+
   interface Builder extends PublicTokensRequestBase.Builder<PasswordTokensRequest> {
+    @CanIgnoreReturnValue
     Builder username(String username);
 
+    @CanIgnoreReturnValue
     Builder password(String password);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PasswordTokensRequest.java
@@ -38,10 +38,10 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutablePasswordTokensRequest.class)
 @JsonDeserialize(as = ImmutablePasswordTokensRequest.class)
-interface PasswordTokensRequest extends TokensRequestBase {
+interface PasswordTokensRequest extends PublicTokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "password". */
-  @Value.Default
+  @Value.Derived
   @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
@@ -55,4 +55,10 @@ interface PasswordTokensRequest extends TokensRequestBase {
   /** REQUIRED. The resource owner password. */
   @JsonProperty("password")
   String getPassword();
+
+  interface Builder extends PublicTokensRequestBase.Builder<PasswordTokensRequest> {
+    Builder username(String username);
+
+    Builder password(String password);
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PublicClientRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PublicClientRequest.java
@@ -20,15 +20,15 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import javax.annotation.Nullable;
 
 /**
- * Common base for requests to the token endpoint using grant types compatible with public clients.
+ * Common interface for requests using grant types compatible with public clients.
  *
- * @see PasswordTokensRequest
  * @see AuthorizationCodeTokensRequest
  * @see DeviceCodeRequest
+ * @see PasswordTokensRequest
  * @see RefreshTokensRequest
  * @see TokensExchangeRequest
  */
-interface PublicTokensRequestBase extends TokensRequestBase {
+interface PublicClientRequest {
 
   /**
    * The client identifier as described in Section 2.2 of [RFC6749]. REQUIRED if the client is not
@@ -38,8 +38,7 @@ interface PublicTokensRequestBase extends TokensRequestBase {
   @Nullable
   String getClientId();
 
-  interface Builder<T extends PublicTokensRequestBase> extends TokensRequestBase.Builder<T> {
-
+  interface Builder<T> {
     @CanIgnoreReturnValue
     Builder<T> clientId(String clientId);
   }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PublicTokensRequestBase.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PublicTokensRequestBase.java
@@ -17,42 +17,28 @@ package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nullable;
-import org.immutables.value.Value;
 
 /**
- * Common base for all requests to the token endpoint.
+ * Common base for requests to the token endpoint using grant types compatible with public clients.
  *
- * @see ClientCredentialsTokensRequest
  * @see PasswordTokensRequest
  * @see AuthorizationCodeTokensRequest
  * @see DeviceCodeRequest
  * @see RefreshTokensRequest
  * @see TokensExchangeRequest
  */
-interface TokensRequestBase {
-
-  /** REQUIRED. The authorization grant type. */
-  @JsonProperty("grant_type")
-  @Value.Derived
-  GrantType getGrantType();
+interface PublicTokensRequestBase extends TokensRequestBase {
 
   /**
-   * OPTIONAL, if identical to the scope requested by the client; otherwise, REQUIRED. The scope of
-   * the access token as described by <a
-   * href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">Section 3.3</a>.
-   *
-   * <p>In case of refresh, the requested scope MUST NOT include any scope not originally granted by
-   * the resource owner, and if omitted is treated as equal to the scope originally granted by the
-   * resource owner.
+   * The client identifier as described in Section 2.2 of [RFC6749]. REQUIRED if the client is not
+   * authenticating with the authorization server as described in Section 3.2.1. of [RFC6749].
    */
+  @JsonProperty("client_id")
   @Nullable
-  @JsonProperty("scope")
-  String getScope();
+  String getClientId();
 
-  interface Builder<T extends TokensRequestBase> {
+  interface Builder<T extends PublicTokensRequestBase> extends TokensRequestBase.Builder<T> {
 
-    Builder<T> scope(String scope);
-
-    T build();
+    Builder<T> clientId(String clientId);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PublicTokensRequestBase.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/PublicTokensRequestBase.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import javax.annotation.Nullable;
 
 /**
@@ -39,6 +40,7 @@ interface PublicTokensRequestBase extends TokensRequestBase {
 
   interface Builder<T extends PublicTokensRequestBase> extends TokensRequestBase.Builder<T> {
 
+    @CanIgnoreReturnValue
     Builder<T> clientId(String clientId);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensFlow.java
@@ -38,11 +38,9 @@ class RefreshTokensFlow extends AbstractFlow {
     if (isAboutToExpire(currentTokens.getRefreshToken())) {
       throw new MustFetchNewTokensException("Refresh token is about to expire");
     }
-    RefreshTokensRequest request =
+    RefreshTokensRequest.Builder request =
         ImmutableRefreshTokensRequest.builder()
-            .refreshToken(currentTokens.getRefreshToken().getPayload())
-            .scope(config.getScope().orElse(null))
-            .build();
+            .refreshToken(currentTokens.getRefreshToken().getPayload());
     return invokeTokenEndpoint(request, RefreshTokensResponse.class);
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensFlow.java
@@ -39,8 +39,7 @@ class RefreshTokensFlow extends AbstractFlow {
       throw new MustFetchNewTokensException("Refresh token is about to expire");
     }
     RefreshTokensRequest.Builder request =
-        ImmutableRefreshTokensRequest.builder()
-            .refreshToken(currentTokens.getRefreshToken().getPayload());
+        RefreshTokensRequest.builder().refreshToken(currentTokens.getRefreshToken().getPayload());
     return invokeTokenEndpoint(request, RefreshTokensResponse.class);
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensRequest.java
@@ -43,7 +43,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableRefreshTokensRequest.class)
 @JsonDeserialize(as = ImmutableRefreshTokensRequest.class)
 @JsonTypeName(GrantType.Constants.REFRESH_TOKEN)
-interface RefreshTokensRequest extends PublicTokensRequestBase {
+interface RefreshTokensRequest extends TokensRequestBase, PublicClientRequest {
 
   /** REQUIRED. Value MUST be set to "refresh_token". */
   @Value.Derived
@@ -60,7 +60,9 @@ interface RefreshTokensRequest extends PublicTokensRequestBase {
     return ImmutableRefreshTokensRequest.builder();
   }
 
-  interface Builder extends PublicTokensRequestBase.Builder<RefreshTokensRequest> {
+  interface Builder
+      extends TokensRequestBase.Builder<RefreshTokensRequest>,
+          PublicClientRequest.Builder<RefreshTokensRequest> {
 
     @CanIgnoreReturnValue
     Builder refreshToken(String refreshToken);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensRequest.java
@@ -35,15 +35,15 @@ import org.immutables.value.Value;
  * grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA
  * </pre>
  *
- * The response to this request is an {@link ClientCredentialsTokensResponse}.
+ * The response to this request is a {@link RefreshTokensResponse}.
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableRefreshTokensRequest.class)
 @JsonDeserialize(as = ImmutableRefreshTokensRequest.class)
-interface RefreshTokensRequest extends TokensRequestBase {
+interface RefreshTokensRequest extends PublicTokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "refresh_token". */
-  @Value.Default
+  @Value.Derived
   @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
@@ -53,4 +53,9 @@ interface RefreshTokensRequest extends TokensRequestBase {
   /** REQUIRED. The refresh token issued to the client. */
   @JsonProperty("refresh_token")
   String getRefreshToken();
+
+  interface Builder extends PublicTokensRequestBase.Builder<RefreshTokensRequest> {
+
+    Builder refreshToken(String refreshToken);
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensRequest.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -41,11 +42,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableRefreshTokensRequest.class)
 @JsonDeserialize(as = ImmutableRefreshTokensRequest.class)
+@JsonTypeName(GrantType.Constants.REFRESH_TOKEN)
 interface RefreshTokensRequest extends PublicTokensRequestBase {
 
   /** REQUIRED. Value MUST be set to "refresh_token". */
   @Value.Derived
-  @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
     return GrantType.REFRESH_TOKEN;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensRequest.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.auth.oauth2;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.immutables.value.Value;
 
 /**
@@ -54,8 +55,13 @@ interface RefreshTokensRequest extends PublicTokensRequestBase {
   @JsonProperty("refresh_token")
   String getRefreshToken();
 
+  static Builder builder() {
+    return ImmutableRefreshTokensRequest.builder();
+  }
+
   interface Builder extends PublicTokensRequestBase.Builder<RefreshTokensRequest> {
 
+    @CanIgnoreReturnValue
     Builder refreshToken(String refreshToken);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeFlow.java
@@ -42,7 +42,7 @@ class TokenExchangeFlow extends AbstractFlow {
     }
     Objects.requireNonNull(currentTokens);
     TokensExchangeRequest.Builder request =
-        ImmutableTokensExchangeRequest.builder()
+        TokensExchangeRequest.builder()
             .subjectToken(currentTokens.getAccessToken().getPayload())
             .subjectTokenType(ACCESS_TOKEN_ID)
             .requestedTokenType(REFRESH_TOKEN_ID);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokenExchangeFlow.java
@@ -41,13 +41,11 @@ class TokenExchangeFlow extends AbstractFlow {
       throw new MustFetchNewTokensException("Token exchange is disabled");
     }
     Objects.requireNonNull(currentTokens);
-    TokensExchangeRequest request =
+    TokensExchangeRequest.Builder request =
         ImmutableTokensExchangeRequest.builder()
             .subjectToken(currentTokens.getAccessToken().getPayload())
             .subjectTokenType(ACCESS_TOKEN_ID)
-            .requestedTokenType(REFRESH_TOKEN_ID)
-            .scope(config.getScope().orElse(null))
-            .build();
+            .requestedTokenType(REFRESH_TOKEN_ID);
     return invokeTokenEndpoint(request, TokensExchangeResponse.class);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensExchangeRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensExchangeRequest.java
@@ -46,7 +46,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableTokensExchangeRequest.class)
 @JsonDeserialize(as = ImmutableTokensExchangeRequest.class)
 @JsonTypeName(GrantType.Constants.TOKEN_EXCHANGE)
-interface TokensExchangeRequest extends PublicTokensRequestBase {
+interface TokensExchangeRequest extends TokensRequestBase, PublicClientRequest {
 
   /**
    * REQUIRED. The value {@link GrantType#TOKEN_EXCHANGE} indicates that a token exchange is being
@@ -143,7 +143,9 @@ interface TokensExchangeRequest extends PublicTokensRequestBase {
     return ImmutableTokensExchangeRequest.builder();
   }
 
-  interface Builder extends PublicTokensRequestBase.Builder<TokensExchangeRequest> {
+  interface Builder
+      extends TokensRequestBase.Builder<TokensExchangeRequest>,
+          PublicClientRequest.Builder<TokensExchangeRequest> {
 
     @CanIgnoreReturnValue
     Builder resource(URI resource);

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensExchangeRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensExchangeRequest.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -44,6 +45,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableTokensExchangeRequest.class)
 @JsonDeserialize(as = ImmutableTokensExchangeRequest.class)
+@JsonTypeName(GrantType.Constants.TOKEN_EXCHANGE)
 interface TokensExchangeRequest extends PublicTokensRequestBase {
 
   /**
@@ -51,7 +53,6 @@ interface TokensExchangeRequest extends PublicTokensRequestBase {
    * performed.
    */
   @Value.Derived
-  @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
     return GrantType.TOKEN_EXCHANGE;

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensExchangeRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensExchangeRequest.java
@@ -18,6 +18,7 @@ package org.projectnessie.client.auth.oauth2;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.net.URI;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
@@ -137,20 +138,31 @@ interface TokensExchangeRequest extends PublicTokensRequestBase {
   @JsonProperty("actor_token_type")
   URI getActorTokenType();
 
+  static Builder builder() {
+    return ImmutableTokensExchangeRequest.builder();
+  }
+
   interface Builder extends PublicTokensRequestBase.Builder<TokensExchangeRequest> {
 
+    @CanIgnoreReturnValue
     Builder resource(URI resource);
 
+    @CanIgnoreReturnValue
     Builder audience(String audience);
 
+    @CanIgnoreReturnValue
     Builder requestedTokenType(URI requestedTokenType);
 
+    @CanIgnoreReturnValue
     Builder subjectToken(String subjectToken);
 
+    @CanIgnoreReturnValue
     Builder subjectTokenType(URI subjectTokenType);
 
+    @CanIgnoreReturnValue
     Builder actorToken(String actorToken);
 
+    @CanIgnoreReturnValue
     Builder actorTokenType(URI actorTokenType);
   }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensExchangeRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensExchangeRequest.java
@@ -43,13 +43,13 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableTokensExchangeRequest.class)
 @JsonDeserialize(as = ImmutableTokensExchangeRequest.class)
-interface TokensExchangeRequest extends TokensRequestBase {
+interface TokensExchangeRequest extends PublicTokensRequestBase {
 
   /**
    * REQUIRED. The value {@link GrantType#TOKEN_EXCHANGE} indicates that a token exchange is being
    * performed.
    */
-  @Value.Default
+  @Value.Derived
   @JsonProperty("grant_type")
   @Override
   default GrantType getGrantType() {
@@ -136,4 +136,21 @@ interface TokensExchangeRequest extends TokensRequestBase {
   @Nullable
   @JsonProperty("actor_token_type")
   URI getActorTokenType();
+
+  interface Builder extends PublicTokensRequestBase.Builder<TokensExchangeRequest> {
+
+    Builder resource(URI resource);
+
+    Builder audience(String audience);
+
+    Builder requestedTokenType(URI requestedTokenType);
+
+    Builder subjectToken(String subjectToken);
+
+    Builder subjectTokenType(URI subjectTokenType);
+
+    Builder actorToken(String actorToken);
+
+    Builder actorTokenType(URI actorTokenType);
+  }
 }

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensRequestBase.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensRequestBase.java
@@ -16,6 +16,7 @@
 package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
@@ -51,6 +52,7 @@ interface TokensRequestBase {
 
   interface Builder<T extends TokensRequestBase> {
 
+    @CanIgnoreReturnValue
     Builder<T> scope(String scope);
 
     T build();

--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensRequestBase.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/TokensRequestBase.java
@@ -16,9 +16,10 @@
 package org.projectnessie.client.auth.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import javax.annotation.Nullable;
-import org.immutables.value.Value;
 
 /**
  * Common base for all requests to the token endpoint.
@@ -30,11 +31,25 @@ import org.immutables.value.Value;
  * @see RefreshTokensRequest
  * @see TokensExchangeRequest
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "grant_type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(
+      value = AuthorizationCodeTokensRequest.class,
+      name = GrantType.Constants.AUTHORIZATION_CODE),
+  @JsonSubTypes.Type(
+      value = ClientCredentialsTokensRequest.class,
+      name = GrantType.Constants.CLIENT_CREDENTIALS),
+  @JsonSubTypes.Type(value = DeviceCodeTokensRequest.class, name = GrantType.Constants.DEVICE_CODE),
+  @JsonSubTypes.Type(value = PasswordTokensRequest.class, name = GrantType.Constants.PASSWORD),
+  @JsonSubTypes.Type(value = RefreshTokensRequest.class, name = GrantType.Constants.REFRESH_TOKEN),
+  @JsonSubTypes.Type(
+      value = TokensExchangeRequest.class,
+      name = GrantType.Constants.TOKEN_EXCHANGE),
+})
 interface TokensRequestBase {
 
   /** REQUIRED. The authorization grant type. */
   @JsonProperty("grant_type")
-  @Value.Derived
   GrantType getGrantType();
 
   /**

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -595,7 +595,7 @@ class TestOAuth2Client {
       TokensRequestBase request;
       Object response;
       int statusCode = 200;
-      String grantType = data.remove("grant_type"); // determined by the target type
+      String grantType = data.get("grant_type");
       if (grantType.equals(GrantType.CLIENT_CREDENTIALS.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, ClientCredentialsTokensRequest.class);
         soft.assertThat(request.getScope()).isEqualTo("test");

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -605,14 +605,14 @@ class TestOAuth2Client {
         soft.assertThat(request.getScope()).isEqualTo("test");
         soft.assertThat(((PasswordTokensRequest) request).getUsername()).isEqualTo("Bob");
         soft.assertThat(((PasswordTokensRequest) request).getPassword()).isEqualTo("s3cr3t");
-        soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
+        soft.assertThat(((PublicClientRequest) request).getClientId()).isNull();
         response = getPasswordTokensResponse();
       } else if (grantType.equals(GrantType.REFRESH_TOKEN.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, RefreshTokensRequest.class);
         soft.assertThat(request.getScope()).isEqualTo("test");
         soft.assertThat(((RefreshTokensRequest) request).getRefreshToken())
             .isIn("refresh-initial", "refresh-refreshed", "refresh-exchanged");
-        soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
+        soft.assertThat(((PublicClientRequest) request).getClientId()).isNull();
         response = getRefreshTokensResponse();
       } else if (grantType.equals(GrantType.TOKEN_EXCHANGE.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, TokensExchangeRequest.class);
@@ -625,7 +625,7 @@ class TestOAuth2Client {
         soft.assertThat(((TokensExchangeRequest) request).getActorTokenType()).isNull();
         soft.assertThat(((TokensExchangeRequest) request).getRequestedTokenType())
             .isEqualTo(TokenExchangeFlow.REFRESH_TOKEN_ID);
-        soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
+        soft.assertThat(((PublicClientRequest) request).getClientId()).isNull();
         response = getTokensExchangeResponse();
       } else if (grantType.equals(GrantType.AUTHORIZATION_CODE.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, AuthorizationCodeTokensRequest.class);
@@ -635,7 +635,7 @@ class TestOAuth2Client {
         soft.assertThat(((AuthorizationCodeTokensRequest) request).getRedirectUri())
             .contains("http://localhost:")
             .contains("/nessie-client/auth");
-        soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
+        soft.assertThat(((PublicClientRequest) request).getClientId()).isNull();
         response = getAuthorizationCodeTokensResponse();
       } else if (grantType.equals(GrantType.DEVICE_CODE.canonicalName())) {
         if (deviceAuthorized) {
@@ -643,7 +643,7 @@ class TestOAuth2Client {
           soft.assertThat(request.getScope()).isEqualTo("test");
           soft.assertThat(((DeviceCodeTokensRequest) request).getDeviceCode())
               .isEqualTo("device-code");
-          soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
+          soft.assertThat(((PublicClientRequest) request).getClientId()).isNull();
           response = getDeviceAuthorizationTokensResponse();
         } else {
           response =

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -595,8 +595,7 @@ class TestOAuth2Client {
       TokensRequestBase request;
       Object response;
       int statusCode = 200;
-      String grantType = data.get("grant_type");
-      data.remove("grant_type"); // determined by the target type
+      String grantType = data.remove("grant_type"); // determined by the target type
       if (grantType.equals(GrantType.CLIENT_CREDENTIALS.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, ClientCredentialsTokensRequest.class);
         soft.assertThat(request.getScope()).isEqualTo("test");

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -581,7 +581,7 @@ class TestOAuth2Client {
         throws IOException {
       soft.assertThat(req.getMethod()).isEqualTo("POST");
       soft.assertThat(req.getContentType()).isEqualTo("application/x-www-form-urlencoded");
-      soft.assertThat(req.getHeader("Authorization")).isEqualTo("Basic QWxpY2U6czNjcjN0");
+      soft.assertThat(req.getHeader("Authorization")).isEqualTo("Basic Q2xpZW50MTpzM2NyM3Q=");
       Map<String, String> data = BaseTestHttpClient.decodeFormData(req.getInputStream());
       if (data.containsKey("scope") && data.get("scope").equals("invalid-scope")) {
         ErrorResponse response =
@@ -596,6 +596,7 @@ class TestOAuth2Client {
       Object response;
       int statusCode = 200;
       String grantType = data.get("grant_type");
+      data.remove("grant_type"); // determined by the target type
       if (grantType.equals(GrantType.CLIENT_CREDENTIALS.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, ClientCredentialsTokensRequest.class);
         soft.assertThat(request.getScope()).isEqualTo("test");
@@ -605,12 +606,14 @@ class TestOAuth2Client {
         soft.assertThat(request.getScope()).isEqualTo("test");
         soft.assertThat(((PasswordTokensRequest) request).getUsername()).isEqualTo("Bob");
         soft.assertThat(((PasswordTokensRequest) request).getPassword()).isEqualTo("s3cr3t");
+        soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
         response = getPasswordTokensResponse();
       } else if (grantType.equals(GrantType.REFRESH_TOKEN.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, RefreshTokensRequest.class);
         soft.assertThat(request.getScope()).isEqualTo("test");
         soft.assertThat(((RefreshTokensRequest) request).getRefreshToken())
             .isIn("refresh-initial", "refresh-refreshed", "refresh-exchanged");
+        soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
         response = getRefreshTokensResponse();
       } else if (grantType.equals(GrantType.TOKEN_EXCHANGE.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, TokensExchangeRequest.class);
@@ -623,6 +626,7 @@ class TestOAuth2Client {
         soft.assertThat(((TokensExchangeRequest) request).getActorTokenType()).isNull();
         soft.assertThat(((TokensExchangeRequest) request).getRequestedTokenType())
             .isEqualTo(TokenExchangeFlow.REFRESH_TOKEN_ID);
+        soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
         response = getTokensExchangeResponse();
       } else if (grantType.equals(GrantType.AUTHORIZATION_CODE.canonicalName())) {
         request = OBJECT_MAPPER.convertValue(data, AuthorizationCodeTokensRequest.class);
@@ -632,8 +636,7 @@ class TestOAuth2Client {
         soft.assertThat(((AuthorizationCodeTokensRequest) request).getRedirectUri())
             .contains("http://localhost:")
             .contains("/nessie-client/auth");
-        soft.assertThat(((AuthorizationCodeTokensRequest) request).getClientId())
-            .isEqualTo("Alice");
+        soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
         response = getAuthorizationCodeTokensResponse();
       } else if (grantType.equals(GrantType.DEVICE_CODE.canonicalName())) {
         if (deviceAuthorized) {
@@ -641,6 +644,7 @@ class TestOAuth2Client {
           soft.assertThat(request.getScope()).isEqualTo("test");
           soft.assertThat(((DeviceCodeTokensRequest) request).getDeviceCode())
               .isEqualTo("device-code");
+          soft.assertThat(((PublicTokensRequestBase) request).getClientId()).isNull();
           response = getDeviceAuthorizationTokensResponse();
         } else {
           response =
@@ -668,7 +672,7 @@ class TestOAuth2Client {
       Map<String, String> data = HttpUtils.parseQueryString(req.getQueryString());
       soft.assertThat(data)
           .containsEntry("response_type", "code")
-          .containsEntry("client_id", "Alice")
+          .containsEntry("client_id", "Client1")
           .containsEntry("scope", "test")
           .containsKey("redirect_uri")
           .containsKey("state");
@@ -681,7 +685,7 @@ class TestOAuth2Client {
         throws IOException {
       soft.assertThat(req.getMethod()).isEqualTo("POST");
       soft.assertThat(req.getContentType()).isEqualTo("application/x-www-form-urlencoded");
-      soft.assertThat(req.getHeader("Authorization")).isEqualTo("Basic QWxpY2U6czNjcjN0");
+      soft.assertThat(req.getHeader("Authorization")).isEqualTo("Basic Q2xpZW50MTpzM2NyM3Q=");
       Map<String, String> data = BaseTestHttpClient.decodeFormData(req.getInputStream());
       soft.assertThat(data).containsEntry("scope", "test");
       URI uri = URI.create(req.getRequestURL().toString());
@@ -836,7 +840,7 @@ class TestOAuth2Client {
   private OAuth2ClientConfig.Builder configBuilder(HttpTestServer server, boolean discovery) {
     OAuth2ClientConfig.Builder builder =
         OAuth2ClientConfig.builder()
-            .clientId("Alice")
+            .clientId("Client1")
             .clientSecret("s3cr3t")
             .scope("test")
             .clock(() -> now);

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2ClientConfig.java
@@ -109,6 +109,12 @@ class TestOAuth2ClientConfig {
             singletonList("client ID must not be empty (nessie.authentication.oauth2.client-id)")),
         Arguments.of(
             OAuth2ClientConfig.builder()
+                .clientId("client1")
+                .tokenEndpoint(URI.create("https://example.com/token")),
+            singletonList(
+                "client secret must not be empty when grant type is 'client_credentials' (nessie.authentication.oauth2.grant-type / nessie.authentication.oauth2.client-secret)")),
+        Arguments.of(
+            OAuth2ClientConfig.builder()
                 .clientId("Alice")
                 .clientSecret("s3cr3t")
                 .tokenEndpoint(URI.create("https://example.com/token"))


### PR DESCRIPTION
In #8323 client secrets were made optional, but support for public clients wasn't fully implemented.