### PR TITLE
Prevent Quarkus warning about unindexed dependency

### DIFF
--- a/tools/server-admin/build.gradle.kts
+++ b/tools/server-admin/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
   implementation(project(":nessie-versioned-storage-rocksdb"))
 
   implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation("io.quarkus:quarkus-core-deployment")
   implementation(enforcedPlatform(libs.quarkus.amazon.services.bom))
   implementation("io.quarkus:quarkus-picocli")
 


### PR DESCRIPTION
Works around
```
Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index:
        - org.projectnessie.nessie.relocated.protobuf.ByteString (sources: JacksonProcessor > org.projectnessie.model.Content, JacksonProcessor > org.projectnessie.versioned.storage.common.objtypes.ImmutableJsonObj$Json)
Consider adding them to the index either by creating a Jandex index for your dependency via the Maven plugin, an empty META-INF/beans.xml or quarkus.index-dependency properties.
```