### PR TITLE
Site: let site use wider horizontal space

### DIFF
--- a/site/docs/stylesheets/extra.css
+++ b/site/docs/stylesheets/extra.css
@@ -13,6 +13,7 @@ img.bordered {
   background-color: #5d6cc0;
 }
 
-.md-nav__item {
-  font-size: 1.2em;
+/* Maximum space for text block */
+.md-grid {
+  max-width: 80%; /* or 100%, if you want to stretch to full-width */
 }


### PR DESCRIPTION
This change does two things:
* It "widens" the default max size of the content area
* It allows the content to use most of the available horizontal space of the browser window

Cannot use 100% here, because then the start page would look awkward.