### PR TITLE
Always close BigTable clients

### DIFF
--- a/versioned/storage/bigtable-tests/src/main/java/org/projectnessie/versioned/storage/bigtabletests/AbstractBigTableBackendTestFactory.java
+++ b/versioned/storage/bigtable-tests/src/main/java/org/projectnessie/versioned/storage/bigtabletests/AbstractBigTableBackendTestFactory.java
@@ -35,13 +35,11 @@ public abstract class AbstractBigTableBackendTestFactory implements BackendTestF
 
   @Override
   public Backend createNewBackend() {
-    return createNewBackend(bigtableConfigBuilder().build(), true);
+    return createNewBackend(bigtableConfigBuilder().build());
   }
 
-  @SuppressWarnings("ClassEscapesDefinedScope")
-  public BigTableBackend createNewBackend(
-      BigTableBackendConfig bigtableConfig, boolean closeClient) {
-    return new BigTableBackend(bigtableConfig, closeClient);
+  public Backend createNewBackend(BigTableBackendConfig bigtableConfig) {
+    return new BigTableBackend(bigtableConfig);
   }
 
   public Builder bigtableConfigBuilder() {

--- a/versioned/storage/bigtable/src/intTest/java/org/projectnessie/versioned/storage/bigtable/ITBigTableBackendFactory.java
+++ b/versioned/storage/bigtable/src/intTest/java/org/projectnessie/versioned/storage/bigtable/ITBigTableBackendFactory.java
@@ -49,7 +49,6 @@ public class ITBigTableBackendFactory {
 
       try (BigtableDataClient dataClient = testFactory.buildNewDataClient();
           BigtableTableAdminClient tableAdminClient = testFactory.buildNewTableAdminClient()) {
-        RepositoryDescription repoDesc;
         try (Backend backend =
             factory.buildBackend(
                 BigTableBackendConfig.builder()
@@ -65,10 +64,13 @@ public class ITBigTableBackendFactory {
 
           RepositoryLogic repositoryLogic = repositoryLogic(persist);
           repositoryLogic.initialize("initializeAgain");
-          repoDesc = repositoryLogic.fetchRepositoryDescription();
+          RepositoryDescription repoDesc = repositoryLogic.fetchRepositoryDescription();
           soft.assertThat(repoDesc).isNotNull();
         }
+      }
 
+      try (BigtableDataClient dataClient = testFactory.buildNewDataClient();
+          BigtableTableAdminClient tableAdminClient = testFactory.buildNewTableAdminClient()) {
         try (Backend backend =
             factory.buildBackend(
                 BigTableBackendConfig.builder()
@@ -84,6 +86,7 @@ public class ITBigTableBackendFactory {
 
           RepositoryLogic repositoryLogic = repositoryLogic(persist);
           repositoryLogic.initialize("initializeAgain");
+          RepositoryDescription repoDesc = repositoryLogic.fetchRepositoryDescription();
           soft.assertThat(repositoryLogic.fetchRepositoryDescription()).isEqualTo(repoDesc);
         }
       }

--- a/versioned/storage/bigtable/src/intTest/java/org/projectnessie/versioned/storage/bigtable/ITBigTableBackendFactory.java
+++ b/versioned/storage/bigtable/src/intTest/java/org/projectnessie/versioned/storage/bigtable/ITBigTableBackendFactory.java
@@ -46,6 +46,7 @@ public class ITBigTableBackendFactory {
       BackendFactory<BigTableBackendConfig> factory =
           PersistLoader.findFactoryByName(BigTableBackendFactory.NAME);
       soft.assertThat(factory).isNotNull().isInstanceOf(BigTableBackendFactory.class);
+      RepositoryDescription repoDesc;
 
       try (BigtableDataClient dataClient = testFactory.buildNewDataClient();
           BigtableTableAdminClient tableAdminClient = testFactory.buildNewTableAdminClient()) {
@@ -64,7 +65,7 @@ public class ITBigTableBackendFactory {
 
           RepositoryLogic repositoryLogic = repositoryLogic(persist);
           repositoryLogic.initialize("initializeAgain");
-          RepositoryDescription repoDesc = repositoryLogic.fetchRepositoryDescription();
+          repoDesc = repositoryLogic.fetchRepositoryDescription();
           soft.assertThat(repoDesc).isNotNull();
         }
       }
@@ -86,7 +87,6 @@ public class ITBigTableBackendFactory {
 
           RepositoryLogic repositoryLogic = repositoryLogic(persist);
           repositoryLogic.initialize("initializeAgain");
-          RepositoryDescription repoDesc = repositoryLogic.fetchRepositoryDescription();
           soft.assertThat(repositoryLogic.fetchRepositoryDescription()).isEqualTo(repoDesc);
         }
       }

--- a/versioned/storage/bigtable/src/intTest/java/org/projectnessie/versioned/storage/bigtable/ITBigTablePersist.java
+++ b/versioned/storage/bigtable/src/intTest/java/org/projectnessie/versioned/storage/bigtable/ITBigTablePersist.java
@@ -49,9 +49,7 @@ public class ITBigTablePersist extends AbstractPersistTests {
     @BeforeEach
     void noAdminClient() {
       BigTableBackend b = (BigTableBackend) backend;
-      backend =
-          new BigTableBackend(
-              BigTableBackendConfig.builder().dataClient(b.client()).build(), false);
+      backend = new BigTableBackend(BigTableBackendConfig.builder().dataClient(b.client()).build());
     }
   }
 
@@ -67,13 +65,19 @@ public class ITBigTablePersist extends AbstractPersistTests {
     void tablePrefix() {
       AbstractBigTableBackendTestFactory btFactory = (AbstractBigTableBackendTestFactory) factory;
       try (BigTableBackend backendA =
-              btFactory.createNewBackend(
-                  btFactory.bigtableConfigBuilder().tablePrefix(Optional.of("instanceA")).build(),
-                  true);
+              (BigTableBackend)
+                  btFactory.createNewBackend(
+                      btFactory
+                          .bigtableConfigBuilder()
+                          .tablePrefix(Optional.of("instanceA"))
+                          .build());
           BigTableBackend backendB =
-              btFactory.createNewBackend(
-                  btFactory.bigtableConfigBuilder().tablePrefix(Optional.of("instanceB")).build(),
-                  true)) {
+              (BigTableBackend)
+                  btFactory.createNewBackend(
+                      btFactory
+                          .bigtableConfigBuilder()
+                          .tablePrefix(Optional.of("instanceB"))
+                          .build())) {
 
         BigtableTableAdminClient adminClientA = requireNonNull(backendA.adminClient());
         BigtableTableAdminClient adminClientB = requireNonNull(backendB.adminClient());

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackendFactory.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTableBackendFactory.java
@@ -40,6 +40,6 @@ public class BigTableBackendFactory implements BackendFactory<BigTableBackendCon
   @Override
   @Nonnull
   public Backend buildBackend(@Nonnull BigTableBackendConfig config) {
-    return new BigTableBackend(config, false);
+    return new BigTableBackend(config);
   }
 }


### PR DESCRIPTION
Quarkus tests periodically output the below warning:

```
*~*~*~ Previous channel ManagedChannelImpl{logId=3, target=localhost:53285} was garbage collected without being shut down! ~*~*~*
    Make sure to call shutdown()/shutdownNow()
java.lang.RuntimeException: ManagedChannel allocation site
        at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:102)
        at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:60)
        at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:51)
        at io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:672)
        at io.grpc.ForwardingChannelBuilder2.build(ForwardingChannelBuilder2.java:260)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createSingleChannel(InstantiatingGrpcChannelProvider.java:442)
        at com.google.api.gax.grpc.ChannelPool.<init>(ChannelPool.java:107)
        at com.google.api.gax.grpc.ChannelPool.create(ChannelPool.java:85)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createChannel(InstantiatingGrpcChannelProvider.java:243)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.getTransportChannel(InstantiatingGrpcChannelProvider.java:237)
        at com.google.api.gax.rpc.ClientContext.create(ClientContext.java:226)
        at com.google.cloud.bigtable.admin.v2.stub.EnhancedBigtableTableAdminStub.createEnhanced(EnhancedBigtableTableAdminStub.java:61)
        at com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient.create(BigtableTableAdminClient.java:158)
        at org.projectnessie.versioned.storage.bigtable.BigTableClientsFactory.createTableAdminClient(BigTableClientsFactory.java:151)
        at org.projectnessie.quarkus.providers.storage.BigTableBackendBuilder.buildBackend(BigTableBackendBuilder.java:105)
        at org.projectnessie.quarkus.providers.storage.PersistProvider.produceBackend(PersistProvider.java:81)
```