### PR TITLE
JDBC: remove options 'catalog' and 'schema' and revisit schema creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ as necessary. Empty sections will not end in the release notes.
 - Support for Java 8 is officially deprecated and users are encouraged to upgrade all clients to
   at least Java 11, better Java 17 or 21, if possible. Current Spark versions 3.3, 3.4 and 3.5 
   work with Java 11 and 17. Support for Java 8 will eventually be removed.
+- For JDBC version stores, the following settings, which never worked as expected, are now 
+  deprecated and will be removed in a future release. The catalog and the schema must always be
+  specified explicitly in the JDBC URL.
+  - `nessie.version.store.persist.jdbc.catalog`
+  - `nessie.version.store.persist.jdbc.schema`
 
 ### Fixes
 

--- a/helm/nessie/templates/configmap.yaml
+++ b/helm/nessie/templates/configmap.yaml
@@ -65,12 +65,6 @@ data:
     {{- $jdbcUrl := coalesce $oldConfig.jdbcUrl $newConfig.jdbcUrl -}}
     {{- $dbKind := include "nessie.dbKind" $jdbcUrl -}}
     {{- $_ = set $map "nessie.version.store.persist.jdbc.datasource"  $dbKind -}}
-    {{- if .Values.jdbc.catalog -}}
-    {{- $_ = set $map "nessie.version.store.persist.jdbc.catalog" .Values.jdbc.catalog -}}
-    {{- end -}}
-    {{- if .Values.jdbc.schema -}}
-    {{- $_ = set $map "nessie.version.store.persist.jdbc.schema" .Values.jdbc.schema -}}
-    {{- end -}}
     {{- $_ = set $map ( printf "quarkus.datasource.%s.jdbc.url" $dbKind ) $jdbcUrl }}
     {{- end -}}
 

--- a/helm/nessie/values.yaml
+++ b/helm/nessie/values.yaml
@@ -84,10 +84,6 @@ jdbc:
   # PostgreSQL, MariaDB and MySQL URLs are supported. Check your JDBC driver documentation
   # for the correct URL format.
   jdbcUrl: jdbc:postgresql://localhost:5432/my_database?currentSchema=nessie
-  # -- The catalog name to use. Required only if the JDBC URL does not contain a catalog name, or if you want to override it.
-  catalog: ""
-  # -- The schema name to use. Required only if the JDBC URL does not contain a schema name, or if you want to override it.
-  schema: ""
   secret:
     # -- The secret name to pull datasource credentials from.
     name: datasource-creds

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusJdbcConfig.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/config/QuarkusJdbcConfig.java
@@ -17,6 +17,7 @@ package org.projectnessie.quarkus.config;
 
 import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
 import java.util.Optional;
 import org.projectnessie.versioned.storage.jdbc.JdbcBackendBaseConfig;
 
@@ -83,11 +84,7 @@ public interface QuarkusJdbcConfig extends JdbcBackendBaseConfig {
    * href="https://quarkus.io/guides/datasource#jdbc-configuration">Quarkus JDBC config
    * reference</a>.
    */
-  Optional<String> datasource();
-
+  @WithName("datasource")
   @Override
-  Optional<String> catalog();
-
-  @Override
-  Optional<String> schema();
+  Optional<String> datasourceName();
 }

