### PR TITLE
Update GH workflows / Gradle run steps

### DIFF
--- a/.github/actions/ci-incr-build-cache-prepare/action.yml
+++ b/.github/actions/ci-incr-build-cache-prepare/action.yml
@@ -28,11 +28,14 @@ runs:
           echo "GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE=${{ inputs.job-instance }}" >> ${GITHUB_ENV}
         fi
 
-    - name: Gradle / Init
+    - name: Gradle / Setup
       uses: gradle/actions/setup-gradle@v3
       with:
         cache-read-only: ${{ inputs.cache-read-only }}
-        arguments: -h
+
+    - name: Gradle / Init
+      shell: bash
+      run: ./gradlew -h
 
     - name: Download existing workflow artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Get previous version information
       run: echo "PREVIOUS_VERSION=$(cat version.txt)" >> ${GITHUB_ENV}
 
-    - name: Bump to version
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       env:
         # Same as for ci.yml
@@ -72,7 +72,9 @@ jobs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
       with:
         cache-read-only: true
-        arguments: :bumpVersion --bumpType ${{ env.BUMP_TYPE }}
+
+    - name: Bump to version
+      run: ./gradlew :bumpVersion --bumpType ${{ env.BUMP_TYPE }}
 
     - name: Get bumped version information
       run: |

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
 
-    - name: Gradle / compile
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       env:
         # Same as for ci.yml
@@ -59,14 +59,14 @@ jobs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
       with:
         cache-read-only: true
-        arguments: assemble --scan
+
+    - name: Gradle / compile
+      run: ./gradlew assemble --scan
 
     - name: Gradle / unit test
-      uses: gradle/actions/setup-gradle@v3
       env:
         SPARK_LOCAL_IP: localhost
-      with:
-        arguments: test --scan
+      run: ./gradlew test --scan
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
 
-    - name: Gradle / compile
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       env:
         # Same as for ci.yml
@@ -71,4 +71,6 @@ jobs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
       with:
         cache-read-only: true
-        arguments: assemble --scan
+
+    - name: Gradle / compile
+      run: ./gradlew assemble --scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,13 @@ jobs:
           java-version: ${{ matrix.java-version }}
 
       - name: Gradle / Compile
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: |
-            spotlessCheck
-            compileAll
-            -x :nessie-quarkus:compileAll
-            -x :nessie-quarkus-cli:compileAll
-            -x :nessie-events-quarkus:compileAll
+        run: |
+          ./gradlew \
+            spotlessCheck \
+            compileAll \
+            -x :nessie-quarkus:compileAll \
+            -x :nessie-quarkus-cli:compileAll \
+            -x :nessie-events-quarkus:compileAll \
             --scan
 
       - name: Gradle / Compile Quarkus
@@ -99,26 +98,18 @@ jobs:
             ./gradlew :nessie-quarkus:compileAll :nessie-quarkus-cli:compileAll :nessie-events-quarkus:compileAll --scan
 
       - name: Gradle / Checkstyle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: checkstyle --scan
+        run: ./gradlew checkstyle --scan
 
       - name: Gradle / Assemble
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: assemble --scan
+        run: ./gradlew assemble --scan
 
       - name: Gradle / Publish to Maven local
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: publishToMavenLocal --scan
+        run: ./gradlew publishToMavenLocal --scan
 
       # This is a rather quick one and uses the output of 'publishToMavenLocal', which uses the
       # outputs of 'assemble'
       - name: Gradle / build tools integration tests
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: buildToolsIntegrationTest
+        run: ./gradlew buildToolsIntegrationTest
 
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
@@ -150,16 +141,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
 
       - name: Gradle / test
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: |
-            test
-            :nessie-client:check 
-            -x :nessie-client:intTest 
-            -x :nessie-quarkus:test
-            -x :nessie-quarkus-cli:test
-            -x :nessie-events-quarkus:test
-            --scan
+        run: ./gradlew test :nessie-client:check -x :nessie-client:intTest -x :nessie-quarkus:test -x :nessie-quarkus-cli:test -x :nessie-events-quarkus:test --scan
 
       - name: Capture Test Reports
         uses: actions/upload-artifact@v4
@@ -848,31 +830,25 @@ jobs:
             11
             17
 
