### PR TITLE
[Catalog] Collect table base locations in snapshots

### DIFF
--- a/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
+++ b/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java
@@ -443,6 +443,11 @@ public class NessieModelIceberg {
     NessieViewSnapshot.Builder snapshot = NessieViewSnapshot.builder().id(snapshotId);
     if (previous != null) {
       snapshot.from(previous);
+
+      String previousLocation = previous.icebergLocation();
+      if (previousLocation != null && !previousLocation.equals(iceberg.location())) {
+        snapshot.addAdditionalKnownLocation(previous.icebergLocation());
+      }
     }
 
     int formatVersion = iceberg.formatVersion();
@@ -500,6 +505,11 @@ public class NessieModelIceberg {
     NessieTableSnapshot.Builder snapshot = NessieTableSnapshot.builder().id(snapshotId);
     if (previous != null) {
       snapshot.from(previous);
+
+      String previousLocation = previous.icebergLocation();
+      if (previousLocation != null && !previousLocation.equals(iceberg.location())) {
+        snapshot.addAdditionalKnownLocation(previous.icebergLocation());
+      }
     }
 
     int formatVersion = iceberg.formatVersion();

--- a/catalog/model/src/main/java/org/projectnessie/catalog/model/snapshot/NessieEntitySnapshot.java
+++ b/catalog/model/src/main/java/org/projectnessie/catalog/model/snapshot/NessieEntitySnapshot.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
@@ -116,6 +117,9 @@ public interface NessieEntitySnapshot<E extends NessieEntity> {
   // FIXME is this nullable? The builder method says yes, but the interface says no.
   Instant lastUpdatedTimestamp();
 
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  Set<String> additionalKnownLocations();
+
   @SuppressWarnings("unused")
   interface Builder<B extends Builder<B>> {
     @CanIgnoreReturnValue
@@ -159,5 +163,17 @@ public interface NessieEntitySnapshot<E extends NessieEntity> {
 
     @CanIgnoreReturnValue
     B icebergLocation(String icebergLocation);
+
+    @CanIgnoreReturnValue
+    B addAdditionalKnownLocation(String element);
+
+    @CanIgnoreReturnValue
+    B addAdditionalKnownLocations(String... elements);
+
+    @CanIgnoreReturnValue
+    B additionalKnownLocations(Iterable<String> elements);
+
+    @CanIgnoreReturnValue
+    B addAllAdditionalKnownLocations(Iterable<String> elements);
   }
 }


### PR DESCRIPTION
Start collecting all base locations in `NessieTableSnapshot`. This change is a start to collect _all_ (base) table locations, to handle cases when a table's (meta)data files are "spread" across multiple base locations. Ideally (and probably usually), each table has only one base location.
