### PR TITLE
Site: exclude generated .md files from search index

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -59,7 +59,8 @@ plugins:
       authors_file: ./blog/.authors.yml
       post_excerpt: required
       pagination_per_page: 5
-  - include-markdown
+  - include-markdown:
+      start: "<!--start-->"
   - macros:
       on_error_fail: true
       module_name: macros


### PR DESCRIPTION
The generated markdown files, meant to be only included in other pages, sadly still occur in the site search results as individual pages, which is not intended.

This change updates the site generation by adding a 'dont include in search' to the front-matter of the generated files, including "latest/generated".