### PR TITLE
Fix downloads on site + publish CLI uber jar

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -131,6 +131,7 @@ jobs:
           ./gradlew publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar || \
           ./gradlew publishToMavenLocal publishToSonatype closeAndReleaseSonatypeStagingRepository -Prelease -Puber-jar
         mv servers/quarkus-server/build/nessie-quarkus-${RELEASE_VERSION}-runner.jar "${ARTIFACTS}"
+        mv cli/cli/build/libs/nessie-cli-${RELEASE_VERSION}.jar "${ARTIFACTS}"
         mv tools/server-admin/build/nessie-server-admin-tool-${RELEASE_VERSION}-runner.jar "${ARTIFACTS}"
         mv gc/gc-tool/build/executable/nessie-gc.jar "${ARTIFACTS}"/nessie-gc-${RELEASE_VERSION}.jar
         echo "::endgroup::"
@@ -158,6 +159,7 @@ jobs:
         cp api/model/build/generated/openapi/META-INF/openapi/openapi.yaml api/model/build/nessie-openapi-${RELEASE_VERSION}.yaml
 
         echo "QUARKUS_UBER_JAR=${ARTIFACTS}/nessie-quarkus-${RELEASE_VERSION}-runner.jar" >> ${GITHUB_ENV}
+        echo "CLI_UBER_JAR=${ARTIFACTS}/nessie-cli-${RELEASE_VERSION}.jar" >> ${GITHUB_ENV}
         echo "GC_UBER_JAR=${ARTIFACTS}/nessie-gc-${RELEASE_VERSION}.jar" >> ${GITHUB_ENV}
         echo "SERVER_ADMIN_UBER_JAR=${ARTIFACTS}/nessie-server-admin-tool-${RELEASE_VERSION}-runner.jar" >> ${GITHUB_ENV}
         echo "NESSIE_OPENAPI=api/model/build/nessie-openapi-${RELEASE_VERSION}.yaml" >> ${GITHUB_ENV}
@@ -259,6 +261,7 @@ jobs:
           --notes-file ${{ env.NOTES_FILE }} \
           --title "Nessie ${RELEASE_VERSION}" \
           "${QUARKUS_UBER_JAR}" \
+          "${CLI_UBER_JAR}" \
           "${GC_UBER_JAR}" \
           "${SERVER_ADMIN_UBER_JAR}" \
           "${NESSIE_OPENAPI}" \

--- a/site/docs/downloads/index.md
+++ b/site/docs/downloads/index.md
@@ -40,7 +40,7 @@ Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
 Requires Java 17 or newer.
 
 ```bash
-curl -o nessie-quarkus-{{ versions.nessie }}-runner.jar \
+curl -L -o nessie-quarkus-{{ versions.nessie }}-runner.jar \
   https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-quarkus-{{ versions.nessie }}-runner.jar
 java -jar nessie-quarkus-{{ versions.nessie }}-runner.jar
 ```
@@ -50,9 +50,9 @@ java -jar nessie-quarkus-{{ versions.nessie }}-runner.jar
 Requires Java 11 or newer.
 
 ```bash
-curl -o nessie-cli-{{ versions.nessie }}-runner.jar \
-  https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-cli-{{ versions.nessie }}-runner.jar
-java -jar nessie-cli-{{ versions.nessie }}-runner.jar
+curl -L -o nessie-cli-{{ versions.nessie }}.jar \
+  https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-cli-{{ versions.nessie }}.jar
+java -jar nessie-cli-{{ versions.nessie }}.jar
 ```
 
 ## Nessie GC Tool as Docker image
@@ -77,9 +77,9 @@ Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
 Requires Java 11, Java 17 recommended.
 
 ```bash
-curl -o https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-gc-{{ versions.nessie }} \
-  https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-gc-{{ versions.nessie }}
-java -jar https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-gc-{{ versions.nessie }}
+curl -L -o nessie-gc-{{ versions.nessie }}.jar \
+  https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-gc-{{ versions.nessie }}.jar
+java -jar nessie-gc-{{ versions.nessie }}.jar
 ```
 
 ## Nessie Repository Management tool as a standalone uber jar
