### PR TITLE
Nessie client: optionally disable certificate verifications

### DIFF
--- a/api/client/src/main/java/org/projectnessie/client/NessieClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieClientBuilder.java
@@ -23,6 +23,7 @@ import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_DISABLE
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_SNI_HOSTS;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_SNI_MATCHER;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_SSL_CIPHER_SUITES;
+import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_SSL_NO_CERTIFICATE_VERIFICATION;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_SSL_PROTOCOLS;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_TRACING;
 import static org.projectnessie.client.NessieConfigConstants.CONF_NESSIE_URI;
@@ -159,6 +160,13 @@ public interface NessieClientBuilder {
   /** Disables compression for remote requests. */
   @CanIgnoreReturnValue
   NessieClientBuilder withDisableCompression(boolean disableCompression);
+
+  /**
+   * Optional, disables certificate verifications, if set to {@code true}. Can be useful for testing
+   * purposes, not recommended for production systems.
+   */
+  @CanIgnoreReturnValue
+  NessieClientBuilder withSSLNoCertificateVerification(boolean noCertificateVerification);
 
   /**
    * Optionally configure a specific {@link SSLContext}, currently only the Java 11+ accepts this
@@ -340,6 +348,11 @@ public interface NessieClientBuilder {
         withDisableCompression(Boolean.parseBoolean(s));
       }
 
+      s = configuration.apply(CONF_NESSIE_SSL_NO_CERTIFICATE_VERIFICATION);
+      if (s != null) {
+        withSSLNoCertificateVerification(Boolean.parseBoolean(s));
+      }
+
       SSLParameters sslParameters = new SSLParameters();
       boolean hasSslParameters = false;
       s = configuration.apply(CONF_NESSIE_SSL_CIPHER_SUITES);
@@ -436,6 +449,11 @@ public interface NessieClientBuilder {
 
     @Override
     public NessieClientBuilder withDisableCompression(boolean disableCompression) {
+      return this;
+    }
+
+    @Override
+    public NessieClientBuilder withSSLNoCertificateVerification(boolean noCertificateVerification) {
       return this;
     }
 

--- a/api/client/src/main/java/org/projectnessie/client/NessieClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieClientBuilder.java
@@ -166,7 +166,8 @@ public interface NessieClientBuilder {
    * purposes, not recommended for production systems.
    */
   @CanIgnoreReturnValue
-  NessieClientBuilder withSSLNoCertificateVerification(boolean noCertificateVerification);
+  NessieClientBuilder withSSLCertificateVerificationDisabled(
+      boolean certificateVerificationDisabled);
 
   /**
    * Optionally configure a specific {@link SSLContext}, currently only the Java 11+ accepts this
@@ -350,7 +351,7 @@ public interface NessieClientBuilder {
 
       s = configuration.apply(CONF_NESSIE_SSL_NO_CERTIFICATE_VERIFICATION);
       if (s != null) {
-        withSSLNoCertificateVerification(Boolean.parseBoolean(s));
+        withSSLCertificateVerificationDisabled(Boolean.parseBoolean(s));
       }
 
       SSLParameters sslParameters = new SSLParameters();
@@ -453,7 +454,8 @@ public interface NessieClientBuilder {
     }
 
     @Override
-    public NessieClientBuilder withSSLNoCertificateVerification(boolean noCertificateVerification) {
+    public NessieClientBuilder withSSLCertificateVerificationDisabled(
+        boolean certificateVerificationDisabled) {
       return this;
     }
 

--- a/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
+++ b/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java
@@ -430,6 +430,14 @@ public final class NessieConfigConstants {
   public static final String CONF_NESSIE_CLIENT_BUILDER_IMPL = "nessie.client-builder-impl";
 
   /**
+   * Optional, disables certificate verifications, if set to {@code true}. Can be useful for testing
+   * purposes, not recommended for production systems.
+   */
+  @ConfigItem(section = "Network")
+  public static final String CONF_NESSIE_SSL_NO_CERTIFICATE_VERIFICATION =
+      "nessie.ssl.no-certificate-verification";
+
+  /**
    * Optional, list of comma-separated cipher suites for SSL connections.
    *
    * <p>This parameter only works on Java 11 and newer with the Java HTTP client.

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClient.java
@@ -75,6 +75,9 @@ public interface HttpClient extends AutoCloseable {
     Builder setResponseFactory(HttpResponseFactory responseFactory);
 
     @CanIgnoreReturnValue
+    Builder setSslNoCertificateVerification(boolean noCertificateVerification);
+
+    @CanIgnoreReturnValue
     Builder setSslContext(SSLContext sslContext);
 
     @CanIgnoreReturnValue

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -104,6 +104,11 @@ public class HttpClientBuilder extends NessieHttpClientBuilderImpl {
   }
 
   @Override
+  public HttpClientBuilder withSSLNoCertificateVerification(boolean noCertificateVerification) {
+    return (HttpClientBuilder) super.withSSLNoCertificateVerification(noCertificateVerification);
+  }
+
+  @Override
   public HttpClientBuilder withSSLContext(SSLContext sslContext) {
     return (HttpClientBuilder) super.withSSLContext(sslContext);
   }

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java
@@ -104,8 +104,10 @@ public class HttpClientBuilder extends NessieHttpClientBuilderImpl {
   }
 
   @Override
-  public HttpClientBuilder withSSLNoCertificateVerification(boolean noCertificateVerification) {
-    return (HttpClientBuilder) super.withSSLNoCertificateVerification(noCertificateVerification);
+  public HttpClientBuilder withSSLCertificateVerificationDisabled(
+      boolean certificateVerificationDisabled) {
+    return (HttpClientBuilder)
+        super.withSSLCertificateVerificationDisabled(certificateVerificationDisabled);
   }
 
   @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -255,7 +255,7 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
     if (sslNoCertificateVerification) {
       checkArgument(
           sslCtx == null,
-          "Cannot construct Http client, must not combine %s and with an explicitly configured SSLContext",
+          "Cannot construct Http client, must not combine %s and an explicitly configured SSLContext",
           CONF_NESSIE_SSL_NO_CERTIFICATE_VERIFICATION);
       try {
         sslCtx = SSLContext.getInstance("TLS");

--- a/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilderImpl.java
@@ -19,8 +19,12 @@ import static java.util.Locale.ROOT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.net.Socket;
 import java.net.URI;
+import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,7 +33,10 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.http.impl.HttpClientFactory;
 import org.projectnessie.client.http.impl.HttpRuntimeConfig;
@@ -44,6 +51,7 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
   private ObjectMapper mapper;
   private Class<?> jsonView;
   private HttpResponseFactory responseFactory = HttpResponse::new;
+  private boolean sslNoCertificateVerification;
   private SSLContext sslContext;
   private SSLParameters sslParameters;
   private HttpAuthentication authentication;
@@ -71,6 +79,7 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
     this.mapper = other.mapper;
     this.jsonView = other.jsonView;
     this.responseFactory = other.responseFactory;
+    this.sslNoCertificateVerification = other.sslNoCertificateVerification;
     this.sslContext = other.sslContext;
     this.sslParameters = other.sslParameters;
     this.authentication = other.authentication;
@@ -126,6 +135,12 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
   @Override
   public HttpClient.Builder setResponseFactory(HttpResponseFactory responseFactory) {
     this.responseFactory = responseFactory;
+    return this;
+  }
+
+  @Override
+  public HttpClient.Builder setSslNoCertificateVerification(boolean noCertificateVerification) {
+    this.sslNoCertificateVerification = noCertificateVerification;
     return this;
   }
 
@@ -233,6 +248,48 @@ final class HttpClientBuilderImpl implements HttpClient.Builder {
   public HttpClient build() {
     HttpUtils.checkArgument(
         mapper != null, "Cannot construct Http client. Must have a non-null object mapper");
+
+    if (sslNoCertificateVerification) {
+      HttpUtils.checkArgument(
+          sslContext == null, "Cannot construct Http client, must not combine %s and ");
+      try {
+        sslContext = SSLContext.getInstance("TLS");
+        TrustManager trustManager =
+            new X509ExtendedTrustManager() {
+              @Override
+              public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[] {};
+              }
+
+              @Override
+              public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+              @Override
+              public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+              @Override
+              public void checkClientTrusted(
+                  X509Certificate[] chain, String authType, Socket socket) {}
+
+              @Override
+              public void checkServerTrusted(
+                  X509Certificate[] chain, String authType, Socket socket) {}
+
+              @Override
+              public void checkClientTrusted(
+                  X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+              @Override
+              public void checkServerTrusted(
+                  X509Certificate[] chain, String authType, SSLEngine engine) {}
+            };
+        sslContext.init(null, new TrustManager[] {trustManager}, new SecureRandom());
+      } catch (KeyManagementException | NoSuchAlgorithmException e) {
+        throw new HttpClientException(
+            "Cannot construct Http Client, unable to configure noop trust-manager", e);
+      }
+    }
+
     if (sslContext == null) {
       try {
         sslContext = SSLContext.getDefault();

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilder.java
@@ -253,10 +253,10 @@ public interface NessieHttpClientBuilder extends NessieClientBuilder {
     }
 
     @Override
-    public NessieHttpClientBuilder withSSLNoCertificateVerification(
-        boolean noCertificateVerification) {
+    public NessieHttpClientBuilder withSSLCertificateVerificationDisabled(
+        boolean certificateVerificationDisabled) {
       return (NessieHttpClientBuilder)
-          super.withSSLNoCertificateVerification(noCertificateVerification);
+          super.withSSLCertificateVerificationDisabled(certificateVerificationDisabled);
     }
 
     @Override

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilder.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilder.java
@@ -253,6 +253,13 @@ public interface NessieHttpClientBuilder extends NessieClientBuilder {
     }
 
     @Override
+    public NessieHttpClientBuilder withSSLNoCertificateVerification(
+        boolean noCertificateVerification) {
+      return (NessieHttpClientBuilder)
+          super.withSSLNoCertificateVerification(noCertificateVerification);
+    }
+
+    @Override
     public NessieHttpClientBuilder withSSLContext(SSLContext sslContext) {
       return (NessieHttpClientBuilder) super.withSSLContext(sslContext);
     }

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
@@ -151,6 +151,14 @@ public class NessieHttpClientBuilderImpl
     return this;
   }
 
+  @CanIgnoreReturnValue
+  @Override
+  public NessieHttpClientBuilderImpl withSSLNoCertificateVerification(
+      boolean noCertificateVerification) {
+    builder.setSslNoCertificateVerification(noCertificateVerification);
+    return this;
+  }
+
   /**
    * Set the SSL context for this client.
    *

--- a/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
+++ b/api/client/src/main/java/org/projectnessie/client/http/NessieHttpClientBuilderImpl.java
@@ -153,9 +153,9 @@ public class NessieHttpClientBuilderImpl
 
   @CanIgnoreReturnValue
   @Override
-  public NessieHttpClientBuilderImpl withSSLNoCertificateVerification(
-      boolean noCertificateVerification) {
-    builder.setSslNoCertificateVerification(noCertificateVerification);
+  public NessieHttpClientBuilderImpl withSSLCertificateVerificationDisabled(
+      boolean certificateVerificationDisabled) {
+    builder.setSslNoCertificateVerification(certificateVerificationDisabled);
     return this;
   }
 

--- a/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -18,16 +18,20 @@ package org.projectnessie.client.http;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.projectnessie.client.NessieClientBuilder.createClientBuilderFromSystemSettings;
 import static org.projectnessie.client.NessieConfigConstants.CONF_ENABLE_API_COMPATIBILITY_CHECK;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import javax.net.ssl.SSLContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -173,6 +177,34 @@ public class TestHttpClientBuilder {
         client.getConfig();
       }
     }
+  }
+
+  @Test
+  void testBuilderFromBuilderWithNoSslCertificateVerification() {
+    HttpClient.Builder builder1 =
+        HttpClient.builder()
+            .setSslNoCertificateVerification(true)
+            .setObjectMapper(new ObjectMapper());
+    assertThatCode(() -> builder1.copy().build().close()).doesNotThrowAnyException();
+    assertThatCode(() -> builder1.copy().build().close()).doesNotThrowAnyException();
+    assertThatCode(() -> builder1.build().close()).doesNotThrowAnyException();
+  }
+
+  @Test
+  void testNoSslCertificateVerificationWithSslContext() throws NoSuchAlgorithmException {
+    HttpClient.Builder builder1 =
+        HttpClient.builder()
+            .setSslNoCertificateVerification(true)
+            .setSslContext(SSLContext.getDefault())
+            .setObjectMapper(new ObjectMapper());
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> builder1.build().close())
+        .withMessage(
+            "Cannot construct Http client, must not combine nessie.ssl.no-certificate-verification and with an explicitly configured SSLContext");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> builder1.copy().build().close())
+        .withMessage(
+            "Cannot construct Http client, must not combine nessie.ssl.no-certificate-verification and with an explicitly configured SSLContext");
   }
 
   static HttpTestServer.RequestHandler handlerForHeaderTest(

--- a/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
+++ b/api/client/src/test/java/org/projectnessie/client/http/TestHttpClientBuilder.java
@@ -200,11 +200,11 @@ public class TestHttpClientBuilder {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> builder1.build().close())
         .withMessage(
-            "Cannot construct Http client, must not combine nessie.ssl.no-certificate-verification and with an explicitly configured SSLContext");
+            "Cannot construct Http client, must not combine nessie.ssl.no-certificate-verification and an explicitly configured SSLContext");
     assertThatIllegalArgumentException()
         .isThrownBy(() -> builder1.copy().build().close())
         .withMessage(
-            "Cannot construct Http client, must not combine nessie.ssl.no-certificate-verification and with an explicitly configured SSLContext");
+            "Cannot construct Http client, must not combine nessie.ssl.no-certificate-verification and an explicitly configured SSLContext");
   }
 
   static HttpTestServer.RequestHandler handlerForHeaderTest(


### PR DESCRIPTION
Disabling cerficate verfications is strongly not recommended for production use. It shall only be used for testing purposes.