### PR TITLE
Add Amazon STS to dependencies of Nessie Core server

### DIFF
--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
   implementation("io.quarkus:quarkus-micrometer")
   implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
   implementation("io.quarkiverse.amazonservices:quarkus-amazon-dynamodb")
+  implementation("software.amazon.awssdk:sts")
   implementation("software.amazon.awssdk:apache-client") {
     exclude("commons-logging", "commons-logging")
   }


### PR DESCRIPTION
See [this Zulip thread](https://project-nessie.zulipchat.com/#narrow/stream/371187-general/topic/EKS.20Service.20Account.20with.20IAM.20Role.20for.20DynamoDB.20access/near/434430424) for context.

It's hard to test if the new dependency makes a difference, but here is what I did:

* Manually created a dummy JWT token in `~/dummy.jwt`
* Manually created a section in `~/.aws/credentials`:

```
[default]
role_arn=arn:aws:iam:123456789012:role/WhateverRole
web_identity_token_file=/Users/adutra/dummy.jwt
```

* Changed `QuarkusTestProfilePersistDynamo` to use `default` credentials provider.

Without STS the error is:

```
Unable to load credentials [...] To use web identity tokens, the 'sts' service module must be on the class path
```

With STS the error becomes:

```
Unable to load credentials [...] Request ARN is invalid (Service: Sts, Status Code: 400, Request ID: 4bc9fc14-4e44-4e30-a30a-84bca8ff864d)
```

So it does seem that including STS allows for more authentication methods to work properly.