### PR TITLE
Renovate: add some recommended extensions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,11 @@
     "config:base",
     // Required to not pin dependencies to _exact_ versions (pip)
     ":preserveSemverRanges",
+    "group:monorepos",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
+    ":semanticPrefixFixDepsChoreOthers",
+    ":dependencyDashboard",
   ],
 
   pip_requirements: {


### PR DESCRIPTION
Following from
[`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices) this change adds a few of the presets included in it:
* `docker:pinDigests`
* `helpers:pinGitHubActionDigests`
* `:dependencyDashboard` (just explicit now)
* `:semanticPrefixFixDepsChoreOthers`
* `group:monorepos`