-      - name: Iceberg Nessie test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: true
-          arguments: :iceberg:iceberg-nessie:test --scan
+
+      - name: Iceberg Nessie test
+        run: ./gradlew :iceberg:iceberg-nessie:test --scan
 
       - name: Nessie Spark 3.3 / 2.12 Extensions test
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest --scan
+        run: ./gradlew :nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest --scan
 
       - name: Nessie Spark 3.4 / 2.13 Extensions test
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:intTest --scan
+        run: ./gradlew :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:intTest --scan
 
       - name: Nessie Spark 3.5 / 2.13 Extensions test
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest --scan
+        run: ./gradlew :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest --scan
 
       #- name: Publish Nessie + Iceberg to local Maven repo
-      #  uses: gradle/gradle-build-action@v2
-      #  with:
-      #    arguments: publishLocal --scan
+      #  run: ./gradlew publishLocal --scan
       #
       #- name: Gather locally published versions
       #  run: |
@@ -888,9 +864,7 @@ jobs:
       #    !
 
       - name: Tools & Integrations tests
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: intTest --scan
+        run: ./gradlew intTest --scan
 
   site:
     name: CI Website

--- a/.github/workflows/newer-java.yml
+++ b/.github/workflows/newer-java.yml
@@ -40,6 +40,11 @@ jobs:
         more-memory: 'true'
     - name: Setup Java, Gradle
       uses: ./.github/actions/dev-tool-java
+      with:
+        java-version: ${{ matrix.java-version }}
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
       env:
         # Same as for ci.yml
         GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-17
@@ -47,47 +52,36 @@ jobs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ci
       with:
         cache-read-only: true
-        java-version: ${{ matrix.java-version }}
 
     - name: Gradle / compile
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: |
-          spotlessCheck
-          compileAll
-          -x :nessie-quarkus:compileAll
-          -x :nessie-quarkus-cli:compileAll
-          -x :nessie-events-quarkus:compileAll
+      run: |
+        ./gradlew \
+          spotlessCheck \
+          compileAll \
+          -x :nessie-quarkus:compileAll \
+          -x :nessie-quarkus-cli:compileAll \
+          -x :nessie-events-quarkus:compileAll \
           --scan
 
     - name: Gradle / Compile Quarkus
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: |
-          :nessie-quarkus:compileAll
-          :nessie-quarkus-cli:compileAll
-          :nessie-events-quarkus:compileAll
+      run: |
+        ./gradlew \
+          :nessie-quarkus:compileAll \
+          :nessie-quarkus-cli:compileAll \
+          :nessie-events-quarkus:compileAll \
           --scan
 
     - name: Gradle / unit test
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: test --scan
+      run: ./gradlew test --scan
 
     - name: Gradle / check incl. integ-test
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: check --scan
+      run: ./gradlew check --scan
 
     - name: Gradle / assemble + publish local
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: assemble publishToMavenLocal --scan
+      run: ./gradlew assemble publishToMavenLocal --scan
 
     - name: Gradle / build tools integration tests
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: buildToolsIntegrationTest
+      run: ./gradlew buildToolsIntegrationTest
 
     - name: Capture Test Reports
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -74,11 +74,13 @@ jobs:
         git config --global user.email "nessie-release-workflow-noreply@projectnessie.org"
         git config --global user.name "Nessie Release Workflow [bot]"
 
-    - name: Bump to release version
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
         cache-disabled: true
-        arguments: :bumpVersion --bumpType ${{ env.BUMP_TYPE }} --bumpToRelease
+
+    - name: Bump to release version
+      run: ./gradlew :bumpVersion --bumpType ${{ env.BUMP_TYPE }} --bumpToRelease
 
     - name: Get release version
       run: |
@@ -129,10 +131,7 @@ jobs:
         fi
 
     - name: Patch changelog
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        cache-disabled: true
-        arguments: :patchChangelog
+      run: ./gradlew :patchChangelog
 
     - name: Update site
       shell: bash
@@ -200,9 +199,7 @@ jobs:
 
     # Bump to the next patch version as a SNAPSHOT
     - name: Bump to next patch version
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: :bumpVersion --bumpType patch
+      run: ./gradlew :bumpVersion --bumpType patch
 
     - name: Get next patch version
       run: |

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -28,11 +28,13 @@ jobs:
       - name: Setup Java, Gradle
         uses: ./.github/actions/dev-tool-java
 
-      - name: Gradle / setup
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-disabled: true
-          arguments: projects
+
+      - name: List projects
+        run: ./gradlew projects
 
       - name: Gradle / publish snapshot
         env:


### PR DESCRIPTION
See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated for details.

Fixes #8384