### PR TITLE
GC: fix incorrect paths when listing prefixes with ADLS

### DIFF
--- a/gc/gc-base/src/main/java/org/projectnessie/gc/files/FileReference.java
+++ b/gc/gc-base/src/main/java/org/projectnessie/gc/files/FileReference.java
@@ -15,6 +15,8 @@
  */
 package org.projectnessie.gc.files;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.immutables.value.Value;
 import org.projectnessie.storage.uri.StorageUri;
 
@@ -35,9 +37,18 @@ public interface FileReference {
   @Value.Auxiliary
   long modificationTimeMillisEpoch();
 
-  @Value.NonAttribute
+  /**
+   * Absolute path to the file/directory. Virtually equivalent to {@code base().resolve(path())}.
+   */
+  @Value.Lazy
   default StorageUri absolutePath() {
     return base().resolve(path());
+  }
+
+  @Value.Check
+  default void check() {
+    checkArgument(base().isAbsolute(), "Base location must be absolute: %s", base());
+    checkArgument(!path().isAbsolute(), "Path must be relative: %s", path());
   }
 
   static ImmutableFileReference.Builder builder() {

--- a/gc/gc-iceberg-files/src/main/java/org/projectnessie/gc/iceberg/files/IcebergFiles.java
+++ b/gc/gc-iceberg-files/src/main/java/org/projectnessie/gc/iceberg/files/IcebergFiles.java
@@ -140,9 +140,14 @@ public abstract class IcebergFiles implements FilesLister, FileDeleter, AutoClos
       }
       return StreamSupport.stream(fileInfos.spliterator(), false)
           .map(
-              f ->
-                  FileReference.of(
-                      basePath.relativize(f.location()), basePath, f.createdAtMillis()));
+              f -> {
+                StorageUri location = StorageUri.of(f.location());
+                if (!location.isAbsolute()) {
+                  location = basePath.resolve("/").resolve(location);
+                }
+                return FileReference.of(
+                    basePath.relativize(location), basePath, f.createdAtMillis());
+              });
     }
 
     return listHadoop(basePath);

