### PR TITLE
[Catalog] Refactor secrets handling

### DIFF
--- a/catalog/files/impl/build.gradle.kts
+++ b/catalog/files/impl/build.gradle.kts
@@ -62,6 +62,9 @@ dependencies {
 
   testFixturesApi(project(":nessie-object-storage-mock"))
 
+  testCompileOnly(project(":nessie-immutables"))
+  testAnnotationProcessor(project(":nessie-immutables", configuration = "processor"))
+
   testRuntimeOnly(libs.logback.classic)
 
   jmhImplementation(libs.jmh.core)

--- a/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/adls/AdlsClientResourceBench.java
+++ b/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/adls/AdlsClientResourceBench.java
@@ -22,6 +22,7 @@ import static org.projectnessie.catalog.files.BenchUtils.mockServer;
 import com.azure.core.http.HttpClient;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.stream.Collectors;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -61,13 +62,17 @@ public class AdlsClientResourceBench {
 
       AdlsOptions<AdlsFileSystemOptions> adlsOptions =
           AdlsProgrammaticOptions.builder()
-              .accountKeyRef("foo")
-              .accountNameRef("foo")
-              .sasTokenRef("foo")
+              .accountKey("foo")
+              .accountName("foo")
+              .sasToken("foo")
               .endpoint(server.getAdlsGen2BaseUri().toString())
               .build();
 
-      clientSupplier = new AdlsClientSupplier(httpClient, adlsOptions, secret -> "secret");
+      clientSupplier =
+          new AdlsClientSupplier(
+              httpClient,
+              adlsOptions,
+              (names) -> names.stream().collect(Collectors.toMap(k -> k, k -> k)));
     }
 
     @TearDown

--- a/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/gcs/GcsClientResourceBench.java
+++ b/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/gcs/GcsClientResourceBench.java
@@ -23,6 +23,7 @@ import static org.projectnessie.catalog.files.gcs.GcsLocation.gcsLocation;
 import com.google.auth.http.HttpTransportFactory;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.stream.Collectors;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -60,13 +61,13 @@ public class GcsClientResourceBench {
       HttpTransportFactory httpTransportFactory = GcsClients.buildSharedHttpTransportFactory();
 
       GcsOptions<GcsBucketOptions> gcsOptions =
-          GcsProgrammaticOptions.builder()
-              .oauth2TokenRef("foo")
-              .host(server.getGcsBaseUri())
-              .build();
+          GcsProgrammaticOptions.builder().oauth2Token("foo").host(server.getGcsBaseUri()).build();
 
       storageSupplier =
-          new GcsStorageSupplier(httpTransportFactory, gcsOptions, secret -> "secret");
+          new GcsStorageSupplier(
+              httpTransportFactory,
+              gcsOptions,
+              (names) -> names.stream().collect(Collectors.toMap(k -> k, k -> k)));
     }
 
     @TearDown

--- a/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/s3/S3ClientResourceBench.java
+++ b/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/s3/S3ClientResourceBench.java
@@ -22,6 +22,7 @@ import static org.projectnessie.catalog.files.BenchUtils.mockServer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Clock;
+import java.util.stream.Collectors;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -63,8 +64,8 @@ public class S3ClientResourceBench {
 
       S3Options<S3BucketOptions> s3options =
           S3ProgrammaticOptions.builder()
-              .accessKeyIdRef("foo")
-              .secretAccessKeyRef("bar")
+              .accessKeyId("foo")
+              .secretAccessKey("bar")
               .region("eu-central-1")
               .endpoint(server.getS3BaseUri())
               .pathStyleAccess(true)
@@ -73,7 +74,12 @@ public class S3ClientResourceBench {
       S3Sessions sessions = new S3Sessions("foo", null);
 
       clientSupplier =
-          new S3ClientSupplier(httpClient, s3config, s3options, secret -> "secret", sessions);
+          new S3ClientSupplier(
+              httpClient,
+              s3config,
+              s3options,
+              (names) -> names.stream().collect(Collectors.toMap(k -> k, k -> k)),
+              sessions);
     }
 
     @TearDown

--- a/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/s3/S3SessionCacheResourceBench.java
+++ b/catalog/files/impl/src/jmh/java/org/projectnessie/catalog/files/s3/S3SessionCacheResourceBench.java
@@ -73,21 +73,15 @@ public class S3SessionCacheResourceBench {
 
       S3Options<S3BucketOptions> s3options =
           S3ProgrammaticOptions.builder()
-              .accessKeyIdRef("foo")
-              .secretAccessKeyRef("bar")
+              .accessKeyId("foo")
+              .secretAccessKey("bar")
               .region("eu-central-1")
               .pathStyleAccess(true)
               .build();
 
       s3SessionsManager =
           new S3SessionsManager(
-              s3options,
-              System::currentTimeMillis,
-              httpClient,
-              null,
-              Optional.empty(),
-              secret -> "secret",
-              null);
+              s3options, System::currentTimeMillis, httpClient, null, Optional.empty(), null);
 
       List<String> regions =
           Region.regions().stream()
@@ -101,8 +95,8 @@ public class S3SessionCacheResourceBench {
               .mapToObj(
                   i ->
                       S3ProgrammaticOptions.S3PerBucketOptions.builder()
-                          .accessKeyIdRef("key" + i)
-                          .secretAccessKeyRef("secret" + i)
+                          .accessKeyId("key" + i)
+                          .secretAccessKey("secret" + i)
                           .externalId("externalId" + i)
                           .region(regions.get(i % regions.size()))
                           .roleSessionName("roleSessionName" + i)

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsClientSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsClientSupplier.java
@@ -65,7 +65,7 @@ public final class AdlsClientSupplier {
     adlsOptions.configurationOptions().forEach(clientConfig::putProperty);
 
     AdlsFileSystemOptions fileSystemOptions =
-        adlsOptions.effectiveOptionsForFileSystem(location.container());
+        adlsOptions.effectiveOptionsForFileSystem(location.container(), secretsProvider);
 
     DataLakeFileSystemClientBuilder clientBuilder =
         new DataLakeFileSystemClientBuilder()
@@ -75,19 +75,15 @@ public final class AdlsClientSupplier {
     // MUST set the endpoint FIRST, because it ALSO sets accountName, fileSystemName and sasToken!
     // See com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder.endpoint
 
-    String accountName =
-        fileSystemOptions
-            .accountNameRef()
-            .map(secretsProvider::getSecret)
-            .orElse(location.storageAccount());
+    String accountName = fileSystemOptions.accountName().orElse(location.storageAccount());
 
     clientBuilder.endpoint(
         fileSystemOptions.endpoint().orElse(location.getUri().resolve("/").toString()));
 
-    if (fileSystemOptions.sasTokenRef().isPresent()) {
-      clientBuilder.sasToken(secretsProvider.getSecret(fileSystemOptions.sasTokenRef().get()));
-    } else if (fileSystemOptions.accountKeyRef().isPresent()) {
-      String accountKey = secretsProvider.getSecret(fileSystemOptions.accountKeyRef().get());
+    if (fileSystemOptions.sasToken().isPresent()) {
+      clientBuilder.sasToken(fileSystemOptions.sasToken().get());
+    } else if (fileSystemOptions.accountKey().isPresent()) {
+      String accountKey = fileSystemOptions.accountKey().get();
       clientBuilder.credential(new StorageSharedKeyCredential(accountName, accountKey));
     } else {
       throw new IllegalStateException(

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsFileSystemOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsFileSystemOptions.java
@@ -20,17 +20,20 @@ import java.util.Optional;
 
 public interface AdlsFileSystemOptions {
 
-  /** Fully-qualified account name, e.g. {@code "myaccount.dfs.core.windows.net"}. */
-  Optional<String> accountNameRef();
-
-  /** Account key to access the ADLS file system. */
-  Optional<String> accountKeyRef();
+  /**
+   * Fully-qualified account name, e.g. {@code "myaccount.dfs.core.windows.net"}. If not specified,
+   * it will be queried via the configured credentials provider.
+   */
+  Optional<String> accountName();
 
   /**
-   * SAS token <em>reference</em> to access the ADLS file system, the actual secret value is defined
-   * as secrets via {@code nessie.catalog.secrets.}<em>{@code secret-ref}</em>.
+   * Account key to access the ADLS file system. If not specified, it will be queried via the
+   * configured credentials provider.
    */
-  Optional<String> sasTokenRef();
+  Optional<String> accountKey();
+
+  /** SAS token <em>reference</em> to access the ADLS file system. */
+  Optional<String> sasToken();
 
   /**
    * Define a custom HTTP endpoint. In case clients need to use a different URI, use the {@code

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsOptions.java
@@ -81,9 +81,8 @@ public interface AdlsOptions<PER_FILE_SYSTEM extends AdlsFileSystemOptions>
       builder.from(specific);
     }
 
-    SecretsHelper.resolveSecrets(
-        secretsProvider, "object-stores.adls", builder, this, filesystemName, specific, SECRETS);
-
-    return builder.build();
+    return SecretsHelper.resolveSecrets(
+            secretsProvider, "object-stores.adls", builder, this, filesystemName, specific, SECRETS)
+        .build();
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsOptions.java
@@ -15,11 +15,17 @@
  */
 package org.projectnessie.catalog.files.adls;
 
+import static org.projectnessie.catalog.files.secrets.SecretsHelper.Specializeable.specializable;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import org.projectnessie.catalog.files.adls.AdlsProgrammaticOptions.AdlsPerFileSystemOptions;
+import org.projectnessie.catalog.files.secrets.SecretsHelper;
+import org.projectnessie.catalog.files.secrets.SecretsProvider;
 import org.projectnessie.nessie.docgen.annotations.ConfigDocs.ConfigPropertyName;
 
 public interface AdlsOptions<PER_FILE_SYSTEM extends AdlsFileSystemOptions>
@@ -38,15 +44,46 @@ public interface AdlsOptions<PER_FILE_SYSTEM extends AdlsFileSystemOptions>
   @ConfigPropertyName("filesystem-name")
   Map<String, PER_FILE_SYSTEM> fileSystems();
 
-  default AdlsFileSystemOptions effectiveOptionsForFileSystem(Optional<String> filesystemName) {
+  default AdlsFileSystemOptions effectiveOptionsForFileSystem(
+      Optional<String> filesystemName, SecretsProvider secretsProvider) {
     if (filesystemName.isEmpty()) {
-      return this;
+      return resolveSecrets(null, null, secretsProvider);
     }
-    AdlsFileSystemOptions perBucket = fileSystems().get(filesystemName.get());
+    String name = filesystemName.get();
+    AdlsFileSystemOptions perBucket = fileSystems().get(name);
     if (perBucket == null) {
-      return this;
+      return resolveSecrets(name, null, secretsProvider);
     }
 
-    return AdlsPerFileSystemOptions.builder().from(this).from(perBucket).build();
+    return resolveSecrets(name, perBucket, secretsProvider);
+  }
+
+  List<SecretsHelper.Specializeable<AdlsFileSystemOptions, AdlsPerFileSystemOptions.Builder>>
+      SECRETS =
+          ImmutableList.of(
+              specializable(
+                  "accountName",
+                  AdlsFileSystemOptions::accountName,
+                  AdlsPerFileSystemOptions.Builder::accountName),
+              specializable(
+                  "accountKey",
+                  AdlsFileSystemOptions::accountKey,
+                  AdlsPerFileSystemOptions.Builder::accountKey),
+              specializable(
+                  "sasToken",
+                  AdlsFileSystemOptions::sasToken,
+                  AdlsPerFileSystemOptions.Builder::sasToken));
+
+  default AdlsFileSystemOptions resolveSecrets(
+      String filesystemName, AdlsFileSystemOptions specific, SecretsProvider secretsProvider) {
+    AdlsPerFileSystemOptions.Builder builder = AdlsPerFileSystemOptions.builder().from(this);
+    if (specific != null) {
+      builder.from(specific);
+    }
+
+    SecretsHelper.resolveSecrets(
+        secretsProvider, "object-stores.adls", builder, this, filesystemName, specific, SECRETS);
+
+    return builder.build();
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsProgrammaticOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/adls/AdlsProgrammaticOptions.java
@@ -58,13 +58,13 @@ public interface AdlsProgrammaticOptions extends AdlsOptions<AdlsFileSystemOptio
     Builder putAllFileSystems(Map<String, ? extends AdlsFileSystemOptions> entries);
 
     @CanIgnoreReturnValue
-    Builder accountNameRef(String accountNameRef);
+    Builder accountName(String accountName);
 
     @CanIgnoreReturnValue
-    Builder accountKeyRef(String accountKeyRef);
+    Builder accountKey(String accountKey);
 
     @CanIgnoreReturnValue
-    Builder sasTokenRef(String sasTokenRef);
+    Builder sasToken(String sasToken);
 
     @CanIgnoreReturnValue
     Builder endpoint(String endpoint);
@@ -99,13 +99,13 @@ public interface AdlsProgrammaticOptions extends AdlsOptions<AdlsFileSystemOptio
       Builder from(AdlsFileSystemOptions instance);
 
       @CanIgnoreReturnValue
-      Builder accountNameRef(String accountNameRef);
+      Builder accountName(String accountName);
 
       @CanIgnoreReturnValue
-      Builder accountKeyRef(String accountKeyRef);
+      Builder accountKey(String accountKey);
 
       @CanIgnoreReturnValue
-      Builder sasTokenRef(String sasTokenRef);
+      Builder sasToken(String sasToken);
 
       @CanIgnoreReturnValue
       Builder endpoint(String endpoint);

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsBucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsBucketOptions.java
@@ -64,13 +64,13 @@ public interface GcsBucketOptions {
    * Reference to the credentials-JSON. This value is the name of the credential to use, the actual
    * credential is defined via secrets.
    */
-  Optional<String> authCredentialsJsonRef();
+  Optional<String> authCredentialsJson();
 
   /**
    * Reference to the OAuth2 token. This value is the name of the credential to use, the actual
    * credential is defined via secrets.
    */
-  Optional<String> oauth2TokenRef();
+  Optional<String> oauth2Token();
 
   /** Timestamp when the OAuth2 token referenced via {@code oauth2-token-ref} expires. */
   Optional<Instant> oauth2TokenExpiresAt();
@@ -116,14 +116,14 @@ public interface GcsBucketOptions {
    *
    * @implNote This is currently unsupported.
    */
-  Optional<String> encryptionKeyRef();
+  Optional<String> encryptionKey();
 
   /**
    * Customer-supplied AES256 key for blob decryption when reading.
    *
    * @implNote This is currently unsupported.
    */
-  Optional<String> decryptionKeyRef();
+  Optional<String> decryptionKey();
 
   enum GcsAuthType {
     NONE,

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsObjectIO.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsObjectIO.java
@@ -43,11 +43,11 @@ public class GcsObjectIO implements ObjectIO {
   public InputStream readObject(StorageUri uri) {
     GcsLocation location = gcsLocation(uri);
     GcsBucketOptions bucketOptions = storageSupplier.bucketOptions(location);
+    @SuppressWarnings("resource")
     Storage client = storageSupplier.forLocation(bucketOptions);
     List<BlobSourceOption> sourceOptions = new ArrayList<>();
     bucketOptions
-        .decryptionKeyRef()
-        .map(keyRef -> storageSupplier.secretsProvider().getSecret(keyRef))
+        .decryptionKey()
         .map(BlobSourceOption::decryptionKey)
         .ifPresent(sourceOptions::add);
     bucketOptions.userProject().map(BlobSourceOption::userProject).ifPresent(sourceOptions::add);
@@ -63,14 +63,11 @@ public class GcsObjectIO implements ObjectIO {
   public OutputStream writeObject(StorageUri uri) {
     GcsLocation location = gcsLocation(uri);
     GcsBucketOptions bucketOptions = storageSupplier.bucketOptions(location);
+    @SuppressWarnings("resource")
     Storage client = storageSupplier.forLocation(bucketOptions);
     List<BlobWriteOption> writeOptions = new ArrayList<>();
 
-    bucketOptions
-        .encryptionKeyRef()
-        .map(keyRef -> storageSupplier.secretsProvider().getSecret(keyRef))
-        .map(BlobWriteOption::encryptionKey)
-        .ifPresent(writeOptions::add);
+    bucketOptions.encryptionKey().map(BlobWriteOption::encryptionKey).ifPresent(writeOptions::add);
     bucketOptions.userProject().map(BlobWriteOption::userProject).ifPresent(writeOptions::add);
 
     BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(location.bucket(), location.path())).build();

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsOptions.java
@@ -75,9 +75,8 @@ public interface GcsOptions<PER_BUCKET extends GcsBucketOptions> extends GcsBuck
       builder.from(specific);
     }
 
-    SecretsHelper.resolveSecrets(
-        secretsProvider, "object-stores.gcs", builder, this, filesystemName, specific, SECRETS);
-
-    return builder.build();
+    return SecretsHelper.resolveSecrets(
+            secretsProvider, "object-stores.gcs", builder, this, filesystemName, specific, SECRETS)
+        .build();
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsOptions.java
@@ -18,11 +18,9 @@ package org.projectnessie.catalog.files.gcs;
 import static org.projectnessie.catalog.files.secrets.SecretsHelper.Specializeable.specializable;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.projectnessie.catalog.files.gcs.GcsProgrammaticOptions.GcsPerBucketOptions;
 import org.projectnessie.catalog.files.secrets.SecretsHelper;
 import org.projectnessie.catalog.files.secrets.SecretsProvider;
@@ -50,9 +48,6 @@ public interface GcsOptions<PER_BUCKET extends GcsBucketOptions> extends GcsBuck
 
     return resolveSecrets(name, perBucket, secretsProvider);
   }
-
-  Set<String> SECRET_NAMES =
-      ImmutableSet.of("authCredentialsJson", "oauth2Token", "encryptionKey", "decryptionKey");
 
   List<SecretsHelper.Specializeable<GcsBucketOptions, GcsPerBucketOptions.Builder>> SECRETS =
       ImmutableList.of(

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsProgrammaticOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsProgrammaticOptions.java
@@ -60,10 +60,10 @@ public interface GcsProgrammaticOptions extends GcsOptions<GcsBucketOptions> {
     Builder authType(GcsAuthType authType);
 
     @CanIgnoreReturnValue
-    Builder authCredentialsJsonRef(String authCredentialsJsonRef);
+    Builder authCredentialsJson(String authCredentialsJson);
 
     @CanIgnoreReturnValue
-    Builder oauth2TokenRef(String oauth2tokenRef);
+    Builder oauth2Token(String oauth2token);
 
     @CanIgnoreReturnValue
     Builder oauth2TokenExpiresAt(Instant oauth2TokenExpiresAt);
@@ -102,7 +102,7 @@ public interface GcsProgrammaticOptions extends GcsOptions<GcsBucketOptions> {
     Builder writeChunkSize(int writeChunkSize);
 
     @CanIgnoreReturnValue
-    Builder encryptionKeyRef(String encryptionKeyRef);
+    Builder encryptionKey(String encryptionKey);
 
     @CanIgnoreReturnValue
     Builder userProject(String userProject);
@@ -146,10 +146,10 @@ public interface GcsProgrammaticOptions extends GcsOptions<GcsBucketOptions> {
       Builder authType(GcsAuthType authType);
 
       @CanIgnoreReturnValue
-      Builder authCredentialsJsonRef(String authCredentialsJsonRef);
+      Builder authCredentialsJson(String authCredentialsJson);
 
       @CanIgnoreReturnValue
-      Builder oauth2TokenRef(String oauth2tokenRef);
+      Builder oauth2Token(String oauth2token);
 
       @CanIgnoreReturnValue
       Builder oauth2TokenExpiresAt(Instant oauth2TokenExpiresAt);
@@ -188,7 +188,10 @@ public interface GcsProgrammaticOptions extends GcsOptions<GcsBucketOptions> {
       Builder writeChunkSize(int writeChunkSize);
 
       @CanIgnoreReturnValue
-      Builder encryptionKeyRef(String encryptionKeyRef);
+      Builder encryptionKey(String encryptionKey);
+
+      @CanIgnoreReturnValue
+      Builder decryptionKey(String decryptionKey);
 
       @CanIgnoreReturnValue
       Builder userProject(String userProject);

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/gcs/GcsStorageSupplier.java
@@ -34,15 +34,11 @@ public final class GcsStorageSupplier {
     this.secretsProvider = secretsProvider;
   }
 
-  public SecretsProvider secretsProvider() {
-    return secretsProvider;
-  }
-
   public GcsBucketOptions bucketOptions(GcsLocation location) {
-    return gcsOptions.effectiveOptionsForBucket(Optional.of(location.bucket()));
+    return gcsOptions.effectiveOptionsForBucket(Optional.of(location.bucket()), secretsProvider);
   }
 
   public Storage forLocation(GcsBucketOptions bucketOptions) {
-    return GcsClients.buildStorage(bucketOptions, httpTransportFactory, secretsProvider);
+    return GcsClients.buildStorage(bucketOptions, httpTransportFactory);
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3BucketOptions.java
@@ -99,20 +99,18 @@ public interface S3BucketOptions {
   Optional<String> projectId();
 
   /**
-   * Key used to look up the access-key-ID via {@link
-   * org.projectnessie.catalog.files.secrets.SecretsProvider SecretsProvider}. An access-key-id must
-   * be configured, either per bucket or in {@link S3Options S3Options}. For STS, this defines the
-   * Access Key ID to be used as a basic credential for obtaining temporary session credentials.
+   * An access-key-id must be configured, either per bucket or in {@link S3Options S3Options}. For
+   * STS, this defines the Access Key ID to be used as a basic credential for obtaining temporary
+   * session credentials.
    */
-  Optional<String> accessKeyIdRef();
+  Optional<String> accessKeyId();
 
   /**
-   * Key used to look up the secret-access-key via {@link
-   * org.projectnessie.catalog.files.secrets.SecretsProvider SecretsProvider}. A secret-access-key
-   * must be configured, either per bucket or in {@link S3Options S3Options}. For STS, this defines
-   * the Secret Key ID to be used as a basic credential for obtaining temporary session credentials.
+   * A secret-access-key must be configured, either per bucket or in {@link S3Options S3Options}.
+   * For STS, this defines the Secret Key ID to be used as a basic credential for obtaining
+   * temporary session credentials.
    */
-  Optional<String> secretAccessKeyRef();
+  Optional<String> secretAccessKey();
 
   /**
    * The <a href="https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html">Security Token

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ClientSupplier.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ClientSupplier.java
@@ -82,12 +82,13 @@ public class S3ClientSupplier {
 
     // Supply an empty profile file
 
-    S3BucketOptions bucketOptions = s3options.effectiveOptionsForBucket(Optional.of(bucketName));
+    S3BucketOptions bucketOptions =
+        s3options.effectiveOptionsForBucket(Optional.of(bucketName), secretsProvider);
 
     S3ClientBuilder builder =
         S3Client.builder()
             .httpClient(sdkClient)
-            .credentialsProvider(awsCredentialsProvider(bucketOptions, secretsProvider, sessions))
+            .credentialsProvider(awsCredentialsProvider(bucketOptions, sessions))
             .overrideConfiguration(
                 override -> override.defaultProfileFileSupplier(() -> EMPTY_PROFILE_FILE))
             .serviceConfiguration(
@@ -136,10 +137,6 @@ public class S3ClientSupplier {
         + options.region().orElse("<undefined>")
         + ", projectId="
         + options.projectId().orElse("<undefined>")
-        + ", accessKeyIdRef="
-        + options.accessKeyIdRef().orElse("<undefined>")
-        + ", secretAccessKeyRef="
-        + options.secretAccessKeyRef().orElse("<undefined>")
         + "}";
   }
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Options.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Options.java
@@ -167,9 +167,8 @@ public interface S3Options<PER_BUCKET extends S3BucketOptions> extends S3BucketO
       builder.from(specific);
     }
 
-    SecretsHelper.resolveSecrets(
-        secretsProvider, "object-stores.s3", builder, this, filesystemName, specific, SECRETS);
-
-    return builder.build();
+    return SecretsHelper.resolveSecrets(
+            secretsProvider, "object-stores.s3", builder, this, filesystemName, specific, SECRETS)
+        .build();
   }
 }

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ProgrammaticOptions.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3ProgrammaticOptions.java
@@ -52,10 +52,10 @@ public interface S3ProgrammaticOptions extends S3Options<S3BucketOptions> {
     Builder projectId(String projectId);
 
     @CanIgnoreReturnValue
-    Builder accessKeyIdRef(String accessKeyIdRef);
+    Builder accessKeyId(String accessKeyId);
 
     @CanIgnoreReturnValue
-    Builder secretAccessKeyRef(String secretAccessKeyRef);
+    Builder secretAccessKey(String secretAccessKey);
 
     @CanIgnoreReturnValue
     Builder sessionCredentialCacheMaxEntries(int sessionCredentialCacheMaxEntries);
@@ -111,10 +111,10 @@ public interface S3ProgrammaticOptions extends S3Options<S3BucketOptions> {
       Builder projectId(String projectId);
 
       @CanIgnoreReturnValue
-      Builder accessKeyIdRef(String accessKeyIdRef);
+      Builder accessKeyId(String accessKeyId);
 
       @CanIgnoreReturnValue
-      Builder secretAccessKeyRef(String secretAccessKeyRef);
+      Builder secretAccessKey(String secretAccessKey);
 
       @CanIgnoreReturnValue
       Builder accessPoint(String accessPoint);

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Signer.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3Signer.java
@@ -66,9 +66,10 @@ public class S3Signer implements RequestSigner {
       throw new IllegalArgumentException("DELETE requests must have a non-empty body");
     }
 
-    S3BucketOptions bucketOptions = s3Options.effectiveOptionsForBucket(clientRequest.bucket());
+    S3BucketOptions bucketOptions =
+        s3Options.effectiveOptionsForBucket(clientRequest.bucket(), secretsProvider);
     AwsCredentialsProvider credentialsProvider =
-        S3Clients.awsCredentialsProvider(bucketOptions, secretsProvider, s3sessions);
+        S3Clients.awsCredentialsProvider(bucketOptions, s3sessions);
 
     SdkHttpFullRequest.Builder request =
         SdkHttpFullRequest.builder()

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/secrets/SecretsHelper.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/secrets/SecretsHelper.java
@@ -51,7 +51,7 @@ public final class SecretsHelper {
       @Nonnull String baseName,
       @Nonnull B builder,
       @Nonnull R base,
-      @Nonnull String specificName,
+      String specificName,
       R specific,
       @Nonnull List<Specializeable<R, B>> secrets) {
 

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/secrets/SecretsHelper.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/secrets/SecretsHelper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.files.secrets;
+
+import static java.util.Collections.emptyMap;
+
+import jakarta.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+
+public final class SecretsHelper {
+  private SecretsHelper() {}
+
+  /**
+   * Helper to resolve the secrets described via {@link Specializeable}s using the given
+   * secrets-provider.
+   *
+   * <p>Individual secrets are resolved in the following order:
+   *
+   * <ol>
+   *   <li>The value of the attribute on the {@code specific} object,
+   *   <li>The resolved secret for the specific object (lookup via {@code baseName + '.' +
+   *       specificName + '.' + Specializeable.name()},
+   *   <li>The value of the attribute on the {@code base} object,
+   *   <li>The resolved secret for the base object (lookup via {@code baseName + '.' +
+   *       Specializeable.name()},
+   * </ol>
+   */
+  public static <R, B> B resolveSecrets(
+      @Nonnull SecretsProvider secretsProvider,
+      @Nonnull String baseName,
+      @Nonnull B builder,
+      @Nonnull R base,
+      @Nonnull String specificName,
+      R specific,
+      @Nonnull List<Specializeable<R, B>> secrets) {
+
+    String basePrefix = baseName + '.';
+    String specificPrefix = basePrefix + specificName + '.';
+
+    Map<String, String> baseSecrets = new HashMap<>();
+    Set<String> names = new HashSet<>();
+
+    for (Specializeable<R, B> secret : secrets) {
+      Optional<String> specificSecret =
+          specific != null ? secret.current().apply(specific) : Optional.empty();
+      if (specificSecret.isPresent()) {
+        secret.applicator().accept(builder, specificSecret.get());
+      } else {
+        names.add(specificPrefix + secret.name());
+
+        Optional<String> baseSecret = secret.current().apply(base);
+        if (baseSecret.isPresent()) {
+          baseSecrets.put(secret.name(), baseSecret.get());
+        } else {
+          names.add(basePrefix + secret.name());
+        }
+      }
+    }
+
+    Map<String, String> resolvedSecrets =
+        names.isEmpty() ? emptyMap() : secretsProvider.resolveSecrets(names);
+
+    for (Specializeable<R, B> secret : secrets) {
+      Optional<String> specificSecret =
+          specific != null ? secret.current().apply(specific) : Optional.empty();
+      if (specificSecret.isEmpty()) {
+        String resolved = resolvedSecrets.get(specificPrefix + secret.name());
+        if (resolved == null) {
+          resolved = baseSecrets.get(secret.name());
+          if (resolved == null) {
+            resolved = resolvedSecrets.get(basePrefix + secret.name());
+          }
+        }
+        if (resolved != null) {
+          secret.applicator().accept(builder, resolved);
+        }
+      }
+    }
+
+    return builder;
+  }
+
+  @NessieImmutable
+  public interface Specializeable<R, B> {
+    String name();
+
+    Function<R, Optional<String>> current();
+
+    BiConsumer<B, String> applicator();
+
+    static <R, B> Specializeable<R, B> specializable(
+        String name, Function<R, Optional<String>> current, BiConsumer<B, String> applicator) {
+      return ImmutableSpecializeable.of(name, current, applicator);
+    }
+  }
+}

--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/secrets/SecretsProvider.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/secrets/SecretsProvider.java
@@ -15,6 +15,23 @@
  */
 package org.projectnessie.catalog.files.secrets;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 public interface SecretsProvider {
-  String getSecret(String secret);
+  Map<String, String> resolveSecrets(Set<String> names);
+
+  static SecretsProvider mapSecretsProvider(Map<String, String> secretsMap) {
+    return names -> {
+      Map<String, String> resolved = new HashMap<>();
+      for (String name : names) {
+        String r = secretsMap.get(name);
+        if (r != null) {
+          resolved.put(name, r);
+        }
+      }
+      return resolved;
+    };
+  }
 }

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/AbstractClients.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/AbstractClients.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.catalog.files.s3;
+package org.projectnessie.catalog.files;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.projectnessie.objectstoragemock.HeapStorageBucket.newHeapStorageBucket;

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/adls/TestAdlsClients.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/adls/TestAdlsClients.java
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.catalog.files.s3;
+package org.projectnessie.catalog.files.adls;
 
 import com.azure.core.http.HttpClient;
-import org.projectnessie.catalog.files.adls.AdlsClientSupplier;
-import org.projectnessie.catalog.files.adls.AdlsClients;
-import org.projectnessie.catalog.files.adls.AdlsConfig;
-import org.projectnessie.catalog.files.adls.AdlsObjectIO;
-import org.projectnessie.catalog.files.adls.AdlsProgrammaticOptions;
+import java.util.stream.Collectors;
+import org.projectnessie.catalog.files.AbstractClients;
 import org.projectnessie.catalog.files.api.ObjectIO;
 import org.projectnessie.objectstoragemock.ObjectStorageMock;
 import org.projectnessie.storage.uri.StorageUri;
@@ -43,21 +40,24 @@ public class TestAdlsClients extends AbstractClients {
                 BUCKET_1,
                 AdlsProgrammaticOptions.AdlsPerFileSystemOptions.builder()
                     .endpoint(server1.getAdlsGen2BaseUri().toString())
-                    .accountNameRef("accountName")
-                    .accountKeyRef("accountKey")
+                    .accountName("accountName")
+                    .accountKey("accountKey")
                     .build());
     if (server2 != null) {
       adlsOptions.putFileSystems(
           BUCKET_2,
           AdlsProgrammaticOptions.AdlsPerFileSystemOptions.builder()
               .endpoint(server2.getAdlsGen2BaseUri().toString())
-              .accountNameRef("accountName")
-              .accountKeyRef("accountKey")
+              .accountName("accountName")
+              .accountKey("accountKey")
               .build());
     }
 
     AdlsClientSupplier supplier =
-        new AdlsClientSupplier(httpClient, adlsOptions.build(), secret -> "secret");
+        new AdlsClientSupplier(
+            httpClient,
+            adlsOptions.build(),
+            (names) -> names.stream().collect(Collectors.toMap(k -> k, k -> "secret")));
 
     return new AdlsObjectIO(supplier);
   }

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/TestGcsClients.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/gcs/TestGcsClients.java
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.projectnessie.catalog.files.s3;
+package org.projectnessie.catalog.files.gcs;
 
 import static org.projectnessie.catalog.files.gcs.GcsClients.buildSharedHttpTransportFactory;
 
 import com.google.auth.http.HttpTransportFactory;
+import java.util.stream.Collectors;
+import org.projectnessie.catalog.files.AbstractClients;
 import org.projectnessie.catalog.files.api.ObjectIO;
-import org.projectnessie.catalog.files.gcs.GcsBucketOptions;
-import org.projectnessie.catalog.files.gcs.GcsObjectIO;
-import org.projectnessie.catalog.files.gcs.GcsProgrammaticOptions;
-import org.projectnessie.catalog.files.gcs.GcsStorageSupplier;
 import org.projectnessie.objectstoragemock.ObjectStorageMock;
 import org.projectnessie.storage.uri.StorageUri;
 
@@ -57,7 +55,10 @@ public class TestGcsClients extends AbstractClients {
     }
 
     GcsStorageSupplier supplier =
-        new GcsStorageSupplier(httpTransportFactory, gcsOptions.build(), secret -> "secret");
+        new GcsStorageSupplier(
+            httpTransportFactory,
+            gcsOptions.build(),
+            (names) -> names.stream().collect(Collectors.toMap(k -> k, k -> "secret")));
 
     return new GcsObjectIO(supplier);
   }

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/s3/TestS3Clients.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/s3/TestS3Clients.java
@@ -16,8 +16,10 @@
 package org.projectnessie.catalog.files.s3;
 
 import java.time.Clock;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.projectnessie.catalog.files.AbstractClients;
 import org.projectnessie.catalog.files.api.ObjectIO;
 import org.projectnessie.objectstoragemock.ObjectStorageMock;
 import org.projectnessie.storage.uri.StorageUri;
@@ -52,8 +54,8 @@ public class TestS3Clients extends AbstractClients {
                 S3ProgrammaticOptions.S3PerBucketOptions.builder()
                     .endpoint(server1.getS3BaseUri())
                     .region("us-west-1")
-                    .accessKeyIdRef("ak1")
-                    .secretAccessKeyRef("sak1")
+                    .accessKeyId("ak1")
+                    .secretAccessKey("sak1")
                     .accessPoint(BUCKET_1)
                     .build());
     if (server2 != null) {
@@ -62,14 +64,18 @@ public class TestS3Clients extends AbstractClients {
           S3ProgrammaticOptions.S3PerBucketOptions.builder()
               .endpoint(server2.getS3BaseUri())
               .region("eu-central-2")
-              .accessKeyIdRef("ak2")
-              .secretAccessKeyRef("sak2")
+              .accessKeyId("ak2")
+              .secretAccessKey("sak2")
               .build());
     }
 
     S3ClientSupplier supplier =
         new S3ClientSupplier(
-            sdkHttpClient, S3Config.builder().build(), s3options.build(), secret -> "secret", null);
+            sdkHttpClient,
+            S3Config.builder().build(),
+            s3options.build(),
+            (names) -> names.stream().collect(Collectors.toMap(k -> k, k -> "secret")),
+            null);
     return new S3ObjectIO(supplier, Clock.systemUTC());
   }
 

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/s3/TestS3SessionsManager.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/s3/TestS3SessionsManager.java
@@ -76,8 +76,7 @@ class TestS3SessionsManager {
         };
 
     S3SessionsManager manager =
-        new S3SessionsManager(
-            s3options, time::get, null, clientBuilder, Optional.empty(), s -> s, loader);
+        new S3SessionsManager(s3options, time::get, null, clientBuilder, Optional.empty(), loader);
     S3BucketOptions options = S3ProgrammaticOptions.builder().region("R1").roleArn("role").build();
 
     credentials.set(credentials(time.get() + 100));
@@ -133,8 +132,7 @@ class TestS3SessionsManager {
         };
 
     S3SessionsManager manager =
-        new S3SessionsManager(
-            s3options, time::get, null, clientBuilder, Optional.empty(), s -> s, loader);
+        new S3SessionsManager(s3options, time::get, null, clientBuilder, Optional.empty(), loader);
     S3BucketOptions options = S3ProgrammaticOptions.builder().region("R1").roleArn("role").build();
 
     credentials.set(credentials(time.get() + 100));
@@ -157,8 +155,7 @@ class TestS3SessionsManager {
     AtomicReference<Credentials> credentials = new AtomicReference<>();
     SessionCredentialsFetcher loader = (client, key, duration) -> credentials.get();
     S3SessionsManager manager =
-        new S3SessionsManager(
-            s3options, time::get, null, (p) -> null, Optional.empty(), s -> s, loader);
+        new S3SessionsManager(s3options, time::get, null, (p) -> null, Optional.empty(), loader);
 
     S3BucketOptions options = S3ProgrammaticOptions.builder().region("R1").roleArn("role").build();
     Credentials c1 = credentials(time.get() + 100);
@@ -185,7 +182,6 @@ class TestS3SessionsManager {
         null,
         (p) -> null,
         Optional.of(meterRegistry),
-        s -> s,
         (client, key, duration) -> null);
 
     Function<Meter, AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>>> extractor =

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/secrets/TestSecretsHelper.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/secrets/TestSecretsHelper.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.catalog.files.secrets;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.projectnessie.catalog.files.secrets.SecretsHelper.Specializeable.specializable;
+import static org.projectnessie.catalog.files.secrets.SecretsProvider.mapSecretsProvider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.projectnessie.nessie.immutables.NessieImmutable;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class TestSecretsHelper {
+  @InjectSoftAssertions protected SoftAssertions soft;
+
+  @ParameterizedTest
+  @MethodSource
+  public void secretsHelper(Opts base, Opts spec, Opts expected, Map<String, String> secrets) {
+    Opts.Builder builder = Opts.builder();
+    List<SecretsHelper.Specializeable<Opts, Opts.Builder>> specializables =
+        List.of(
+            specializable("foo", Opts::foo, Opts.Builder::foo),
+            specializable("bar", Opts::bar, Opts.Builder::bar),
+            specializable("baz", Opts::baz, Opts.Builder::baz));
+
+    SecretsHelper.resolveSecrets(
+        mapSecretsProvider(secrets), "base", builder, base, "spec", spec, specializables);
+
+    soft.assertThat(builder.build()).isEqualTo(expected);
+  }
+
+  public static Stream<Arguments> secretsHelper() {
+    Opts fooBarBaz = Opts.builder().foo("foo").bar("bar").baz("baz").build();
+    Opts nopeNopeNope = Opts.builder().foo("nope").bar("nope").baz("nope").build();
+    return Stream.of(
+        arguments(Opts.EMPTY, null, Opts.EMPTY, Map.of()),
+        arguments(Opts.EMPTY, Opts.EMPTY, Opts.EMPTY, Map.of()),
+        //
+        arguments(
+            Opts.EMPTY,
+            Opts.EMPTY,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.bar", "bar",
+                "base.spec.baz", "baz")),
+        arguments(
+            Opts.EMPTY,
+            null,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.bar", "bar",
+                "base.spec.baz", "baz")),
+        //
+        arguments(
+            Opts.EMPTY,
+            Opts.EMPTY,
+            fooBarBaz,
+            Map.of(
+                "base.foo", "foo",
+                "base.bar", "bar",
+                "base.baz", "baz")),
+        //
+        arguments(
+            Opts.EMPTY,
+            Opts.EMPTY,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.bar", "bar",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "no",
+                "base.baz", "no")),
+        arguments(
+            Opts.EMPTY,
+            null,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.bar", "bar",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "no",
+                "base.baz", "no")),
+        //
+        arguments(
+            Opts.EMPTY,
+            Opts.EMPTY,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "bar",
+                "base.baz", "no")),
+        arguments(
+            Opts.EMPTY,
+            null,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "bar",
+                "base.baz", "no")),
+        //
+        arguments(
+            Opts.EMPTY,
+            Opts.builder().bar("bar").build(),
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.bar", "no-spec",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "no-base",
+                "base.baz", "no")),
+        //
+        arguments(
+            Opts.builder().bar("bar").build(),
+            Opts.EMPTY,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "no-base",
+                "base.baz", "no")),
+        arguments(
+            Opts.builder().bar("bar").build(),
+            null,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "no-base",
+                "base.baz", "no")),
+        //
+        arguments(
+            fooBarBaz,
+            Opts.EMPTY,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "no-base",
+                "base.baz", "no")),
+        arguments(
+            nopeNopeNope,
+            null,
+            fooBarBaz,
+            Map.of(
+                "base.spec.foo", "foo",
+                "base.spec.bar", "bar",
+                "base.spec.baz", "baz",
+                "base.foo", "no",
+                "base.bar", "no",
+                "base.baz", "no")),
+        //
+        arguments(fooBarBaz, Opts.EMPTY, fooBarBaz, Map.of()),
+        arguments(fooBarBaz, null, fooBarBaz, Map.of()),
+        arguments(nopeNopeNope, fooBarBaz, fooBarBaz, Map.of())
+        //
+        );
+  }
+
+  @NessieImmutable
+  public interface Opts {
+    Opts EMPTY = Opts.builder().build();
+
+    Optional<String> foo();
+
+    Optional<String> bar();
+
+    Optional<String> baz();
+
+    static Builder builder() {
+      return ImmutableOpts.builder();
+    }
+
+    interface Builder {
+      Builder foo(String foo);
+
+      Builder bar(String bar);
+
+      Builder baz(String baz);
+
+      Opts build();
+    }
+  }
+}

--- a/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/secrets/TestSecretsHelper.java
+++ b/catalog/files/impl/src/test/java/org/projectnessie/catalog/files/secrets/TestSecretsHelper.java
@@ -46,10 +46,12 @@ public class TestSecretsHelper {
             specializable("bar", Opts::bar, Opts.Builder::bar),
             specializable("baz", Opts::baz, Opts.Builder::baz));
 
-    SecretsHelper.resolveSecrets(
-        mapSecretsProvider(secrets), "base", builder, base, "spec", spec, specializables);
+    Opts opts =
+        SecretsHelper.resolveSecrets(
+                mapSecretsProvider(secrets), "base", builder, base, "spec", spec, specializables)
+            .build();
 
-    soft.assertThat(builder.build()).isEqualTo(expected);
+    soft.assertThat(opts).isEqualTo(expected);
   }
 
   public static Stream<Arguments> secretsHelper() {

--- a/docker/catalog-full/docker-compose.yml
+++ b/docker/catalog-full/docker-compose.yml
@@ -54,10 +54,8 @@ services:
         # MinIO endpoint for clients (on the Podman/Docker host)
       - nessie.catalog.service.s3.external-endpoint=http://127.0.0.1:9000/
       - nessie.catalog.service.s3.path-style-access=true
-      - nessie.catalog.service.s3.access-key-id-ref=accessKeyRefId
-      - nessie.catalog.service.s3.secret-access-key-ref=awsSecretAccessKeyRefId
-      - nessie.catalog.secrets.accessKeyRefId=minioadmin
-      - nessie.catalog.secrets.awsSecretAccessKeyRefId=minioadmin
+      - nessie.catalog.service.s3.access-key-id=minioadmin
+      - nessie.catalog.service.s3.secret-access-key=minioadmin
       - nessie.catalog.default-warehouse=warehouse
       - nessie.catalog.warehouses.warehouse.location=s3://demobucket/
       # Telemetry

--- a/integrations/spark-extensions/shared/src/intTest/java/org/projectnessie/spark/extensions/ITNessieStatementsViaIcebergRest.java
+++ b/integrations/spark-extensions/shared/src/intTest/java/org/projectnessie/spark/extensions/ITNessieStatementsViaIcebergRest.java
@@ -42,10 +42,8 @@ public class ITNessieStatementsViaIcebergRest extends AbstractNessieSparkSqlExte
         "-Dnessie.catalog.service.s3.endpoint=" + objectStorage.getS3BaseUri().toString(),
         "-Dnessie.catalog.service.s3.path-style-access=true",
         "-Dnessie.catalog.service.s3.region=eu-central-1",
-        "-Dnessie.catalog.service.s3.access-key-id-ref=awsAccessKeyId",
-        "-Dnessie.catalog.service.s3.secret-access-key-ref=awsSecretAccessKey",
-        "-Dnessie.catalog.secrets.awsAccessKeyId=accessKey",
-        "-Dnessie.catalog.secrets.awsSecretAccessKey=secretKey");
+        "-Dnessie.catalog.service.s3.access-key-id=accessKey",
+        "-Dnessie.catalog.service.s3.secret-access-key=secretKey");
   }
 
   @BeforeEach

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogAdlsConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogAdlsConfig.java
@@ -81,13 +81,13 @@ public interface CatalogAdlsConfig extends AdlsConfig, AdlsOptions<CatalogAdlsFi
   // file-system options
 
   @Override
-  Optional<String> accountNameRef();
+  Optional<String> accountName();
 
   @Override
-  Optional<String> accountKeyRef();
+  Optional<String> accountKey();
 
   @Override
-  Optional<String> sasTokenRef();
+  Optional<String> sasToken();
 
   @Override
   Optional<String> endpoint();

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogAdlsFileSystemOptions.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogAdlsFileSystemOptions.java
@@ -21,13 +21,13 @@ import org.projectnessie.catalog.files.adls.AdlsFileSystemOptions;
 
 public interface CatalogAdlsFileSystemOptions extends AdlsFileSystemOptions {
   @Override
-  Optional<String> accountNameRef();
+  Optional<String> accountName();
 
   @Override
-  Optional<String> accountKeyRef();
+  Optional<String> accountKey();
 
   @Override
-  Optional<String> sasTokenRef();
+  Optional<String> sasToken();
 
   @Override
   Optional<String> endpoint();

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogGcsBucketConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogGcsBucketConfig.java
@@ -53,10 +53,10 @@ public interface CatalogGcsBucketConfig extends GcsBucketOptions {
   Optional<GcsAuthType> authType();
 
   @Override
-  Optional<String> authCredentialsJsonRef();
+  Optional<String> authCredentialsJson();
 
   @Override
-  Optional<String> oauth2TokenRef();
+  Optional<String> oauth2Token();
 
   @Override
   Optional<Instant> oauth2TokenExpiresAt();
@@ -98,8 +98,8 @@ public interface CatalogGcsBucketConfig extends GcsBucketOptions {
   OptionalInt deleteBatchSize();
 
   @Override
-  Optional<String> encryptionKeyRef();
+  Optional<String> encryptionKey();
 
   @Override
-  Optional<String> decryptionKeyRef();
+  Optional<String> decryptionKey();
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogGcsConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogGcsConfig.java
@@ -62,10 +62,10 @@ public interface CatalogGcsConfig extends GcsConfig, GcsOptions<CatalogGcsBucket
   Optional<GcsAuthType> authType();
 
   @Override
-  Optional<String> authCredentialsJsonRef();
+  Optional<String> authCredentialsJson();
 
   @Override
-  Optional<String> oauth2TokenRef();
+  Optional<String> oauth2Token();
 
   @Override
   Optional<Instant> oauth2TokenExpiresAt();
@@ -107,10 +107,10 @@ public interface CatalogGcsConfig extends GcsConfig, GcsOptions<CatalogGcsBucket
   OptionalInt deleteBatchSize();
 
   @Override
-  Optional<String> encryptionKeyRef();
+  Optional<String> encryptionKey();
 
   @Override
-  Optional<String> decryptionKeyRef();
+  Optional<String> decryptionKey();
 
   @Override
   Optional<String> userProject();

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3BucketConfig.java
@@ -44,10 +44,10 @@ public interface CatalogS3BucketConfig extends S3BucketOptions {
   Optional<String> projectId();
 
   @Override
-  Optional<String> accessKeyIdRef();
+  Optional<String> accessKeyId();
 
   @Override
-  Optional<String> secretAccessKeyRef();
+  Optional<String> secretAccessKey();
 
   @Override
   Optional<String> accessPoint();

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3Config.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/CatalogS3Config.java
@@ -92,10 +92,10 @@ public interface CatalogS3Config extends S3Config, S3Options<CatalogS3BucketConf
   Optional<String> projectId();
 
   @Override
-  Optional<String> accessKeyIdRef();
+  Optional<String> accessKeyId();
 
   @Override
-  Optional<String> secretAccessKeyRef();
+  Optional<String> secretAccessKey();
 
   @Override
   Optional<String> accessPoint();

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusCatalogConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusCatalogConfig.java
@@ -20,7 +20,6 @@ import io.smallrye.config.WithName;
 import java.util.Map;
 import java.util.Optional;
 import org.projectnessie.catalog.service.config.CatalogConfig;
-import org.projectnessie.nessie.docgen.annotations.ConfigDocs.ConfigPropertyName;
 
 @ConfigMapping(prefix = "nessie.catalog")
 public interface QuarkusCatalogConfig extends CatalogConfig {
@@ -39,12 +38,4 @@ public interface QuarkusCatalogConfig extends CatalogConfig {
   @Override
   @WithName("iceberg-config-overrides")
   Map<String, String> icebergConfigOverrides();
-
-  /**
-   * Secrets must be provided in the configuration as key-value pairs of the form: {@code
-   * nessie.catalog.secrets.<secret-ref>=<value>}, where _`secret-ref`_ is the name used where it is
-   * referenced, for example via `nessie.catalog.service.s3.access-key-id-ref`.
-   */
-  @ConfigPropertyName("secret-ref")
-  Map<String, String> secrets();
 }

--- a/servers/quarkus-server/src/main/java/org/projectnessie/server/catalog/CatalogProducers.java
+++ b/servers/quarkus-server/src/main/java/org/projectnessie/server/catalog/CatalogProducers.java
@@ -30,6 +30,8 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import java.time.Clock;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -132,9 +134,8 @@ public class CatalogProducers {
   public S3SessionsManager s3SessionsManager(
       S3Options<?> s3options,
       @CatalogS3Client SdkHttpClient sdkClient,
-      MeterRegistry meterRegistry,
-      SecretsProvider secretsProvider) {
-    return new S3SessionsManager(s3options, sdkClient, meterRegistry, secretsProvider);
+      MeterRegistry meterRegistry) {
+    return new S3SessionsManager(s3options, sdkClient, meterRegistry);
   }
 
   @Produces
@@ -155,17 +156,8 @@ public class CatalogProducers {
   public SecretsProvider secretsProvider(QuarkusCatalogConfig config) {
     return new SecretsProvider() {
       @Override
-      public String getSecret(String secret) {
-        String value = config.secrets().get(secret);
-        if (value != null) {
-          return value;
-        }
-        throw new IllegalArgumentException(
-            "Secret '"
-                + secret
-                + "' is not defined, configure it using the configuration option 'nessie.catalog.secrets."
-                + secret
-                + "'.");
+      public Map<String, String> resolveSecrets(Set<String> names) {
+        return Map.of();
       }
     };
   }

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -42,13 +42,13 @@ nessie.server.send-stacktrace-to-client=false
 #nessie.catalog.service.s3.path-style-access=false
 #nessie.catalog.service.s3.region=us-west-2
 #nessie.catalog.service.s3.cloud=PRIVATE
-#nessie.catalog.service.s3.access-key-id-ref=awsAccessKeyId
-#nessie.catalog.service.s3.secret-access-key-ref=awsSecretAccessKey
+#nessie.catalog.service.s3.access-key-id=awsAccessKeyId
+#nessie.catalog.service.s3.secret-access-key=awsSecretAccessKey
 # per-bucket S3 settings
 #nessie.catalog.service.s3.buckets.bucket1.endpoint=s3a://bucket1
 #nessie.catalog.service.s3.buckets.bucket1.cloud=AMAZON
-#nessie.catalog.service.s3.buckets.bucket1.access-key-id-ref=awsAccessKeyId1
-#nessie.catalog.service.s3.buckets.bucket1.secret-access-key-ref=awsSecretAccessKey1
+#nessie.catalog.service.s3.buckets.bucket1.access-key-id=awsAccessKeyId1
+#nessie.catalog.service.s3.buckets.bucket1.secret-access-key=awsSecretAccessKey1
 #nessie.catalog.service.s3.buckets.bucket1.region=us-east-1
 
 # GCS settings
@@ -56,29 +56,22 @@ nessie.server.send-stacktrace-to-client=false
 #nessie.catalog.service.gcs.host=http://localhost:4443
 #nessie.catalog.service.gcs.project-id=nessie
 #nessie.catalog.service.gcs.auth-type=access_token
-#nessie.catalog.service.gcs.oauth2-token-ref=tokenRef
+#nessie.catalog.service.gcs.oauth2-token=tokenRef
 # per-bucket GCS settings
 #nessie.catalog.service.gcs.buckets.bucket1.host=http://localhost:4443
 #nessie.catalog.service.gcs.buckets.bucket1.project-id=nessie
 #nessie.catalog.service.gcs.buckets.bucket1.auth-type=access_token
-#nessie.catalog.service.gcs.buckets.bucket1.oauth2-token-ref=tokenRef
+#nessie.catalog.service.gcs.buckets.bucket1.oauth2-token=tokenRef
 
 # ADLS settings
 
 #nessie.catalog.service.adls.endpoint=http://localhost/adlsgen2/bucket
-#nessie.catalog.service.adls.account-key-ref=accountKeyRef
+#nessie.catalog.service.adls.account-key=accountKeyRef
 #nessie.catalog.service.adls.configuration.propname=propvalue
 # per-file-system ADLS settings
 #nessie.catalog.service.adls.file-systems.bucket1.endpoint=http://localhost/adlsgen2/bucket
-#nessie.catalog.service.adls.file-systems.bucket1.account-key-ref=accountKeyRef
+#nessie.catalog.service.adls.file-systems.bucket1.account-key=accountKeyRef
 #nessie.catalog.service.adls.file-systems.bucket1.configuration.propname=propvalue
-
-# Secrets
-
-#nessie.catalog.secrets.awsAccessKeyId=<access-key>
-#nessie.catalog.secrets.awsSecretAccessKey=<secret-key>
-#nessie.catalog.secrets.awsAccessKeyId1=<access-key1>
-#nessie.catalog.secrets.awsSecretAccessKey1=<secret-key1>
 
 
 

--- a/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/s3/TestVendedS3CredentialsExpiry.java
+++ b/servers/quarkus-server/src/test/java/org/projectnessie/server/catalog/s3/TestVendedS3CredentialsExpiry.java
@@ -117,10 +117,8 @@ public class TestVendedS3CredentialsExpiry {
           .put("nessie.catalog.service.s3.role-session-name", "test-session-name")
           .put("nessie.catalog.service.s3.assumed-role", "test-role")
           .put("nessie.catalog.service.s3.external-id", "test-external-id")
-          .put("nessie.catalog.service.s3.access-key-id-ref", "awsAccessKeyId")
-          .put("nessie.catalog.service.s3.secret-access-key-ref", "awsSecretAccessKey")
-          .put("nessie.catalog.secrets.awsAccessKeyId", "test-access-key")
-          .put("nessie.catalog.secrets.awsSecretAccessKey", "test-secret-key")
+          .put("nessie.catalog.service.s3.access-key-id", "test-access-key")
+          .put("nessie.catalog.service.s3.secret-access-key", "test-secret-key")
           .build();
     }
   }

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/GcsEmulatorTestResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/GcsEmulatorTestResourceLifecycleManager.java
@@ -46,8 +46,7 @@ public class GcsEmulatorTestResourceLifecycleManager
         .put("nessie.catalog.service.gcs.host", gcs.baseUri())
         .put("nessie.catalog.service.gcs.project-id", gcs.projectId())
         .put("nessie.catalog.service.gcs.auth-type", "ACCESS_TOKEN")
-        .put("nessie.catalog.service.gcs.oauth2-token-ref", "gcsTokenRef")
-        .put("nessie.catalog.secrets.gcsTokenRef", gcs.oauth2token())
+        .put("nessie.catalog.service.gcs.oauth2-token", gcs.oauth2token())
         .put("nessie.catalog.default-warehouse", "warehouse")
         .put("nessie.catalog.warehouses.warehouse.location", warehouseLocation.toString())
         .build();

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/MinioTestResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/MinioTestResourceLifecycleManager.java
@@ -35,10 +35,8 @@ public class MinioTestResourceLifecycleManager implements QuarkusTestResourceLif
         .put("nessie.catalog.service.s3.path-style-access", "true")
         .put("nessie.catalog.service.s3.sts.endpoint", minio.s3endpoint())
         .put("nessie.catalog.service.s3.region", TEST_REGION)
-        .put("nessie.catalog.service.s3.access-key-id-ref", "awsAccessKeyId")
-        .put("nessie.catalog.service.s3.secret-access-key-ref", "awsSecretAccessKey")
-        .put("nessie.catalog.secrets.awsAccessKeyId", minio.accessKey())
-        .put("nessie.catalog.secrets.awsSecretAccessKey", minio.secretKey())
+        .put("nessie.catalog.service.s3.access-key-id", minio.accessKey())
+        .put("nessie.catalog.service.s3.secret-access-key", minio.secretKey())
         .put("nessie.catalog.default-warehouse", "warehouse")
         .put("nessie.catalog.warehouses.warehouse.location", minio.s3BucketUri("").toString())
         .build();

--- a/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/ObjectStorageMockTestResourceLifecycleManager.java
+++ b/servers/quarkus-server/src/testFixtures/java/org/projectnessie/server/catalog/ObjectStorageMockTestResourceLifecycleManager.java
@@ -76,20 +76,15 @@ public class ObjectStorageMockTestResourceLifecycleManager
         .put("nessie.catalog.service.s3.buckets." + BUCKET + ".endpoint", s3Endpoint)
         .put("nessie.catalog.service.s3.buckets." + BUCKET + ".region", "us-east-1")
         .put("nessie.catalog.service.s3.buckets." + BUCKET + ".path-style-access", "true")
-        .put("nessie.catalog.service.s3.buckets." + BUCKET + ".access-key-id-ref", "awsAccessKeyId")
-        .put(
-            "nessie.catalog.service.s3.buckets." + BUCKET + ".secret-access-key-ref",
-            "awsSecretAccessKey")
-        .put("nessie.catalog.secrets.awsAccessKeyId", "accessKey")
-        .put("nessie.catalog.secrets.awsSecretAccessKey", "secretKey")
+        .put("nessie.catalog.service.s3.buckets." + BUCKET + ".access-key-id", "accessKey")
+        .put("nessie.catalog.service.s3.buckets." + BUCKET + ".secret-access-key", "accessKey")
         // GCS
         .put("nessie.catalog.service.gcs.buckets." + BUCKET + ".host", gcsEndpoint)
         .put("nessie.catalog.service.gcs.buckets." + BUCKET + ".project-id", "my-project")
         .put("nessie.catalog.service.gcs.buckets." + BUCKET + ".auth-type", "none")
         // ADLS
         .put("nessie.catalog.service.adls.file-systems." + BUCKET + ".endpoint", adlsEndpoint)
-        .put("nessie.catalog.service.adls.file-systems." + BUCKET + ".sas-token-ref", "sasToken")
-        .put("nessie.catalog.secrets.sasToken", "token")
+        .put("nessie.catalog.service.adls.file-systems." + BUCKET + ".sas-token", "token")
         .build();
   }
 


### PR DESCRIPTION
The handling of secrets is a bit awkward at the moment. We declare "IDs" on the objects, which are to be looked up via the `SecretsProvider`, which is currently just a `Map<String, String>`.

This change changes the behavior: The (default) behavior to lookup via another map is gone.

Secrets are now generally looked up in the following order:
1. If the value is defined on the "per bucket" config, it is used as is.
2. If a secret for the bucket can be resolved, it is used.
3. If the value is defined on the "default" config, it is used as is.
4. If a secret for the "default" config can be resolved, it is used.
5. The secret is assumed to not exist.

The above logic is implemented in the new `SecretsHelper` class. It calls the `SecretProvider` using a collection of keys to look up, which shall return a map with the existing, resolved secrets.

Follow-up, after #7043 is merged to `main`: refactor secrets handlings in "Nessie Core", where/if necessary.