### PR TITLE
Nessie CLI: Add initial Iceberg REST functionality

### DIFF
--- a/catalog/format/iceberg-fixturegen/src/main/java/org/projectnessie/catalog/formats/iceberg/fixtures/IcebergFixtures.java
+++ b/catalog/format/iceberg-fixturegen/src/main/java/org/projectnessie/catalog/formats/iceberg/fixtures/IcebergFixtures.java
@@ -45,6 +45,8 @@ import static org.projectnessie.catalog.formats.iceberg.types.IcebergType.uuidTy
 
 import java.util.Iterator;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
 import java.util.stream.Stream;
 import org.projectnessie.catalog.formats.iceberg.meta.IcebergBlobMetadata;
 import org.projectnessie.catalog.formats.iceberg.meta.IcebergNestedField;
@@ -59,6 +61,11 @@ import org.projectnessie.catalog.formats.iceberg.types.IcebergType;
 
 public class IcebergFixtures {
   public static Stream<IcebergType> icebergTypes() {
+    AtomicInteger idGen = new AtomicInteger();
+    return icebergTypes(idGen::incrementAndGet);
+  }
+
+  public static Stream<IcebergType> icebergTypes(IntSupplier idSupplier) {
     return Stream.of(
         booleanType(),
         uuidType(),
@@ -70,16 +77,20 @@ public class IcebergFixtures {
         doubleType(),
         dateType(),
         timeType(),
-        structType(singletonList(nestedField(11, "field11", true, stringType(), null)), null),
-        structType(singletonList(nestedField(11, "field11", false, stringType(), null)), null),
-        listType(1, stringType(), true),
-        listType(1, stringType(), false),
-        listType(1, uuidType(), true),
-        listType(1, uuidType(), false),
-        mapType(3, stringType(), 4, dateType(), true),
-        mapType(3, stringType(), 4, dateType(), false),
-        mapType(3, uuidType(), 4, timeType(), true),
-        mapType(3, uuidType(), 4, timeType(), false),
+        structType(
+            singletonList(nestedField(idSupplier.getAsInt(), "field11", true, stringType(), null)),
+            null),
+        structType(
+            singletonList(nestedField(idSupplier.getAsInt(), "field11", false, stringType(), null)),
+            null),
+        listType(idSupplier.getAsInt(), stringType(), true),
+        listType(idSupplier.getAsInt(), stringType(), false),
+        listType(idSupplier.getAsInt(), uuidType(), true),
+        listType(idSupplier.getAsInt(), uuidType(), false),
+        mapType(idSupplier.getAsInt(), stringType(), idSupplier.getAsInt(), dateType(), true),
+        mapType(idSupplier.getAsInt(), stringType(), idSupplier.getAsInt(), dateType(), false),
+        mapType(idSupplier.getAsInt(), uuidType(), idSupplier.getAsInt(), timeType(), true),
+        mapType(idSupplier.getAsInt(), uuidType(), idSupplier.getAsInt(), timeType(), false),
         decimalType(10, 3),
         fixedType(42),
         timestampType(),

--- a/cli/cli/build.gradle.kts
+++ b/cli/cli/build.gradle.kts
@@ -28,6 +28,10 @@ extra["maven.name"] = "Nessie - CLI"
 
 configurations.all { exclude(group = "org.projectnessie.nessie", module = "nessie-model") }
 
+val versionIceberg = libs.versions.iceberg.get()
+
+val nessieQuarkusServer by configurations.creating
+
 dependencies {
   implementation(project(":nessie-model-quarkus"))
   implementation(project(":nessie-client"))
@@ -36,6 +40,10 @@ dependencies {
 
   implementation(libs.jline)
   implementation(libs.picocli)
+
+  implementation(platform("org.apache.iceberg:iceberg-bom:$versionIceberg"))
+  implementation("org.apache.iceberg:iceberg-core")
+  runtimeOnly(libs.hadoop.common) { isTransitive = false }
 
   compileOnly(libs.immutables.value.annotations)
   annotationProcessor(libs.immutables.value.processor)
@@ -56,12 +64,29 @@ dependencies {
 
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi(libs.bundles.junit.testing)
+  testFixturesImplementation(project(":nessie-client"))
+  testFixturesImplementation(project(":nessie-cli-grammar"))
+  testFixturesImplementation(libs.jline)
 
   testImplementation(project(":nessie-jaxrs-testextension"))
 
   testImplementation(project(":nessie-versioned-storage-inmemory-tests"))
 
   testCompileOnly(libs.immutables.value.annotations)
+
+  intTestImplementation(project(":nessie-object-storage-mock"))
+  intTestImplementation(project(":nessie-catalog-format-iceberg"))
+  intTestImplementation(project(":nessie-catalog-format-iceberg-fixturegen"))
+  intTestImplementation(project(":nessie-catalog-files-api"))
+  intTestImplementation(project(":nessie-catalog-files-impl"))
+  intTestImplementation(libs.nessie.runner.common)
+  intTestImplementation(platform(libs.awssdk.bom))
+  intTestImplementation("software.amazon.awssdk:s3")
+  intTestImplementation("software.amazon.awssdk:apache-client") {
+    exclude("commons-logging", "commons-logging")
+  }
+
+  nessieQuarkusServer(project(":nessie-quarkus", "quarkusRunner"))
 }
 
 tasks.withType<ProcessResources>().configureEach {
@@ -80,4 +105,17 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
 // Issue w/ testcontainers/podman in GH workflows :(
 if (Os.isFamily(Os.FAMILY_MAC) && System.getenv("CI") != null) {
   tasks.named<Test>("intTest").configure { this.enabled = false }
+}
+
+tasks.named<Test>("intTest").configure {
+  // Spark keeps a lot of stuff around in the JVM, breaking tests against different Iceberg
+  // catalogs, so give every test class its own JVM
+  forkEvery = 1
+  inputs.files(nessieQuarkusServer)
+  val execJarProvider =
+    configurations.named("nessieQuarkusServer").map { c ->
+      val file = c.fileCollection(*c.dependencies.toTypedArray()).files.first()
+      listOf("-Dnessie.exec-jar=${file.absolutePath}")
+    }
+  jvmArgumentProviders.add(CommandLineArgumentProvider { execJarProvider.get() })
 }

--- a/cli/cli/src/intTest/java/org/projectnessie/nessie/cli/commands/ITIcebergREST.java
+++ b/cli/cli/src/intTest/java/org/projectnessie/nessie/cli/commands/ITIcebergREST.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.cli.commands;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.projectnessie.catalog.formats.iceberg.fixtures.IcebergGenerateFixtures.generateMetadataWithManifestList;
+import static org.projectnessie.objectstoragemock.HeapStorageBucket.newHeapStorageBucket;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Clock;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.catalog.files.api.ObjectIO;
+import org.projectnessie.catalog.files.s3.S3BucketOptions;
+import org.projectnessie.catalog.files.s3.S3ClientSupplier;
+import org.projectnessie.catalog.files.s3.S3Clients;
+import org.projectnessie.catalog.files.s3.S3Config;
+import org.projectnessie.catalog.files.s3.S3ObjectIO;
+import org.projectnessie.catalog.files.s3.S3Options;
+import org.projectnessie.catalog.files.s3.S3ProgrammaticOptions;
+import org.projectnessie.catalog.files.s3.S3Sessions;
+import org.projectnessie.catalog.formats.iceberg.fixtures.IcebergGenerateFixtures;
+import org.projectnessie.catalog.formats.iceberg.meta.IcebergTableMetadata;
+import org.projectnessie.client.NessieClientBuilder;
+import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.CommitResponse;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Namespace;
+import org.projectnessie.model.Operation;
+import org.projectnessie.model.Reference;
+import org.projectnessie.nessie.cli.cli.NotConnectedException;
+import org.projectnessie.nessie.cli.cmdspec.ImmutableConnectCommandSpec;
+import org.projectnessie.nessie.cli.cmdspec.ImmutableListContentsCommandSpec;
+import org.projectnessie.nessie.cli.cmdspec.ImmutableShowContentCommandSpec;
+import org.projectnessie.nessie.cli.cmdspec.ImmutableUseReferenceCommandSpec;
+import org.projectnessie.objectstoragemock.HeapStorageBucket;
+import org.projectnessie.objectstoragemock.ObjectStorageMock;
+import org.projectnessie.storage.uri.StorageUri;
+import software.amazon.awssdk.http.SdkHttpClient;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class ITIcebergREST {
+
+  public static final String S3_BUCKET = "s3://bucket/";
+  static String nessieApiUri;
+  static String icebergUri;
+
+  static ObjectStorageMock.MockServer objectStorage;
+  static HeapStorageBucket bucket;
+
+  static Branch defaultBranch;
+  static Branch testBranch;
+
+  static String tableOneBase;
+  static String tableTwoBase;
+
+  static ContentKey tableOneKey = ContentKey.of("tables", "one");
+  static ContentKey tableTwoKey = ContentKey.of("tables", "two");
+  static String tableOneId;
+  static String tableTwoId;
+  static IcebergTableMetadata tableOneMetadata;
+  static IcebergTableMetadata tableTwoMetadata;
+  static String tableOneMetadataLocation;
+  static String tableTwoMetadataLocation;
+
+  @BeforeAll
+  public static void start() throws Exception {
+    bucket = newHeapStorageBucket();
+    objectStorage =
+        ObjectStorageMock.builder().putBuckets("bucket", bucket.bucket()).build().start();
+
+    NessieProcess.start(
+        "-Dnessie.catalog.default-warehouse=warehouse",
+        "-Dnessie.catalog.warehouses.warehouse.location=" + S3_BUCKET,
+        "-Dnessie.catalog.service.s3.cloud=private",
+        "-Dnessie.catalog.service.s3.endpoint=" + objectStorage.getS3BaseUri().toString(),
+        "-Dnessie.catalog.service.s3.path-style-access=true",
+        "-Dnessie.catalog.service.s3.region=eu-central-1",
+        "-Dnessie.catalog.service.s3.access-key-id=accessKey",
+        "-Dnessie.catalog.service.s3.secret-access-key=secretKey");
+
+    tableOneBase = S3_BUCKET + "/" + UUID.randomUUID() + "/";
+    tableTwoBase = S3_BUCKET + "/" + UUID.randomUUID() + "/";
+
+    nessieApiUri = NessieProcess.baseUri + "api/v2";
+    icebergUri = NessieProcess.baseUri + "iceberg";
+
+    S3Config s3config = S3Config.builder().build();
+    SdkHttpClient httpClient = S3Clients.apacheHttpClient(s3config);
+
+    S3Options<S3BucketOptions> s3options =
+        S3ProgrammaticOptions.builder()
+            .accessKeyId("foo")
+            .secretAccessKey("bar")
+            .region("eu-central-1")
+            .endpoint(objectStorage.getS3BaseUri())
+            .pathStyleAccess(true)
+            .build();
+
+    S3Sessions sessions = new S3Sessions("foo", null);
+
+    S3ClientSupplier clientSupplier =
+        new S3ClientSupplier(
+            httpClient,
+            s3config,
+            s3options,
+            (names) -> names.stream().collect(Collectors.toMap(k -> k, k -> "secret")),
+            sessions);
+
+    ObjectIO objectIO = new S3ObjectIO(clientSupplier, Clock.systemUTC());
+
+    tableOneMetadataLocation =
+        generateMetadataWithManifestList(
+            tableOneBase, objectWriter(objectIO, tableOneBase), m -> tableOneMetadata = m);
+    tableTwoMetadataLocation =
+        generateMetadataWithManifestList(
+            tableTwoBase, objectWriter(objectIO, tableTwoBase), m -> tableTwoMetadata = m);
+
+    try (NessieApiV2 api =
+        NessieClientBuilder.createClientBuilderFromSystemSettings()
+            .withUri(nessieApiUri)
+            .build(NessieApiV2.class)) {
+      defaultBranch = api.getDefaultBranch();
+
+      Namespace namespace = tableOneKey.getNamespace();
+
+      defaultBranch =
+          api.commitMultipleOperations()
+              .branch(defaultBranch)
+              .operation(Operation.Put.of(namespace.toContentKey(), namespace))
+              .commitMeta(CommitMeta.fromMessage("namespace"))
+              .commit();
+
+      testBranch = Branch.of("testBranch", defaultBranch.getHash());
+      api.createReference().reference(testBranch).sourceRefName(defaultBranch.getName()).create();
+
+      CommitResponse committed =
+          api.commitMultipleOperations()
+              .branch(defaultBranch)
+              .operation(
+                  Operation.Put.of(
+                      tableOneKey,
+                      IcebergTable.of(
+                          tableOneMetadataLocation,
+                          tableOneMetadata.currentSnapshotId(),
+                          tableOneMetadata.currentSchemaId(),
+                          tableOneMetadata.defaultSpecId(),
+                          tableOneMetadata.defaultSortOrderId())))
+              .commitMeta(CommitMeta.fromMessage("table one"))
+              .commitWithResponse();
+      defaultBranch = committed.getTargetBranch();
+      tableOneId = committed.getAddedContents().get(0).contentId();
+
+      committed =
+          api.commitMultipleOperations()
+              .branch(testBranch)
+              .operation(
+                  Operation.Put.of(
+                      tableTwoKey,
+                      IcebergTable.of(
+                          tableTwoMetadataLocation,
+                          tableTwoMetadata.currentSnapshotId(),
+                          tableTwoMetadata.currentSchemaId(),
+                          tableTwoMetadata.defaultSpecId(),
+                          tableTwoMetadata.defaultSortOrderId())))
+              .commitMeta(CommitMeta.fromMessage("table two"))
+              .commitWithResponse();
+      testBranch = committed.getTargetBranch();
+      tableTwoId = committed.getAddedContents().get(0).contentId();
+    }
+  }
+
+  protected static IcebergGenerateFixtures.ObjectWriter objectWriter(
+      ObjectIO objectIO, String currentBase) {
+    return (name, data) -> {
+      StorageUri location =
+          name.isAbsolute()
+              ? StorageUri.of(name)
+              : StorageUri.of(currentBase + "/" + name.getPath());
+      try (OutputStream output = objectIO.writeObject(location)) {
+        output.write(data);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return location.toString();
+    };
+  }
+
+  @AfterAll
+  public static void stop() throws Exception {
+    objectStorage.close();
+    NessieProcess.stop();
+  }
+
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @ParameterizedTest
+  @MethodSource
+  public void connectAndUse(
+      String initialUri,
+      String icebergConnectedUri,
+      String initialReference,
+      Reference expectedReference)
+      throws Exception {
+    ImmutableConnectCommandSpec spec =
+        ImmutableConnectCommandSpec.builder()
+            .uri(initialUri)
+            .initialReference(initialReference)
+            .build();
+
+    try (NessieCliTester cli = new NessieCliTester()) {
+      soft.assertThatThrownBy(cli::mandatoryNessieApi).isInstanceOf(NotConnectedException.class);
+
+      soft.assertThatCode(() -> cli.execute(spec)).doesNotThrowAnyException();
+
+      soft.assertThat(cli.capturedOutput())
+          .containsExactly(
+              format("Connecting to %s ...", initialUri),
+              format("Successfully connected to Iceberg REST at %s", icebergConnectedUri),
+              format("Connecting to Nessie REST at %s/ ...", nessieApiUri),
+              format(
+                  "Successfully connected to Nessie REST at %s/ - Nessie API version 2, spec version 2.1.0",
+                  nessieApiUri));
+
+      soft.assertThatCode(cli::mandatoryNessieApi).doesNotThrowAnyException();
+
+      soft.assertThat(cli.getCurrentReference()).isEqualTo(expectedReference);
+
+      // "USE main" & check contents to verify that "USE" works for Nessie + Iceberg REST
+
+      cli.execute(ImmutableUseReferenceCommandSpec.of(null, "BRANCH", "main"));
+      soft.assertThat(cli.getCurrentReference()).isEqualTo(defaultBranch);
+
+      cli.execute(ImmutableListContentsCommandSpec.of(null, null, null, null, null, null));
+      soft.assertThat(cli.capturedOutput())
+          .containsExactly("      NAMESPACE tables", "  ICEBERG_TABLE " + tableOneKey);
+      cli.execute(
+          ImmutableShowContentCommandSpec.of(null, "TABLE", null, null, tableOneKey.toString()));
+      soft.assertThat(cli.capturedOutput())
+          .map(s -> s.endsWith(",") ? s.substring(0, s.length() - 1) : s)
+          .contains(
+              "        JSON: ",
+              "Content type: ICEBERG_TABLE",
+              " Content Key: " + tableOneKey,
+              "          ID: " + tableOneId,
+              //
+              "Nessie metadata:",
+              "  \"id\": \"" + tableOneId + "\"",
+              "  \"metadataLocation\": \"" + tableOneMetadataLocation + "\"",
+              //
+              "Iceberg metadata:",
+              "    \"nessie.catalog.content-id\": \"" + tableOneId + "\"",
+              "    \"nessie.commit.id\": \"" + defaultBranch.getHash() + "\"",
+              "    \"nessie.commit.ref\": \""
+                  + defaultBranch.getName()
+                  + "@"
+                  + defaultBranch.getHash()
+                  + "\"");
+
+      // "USE testBranch" & check contents to verify that "USE" works for Nessie + Iceberg REST
+
+      cli.execute(ImmutableUseReferenceCommandSpec.of(null, "BRANCH", testBranch.getName()));
+      soft.assertThat(cli.getCurrentReference()).isEqualTo(testBranch);
+
+      cli.execute(ImmutableListContentsCommandSpec.of(null, null, null, null, null, null));
+      soft.assertThat(cli.capturedOutput())
+          .containsExactly("      NAMESPACE tables", "  ICEBERG_TABLE " + tableTwoKey);
+      cli.execute(
+          ImmutableShowContentCommandSpec.of(null, "TABLE", null, null, tableTwoKey.toString()));
+      soft.assertThat(cli.capturedOutput())
+          .map(s -> s.endsWith(",") ? s.substring(0, s.length() - 1) : s)
+          .contains(
+              "        JSON: ",
+              "Content type: ICEBERG_TABLE",
+              " Content Key: " + tableTwoKey,
+              "          ID: " + tableTwoId,
+              //
+              "Nessie metadata:",
+              "  \"id\": \"" + tableTwoId + "\"",
+              "  \"metadataLocation\": \"" + tableTwoMetadataLocation + "\"",
+              //
+              "Iceberg metadata:",
+              "    \"nessie.catalog.content-id\": \"" + tableTwoId + "\"",
+              "    \"nessie.commit.id\": \"" + testBranch.getHash() + "\"",
+              "    \"nessie.commit.ref\": \""
+                  + testBranch.getName()
+                  + "@"
+                  + testBranch.getHash()
+                  + "\"");
+    }
+  }
+
+  static Stream<Arguments> connectAndUse() {
+    return Stream.of(
+        // CONNECT TO with initial reference to "testBranch"
+        arguments(icebergUri, icebergUri, testBranch.getName(), testBranch),
+        // CONNECT TO with a "prefixed" Iceberg REST URI, but a different initial reference
+        arguments(
+            icebergUri + "/" + testBranch.getName() + "/",
+            icebergUri + "/" + testBranch.getName() + "/",
+            defaultBranch.getName(),
+            defaultBranch),
+        // CONNECT TO with a "prefixed" Iceberg REST URI
+        arguments(
+            icebergUri + "/" + testBranch.getName() + "/",
+            icebergUri + "/" + testBranch.getName() + "/",
+            null,
+            testBranch),
+        arguments(
+            icebergUri + "/" + testBranch.getName(),
+            icebergUri + "/" + testBranch.getName(),
+            null,
+            testBranch),
+        // CONNECT TO with a Nessie API URI
+        arguments(nessieApiUri, icebergUri + "/", null, defaultBranch),
+        arguments(nessieApiUri + "/", icebergUri + "/", null, defaultBranch),
+        // CONNECT TO with an Iceberg REST URI
+        arguments(icebergUri, icebergUri, null, defaultBranch),
+        arguments(icebergUri + "/", icebergUri + "/", null, defaultBranch));
+  }
+}

--- a/cli/cli/src/intTest/java/org/projectnessie/nessie/cli/commands/NessieProcess.java
+++ b/cli/cli/src/intTest/java/org/projectnessie/nessie/cli/commands/NessieProcess.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.cli.commands;
+
+import static java.lang.String.format;
+import static java.lang.System.getProperty;
+import static java.util.Arrays.asList;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.projectnessie.nessierunner.common.ProcessHandler;
+
+/**
+ * Manages the Nessie process.
+ *
+ * <p>Since Nessie Catalog (Iceberg REST) does not allow the usage of {@code file:} based
+ * warehouses, we can no longer use the nessie-quarkus-runner Gradle plugin, because we now also
+ * need an object store - and the endpoint of the object store needs to be passed to Nessie Catalog,
+ * which is rather not doable in a build script.
+ *
+ * <p>We leverage the code to manage a process from nessie-quarkus-runner but start the process from
+ * the JVM running the test, while having a best-effort implementation to make sure that the process
+ * eventually terminates: via JUnit's {@code @AfterAll}, via a shutdown hook and the JVM
+ * self-destruct option {@code -XX:SelfDestructTimer=30}.
+ */
+final class NessieProcess {
+  private NessieProcess() {}
+
+  static ProcessHandler processHandler;
+  static String baseUri;
+
+  static void start(String... args) throws Exception {
+    if (processHandler != null) {
+      throw new IllegalStateException("Already started");
+    }
+
+    String execJar = getProperty("nessie.exec-jar");
+
+    List<String> command = new ArrayList<>();
+    command.add(format("%s/bin/java", getProperty("java.home")));
+    command.add("-XX:SelfDestructTimer=30");
+    command.add("-Dquarkus.http.port=0");
+    command.add("-Dquarkus.management.port=0");
+    command.add("-Dquarkus.http.port=0");
+    command.add("-Dquarkus.management.port=0");
+    command.add("-Dnessie.server.send-stacktrace-to-client=true");
+    command.addAll(asList(args));
+    command.add("-jar");
+    command.add(execJar);
+
+    processHandler = new ProcessHandler();
+    processHandler.start(new ProcessBuilder().command(command));
+
+    Runtime.getRuntime().addShutdownHook(new Thread(NessieProcess::stop));
+
+    List<String> listenUrls = processHandler.getListenUrls();
+    String httpListenUrl = listenUrls.get(0);
+    int httpListenPort = URI.create(httpListenUrl).getPort();
+    baseUri = format("http://127.0.0.1:%s/", httpListenPort);
+  }
+
+  public static void stop() {
+    if (processHandler != null) {
+      try {
+        processHandler.stop();
+      } finally {
+        processHandler = null;
+      }
+    }
+  }
+}

--- a/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/NessieCliImpl.java
+++ b/cli/cli/src/main/java/org/projectnessie/nessie/cli/cli/NessieCliImpl.java
@@ -31,6 +31,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.Callable;
+import org.apache.iceberg.exceptions.ServiceFailureException;
+import org.apache.iceberg.rest.RESTCatalog;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -161,8 +163,8 @@ public class NessieCliImpl extends BaseNessieCli implements Callable<Integer> {
   }
 
   @Override
-  public void connected(NessieApiV2 nessieApi) {
-    super.connected(nessieApi);
+  public void connected(NessieApiV2 nessieApi, RESTCatalog icebergClient) {
+    super.connected(nessieApi, icebergClient);
     updatePrompt();
   }
 
@@ -453,6 +455,7 @@ public class NessieCliImpl extends BaseNessieCli implements Callable<Integer> {
 
     errMsg.append("\n\n");
     if (!(e instanceof HttpClientException)
+        && !(e instanceof ServiceFailureException)
         && !(e instanceof BaseNessieClientServerException)
         && !(e instanceof NessieServiceException)
         && !(e instanceof IllegalArgumentException)) {

--- a/cli/cli/src/main/resources/logback.xml
+++ b/cli/cli/src/main/resources/logback.xml
@@ -23,8 +23,7 @@
       <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root>
-    <level value="${log.level.console:-WARN}"/>
+  <root level="${log.level.console:-WARN}">
     <appender-ref ref="console"/>
   </root>
 </configuration>

--- a/cli/cli/src/test/java/org/projectnessie/nessie/cli/commands/BaseTestCommand.java
+++ b/cli/cli/src/test/java/org/projectnessie/nessie/cli/commands/BaseTestCommand.java
@@ -22,12 +22,9 @@ import java.util.Map;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.projectnessie.client.api.NessieApiV2;
-import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.client.ext.NessieClientUri;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.nessie.cli.cmdspec.ImmutableConnectCommandSpec;
@@ -49,18 +46,11 @@ public abstract class BaseTestCommand {
 
   @RegisterExtension static NessieJaxRsExtension server = jaxRsExtension(() -> persist);
 
-  private NessieApiV2 nessieApi;
   private URI uri;
 
   @BeforeEach
-  public void setUp(NessieClientFactory clientFactory, @NessieClientUri URI uri) {
-    nessieApi = (NessieApiV2) clientFactory.make();
+  public void setUp(@NessieClientUri URI uri) {
     this.uri = uri;
-  }
-
-  @AfterEach
-  public void tearDown() {
-    nessieApi.close();
   }
 
   protected URI nessieBaseUri() {

--- a/cli/cli/src/test/java/org/projectnessie/nessie/cli/commands/TestConnect.java
+++ b/cli/cli/src/test/java/org/projectnessie/nessie/cli/commands/TestConnect.java
@@ -36,8 +36,9 @@ public class TestConnect extends BaseTestCommand {
       soft.assertThat(cli.capturedOutput())
           .containsExactly(
               format("Connecting to %s ...", nessieBaseUri()),
+              format("No Iceberg REST endpoint at %s ...", nessieBaseUri().resolve("../iceberg/")),
               format(
-                  "Successfully connected to %s - Nessie API version 2, spec version 2.1.0",
+                  "Successfully connected to Nessie REST at %s - Nessie API version 2, spec version 2.1.0",
                   nessieBaseUri()));
 
       soft.assertThatCode(cli::mandatoryNessieApi).doesNotThrowAnyException();
@@ -55,7 +56,10 @@ public class TestConnect extends BaseTestCommand {
 
       soft.assertThatThrownBy(() -> cli.execute(spec)).isInstanceOf(HttpClientException.class);
 
-      soft.assertThat(cli.capturedOutput()).containsExactly(format("Connecting to %s ...", badUri));
+      soft.assertThat(cli.capturedOutput())
+          .containsExactly(
+              format("Connecting to %s ...", badUri),
+              format("No Iceberg REST endpoint at %s ...", badUri));
     }
   }
 }

--- a/cli/cli/src/testFixtures/java/org/projectnessie/nessie/cli/commands/NessieCliTester.java
+++ b/cli/cli/src/testFixtures/java/org/projectnessie/nessie/cli/commands/NessieCliTester.java
@@ -29,7 +29,7 @@ import org.projectnessie.nessie.cli.cmdspec.CommandSpec;
 public class NessieCliTester extends BaseNessieCli implements AutoCloseable {
   private final ByteArrayOutputStream out;
 
-  protected NessieCliTester() throws Exception {
+  public NessieCliTester() throws Exception {
     InputStream in = InputStream.nullInputStream();
     out = new ByteArrayOutputStream();
 

--- a/cli/grammar/src/main/congocc/nessie/nessie-cli-java.ccc
+++ b/cli/grammar/src/main/congocc/nessie/nessie-cli-java.ccc
@@ -130,7 +130,7 @@ import org.projectnessie.nessie.cli.cmdspec.*;
 
   @Override
   public String getInitialReference() {
-    return null;
+    return stringValueOf("initialRef");
   }
 
   @Override

--- a/cli/grammar/src/main/congocc/nessie/nessie-cli.ccc
+++ b/cli/grammar/src/main/congocc/nessie/nessie-cli.ccc
@@ -126,7 +126,12 @@ ExitStatement
 ConnectStatement
     : <CONNECT>
       <TO> /uri/=Uri
-      { setOptionalNextTokenTypes(TokenType.USING); }
+      { setOptionalNextTokenTypes(TokenType.ON, TokenType.USING); }
+      [ <ON>
+        { setOptionalNextTokenTypes(); }
+        /initialRef/=ReferenceName
+        { setOptionalNextTokenTypes(TokenType.USING); }
+      ]
       [ <USING>
         { setOptionalNextTokenTypes();
           completionType = CompletionType.CONNECT_OPTIONS; }

--- a/cli/grammar/src/main/resources/org/projectnessie/nessie/cli/syntax/ConnectStatement.help.txt
+++ b/cli/grammar/src/main/resources/org/projectnessie/nessie/cli/syntax/ConnectStatement.help.txt
@@ -1,5 +1,8 @@
 Connect to a Nessie repository using the Nessie REST API base URI specified via `Uri`.
 
+When using Nessie with Iceberg REST, it is recommended to use the Iceberg REST base URI
+instead of the Nessie REST base URI.
+
 Nessie client options can be specified using the `ParamKey = Value` pairs, see
 https://projectnessie.org/nessie-latest/client_config/,
 
@@ -11,9 +14,20 @@ statement in the history file.
 
 Examples:
 
+* Local Nessie with Iceberg REST, using the default branch:
+  `CONNECT TO http://127.0.0.1:19120/iceberg/` for a locally running Nessie instance with
+  Iceberg REST (on your machine) without authentication enabled.
+* Nessie with Iceberg REST, using another branch:
+  `CONNECT TO http://127.0.0.1:19120/iceberg ON myBranch` for a locally running Nessie
+  instance with Iceberg REST (on your machine) without authentication enabled, using `myBranch`
+  as the initial reference name. Alternatively, you can add the initial reference name to
+  the URI like this: `CONNECT TO http://127.0.0.1:19120/iceberg/myBranch`.
 * Local Nessie:
   `CONNECT TO http://127.0.0.1:19120/api/v2` for a locally running Nessie instance (on your
   machine) without authentication enabled.
+* Local Nessie:
+  `CONNECT TO http://127.0.0.1:19120/api/v2 ON myBranch` for a locally running Nessie instance
+  (on your machine) without authentication enabled, but using `myBranch` as the initial reference.
 * Dremio Cloud:
   `CONNECT to https://app.dremio.cloud/repositories/beeff00d-1122-1234-4242-feedcafebabe/api/v2
     USING "nessie.authentication.type" = BEARER

--- a/cli/grammar/src/test/java/org/projectnessie/nessie/cli/completer/TestCliCompleter.java
+++ b/cli/grammar/src/test/java/org/projectnessie/nessie/cli/completer/TestCliCompleter.java
@@ -211,15 +211,31 @@ public class TestCliCompleter {
             false,
             List.of(),
             List.of(),
-            List.of("CONNECT TO http://127.0.0.1 USING"),
+            List.of("CONNECT TO http://127.0.0.1 ON", "CONNECT TO http://127.0.0.1 USING"),
             CompletionType.NONE,
-            List.of(TokenType.USING)),
+            List.of(TokenType.ON, TokenType.USING)),
         arguments(
             "CONNECT TO \"http://127.0.0.1\"",
             false,
             List.of(),
             List.of(),
-            List.of("CONNECT TO \"http://127.0.0.1\" USING"),
+            List.of("CONNECT TO \"http://127.0.0.1\" ON", "CONNECT TO \"http://127.0.0.1\" USING"),
+            CompletionType.NONE,
+            List.of(TokenType.ON, TokenType.USING)),
+        arguments(
+            "CONNECT TO http://127.0.0.1 ON ",
+            true,
+            List.of(),
+            List.of(),
+            List.of(),
+            CompletionType.NONE,
+            List.of()),
+        arguments(
+            "CONNECT TO http://127.0.0.1 ON myBranch",
+            false,
+            List.of(),
+            List.of(),
+            List.of("CONNECT TO http://127.0.0.1 ON myBranch USING"),
             CompletionType.NONE,
             List.of(TokenType.USING)),
         arguments(
@@ -1006,12 +1022,28 @@ public class TestCliCompleter {
             List.of(
                 ImmutableConnectCommandSpec.builder().uri("http://foo.bar:1234/api/v2").build())),
         arguments(
+            "CONNECT TO \"http://foo.bar:1234/api/v2\" ON myBranch",
+            List.of(
+                ImmutableConnectCommandSpec.builder()
+                    .uri("http://foo.bar:1234/api/v2")
+                    .initialReference("myBranch")
+                    .build())),
+        arguments(
             "CONNECT TO https://foo.bar/x/y/zapi/v2 USING a=b AND c=d",
             List.of(
                 ImmutableConnectCommandSpec.builder()
                     .uri("https://foo.bar/x/y/zapi/v2")
                     .putParameter("a", "b")
                     .putParameter("c", "d")
+                    .build())),
+        arguments(
+            "CONNECT TO https://foo.bar/x/y/zapi/v2 ON myBranch USING a=b AND c=d",
+            List.of(
+                ImmutableConnectCommandSpec.builder()
+                    .uri("https://foo.bar/x/y/zapi/v2")
+                    .putParameter("a", "b")
+                    .putParameter("c", "d")
+                    .initialReference("myBranch")
                     .build())),
         arguments("HELP", List.of(ImmutableHelpCommandSpec.builder().build())),
         arguments(

--- a/site/in-dev/cli.md
+++ b/site/in-dev/cli.md
@@ -10,7 +10,7 @@ and tag management capabilities. This is installed as a standalone uber jar from
 [releases page on GitHub](https://github.com/projectnessie/nessie/releases/). 
 
 Nessie CLI is designed to be usable as an interactive REPL supporting auto-completion,
-highlighting where appropriage and has built-in help. Long outputs, like a commit log,
+highlighting where appropriate and has built-in help. Long outputs, like a commit log,
 are automatically paged like the Unix `less` command.
 
 
@@ -24,6 +24,16 @@ Nessie CLI requires Java 11.
 ```bash
 java -jar nessie-cli-<version>.jar
 ```
+
+!!! tip
+    Use `CONNECT TO http://127.0.0.1:19120/iceberg` to connect to a locally running Nessie
+    instance with Iceberg REST. Use `CONNECT TO http://127.0.0.1:19120/api/v2` for Nessie's
+    native REST API.
+
+    Use `CONNECT TO https://app.dremio.cloud/repositories/<project-id>/api/v2` to
+    connect to your Dremio cloud instance using Nessie's native REST API.
+
+    See [`CONNECT` statement](#connect) below.
 
 ### Command line options
 


### PR DESCRIPTION
`CONNECT TO` and `USE` working, `SHOW TABLE/VIEW` displays the table/view metadata.
    
Also adds the `ON initialReference` clause to `CONNECT TO`.
