### PR TITLE
Testing: Centralize image resolution

### DIFF
--- a/api/client/build.gradle.kts
+++ b/api/client/build.gradle.kts
@@ -95,6 +95,8 @@ dependencies {
   intTestImplementation(libs.testcontainers.keycloak) {
     exclude(group = "org.slf4j") // uses SLF4J 2.x, we are not ready yet
   }
+  intTestImplementation(project(":nessie-container-spec-helper"))
+  intTestCompileOnly(libs.immutables.value.annotations)
 }
 
 jandex { skipDefaultProcessing() }

--- a/api/model/build.gradle.kts
+++ b/api/model/build.gradle.kts
@@ -61,6 +61,8 @@ dependencies {
   intTestImplementation(platform(libs.testcontainers.bom))
   intTestImplementation("org.testcontainers:testcontainers")
   intTestImplementation(libs.awaitility)
+  intTestImplementation(project(":nessie-container-spec-helper"))
+  intTestCompileOnly(libs.immutables.value.annotations)
 }
 
 extensions.configure<SmallryeOpenApiExtension> {

--- a/api/model/src/intTest/java/org/projectnessie/model/ITOpenApiValidation.java
+++ b/api/model/src/intTest/java/org/projectnessie/model/ITOpenApiValidation.java
@@ -17,7 +17,6 @@ package org.projectnessie.model;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.System.getProperty;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.copy;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
@@ -36,13 +35,11 @@ import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.PullResponseItem;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
 import org.testcontainers.DockerClientFactory;
 
 public class ITOpenApiValidation {
@@ -136,20 +133,11 @@ public class ITOpenApiValidation {
   }
 
   protected static String dockerImage(String name) {
-    URL resource = ITOpenApiValidation.class.getResource("Dockerfile-" + name + "-version");
-    try (InputStream in = resource.openConnection().getInputStream()) {
-      String[] imageTag =
-          Arrays.stream(new String(in.readAllBytes(), UTF_8).split("\n"))
-              .map(String::trim)
-              .filter(l -> l.startsWith("FROM "))
-              .map(l -> l.substring(5).trim().split(":"))
-              .findFirst()
-              .orElseThrow();
-      String image = imageTag[0];
-      String version = System.getProperty("it.nessie.container." + name + ".tag", imageTag[1]);
-      return image + ':' + version;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to extract tag from " + resource, e);
-    }
+    return ContainerSpecHelper.builder()
+        .name(name)
+        .containerClass(ITOpenApiValidation.class)
+        .build()
+        .dockerImageName(null)
+        .toString();
   }
 }

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     api(project(":nessie-compatibility-common"))
     api(project(":nessie-compatibility-tests"))
     api(project(":nessie-compatibility-jersey"))
+    api(project(":nessie-container-spec-helper"))
     api(project(":nessie-doc-generator-annotations"))
     api(project(":nessie-doc-generator-doclet"))
     api(project(":nessie-gc-base"))

--- a/gc/gc-repository-jdbc/build.gradle.kts
+++ b/gc/gc-repository-jdbc/build.gradle.kts
@@ -65,4 +65,6 @@ dependencies {
   intTestImplementation(platform(libs.testcontainers.bom))
   intTestImplementation("org.testcontainers:postgresql")
   intTestRuntimeOnly(libs.docker.java.api)
+  intTestImplementation(project(":nessie-container-spec-helper"))
+  intTestCompileOnly(libs.immutables.value.annotations)
 }

--- a/gc/gc-repository-jdbc/src/intTest/java/org/projectnessie/gc/contents/jdbc/ITPostgresPersistenceSpi.java
+++ b/gc/gc-repository-jdbc/src/intTest/java/org/projectnessie/gc/contents/jdbc/ITPostgresPersistenceSpi.java
@@ -15,14 +15,11 @@
  */
 package org.projectnessie.gc.contents.jdbc;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Arrays;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class ITPostgresPersistenceSpi extends AbstractJdbcPersistenceSpi {
 
@@ -44,21 +41,12 @@ public class ITPostgresPersistenceSpi extends AbstractJdbcPersistenceSpi {
     }
   }
 
-  protected static String dockerImage(String dbName) {
-    URL resource = ITPostgresPersistenceSpi.class.getResource("Dockerfile-" + dbName + "-version");
-    try (InputStream in = resource.openConnection().getInputStream()) {
-      String[] imageTag =
-          Arrays.stream(new String(in.readAllBytes(), UTF_8).split("\n"))
-              .map(String::trim)
-              .filter(l -> l.startsWith("FROM "))
-              .map(l -> l.substring(5).trim().split(":"))
-              .findFirst()
-              .orElseThrow();
-      String image = imageTag[0];
-      String version = System.getProperty("it.nessie.container." + dbName + ".tag", imageTag[1]);
-      return image + ':' + version;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to extract tag from " + resource, e);
-    }
+  protected static DockerImageName dockerImage(String dbName) {
+    return ContainerSpecHelper.builder()
+        .name(dbName)
+        .containerClass(ITPostgresPersistenceSpi.class)
+        .build()
+        .dockerImageName(null)
+        .asCompatibleSubstituteFor("postgres");
   }
 }

--- a/gradle/projects.main.properties
+++ b/gradle/projects.main.properties
@@ -10,6 +10,7 @@ nessie-combined-cs=testing/combined-cs
 nessie-compatibility-common=compatibility/common
 nessie-compatibility-tests=compatibility/compatibility-tests
 nessie-compatibility-jersey=compatibility/jersey
+nessie-container-spec-helper=testing/container-spec-helper
 nessie-doc-generator-doclet=tools/doc-generator/doclet
 nessie-doc-generator-annotations=tools/doc-generator/annotations
 nessie-doc-generator=tools/doc-generator/site-gen

--- a/servers/quarkus-tests/build.gradle.kts
+++ b/servers/quarkus-tests/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-mongodb-tests"))
   implementation(project(":nessie-versioned-storage-rocksdb-tests"))
   implementation(project(":nessie-versioned-storage-testextension"))
+  implementation(project(":nessie-container-spec-helper"))
 
   implementation(enforcedPlatform(libs.quarkus.bom))
   implementation("io.quarkus:quarkus-junit5")
@@ -51,4 +52,6 @@ dependencies {
 
   implementation(libs.testcontainers.keycloak)
   implementation(libs.keycloak.admin.client)
+
+  compileOnly(libs.immutables.value.annotations)
 }

--- a/testing/azurite-container/build.gradle.kts
+++ b/testing/azurite-container/build.gradle.kts
@@ -20,6 +20,8 @@ extra["maven.name"] = "Nessie - Azurite testcontainer"
 
 dependencies {
   implementation(libs.slf4j.api)
+  implementation(project(":nessie-container-spec-helper"))
+  compileOnly(libs.immutables.value.annotations)
   api(platform(libs.testcontainers.bom))
   api("org.testcontainers:testcontainers")
 

--- a/testing/container-spec-helper/build.gradle.kts
+++ b/testing/container-spec-helper/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Dremio
+ * Copyright (C) 2023 Dremio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,17 @@
  * limitations under the License.
  */
 
-plugins {
-  id("nessie-conventions-server")
-  id("nessie-jacoco")
-}
+plugins { id("nessie-conventions-client") }
 
-extra["maven.name"] = "Nessie - Storage - MongoDB - Tests"
-
-description = "Base test code for creating test backends using MongoDB."
+extra["maven.name"] = "Nessie - Container Specification Helper"
 
 dependencies {
-  implementation(project(":nessie-versioned-storage-mongodb"))
-  implementation(project(":nessie-versioned-storage-common"))
-  implementation(project(":nessie-versioned-storage-testextension"))
-  implementation(project(":nessie-container-spec-helper"))
-
   implementation(libs.slf4j.api)
+  api(platform(libs.testcontainers.bom))
+  api("org.testcontainers:testcontainers")
 
-  compileOnly(libs.immutables.builder)
   compileOnly(libs.immutables.value.annotations)
   annotationProcessor(libs.immutables.value.processor)
 
-  implementation(libs.mongodb.driver.sync)
-
-  implementation(platform(libs.testcontainers.bom))
-  implementation("org.testcontainers:mongodb")
+  testImplementation(libs.bundles.junit.testing)
 }

--- a/testing/container-spec-helper/src/main/java/org/projectnessie/nessie/testing/containerspec/ContainerSpecHelper.java
+++ b/testing/container-spec-helper/src/main/java/org/projectnessie/nessie/testing/containerspec/ContainerSpecHelper.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.nessie.testing.containerspec;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.immutables.value.Value.Style.ImplementationVisibility.PACKAGE;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Locale;
+import java.util.Objects;
+import org.immutables.value.Value;
+import org.testcontainers.shaded.com.google.errorprone.annotations.CanIgnoreReturnValue;
+import org.testcontainers.utility.DockerImageName;
+
+@Value.Immutable
+@Value.Style(visibility = PACKAGE)
+public abstract class ContainerSpecHelper {
+  public static Builder builder() {
+    return ImmutableContainerSpecHelper.builder();
+  }
+
+  public interface Builder {
+    @CanIgnoreReturnValue
+    Builder containerClass(Class<?> containerClass);
+
+    @CanIgnoreReturnValue
+    Builder name(String name);
+
+    ContainerSpecHelper build();
+  }
+
+  public abstract String name();
+
+  public abstract Class<?> containerClass();
+
+  public DockerImageName dockerImageName(String explicitImageName) {
+    if (explicitImageName != null) {
+      return DockerImageName.parse(explicitImageName);
+    }
+
+    String dockerfile = format("Dockerfile-%s-version", name());
+    URL resource = containerClass().getResource(dockerfile);
+    Objects.requireNonNull(resource, dockerfile + " not found");
+
+    String systemPropPrefix1 = "it.nessie.container." + name() + ".";
+    String systemPropPrefix2 = "nessie.testing." + name() + ".";
+    String envPrefix = name().toUpperCase(Locale.ROOT).replaceAll("-", "_") + "_DOCKER_";
+
+    String explicitImage = System.getProperty(systemPropPrefix1 + "image");
+    if (explicitImage == null) {
+      explicitImage = System.getProperty(systemPropPrefix2 + "image");
+    }
+    if (explicitImage == null) {
+      explicitImage = System.getenv(envPrefix + "IMAGE");
+    }
+    String explicitTag = System.getProperty(systemPropPrefix1 + "tag");
+    if (explicitTag == null) {
+      explicitTag = System.getProperty(systemPropPrefix2 + "tag");
+    }
+    if (explicitTag == null) {
+      explicitTag = System.getenv(envPrefix + "TAG");
+    }
+
+    if (explicitImage != null && explicitTag != null) {
+      return DockerImageName.parse(explicitImage + ':' + explicitTag);
+    }
+
+    try (InputStream in = resource.openConnection().getInputStream();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(in, UTF_8))) {
+      String fullImageName = null;
+      String ln;
+      while ((ln = reader.readLine()) != null) {
+        ln = ln.trim();
+        if (ln.startsWith("FROM ")) {
+          fullImageName = ln.substring(5).trim();
+          break;
+        }
+      }
+
+      if (fullImageName == null) {
+        throw new IllegalStateException(
+            "Dockerfile " + dockerfile + " does not contain a line starting with 'FROM '");
+      }
+
+      if (explicitImage != null || explicitTag != null) {
+        throw new IllegalArgumentException(
+            "Must specify either BOTH, image name AND tag via system properties or environment  or omit and leave it to the default "
+                + fullImageName
+                + " from "
+                + dockerfile);
+      }
+
+      return DockerImageName.parse(fullImageName);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to extract tag from " + resource, e);
+    }
+  }
+}

--- a/testing/gcs-container/build.gradle.kts
+++ b/testing/gcs-container/build.gradle.kts
@@ -20,6 +20,8 @@ extra["maven.name"] = "Nessie - GCS testcontainer"
 
 dependencies {
   implementation(libs.slf4j.api)
+  implementation(project(":nessie-container-spec-helper"))
+  compileOnly(libs.immutables.value.annotations)
   api(platform(libs.testcontainers.bom))
   api("org.testcontainers:testcontainers")
 

--- a/testing/keycloak-container/build.gradle.kts
+++ b/testing/keycloak-container/build.gradle.kts
@@ -20,6 +20,8 @@ extra["maven.name"] = "Nessie - Keycloak testcontainer"
 
 dependencies {
   implementation(libs.slf4j.api)
+  implementation(project(":nessie-container-spec-helper"))
+  compileOnly(libs.immutables.value.annotations)
   api(libs.keycloak.admin.client)
   api(libs.testcontainers.keycloak) {
     exclude(group = "org.slf4j") // uses SLF4J 2.x, we are not ready yet

--- a/testing/minio-container/build.gradle.kts
+++ b/testing/minio-container/build.gradle.kts
@@ -23,6 +23,8 @@ description = "JUnit extension providing a Minio instance."
 dependencies {
   implementation(platform(libs.testcontainers.bom))
   implementation("org.testcontainers:testcontainers")
+  implementation(project(":nessie-container-spec-helper"))
+  compileOnly(libs.immutables.value.annotations)
 
   implementation(platform(libs.awssdk.bom))
   implementation("software.amazon.awssdk:s3")

--- a/testing/nessie-container/build.gradle.kts
+++ b/testing/nessie-container/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
   implementation(libs.slf4j.api)
   implementation(platform(libs.testcontainers.bom))
   implementation("org.testcontainers:testcontainers")
+  implementation(project(":nessie-container-spec-helper"))
+  compileOnly(libs.immutables.value.annotations)
 
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.findbugs.jsr305)

--- a/versioned/storage/bigtable-tests/build.gradle.kts
+++ b/versioned/storage/bigtable-tests/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
   implementation(project(":nessie-versioned-storage-bigtable"))
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-versioned-storage-testextension"))
+  implementation(project(":nessie-container-spec-helper"))
+  compileOnly(libs.immutables.value.annotations)
 
   implementation(libs.slf4j.api)
 

--- a/versioned/storage/bigtable-tests/src/main/java/org/projectnessie/versioned/storage/bigtabletests/BigTableBackendContainerTestFactory.java
+++ b/versioned/storage/bigtable-tests/src/main/java/org/projectnessie/versioned/storage/bigtabletests/BigTableBackendContainerTestFactory.java
@@ -15,18 +15,15 @@
  */
 package org.projectnessie.versioned.storage.bigtabletests;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Arrays;
 import java.util.Optional;
+import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
 import org.projectnessie.versioned.storage.bigtable.BigTableBackendFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
 
 /** Bigtable emulator via testcontainers. */
 public class BigTableBackendContainerTestFactory extends AbstractBigTableBackendTestFactory {
@@ -44,25 +41,6 @@ public class BigTableBackendContainerTestFactory extends AbstractBigTableBackend
     return BigTableBackendFactory.NAME + "Container";
   }
 
-  protected static String dockerImage(String dbName) {
-    URL resource =
-        BigTableBackendContainerTestFactory.class.getResource("Dockerfile-" + dbName + "-version");
-    try (InputStream in = resource.openConnection().getInputStream()) {
-      String[] imageTag =
-          Arrays.stream(new String(in.readAllBytes(), UTF_8).split("\n"))
-              .map(String::trim)
-              .filter(l -> l.startsWith("FROM "))
-              .map(l -> l.substring(5).trim().split(":"))
-              .findFirst()
-              .orElseThrow();
-      String image = imageTag[0];
-      String version = System.getProperty("it.nessie.container." + dbName + ".tag", imageTag[1]);
-      return image + ':' + version;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to extract tag from " + resource, e);
-    }
-  }
-
   @Override
   @SuppressWarnings("resource")
   public void start(Optional<String> containerNetworkId) {
@@ -70,7 +48,12 @@ public class BigTableBackendContainerTestFactory extends AbstractBigTableBackend
       throw new IllegalStateException("Already started");
     }
 
-    String imageName = dockerImage("google-cloud-sdk");
+    DockerImageName imageName =
+        ContainerSpecHelper.builder()
+            .name("google-cloud-sdk")
+            .containerClass(BigTableBackendContainerTestFactory.class)
+            .build()
+            .dockerImageName(null);
 
     for (int retry = 0; ; retry++) {
       GenericContainer<?> c =

--- a/versioned/storage/cassandra-tests/build.gradle.kts
+++ b/versioned/storage/cassandra-tests/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-cassandra"))
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-versioned-storage-testextension"))
+  implementation(project(":nessie-container-spec-helper"))
 
   compileOnly(libs.jakarta.annotation.api)
 

--- a/versioned/storage/dynamodb-tests/build.gradle.kts
+++ b/versioned/storage/dynamodb-tests/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-dynamodb"))
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-versioned-storage-testextension"))
+  implementation(project(":nessie-container-spec-helper"))
 
   compileOnly(libs.jakarta.annotation.api)
 

--- a/versioned/storage/jdbc-tests/build.gradle.kts
+++ b/versioned/storage/jdbc-tests/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-jdbc"))
   implementation(project(":nessie-versioned-storage-common"))
   implementation(project(":nessie-versioned-storage-testextension"))
+  implementation(project(":nessie-container-spec-helper"))
 
   compileOnly(libs.jakarta.annotation.api)
 

--- a/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/CockroachBackendTestFactory.java
+++ b/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/CockroachBackendTestFactory.java
@@ -31,7 +31,8 @@ public class CockroachBackendTestFactory extends ContainerBackendTestFactory {
   @Nonnull
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {
-    return new CockroachContainer(dockerImage("cockroach"));
+    return new CockroachContainer(
+        dockerImage("cockroach").asCompatibleSubstituteFor("cockroachdb/cockroach"));
   }
 
   @Override

--- a/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/ContainerBackendTestFactory.java
+++ b/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/ContainerBackendTestFactory.java
@@ -15,42 +15,29 @@
  */
 package org.projectnessie.versioned.storage.jdbctests;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testcontainers.shaded.com.google.common.base.Preconditions.checkState;
 
 import jakarta.annotation.Nonnull;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Arrays;
 import java.util.Optional;
+import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
 
 public abstract class ContainerBackendTestFactory extends AbstractJdbcBackendTestFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(ContainerBackendTestFactory.class);
 
   private JdbcDatabaseContainer<?> container;
 
-  protected static String dockerImage(String dbName) {
-    URL resource =
-        ContainerBackendTestFactory.class.getResource("Dockerfile-" + dbName + "-version");
-    try (InputStream in = resource.openConnection().getInputStream()) {
-      String[] imageTag =
-          Arrays.stream(new String(in.readAllBytes(), UTF_8).split("\n"))
-              .map(String::trim)
-              .filter(l -> l.startsWith("FROM "))
-              .map(l -> l.substring(5).trim().split(":"))
-              .findFirst()
-              .orElseThrow();
-      String image = imageTag[0];
-      String version = System.getProperty("it.nessie.container." + dbName + ".tag", imageTag[1]);
-      return image + ':' + version;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to extract tag from " + resource, e);
-    }
+  protected static DockerImageName dockerImage(String dbName) {
+    return ContainerSpecHelper.builder()
+        .name(dbName)
+        .containerClass(ContainerBackendTestFactory.class)
+        .build()
+        .dockerImageName(null);
   }
 
   @Override

--- a/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/MariaDBBackendTestFactory.java
+++ b/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/MariaDBBackendTestFactory.java
@@ -32,8 +32,8 @@ public class MariaDBBackendTestFactory extends ContainerBackendTestFactory {
   @Override
   @SuppressWarnings("resource")
   protected JdbcDatabaseContainer<?> createContainer() {
-    String dockerImage = dockerImage("mariadb");
-    return new MariaDBContainer<>(dockerImage).withUrlParam("useBulkStmtsForInserts", "false");
+    return new MariaDBContainer<>(dockerImage("mariadb").asCompatibleSubstituteFor("mariadb"))
+        .withUrlParam("useBulkStmtsForInserts", "false");
   }
 
   @Override

--- a/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/MySQLBackendTestFactory.java
+++ b/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/MySQLBackendTestFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.projectnessie.versioned.storage.jdbc.JdbcBackendFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class MySQLBackendTestFactory extends ContainerBackendTestFactory {
 
@@ -48,8 +49,8 @@ public class MySQLBackendTestFactory extends ContainerBackendTestFactory {
   private static class MariaDBDriverMySQLContainer
       extends MySQLContainer<MariaDBDriverMySQLContainer> {
 
-    MariaDBDriverMySQLContainer(String dockerImage) {
-      super(dockerImage);
+    MariaDBDriverMySQLContainer(DockerImageName dockerImage) {
+      super(dockerImage.asCompatibleSubstituteFor("mysql"));
     }
 
     @Override

--- a/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/PostgreSQLBackendTestFactory.java
+++ b/versioned/storage/jdbc-tests/src/main/java/org/projectnessie/versioned/storage/jdbctests/PostgreSQLBackendTestFactory.java
@@ -31,8 +31,7 @@ public class PostgreSQLBackendTestFactory extends ContainerBackendTestFactory {
   @Nonnull
   @Override
   protected JdbcDatabaseContainer<?> createContainer() {
-    String dockerImage = dockerImage("postgres");
-    return new PostgreSQLContainer<>(dockerImage);
+    return new PostgreSQLContainer<>(dockerImage("postgres").asCompatibleSubstituteFor("postgres"));
   }
 
   @Override

--- a/versioned/storage/mongodb-tests/src/main/java/org/projectnessie/versioned/storage/mongodbtests/MongoDBBackendTestFactory.java
+++ b/versioned/storage/mongodb-tests/src/main/java/org/projectnessie/versioned/storage/mongodbtests/MongoDBBackendTestFactory.java
@@ -15,15 +15,11 @@
  */
 package org.projectnessie.versioned.storage.mongodbtests;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.mongodb.client.MongoClient;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.projectnessie.nessie.testing.containerspec.ContainerSpecHelper;
 import org.projectnessie.versioned.storage.common.persist.Backend;
 import org.projectnessie.versioned.storage.mongodb.MongoDBBackend;
 import org.projectnessie.versioned.storage.mongodb.MongoDBBackendConfig;
@@ -34,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
 
 public class MongoDBBackendTestFactory implements BackendTestFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBBackendTestFactory.class);
@@ -48,34 +45,23 @@ public class MongoDBBackendTestFactory implements BackendTestFactory {
     return MongoDBBackendFactory.NAME;
   }
 
-  protected static String dockerImage(String dbName) {
-    URL resource = MongoDBBackendTestFactory.class.getResource("Dockerfile-" + dbName + "-version");
-    try (InputStream in = resource.openConnection().getInputStream()) {
-      String[] imageTag =
-          Arrays.stream(new String(in.readAllBytes(), UTF_8).split("\n"))
-              .map(String::trim)
-              .filter(l -> l.startsWith("FROM "))
-              .map(l -> l.substring(5).trim().split(":"))
-              .findFirst()
-              .orElseThrow();
-      String image = imageTag[0];
-      String version = System.getProperty("it.nessie.container." + dbName + ".tag", imageTag[1]);
-      return image + ':' + version;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to extract tag from " + resource, e);
-    }
-  }
-
   @Override
   public void start(Optional<String> containerNetworkId) {
     if (container != null) {
       throw new IllegalStateException("Already started");
     }
 
+    DockerImageName dockerImage =
+        ContainerSpecHelper.builder()
+            .name("mongodb")
+            .containerClass(MongoDBBackendTestFactory.class)
+            .build()
+            .dockerImageName(null)
+            .asCompatibleSubstituteFor("mongo");
+
     for (int retry = 0; ; retry++) {
       MongoDBContainer c =
-          new MongoDBContainer(dockerImage("mongodb"))
-              .withLogConsumer(new Slf4jLogConsumer(LOGGER));
+          new MongoDBContainer(dockerImage).withLogConsumer(new Slf4jLogConsumer(LOGGER));
       containerNetworkId.ifPresent(c::withNetworkMode);
       try {
         c.start();


### PR DESCRIPTION
* Add `ContainerSpecHelper` to help resolving a Docker image
* Add support for "pinned" image references (including "sha256")