### PR TITLE
Doc-gen: trim-right before style changes

### DIFF
--- a/tools/doc-generator/doclet/src/main/java/org/projectnessie/nessie/docgen/MarkdownFormatter.java
+++ b/tools/doc-generator/doclet/src/main/java/org/projectnessie/nessie/docgen/MarkdownFormatter.java
@@ -258,6 +258,13 @@ public abstract class MarkdownFormatter {
       }
       text.append(' ');
     }
+
+    void trimRight() {
+      int l = text.length();
+      while (l > 0 && Character.isWhitespace(text.charAt(l - 1))) {
+        text.setLength(--l);
+      }
+    }
   }
 
   private class MDFormat {
@@ -491,9 +498,11 @@ public abstract class MarkdownFormatter {
                 break;
               case "em":
               case "i":
+                target.trimRight();
                 target.text.append('_');
                 break;
               case "b":
+                target.trimRight();
                 target.text.append("**");
                 break;
               case "ol":


### PR DESCRIPTION
In markdown, for styles applied using `_` or `**` there must not be any whitespaces, otherwise the `_` and `**` will appear as is.