### PR TITLE
OAuthClient: minor tweaks to the token exchange flow

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensFlow.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/RefreshTokensFlow.java
@@ -15,9 +15,6 @@
  */
 package org.projectnessie.client.auth.oauth2;
 
-import static org.projectnessie.client.auth.oauth2.OAuth2ClientUtils.tokenExpirationTime;
-
-import java.time.Instant;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -41,12 +38,5 @@ class RefreshTokensFlow extends AbstractFlow {
     RefreshTokensRequest.Builder request =
         RefreshTokensRequest.builder().refreshToken(currentTokens.getRefreshToken().getPayload());
     return invokeTokenEndpoint(request, RefreshTokensResponse.class);
-  }
-
-  private boolean isAboutToExpire(Token token) {
-    Instant now = config.getClock().get();
-    Instant expirationTime =
-        tokenExpirationTime(now, token, config.getDefaultRefreshTokenLifespan());
-    return expirationTime.isBefore(now.plus(config.getRefreshSafetyWindow()));
   }
 }

--- a/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
+++ b/api/client/src/test/java/org/projectnessie/client/auth/oauth2/TestOAuth2Client.java
@@ -624,7 +624,7 @@ class TestOAuth2Client {
         soft.assertThat(((TokensExchangeRequest) request).getActorToken()).isNull();
         soft.assertThat(((TokensExchangeRequest) request).getActorTokenType()).isNull();
         soft.assertThat(((TokensExchangeRequest) request).getRequestedTokenType())
-            .isEqualTo(TokenExchangeFlow.REFRESH_TOKEN_ID);
+            .isEqualTo(TokenExchangeFlow.ACCESS_TOKEN_ID);
         soft.assertThat(((PublicClientRequest) request).getClientId()).isNull();
         response = getTokensExchangeResponse();
       } else if (grantType.equals(GrantType.AUTHORIZATION_CODE.canonicalName())) {
@@ -778,7 +778,7 @@ class TestOAuth2Client {
 
   private ImmutableTokensExchangeResponse getTokensExchangeResponse() {
     return ImmutableTokensExchangeResponse.builder()
-        .issuedTokenType(TokenExchangeFlow.REFRESH_TOKEN_ID)
+        .issuedTokenType(TokenExchangeFlow.ACCESS_TOKEN_ID)
         .tokenType("bearer")
         .accessTokenPayload("access-exchanged")
         .accessTokenExpirationTime(now.plus(Duration.ofHours(3)))
@@ -833,7 +833,7 @@ class TestOAuth2Client {
         .isAfterOrEqualTo(now.plus(Duration.ofDays(3)).minusSeconds(10));
     soft.assertThat(tokens.getScope()).isEqualTo("test");
     soft.assertThat(tokens.getExtraParameters()).containsExactly(entry("foo", "bar"));
-    soft.assertThat(tokens.getIssuedTokenType()).isEqualTo(TokenExchangeFlow.REFRESH_TOKEN_ID);
+    soft.assertThat(tokens.getIssuedTokenType()).isEqualTo(TokenExchangeFlow.ACCESS_TOKEN_ID);
   }
 
   private OAuth2ClientConfig.Builder configBuilder(HttpTestServer server, boolean discovery) {


### PR DESCRIPTION
This PR comes from investigation of #8331: in some cases, Keycloak stops updating the expiration time of returned access tokens (maybe a bug). As a consequence, the token eventually expires, and the client recovers by re-fetching using the initial grant. However, if in that tiny window the expired token is used, that would result in an HTTP 401. This happens sometimes in `ITOAuthClient`. Here are some log from the tests that show this behavior:

```
// initial grant
13:33:55.434 - Fetching new tokens using CLIENT_CREDENTIALS
13:33:55.558 - Scheduling token refresh in PT4.995602S

// token exchanges
13:34:00.559 - Refreshing tokens using TOKEN_EXCHANGE
13:34:00.619 - Successfully renewed tokens, access exp: 2024-04-29T11:34:10.618557Z, refresh exp: null
13:34:00.619 - Scheduling token refresh in PT4.999249S
13:34:05.623 - Refreshing tokens using TOKEN_EXCHANGE
13:34:05.650 - Successfully renewed tokens, access exp: 2024-04-29T11:34:15.649901Z, refresh exp: null
13:34:05.650 - Scheduling token refresh in PT4.999807S
13:34:10.650 - Refreshing tokens using TOKEN_EXCHANGE

// returned access tokens have same expiration time as before => client starts "panicking"
13:34:10.673 - Successfully renewed tokens, access exp: 2024-04-29T11:34:15.673563Z, refresh exp: null
13:34:10.673 - Scheduling token refresh in PT1S
13:34:11.674 - Refreshing tokens using TOKEN_EXCHANGE
13:34:11.706 - Successfully renewed tokens, access exp: 2024-04-29T11:34:15.706808Z, refresh exp: null
13:34:11.707 - Scheduling token refresh in PT1S
13:34:12.711 - Refreshing tokens using TOKEN_EXCHANGE
13:34:12.733 - Successfully renewed tokens, access exp: 2024-04-29T11:34:15.733798Z, refresh exp: null
13:34:12.734 - Scheduling token refresh in PT1S
13:34:13.739 - Refreshing tokens using TOKEN_EXCHANGE
13:34:13.762 - Successfully renewed tokens, access exp: 2024-04-29T11:34:15.762344Z, refresh exp: null
13:34:13.763 - Scheduling token refresh in PT1S
13:34:14.764 - Refreshing tokens using TOKEN_EXCHANGE

// Returned token is near expiration
13:34:14.787 - Successfully renewed tokens, access exp: 2024-04-29T11:34:15.787490Z, refresh exp: null
13:34:14.787 - Scheduling token refresh in PT1S

// verification client tries to use an expired token and fails
13:34:15.502 WARN  [org.keycloak.events] (executor-thread-1) type="PERMISSION_TOKEN_ERROR", realmId="3649db18-5886-4dce-9050-644d079dcd97", clientId="Private1", userId="null", ipAddress="172.17.0.1", error="invalid_token", auth_method="oauth_credentials", grant_type="urn:ietf:params:oauth:grant-type:uma-ticket"

// client tries to refresh the token and fails, then trigger an initial fetch
13:34:15.787 - Refreshing tokens using TOKEN_EXCHANGE
13:34:15.800 WARN  [org.keycloak.events] (executor-thread-1) type="TOKEN_EXCHANGE_ERROR", realmId="3649db18-5886-4dce-9050-644d079dcd97", clientId="Private1", userId="null", ipAddress="172.17.0.1", error="invalid_token", reason="subject_token validation failure", auth_method="token_exchange", grant_type="urn:ietf:params:oauth:grant-type:token-exchange", client_auth_method="client-secret"
13:34:15.808 - Fetching new tokens using CLIENT_CREDENTIALS

// client recovers
13:34:15.828 - Successfully renewed tokens, access exp: 2024-04-29T11:34:25.828119Z, refresh exp: null
13:34:15.828 - Scheduling token refresh in PT4.999682S
```

This PR also changes the requested token type to access token. Keycloak accepts both types (access or refresh). But since we only use token exchange when refresh tokens are disabled, it doesn't make sense to request a refresh token.