### PR TITLE
Persistence: properly handle timeout-ish exceptions

### DIFF
--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraBackend.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraBackend.java
@@ -328,8 +328,7 @@ public final class CassandraBackend implements Backend {
       ResultSet rs = session.execute(stmt);
       return rs.wasApplied();
     } catch (DriverException e) {
-      handleDriverException(e);
-      return false;
+      throw unhandledException(e);
     }
   }
 
@@ -354,18 +353,6 @@ public final class CassandraBackend implements Backend {
       return new UnknownOperationResultException(e);
     } else {
       return e;
-    }
-  }
-
-  static void handleDriverException(DriverException e) {
-    if (e instanceof QueryExecutionException) {
-      throw new UnknownOperationResultException(e);
-    } else if (e instanceof DriverTimeoutException
-        || e instanceof NodeUnavailableException
-        || e instanceof AllNodesFailedException) {
-      throw new UnknownOperationResultException(e);
-    } else {
-      throw e;
     }
   }
 

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraBackend.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraBackend.java
@@ -61,7 +61,6 @@ import com.datastax.oss.driver.api.core.metadata.Metadata;
 import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
-import com.datastax.oss.driver.api.core.servererrors.CASWriteUnknownException;
 import com.datastax.oss.driver.api.core.servererrors.QueryExecutionException;
 import jakarta.annotation.Nonnull;
 import java.lang.reflect.Array;
@@ -360,29 +359,13 @@ public final class CassandraBackend implements Backend {
 
   static void handleDriverException(DriverException e) {
     if (e instanceof QueryExecutionException) {
-      if (e instanceof CASWriteUnknownException) {
-        logCASWriteUnknown((CASWriteUnknownException) e);
-      } else {
-        throw new UnknownOperationResultException(e);
-      }
+      throw new UnknownOperationResultException(e);
     } else if (e instanceof DriverTimeoutException
         || e instanceof NodeUnavailableException
         || e instanceof AllNodesFailedException) {
       throw new UnknownOperationResultException(e);
     } else {
       throw e;
-    }
-  }
-
-  @SuppressWarnings("Slf4jDoNotLogMessageOfExceptionExplicitly")
-  private static void logCASWriteUnknown(CASWriteUnknownException e) {
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug(
-          "Assuming CAS failed due to CASWriteUnknownException with message'{}', coordinator: {}, errors: {}, warnings: {}",
-          e.getMessage(),
-          e.getExecutionInfo().getCoordinator(),
-          e.getExecutionInfo().getErrors(),
-          e.getExecutionInfo().getWarnings());
     }
   }
 

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
-import static org.projectnessie.versioned.storage.cassandra.CassandraBackend.handleDriverException;
 import static org.projectnessie.versioned.storage.cassandra.CassandraBackend.unhandledException;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.ADD_REFERENCE;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.COL_OBJ_ID;
@@ -403,7 +402,7 @@ public class CassandraPersist implements Persist {
                       (resultSet, e) -> {
                         if (e != null) {
                           if (e instanceof DriverException) {
-                            handleDriverException((DriverException) e);
+                            throw unhandledException((DriverException) e);
                           }
                           if (e instanceof RuntimeException) {
                             throw (RuntimeException) e;

--- a/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
+++ b/versioned/storage/cassandra/src/main/java/org/projectnessie/versioned/storage/cassandra/CassandraPersist.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
+import static org.projectnessie.versioned.storage.cassandra.CassandraBackend.handleDriverException;
+import static org.projectnessie.versioned.storage.cassandra.CassandraBackend.unhandledException;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.ADD_REFERENCE;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.COL_OBJ_ID;
 import static org.projectnessie.versioned.storage.cassandra.CassandraConstants.COL_OBJ_TYPE;
@@ -122,6 +124,8 @@ public class CassandraPersist implements Persist {
       }
 
       return batchedQuery.finish();
+    } catch (DriverException e) {
+      throw unhandledException(e);
     }
   }
 
@@ -298,6 +302,8 @@ public class CassandraPersist implements Persist {
       }
 
       r = batchedQuery.finish();
+    } catch (DriverException e) {
+      throw unhandledException(e);
     }
 
     List<ObjId> notFound = null;
@@ -397,7 +403,7 @@ public class CassandraPersist implements Persist {
                       (resultSet, e) -> {
                         if (e != null) {
                           if (e instanceof DriverException) {
-                            backend.handleDriverException((DriverException) e);
+                            handleDriverException((DriverException) e);
                           }
                           if (e instanceof RuntimeException) {
                             throw (RuntimeException) e;
@@ -412,6 +418,8 @@ public class CassandraPersist implements Persist {
           requests.submitted(cs);
         }
       }
+    } catch (DriverException e) {
+      throw unhandledException(e);
     }
 
     int l = results.length();
@@ -476,6 +484,8 @@ public class CassandraPersist implements Persist {
           requests.submitted(backend.executeAsync(stmt));
         }
       }
+    } catch (DriverException e) {
+      throw unhandledException(e);
     }
   }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/exceptions/UnknownOperationResultException.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/exceptions/UnknownOperationResultException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.versioned.storage.common.exceptions;