--- a/gc/gc-iceberg-inttest/build.gradle.kts
+++ b/gc/gc-iceberg-inttest/build.gradle.kts
@@ -22,12 +22,17 @@ plugins {
 
 extra["maven.name"] = "Nessie - GC - Integration tests"
 
-val sparkScala = useSparkScalaVersionsForProject("3.4", "2.12")
+val sparkScala = useSparkScalaVersionsForProject("3.5", "2.12")
 
 dependencies {
   implementation(libs.hadoop.client)
 
   implementation(platform(libs.iceberg.bom))
+
+  // Enforce a single version of Netty among dependencies
+  // (Spark, Hadoop and Azure)
+  implementation(platform("io.netty:netty-bom:4.1.110.Final"))
+
   implementation("org.apache.iceberg:iceberg-core")
   implementation("org.apache.iceberg:iceberg-aws")
   implementation("org.apache.iceberg:iceberg-gcp")
@@ -53,7 +58,9 @@ dependencies {
 
   intTestImplementation(
     nessieProject("nessie-spark-extensions-basetests_${sparkScala.scalaMajorVersion}")
-  )
+  ) {
+    exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
+  }
   intTestImplementation(
     nessieProject(
       "nessie-spark-extensions-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}"
@@ -65,12 +72,15 @@ dependencies {
 
   intTestImplementation("org.apache.spark:spark-sql_${sparkScala.scalaMajorVersion}") {
     forSpark(sparkScala.sparkVersion)
+    exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
   }
   intTestImplementation("org.apache.spark:spark-core_${sparkScala.scalaMajorVersion}") {
     forSpark(sparkScala.sparkVersion)
+    exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
   }
   intTestRuntimeOnly("org.apache.spark:spark-hive_${sparkScala.scalaMajorVersion}") {
     forSpark(sparkScala.sparkVersion)
+    exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
   }
 
   intTestRuntimeOnly(platform(libs.iceberg.bom))

--- a/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieAzure.java
+++ b/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieAzure.java
@@ -26,13 +26,20 @@ import org.projectnessie.testing.azurite.Azurite;
 import org.projectnessie.testing.azurite.AzuriteAccess;
 import org.projectnessie.testing.azurite.AzuriteExtension;
 
-@Disabled("Needs an Iceberg release with https://github.com/apache/iceberg/pull/10045")
+@Disabled(
+    "1) Needs an Iceberg release with https://github.com/apache/iceberg/pull/10045 "
+        + "2) Azurite is incompatible with ADLS v2 list-prefix REST endpoint")
 @ExtendWith(AzuriteExtension.class)
 public class ITSparkIcebergNessieAzure extends AbstractITSparkIcebergNessieObjectStorage {
 
   public static final String BUCKET_URI = "/my/prefix";
 
   private static @Azurite AzuriteAccess azuriteAccess;
+
+  @Override
+  Storage storage() {
+    return Storage.ADLS;
+  }
 
   @Override
   protected String warehouseURI() {

--- a/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieAzureMock.java
+++ b/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieAzureMock.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.gc.iceberg.inttest;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.URI;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.projectnessie.gc.iceberg.files.IcebergFiles;
+import org.projectnessie.objectstoragemock.HeapStorageBucket;
+import org.projectnessie.objectstoragemock.ObjectStorageMock;
+import org.projectnessie.objectstoragemock.ObjectStorageMock.MockServer;
+import org.projectnessie.storage.uri.StorageUri;
+
+@Disabled("Needs an Iceberg release with https://github.com/apache/iceberg/pull/10045")
+public class ITSparkIcebergNessieAzureMock extends AbstractITSparkIcebergNessieObjectStorage {
+
+  private static final String FILESYSTEM = "filesystem1";
+  private static final String ACCOUNT = "account123";
+  private static final String ACCOUNT_FQ = ACCOUNT + ".dfs.core.windows.net";
+  private static final String SECRET = "s3cr3t";
+  private static final String SECRET_BASE_64 =
+      new String(Base64.getEncoder().encode(SECRET.getBytes(UTF_8)));
+  private static final String ADLS_WAREHOUSE_LOCATION =
+      "abfs://" + FILESYSTEM + "@" + ACCOUNT_FQ + "/warehouse";
+
+  private static MockServer server;
+  private static URI endpoint;
+
+  @Override
+  Storage storage() {
+    return Storage.ADLS;
+  }
+
+  @BeforeAll
+  static void beforeAll() {
+    HeapStorageBucket bucket = HeapStorageBucket.newHeapStorageBucket();
+    server = ObjectStorageMock.builder().putBuckets(FILESYSTEM, bucket.bucket()).build().start();
+    endpoint = server.getAdlsGen2BaseUri().resolve(FILESYSTEM);
+  }
+
+  @AfterAll
+  static void afterAll() throws Exception {
+    if (server != null) {
+      server.close();
+    }
+  }
+
+  @Override
+  protected StorageUri bucketUri() {
+    return StorageUri.of(ADLS_WAREHOUSE_LOCATION);
+  }
+
+  @Override
+  protected String warehouseURI() {
+    return bucketUri().location();
+  }
+
+  @Override
+  protected Map<String, String> sparkHadoop() {
+    Map<String, String> r = new HashMap<>();
+    r.put("fs.azure.impl", "org.apache.hadoop.fs.azure.AzureNativeFileSystemStore");
+    r.put("fs.AbstractFileSystem.azure.impl", "org.apache.hadoop.fs.azurebfs.Abfs");
+    r.put("fs.azure.always.use.https", "false");
+    r.put("fs.azure.abfs.endpoint", endpoint.getHost() + ":" + endpoint.getPort());
+    r.put("fs.azure.test.emulator", "true");
+    r.put("fs.azure.storage.emulator.account.name", ACCOUNT);
+    r.put("fs.azure.account.auth.type", "SharedKey");
+    r.put("fs.azure.account.key." + ACCOUNT_FQ, SECRET_BASE_64);
+    return r;
+  }
+
+  @Override
+  protected Map<String, String> nessieParams() {
+    Map<String, String> r = new HashMap<>(super.nessieParams());
+    r.put("io-impl", "org.apache.iceberg.azure.adlsv2.ADLSFileIO");
+    r.put("adls.connection-string." + ACCOUNT_FQ, endpoint.toString());
+    r.put("adls.auth.shared-key.account.name", ACCOUNT);
+    r.put("adls.auth.shared-key.account.key", SECRET_BASE_64);
+    return r;
+  }
+
+  @Override
+  IcebergFiles icebergFiles() {
+    Configuration conf = new Configuration();
+    sparkHadoop().forEach(conf::set);
+    return IcebergFiles.builder().properties(nessieParams()).hadoopConfiguration(conf).build();
+  }
+}

--- a/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieGCP.java
+++ b/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieGCP.java
@@ -33,6 +33,11 @@ public class ITSparkIcebergNessieGCP extends AbstractITSparkIcebergNessieObjectS
   private static @Gcs GcsAccess gcsAccess;
 
   @Override
+  Storage storage() {
+    return Storage.GCS;
+  }
+
+  @Override
   protected String warehouseURI() {
     return gcsAccess.bucketUri(BUCKET_URI).toString();
   }

--- a/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieS3.java
+++ b/gc/gc-iceberg-inttest/src/intTest/java/org/projectnessie/gc/iceberg/inttest/ITSparkIcebergNessieS3.java
@@ -42,6 +42,11 @@ public class ITSparkIcebergNessieS3 extends AbstractITSparkIcebergNessieObjectSt
   @Minio static MinioAccess minio;
 
   @Override
+  Storage storage() {
+    return Storage.S3;
+  }
+
+  @Override
   protected String warehouseURI() {
     return minio.s3BucketUri(S3_BUCKET_URI).toString();
   }

--- a/gc/gc-iceberg-inttest/src/intTest/resources/logback-test.xml
+++ b/gc/gc-iceberg-inttest/src/intTest/resources/logback-test.xml
@@ -23,8 +23,7 @@
       <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root>
-    <level value="${test.log.level:-INFO}"/>
+  <root level="${test.log.level:-INFO}">
     <appender-ref ref="console"/>
   </root>
 </configuration>

--- a/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/IcebergContentToFiles.java
+++ b/gc/gc-iceberg/src/main/java/org/projectnessie/gc/iceberg/IcebergContentToFiles.java
@@ -53,7 +53,10 @@ public abstract class IcebergContentToFiles implements ContentToFiles {
   public static final String S3_KEY_NOT_FOUND =
       "software.amazon.awssdk.services.s3.model.NoSuchKeyException";
   public static final String GCS_STORAGE_EXCEPTION = "com.google.cloud.storage.StorageException";
+  public static final String ADLS_STORAGE_EXCEPTION =
+      "com.azure.storage.blob.models.BlobStorageException";
   public static final String GCS_NOT_FOUND_START = "404 Not Found";
+  public static final String ADLS_NOT_FOUND_CODE = "PathNotFound";
 
   public static Builder builder() {
     return ImmutableIcebergContentToFiles.builder();
@@ -89,9 +92,14 @@ public abstract class IcebergContentToFiles implements ContentToFiles {
           || S3_KEY_NOT_FOUND.equals(notFoundCandidate.getClass().getName())) {
         notFound = true;
       } else {
-        for (Throwable c = notFoundCandidate.getCause(); c != null; c = c.getCause()) {
+        for (Throwable c = notFoundCandidate; c != null; c = c.getCause()) {
           if (GCS_STORAGE_EXCEPTION.equals(c.getClass().getName())
               && c.getMessage().startsWith(GCS_NOT_FOUND_START)) {
+            notFound = true;
+            break;
+          }
+          if (ADLS_STORAGE_EXCEPTION.equals(c.getClass().getName())
+              && c.getMessage().contains(ADLS_NOT_FOUND_CODE)) {
             notFound = true;
             break;
           }

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/AdlsGen2Resource.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/AdlsGen2Resource.java
@@ -295,6 +295,7 @@ public class AdlsGen2Resource {
                           RFC_1123_DATE_TIME.format(
                               ZonedDateTime.ofInstant(
                                   Instant.ofEpochMilli(obj.lastModified()), ZoneId.of("UTC"))))
+                      .creationTime(1000L) // cannot be zero
                       .directory(false)
                       .build());
               keyCount++;

--- a/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/adlsgen2/Path.java
+++ b/testing/object-storage-mock/src/main/java/org/projectnessie/objectstoragemock/adlsgen2/Path.java
@@ -39,6 +39,12 @@ public interface Path {
 
   String lastModified();
 
+  /**
+   * Not mentioned in the specs, but required by the ADLS client. See {@code
+   * com.azure.storage.file.datalake.models.PathItem}.
+   */
+  long creationTime();
+
   String name();
 
   @Nullable


### PR DESCRIPTION
Fixes #8659.

The core of the issue is that ADLS returns relative paths in response to a prefix-list operation, while S3 and GCS return absolute paths.

Fixing that issue uncovered a second issue: the `BlobStorageException` with error code `PathNotFound` wasn't being flagged as a not-found error.

A third issue was that we had multiple SLF4J bindings on the classpath, so no log messages were printed during tests. I fixed that too.

It was extremely hard to diagnose the issue given how difficult it is to test with ADLS:

1. `ITSparkIcebergNessieAzure` had issues with incompatible Netty versions on the classpath; I fixed these, but it seems Azurite is not compatible with ADLS v2 list-prefix REST endpoint, so it's basically unusable.
2. I introduced `ITSparkIcebergNessieAzureMock` that uses @snazy excellent mock server, and that worked once I got past two more issues:
  a. the serializability issue in `AzureProperties` (PR by @snazy still not merged).
  b. an issue with the list-prefix REST endpoint response – there was un undocumented required field (!!).

Basically if you want to test:

1. Checkout @snazy branch https://github.com/apache/iceberg/pull/10045;
2. Publish your branch to Maven local: `./gradlew clean publishToMavenLocal -DsparkVersions=3.3,3.4,3.5`;
3. Change the iceberg version in `gradle/libs.versions.toml`;
4. Remove the `@Disabled` annotation on `ITSparkIcebergNessieAzureMock`;

Then run:

```bash
./gradlew :nessie-gc-iceberg-inttest:intTest -DwithMavenLocal=true --tests org.projectnessie.gc.iceberg.inttest.ITSparkIcebergNessieAzureMock
```

One last issue that I decided not to fix is an issue with special chars (test case 3): I think that `ADLSFileIO` is inherently broken since it passes blob names unencoded to the ADLS client, but the client attempts to URL-decode the name, see `com.azure.storage.blob.specialized.BlobAsyncClientBase`. This blows up with:

```
URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: "^&"
java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: "^&"
	at java.base/java.net.URLDecoder.decode(URLDecoder.java:237)
	at java.base/java.net.URLDecoder.decode(URLDecoder.java:147)
	at com.azure.storage.common.Utility.decode(Utility.java:88)
	at com.azure.storage.common.Utility.urlDecode(Utility.java:55)
	at com.azure.storage.blob.specialized.BlobAsyncClientBase.<init>(BlobAsyncClientBase.java:242)
```