### PR TITLE
Update `UDF` + `IcebergView`content types

### DIFF
--- a/api/model/src/main/java/org/projectnessie/model/IcebergView.java
+++ b/api/model/src/main/java/org/projectnessie/model/IcebergView.java
@@ -51,12 +51,18 @@ public abstract class IcebergView extends IcebergContent {
 
   @NotBlank
   @jakarta.validation.constraints.NotBlank
-  @NotNull
-  @jakarta.validation.constraints.NotNull
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
   public abstract String getSqlText();
 
   @Nullable
-  @jakarta.annotation.Nullable // TODO this is currently undefined in Iceberg
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
   public abstract String getDialect();
 
   @Override
@@ -80,6 +86,24 @@ public abstract class IcebergView extends IcebergContent {
     return ImmutableIcebergView.builder();
   }
 
+  public static IcebergView of(String metadataLocation, long versionId, int schemaId) {
+    return builder()
+        .metadataLocation(metadataLocation)
+        .versionId(versionId)
+        .schemaId(schemaId)
+        .build();
+  }
+
+  public static IcebergView of(String id, String metadataLocation, long versionId, int schemaId) {
+    return builder()
+        .id(id)
+        .metadataLocation(metadataLocation)
+        .versionId(versionId)
+        .schemaId(schemaId)
+        .build();
+  }
+
+  @Deprecated
   public static IcebergView of(
       String metadataLocation, long versionId, int schemaId, String dialect, String sqlText) {
     return builder()
@@ -91,6 +115,7 @@ public abstract class IcebergView extends IcebergContent {
         .build();
   }
 
+  @Deprecated
   public static IcebergView of(
       String id,
       String metadataLocation,

--- a/api/model/src/main/java/org/projectnessie/model/UDF.java
+++ b/api/model/src/main/java/org/projectnessie/model/UDF.java
@@ -15,12 +15,12 @@
  */
 package org.projectnessie.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -31,13 +31,29 @@ public abstract class UDF extends Content {
 
   @NotBlank
   @jakarta.validation.constraints.NotBlank
-  @NotNull
-  @jakarta.validation.constraints.NotNull
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated
   public abstract String getSqlText();
 
   @Nullable
-  @jakarta.annotation.Nullable // TODO this is currently undefined in Iceberg
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated
   public abstract String getDialect();
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public abstract Long getVersionId();
+
+  @Nullable
+  @jakarta.annotation.Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public abstract String getMetadataLocation();
 
   @Override
   public Type getType() {
@@ -51,10 +67,20 @@ public abstract class UDF extends Content {
     return ImmutableUDF.builder();
   }
 
+  public static UDF of(String metadataLocation, long versionId) {
+    return builder().metadataLocation(metadataLocation).versionId(versionId).build();
+  }
+
+  public static UDF of(String id, String metadataLocation, long versionId) {
+    return builder().id(id).metadataLocation(metadataLocation).versionId(versionId).build();
+  }
+
+  @Deprecated
   public static UDF of(String dialect, String sqlText) {
     return builder().dialect(dialect).sqlText(sqlText).build();
   }
 
+  @Deprecated
   public static UDF of(String id, String dialect, String sqlText) {
     return builder().id(id).dialect(dialect).sqlText(sqlText).build();
   }

--- a/api/model/src/test/java/org/projectnessie/model/types/TestGenericContent.java
+++ b/api/model/src/test/java/org/projectnessie/model/types/TestGenericContent.java
@@ -86,10 +86,10 @@ public class TestGenericContent {
     return Stream.of(
         IcebergTable.of("meta", 1, 2, 3, 4),
         IcebergTable.of("meta", 1, 2, 3, 4, "cid"),
-        IcebergView.of("meta", 1, 2, "awesome-db", "select what_i_want"),
-        IcebergView.of("cid", "meta", 1, 2, "awesome-db", "select what_i_want"),
-        UDF.of("awesome-db", "select what_i_want"),
-        UDF.of("cid", "awesome-db", "select what_i_want"),
+        IcebergView.of("meta", 1, 2),
+        IcebergView.of("cid", "meta", 1, 2),
+        UDF.of("/udf-metadata", 666),
+        UDF.of("cid", "/udf-metadata", 42),
         Namespace.of("foo", "bar"),
         Namespace.builder().from(Namespace.of("foo", "bar")).id("cid").build());
   }

--- a/events/service/src/test/java/org/projectnessie/events/service/util/TestContentMapping.java
+++ b/events/service/src/test/java/org/projectnessie/events/service/util/TestContentMapping.java
@@ -52,6 +52,7 @@ class TestContentMapping {
     assertThat(actual).isEqualTo(expected);
   }
 
+  @SuppressWarnings("deprecation")
   public static Stream<Arguments> mapContent() {
     return Stream.of(
         Arguments.of(
@@ -130,6 +131,18 @@ class TestContentMapping {
                 .putProperty("checkpointLocationHistory", Collections.singletonList("checkpoint"))
                 .putProperty("metadataLocationHistory", Collections.singletonList("metadata"))
                 .putProperty("lastCheckpoint", "lastCheckpoint")
+                .build()),
+        Arguments.of(
+            org.projectnessie.model.ImmutableUDF.builder()
+                .id("id")
+                .metadataLocation("metadataLocation")
+                .versionId(1L)
+                .build(),
+            ImmutableContent.builder()
+                .id("id")
+                .type("UDF")
+                .putProperty("metadataLocation", "metadataLocation")
+                .putProperty("versionId", 1L)
                 .build()),
         Arguments.of(
             org.projectnessie.model.ImmutableUDF.builder()

--- a/gc/gc-iceberg/src/test/java/org/projectnessie/gc/iceberg/TestIcebergContentToContentReference.java
+++ b/gc/gc-iceberg/src/test/java/org/projectnessie/gc/iceberg/TestIcebergContentToContentReference.java
@@ -36,8 +36,8 @@ public class TestIcebergContentToContentReference {
   static Stream<Content> nonIcebergTable() {
     return Stream.of(
         ImmutableDeltaLakeTable.builder().id("123").lastCheckpoint("lc").build(),
-        IcebergView.of("cid", "meta", 42, 43, "dialect", "sql"),
-        UDF.of("dialect", "sql"),
+        IcebergView.of("cid", "meta", 42, 43),
+        UDF.of("udf-meta", 42),
         Namespace.of("foo", "bar"));
   }
 

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieApi.java
@@ -1706,7 +1706,7 @@ public abstract class BaseTestNessieApi {
     ContentKey a = ContentKey.of("a");
     ContentKey b = ContentKey.of("b");
     IcebergTable ta = IcebergTable.of("path1", 42, 42, 42, 42);
-    IcebergView tb = IcebergView.of("pathx", 1, 1, "select * from table", "Dremio");
+    IcebergView tb = IcebergView.of("pathx", 1, 1);
     branch =
         api()
             .commitMultipleOperations()

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusEvents.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/AbstractQuarkusEvents.java
@@ -62,7 +62,7 @@ import org.projectnessie.server.events.fixtures.MockEventSubscriber;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractQuarkusEvents {
 
-  private final Put putInitial = Put.of(ContentKey.of("foo"), UDF.of("foo", "bar"));
+  private final Put putInitial = Put.of(ContentKey.of("foo"), UDF.of("udf-meta", 42));
   private final Put put = Put.of(ContentKey.of("key1"), IcebergTable.of("somewhere", 1, 1, 3, 4));
   private final CommitMeta commitMeta = CommitMeta.fromMessage("test commit");
 

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestAccessChecks.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestAccessChecks.java
@@ -113,7 +113,7 @@ public abstract class AbstractTestAccessChecks extends BaseTestServiceImpl {
     Namespace namespace2 = Namespace.of(keyNamespace2);
     IcebergTable table1 = IcebergTable.of("foo", 42, 42, 42, 42);
     IcebergTable table2 = IcebergTable.of("bar", 42, 42, 42, 42);
-    UDF unrelated = UDF.of("meep", "sql");
+    UDF unrelated = UDF.of("udf-meta", 42);
 
     Branch common = createBranch("common");
     CommitResponse commonResponse =

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestCommitLog.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestCommitLog.java
@@ -107,8 +107,8 @@ public abstract class AbstractTestCommitLog extends BaseTestServiceImpl {
         commit(
                 branch,
                 fromMessage("some awkward message"),
-                Put.of(hello, IcebergView.of("path1", 1, 1, "Spark", "SELECT ALL THE THINGS")),
-                Put.of(ollah, IcebergView.of("path2", 1, 1, "Spark", "SELECT ALL THE THINGS")))
+                Put.of(hello, IcebergView.of("path1", 1, 1)),
+                Put.of(ollah, IcebergView.of("path2", 1, 1)))
             .getTargetBranch();
 
     soft.assertThat(

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestContents.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestContents.java
@@ -89,12 +89,9 @@ public abstract class AbstractTestContents extends BaseTestServiceImpl {
                 ContentKey.of("a", "iceberg"), IcebergTable.of("/iceberg/table", 42, 42, 42, 42))),
         new ContentAndOperationType(
             Content.Type.ICEBERG_VIEW,
-            Put.of(
-                ContentKey.of("a", "view"),
-                IcebergView.of("/iceberg/view", 1, 1, "dial", "SELECT foo FROM table"))),
+            Put.of(ContentKey.of("a", "view"), IcebergView.of("/iceberg/view", 1, 1))),
         new ContentAndOperationType(
-            Content.Type.UDF,
-            Put.of(ContentKey.of("a", "udf"), UDF.of("dial", "SELECT foo FROM table"))),
+            Content.Type.UDF, Put.of(ContentKey.of("a", "udf"), UDF.of("/udf-meta", 42))),
         new ContentAndOperationType(
             Content.Type.DELTA_LAKE_TABLE,
             Put.of(
@@ -118,23 +115,19 @@ public abstract class AbstractTestContents extends BaseTestServiceImpl {
         new ContentAndOperationType(
             Content.Type.UDF,
             Delete.of(ContentKey.of("a", "udf_delete")),
-            Put.of(ContentKey.of("a", "udf_delete"), UDF.of("dial", "sql"))),
+            Put.of(ContentKey.of("a", "udf_delete"), UDF.of("/udf-metadata", 42))),
         new ContentAndOperationType(
             Content.Type.ICEBERG_VIEW,
             Delete.of(ContentKey.of("a", "view_delete")),
-            Put.of(
-                ContentKey.of("a", "view_delete"),
-                IcebergView.of("/iceberg/view", 42, 42, "dial", "sql"))),
+            Put.of(ContentKey.of("a", "view_delete"), IcebergView.of("/iceberg/view", 42, 42))),
         new ContentAndOperationType(
             Content.Type.ICEBERG_VIEW,
             Unchanged.of(ContentKey.of("a", "view_unchanged")),
-            Put.of(
-                ContentKey.of("a", "view_unchanged"),
-                IcebergView.of("/iceberg/view", 42, 42, "dial", "sql"))),
+            Put.of(ContentKey.of("a", "view_unchanged"), IcebergView.of("/iceberg/view", 42, 42))),
         new ContentAndOperationType(
             Content.Type.UDF,
             Unchanged.of(ContentKey.of("a", "udf_unchanged")),
-            Put.of(ContentKey.of("a", "udf_unchanged"), UDF.of("dial", "sql"))),
+            Put.of(ContentKey.of("a", "udf_unchanged"), UDF.of("/udf-meta-data", 42))),
         new ContentAndOperationType(
             Content.Type.DELTA_LAKE_TABLE,
             Delete.of(ContentKey.of("a", "delta_delete")),

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestEntries.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestEntries.java
@@ -98,7 +98,7 @@ public abstract class AbstractTestEntries extends BaseTestServiceImpl {
     ContentKey a = ContentKey.of("a");
     ContentKey b = ContentKey.of("b");
     IcebergTable tam = IcebergTable.of("path1", 42, 42, 42, 42);
-    IcebergView tb = IcebergView.of("pathx", 1, 1, "select * from table", "Dremio");
+    IcebergView tb = IcebergView.of("pathx", 1, 1);
     branch = commit(branch, fromMessage("commit"), Put.of(a, tam), Put.of(b, tb)).getTargetBranch();
     List<EntriesResponse.Entry> entries = entries(refMode.transform(branch));
     Map<ContentKey, Content.Type> expect =
@@ -382,7 +382,7 @@ public abstract class AbstractTestEntries extends BaseTestServiceImpl {
     ContentKey a = ContentKey.of("a");
     ContentKey b = ContentKey.of("b");
     IcebergTable ta = IcebergTable.of("path1", 42, 42, 42, 42);
-    IcebergView tb = IcebergView.of("pathx", 1, 1, "select * from table", "Dremio");
+    IcebergView tb = IcebergView.of("pathx", 1, 1);
     branch =
         commit(branch, fromMessage("commit 1"), Put.of(a, ta), Put.of(b, tb)).getTargetBranch();
     List<EntriesResponse.Entry> entries = entries(Detached.of(branch.getHash()));

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestReferences.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestReferences.java
@@ -294,23 +294,17 @@ public abstract class AbstractTestReferences extends BaseTestServiceImpl {
     commit(
         createBranch("refs.branch.1"),
         fromMessage("some awkward message"),
-        Put.of(
-            ContentKey.of("hello.world.BaseTable"),
-            IcebergView.of("path1", 1, 1, "Spark", "SELECT ALL THE THINGS")));
+        Put.of(ContentKey.of("hello.world.BaseTable"), IcebergView.of("path1", 1, 1)));
     Branch b2 =
         commit(
                 createBranch("other-development"),
                 fromMessage("invent awesome things"),
-                Put.of(
-                    ContentKey.of("cool.stuff.Caresian"),
-                    IcebergView.of("path2", 1, 1, "Spark", "CARTESIAN JOINS ARE AWESOME")))
+                Put.of(ContentKey.of("cool.stuff.Caresian"), IcebergView.of("path2", 1, 1)))
             .getTargetBranch();
     commit(
         createBranch("archive"),
         fromMessage("boring old stuff"),
-        Put.of(
-            ContentKey.of("super.old.Numbers"),
-            IcebergView.of("path3", 1, 1, "Spark", "AGGREGATE EVERYTHING")));
+        Put.of(ContentKey.of("super.old.Numbers"), IcebergView.of("path3", 1, 1)));
     Tag t1 = createTag("my-tag", b2);
 
     soft.assertThat(allReferences(MINIMAL, "ref.name == 'other-development'"))

--- a/servers/store-proto/src/main/proto/org/projectnessie/server/store/proto/table.proto
+++ b/servers/store-proto/src/main/proto/org/projectnessie/server/store/proto/table.proto
@@ -100,8 +100,8 @@ message IcebergRefState {
 message IcebergViewState {
   int64 version_id = 1;
   int32 schema_id = 2;
-  string sql_text = 3;
-  string dialect = 4;
+  optional string sql_text = 3;
+  optional string dialect = 4;
 
   // See above for the rules how to retrieve metadata.
 
@@ -152,6 +152,9 @@ message Namespace {
 }
 
 message UDF {
-  string sql_text = 1;
-  string dialect = 2;
+  optional string sql_text = 1;
+  optional string dialect = 2;
+
+  optional int64 version_id = 3;
+  optional string metadata_location = 4;
 }

--- a/servers/store/src/main/java/org/projectnessie/server/store/BaseSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/BaseSerializer.java
@@ -22,6 +22,7 @@ import org.projectnessie.model.IcebergView;
 import org.projectnessie.model.ImmutableDeltaLakeTable;
 import org.projectnessie.model.ImmutableIcebergTable;
 import org.projectnessie.model.ImmutableIcebergView;
+import org.projectnessie.model.ImmutableUDF;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.model.UDF;
 import org.projectnessie.nessie.relocated.protobuf.ByteString;
@@ -68,7 +69,20 @@ abstract class BaseSerializer<C extends Content> implements LegacyContentSeriali
 
   static UDF valueFromStoreUDF(ObjectTypes.Content content) {
     ObjectTypes.UDF udf = content.getUdf();
-    return UDF.of(content.getId(), udf.getDialect(), udf.getSqlText());
+    ImmutableUDF.Builder builder = ImmutableUDF.builder().id(content.getId());
+    if (udf.hasDialect()) {
+      builder.dialect(udf.getDialect());
+    }
+    if (udf.hasSqlText()) {
+      builder.sqlText(udf.getSqlText());
+    }
+    if (udf.hasMetadataLocation()) {
+      builder.metadataLocation(udf.getMetadataLocation());
+    }
+    if (udf.hasVersionId()) {
+      builder.versionId(udf.getVersionId());
+    }
+    return builder.build();
   }
 
   static Namespace valueFromStoreNamespace(ObjectTypes.Content content) {
@@ -111,9 +125,13 @@ abstract class BaseSerializer<C extends Content> implements LegacyContentSeriali
             .metadataLocation(metadataLocation)
             .versionId(view.getVersionId())
             .schemaId(view.getSchemaId())
-            .dialect(view.getDialect())
-            .sqlText(view.getSqlText())
             .id(content.getId());
+    if (view.hasDialect()) {
+      viewBuilder.dialect(view.getDialect());
+    }
+    if (view.hasSqlText()) {
+      viewBuilder.sqlText(view.getSqlText());
+    }
 
     return viewBuilder.build();
   }

--- a/servers/store/src/main/java/org/projectnessie/server/store/IcebergViewSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/IcebergViewSerializer.java
@@ -34,14 +34,24 @@ public final class IcebergViewSerializer extends BaseSerializer<IcebergView> {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   protected void toStoreOnRefState(IcebergView view, ObjectTypes.Content.Builder builder) {
     ObjectTypes.IcebergViewState.Builder stateBuilder =
         ObjectTypes.IcebergViewState.newBuilder()
             .setVersionId(view.getVersionId())
-            .setSchemaId(view.getSchemaId())
-            .setDialect(view.getDialect())
-            .setSqlText(view.getSqlText())
-            .setMetadataLocation(view.getMetadataLocation());
+            .setSchemaId(view.getSchemaId());
+    String dialect = view.getDialect();
+    String sqlText = view.getSqlText();
+    String metadataLocation = view.getMetadataLocation();
+    if (dialect != null) {
+      stateBuilder.setDialect(dialect);
+    }
+    if (sqlText != null) {
+      stateBuilder.setSqlText(sqlText);
+    }
+    if (metadataLocation != null) {
+      stateBuilder.setMetadataLocation(metadataLocation);
+    }
 
     builder.setIcebergViewState(stateBuilder);
   }

--- a/servers/store/src/main/java/org/projectnessie/server/store/UDFSerializer.java
+++ b/servers/store/src/main/java/org/projectnessie/server/store/UDFSerializer.java
@@ -33,10 +33,29 @@ public final class UDFSerializer extends BaseSerializer<UDF> {
     return 5;
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   protected void toStoreOnRefState(UDF udf, ObjectTypes.Content.Builder builder) {
-    ObjectTypes.UDF.Builder stateBuilder =
-        ObjectTypes.UDF.newBuilder().setDialect(udf.getDialect()).setSqlText(udf.getSqlText());
+    ObjectTypes.UDF.Builder stateBuilder = ObjectTypes.UDF.newBuilder();
+
+    String dialect = udf.getDialect();
+    if (dialect != null) {
+      stateBuilder.setDialect(udf.getDialect());
+    }
+    String sqlText = udf.getSqlText();
+    if (sqlText != null) {
+      stateBuilder.setSqlText(udf.getSqlText());
+    }
+
+    String metadata = udf.getMetadataLocation();
+    if (metadata != null) {
+      stateBuilder.setMetadataLocation(udf.getMetadataLocation());
+    }
+
+    Long version = udf.getVersionId();
+    if (version != null) {
+      stateBuilder.setVersionId(version);
+    }
 
     builder.setUdf(stateBuilder);
   }

--- a/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
+++ b/servers/store/src/test/java/org/projectnessie/server/store/TestStoreWorker.java
@@ -177,6 +177,7 @@ class TestStoreWorker {
         .containsExactly("metadata-location", 42L);
   }
 
+  @SuppressWarnings("deprecation")
   static Stream<Arguments> requiresGlobalStateModelType() {
     return Stream.of(
         Arguments.of(
@@ -184,6 +185,15 @@ class TestStoreWorker {
             ObjectTypes.Content.newBuilder()
                 .setId(CID)
                 .setUdf(ObjectTypes.UDF.newBuilder().setDialect("dialect").setSqlText("sqlText")),
+            null,
+            Content.Type.UDF),
+        //
+        Arguments.of(
+            UDF.of(CID, "metadata", 42),
+            ObjectTypes.Content.newBuilder()
+                .setId(CID)
+                .setUdf(
+                    ObjectTypes.UDF.newBuilder().setMetadataLocation("metadata").setVersionId(42)),
             null,
             Content.Type.UDF),
         //

--- a/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
+++ b/tools/content-generator/src/main/java/org/projectnessie/tools/contentgenerator/cli/GenerateContent.java
@@ -48,9 +48,11 @@ import org.projectnessie.model.GetMultipleContentsResponse;
 import org.projectnessie.model.ImmutableDeltaLakeTable;
 import org.projectnessie.model.ImmutableIcebergTable;
 import org.projectnessie.model.ImmutableIcebergView;
+import org.projectnessie.model.ImmutableUDF;
 import org.projectnessie.model.Namespace;
 import org.projectnessie.model.Operation.Put;
 import org.projectnessie.model.Tag;
+import org.projectnessie.model.UDF;
 import org.projectnessie.model.types.ContentTypes;
 import org.projectnessie.tools.contentgenerator.keygen.KeyGenerator;
 import picocli.CommandLine.Command;
@@ -342,6 +344,7 @@ public class GenerateContent extends CommittingCommand {
       return deltaBuilder.build();
     }
     if (contentType.equals(Content.Type.ICEBERG_VIEW)) {
+      @SuppressWarnings("deprecation")
       ImmutableIcebergView.Builder viewBuilder =
           ImmutableIcebergView.builder()
               .metadataLocation("metadata " + random.nextLong())
@@ -356,6 +359,17 @@ public class GenerateContent extends CommittingCommand {
         viewBuilder.id(contentId);
       }
       return viewBuilder.build();
+    }
+    if (contentType.equals(Content.Type.UDF)) {
+      ImmutableUDF.Builder udfBuilder =
+          UDF.builder().metadataLocation("metadata " + random.nextLong());
+      if (currentContents != null) {
+        udfBuilder.id(currentContents.getId());
+      }
+      if (contentId != null) {
+        udfBuilder.id(contentId);
+      }
+      return udfBuilder.build();
     }
     throw new UnsupportedOperationException(
         String.format("Content type %s not supported", contentType.name()));

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestContentMapping.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestContentMapping.java
@@ -78,8 +78,8 @@ public class TestContentMapping {
   static Stream<Content> contentSamples() {
     return Stream.of(
         IcebergTable.of("/dev/null", 42, 43, 44, 45),
-        IcebergView.of("/dev/null", 42, 43, "dial", "sql"),
-        UDF.of("dial", "sql"),
+        IcebergView.of("/dev/null", 42, 43),
+        UDF.of("udf-meta", 42),
         Namespace.of("foo", "bar"),
         OnRefOnly.newOnRef("value"),
         ImmutableDeltaLakeTable.builder()


### PR DESCRIPTION
* `UDF`: add metadata-location and version-ID
* `IcebergView`: make dialect + schema optional

The changes to the `UDF` type are non-controversial, becasue `UDF` isn't used anywhere yet. The changes to `IcebergView` allow clients to omit the dialect + schema fields _later_, i.e. after a few Nessie/Iceberg versions. "Later" due to backwards compatibility reasons, as long as Nessie/Iceberg versions are around that require these attributes.