### PR TITLE
Tests/Scylla: Cap SMP to 1/3 of num-CPUs

### DIFF
--- a/versioned/storage/cassandra-tests/src/main/java/org/projectnessie/versioned/storage/cassandratests/ScyllaDBBackendTestFactory.java
+++ b/versioned/storage/cassandra-tests/src/main/java/org/projectnessie/versioned/storage/cassandratests/ScyllaDBBackendTestFactory.java
@@ -30,7 +30,7 @@ public class ScyllaDBBackendTestFactory extends AbstractCassandraBackendTestFact
         "scylladb",
         asList(
             "--smp",
-            Integer.toString(max(getRuntime().availableProcessors(), 2)),
+            Integer.toString(max(getRuntime().availableProcessors() / 3, 2)),
             "--developer-mode",
             "1",
             "--skip-wait-for-gossip-to-settle",


### PR DESCRIPTION
This prevents local machines' CPU fans from spinning like crazy...