### PR TITLE
[Catalog] S3CredentialsResolver: remove one second from session end

### DIFF
--- a/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3CredentialsResolver.java
+++ b/catalog/files/impl/src/main/java/org/projectnessie/catalog/files/s3/S3CredentialsResolver.java
@@ -43,7 +43,9 @@ public class S3CredentialsResolver {
       Instant now = clock.instant();
       // Note: expiry instance accuracy in STS is seconds.
       Duration requiredDuration = bucketOptions.minSessionCredentialValidityPeriod();
-      Instant sessionEnd = now.plus(requiredDuration).truncatedTo(ChronoUnit.SECONDS);
+      // Remove one second from the session end to account for the truncation to seconds.
+      Instant sessionEnd =
+          now.plus(requiredDuration).truncatedTo(ChronoUnit.SECONDS).minus(1, ChronoUnit.SECONDS);
       checkArgument(
           !sessionEnd.isAfter(expirationInstant.get()),
           "Provided credentials expire (%s) before the expected session end (now: %s, duration: %s)",


### PR DESCRIPTION
Prevents test errors such as:

```
java.lang.IllegalArgumentException: Provided credentials expire (2024-06-03T12:22:38Z) before the expected session end (now: 2024-06-03T11:22:39.011452457Z, duration: PT1H)
```