### PR TITLE
Build: fix a bunch of deprecation warnings and no non-consumed apt arg

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/NessieClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieClientBuilder.java
@@ -18,7 +18,6 @@ package org.projectnessie.client;
 import static java.util.Collections.singleton;
 import static org.projectnessie.client.NessieConfigConstants.CONF_CONNECT_TIMEOUT;
 import static org.projectnessie.client.NessieConfigConstants.CONF_ENABLE_API_COMPATIBILITY_CHECK;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_CLIENT_NAME;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_DISABLE_COMPRESSION;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_SNI_HOSTS;
@@ -190,6 +189,7 @@ public interface NessieClientBuilder {
    *   .withCancellationFuture(cancel);
    * }</pre>
    */
+  @SuppressWarnings("unused")
   @CanIgnoreReturnValue
   NessieClientBuilder withCancellationFuture(CompletionStage<?> cancellationFuture);
 
@@ -214,7 +214,8 @@ public interface NessieClientBuilder {
     NessieClientConfigSource configSource = mainConfigSource.fallbackTo(defaultConfigSources());
     String clientName = configSource.getValue(CONF_NESSIE_CLIENT_NAME);
     @SuppressWarnings("deprecation")
-    String clientBuilderImpl = configSource.getValue(CONF_NESSIE_CLIENT_BUILDER_IMPL);
+    String clientBuilderImpl =
+        configSource.getValue(NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL);
     return createClientBuilder(clientName, clientBuilderImpl).fromConfig(configSource.asFunction());
   }
 

--- a/api/client/src/main/java/org/projectnessie/client/auth/BasicAuthenticationProvider.java
+++ b/api/client/src/main/java/org/projectnessie/client/auth/BasicAuthenticationProvider.java
@@ -15,12 +15,10 @@
  */
 package org.projectnessie.client.auth;
 
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_PASSWORD;
-import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_USERNAME;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.function.Function;
+import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.http.HttpAuthentication;
 import org.projectnessie.client.http.HttpClient;
 import org.projectnessie.client.http.RequestContext;
