### PR TITLE
Build: Prevent unnecessary scala compile warning

### DIFF
--- a/build-logic/src/main/kotlin/nessie-conventions-scala.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-scala.gradle.kts
@@ -29,4 +29,7 @@ plugins {
 
 tasks.withType<JavaCompile>().configureEach { options.release = 11 }
 
-tasks.withType<ScalaCompile>().configureEach { options.release = 11 }
+tasks.withType<ScalaCompile>().configureEach {
+  options.release = 11
+  scalaCompileOptions.additionalParameters.add("-release:11")
+}

--- a/build-logic/src/main/kotlin/nessie-conventions-spark.gradle.kts
+++ b/build-logic/src/main/kotlin/nessie-conventions-spark.gradle.kts
@@ -29,4 +29,7 @@ plugins {
 
 tasks.withType<JavaCompile>().configureEach { options.release = 8 }
 
-tasks.withType<ScalaCompile>().configureEach { options.release = 8 }
+tasks.withType<ScalaCompile>().configureEach {
+  options.release = 8
+  scalaCompileOptions.additionalParameters.add("-release:8")
+}


### PR DESCRIPTION
Currently, `ScalaCompile` emits the warning `[Warn] : -target is deprecated: Use -release instead to compile against the correct platform API.`, although nothing sets a target release/compatibility. It's a Scala compiler / Gradle annoyance.

This change adds the Scala compile specific option as well.