### PR TITLE
JDBC persist: properly handle SUCCESS_NO_INFO and EXECUTE_FAILED

### DIFF
--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -508,6 +508,13 @@ abstract class AbstractJdbcPersist implements Persist {
               if (updated[i] == 1) {
                 r[batchIndexToObjIndex.get(i)] = true;
               }
+              if (updated[i] == PreparedStatement.SUCCESS_NO_INFO) {
+                throw new IllegalStateException(
+                    "driver returned SUCCESS_NO_INFO for a batch update");
+              } else if (updated[i] == PreparedStatement.EXECUTE_FAILED) {
+                throw new IllegalStateException(
+                    "driver returned EXECUTE_FAILED for a batch update");
+              }
             }
           };
 

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -507,7 +507,7 @@ abstract class AbstractJdbcPersist implements Persist {
             for (int i = 0; i < updated.length; i++) {
               if (updated[i] == 1) {
                 r[batchIndexToObjIndex.get(i)] = true;
-              } else if (updated[i] < 0 || updated[i] > 1) {
+              } else if (updated[i] != 0) {
                 throw new IllegalStateException(
                     "driver returned unexpected value for a batch update: " + updated[i]);
               }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/AbstractJdbcPersist.java
@@ -507,13 +507,9 @@ abstract class AbstractJdbcPersist implements Persist {
             for (int i = 0; i < updated.length; i++) {
               if (updated[i] == 1) {
                 r[batchIndexToObjIndex.get(i)] = true;
-              }
-              if (updated[i] == PreparedStatement.SUCCESS_NO_INFO) {
+              } else if (updated[i] < 0 || updated[i] > 1) {
                 throw new IllegalStateException(
-                    "driver returned SUCCESS_NO_INFO for a batch update");
-              } else if (updated[i] == PreparedStatement.EXECUTE_FAILED) {
-                throw new IllegalStateException(
-                    "driver returned EXECUTE_FAILED for a batch update");
+                    "driver returned unexpected value for a batch update: " + updated[i]);
               }
             }
           };


### PR DESCRIPTION
`PreparedStatement.executeBatch()` returns an array of int results. Each element of the array denotes how many rows were affected, but two special values exist: `SUCCESS_NO_INFO` and `EXECUTE_FAILED`. 

So far, no supported Jdbc backend returns such values, but this will change soon (spoiler alert: MariaDB does return `SUCCESS_NO_INFO`).

Ignoring these special values can be very bad as the code would assume no rows were affected, while in fact a row has been affected. It's safer to throw an exception when that happens (in the case of MariaDB, there is a connection option to disallow `SUCCESS_NO_INFO`).

Note: when #8533 is merged we could change the exception thrown. Currently, it's ISE.