+
+import org.projectnessie.versioned.storage.common.persist.Persist;
+
+/**
+ * Thrown by {@link Persist} implementations when the result of a database operation is unknown, for
+ * example due to a timeout.
+ */
+public class UnknownOperationResultException extends RuntimeException {
+  public UnknownOperationResultException(Throwable cause) {
+    super(cause);
+  }
+
+  public UnknownOperationResultException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
@@ -15,6 +15,9 @@
  */
 package org.projectnessie.versioned.storage.common.logic;
 
+import static org.projectnessie.versioned.storage.common.logic.CommitLogic.ValueReplacement.NO_VALUE_REPLACEMENT;
+import static org.projectnessie.versioned.storage.common.logic.ConflictHandler.ConflictResolution.CONFLICT;
+
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
@@ -170,6 +173,13 @@ public interface CommitLogic {
       @Nonnull ValueReplacement expectedValueReplacement,
       @Nonnull ValueReplacement committedValueReplacement)
       throws CommitConflictException, ObjNotFoundException;
+
+  @Nonnull
+  default CommitObj buildCommitObj(@Nonnull CreateCommit createCommit)
+      throws CommitConflictException, ObjNotFoundException {
+    return buildCommitObj(
+        createCommit, c -> CONFLICT, (k, v) -> {}, NO_VALUE_REPLACEMENT, NO_VALUE_REPLACEMENT);
+  }
 
   @FunctionalInterface
   interface ValueReplacement {

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogic.java
@@ -71,13 +71,14 @@ public interface CommitLogic {
    *
    * @param commit commit to store
    * @param additionalObjects additional {@link Obj}s to store, for example {@link ContentValueObj}
-   * @return {@code true} if committed
+   * @return the persisted {@link CommitObj} if successful
    * @see #doCommit(CreateCommit, List)
    * @see #buildCommitObj(CreateCommit, ConflictHandler, CommitOpHandler, ValueReplacement,
    *     ValueReplacement)
    * @see #updateCommit(CommitObj)
    */
-  boolean storeCommit(@Nonnull CommitObj commit, @Nonnull List<Obj> additionalObjects);
+  @Nullable
+  CommitObj storeCommit(@Nonnull CommitObj commit, @Nonnull List<Obj> additionalObjects);
 
   /**
    * Updates an <em>existing</em> commit and handles storing the (external) {@link

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
@@ -34,7 +34,6 @@ import static org.projectnessie.versioned.storage.common.logic.CommitConflict.Co
 import static org.projectnessie.versioned.storage.common.logic.CommitConflict.ConflictType.PAYLOAD_DIFFERS;
 import static org.projectnessie.versioned.storage.common.logic.CommitConflict.ConflictType.VALUE_DIFFERS;
 import static org.projectnessie.versioned.storage.common.logic.CommitConflict.commitConflict;
-import static org.projectnessie.versioned.storage.common.logic.CommitLogic.ValueReplacement.NO_VALUE_REPLACEMENT;
 import static org.projectnessie.versioned.storage.common.logic.ConflictHandler.ConflictResolution.CONFLICT;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Add.commitAdd;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Remove.commitRemove;
@@ -274,9 +273,7 @@ final class CommitLogicImpl implements CommitLogic {
   public CommitObj doCommit(
       @Nonnull CreateCommit createCommit, @Nonnull List<Obj> additionalObjects)
       throws CommitConflictException, ObjNotFoundException {
-    CommitObj commit =
-        buildCommitObj(
-            createCommit, c -> CONFLICT, (k, v) -> {}, NO_VALUE_REPLACEMENT, NO_VALUE_REPLACEMENT);
+    CommitObj commit = buildCommitObj(createCommit);
     return storeCommit(commit, additionalObjects);
   }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
@@ -312,11 +312,11 @@ final class CommitLogicImpl implements CommitLogic {
   }
 
   /**
-   * Called when the above {@link #storeCommit(CommitObj, List)} could not persist the {@link
-   * CommitObj} (duplicate object-id). Checks whether the persisted object is actually the object
-   * that's expected to be persisted - and yields "OK" in that case. This mitigates the risk of
-   * false-positive hash-collision errors in case the backend database runs into timeout situations
-   * with an undefined outcome.
+   * Called from the above {@link #storeCommit(CommitObj, List)}, handles the case when it could not
+   * persist the {@link CommitObj} (duplicate object-id). Checks whether the persisted object is
+   * actually the object that's expected to be persisted - and yields "OK" in that case. This
+   * mitigates the risk of false-positive hash-collision errors in case the backend database runs
+   * into timeout situations with an undefined outcome.
    */
   private CommitObj mitigateHashCollision(boolean storeResult, CommitObj commit) {
     if (storeResult) {

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
@@ -277,18 +277,19 @@ final class CommitLogicImpl implements CommitLogic {
     CommitObj commit =
         buildCommitObj(
             createCommit, c -> CONFLICT, (k, v) -> {}, NO_VALUE_REPLACEMENT, NO_VALUE_REPLACEMENT);
-    return storeCommit(commit, additionalObjects) ? commit : null;
+    return storeCommit(commit, additionalObjects);
   }
 
+  @Nullable
   @Override
-  public boolean storeCommit(@Nonnull CommitObj commit, @Nonnull List<Obj> additionalObjects) {
+  public CommitObj storeCommit(@Nonnull CommitObj commit, @Nonnull List<Obj> additionalObjects) {
     int numAdditional = additionalObjects.size();
     try {
       Obj[] allObjs = additionalObjects.toArray(new Obj[numAdditional + 1]);
       allObjs[numAdditional] = commit;
 
       boolean[] stored = persist.storeObjs(allObjs);
-      return stored[numAdditional];
+      return mitigateHashCollision(stored[numAdditional], commit);
     } catch (ObjTooLargeException e) {
       // The incremental index became too big - need to spill out the INCREMENTAL_* operations to
       // the reference index.
@@ -302,11 +303,35 @@ final class CommitLogicImpl implements CommitLogic {
       commit = indexTooBigStoreUpdate(commit);
 
       try {
-        return persist.storeObj(commit, true);
+        return mitigateHashCollision(persist.storeObj(commit, true), commit);
       } catch (ObjTooLargeException ex) {
         // Hit the "Hard database object size limit"
         throw new RuntimeException(ex);
       }
+    }
+  }
+
+  /**
+   * Called when the above {@link #storeCommit(CommitObj, List)} could not persist the {@link
+   * CommitObj} (duplicate object-id). Checks whether the persisted object is actually the object
+   * that's expected to be persisted - and yields "OK" in that case. This mitigates the risk of
+   * false-positive hash-collision errors in case the backend database runs into timeout situations
+   * with an undefined outcome.
+   */
+  private CommitObj mitigateHashCollision(boolean storeResult, CommitObj commit) {
+    if (storeResult) {
+      return commit;
+    }
+
+    // Check whether the existing object is the same commit (w/o considering the internal "created"
+    // timestamp of the commit-obj).
+    try {
+      CommitObj existing = persist.fetchTypedObj(commit.id(), COMMIT, CommitObj.class);
+      CommitObj commitWithNewCreatedTimestamp =
+          CommitObj.commitBuilder().from(commit).created(existing.created()).build();
+      return commitWithNewCreatedTimestamp.equals(existing) ? existing : null;
+    } catch (ObjNotFoundException e) {
+      return null;
     }
   }
 

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitRetry.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitRetry.java
@@ -30,6 +30,7 @@ import org.projectnessie.versioned.storage.common.config.StoreConfig;
 import org.projectnessie.versioned.storage.common.exceptions.CommitConflictException;
 import org.projectnessie.versioned.storage.common.exceptions.CommitWrappedException;
 import org.projectnessie.versioned.storage.common.exceptions.RetryTimeoutException;
+import org.projectnessie.versioned.storage.common.exceptions.UnknownOperationResultException;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 
 public class CommitRetry {
@@ -60,6 +61,10 @@ public class CommitRetry {
           throw new RetryTimeoutException(i, tls.currentNanos() - t0);
         }
         retryState = e.retryState();
+      } catch (UnknownOperationResultException e) {
+        if (!tls.retry(t1)) {
+          throw new RetryTimeoutException(i, tls.currentNanos() - t0);
+        }
       }
     }
   }

--- a/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestCommitConflicts.java
+++ b/versioned/storage/common/src/test/java/org/projectnessie/versioned/storage/common/logic/TestCommitConflicts.java
@@ -478,7 +478,7 @@ public class TestCommitConflicts {
         .containsEntry(fooKey, fooAddId)
         .containsEntry(barKey, barAddId);
 
-    soft.assertThat(commitLogic.storeCommit(firstCommit, emptyList())).isTrue();
+    soft.assertThat(commitLogic.storeCommit(firstCommit, emptyList())).isEqualTo(firstCommit);
     ObjId firstCommitId = firstCommit.id();
 
     // callback for a remove + update
@@ -502,7 +502,7 @@ public class TestCommitConflicts {
         .containsEntry(fooKey, null)
         .containsEntry(barKey, barUpdateId);
 
-    soft.assertThat(commitLogic.storeCommit(secondCommit, emptyList())).isTrue();
+    soft.assertThat(commitLogic.storeCommit(secondCommit, emptyList())).isEqualTo(secondCommit);
     ObjId secondCommitId = secondCommit.id();
     CommitObj secondCommitLoaded = requireNonNull(commitLogic.fetchCommit(secondCommitId));
     commitLogic.updateCommit(secondCommitLoaded);

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
 import static org.projectnessie.versioned.storage.common.util.Closing.closeMultiple;
-import static org.projectnessie.versioned.storage.jdbc.JdbcBackend.unhandledSQLException;
 import static org.projectnessie.versioned.storage.jdbc.JdbcSerde.deserializeObjId;
 import static org.projectnessie.versioned.storage.jdbc.JdbcSerde.serializeObjId;
 import static org.projectnessie.versioned.storage.jdbc.SqlConstants.ADD_REFERENCE;
@@ -667,7 +666,7 @@ abstract class AbstractJdbcPersist implements Persist {
     }
   }
 
-  private abstract static class ResultSetIterator<R> extends AbstractIterator<R>
+  private abstract class ResultSetIterator<R> extends AbstractIterator<R>
       implements CloseableIterator<R> {
 
     private final Connection conn;
@@ -714,10 +713,14 @@ abstract class AbstractJdbcPersist implements Persist {
 
         return mapToObj(rs);
       } catch (SQLException e) {
-        throw new RuntimeException(e);
+        throw unhandledSQLException(e);
       }
     }
 
     protected abstract R mapToObj(ResultSet rs) throws SQLException;
+  }
+
+  protected RuntimeException unhandledSQLException(SQLException e) {
+    return JdbcBackend.unhandledSQLException(databaseSpecific, e);
   }
 }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
@@ -16,7 +16,6 @@
 package org.projectnessie.versioned.storage.jdbc;
 
 import static java.util.Collections.singleton;
-import static org.projectnessie.versioned.storage.jdbc.JdbcBackend.unhandledSQLException;
 
 import jakarta.annotation.Nonnull;
 import java.sql.Connection;

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -788,13 +788,7 @@ public class MongoDBPersist implements Persist {
   }
 
   static RuntimeException handleMongoWriteException(MongoWriteException e) {
-    switch (e.getError().getCategory()) {
-      case EXECUTION_TIMEOUT:
-      case UNCATEGORIZED:
-        return new UnknownOperationResultException(e);
-      default:
-        return e;
-    }
+    return handleMongoWriteError(e, e.getError());
   }
 
   static RuntimeException handleMongoWriteError(MongoException e, WriteError error) {

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -46,7 +46,14 @@ import static org.projectnessie.versioned.storage.serialize.ProtoSerialization.s
 
 import com.google.common.collect.AbstractIterator;
 import com.mongodb.MongoBulkWriteException;
+import com.mongodb.MongoException;
+import com.mongodb.MongoExecutionTimeoutException;
+import com.mongodb.MongoInterruptedException;
+import com.mongodb.MongoServerUnavailableException;
+import com.mongodb.MongoSocketReadTimeoutException;
+import com.mongodb.MongoTimeoutException;
 import com.mongodb.MongoWriteException;
+import com.mongodb.WriteError;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.bulk.BulkWriteInsert;
 import com.mongodb.bulk.BulkWriteResult;
@@ -77,6 +84,7 @@ import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeExceptio
 import org.projectnessie.versioned.storage.common.exceptions.RefAlreadyExistsException;
 import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
 import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.UnknownOperationResultException;
 import org.projectnessie.versioned.storage.common.persist.CloseableIterator;
 import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
@@ -155,7 +163,9 @@ public class MongoDBPersist implements Persist {
       if (e.getError().getCategory() == DUPLICATE_KEY) {
         throw new RefAlreadyExistsException(fetchReference(reference.name()));
       }
-      throw e;
+      throw unhandledException(e);
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
     }
     return reference;
   }
@@ -165,8 +175,17 @@ public class MongoDBPersist implements Persist {
   public Reference markReferenceAsDeleted(@Nonnull Reference reference)
       throws RefNotFoundException, RefConditionFailedException {
     reference = reference.withDeleted(false);
-    UpdateResult result =
-        backend.refs().updateOne(referenceCondition(reference), set(COL_REFERENCES_DELETED, true));
+
+    UpdateResult result;
+    try {
+      result =
+          backend
+              .refs()
+              .updateOne(referenceCondition(reference), set(COL_REFERENCES_DELETED, true));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
+
     if (result.getModifiedCount() != 1) {
       Reference ex = fetchReference(reference.name());
       if (ex == null) {
@@ -213,7 +232,13 @@ public class MongoDBPersist implements Persist {
       updates.add(set(COL_REFERENCES_PREVIOUS, new Binary(previous)));
     }
 
-    UpdateResult result = backend.refs().updateOne(referenceCondition(reference), updates);
+    UpdateResult result;
+    try {
+      result = backend.refs().updateOne(referenceCondition(reference), updates);
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
+
     if (result.getModifiedCount() != 1) {
       if (result.getMatchedCount() == 1) {
         // not updated
@@ -234,7 +259,14 @@ public class MongoDBPersist implements Persist {
   public void purgeReference(@Nonnull Reference reference)
       throws RefNotFoundException, RefConditionFailedException {
     reference = reference.withDeleted(true);
-    DeleteResult result = backend.refs().deleteOne(referenceCondition(reference));
+
+    DeleteResult result;
+    try {
+      result = backend.refs().deleteOne(referenceCondition(reference));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
+
     if (result.getDeletedCount() != 1) {
       Reference ex = fetchReference(reference.name());
       if (ex == null) {
@@ -246,7 +278,12 @@ public class MongoDBPersist implements Persist {
 
   @Override
   public Reference fetchReference(@Nonnull String name) {
-    FindIterable<Document> result = backend.refs().find(eq(ID_PROPERTY_NAME, idRefDoc(name)));
+    FindIterable<Document> result;
+    try {
+      result = backend.refs().find(eq(ID_PROPERTY_NAME, idRefDoc(name)));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
 
     Document doc = result.first();
     if (doc == null) {
@@ -274,7 +311,13 @@ public class MongoDBPersist implements Persist {
   public Reference[] fetchReferences(@Nonnull String[] names) {
     List<Document> nameIdDocs =
         Arrays.stream(names).filter(Objects::nonNull).map(this::idRefDoc).collect(toList());
-    FindIterable<Document> result = backend.refs().find(in(ID_PROPERTY_NAME, nameIdDocs));
+    FindIterable<Document> result;
+    try {
+      result = backend.refs().find(in(ID_PROPERTY_NAME, nameIdDocs));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
+
     Reference[] r = new Reference[names.length];
 
     for (Document doc : result) {
@@ -303,7 +346,12 @@ public class MongoDBPersist implements Persist {
   @Override
   @Nonnull
   public Obj fetchObj(@Nonnull ObjId id) throws ObjNotFoundException {
-    FindIterable<Document> result = backend.objs().find(eq(ID_PROPERTY_NAME, idObjDoc(id)));
+    FindIterable<Document> result;
+    try {
+      result = backend.objs().find(eq(ID_PROPERTY_NAME, idObjDoc(id)));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
 
     Document doc = result.first();
     if (doc == null) {
@@ -317,10 +365,15 @@ public class MongoDBPersist implements Persist {
   @Nonnull
   public <T extends Obj> T fetchTypedObj(@Nonnull ObjId id, ObjType type, Class<T> typeClass)
       throws ObjNotFoundException {
-    FindIterable<Document> result =
-        backend
-            .objs()
-            .find(and(eq(ID_PROPERTY_NAME, idObjDoc(id)), eq(COL_OBJ_TYPE, type.shortName())));
+    FindIterable<Document> result;
+    try {
+      result =
+          backend
+              .objs()
+              .find(and(eq(ID_PROPERTY_NAME, idObjDoc(id)), eq(COL_OBJ_TYPE, type.shortName())));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
 
     Document doc = result.first();
     if (doc == null) {
@@ -337,7 +390,12 @@ public class MongoDBPersist implements Persist {
   @Override
   @Nonnull
   public ObjType fetchObjType(@Nonnull ObjId id) throws ObjNotFoundException {
-    FindIterable<Document> result = backend.objs().find(eq(ID_PROPERTY_NAME, idObjDoc(id)));
+    FindIterable<Document> result;
+    try {
+      result = backend.objs().find(eq(ID_PROPERTY_NAME, idObjDoc(id)));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
 
     Document doc = result.first();
     if (doc == null) {
@@ -384,7 +442,12 @@ public class MongoDBPersist implements Persist {
   }
 
   private void fetchObjsPage(Obj[] r, List<Document> list, Object2IntHashMap<ObjId> idToIndex) {
-    FindIterable<Document> result = backend.objs().find(in(ID_PROPERTY_NAME, list));
+    FindIterable<Document> result;
+    try {
+      result = backend.objs().find(in(ID_PROPERTY_NAME, list));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
     for (Document doc : result) {
       Obj obj = docToObj(doc);
       int idx = idToIndex.getValue(obj.id());
@@ -404,7 +467,9 @@ public class MongoDBPersist implements Persist {
       if (e.getError().getCategory() == DUPLICATE_KEY) {
         return false;
       }
-      throw e;
+      throw handleMongoWriteException(e);
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
     }
 
     return true;
@@ -439,7 +504,7 @@ public class MongoDBPersist implements Persist {
         List<BulkWriteError> errs = e.getWriteErrors();
         for (BulkWriteError err : errs) {
           if (err.getCategory() != DUPLICATE_KEY) {
-            throw e;
+            throw handleMongoWriteError(e, err);
           }
         }
         BulkWriteResult res = e.getWriteResult();
@@ -449,6 +514,8 @@ public class MongoDBPersist implements Persist {
             .mapToInt(id -> objIdIndex(objs, id))
             .mapToObj(docs::get)
             .forEach(inserts::add);
+      } catch (RuntimeException e) {
+        throw unhandledException(e);
       }
     }
     return r;
@@ -473,7 +540,11 @@ public class MongoDBPersist implements Persist {
 
   @Override
   public void deleteObj(@Nonnull ObjId id) {
-    backend.objs().deleteOne(eq(ID_PROPERTY_NAME, idObjDoc(id)));
+    try {
+      backend.objs().deleteOne(eq(ID_PROPERTY_NAME, idObjDoc(id)));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
   }
 
   @Override
@@ -483,7 +554,11 @@ public class MongoDBPersist implements Persist {
     if (list.isEmpty()) {
       return;
     }
-    backend.objs().deleteMany(in(ID_PROPERTY_NAME, list));
+    try {
+      backend.objs().deleteMany(in(ID_PROPERTY_NAME, list));
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
   }
 
   @Override
@@ -494,8 +569,12 @@ public class MongoDBPersist implements Persist {
     ReplaceOptions options = upsertOptions();
 
     Document doc = objToDoc(obj, false);
-    UpdateResult result =
-        backend.objs().replaceOne(eq(ID_PROPERTY_NAME, idObjDoc(id)), doc, options);
+    UpdateResult result;
+    try {
+      result = backend.objs().replaceOne(eq(ID_PROPERTY_NAME, idObjDoc(id)), doc, options);
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
     if (!result.wasAcknowledged()) {
       throw new RuntimeException("Upsert not acknowledged");
     }
@@ -525,7 +604,12 @@ public class MongoDBPersist implements Persist {
 
     List<WriteModel<Document>> updates = new ArrayList<>(docs);
     if (!updates.isEmpty()) {
-      BulkWriteResult res = backend.objs().bulkWrite(updates);
+      BulkWriteResult res;
+      try {
+        res = backend.objs().bulkWrite(updates);
+      } catch (RuntimeException e) {
+        throw unhandledException(e);
+      }
       if (!res.wasAcknowledged()) {
         throw new RuntimeException("Upsert not acknowledged");
       }
@@ -537,14 +621,18 @@ public class MongoDBPersist implements Persist {
     ObjId id = obj.id();
     ObjType type = obj.type();
 
-    return backend
-            .objs()
-            .findOneAndDelete(
-                and(
-                    eq(ID_PROPERTY_NAME, idObjDoc(id)),
-                    eq(COL_OBJ_TYPE, type.shortName()),
-                    eq(COL_OBJ_VERS, obj.versionToken())))
-        != null;
+    try {
+      return backend
+              .objs()
+              .findOneAndDelete(
+                  and(
+                      eq(ID_PROPERTY_NAME, idObjDoc(id)),
+                      eq(COL_OBJ_TYPE, type.shortName()),
+                      eq(COL_OBJ_VERS, obj.versionToken())))
+          != null;
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
   }
 
   @Override
@@ -568,15 +656,19 @@ public class MongoDBPersist implements Persist {
 
     Bson update = Updates.combine(updates);
 
-    return backend
-            .objs()
-            .findOneAndUpdate(
-                and(
-                    eq(ID_PROPERTY_NAME, idObjDoc(id)),
-                    eq(COL_OBJ_TYPE, type.shortName()),
-                    eq(COL_OBJ_VERS, expectedVersion)),
-                update)
-        != null;
+    try {
+      return backend
+              .objs()
+              .findOneAndUpdate(
+                  and(
+                      eq(ID_PROPERTY_NAME, idObjDoc(id)),
+                      eq(COL_OBJ_TYPE, type.shortName()),
+                      eq(COL_OBJ_VERS, expectedVersion)),
+                  update)
+          != null;
+    } catch (RuntimeException e) {
+      throw unhandledException(e);
+    }
   }
 
   @Nonnull
@@ -635,12 +727,18 @@ public class MongoDBPersist implements Persist {
     public ScanAllObjectsIterator(Set<ObjType> returnedObjTypes) {
       List<String> objTypeShortNames =
           returnedObjTypes.stream().map(ObjType::shortName).collect(toList());
-      result =
-          backend
-              .objs()
-              .find(
-                  and(eq(ID_REPO_PATH, config.repositoryId()), in(COL_OBJ_TYPE, objTypeShortNames)))
-              .iterator();
+      try {
+        result =
+            backend
+                .objs()
+                .find(
+                    and(
+                        eq(ID_REPO_PATH, config.repositoryId()),
+                        in(COL_OBJ_TYPE, objTypeShortNames)))
+                .iterator();
+      } catch (RuntimeException e) {
+        throw unhandledException(e);
+      }
     }
 
     @Override
@@ -649,13 +747,63 @@ public class MongoDBPersist implements Persist {
         return endOfData();
       }
 
-      Document doc = result.next();
-      return docToObj(doc);
+      try {
+        Document doc = result.next();
+        return docToObj(doc);
+      } catch (RuntimeException e) {
+        throw unhandledException(e);
+      }
     }
 
     @Override
     public void close() {
       result.close();
+    }
+  }
+
+  static RuntimeException unhandledException(RuntimeException e) {
+    if (e instanceof MongoInterruptedException
+        || e instanceof MongoTimeoutException
+        || e instanceof MongoServerUnavailableException
+        || e instanceof MongoSocketReadTimeoutException
+        || e instanceof MongoExecutionTimeoutException) {
+      return new UnknownOperationResultException(e);
+    }
+    if (e instanceof MongoWriteException) {
+      return handleMongoWriteException((MongoWriteException) e);
+    }
+    if (e instanceof MongoBulkWriteException) {
+      MongoBulkWriteException specific = (MongoBulkWriteException) e;
+      for (BulkWriteError error : specific.getWriteErrors()) {
+        switch (error.getCategory()) {
+          case EXECUTION_TIMEOUT:
+          case UNCATEGORIZED:
+            return new UnknownOperationResultException(e);
+          default:
+            break;
+        }
+      }
+    }
+    return e;
+  }
+
+  static RuntimeException handleMongoWriteException(MongoWriteException e) {
+    switch (e.getError().getCategory()) {
+      case EXECUTION_TIMEOUT:
+      case UNCATEGORIZED:
+        return new UnknownOperationResultException(e);
+      default:
+        return e;
+    }
+  }
+
+  static RuntimeException handleMongoWriteError(MongoException e, WriteError error) {
+    switch (error.getCategory()) {
+      case EXECUTION_TIMEOUT:
+      case UNCATEGORIZED:
+        return new UnknownOperationResultException(e);
+      default:
+        return e;
     }
   }
 }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -87,6 +87,7 @@ import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeExceptio
 import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
 import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
 import org.projectnessie.versioned.storage.common.exceptions.RetryTimeoutException;
+import org.projectnessie.versioned.storage.common.exceptions.UnknownOperationResultException;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndex;
 import org.projectnessie.versioned.storage.common.indexes.StoreIndexElement;
 import org.projectnessie.versioned.storage.common.indexes.StoreKey;
@@ -618,7 +619,7 @@ class BaseCommitHelper {
   void bumpReferencePointer(ObjId newHead, Optional<?> retryState) throws RetryException {
     try {
       persist.updateReferencePointer(reference, newHead);
-    } catch (RefConditionFailedException e) {
+    } catch (UnknownOperationResultException | RefConditionFailedException e) {
       throw new RetryException(retryState);
     } catch (RefNotFoundException e) {
       throw new RuntimeException("Internal reference not found", e);

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseCommitHelper.java
@@ -623,7 +623,7 @@ class BaseCommitHelper {
       // If the above pointer-bump returned an "unknown result", we check once (and only once!)
       // whether the reference-pointer-change succeeded. This mitigation may not always work,
       // especially not in highly concurrent update situations.
-      Reference r = persist.fetchReference(reference.name());
+      Reference r = persist.fetchReferenceForUpdate(reference.name());
       if (!reference.forNewPointer(newHead, persist.config()).equals(r)) {
         throw new RetryException(retryState);
       }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantSquash.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/BaseMergeTransplantSquash.java
@@ -119,8 +119,9 @@ class BaseMergeTransplantSquash extends BaseCommitHelper {
     } else {
       CommitLogic commitLogic = commitLogic(persist);
       newHead = mergeCommit.id();
-      boolean committed = commitLogic.storeCommit(mergeCommit, objsToStore);
-      if (committed) {
+      CommitObj committed = commitLogic.storeCommit(mergeCommit, objsToStore);
+      if (committed != null) {
+        mergeCommit = committed;
         mergeResult.addCreatedCommits(commitObjToCommit(mergeCommit));
       }
     }

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
@@ -175,7 +175,7 @@ class CommitImpl extends BaseCommitHelper {
     // `CommitRetryState.storedContents` to not store those objects during a retry.
     // This mechanism ensures that we retry the store-objects in case that one fails with an
     // `UnknownOperationResultException`.
-    Set<ObjId> toStore = new HashSet<>();
+    Set<ObjId> toStore = new HashSet<>(commitRetryState.storedContents);
     Consumer<Obj> valueConsumer =
         obj -> {
           if (toStore.add(obj.id())) {

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
@@ -214,12 +214,14 @@ class CommitImpl extends BaseCommitHelper {
       // successfully persisted that commit. This can happen, if the `Persist` implementation raised
       // an `UnknownOperationResultException` in one of the following operations (reference bump for
       // example).
-      boolean stored = commitLogic.storeCommit(newHead, objectsToStore);
-      if (stored) {
+      CommitObj stored = commitLogic.storeCommit(newHead, objectsToStore);
+      if (stored != null) {
+        newHead = stored;
         commitRetryState.commitPersisted = newHead.id();
         commitRetryState.storedContents.addAll(toStore);
       }
-      boolean commitPersisted = stored || newHead.id().equals(commitRetryState.commitPersisted);
+      boolean commitPersisted =
+          stored != null || newHead.id().equals(commitRetryState.commitPersisted);
       checkState(
           commitPersisted,
           "Hash collision detected, a commit with the same parent commit, commit message, "

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/CommitImpl.java
@@ -26,8 +26,6 @@ import static org.projectnessie.versioned.CommitValidation.CommitOperationType.C
 import static org.projectnessie.versioned.CommitValidation.CommitOperationType.DELETE;
 import static org.projectnessie.versioned.CommitValidation.CommitOperationType.UPDATE;
 import static org.projectnessie.versioned.storage.common.indexes.StoreIndexes.lazyStoreIndex;
-import static org.projectnessie.versioned.storage.common.logic.CommitLogic.ValueReplacement.NO_VALUE_REPLACEMENT;
-import static org.projectnessie.versioned.storage.common.logic.ConflictHandler.ConflictResolution.CONFLICT;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Add.commitAdd;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Remove.commitRemove;
 import static org.projectnessie.versioned.storage.common.logic.CreateCommit.Unchanged.commitUnchanged;
@@ -202,13 +200,7 @@ class CommitImpl extends BaseCommitHelper {
     CommitObj newHead;
     try {
       CreateCommit createCommit = commit.build();
-      newHead =
-          commitLogic.buildCommitObj(
-              createCommit,
-              c -> CONFLICT,
-              (k, v) -> {},
-              NO_VALUE_REPLACEMENT,
-              NO_VALUE_REPLACEMENT);
+      newHead = commitLogic.buildCommitObj(createCommit);
 
       // If 'commitRetryState.storedContents' already contains the commit-ID, __we__ already
       // successfully persisted that commit. This can happen, if the `Persist` implementation raised

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
@@ -114,8 +114,13 @@ final class TransplantIndividualImpl extends BaseCommitHelper implements Transpl
       empty = false;
       if (!transplantOp.dryRun()) {
         newHead = newCommit.id();
-        boolean committed = commitLogic.storeCommit(newCommit, objsToStore);
-        if (committed) {
+        CommitObj committed = commitLogic.storeCommit(newCommit, objsToStore);
+        // Here we have to know whether "our" 'newCommit' object has been persisted or not.
+        // If not equal, we have to assume that the commit already existed - aka a "fast-forward
+        // transplant". This is only to maintain compatibility with (pre-)existing behavior.
+        // (This .equals has been introduced with https://github.com/projectnessie/nessie/pull/8533)
+        if (newCommit.equals(committed)) {
+          newCommit = committed;
           mergeResult.addCreatedCommits(commitObjToCommit(newCommit));
         }
       }

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreImpl.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreImpl.java
@@ -17,6 +17,7 @@ package org.projectnessie.versioned.storage.versionstore;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.projectnessie.model.CommitMeta.fromMessage;
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_COMMIT_RETRIES;
 import static org.projectnessie.versioned.storage.common.config.StoreConfig.CONFIG_COMMIT_TIMEOUT_MILLIS;
@@ -25,9 +26,14 @@ import jakarta.annotation.Nonnull;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.versioned.BranchName;
@@ -37,8 +43,11 @@ import org.projectnessie.versioned.ReferenceConflictException;
 import org.projectnessie.versioned.ReferenceNotFoundException;
 import org.projectnessie.versioned.ReferenceRetryFailureException;
 import org.projectnessie.versioned.VersionStore;
+import org.projectnessie.versioned.storage.common.exceptions.ObjTooLargeException;
 import org.projectnessie.versioned.storage.common.exceptions.RefConditionFailedException;
 import org.projectnessie.versioned.storage.common.exceptions.RefNotFoundException;
+import org.projectnessie.versioned.storage.common.exceptions.UnknownOperationResultException;
+import org.projectnessie.versioned.storage.common.persist.Obj;
 import org.projectnessie.versioned.storage.common.persist.ObjId;
 import org.projectnessie.versioned.storage.common.persist.Persist;
 import org.projectnessie.versioned.storage.common.persist.Reference;
@@ -155,5 +164,81 @@ public class TestVersionStoreImpl extends AbstractVersionStoreTests {
         Optional.of(branch1),
         fromMessage("commit foo"),
         singletonList(Put.of(ContentKey.of("some-key"), IcebergTable.of("meta", 42, 43, 44, 45))));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void commitWithDatabaseTimeout(
+      @SuppressWarnings("unused") String name,
+      BiFunction<AtomicBoolean, Persist, Persist> delegateFactory)
+      throws Exception {
+    VersionStore store = new VersionStoreImpl(persist);
+
+    BranchName branch = BranchName.of("branch1");
+    Hash branch1 = store.create(branch, Optional.empty()).getHash();
+
+    AtomicBoolean called = new AtomicBoolean();
+    Persist tested = delegateFactory.apply(called, persist);
+
+    VersionStore storeTested = new VersionStoreImpl(tested);
+    storeTested.commit(
+        branch,
+        Optional.of(branch1),
+        fromMessage("commit foo"),
+        singletonList(Put.of(ContentKey.of("some-key"), IcebergTable.of("meta", 42, 43, 44, 45))));
+
+    soft.assertThat(called).isTrue();
+  }
+
+  public static Stream<Arguments> commitWithDatabaseTimeout() {
+    return Stream.of(
+        arguments(
+            "updateReferencePointer",
+            (BiFunction<AtomicBoolean, Persist, Persist>)
+                (called, p) ->
+                    new PersistDelegate(p) {
+                      @Nonnull
+                      @Override
+                      public Reference updateReferencePointer(
+                          @Nonnull Reference reference, @Nonnull ObjId newPointer)
+                          throws RefNotFoundException, RefConditionFailedException {
+                        if (called.compareAndSet(false, true)) {
+                          throw new UnknownOperationResultException("test", new RuntimeException());
+                        } else {
+                          return super.updateReferencePointer(reference, newPointer);
+                        }
+                      }
+                    }),
+        arguments(
+            "storeObj",
+            (BiFunction<AtomicBoolean, Persist, Persist>)
+                (called, p) ->
+                    new PersistDelegate(p) {
+                      @Override
+                      public boolean storeObj(@Nonnull Obj obj) throws ObjTooLargeException {
+                        if (called.compareAndSet(false, true)) {
+                          throw new UnknownOperationResultException("test", new RuntimeException());
+                        } else {
+                          return super.storeObj(obj);
+                        }
+                      }
+                    }),
+        arguments(
+            "storeObjs",
+            (BiFunction<AtomicBoolean, Persist, Persist>)
+                (called, p) ->
+                    new PersistDelegate(p) {
+                      @Nonnull
+                      @Override
+                      public boolean[] storeObjs(@Nonnull Obj[] objs) throws ObjTooLargeException {
+                        if (called.compareAndSet(false, true)) {
+                          throw new UnknownOperationResultException("test", new RuntimeException());
+                        } else {
+                          return super.storeObjs(objs);
+                        }
+                      }
+                    })
+        //
+        );
   }
 }

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreImpl.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/TestVersionStoreImpl.java
@@ -193,7 +193,57 @@ public class TestVersionStoreImpl extends AbstractVersionStoreTests {
   public static Stream<Arguments> commitWithDatabaseTimeout() {
     return Stream.of(
         arguments(
-            "updateReferencePointer",
+            "updateReferencePointer-success-but-timeout",
+            (BiFunction<AtomicBoolean, Persist, Persist>)
+                (called, p) ->
+                    new PersistDelegate(p) {
+                      @Nonnull
+                      @Override
+                      public Reference updateReferencePointer(
+                          @Nonnull Reference reference, @Nonnull ObjId newPointer)
+                          throws RefNotFoundException, RefConditionFailedException {
+                        if (called.compareAndSet(false, true)) {
+                          super.updateReferencePointer(reference, newPointer);
+                          throw new UnknownOperationResultException("test", new RuntimeException());
+                        } else {
+                          return super.updateReferencePointer(reference, newPointer);
+                        }
+                      }
+                    }),
+        arguments(
+            "storeObj-success-but-timeout",
+            (BiFunction<AtomicBoolean, Persist, Persist>)
+                (called, p) ->
+                    new PersistDelegate(p) {
+                      @Override
+                      public boolean storeObj(@Nonnull Obj obj) throws ObjTooLargeException {
+                        if (called.compareAndSet(false, true)) {
+                          super.storeObj(obj);
+                          throw new UnknownOperationResultException("test", new RuntimeException());
+                        } else {
+                          return super.storeObj(obj);
+                        }
+                      }
+                    }),
+        arguments(
+            "storeObjs-success-but-timeout",
+            (BiFunction<AtomicBoolean, Persist, Persist>)
+                (called, p) ->
+                    new PersistDelegate(p) {
+                      @Nonnull
+                      @Override
+                      public boolean[] storeObjs(@Nonnull Obj[] objs) throws ObjTooLargeException {
+                        if (called.compareAndSet(false, true)) {
+                          super.storeObjs(objs);
+                          throw new UnknownOperationResultException("test", new RuntimeException());
+                        } else {
+                          return super.storeObjs(objs);
+                        }
+                      }
+                    }),
+        //
+        arguments(
+            "updateReferencePointer-no-success",
             (BiFunction<AtomicBoolean, Persist, Persist>)
                 (called, p) ->
                     new PersistDelegate(p) {
@@ -210,7 +260,7 @@ public class TestVersionStoreImpl extends AbstractVersionStoreTests {
                       }
                     }),
         arguments(
-            "storeObj",
+            "storeObj-no-success",
             (BiFunction<AtomicBoolean, Persist, Persist>)
                 (called, p) ->
                     new PersistDelegate(p) {
@@ -224,7 +274,7 @@ public class TestVersionStoreImpl extends AbstractVersionStoreTests {
                       }
                     }),
         arguments(
-            "storeObjs",
+            "storeObjs-no-success",
             (BiFunction<AtomicBoolean, Persist, Persist>)
                 (called, p) ->
                     new PersistDelegate(p) {


### PR DESCRIPTION
Databases can run into timeout situations, which should not happen, but do happen.

This change introduces a new `UnknownOperationResultException`, which signals that the database operation did not return a meaningful result and the outcome of the operation is unknown. Within the Nessie commit-retry loop this exception is handled via a "regular" commit-retry.

Included are also related changes to the database specific implementations.