### PR TITLE
Exclude `CommitObj.created()` from `.equals()` and `.hashCode()`

### DIFF
--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/logic/CommitLogicImpl.java
@@ -324,9 +324,7 @@ final class CommitLogicImpl implements CommitLogic {
     // timestamp of the commit-obj).
     try {
       CommitObj existing = persist.fetchTypedObj(commit.id(), COMMIT, CommitObj.class);
-      CommitObj commitWithNewCreatedTimestamp =
-          CommitObj.commitBuilder().from(commit).created(existing.created()).build();
-      return commitWithNewCreatedTimestamp.equals(existing) ? existing : null;
+      return commit.equals(existing) ? existing : null;
     } catch (ObjNotFoundException e) {
       return null;
     }

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/CommitObj.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/objtypes/CommitObj.java
@@ -137,7 +137,12 @@ public interface CommitObj extends Obj {
     CommitObj build();
   }
 
-  /** Creation timestamp in microseconds since epoch. */
+  /**
+   * Creation timestamp in microseconds since epoch.
+   *
+   * <p>Note that this value is not considered during Nessie commit hash value computations.
+   */
+  @Value.Auxiliary
   long created();
 
   /**

--- a/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
+++ b/versioned/storage/store/src/main/java/org/projectnessie/versioned/storage/versionstore/TransplantIndividualImpl.java
@@ -115,11 +115,13 @@ final class TransplantIndividualImpl extends BaseCommitHelper implements Transpl
       if (!transplantOp.dryRun()) {
         newHead = newCommit.id();
         CommitObj committed = commitLogic.storeCommit(newCommit, objsToStore);
-        // Here we have to know whether "our" 'newCommit' object has been persisted or not.
-        // If not equal, we have to assume that the commit already existed - aka a "fast-forward
+        if (committed != null) {
+          newCommit = committed;
+        }
+        // Here we have to know whether "our" 'newCommit' object is actually new or not.
+        // If it is equal to the source commit, we have to assume that it is a "fast-forward
         // transplant". This is only to maintain compatibility with (pre-)existing behavior.
-        // (This .equals has been introduced with https://github.com/projectnessie/nessie/pull/8533)
-        if (newCommit.equals(committed)) {
+        if (!newCommit.equals(sourceCommit)) {
           newCommit = committed;
           mergeResult.addCreatedCommits(commitObjToCommit(newCommit));
         }


### PR DESCRIPTION
This is to simplify reasoning about `CommitObj` since the value of `created()` was never part of its "commit hash", therefore it was never considered for equality comparisons at the storage layer.

* Remove the rebuilding of `CommitObj` in `mitigateHashCollision()`, which is redundant now.

* Fix the handling of fast-forward transplants by comparing source and transplanted commits vs. transplanted in-memory and transplanted in storage.