@@ -87,7 +87,7 @@ java -jar https://github.com/projectnessie/nessie/releases/download/nessie-{{ ve
 Requires Java 17 or newer.
 
 ```bash
-curl -o nessie-server-admin-tool-{{ versions.nessie }}-runner.jar \
+curl -L -o nessie-server-admin-tool-{{ versions.nessie }}-runner.jar \
   https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-server-admin-tool-{{ versions.nessie }}-runner.jar
 java -jar nessie-server-admin-tool-{{ versions.nessie }}-runner.jar
 ```

--- a/site/docs/guides/docker.md
+++ b/site/docs/guides/docker.md
@@ -84,6 +84,6 @@ From there, you can use one of the three main Nessie integrations of:
 You can also install the [Nessie CLI/REPL](../nessie-latest/cli.md).
 
 ```bash
-curl -o nessie-cli-{{ versions.nessie }}-runner.jar \
+curl -L -o nessie-cli-{{ versions.nessie }}-runner.jar \
   https://github.com/projectnessie/nessie/releases/download/nessie-{{ versions.nessie }}/nessie-cli-{{ versions.nessie }}-runner.jar
 ```

--- a/site/in-dev/index-release.md
+++ b/site/in-dev/index-release.md
@@ -42,7 +42,7 @@ Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
 Requires Java 17 or newer.
 
 ```bash
-curl -o nessie-quarkus-::NESSIE_VERSION::-runner.jar \
+curl -L -o nessie-quarkus-::NESSIE_VERSION::-runner.jar \
   https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-quarkus-::NESSIE_VERSION::-runner.jar
 java -jar nessie-quarkus-::NESSIE_VERSION::-runner.jar
 ```
@@ -52,9 +52,9 @@ java -jar nessie-quarkus-::NESSIE_VERSION::-runner.jar
 Requires Java 11 or newer.
 
 ```bash
-curl -o nessie-cli-::NESSIE_VERSION::-runner.jar \
-  https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-cli-::NESSIE_VERSION::-runner.jar
-java -jar nessie-cli-::NESSIE_VERSION::-runner.jar
+curl -L -o nessie-cli-::NESSIE_VERSION::.jar \
+  https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-cli-::NESSIE_VERSION::.jar
+java -jar nessie-cli-::NESSIE_VERSION::.jar
 ```
 
 ## Nessie GC Tool as Docker image
@@ -79,9 +79,9 @@ Docker images are multiplatform images for amd64, arm64, ppc64le, s390x.
 Requires Java 11, Java 17 recommended.
 
 ```bash
-curl -o https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-gc-::NESSIE_VERSION:: \
-  https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-gc-::NESSIE_VERSION::
-java -jar https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-gc-::NESSIE_VERSION::
+curl -L -o nessie-gc-::NESSIE_VERSION::.jar \
+  https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-gc-::NESSIE_VERSION::.jar
+java -jar nessie-gc-::NESSIE_VERSION::.jar
 ```
 
 ### Nessie Repository Management tool as a standalone uber jar
@@ -89,7 +89,7 @@ java -jar https://github.com/projectnessie/nessie/releases/download/nessie-::NES
 Requires Java 17 or newer.
 
 ```bash
-curl -o nessie-server-admin-tool-::NESSIE_VERSION::-runner.jar \
+curl -L -o nessie-server-admin-tool-::NESSIE_VERSION::-runner.jar \
   https://github.com/projectnessie/nessie/releases/download/nessie-::NESSIE_VERSION::/nessie-server-admin-tool-::NESSIE_VERSION::-runner.jar
 java -jar nessie-server-admin-tool-::NESSIE_VERSION::-runner.jar
 ```


### PR DESCRIPTION
A bunch of download links are wrong on our web site, and the Nessie CLI uber jar wasn't published to the GH release page. Also, basically all `curl -o` didn't work, because GH release artifact URLs are now redirected.