### PR TITLE
Simpler workaround for #8390

### DIFF
--- a/api/model-quarkus/build.gradle.kts
+++ b/api/model-quarkus/build.gradle.kts
@@ -20,11 +20,18 @@ import io.smallrye.openapi.gradleplugin.SmallryeOpenApiTask
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
-  id("nessie-conventions-client")
+  id("nessie-conventions-quarkus")
   id("nessie-jacoco")
-  alias(libs.plugins.annotations.stripper)
   alias(libs.plugins.smallrye.openapi)
 }
+
+extra["maven.name"] = "Nessie - Model - Variant only for Java 17+ consumers"
+
+description =
+  "nessie-model-jakarta is effectively the same as nessie-model, but it is _not_ a " +
+    "multi-release jar and retains the jakarta annotations in the canonical classes. " +
+    "Please note that this artifact will go away, once Nessie no longer support Java 8 for clients. " +
+    "Therefore, do _not_ refer to this artifact - it is only meant for consumption by Nessie-Quarkus."
 
 dependencies {
   implementation(platform(libs.jackson.bom))
@@ -44,23 +51,6 @@ dependencies {
   compileOnly(libs.immutables.builder)
   compileOnly(libs.immutables.value.annotations)
   annotationProcessor(libs.immutables.value.processor)
-
-  testCompileOnly(libs.microprofile.openapi)
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
-  testCompileOnly(libs.jakarta.ws.rs.api)
-  testCompileOnly(libs.javax.ws.rs)
-  testCompileOnly(libs.jakarta.validation.api)
-  testCompileOnly(libs.javax.validation.api)
-  testCompileOnly(libs.jakarta.annotation.api)
-  testCompileOnly(libs.findbugs.jsr305)
-
-  testImplementation(platform(libs.junit.bom))
-  testImplementation(libs.bundles.junit.testing)
-
-  intTestImplementation(platform(libs.testcontainers.bom))
-  intTestImplementation("org.testcontainers:testcontainers")
-  intTestImplementation(libs.awaitility)
 }
 
 extensions.configure<SmallryeOpenApiExtension> {
@@ -97,19 +87,3 @@ generateOpenApiSpec.configure {
 }
 
 artifacts { add(openapiSource.name, file("src/main/resources/META-INF")) }
-
-annotationStripper {
-  registerDefault().configure {
-    annotationsToDrop("^jakarta[.].+".toRegex())
-    unmodifiedClassesForJavaVersion = 11
-  }
-}
-
-tasks.named<Test>("intTest").configure {
-  dependsOn(generateOpenApiSpec)
-  systemProperty(
-    "openapiSchemaDir",
-    project.layout.buildDirectory.dir("generated/openapi/META-INF/openapi").get().toString()
-  )
-  systemProperty("redoclyConfDir", "$projectDir/src/redocly")
-}

--- a/api/model-quarkus/src/main
+++ b/api/model-quarkus/src/main
@@ -1,0 +1,1 @@
+../../model/src/main

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     api(project(":nessie-gc-repository-jdbc"))
     api(project(":nessie-gcs-testcontainer"))
     api(project(":nessie-model"))
+    api(project(":nessie-model-quarkus"))
     api(project(":nessie-jaxrs-testextension"))
     api(project(":nessie-jaxrs-tests"))
     api(project(":nessie-keycloak-testcontainer"))

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -14,6 +14,7 @@ nessie-events-quarkus=events/quarkus
 nessie-events-service=events/service
 nessie-events-spi=events/spi
 nessie-model=api/model
+nessie-model-quarkus=api/model-quarkus
 nessie-gc-base=gc/gc-base
 nessie-gc-base-tests=gc/gc-base-tests
 nessie-gc-repository-jdbc=gc/gc-repository-jdbc

--- a/servers/quarkus-cli/build.gradle.kts
+++ b/servers/quarkus-cli/build.gradle.kts
@@ -25,6 +25,13 @@ plugins {
 
 extra["maven.name"] = "Nessie - Quarkus CLI"
 
+// Need to use :nessie-model-jakarta instead of :nessie-model here, because Quarkus w/
+// resteasy-reactive does not work well with multi-release jars, but as long as we support Java 8
+// for clients, we have to live with :nessie-model producing an MR-jar. See
+// https://github.com/quarkusio/quarkus/issues/40236 and
+// https://github.com/projectnessie/nessie/issues/8390.
+configurations.all { exclude(group = "org.projectnessie.nessie", module = "nessie-model") }
+
 dependencies {
   implementation(project(":nessie-quarkus-common"))
   implementation(project(":nessie-services"))
@@ -33,7 +40,7 @@ dependencies {
   implementation(project(":nessie-versioned-spi"))
   implementation(project(":nessie-versioned-transfer"))
   implementation(project(":nessie-versioned-transfer-proto"))
-  implementation(project(":nessie-model"))
+  implementation(project(":nessie-model-quarkus"))
 
   implementation(project(":nessie-versioned-storage-store"))
   implementation(project(":nessie-versioned-storage-bigtable"))


### PR DESCRIPTION
This change effectively reverts the hacky approach from #8394 and uses a simpler approach.

Initially it looked that https://github.com/quarkusio/quarkus/issues/40236 could be fixed relatively soon, but handling MR-jars is a rabbit-hole. There might at some point be a solution/fix for MR-jars in Quarkus, but likely not soon.

So this change introduces a new artifact `:nessie-model-quarkus`, which is solely meant to be consumed by `:nessie-quarkus`. It is _not_ a MR file, so it retains the `jakarta.*` annotations, which prevents Quarkus/resteasy-reactive running into the MR-jar rabbit-hole.

`:nessie-model-quarkus` just builds a jar using the exact same sources and build file instructions as `:nessie-model`, so it can serve as a proper replacement for `:nessie-model` in `:nessie-quarkus`

Fixes #8390 (again)