### PR TITLE
Build: Prevent log4j2 to register its MBean

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,11 @@ org.gradle.jvmargs=\
   --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+
+# Log4j2 registers an MBean, which has multiple issues when used via a Gradle plugin:
+#  * Classes (and class loaders) are held across the lifecycle of a single build,
+#    causing memory issues.
+#  * Simply leads to an exception logged during the build:
+#     javax.management.InstanceAlreadyExistsException: org.apache.logging.log4j2:type=...
+# Log4j2 is used via JBoss logging via Smallrye Config via Smallrye OpenAPI generator.
+systemProp.log4j2.disableJmx=true


### PR DESCRIPTION
Log4j2 registers an MBean, which has multiple issues when used via a Gradle plugin:
 * Classes (and class loaders) are held across the lifecycle of a single build, causing memory issues.
 * Simply leads to an exception logged during the build: javax.management.InstanceAlreadyExistsException: org.apache.logging.log4j2:type=... Log4j2 is used via JBoss logging via Smallrye Config via Smallrye OpenAPI generator.