--- a/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/JdbcBackendBuilder.java
+++ b/servers/quarkus-common/src/main/java/org/projectnessie/quarkus/providers/storage/JdbcBackendBuilder.java
@@ -99,7 +99,7 @@ public class JdbcBackendBuilder implements BackendBuilder {
   private DataSource selectDataSource() {
     String dataSourceName =
         config
-            .datasource()
+            .datasourceName()
             .map(JdbcBackendBuilder::unquoteDataSourceName)
             .orElse(DEFAULT_DATA_SOURCE_NAME);
     DataSource dataSource = findDataSourceByName(dataSourceName);

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/DatabaseSpecific.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/DatabaseSpecific.java
@@ -28,5 +28,7 @@ public interface DatabaseSpecific {
 
   boolean isRetryTransaction(SQLException e);
 
+  boolean isAlreadyExists(SQLException e);
+
   String wrapInsert(String sql);
 }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/DatabaseSpecifics.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/DatabaseSpecifics.java
@@ -97,6 +97,9 @@ public final class DatabaseSpecifics {
     /** Deadlock error, returned by Postgres. */
     private static final String DEADLOCK_SQL_STATE_POSTGRES = "40P01";
 
+    /** Already exists error, returned by Postgres, H2 and Cockroach. */
+    private static final String ALREADY_EXISTS_STATE_POSTGRES = "42P07";
+
     /**
      * Cockroach "retry, write too old" error, see <a
      * href="https://www.cockroachlabs.com/docs/v21.1/transaction-retry-error-reference.html#retry_write_too_old">Cockroach's
@@ -156,6 +159,11 @@ public final class DatabaseSpecifics {
     }
 
     @Override
+    public boolean isAlreadyExists(SQLException e) {
+      return ALREADY_EXISTS_STATE_POSTGRES.equals(e.getSQLState());
+    }
+
+    @Override
     public String wrapInsert(String sql) {
       return sql + " ON CONFLICT DO NOTHING";
     }
@@ -165,9 +173,10 @@ public final class DatabaseSpecifics {
 
     private static final String VARCHAR = "VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
     private static final String TEXT = "TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
-    private static final String MYSQL_CONSTRAINT_VIOLATION_SQL_STATE = "23000";
 
+    private static final String MYSQL_CONSTRAINT_VIOLATION_SQL_STATE = "23000";
     private static final String MYSQL_LOCK_DEADLOCK_SQL_STATE = "40001";
+    private static final String MYSQL_ALREADY_EXISTS_SQL_STATE = "42S01";
 
     private final Map<JdbcColumnType, String> typeMap;
     private final Map<JdbcColumnType, Integer> typeIdMap;
@@ -209,6 +218,11 @@ public final class DatabaseSpecifics {
     @Override
     public boolean isRetryTransaction(SQLException e) {
       return MYSQL_LOCK_DEADLOCK_SQL_STATE.equals(e.getSQLState());
+    }
+
+    @Override
+    public boolean isAlreadyExists(SQLException e) {
+      return MYSQL_ALREADY_EXISTS_SQL_STATE.equals(e.getSQLState());
     }
 
     @Override

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcBackend.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcBackend.java
@@ -51,34 +51,52 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.projectnessie.versioned.storage.common.exceptions.UnknownOperationResultException;
 import org.projectnessie.versioned.storage.common.persist.Backend;
 import org.projectnessie.versioned.storage.common.persist.PersistFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class JdbcBackend implements Backend {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JdbcBackend.class);
 
   private final DatabaseSpecific databaseSpecific;
   private final DataSource dataSource;
   private final boolean closeDataSource;
   private final String createTableRefsSql;
   private final String createTableObjsSql;
+
+  private final AtomicBoolean first = new AtomicBoolean(true);
   private String catalog;
   private String schema;
 
+  @SuppressWarnings("removal")
   public JdbcBackend(
       @Nonnull JdbcBackendConfig config,
       @Nonnull DatabaseSpecific databaseSpecific,
       boolean closeDataSource) {
     this.dataSource = config.dataSource();
-    this.catalog = config.catalog().orElse(null);
-    this.schema = config.schema().orElse(null);
     this.databaseSpecific = databaseSpecific;
     this.closeDataSource = closeDataSource;
     createTableRefsSql = buildCreateTableRefsSql(databaseSpecific);
     createTableObjsSql = buildCreateTableObjsSql(databaseSpecific);
+    if (config.catalog().isPresent()) {
+      LOGGER.warn(
+          "Configuration 'nessie.version.store.persist.jdbc.catalog' is now obsolete, please remove it. "
+              + "The catalog must be specified directly in the JDBC URL using the option 'quarkus.datasource.{}.jdbc.url'",
+          config.datasourceName().orElse("postgresql"));
+    }
+    if (config.schema().isPresent()) {
+      LOGGER.warn(
+          "Configuration 'nessie.version.store.persist.jdbc.schema' is now obsolete, please remove it. "
+              + "The schema must be specified directly in the JDBC URL using the option 'quarkus.datasource.{}.jdbc.url'",
+          config.datasourceName().orElse("postgresql"));
+    }
   }
 
   private String buildCreateTableRefsSql(DatabaseSpecific databaseSpecific) {
@@ -169,18 +187,24 @@ public final class JdbcBackend implements Backend {
   Connection borrowConnection() throws SQLException {
     Connection c = dataSource.getConnection();
     c.setAutoCommit(false);
+    if (first.compareAndSet(true, false)) {
+      catalog = c.getCatalog();
+      schema = c.getSchema();
+      if (catalog == null) {
+        LOGGER.warn(
+            "Could not determine catalog name from JDBC properties: schema checks might fail");
+      }
+      if (schema == null) {
+        LOGGER.warn(
+            "Could not determine schema name from JDBC properties: schema checks might fail");
+      }
+    }
     return c;
   }
 
   @Override
   public void setupSchema() {
     try (Connection conn = borrowConnection()) {
-      if (catalog == null || catalog.isEmpty()) {
-        catalog = conn.getCatalog();
-      }
-      if (schema == null || schema.isEmpty()) {
-        schema = conn.getSchema();
-      }
       Integer nameTypeId = databaseSpecific.columnTypeIds().get(NAME);
       Integer objIdTypeId = databaseSpecific.columnTypeIds().get(OBJ_ID);
       createTableIfNotExists(
@@ -223,6 +247,9 @@ public final class JdbcBackend implements Backend {
       } else if (conn.getMetaData().storesUpperCaseIdentifiers()) {
         tableName = tableName.toUpperCase(Locale.ROOT);
       }
+
+      String catalog = conn.getCatalog();
+      String schema = conn.getSchema();
 
       try (ResultSet rs = conn.getMetaData().getTables(catalog, schema, tableName, null)) {
         if (rs.next()) {
@@ -269,7 +296,15 @@ public final class JdbcBackend implements Backend {
         }
       }
 
-      st.executeUpdate(createTable);
+      try {
+        st.executeUpdate(createTable);
+      } catch (SQLException e) {
+        if (databaseSpecific.isAlreadyExists(e)) {
+          // table was created by another process, proceed
+          return;
+        }
+        throw e;
+      }
     }
   }
 

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcBackendBaseConfig.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcBackendBaseConfig.java
@@ -19,9 +19,25 @@ import java.util.Optional;
 
 public interface JdbcBackendBaseConfig {
 
-  /** The JDBC catalog name. If not provided, will be inferred from the datasource. */
+  Optional<String> datasourceName();
+
+  /**
+   * The JDBC catalog name.
+   *
+   * @deprecated This setting has never worked as expected and is now ineffective. The catalog must
+   *     be specified directly in the JDBC URL using the option {@code
+   *     quarkus.datasource.*.jdbc.url}.
+   */
+  @Deprecated(forRemoval = true)
   Optional<String> catalog();
 
-  /** The JDBC schema name. If not provided, will be inferred from the datasource. */
+  /**
+   * The JDBC schema name.
+   *
+   * @deprecated This setting has never worked as expected and is now ineffective. The schema must
+   *     be specified directly in the JDBC URL using the option {@code
+   *     quarkus.datasource.*.jdbc.url}.
+   */
+  @Deprecated(forRemoval = true)
   Optional<String> schema();
 }


### PR DESCRIPTION
This PR:

* Removes the `catalog` and `schema` options, which did not work as expected;
* Makes `JdbcBackend` rely exclusively on the catalog and schema coming from the connection, and hence from the JDBC URL;
* Also protects against potential races when creating the JDBC schema, by checking if the error is an "already exists" error.