### PR TITLE
OAuthClient: consider zero as null for refresh_expires_in field

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/auth/oauth2/JacksonSerializers.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/oauth2/JacksonSerializers.java
@@ -56,7 +56,9 @@ class JacksonSerializers {
     public Instant deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       if (p.currentToken().isNumeric()) {
         int seconds = p.getValueAsInt();
-        return Instant.now().plusSeconds(seconds);
+        if (seconds != 0) {
+          return Instant.now().plusSeconds(seconds);
+        }
       }
       return null;
     }
@@ -89,7 +91,9 @@ class JacksonSerializers {
     public Duration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       if (p.currentToken().isNumeric()) {
         int seconds = p.getValueAsInt();
-        return Duration.ofSeconds(seconds);
+        if (seconds != 0) {
+          return Duration.ofSeconds(seconds);
+        }
       }
       return null;
     }


### PR DESCRIPTION
This PR is an outcome of #8331 investigation: Keycloak sends "0" for `refresh_expires_in` when there is no refresh token.

See:

https://github.com/keycloak/keycloak/blob/ad32896725b05bc4c6d274395268c8eda6459037/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java#L231-L232