### PR TITLE
Use `ubi9/openjdk-21-runtime` instead of `ubi9/openjdk-21` as the base image

### DIFF
--- a/site/in-dev/configuration.md
+++ b/site/in-dev/configuration.md
@@ -239,7 +239,7 @@ Nessie publishes a Java based multiplatform (for amd64, arm64, ppc64le, s390x) i
 There are many environment variables available to configure the Docker image. If in doubt, leave
 everything at its default. You can configure the behavior using the following environment
 variables. They come from the base image used by Nessie,
-[ubi8/openjdk-17](https://catalog.redhat.com/software/containers/ubi8/openjdk-17/618bdbf34ae3739687568813).
+[ubi9/openjdk-21-runtime](https://catalog.redhat.com/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f?architecture=amd64&image=66315a8390b0479a656a2f97).
 The extensive list of supported environment variables can be found 
 [here](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/reference#configuration_environment_variables).
 

--- a/tools/dockerbuild/docker/Dockerfile-gctool
+++ b/tools/dockerbuild/docker/Dockerfile-gctool
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.18-4
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.18-4
 
 LABEL org.opencontainers.image.source=https://github.com/projectnessie/nessie
 LABEL org.opencontainers.image.description="Projectnessie GC Tool"

--- a/tools/dockerbuild/docker/Dockerfile-server
+++ b/tools/dockerbuild/docker/Dockerfile-server
@@ -20,7 +20,7 @@
 # (See site/docs/try/configuration.md)
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.18-4
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.18-4
 
 LABEL org.opencontainers.image.source=https://github.com/projectnessie/nessie
 LABEL org.opencontainers.image.description="Projectnessie Nessie Core Server"


### PR DESCRIPTION
Supersedes #8502 