### PR TITLE
Doc-gen: traverse really all supertypes

### DIFF
--- a/tools/doc-generator/doclet/src/test/java/org/projectnessie/nessie/docgen/TestDocGenTool.java
+++ b/tools/doc-generator/doclet/src/test/java/org/projectnessie/nessie/docgen/TestDocGenTool.java
@@ -71,6 +71,9 @@ public class TestDocGenTool {
 
     Path fileMyPrefix = dir.resolve("smallrye-my_prefix.md");
     Path fileMyTypes = dir.resolve("smallrye-my_types.md");
+    Path fileExtremelyNested = dir.resolve("smallrye-extremely_nested.md");
+    Path fileVeryNested = dir.resolve("smallrye-very_nested.md");
+
     soft.assertThat(fileMyPrefix)
         .isRegularFile()
         .content()
@@ -141,5 +144,29 @@ public class TestDocGenTool {
                 + "| `my.types.some-duration` |  | `Duration` | A duration of something.  |\n"
                 + "| `my.types.config-option-foo` |  | `String` | Something that configures something.  |\n"
                 + "| `my.types.some-int-thing` |  | `int` | Something int-ish.  |\n");
+    soft.assertThat(fileExtremelyNested)
+        .isRegularFile()
+        .content()
+        .isEqualTo(
+            "| Property | Default Value | Type | Description |\n"
+                + "|----------|---------------|------|-------------|\n"
+                + "| `extremely.nested.extremely-nested` |  | `int` | Extremely nested.  |\n"
+                + "| `extremely.nested.nested-a1` |  | `int` | A1.  |\n"
+                + "| `extremely.nested.nested-a2` |  | `int` | A2.  |\n"
+                + "| `extremely.nested.nested-b1` |  | `int` | B1.  |\n"
+                + "| `extremely.nested.nested-a11` |  | `int` | A11.  |\n"
+                + "| `extremely.nested.nested-b12` |  | `int` | B12.  |\n");
+    soft.assertThat(fileVeryNested)
+        .isRegularFile()
+        .content()
+        .isEqualTo(
+            "| Property | Default Value | Type | Description |\n"
+                + "|----------|---------------|------|-------------|\n"
+                + "| `very.nested.very-nested` |  | `int` | Very nested.  |\n"
+                + "| `very.nested.nested-a1` |  | `int` | A1.  |\n"
+                + "| `very.nested.nested-a2` |  | `int` | A2.  |\n"
+                + "| `very.nested.nested-b1` |  | `int` | B1.  |\n"
+                + "| `very.nested.nested-a11` |  | `int` | A11.  |\n"
+                + "| `very.nested.nested-b12` |  | `int` | B12.  |\n");
   }
 }

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/ExtremelyNested.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/ExtremelyNested.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "extremely.nested")
+public interface ExtremelyNested extends NestedA, NestedB {
+  /** Extremely nested. */
+  int extremelyNested();
+
+  @Override
+  int nestedA1();
+
+  @Override
+  int nestedA2();
+
+  @Override
+  int nestedB1();
+
+  @Override
+  int nestedA11();
+
+  @Override
+  int nestedB12();
+}

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedA.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedA.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+public interface NestedA extends NestedA1, NestedA2 {}

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedA1.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedA1.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+public interface NestedA1 extends NestedA11 {
+  /** A1. */
+  int nestedA1();
+}

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedA11.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedA11.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+public interface NestedA11 {
+  /** A11. */
+  int nestedA11();
+}

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedA2.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedA2.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+public interface NestedA2 extends NestedA11 {
+  /** A2. */
+  int nestedA2();
+}

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedB.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedB.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+public interface NestedB extends NestedB1, NestedA2 {}

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedB1.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedB1.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+public interface NestedB1 extends NestedA11, NestedB12 {
+  /** B1. */
+  int nestedB1();
+}

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedB12.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/NestedB12.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+public interface NestedB12 {
+  /** B12. */
+  int nestedB12();
+}

--- a/tools/doc-generator/doclet/src/test/java/tests/smallrye/VeryNested.java
+++ b/tools/doc-generator/doclet/src/test/java/tests/smallrye/VeryNested.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.smallrye;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "very.nested")
+public interface VeryNested extends NestedA, NestedB {
+  /** Very nested. */
+  int veryNested();
+}

--- a/tools/doc-generator/site-gen/build.gradle.kts
+++ b/tools/doc-generator/site-gen/build.gradle.kts
@@ -107,7 +107,7 @@ tasks.register("generateDocs", JavaExec::class.java) {
       "--classpath", classes.joinToString(":"),
       "--sourcepath", sources.joinToString(":"),
       "--destination", targetDir.get().toString()
-    )
+    ) + (if (logger.isInfoEnabled) listOf("--verbose") else listOf())
   })
 
   classpath(doclet)


### PR DESCRIPTION
Under some not fully understood circumstances, `ConfigMappingInterface.getSuperTypes()` does not return all extended interfaces. This change additionaly traverse the super types retrieved via reflection as well, skipping all the types that have been visited via `getSuperTypes()`.