### PR TITLE
Persist: add `fetchObjsIfExist()`

### DIFF
--- a/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
+++ b/versioned/storage/batching/src/main/java/org/projectnessie/versioned/storage/batching/BatchingPersistImpl.java
@@ -252,6 +252,17 @@ final class BatchingPersistImpl implements BatchingPersist, ValidatingPersist {
     ObjId[] backendIds = null;
     Obj[] r = new Obj[ids.length];
 
+    backendIds = fetchObjsPre(ids, r, backendIds);
+
+    if (backendIds == null) {
+      return r;
+    }
+
+    Obj[] backendResult = delegate().fetchObjs(backendIds);
+    return fetchObjsPost(backendResult, r);
+  }
+
+  private ObjId[] fetchObjsPre(ObjId[] ids, Obj[] r, ObjId[] backendIds) {
     readLock();
     try {
       for (int i = 0; i < ids.length; i++) {
@@ -272,12 +283,10 @@ final class BatchingPersistImpl implements BatchingPersist, ValidatingPersist {
     } finally {
       readUnlock();
     }
+    return backendIds;
+  }
 
-    if (backendIds == null) {
-      return r;
-    }
-
-    Obj[] backendResult = delegate().fetchObjs(backendIds);
+  private static Obj[] fetchObjsPost(Obj[] backendResult, Obj[] r) {
     for (int i = 0; i < backendResult.length; i++) {
       Obj o = backendResult[i];
       if (o != null) {
@@ -285,6 +294,24 @@ final class BatchingPersistImpl implements BatchingPersist, ValidatingPersist {
       }
     }
     return r;
+  }
+
+  @Override
+  @Nonnull
+  @javax.annotation.Nonnull
+  public Obj[] fetchObjsIfExist(@Nonnull @javax.annotation.Nonnull ObjId[] ids) {
+
+    ObjId[] backendIds = null;
+    Obj[] r = new Obj[ids.length];
+
+    backendIds = fetchObjsPre(ids, r, backendIds);
+
+    if (backendIds == null) {
+      return r;
+    }
+
+    Obj[] backendResult = delegate().fetchObjsIfExist(backendIds);
+    return fetchObjsPost(backendResult, r);
   }
 
   @Override

--- a/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
+++ b/versioned/storage/bigtable/src/main/java/org/projectnessie/versioned/storage/bigtable/BigTablePersist.java
@@ -362,6 +362,24 @@ public class BigTablePersist implements Persist {
   }
 
   @Override
+  @Nonnull
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
+    try {
+      Obj[] r = new Obj[ids.length];
+      bulkFetch(backend.tableObjsId, ids, r, this::dbKey, this::objFromRow, x -> {});
+
+      return r;
+    } catch (ExecutionException | TimeoutException e) {
+      throw new RuntimeException(e);
+    } catch (ApiException e) {
+      throw apiException(e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
   public boolean storeObj(@Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
       throws ObjTooLargeException {
 

--- a/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
+++ b/versioned/storage/cache/src/main/java/org/projectnessie/versioned/storage/cache/CachingPersistImpl.java
@@ -101,6 +101,17 @@ class CachingPersistImpl implements Persist {
     ObjId[] backendIds = null;
     Obj[] r = new Obj[ids.length];
 
+    backendIds = fetchObjsPre(ids, r, backendIds);
+
+    if (backendIds == null) {
+      return r;
+    }
+
+    Obj[] backendResult = persist.fetchObjs(backendIds);
+    return fetchObjsPost(backendResult, r);
+  }
+
+  private ObjId[] fetchObjsPre(ObjId[] ids, Obj[] r, ObjId[] backendIds) {
     for (int i = 0; i < ids.length; i++) {
       ObjId id = ids[i];
       if (id == null) {
@@ -116,12 +127,10 @@ class CachingPersistImpl implements Persist {
         backendIds[i] = id;
       }
     }
+    return backendIds;
+  }
 
-    if (backendIds == null) {
-      return r;
-    }
-
-    Obj[] backendResult = persist.fetchObjs(backendIds);
+  private Obj[] fetchObjsPost(Obj[] backendResult, Obj[] r) {
     for (int i = 0; i < backendResult.length; i++) {
       Obj o = backendResult[i];
       if (o != null) {
@@ -130,6 +139,22 @@ class CachingPersistImpl implements Persist {
       }
     }
     return r;
+  }
+
+  @Override
+  @Nonnull
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
+    ObjId[] backendIds = null;
+    Obj[] r = new Obj[ids.length];
+
+    backendIds = fetchObjsPre(ids, r, backendIds);
+
+    if (backendIds == null) {
+      return r;
+    }
+
+    Obj[] backendResult = persist.fetchObjsIfExist(backendIds);
+    return fetchObjsPost(backendResult, r);
   }
 
   @Override

--- a/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
+++ b/versioned/storage/common/src/main/java/org/projectnessie/versioned/storage/common/persist/ObservingPersist.java
@@ -187,6 +187,15 @@ public class ObservingPersist implements Persist {
   @Override
   @Counted(PREFIX)
   @Timed(value = PREFIX, histogram = true)
+  @Nonnull
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
+    return delegate.fetchObjsIfExist(ids);
+  }
+
+  @WithSpan
+  @Override
+  @Counted(PREFIX)
+  @Timed(value = PREFIX, histogram = true)
   public boolean storeObj(@Nonnull Obj obj) throws ObjTooLargeException {
     return delegate.storeObj(obj);
   }

--- a/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
+++ b/versioned/storage/dynamodb/src/main/java/org/projectnessie/versioned/storage/dynamodb/DynamoDBPersist.java
@@ -376,7 +376,7 @@ public class DynamoDBPersist implements Persist {
 
   @Nonnull
   @Override
-  public Obj[] fetchObjs(@Nonnull ObjId[] ids) throws ObjNotFoundException {
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
     List<Map<String, AttributeValue>> keys = new ArrayList<>(Math.min(ids.length, BATCH_GET_LIMIT));
     Object2IntHashMap<ObjId> idToIndex =
         new Object2IntHashMap<>(200, Hashing.DEFAULT_LOAD_FACTOR, -1);
@@ -397,20 +397,6 @@ public class DynamoDBPersist implements Persist {
 
     if (!keys.isEmpty()) {
       fetchObjsPage(r, keys, idToIndex);
-    }
-
-    List<ObjId> notFound = null;
-    for (int i = 0; i < ids.length; i++) {
-      ObjId id = ids[i];
-      if (id != null && r[i] == null) {
-        if (notFound == null) {
-          notFound = new ArrayList<>();
-        }
-        notFound.add(id);
-      }
-    }
-    if (notFound != null) {
-      throw new ObjNotFoundException(notFound);
     }
 
     return r;

--- a/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
+++ b/versioned/storage/inmemory/src/main/java/org/projectnessie/versioned/storage/inmemory/InmemoryPersist.java
@@ -20,9 +20,7 @@ import static java.util.Collections.singleton;
 
 import com.google.common.collect.AbstractIterator;
 import jakarta.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -216,25 +214,14 @@ class InmemoryPersist implements ValidatingPersist {
 
   @Override
   @Nonnull
-  public Obj[] fetchObjs(@Nonnull ObjId[] ids) throws ObjNotFoundException {
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
     Obj[] r = new Obj[ids.length];
-    List<ObjId> notFound = null;
     for (int i = 0; i < ids.length; i++) {
       ObjId id = ids[i];
       if (id == null) {
         continue;
       }
-      try {
-        r[i] = fetchObj(id);
-      } catch (ObjNotFoundException e) {
-        if (notFound == null) {
-          notFound = new ArrayList<>();
-        }
-        notFound.addAll(e.objIds());
-      }
-    }
-    if (notFound != null) {
-      throw new ObjNotFoundException(notFound);
+      r[i] = inmemory.objects.get(compositeKey(id));
     }
     return r;
   }

--- a/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
+++ b/versioned/storage/jdbc/src/main/java/org/projectnessie/versioned/storage/jdbc/JdbcPersist.java
@@ -210,6 +210,12 @@ class JdbcPersist extends AbstractJdbcPersist {
   }
 
   @Override
+  @Nonnull
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
+    return withConnectionException(true, conn -> super.fetchObjsIfExist(conn, ids));
+  }
+
+  @Override
   public boolean storeObj(@Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
       throws ObjTooLargeException {
     return withConnectionException(

--- a/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
+++ b/versioned/storage/mongodb/src/main/java/org/projectnessie/versioned/storage/mongodb/MongoDBPersist.java
@@ -407,7 +407,7 @@ public class MongoDBPersist implements Persist {
 
   @Nonnull
   @Override
-  public Obj[] fetchObjs(@Nonnull ObjId[] ids) throws ObjNotFoundException {
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
     List<Document> list = new ArrayList<>(ids.length);
     Object2IntHashMap<ObjId> idToIndex =
         new Object2IntHashMap<>(ids.length * 2, Hashing.DEFAULT_LOAD_FACTOR, -1);
@@ -422,20 +422,6 @@ public class MongoDBPersist implements Persist {
 
     if (!list.isEmpty()) {
       fetchObjsPage(r, list, idToIndex);
-    }
-
-    List<ObjId> notFound = null;
-    for (int i = 0; i < ids.length; i++) {
-      ObjId id = ids[i];
-      if (r[i] == null && id != null) {
-        if (notFound == null) {
-          notFound = new ArrayList<>();
-        }
-        notFound.add(id);
-      }
-    }
-    if (notFound != null) {
-      throw new ObjNotFoundException(notFound);
     }
 
     return r;

--- a/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
+++ b/versioned/storage/rocksdb/src/main/java/org/projectnessie/versioned/storage/rocksdb/RocksDBPersist.java
@@ -295,7 +295,7 @@ class RocksDBPersist implements Persist {
 
   @Override
   @Nonnull
-  public Obj[] fetchObjs(@Nonnull ObjId[] ids) throws ObjNotFoundException {
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
     try {
       RocksDBBackend b = backend;
       TransactionDB db = b.db();
@@ -313,24 +313,15 @@ class RocksDBPersist implements Persist {
       }
 
       if (!keys.isEmpty()) {
-        List<ObjId> notFound = null;
         List<byte[]> dbResult = db.multiGetAsList(handles, keys);
         for (int i = 0, ri = 0; i < num; i++) {
           ObjId id = ids[i];
           if (id != null) {
             byte[] obj = dbResult.get(ri++);
-            if (obj == null) {
-              if (notFound == null) {
-                notFound = new ArrayList<>();
-              }
-              notFound.add(id);
-            } else {
+            if (obj != null) {
               r[i] = deserializeObj(id, obj, null);
             }
           }
-        }
-        if (notFound != null) {
-          throw new ObjNotFoundException(notFound);
         }
       }
 

--- a/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
+++ b/versioned/storage/store/src/test/java/org/projectnessie/versioned/storage/versionstore/PersistDelegate.java
@@ -144,6 +144,11 @@ public class PersistDelegate implements Persist {
   }
 
   @Override
+  public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
+    return delegate.fetchObjsIfExist(ids);
+  }
+
+  @Override
   public boolean storeObj(@Nonnull Obj obj) throws ObjTooLargeException {
     return delegate.storeObj(obj);
   }

--- a/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
+++ b/versioned/transfer/src/testFixtures/java/org/projectnessie/versioned/transfer/AbstractExportImport.java
@@ -360,6 +360,12 @@ public abstract class AbstractExportImport {
             return inmemory.fetchObjs(ids);
           }
 
+          @Nonnull
+          @Override
+          public Obj[] fetchObjsIfExist(@Nonnull ObjId[] ids) {
+            return inmemory.fetchObjsIfExist(ids);
+          }
+
           @Override
           public boolean storeObj(@Nonnull Obj obj, boolean ignoreSoftSizeRestrictions)
               throws ObjTooLargeException {


### PR DESCRIPTION
Same as `fetchObjs`, but returns `null` instead of throwing an `ObjNotFoundException`.