@@ -47,12 +45,12 @@ public class BasicAuthenticationProvider implements NessieAuthenticationProvider
 
   @Override
   public HttpAuthentication build(Function<String, String> configSupplier) {
-    String username = configSupplier.apply(CONF_NESSIE_USERNAME);
+    String username = configSupplier.apply(NessieConfigConstants.CONF_NESSIE_USERNAME);
     if (username == null) {
       username = configSupplier.apply("nessie.username"); // legacy property name
     }
 
-    String password = configSupplier.apply(CONF_NESSIE_PASSWORD);
+    String password = configSupplier.apply(NessieConfigConstants.CONF_NESSIE_PASSWORD);
     if (password == null) {
       password = configSupplier.apply("nessie.password"); // legacy property name
     }

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -55,6 +55,7 @@ public interface HttpClient extends AutoCloseable {
   interface Builder {
     Builder copy();
 
+    @SuppressWarnings("unused")
     @CanIgnoreReturnValue
     Builder setClientSpec(int clientSpec);
 
@@ -88,6 +89,7 @@ public interface HttpClient extends AutoCloseable {
     @CanIgnoreReturnValue
     Builder setFollowRedirects(String followRedirects);
 
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @CanIgnoreReturnValue
     @Deprecated
     Builder setForceUrlConnectionClient(boolean forceUrlConnectionClient);

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -57,6 +57,7 @@ public class HttpClientBuilder extends NessieHttpClientBuilderImpl {
     return (HttpClientBuilder) super.withUri(uri);
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public HttpClientBuilder fromSystemProperties() {
     return (HttpClientBuilder) super.fromSystemProperties();

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -160,6 +160,7 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
   }
 
   @Override
+  @Deprecated
   public HttpClient.Builder setForceUrlConnectionClient(boolean forceUrlConnectionClient) {
     this.forceUrlConnectionClient = forceUrlConnectionClient;
     return this;

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
@@ -185,6 +185,7 @@ public class NessieHttpClientBuilderImpl
     return this;
   }
 
+  @SuppressWarnings("deprecation")
   @CanIgnoreReturnValue
   @Override
   @Deprecated

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheHttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheHttpClient.java
@@ -17,6 +17,7 @@ package org.projectnessie.client.http.impl.apache;
 
 import java.io.IOException;
 import java.net.URI;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -67,13 +68,16 @@ final class ApacheHttpClient implements HttpClient {
             .build();
 
     connManager.setDefaultSocketConfig(socketConfig);
-    connManager.setValidateAfterInactivity(TimeValue.ofSeconds(10));
+    connManager.setDefaultConnectionConfig(
+        ConnectionConfig.custom()
+            .setValidateAfterInactivity(TimeValue.ofSeconds(10))
+            .setConnectTimeout(Timeout.ofMilliseconds(config.getConnectionTimeoutMillis()))
+            .build());
     connManager.setMaxTotal(100);
     connManager.setDefaultMaxPerRoute(10);
 
     RequestConfig defaultRequestConfig =
         RequestConfig.custom()
-            .setConnectTimeout(Timeout.ofMilliseconds(config.getConnectionTimeoutMillis()))
             .setResponseTimeout(Timeout.ofMilliseconds(config.getReadTimeoutMillis()))
             .setRedirectsEnabled(true)
             .setCircularRedirectsAllowed(false)

--- a/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheRequest.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/impl/apache/ApacheRequest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import org.apache.hc.client5.http.ConnectTimeoutException;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
@@ -72,9 +72,9 @@ final class ApacheRequest extends BaseHttpRequest {
       request.setEntity(entity);
     }
 
-    CloseableHttpResponse response = null;
+    ClassicHttpResponse response = null;
     try {
-      response = client.client.execute(request);
+      response = client.client.executeOpen(null, request, null);
 
       ApacheResponseContext responseContext = new ApacheResponseContext(response, uri);
 

--- a/api/client/src/main/java/org/projectnessie/client/rest/v1/HttpGetEntries.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/v1/HttpGetEntries.java
@@ -34,6 +34,7 @@ final class HttpGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
   }
 
   @Override
+  @Deprecated
   public GetEntriesBuilder namespaceDepth(Integer namespaceDepth) {
     this.namespaceDepth = namespaceDepth;
     return this;

--- a/api/client/src/main/java/org/projectnessie/client/rest/v1/HttpMergeReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/v1/HttpMergeReference.java
@@ -44,6 +44,7 @@ final class HttpMergeReference extends BaseMergeReferenceBuilder {
 
   @Override
   public MergeResponse merge() throws NessieNotFoundException, NessieConflictException {
+    @SuppressWarnings("deprecation")
     ImmutableMerge.Builder merge =
         ImmutableMerge.builder()
             .fromHash(fromHash)

--- a/api/client/src/main/java/org/projectnessie/client/rest/v1/HttpTransplantCommits.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/v1/HttpTransplantCommits.java
@@ -31,6 +31,7 @@ final class HttpTransplantCommits extends BaseTransplantCommitsBuilder {
 
   @Override
   public MergeResponse transplant() throws NessieNotFoundException, NessieConflictException {
+    @SuppressWarnings("deprecation")
     ImmutableTransplant.Builder transplant =
         ImmutableTransplant.builder()
             .fromRefName(fromRefName)

--- a/api/client/src/main/java/org/projectnessie/client/rest/v2/HttpGetEntries.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/v2/HttpGetEntries.java
@@ -35,6 +35,7 @@ final class HttpGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
   }
 
   @Override
+  @Deprecated
   public GetEntriesBuilder namespaceDepth(Integer namespaceDepth) {
     throw new UnsupportedOperationException("namespaceDepth is not supported for Nessie API v2");
   }

--- a/api/client/src/main/java/org/projectnessie/client/rest/v2/HttpMergeReference.java
+++ b/api/client/src/main/java/org/projectnessie/client/rest/v2/HttpMergeReference.java
@@ -41,6 +41,7 @@ final class HttpMergeReference extends BaseMergeReferenceBuilder {
 
   @Override
   public MergeResponse merge() throws NessieNotFoundException, NessieConflictException {
+    @SuppressWarnings("deprecation")
     ImmutableMerge.Builder merge =
         ImmutableMerge.builder()
             .fromHash(fromHash)

--- a/api/client/src/testFixtures/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeResourceOwnerEmulator.java
+++ b/api/client/src/testFixtures/java/org/projectnessie/client/auth/oauth2/AuthorizationCodeResourceOwnerEmulator.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.HashSet;
@@ -93,7 +94,7 @@ public class AuthorizationCodeResourceOwnerEmulator extends InteractiveResourceO
   }
 
   /** Emulate browser being redirected to callback URL. */
-  private void invokeCallbackUrl(URL callbackUrl) throws IOException {
+  private void invokeCallbackUrl(URL callbackUrl) throws Exception {
     LOGGER.info("Opening callback URL...");
     assertThat(callbackUrl)
         .hasPath(AuthorizationCodeFlow.CONTEXT_PATH)
@@ -103,15 +104,15 @@ public class AuthorizationCodeResourceOwnerEmulator extends InteractiveResourceO
     if (code != null) {
       Map<String, String> params = HttpUtils.parseQueryString(callbackUrl.getQuery());
       callbackUrl =
-          new URL(
-              callbackUrl.getProtocol(),
-              callbackUrl.getHost(),
-              callbackUrl.getPort(),
-              callbackUrl.getPath()
-                  + "?code="
-                  + URLEncoder.encode(code, "UTF-8")
-                  + "&state="
-                  + params.get("state"));
+          new URI(
+                  callbackUrl.getProtocol(),
+                  null,
+                  callbackUrl.getHost(),
+                  callbackUrl.getPort(),
+                  callbackUrl.getPath(),
+                  "code=" + URLEncoder.encode(code, "UTF-8") + "&state=" + params.get("state"),
+                  null)
+              .toURL();
     }
     HttpURLConnection conn = (HttpURLConnection) callbackUrl.openConnection();
     conn.setRequestMethod("GET");

--- a/api/model/src/main/java/org/projectnessie/api/v1/params/RefLogParams.java
+++ b/api/model/src/main/java/org/projectnessie/api/v1/params/RefLogParams.java
@@ -30,6 +30,7 @@ import org.projectnessie.model.Validation;
  * <p>For easier usage of this class, there is {@link RefLogParams#builder()}, which allows
  * configuring/setting the different parameters.
  */
+@SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
 @Deprecated
 public class RefLogParams extends AbstractParams<RefLogParams> {
 
@@ -78,6 +79,7 @@ public class RefLogParams extends AbstractParams<RefLogParams> {
   @jakarta.ws.rs.QueryParam("filter")
   private String filter;
 
+  @SuppressWarnings("unused")
   public RefLogParams() {}
 
   @org.immutables.builder.Builder.Constructor

--- a/api/model/src/main/java/org/projectnessie/model/LogResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/LogResponse.java
@@ -55,6 +55,7 @@ public interface LogResponse extends PaginatedResponse {
     @jakarta.validation.constraints.NotNull
     CommitMeta getCommitMeta();
 
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @JsonView(Views.V1.class)
     @Deprecated // for removal - duplicated in CommitMeta
     @JsonInclude(Include.NON_EMPTY)

--- a/api/model/src/main/java/org/projectnessie/model/RefLogResponse.java
+++ b/api/model/src/main/java/org/projectnessie/model/RefLogResponse.java
@@ -40,6 +40,7 @@ public interface RefLogResponse extends PaginatedResponse {
   @Schema(type = SchemaType.OBJECT, title = "RefLogResponseEntry", deprecated = true, hidden = true)
   @JsonSerialize(as = ImmutableRefLogResponseEntry.class)
   @JsonDeserialize(as = ImmutableRefLogResponseEntry.class)
+  @Deprecated // Not supported since API v2
   interface RefLogResponseEntry {
     static ImmutableRefLogResponseEntry.Builder builder() {
       return ImmutableRefLogResponseEntry.builder();

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/RefLogParamsTest.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/RefLogParamsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation")
 public class RefLogParamsTest {
 
   @Test

--- a/api/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/api/v1/params/TestParamObjectsSerialization.java
@@ -31,7 +31,10 @@ import org.projectnessie.model.TestModelObjectsSerialization;
  */
 public class TestParamObjectsSerialization extends TestModelObjectsSerialization {
 
-  @SuppressWarnings("unused") // called by JUnit framework based on annotations in superclass
+  @SuppressWarnings({
+    "unused",
+    "deprecation"
+  }) // called by JUnit framework based on annotations in superclass
   static List<Case> goodCases() {
     final String branchName = "testBranch";
 

--- a/api/model/src/test/java/org/projectnessie/api/v2/params/TestParamObjectsSerialization.java
+++ b/api/model/src/test/java/org/projectnessie/api/v2/params/TestParamObjectsSerialization.java
@@ -31,7 +31,10 @@ import org.projectnessie.model.TestModelObjectsSerialization;
  */
 public class TestParamObjectsSerialization extends TestModelObjectsSerialization {
 
-  @SuppressWarnings("unused") // called by JUnit framework based on annotations in superclass
+  @SuppressWarnings({
+    "unused",
+    "deprecation"
+  }) // called by JUnit framework based on annotations in superclass
   static List<Case> goodCases() {
     final String branchName = "testBranch";
 

--- a/api/model/src/test/java/org/projectnessie/model/TestEnums.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestEnums.java
@@ -39,10 +39,7 @@ import org.projectnessie.model.MergeResponse.ContentKeyDetails;
 public class TestEnums {
   @InjectSoftAssertions protected SoftAssertions soft;
 
-  @SuppressWarnings({
-    "unused",
-    "JUnit3StyleTestMethodInJUnit4Class"
-  }) // IntelliJ false positive warnings :(
+  @SuppressWarnings("unused")
   abstract class AbstractEnum<E extends Enum<E>> {
     final Function<String, E> parse;
     final E unknownValue;
@@ -161,6 +158,7 @@ public class TestEnums {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Nested
   public class TestContentKeyConflict extends AbstractEnum<ContentKeyConflict> {
     TestContentKeyConflict() {

--- a/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
+++ b/servers/services/src/main/java/org/projectnessie/services/cel/CELUtil.java
@@ -29,7 +29,6 @@ import org.projectnessie.model.Namespace;
 import org.projectnessie.model.Operation;
 import org.projectnessie.model.Operation.Delete;
 import org.projectnessie.model.Operation.Put;
-import org.projectnessie.model.RefLogResponse;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.ReferenceMetadata;
 import org.projectnessie.versioned.KeyEntry;
@@ -51,7 +50,6 @@ public final class CELUtil {
   public static final String VAR_ROLE = "role";
   public static final String VAR_OP = "op";
   public static final String VAR_OPERATIONS = "operations";
-  public static final String VAR_REFLOG = "reflog";
 
   public static final List<Decl> REFERENCES_DECLARATIONS =
       ImmutableList.of(
@@ -87,10 +85,6 @@ public final class CELUtil {
 
   public static final List<Object> CONTENT_KEY_TYPES = ImmutableList.of(KeyedEntityForCel.class);
 
-  @SuppressWarnings("deprecation")
-  public static final List<Object> REFLOG_TYPES =
-      ImmutableList.of(RefLogResponse.RefLogResponseEntry.class);
-
   public static final List<Object> REFERENCES_TYPES =
       ImmutableList.of(CommitMeta.class, ReferenceMetadata.class, Reference.class);
 
@@ -99,12 +93,6 @@ public final class CELUtil {
   public static final CommitMeta EMPTY_COMMIT_META = CommitMeta.fromMessage("");
   public static final ReferenceMetadata EMPTY_REFERENCE_METADATA =
       ImmutableReferenceMetadata.builder().commitMetaOfHEAD(EMPTY_COMMIT_META).build();
-
-  @SuppressWarnings("deprecation")
-  public static final List<Decl> REFLOG_DECLARATIONS =
-      ImmutableList.of(
-          Decls.newVar(
-              VAR_REFLOG, Decls.newObjectType(RefLogResponse.RefLogResponseEntry.class.getName())));
 
   private CELUtil() {}
 

--- a/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
+++ b/servers/services/src/main/java/org/projectnessie/services/impl/TreeApiImpl.java
@@ -808,6 +808,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
     }
   }
 
+  @SuppressWarnings("deprecation")
   private MergeResponse createResponse(Boolean fetchAdditionalInfo, MergeResult<Commit> result) {
     Function<Hash, String> hashToString = h -> h != null ? h.asString() : null;
     ImmutableMergeResponse.Builder response =
@@ -921,7 +922,7 @@ public class TreeApiImpl extends BaseApiImpl implements TreeService {
 
       // apply filter as early as possible to avoid work (i.e. content loading, authz checks)
       // for entries that we will eventually throw away
-      final int namespaceFilterDepth = namespaceDepth == null ? 0 : namespaceDepth.intValue();
+      final int namespaceFilterDepth = namespaceDepth == null ? 0 : namespaceDepth;
       if (namespaceFilterDepth > 0) {
         BiPredicate<ContentKey, Content.Type> depthFilter =
             (key, type) -> key.getElementCount() >= namespaceFilterDepth;

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestCommitLog.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestCommitLog.java
@@ -216,7 +216,7 @@ public abstract class AbstractTestCommitLog extends BaseTestServiceImpl {
     soft.assertThat(initialCommitTime).isNotNull();
     Instant lastCommitTime = log.get(0).getCommitMeta().getCommitTime();
     soft.assertThat(lastCommitTime).isNotNull();
-    Instant fiveMinLater = initialCommitTime.plus(5, ChronoUnit.MINUTES);
+    Instant fiveMinLater = requireNonNull(initialCommitTime).plus(5, ChronoUnit.MINUTES);
 
     log =
         commitLog(
@@ -419,6 +419,7 @@ public abstract class AbstractTestCommitLog extends BaseTestServiceImpl {
         .containsExactlyElementsOf(allMessages);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void commitLogExtended() throws Exception {
     String branch = "commitLogExtended";

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestMergeTransplant.java
@@ -128,6 +128,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
         throws NessieNotFoundException, NessieConflictException;
   }
 
+  @SuppressWarnings("deprecation")
   private void mergeTransplant(
       boolean verifyAdditionalParents,
       MergeTransplantActor actor,
@@ -572,6 +573,7 @@ public abstract class AbstractTestMergeTransplant extends BaseTestServiceImpl {
                     returnConflictAsResult));
   }
 
+  @SuppressWarnings("deprecation")
   private void testMergeTransplantWithCustomModes(MergeTransplantActor actor)
       throws BaseNessieClientServerException {
     Branch target = createBranch("target");

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientImpl.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedClientImpl.java
@@ -162,21 +162,25 @@ final class CombinedClientImpl implements NessieApiV2 {
   }
 
   @Override
+  @Deprecated
   public AssignTagBuilder assignTag() {
     return new CombinedAssignTag(treeApi);
   }
 
   @Override
+  @Deprecated
   public AssignBranchBuilder assignBranch() {
     return new CombinedAssignBranch(treeApi);
   }
 
   @Override
+  @Deprecated
   public DeleteTagBuilder deleteTag() {
     return new CombinedDeleteTag(treeApi);
   }
 
   @Override
+  @Deprecated
   public DeleteBranchBuilder deleteBranch() {
     return new CombinedDeleteBranch(treeApi);
   }

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetEntries.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedGetEntries.java
@@ -33,6 +33,7 @@ final class CombinedGetEntries extends BaseGetEntriesBuilder<EntriesParams> {
   }
 
   @Override
+  @Deprecated
   public GetEntriesBuilder namespaceDepth(Integer namespaceDepth) {
     throw new UnsupportedOperationException("namespaceDepth is not supported for Nessie API v2");
   }

--- a/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedMergeReference.java
+++ b/testing/combined-cs/src/main/java/org/projectnessie/nessie/combined/CombinedMergeReference.java
@@ -41,6 +41,7 @@ final class CombinedMergeReference extends BaseMergeReferenceBuilder {
 
   @Override
   public MergeResponse merge() throws NessieNotFoundException, NessieConflictException {
+    @SuppressWarnings("deprecation")
     ImmutableMerge.Builder merge =
         ImmutableMerge.builder()
             .fromHash(fromHash)

--- a/testing/object-storage-mock/src/test/java/org/projectnessie/objectstoragemock/TestMockServer.java
+++ b/testing/object-storage-mock/src/test/java/org/projectnessie/objectstoragemock/TestMockServer.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.objectstoragemock;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.BooleanNode;
@@ -25,10 +27,10 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URLConnection;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -68,7 +70,8 @@ public class TestMockServer extends AbstractObjectStorageMockServer {
     soft.assertThat(result)
         .extracting(ListAllMyBucketsResult::buckets)
         .extracting(Buckets::buckets)
-        .asList()
+        .asInstanceOf(
+            InstanceOfAssertFactories.list(org.projectnessie.objectstoragemock.s3.Bucket.class))
         .map(org.projectnessie.objectstoragemock.s3.Bucket.class::cast)
         .map(org.projectnessie.objectstoragemock.s3.Bucket::name)
         .containsExactlyInAnyOrder(BUCKET, "secret");
@@ -107,7 +110,7 @@ public class TestMockServer extends AbstractObjectStorageMockServer {
         ImmutableMockObject.builder()
             .contentLength(content.length())
             .contentType("text/plain")
-            .writer((range, w) -> w.write(content.getBytes(StandardCharsets.UTF_8)))
+            .writer((range, w) -> w.write(content.getBytes(UTF_8)))
             .build();
     objects.put(MY_OBJECT_KEY, obj);
 
@@ -166,7 +169,7 @@ public class TestMockServer extends AbstractObjectStorageMockServer {
       return JSON_MAPPER.readValue(out.toByteArray(), type);
     }
     if (type.isAssignableFrom(String.class)) {
-      return (T) out.toString("UTF-8");
+      return (T) out.toString(UTF_8);
     }
     return (T) out.toByteArray();
   }

--- a/testing/object-storage-mock/src/test/java/org/projectnessie/objectstoragemock/TestWithS3Client.java
+++ b/testing/object-storage-mock/src/test/java/org/projectnessie/objectstoragemock/TestWithS3Client.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -107,6 +108,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
     }
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void assumeRole() {
     createServer(b -> {});
@@ -147,6 +149,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
         .containsExactly("access-key-id", "secret-access-key");
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void listBuckets() {
     createServer(
@@ -156,7 +159,8 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
 
     soft.assertThat(s3.listBuckets())
         .extracting(ListBucketsResponse::buckets)
-        .asList()
+        .asInstanceOf(
+            InstanceOfAssertFactories.list(software.amazon.awssdk.services.s3.model.Bucket.class))
         .map(software.amazon.awssdk.services.s3.model.Bucket.class::cast)
         .map(software.amazon.awssdk.services.s3.model.Bucket::name)
         .containsExactlyInAnyOrder(BUCKET, "secret");
@@ -169,6 +173,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
         .isInstanceOf(NoSuchBucketException.class);
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void listObjectsV2() {
 
@@ -233,6 +238,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
         .isEqualTo(100_000);
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void headObject() {
     Map<String, MockObject> objects = new HashMap<>();
@@ -262,6 +268,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
             obj.contentLength(), '"' + obj.etag() + '"', obj.contentType(), obj.lastModified());
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void deleteObject() {
     Map<String, MockObject> objects = new HashMap<>();
@@ -289,7 +296,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
     soft.assertThat(s3.deleteObject(b -> b.bucket(BUCKET).key(MY_OBJECT_KEY))).isNotNull();
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "resource"})
   @Test
   public void batchDeleteObject() {
     Map<String, MockObject> objects = new HashMap<>();
@@ -331,6 +338,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
         .isNotNull();
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void getObject() {
     Map<String, MockObject> objects = new HashMap<>();
@@ -382,6 +390,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
         .isEqualTo(304);
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void putObject() {
     AtomicReference<String> writtenKey = new AtomicReference<>();
@@ -438,6 +447,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
     soft.assertThat(writtenData.get()).asString().isEqualTo("Hello World");
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void putObjectNoContentType() {
     AtomicReference<String> writtenKey = new AtomicReference<>();
@@ -490,6 +500,7 @@ public class TestWithS3Client extends AbstractObjectStorageMockServer {
     soft.assertThat(writtenData.get()).asString().isEqualTo("Hello World");
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void heapStorage() throws Exception {
     createServer(b -> b.putBuckets(BUCKET, newHeapStorageBucket().bucket()));

--- a/versioned/storage/common/build.gradle.kts
+++ b/versioned/storage/common/build.gradle.kts
@@ -55,10 +55,6 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-api")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 
-  testCompileOnly(libs.immutables.builder)
-  testCompileOnly(libs.immutables.value.annotations)
-  testAnnotationProcessor(libs.immutables.value.processor)
-
   testImplementation(project(":nessie-versioned-storage-testextension"))
   testImplementation(project(":nessie-versioned-storage-inmemory"))
   testImplementation(project(":nessie-versioned-storage-common-tests"))


### PR DESCRIPTION
* Adds the immutables APT to prevent the unnecessary warning about the not consumed APT command line option.
* Add `-Xlint:deprecation` for Java 9+ (see comment in `nessie-java.gradle.kts`)
* Fix a bunch of deprecation warnings
* Fix a few other compiler & IDE warnings