### PR TITLE
Allow secrets in a Keystore

### DIFF
--- a/servers/quarkus-common/build.gradle.kts
+++ b/servers/quarkus-common/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
   implementation("io.quarkus:quarkus-jdbc-mariadb")
   implementation("io.quarkus:quarkus-opentelemetry")
   implementation("io.quarkus:quarkus-micrometer")
+  implementation("io.smallrye.config:smallrye-config-source-keystore")
   implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
   implementation("io.quarkiverse.amazonservices:quarkus-amazon-dynamodb")
   implementation("software.amazon.awssdk:sts")

--- a/servers/quarkus-server/src/main/resources/application.properties
+++ b/servers/quarkus-server/src/main/resources/application.properties
@@ -19,6 +19,15 @@
 nessie.server.default-branch=main
 nessie.server.send-stacktrace-to-client=false
 
+# To provide secrets via a keystore via Quarkus, the following configuration
+# options need to be configured accordingly.
+# For details see https://quarkus.io/guides/config-secrets#store-secrets-in-a-keystore
+#smallrye.config.source.keystore."properties".path=properties
+#smallrye.config.source.keystore."properties".password=arealpassword
+#smallrye.config.source.keystore."properties".handler=aes-gcm-nopadding
+#smallrye.config.source.keystore."key".path=key
+#smallrye.config.source.keystore."key".password=anotherpassword
+
 ##### Nessie Catalog
 
 # Iceberg default config (can be overridden per warehouse)

--- a/site/in-dev/configuration.md
+++ b/site/in-dev/configuration.md
@@ -38,6 +38,11 @@ See [here](https://smallrye.io/smallrye-config/Main/config/environment-variables
 
 For more information on docker images, see [Docker image options](#docker-image-options) below.
 
+## Providing secrets
+
+Instead of providing secrets like passwords in clear text, you can also use a keystore. This
+functionality is provided [natively via Quarkus](https://quarkus.io/guides/config-secrets#store-secrets-in-a-keystore).
+
 ## Core Nessie Configuration Settings
 
 ### Core Settings


### PR DESCRIPTION
This change is enough to allow users to provide secrets via keystores.

See also https://quarkus.io/guides/config-secrets#store-secrets-in-a-keystore