### PR TITLE
Avoid invalid test names due to non-printable characters

### DIFF
--- a/api/model/src/test/java/org/projectnessie/model/TestNamespace.java
+++ b/api/model/src/test/java/org/projectnessie/model/TestNamespace.java
@@ -153,7 +153,7 @@ public class TestNamespace {
     assertThat(namespace.getProperties()).isEqualTo(properties);
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{displayName}[{index}]")
   @MethodSource("elementsProvider")
   void testNamespaceFromElements(String[] elements, String expectedNamespace) {
     Namespace namespace = Namespace.of(elements);
@@ -195,7 +195,7 @@ public class TestNamespace {
         .hasMessage(String.format(Namespace.ERROR_MSG_TEMPLATE, identifier));
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{displayName}[{index}]")
   @ValueSource(
       strings = {"\u0000", "a.\u0000", "a.b.c.\u0000", "\u001D", "a.\u001D", "a.b.c.\u001D"})
   void testZeroByteUsage(String identifier) {

--- a/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRest.java
+++ b/servers/jax-rs-tests/src/main/java/org/projectnessie/jaxrs/tests/BaseTestNessieRest.java
@@ -552,7 +552,7 @@ public abstract class BaseTestNessieRest extends BaseTestNessieApi {
   }
 
   @NessieApiVersions(versions = {NessieApiVersion.V2})
-  @ParameterizedTest
+  @ParameterizedTest(name = "{displayName}[{index}]")
   @CsvSource({
     "simple1,testKey",
     "simple2,test.Key",

--- a/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestNamespace.java
+++ b/servers/services/src/testFixtures/java/org/projectnessie/services/impl/AbstractTestNamespace.java
@@ -56,7 +56,7 @@ import org.projectnessie.services.impl.AbstractTestContents.ContentAndOperationT
 
 public abstract class AbstractTestNamespace extends BaseTestServiceImpl {
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{displayName}[{index}]")
   @ValueSource(strings = {"a.b.c", "a.b\u001Dc.d", "a.b.c.d", "a.b\u0000c.d"})
   public void testNamespaces(String namespaceName) throws BaseNessieClientServerException {
     Namespace ns = Namespace.parse(namespaceName);


### PR DESCRIPTION
Avoids errors such as below:

```
TestExecutionListener [org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener] threw exception for method: executionStarted(TestIdentifier [uniqueId = [engine:nessie-multi-env]/[nessie-api:V2]/[class:org.projectnessie.server.TestQuarkusRestInMemoryPersist]/[test-template:testGetSingleContent(java.lang.String, java.lang.String)]/[test-template-invocation:#8], parentId = [engine:nessie-multi-env]/[nessie-api:V2]/[class:org.projectnessie.server.TestQuarkusRestInMemoryPersist]/[test-template:testGetSingleContent(java.lang.String, java.lang.String)], displayName = '[8] branchName=with/slash4, encodedKey=test.nested.Key', legacyReportingName = 'testGetSingleContent(String, String)[8]', source = MethodSource [className = 'org.projectnessie.server.TestQuarkusRestInMemoryPersist', methodName = 'testGetSingleContent', methodParameterTypes = 'java.lang.String, java.lang.String'], tags = [nessie-multi-env, io.quarkus.test.junit.QuarkusTest], type = TEST])
java.lang.RuntimeException: Failed to write event: Element{domElement=[e:started: null]}
...
Caused by: javax.xml.transform.TransformerException: org.xml.sax.SAXException: com.ctc.wstx.exc.WstxIOException: Invalid white space character (0x1d) in text to output (in xml 1.1, could output as a character entity)
com.ctc.wstx.exc.WstxIOException: Invalid white space character (0x1d) in text to output (in xml 1.1, could output as a character entity)
        at java.xml/com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl.transform(TransformerImpl.java:792)
        at java.xml/com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl.transform(TransformerImpl.java:395)
        at org.junit.platform.reporting.shadow.org.opentest4j.reporting.events.api.DefaultDocumentWriter.append(DefaultDocumentWriter.java:115)
        ... 130 more
...
Caused by: org.xml.sax.SAXException: com.ctc.wstx.exc.WstxIOException: Invalid white space character (0x1d) in text to output (in xml 1.1, could output as a character entity)
com.ctc.wstx.exc.WstxIOException: Invalid white space character (0x1d) in text to output (in xml 1.1, could output as a character entity)
        at java.xml/com.sun.org.apache.xalan.internal.xsltc.trax.SAX2StAXStreamWriter.startElement(SAX2StAXStreamWriter.java:126)
```