### PR TITLE
Build: Remove no longer necessary Java toolchain "constraint"

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -31,6 +31,4 @@ dependencies {
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 
-java { toolchain { languageVersion = JavaLanguageVersion.of(11) } }
-
 tasks.withType<Test>().configureEach { useJUnitPlatform() }


### PR DESCRIPTION
This also eliminates a possible build warning.