### PR TITLE
Let renovate merge all google-cloud-cli Docker tag bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,17 @@
       labels: [],
     },
 
+    // Dockerfile for google-cloud-cli, basically no minor/patch version, daily major version updates
+    {
+      matchManagers: ["dockerfile"],
+      matchUpdateTypes: ["major", "minor", "patch"],
+      matchPackageNames: [
+        "gcr.io/google.com/cloudsdktool/google-cloud-cli"
+      ],
+      automerge: true,
+      platformAutomerge: true
+    },
+
     // Check for updates, merge automatically
     {
       matchManagers: ["maven", "gradle", "gradle-wrapper", "pip_requirements", "pip_setup", "dockerfile"],


### PR DESCRIPTION
There are nearly daily updates to gcr.io/google.com/cloudsdktool/google-cloud-cli as major version bumps - let Renovate merge those automatically.